### PR TITLE
Fix build

### DIFF
--- a/src/backend/src/CMakeLists.txt
+++ b/src/backend/src/CMakeLists.txt
@@ -88,14 +88,15 @@ else()
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         )
 
-    install(TARGETS backend
-        EXPORT dronecode-sdk-targets
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        )
+    if(BUILD_SHARED_LIBS)
+        install(TARGETS backend
+            EXPORT dronecode-sdk-targets
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            )
 
-    install(FILES
-        backend_api.h
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/dronecode_sdk/backend"
-        )
+        install(FILES
+            backend_api.h
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/dronecode_sdk/backend"
+            )
+    endif()
 endif()

--- a/src/backend/src/cmake/compile_proto.cmake
+++ b/src/backend/src/cmake/compile_proto.cmake
@@ -17,7 +17,7 @@ function(compile_proto_pb COMPONENT_NAME PB_COMPILED_SOURCE)
     set(PB_COMPILED_SOURCE ${COMPONENT_NAME}/${COMPONENT_NAME}.pb.cc PARENT_SCOPE)
 endfunction()
 
-function(compile_proto_grpc COMPONENT_NAME GRPC_COMPILED_SOURCES)
+function(compile_proto_grpc COMPONENT_NAME GRPC_COMPILED_SOURCE)
     add_custom_command(OUTPUT ${COMPONENT_NAME}/${COMPONENT_NAME}.grpc.pb.cc
         DEPENDS ${PROTO_DIR}/${COMPONENT_NAME}/${COMPONENT_NAME}.proto
         COMMAND ${PROTOC_BINARY}


### PR DESCRIPTION
That should fix develop by not trying to install `libbackend.a` (when `BUILD_SHARED_LIBS=OFF`).

(and it also fixes a typo in `compile_proto.cmake`)