### PR TITLE
Additional offboard setpoints

### DIFF
--- a/plugins/offboard/include/plugins/offboard/offboard.h
+++ b/plugins/offboard/include/plugins/offboard/offboard.h
@@ -74,11 +74,11 @@ public:
      * @brief Type for Position commands in NED (North East Down) coordinates and yaw.
      */
     struct PositionNEDYaw {
-        float north_m; /**< @brief Position along local north in meters. */
-        float east_m; /**< @brief Position along local east in meters. */
-        float down_m; /**< @brief Position along local down in meters. */
-        float yaw_deg; /**< @brief Yaw in degrees relative to local reference (positive is
-                          clock-wise looking from above). */
+        float north_m; /**< @brief Position along north in meters. */
+        float east_m; /**< @brief Position along east in meters. */
+        float down_m; /**< @brief Position along down in meters. */
+        float yaw_deg; /**< @brief Yaw in degrees (0 North, positive is clock-wise looking from
+                          above). */
     };
 
     /**
@@ -93,19 +93,20 @@ public:
     };
 
     /**
-     * @brief Type for Velocity commands in NE (North East Down) and Altitude in N coordinates and
+     * @brief Type for Velocity commands in NE (North East) and Altitude in N (Down) coordinate and
      * yaw.
      */
     struct VelocityAltitudeNEDYaw {
         float north_m_s; /**< @brief Velocity North in meters/second. */
         float east_m_s; /**< @brief Velocity East in meters/second. */
-        float down_m; /**< @brief Velocity Down in meters. */
+        float down_m; /**< @brief Altitude Down in meters. */
         float yaw_deg; /**< @brief Yaw in degrees (0 North, positive is clock-wise looking from
                           above). */
     };
 
     /**
-     * @brief Type for Velocity commands in NED (North East Down) coordinates and yaw.
+     * @brief Type for Position commands in NE (North East) and Velocity in N (Down) coordinate and
+     * yaw.
      */
     struct PositionClimbRateNEDYaw {
         float north_m; /**< @brief Position North in meters. */
@@ -116,13 +117,14 @@ public:
     };
 
     /**
-     * @brief Type for Velocity commands in NED (North East Down) coordinates and yaw.
+     * @brief Type for Position commands in NE (North East) and Velocity in N (Down) coordinate and
+     * yawspeed.
      */
     struct PositionClimbRateNEDYawspeed {
         float north_m; /**< @brief Position North in meters. */
         float east_m; /**< @brief Position East in meters. */
         float down_m_s; /**< @brief Velocity Down in meters/second. */
-        float yawspeed_deg_s; /**< @brief Yawspeed in degrees / seconds (0 North, positive is
+        float yawspeed_deg_s; /**< @brief Yawspeed in degrees per seconds (positive is
                           clock-wise looking from above). */
     };
 
@@ -185,8 +187,9 @@ public:
     bool is_active() const;
 
     /**
-     * @brief Set the position in NED coordinates and yaw.
+     * @brief Set the position in NED coordinate and yaw.
      *
+     * @see PositionNEDYaw
      * @param position_ned_yaw Position and yaw `struct`.
      */
     void set_position_ned_yaw(PositionNEDYaw position_ned_yaw);
