### PR TITLE
install backend_bin with libs and includes

### DIFF
--- a/DronecodeSDKConfig.cmake.in
+++ b/DronecodeSDKConfig.cmake.in
@@ -9,6 +9,10 @@ if(NOT @BUILD_SHARED_LIBS@)
 
     find_dependency(json11)
     find_dependency(tinyxml2)
+
+    if(@BUILD_BACKEND@)
+        find_dependency(gRPC)
+    endif()
 endif()
 
 get_filename_component(DRONECODESDK_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)

--- a/src/backend/src/CMakeLists.txt
+++ b/src/backend/src/CMakeLists.txt
@@ -79,4 +79,9 @@ else()
         PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/core
     )
+
+install(TARGETS backend_bin
+    EXPORT dronecode-sdk-targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
 endif()

--- a/src/backend/src/CMakeLists.txt
+++ b/src/backend/src/CMakeLists.txt
@@ -35,6 +35,7 @@ else()
 endif()
 
 target_link_libraries(backend
+    PRIVATE
     dronecode_sdk_action
     dronecode_sdk_calibration
     dronecode_sdk_gimbal
@@ -50,10 +51,12 @@ target_link_libraries(backend
 
 target_include_directories(backend
     PRIVATE
-    ${PROJECT_SOURCE_DIR}/core
-    ${PROJECT_SOURCE_DIR}/plugins
-    ${PROJECT_SOURCE_DIR}/backend/src/plugins
-    ${CMAKE_BINARY_DIR}/src/backend/src
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/core>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/plugins>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/backend/src/plugins>
+    PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src/backend/src>
+    $<INSTALL_INTERFACE:include>
 )
 
 if(IOS)
@@ -75,13 +78,19 @@ else()
         dronecode_sdk
     )
 
-    target_include_directories(backend_bin
-        PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/core
-    )
+    install(TARGETS backend_bin
+        EXPORT dronecode-sdk-targets
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        )
 
-install(TARGETS backend_bin
-    EXPORT dronecode-sdk-targets
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    )
+    install(TARGETS backend
+        EXPORT dronecode-sdk-targets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        )
+
+    install(FILES
+        backend_api.h
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/dronecode_sdk/backend"
+        )
 endif()

--- a/src/backend/test/CMakeLists.txt
+++ b/src/backend/test/CMakeLists.txt
@@ -30,6 +30,13 @@ target_include_directories(unit_tests_backend
 
 target_link_libraries(unit_tests_backend
     backend
+    dronecode_sdk_action
+    dronecode_sdk_camera
+    dronecode_sdk_info
+    dronecode_sdk_mission
+    dronecode_sdk_offboard
+    dronecode_sdk_telemetry
+    gRPC::grpc++
     gtest
     gmock
     gmock_main


### PR DESCRIPTION
Let's install `backend_bin` in `<INSTALL_PREFIX>/bin`, alongside `libs` and `include`. So that later it will be possible to fetch that as release artifacts.