### PR TITLE
camera: add support for Yuneec E10T

### DIFF
--- a/src/plugins/camera/CMakeLists.txt
+++ b/src/plugins/camera/CMakeLists.txt
@@ -3,6 +3,7 @@ if(NOT MSVC AND NOT MINGW)
     link_resource_file(camera_definition_files FILE ${CMAKE_CURRENT_SOURCE_DIR}/camera_definition_files/e90.xml VARIABLE e90xml TEXT)
     link_resource_file(camera_definition_files FILE ${CMAKE_CURRENT_SOURCE_DIR}/camera_definition_files/e50.xml VARIABLE e50xml TEXT)
     link_resource_file(camera_definition_files FILE ${CMAKE_CURRENT_SOURCE_DIR}/camera_definition_files/cgoet.xml VARIABLE cgoetxml TEXT)
+    link_resource_file(camera_definition_files FILE ${CMAKE_CURRENT_SOURCE_DIR}/camera_definition_files/e10t.xml VARIABLE e10txml TEXT)
 
     get_property(RSC_CPP_FILE TARGET camera_definition_files PROPERTY _AR_SRC_FILE)
     get_property(RSC_H_DIR TARGET camera_definition_files PROPERTY _AR_H_DIR)

--- a/src/plugins/camera/camera_definition_files/e10t.xml
+++ b/src/plugins/camera/camera_definition_files/e10t.xml
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<mavlinkcamera>
+    <definition version="10">
+        <model>E10T</model>
+        <vendor>Yuneec</vendor>
+    </definition>
+    <parameters>
+        <!-- control = 0 tells us this should not create an automatic UI control -->
+        <parameter name="CAM_IRENV" type="custom" default="0" control="0">
+            <description>Reserved</description>
+        </parameter>
+
+        <parameter name="CAM_IRCALIBD" type="int16" default="0" control="0" writeonly="1">
+            <description>Reserved</description>
+        </parameter>
+
+        <parameter name="CAM_IRCALIRUN" type="uint32" default="0" control="0" writeonly="1">
+            <description>Reserved</description>
+        </parameter>
+
+        <parameter name="CAM_IRSAVE" type="uint32" default="0" control="0" writeonly="1">
+            <description>Reserved</description>
+        </parameter>
+
+        <parameter name="CAM_IRGAINMODE" type="uint32" default="0" control="0">
+            <description>Reserved</description>
+        </parameter>
+
+        <parameter name="CAM_MODE" type="uint32" default="1" control="0">
+            <description>Camera Mode</description>
+            <!-- This tells us when this parameter changes, these parameters must be updated (requested)-->
+            <updates>
+                <update>CAM_SHUTTERSPD</update>
+                <update>CAM_ISO</update>
+                <update>CAM_ASPECTRATIO</update>
+            </updates>
+            <options>
+                <option name="Photo" value="0" />
+                <option name="Video" value="1" />
+            </options>
+        </parameter>
+        <parameter name="CAM_SHUTTERSPD" type="float" default="0.016666">
+            <description>Shutter Speed</description>
+            <options>
+                <option name="1/30" value="0.033333" />
+                <option name="1/50" value="0.02" />
+                <option name="1/60" value="0.016666" />
+                <option name="1/100" value="0.01" />
+                <option name="1/125" value="0.008" />
+                <option name="1/200" value="0.005" />
+                <option name="1/250" value="0.004" />
+                <option name="1/400" value="0.0025" />
+                <option name="1/480" value="0.002083333" />
+                <option name="1/500" value="0.002" />
+                <option name="1/1000" value="0.001" />
+                <option name="1/2000" value="0.0005" />
+                <option name="1/4000" value="0.00025" />
+                <option name="1/8000" value="0.000125" />
+            </options>
+        </parameter>
+        <parameter name="CAM_ISO" type="uint32" default="100">
+            <description>ISO</description>
+            <options>
+                <option name="100" value="100" />
+                <option name="150" value="150" />
+                <option name="200" value="200" />
+                <option name="300" value="300" />
+                <option name="400" value="400" />
+                <option name="600" value="600" />
+                <option name="800" value="800" />
+                <option name="1600" value="1600" />
+                <option name="3200" value="3200" />
+            </options>
+        </parameter>
+        <parameter name="CAM_EXPMODE" type="uint32" default="0">
+            <description>Exposure Mode</description>
+            <updates>
+                <update>CAM_SHUTTERSPD</update>
+                <update>CAM_ISO</update>
+            </updates>
+            <options default="0">
+                <option name="Auto" value="0">
+                    <exclusions>
+                        <exclude>CAM_ISO</exclude>
+                        <exclude>CAM_SHUTTERSPD</exclude>
+                    </exclusions>
+                </option>
+                <option name="Manual" value="1">
+                    <exclusions>
+                        <exclude>CAM_EV</exclude>
+                        <exclude>CAM_METERING</exclude>
+                    </exclusions>
+                </option>
+            </options>
+        </parameter>
+        <parameter name="CAM_WBMODE" type="uint32" default="0">
+            <description>White Balance Mode</description>
+            <options>
+                <option name="Auto" value="0" />
+                <option name="Incandescent" value="1" />
+                <option name="Sunrise" value="2" />
+                <option name="Sunset" value="3" />
+                <option name="Sunny" value="4" />
+                <option name="Cloudy" value="5" />
+                <option name="Fluorescent" value="6" />
+            </options>
+        </parameter>
+        <parameter name="CAM_EV" type="float" default="0">
+            <description>Exposure Compensation</description>
+            <options>
+                <option name="-3" value="-3" />
+                <option name="-2.5" value="-2.5" />
+                <option name="-2" value="-2" />
+                <option name="-1.5" value="-1.5" />
+                <option name="-1" value="-1" />
+                <option name="-0.5" value="-0.5" />
+                <option name="0" value="0" />
+                <option name="+0.5" value="0.5" />
+                <option name="+1" value="1" />
+                <option name="+1.5" value="1.5" />
+                <option name="+2" value="2" />
+                <option name="+2.5" value="2.5" />
+                <option name="+3" value="3" />
+            </options>
+        </parameter>
+        <!-- Not yet supported
+        <parameter name="CAM_VIDRES" type="uint32" default="2">
+            <description>Video Resolution</description>
+            <updates>
+                <update>CAM_SHUTTERSPD</update>
+                <update>CAM_ISO</update>
+                <update>CAM_ASPECTRATIO</update>
+            </updates>
+            <options>
+                <option name="1920 x 1080 24fps (FHD)" value="0" />
+                <option name="1920 x 1080 25fps (FHD)" value="1" />
+                <option name="1920 x 1080 30fps (FHD)" value="2" />
+            </options>
+        </parameter>
+        -->
+        <parameter name="CAM_METERING" type="uint32" default="0">
+            <description>Metering Mode</description>
+            <options>
+                <option name="Average" value="1" />
+                <option name="Center" value="0" />
+            <!-- Not yet supported
+                <option name="Spot" value="2" />
+            -->
+            </options>
+        </parameter>
+        <parameter name="CAM_IRPALETTE" type="uint32" default="0">
+            <description>Infrared Palette</description>
+            <options>
+                <option name="White Hot" value="0" />
+                <option name="Black Hot" value="1" />
+                <option name="Rainbow" value="2" />
+                <option name="RainHC" value="3" />
+                <option name="Ironbow" value="4" />
+                <option name="Lava" value="5" />
+                <option name="Artic" value="6" />
+                <option name="Glowbow" value="7" />
+                <option name="Graded Fire" value="8" />
+                <option name="Hottest" value="9" />
+            </options>
+        </parameter>
+        <parameter name="CAM_IRFFCMODE" type="uint32" default="1">
+            <description>Auto Calibration</description>
+            <options>
+                <option name="Manual" value="0" />
+                <option name="Auto" value="1" />
+                <option name="External" value="2" />
+            </options>
+        </parameter>
+        <parameter name="CAM_IRATMO" type="uint32" default="0">
+            <description>Atmospheric Parameters</description>
+            <options>
+                <option name="Disabled" value="0">
+                    <exclusions>
+                        <exclude>CAM_IREMISS</exclude>
+                        <exclude>CAM_CONVRATIO</exclude>
+                        <exclude>CAM_IRATMOTEMP</exclude>
+                    </exclusions>
+                </option>
+                <option name="Enabled" value="1" />
+            </options>
+        </parameter>
+        <parameter name="CAM_IREMISS" type="float" min="0" max="1" default="0">
+            <description>Scene Emissivity</description>
+        </parameter>
+        <parameter name="CAM_CONVRATIO" type="float" min="0" max="1" default="0">
+            <description>Conversion Coefficient</description>
+        </parameter>
+        <parameter name="CAM_IRATMOTEMP" type="float" default="0" min="-20" max="150" unit="C">
+            <description>Atmospheric Temperature</description>
+        </parameter>
+        <parameter name="CAM_IRACE" type="int16" default="97" min="50" max="400" step="1">
+            <description>Adaptive Contrast Enhancement</description>
+        </parameter>
+        <parameter name="CAM_IRDDE" type="int16" default="95" min="0" max="600" step="1">
+            <description>Digital Detail Enhancement</description>
+        </parameter>
+        <parameter name="CAM_TEMPSTATUS" type="custom" control="0" readonly="1">
+            <!--
+                This holds a udp_ctrl_cam_lepton_area_temp_t structure. All temperatures
+                stored as temp * 100.0. The E10O doesn't support locked. The returned
+                values are always 0.
+                typedef struct
+                {
+                    int32_t center_val;
+                    int32_t max_val;
+                    int32_t min_val;
+                    int32_t avg_val;
+                } udp_ctrl_cam_area_temp_t;
+                typedef struct
+                {
+                    int32_t  locked_max_temp;
+                    int32_t  locked_min_temp;
+                    udp_ctrl_cam_area_temp_t all_area;
+                    udp_ctrl_cam_area_temp_t custom_area;
+                } udp_ctrl_cam_lepton_area_temp_t;
+            -->
+            <description>Temperature Status</description>
+        </parameter>
+        <parameter name="CAM_IRPNINFO" type="custom" control="0" readonly="1">
+            <!--
+                This holds a ync_camera_pn_info_t structure.
+                typedef struct
+                {
+                    uint32_t cameraSN;
+                    uint32_t ver_major;
+                    uint32_t ver_minor;
+                    uint32_t ver_patch;
+                    uint16_t resolution;  //640 or 320 means 640*512 or 320*256
+                    uint8_t  frameRate;   //60hz or 9hz
+                    uint8_t  grade;      // I=industrial, P=Performance, C=commercial
+                    uint8_t  lenCoating;  //one charactor
+                    uint8_t  HFOV;
+                    int16_t  fpa_temp_x10;   //= real fpa temperature * 10
+                    uint16_t focalLength;// = real focal length * 10
+                    uint16_t aperture;//= real aperture *100
+                    uint16_t DFOV;       //= real DFOV * 10
+                    uint16_t reserved[16];
+                } ync_camera_pn_info_t;
+            -->
+            <description>Temperature Status</description>
+        </parameter>
+        <parameter name="CAM_IRRADPNT" type="custom" control="0">
+            <!--
+                This holds a ync_radiometric_point_settings_t structure.
+                typedef struct
+                {
+                    int32_t enable;//0:disable;1:enable
+                    uint16_t x;//e10t:0~319
+                    uint16_t y;//e10t:0~255
+                } ync_radiometric_point_settings_t;
+            -->
+            <description>Radiometric Point</description>
+        </parameter>
+        <parameter name="CAM_IRRADAREA" type="custom" control="0">
+            <!--
+                This holds a ync_radiometric_area_settings_t structure.
+                typedef struct
+                {
+                    uint16_t start_x;//e10t:0~319
+                    uint16_t start_y;//e10t:0~255
+                    uint16_t end_x;//e10t:0~319
+                    uint16_t end_y;//e10t:0~255
+                } ync_radiometric_area_coordinate_t;
+                typedef struct
+                {
+                    int32_t enable;//0:disable;1:enable
+                    ync_radiometric_area_coordinate_t area;
+                } ync_radiometric_area_settings_t;
+            -->
+            <description>Radiometric Area</description>
+        </parameter>
+        <parameter name="CAM_IRROI" type="custom" control="0">
+            <!--
+                This holds a ync_radiometric_area_coordinate_t structure.
+                typedef struct
+                {
+                    uint16_t start_x;//e10t:0~319
+                    uint16_t start_y;//e10t:0~255
+                    uint16_t end_x;//e10t:0~319
+                    uint16_t end_y;//e10t:0~255
+                } ync_radiometric_area_coordinate_t;
+            -->
+            <description>Radiometric Region of Interest</description>
+        </parameter>
+        <!-- 
+            Video stream aspect ratio
+            Float value is width / height (i.e. 3:2 = 1.5)
+        -->
+        <parameter name="CAM_ASPECTRATIO" default="1.7777" type="float" control="0" readonly="1">
+            <description>Video Stream Aspect Ratio</description>
+        </parameter>
+        <parameter name="CAM_WIFIPASSWD" type="string" control="0" writeonly="1">
+            <description>Set WiFi Password</description>
+        </parameter>
+        <parameter name="CAM_SYSTEMTIME" type="uint64" control="0" writeonly="1">
+            <description>Set System Time</description>
+        </parameter>
+    </parameters>
+    <localization />
+</mavlinkcamera>