@@ -199,22 +202,25 @@ public:
     void set_velocity_ned(VelocityNEDYaw velocity_ned_yaw);
 
     /**
-     * @brief Set the velocity in NE coordinates, altitude in D coordinate and yaw.
+     * @brief Set the velocity in NE and altitude in D coordinate and yaw.
      *
+     * @see VelocityAltitudeNEDYaw
      * @param velocity_altitude_ned_yaw Velocity/Altitude and yaw `struct`.
      */
     void set_velocity_altitude_ned_yaw(VelocityAltitudeNEDYaw velocity_altitude_ned_yaw);
 
     /**
-     * @brief Set the position in NE coordinates, climbrate in D coordinate and yaw.
+     * @brief Set the position in NE and climbrate in D coordinate and yaw.
      *
+     * @see PositionClimbRateNEDYaw
      * @param position_climbrate_ned_yaw Position/Climbrate and yaw `struct`.
      */
     void set_position_climbrate_ned_yaw(PositionClimbRateNEDYaw position_climbrate_ned_yaw);
 
     /**
-     * @brief Set the position in NE coordinates, climbrate in D coordinate and yawspeed.
+     * @brief Set the position in NE and climbrate in D coordinate and yawspeed.
      *
+     * @see PositionClimbRateNEDYawspeed
      * @param position_climbrate_ned_yawspeed Position/Climbrate and yawspeed `struct`.
      */
     void set_position_climbrate_ned_yawspeed(

--- a/plugins/offboard/include/plugins/offboard/offboard.h
+++ b/plugins/offboard/include/plugins/offboard/offboard.h
@@ -71,6 +71,17 @@ public:
     typedef std::function<void(Result)> result_callback_t;
 
     /**
+     * @brief Type for Position commands in NED (North East Down) coordinates and yaw.
+     */
+    struct PositionNEDYaw {
+        float north_m; /**< @brief Position along local north in meters. */
+        float east_m; /**< @brief Position along local east in meters. */
+        float down_m; /**< @brief Position along local down in meters. */
+        float yaw_deg; /**< @brief Yaw in degrees relative to local reference (positive is
+                          clock-wise looking from above). */
+    };
+
+    /**
      * @brief Type for Velocity commands in NED (North East Down) coordinates and yaw.
      */
     struct VelocityNEDYaw {
@@ -79,6 +90,40 @@ public:
         float down_m_s; /**< @brief Velocity Down in metres/second. */
         float yaw_deg; /**< @brief Yaw in degrees (0 North, positive is clock-wise looking from
                           above). */
+    };
+
+    /**
+     * @brief Type for Velocity commands in NE (North East Down) and Altitude in N coordinates and
+     * yaw.
+     */
+    struct VelocityAltitudeNEDYaw {
+        float north_m_s; /**< @brief Velocity North in meters/second. */
+        float east_m_s; /**< @brief Velocity East in meters/second. */
+        float down_m; /**< @brief Velocity Down in meters. */
+        float yaw_deg; /**< @brief Yaw in degrees (0 North, positive is clock-wise looking from
+                          above). */
+    };
+
+    /**
+     * @brief Type for Velocity commands in NED (North East Down) coordinates and yaw.
+     */
+    struct PositionClimbRateNEDYaw {
+        float north_m; /**< @brief Position North in meters. */
+        float east_m; /**< @brief Position East in meters. */
+        float down_m_s; /**< @brief Velocity Down in meters/second. */
+        float yaw_deg; /**< @brief Yaw in degrees (0 North, positive is clock-wise looking from
+                          above). */
+    };
+
+    /**
+     * @brief Type for Velocity commands in NED (North East Down) coordinates and yaw.
+     */
+    struct PositionClimbRateNEDYawspeed {
+        float north_m; /**< @brief Position North in meters. */
+        float east_m; /**< @brief Position East in meters. */
+        float down_m_s; /**< @brief Velocity Down in meters/second. */
+        float yawspeed_deg_s; /**< @brief Yawspeed in degrees / seconds (0 North, positive is
+                          clock-wise looking from above). */
     };
 
     /**
@@ -140,11 +185,40 @@ public:
     bool is_active() const;
 
     /**
+     * @brief Set the position in NED coordinates and yaw.
+     *
+     * @param position_ned_yaw Position and yaw `struct`.
+     */
+    void set_position_ned_yaw(PositionNEDYaw position_ned_yaw);
+
+    /**
      * @brief Set the velocity in NED coordinates and yaw.
      *
      * @param velocity_ned_yaw Velocity and yaw `struct`.
      */
     void set_velocity_ned(VelocityNEDYaw velocity_ned_yaw);
+
+    /**
+     * @brief Set the velocity in NE coordinates, altitude in D coordinate and yaw.
+     *
+     * @param velocity_altitude_ned_yaw Velocity/Altitude and yaw `struct`.
+     */
+    void set_velocity_altitude_ned_yaw(VelocityAltitudeNEDYaw velocity_altitude_ned_yaw);
+
+    /**
+     * @brief Set the position in NE coordinates, climbrate in D coordinate and yaw.
+     *
+     * @param position_climbrate_ned_yaw Position/Climbrate and yaw `struct`.
+     */
+    void set_position_climbrate_ned_yaw(PositionClimbRateNEDYaw position_climbrate_ned_yaw);
+
+    /**
+     * @brief Set the position in NE coordinates, climbrate in D coordinate and yawspeed.
+     *
+     * @param position_climbrate_ned_yawspeed Position/Climbrate and yawspeed `struct`.
+     */
+    void set_position_climbrate_ned_yawspeed(
+        PositionClimbRateNEDYawspeed position_climbrate_ned_yawspeed);
 
     /**
      * @brief Set the velocity body coordinates and yaw angular rate.

--- a/plugins/offboard/include/plugins/offboard/offboard.h
+++ b/plugins/offboard/include/plugins/offboard/offboard.h
@@ -74,9 +74,9 @@ public:
      * @brief Type for Position commands in NED (North East Down) coordinates and yaw.
      */
     struct PositionNEDYaw {
-        float north_m; /**< @brief Position along north in meters. */
-        float east_m; /**< @brief Position along east in meters. */
-        float down_m; /**< @brief Position along down in meters. */
+        float north_m; /**< @brief Position along North in meters. */
+        float east_m; /**< @brief Position along East in meters. */
+        float down_m; /**< @brief Position along Down in meters. */
         float yaw_deg; /**< @brief Yaw in degrees (0 North, positive is clock-wise looking from
                           above). */
     };
@@ -93,19 +93,19 @@ public:
     };
 
     /**
-     * @brief Type for Velocity commands in NE (North East) and Altitude in N (Down) coordinate and
+     * @brief Type for Velocity commands in NE (North East) and Altitude in D (Down) coordinate and
      * yaw.
      */
     struct VelocityAltitudeNEDYaw {
         float north_m_s; /**< @brief Velocity North in meters/second. */
         float east_m_s; /**< @brief Velocity East in meters/second. */
-        float down_m; /**< @brief Altitude Down in meters. */
+        float down_m; /**< @brief Altitude along Down in meters.  */
         float yaw_deg; /**< @brief Yaw in degrees (0 North, positive is clock-wise looking from
                           above). */
     };
 
     /**
-     * @brief Type for Position commands in NE (North East) and Velocity in N (Down) coordinate and
+     * @brief Type for Position commands in NE (North East) and Velocity in D (Down) coordinate and
      * yaw.
      */
     struct PositionClimbRateNEDYaw {
@@ -117,7 +117,7 @@ public:
     };
 
     /**
-     * @brief Type for Position commands in NE (North East) and Velocity in N (Down) coordinate and
+     * @brief Type for Position commands in NE (North East) and Velocity in D (Down) coordinate and
      * yawspeed.
      */
     struct PositionClimbRateNEDYawspeed {

--- a/plugins/offboard/offboard.cpp
+++ b/plugins/offboard/offboard.cpp
@@ -32,6 +32,27 @@ bool Offboard::is_active() const
     return _impl->is_active();
 }
 
