### PR TITLE
example: link to thread lib

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -7,6 +7,9 @@ add_definitions("-std=c++11 -Wall -Wextra -Werror")
 # Add DEBUG define for Debug target
 set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG")
 
+# This finds thread libs on Linux, Mac, and Windows.
+find_package(Threads REQUIRED)
+
 include_directories(
     # Not needed if installed system-wide
     ../install/include
@@ -20,4 +23,5 @@ target_link_libraries(takeoff_and_land
     ${CMAKE_SOURCE_DIR}/../install/lib/libdronelink.a
     # If installed system-wide:
     # dronelink
+    ${CMAKE_THREAD_LIBS_INIT}
 )


### PR DESCRIPTION
The thread library such as pthread on Linux was missing from the example.

This fixes #1.