--- a/src/plugins/camera/camera_impl.cpp
+++ b/src/plugins/camera/camera_impl.cpp
@@ -929,6 +929,10 @@ void CameraImpl::process_camera_information(const mavlink_message_t &message)
             LogInfo() << "Using cached file for Yuneec ET.";
             content = cgoetxml;
             found_content = true;
+        } else if (strcmp((const char *)(camera_information.model_name), "E10T") == 0) {
+            LogInfo() << "Using cached file for Yuneec E10T.";
+            content = e10txml;
+            found_content = true;
         }
     } else {
 #endif
@@ -992,6 +996,9 @@ void CameraImpl::process_flight_information(const mavlink_message_t &message)
         } else if (_information.data.vendor_name == "Yuneec" &&
                    _information.data.model_name == "CGOET") {
             folder_name_stream << (101 + flight_information.flight_uuid % 899) << "CGOET";
+        } else if (_information.data.vendor_name == "Yuneec" &&
+                   _information.data.model_name == "E10T") {
+            folder_name_stream << (101 + flight_information.flight_uuid % 899) << "E10T";
         } else {
             // Folder name unknown
         }


### PR DESCRIPTION
This adds support for the [E10T](https://www.yuneec.com/en_GB/accessories/cameras/e10t/specs.html) thermal camera for the Yuneec H520.

Still needs testing.