+void Offboard::set_position_ned_yaw(Offboard::PositionNEDYaw position_ned_yaw)
+{
+    return _impl->set_position_ned_yaw(position_ned_yaw);
+}
+
+void Offboard::set_velocity_altitude_ned_yaw(VelocityAltitudeNEDYaw velocity_altitude_ned_yaw)
+{
+    return _impl->set_velocity_altitude_ned_yaw(velocity_altitude_ned_yaw);
+}
+
+void Offboard::set_position_climbrate_ned_yaw(PositionClimbRateNEDYaw position_climbrate_ned_yaw)
+{
+    return _impl->set_position_climbrate_ned_yaw(position_climbrate_ned_yaw);
+}
+
+void Offboard::set_position_climbrate_ned_yawspeed(
+    PositionClimbRateNEDYawspeed position_climbrate_ned_yawspeed)
+{
+    return _impl->set_position_climbrate_ned_yawspeed(position_climbrate_ned_yawspeed);
+}
+
 void Offboard::set_velocity_ned(Offboard::VelocityNEDYaw velocity_ned_yaw)
 {
     return _impl->set_velocity_ned(velocity_ned_yaw);

--- a/plugins/offboard/offboard_impl.cpp
+++ b/plugins/offboard/offboard_impl.cpp
@@ -286,7 +286,7 @@ void OffboardImpl::send_translation_ned()
     if (std::isfinite(_translation_ned.north_m) && std::isfinite(_translation_ned.east_m)) {
         x = _translation_ned.north_m;
         y = _translation_ned.east_m;
-        // enable xy
+        // enable x/y
         IGNORE_X &= ~(1 << 0);
         IGNORE_Y &= ~(1 << 1);
     }

--- a/plugins/offboard/offboard_impl.cpp
+++ b/plugins/offboard/offboard_impl.cpp
@@ -246,7 +246,7 @@ void OffboardImpl::send_translation_ned()
     const uint16_t IGNORE_AX = (1 << 6);
     const uint16_t IGNORE_AY = (1 << 7);
     const uint16_t IGNORE_AZ = (1 << 8);
-    const uint16_t IS_FORCE = (1 << 9);
+    // const uint16_t IS_FORCE = (1 << 9);
     const uint16_t IGNORE_YAW = (1 << 10);
     const uint16_t IGNORE_YAW_RATE = (1 << 11);
 
@@ -266,39 +266,39 @@ void OffboardImpl::send_translation_ned()
     const float afz = 0.0f;
 
     _mutex.lock();
-    if (std::isfinite(_translation_ned.yaw_deg)) {
+    if (isfinite(_translation_ned.yaw_deg)) {
         yaw = to_rad_from_deg(_translation_ned.yaw_deg);
     } else {
         ignore_flags |= IGNORE_YAW;
     }
 
-    if (std::isfinite(_translation_ned.yawspeed_deg_s)) {
+    if (isfinite(_translation_ned.yawspeed_deg_s)) {
         yawspeed = to_rad_from_deg(_translation_ned.yawspeed_deg_s);
     } else {
         ignore_flags |= IGNORE_YAW_RATE;
     }
 
-    if (std::isfinite(_translation_ned.north_m) && std::isfinite(_translation_ned.east_m)) {
+    if (isfinite(_translation_ned.north_m) && isfinite(_translation_ned.east_m)) {
         x = _translation_ned.north_m;
         y = _translation_ned.east_m;
     } else {
-        ignore_flags |= IGNORE_X |  IGNORE_Y;
+        ignore_flags |= IGNORE_X | IGNORE_Y;
     }
 
-    if (std::isfinite(_translation_ned.north_m_s) && std::isfinite(_translation_ned.east_m_s)) {
+    if (isfinite(_translation_ned.north_m_s) && isfinite(_translation_ned.east_m_s)) {
         vx = _translation_ned.north_m_s;
         vy = _translation_ned.east_m_s;
     } else {
         ignore_flags |= IGNORE_VX | IGNORE_VY;
     }
 
-    if (std::isfinite(_translation_ned.down_m)) {
+    if (isfinite(_translation_ned.down_m)) {
         z = _translation_ned.down_m;
     } else {
         ignore_flags |= IGNORE_Z;
     }
 
-    if (std::isfinite(_translation_ned.down_m_s)) {
+    if (isfinite(_translation_ned.down_m_s)) {
         vz = _translation_ned.down_m_s;
     } else {
         ignore_flags |= IGNORE_VZ;

--- a/plugins/offboard/offboard_impl.cpp
+++ b/plugins/offboard/offboard_impl.cpp
@@ -135,56 +135,48 @@ void OffboardImpl::set_translation_ned(TranslationNED translation_ned)
 
 void OffboardImpl::set_position_ned_yaw(Offboard::PositionNEDYaw position_ned_yaw)
 {
-    TranslationNED translation_ned = {position_ned_yaw.north_m,
-                                      position_ned_yaw.east_m,
-                                      position_ned_yaw.down_m,
-                                      NAN,
-                                      NAN,
-                                      NAN,
-                                      position_ned_yaw.yaw_deg,
-                                      NAN};
+    TranslationNED translation_ned{NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN};
+    translation_ned.north_m = position_ned_yaw.north_m;
+    translation_ned.east_m = position_ned_yaw.east_m;
+    translation_ned.down_m = position_ned_yaw.down_m;
+    translation_ned.yaw_deg = position_ned_yaw.yaw_deg;
+
     set_translation_ned(translation_ned);
 }
 
 void OffboardImpl::set_velocity_altitude_ned_yaw(
     Offboard::VelocityAltitudeNEDYaw velocity_altitude_ned_yaw)
 {
-    TranslationNED translation_ned = {NAN,
-                                      NAN,
-                                      velocity_altitude_ned_yaw.down_m,
-                                      velocity_altitude_ned_yaw.north_m_s,
-                                      velocity_altitude_ned_yaw.east_m_s,
-                                      NAN,
-                                      velocity_altitude_ned_yaw.yaw_deg,
-                                      NAN};
+    TranslationNED translation_ned{NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN};
+    translation_ned.down_m = velocity_altitude_ned_yaw.down_m;
+    translation_ned.north_m_s = velocity_altitude_ned_yaw.north_m_s;
+    translation_ned.east_m_s = velocity_altitude_ned_yaw.east_m_s;
+    translation_ned.yaw_deg = velocity_altitude_ned_yaw.yaw_deg;
+
     set_translation_ned(translation_ned);
 }
 
 void OffboardImpl::set_position_climbrate_ned_yaw(
     Offboard::PositionClimbRateNEDYaw position_climbrate_ned_yaw)
 {
-    TranslationNED translation_ned = {position_climbrate_ned_yaw.north_m,
-                                      position_climbrate_ned_yaw.east_m,
-                                      NAN,
-                                      NAN,
-                                      NAN,
-                                      position_climbrate_ned_yaw.down_m_s,
-                                      position_climbrate_ned_yaw.yaw_deg,
-                                      NAN};
+    TranslationNED translation_ned{NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN};
+    translation_ned.north_m = position_climbrate_ned_yaw.north_m;
+    translation_ned.east_m = position_climbrate_ned_yaw.east_m;
+    translation_ned.down_m_s = position_climbrate_ned_yaw.down_m_s;
+    translation_ned.yaw_deg = position_climbrate_ned_yaw.yaw_deg;
+
     set_translation_ned(translation_ned);
 }
 
 void OffboardImpl::set_position_climbrate_ned_yawspeed(
     Offboard::PositionClimbRateNEDYawspeed position_climbrate_ned_yawspeed)
 {
-    TranslationNED translation_ned = {position_climbrate_ned_yawspeed.north_m,
-                                      position_climbrate_ned_yawspeed.east_m,
-                                      NAN,
-                                      NAN,
-                                      NAN,
-                                      position_climbrate_ned_yawspeed.down_m_s,
-                                      NAN,
-                                      position_climbrate_ned_yawspeed.yawspeed_deg_s};
+    TranslationNED translation_ned{NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN};
+    translation_ned.north_m = position_climbrate_ned_yawspeed.north_m;
+    translation_ned.east_m = position_climbrate_ned_yawspeed.east_m;
+    translation_ned.down_m_s = position_climbrate_ned_yawspeed.down_m_s;
+    translation_ned.yawspeed_deg_s = position_climbrate_ned_yawspeed.yawspeed_deg_s;
+
     set_translation_ned(translation_ned);
 }
 

--- a/plugins/offboard/offboard_impl.h
+++ b/plugins/offboard/offboard_impl.h
@@ -27,10 +27,29 @@ public:
 
     bool is_active() const;
 
+    void set_position_ned_yaw(Offboard::PositionNEDYaw position_ned_yaw);
     void set_velocity_ned(Offboard::VelocityNEDYaw velocity_ned_yaw);
+    void set_velocity_altitude_ned_yaw(Offboard::VelocityAltitudeNEDYaw velocity_altitude_ned_yaw);
+    void
+    set_position_climbrate_ned_yaw(Offboard::PositionClimbRateNEDYaw position_climbrate_ned_yaw);
+    void set_position_climbrate_ned_yawspeed(
+        Offboard::PositionClimbRateNEDYawspeed position_climbrate_ned_yawspeed);
     void set_velocity_body(Offboard::VelocityBodyYawspeed velocity_body_yawspeed);
 
 private:
+    struct TranslationNED {
+        float north_m;
+        float east_m;
+        float down_m;
+        float north_m_s;
+        float east_m_s;
+        float down_m_s;
+        float yaw_deg;
+        float yawspeed_deg_s;
+    };
+
+    void set_translation_ned(TranslationNED translation_ned);
+    void send_translation_ned();
     void send_velocity_ned();
     void send_velocity_body();
 
@@ -43,7 +62,14 @@ private:
     void stop_sending_setpoints();
 
     mutable std::mutex _mutex{};
-    enum class Mode { NOT_ACTIVE, VELOCITY_NED, VELOCITY_BODY } _mode = Mode::NOT_ACTIVE;
+    enum class Mode {
+        NOT_ACTIVE,
+        TRANSLATION_NED,
+        VELOCITY_NED,
+        VELOCITY_BODY
+    } _mode = Mode::NOT_ACTIVE;
+
+    TranslationNED _translation_ned{};
     Offboard::VelocityNEDYaw _velocity_ned_yaw{};
     Offboard::VelocityBodyYawspeed _velocity_body_yawspeed{};
 


### PR DESCRIPTION
a couple more sets of offboard-setpoints. The added sets are as follow:
position-yaw, position-velocity-yaw, velocity-climbrate-yaw, velocity-climbrate-yawspeed,

Note that the firmware does not support it yet. However, once this [PR](https://github.com/PX4/Firmware/pull/9731) gets in together with some changes of this [branch](https://github.com/Stifael/Firmware/tree/offboard_enable_feedforward), any kind of mixing of setpoints should be allowed.

~You don't have to review it yet.~