### PR TITLE
Improve travis deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,16 +149,12 @@ script:
     docker run -it --rm -v $TRAVIS_BUILD_DIR:/home/user/DronecodeSDK:rw -e LOCAL_USER_ID=`id -u` dronecode/dronecode-sdk-fedora-29 ./tools/create_packages.sh;
   fi
 - if [[ "${BUILD_TARGET}" = "manylinux1-x64" ]]; then
-    ./dockcross-manylinux1-x64 cmake -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -DMANYLINUX=TRUE -Bbuild/manylinux1-x64 -H.;
-    ./dockcross-manylinux1-x64 cmake --build build/manylinux1-x64;
+    ./dockcross-manylinux1-x64 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/manylinux1-x64/install -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -DMANYLINUX=TRUE -Bbuild/manylinux1-x64 -H.;
+    ./dockcross-manylinux1-x64 cmake --build build/manylinux1-x64 --target install;
   fi
 - if [[ "${BUILD_TARGET}" = "osx_build" ]]; then
-    cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -Bbuild/debug -H.;
-    cmake --build build/debug;
-    ./build/debug/src/unit_tests_runner;
-    ./build/debug/src/backend/test/unit_tests_backend;
-    cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -Bbuild/release -H.;
-    cmake --build build/release;
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/release/install -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -Bbuild/release -H.;
+    cmake --build build/release --target install;
     ./build/release/src/unit_tests_runner;
     ./build/release/src/backend/test/unit_tests_backend;
   fi
@@ -192,17 +188,49 @@ after_success:
     --exclude-pattern=".*_test.*";
   fi
 
+before_deploy:
+- if ! [ "$BEFORE_DEPLOY_RUN" ]; then
+      export BEFORE_DEPLOY_RUN=1;
+
+      if [[ "${BUILD_TARGET}" = "manylinux1-x64" ]]; then
+          mv build/manylinux1-x64/install/bin/backend_bin build/manylinux1-x64/install/bin/mavsdk_backend_manylinux1-x64;
+      fi;
+      if [[ "${BUILD_TARGET}" = "osx_build" ]]; then
+          mv build/release/install/bin/backend_bin build/release/install/bin/mavsdk_backend_macos;
+      fi;
+  fi
+
 deploy:
-  provider: releases
+- provider: releases
   skip_cleanup: true
   api_key:
-    secure: hBX3pFWNZiDbz4yKnOjhLg3QS9Ubn1XePxSeIt2Btq5GzbomOPDCgpIFijBppliwj9oKc302EMnZSg2QWeAzFKn9UnmIflJ0E4iymYgwWdTJv+bSnYALJEmO8F6gF9FgRlPk8FCtZiECoTsa75w5TrEZKZpFpmzVYRiDu0eo6sEjW7UJPC0A2KSTXLrBCHSIZy/iasbGmuur4brG7NO0QdMOvDXvhsYfkXDRJFMTtTHvLiKJcqiunPfqARzf1H4x4iczRYscKu5Vn8Kmw3NANGkcIDvEj4ooih831EXxACRZw0VgycgNHOKRXKC9pZ4hLQMon+jxpQX+X8k/K5161oEkF/gCVKyFb31Pk/4Uwe81p1GJY2lAC7MDUxA98RKXhdvVYF2Cp44+IbF0YVoWRUtVAhknXRQ3Weg25kyVSu83q2nN2nZq2qGTnpNIbdN56s/F+uaFtipGEh+vmiv8rNUz+Z5MFrY2FQaSvBTFw9K4tNs9uc+VQd1bE7X5wh0yywEqUEw2nzqTB2xR+OubygUASbk2GLNdc254P0lrzCHbNM62Y7sRX06CM7hPlwhELEkVtUXZWJ0KuhQyLvRh3aPJ3Jj30EswTt/FGT1gzSP1FjjHBRZCK4P2D2rwJ5TMn2JrZKfPxmEd3kVmn6h80+gBbKgonGmZspd2SvPEI5g=
+      secure: hBX3pFWNZiDbz4yKnOjhLg3QS9Ubn1XePxSeIt2Btq5GzbomOPDCgpIFijBppliwj9oKc302EMnZSg2QWeAzFKn9UnmIflJ0E4iymYgwWdTJv+bSnYALJEmO8F6gF9FgRlPk8FCtZiECoTsa75w5TrEZKZpFpmzVYRiDu0eo6sEjW7UJPC0A2KSTXLrBCHSIZy/iasbGmuur4brG7NO0QdMOvDXvhsYfkXDRJFMTtTHvLiKJcqiunPfqARzf1H4x4iczRYscKu5Vn8Kmw3NANGkcIDvEj4ooih831EXxACRZw0VgycgNHOKRXKC9pZ4hLQMon+jxpQX+X8k/K5161oEkF/gCVKyFb31Pk/4Uwe81p1GJY2lAC7MDUxA98RKXhdvVYF2Cp44+IbF0YVoWRUtVAhknXRQ3Weg25kyVSu83q2nN2nZq2qGTnpNIbdN56s/F+uaFtipGEh+vmiv8rNUz+Z5MFrY2FQaSvBTFw9K4tNs9uc+VQd1bE7X5wh0yywEqUEw2nzqTB2xR+OubygUASbk2GLNdc254P0lrzCHbNM62Y7sRX06CM7hPlwhELEkVtUXZWJ0KuhQyLvRh3aPJ3Jj30EswTt/FGT1gzSP1FjjHBRZCK4P2D2rwJ5TMn2JrZKfPxmEd3kVmn6h80+gBbKgonGmZspd2SvPEI5g=
+  file_glob: true
+  file: "build/manylinux1-x64/install/bin/mavsdk_backend_manylinux1-x64"
+  on:
+    condition: ${BUILD_TARGET} = manylinux1-x64
+    repo: mavlink/MAVSDK
+    tags: true
+- provider: releases
+  skip_cleanup: true
+  api_key:
+      secure: hBX3pFWNZiDbz4yKnOjhLg3QS9Ubn1XePxSeIt2Btq5GzbomOPDCgpIFijBppliwj9oKc302EMnZSg2QWeAzFKn9UnmIflJ0E4iymYgwWdTJv+bSnYALJEmO8F6gF9FgRlPk8FCtZiECoTsa75w5TrEZKZpFpmzVYRiDu0eo6sEjW7UJPC0A2KSTXLrBCHSIZy/iasbGmuur4brG7NO0QdMOvDXvhsYfkXDRJFMTtTHvLiKJcqiunPfqARzf1H4x4iczRYscKu5Vn8Kmw3NANGkcIDvEj4ooih831EXxACRZw0VgycgNHOKRXKC9pZ4hLQMon+jxpQX+X8k/K5161oEkF/gCVKyFb31Pk/4Uwe81p1GJY2lAC7MDUxA98RKXhdvVYF2Cp44+IbF0YVoWRUtVAhknXRQ3Weg25kyVSu83q2nN2nZq2qGTnpNIbdN56s/F+uaFtipGEh+vmiv8rNUz+Z5MFrY2FQaSvBTFw9K4tNs9uc+VQd1bE7X5wh0yywEqUEw2nzqTB2xR+OubygUASbk2GLNdc254P0lrzCHbNM62Y7sRX06CM7hPlwhELEkVtUXZWJ0KuhQyLvRh3aPJ3Jj30EswTt/FGT1gzSP1FjjHBRZCK4P2D2rwJ5TMn2JrZKfPxmEd3kVmn6h80+gBbKgonGmZspd2SvPEI5g=
+  file_glob: true
+  file: "build/release/install/bin/mavsdk_backend_macos"
+  on:
+    condition: ${BUILD_TARGET} = osx_build
+    repo: mavlink/MAVSDK
+    tags: true
+- provider: releases
+  skip_cleanup: true
+  api_key:
+      secure: hBX3pFWNZiDbz4yKnOjhLg3QS9Ubn1XePxSeIt2Btq5GzbomOPDCgpIFijBppliwj9oKc302EMnZSg2QWeAzFKn9UnmIflJ0E4iymYgwWdTJv+bSnYALJEmO8F6gF9FgRlPk8FCtZiECoTsa75w5TrEZKZpFpmzVYRiDu0eo6sEjW7UJPC0A2KSTXLrBCHSIZy/iasbGmuur4brG7NO0QdMOvDXvhsYfkXDRJFMTtTHvLiKJcqiunPfqARzf1H4x4iczRYscKu5Vn8Kmw3NANGkcIDvEj4ooih831EXxACRZw0VgycgNHOKRXKC9pZ4hLQMon+jxpQX+X8k/K5161oEkF/gCVKyFb31Pk/4Uwe81p1GJY2lAC7MDUxA98RKXhdvVYF2Cp44+IbF0YVoWRUtVAhknXRQ3Weg25kyVSu83q2nN2nZq2qGTnpNIbdN56s/F+uaFtipGEh+vmiv8rNUz+Z5MFrY2FQaSvBTFw9K4tNs9uc+VQd1bE7X5wh0yywEqUEw2nzqTB2xR+OubygUASbk2GLNdc254P0lrzCHbNM62Y7sRX06CM7hPlwhELEkVtUXZWJ0KuhQyLvRh3aPJ3Jj30EswTt/FGT1gzSP1FjjHBRZCK4P2D2rwJ5TMn2JrZKfPxmEd3kVmn6h80+gBbKgonGmZspd2SvPEI5g=
   file_glob: true
   file:
-  - "*.deb"
-  - "*.rpm"
+  - "tools/*.deb"
+  - "tools/*.rpm"
   on:
-    repo: Dronecode/DronecodeSDK
+    repo: mavlink/MAVSDK
     tags: true
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -134,19 +134,15 @@ script:
   fi
 - if [[ "${BUILD_TARGET}" = "docker_build_ubuntu_16.04" ]]; then
     docker run -it --rm -v $TRAVIS_BUILD_DIR:/home/user/DronecodeSDK:rw -e LOCAL_USER_ID=`id -u` dronecode/dronecode-sdk-ubuntu-16.04 ./tools/travis-docker-build.sh;
-    docker run -it --rm -v $TRAVIS_BUILD_DIR:/home/user/DronecodeSDK:rw -e LOCAL_USER_ID=`id -u` dronecode/dronecode-sdk-ubuntu-16.04 ./tools/create_packages.sh;
   fi
 - if [[ "${BUILD_TARGET}" = "docker_build_ubuntu_18.04" ]]; then
     docker run -it --rm -v $TRAVIS_BUILD_DIR:/home/user/DronecodeSDK:rw -e LOCAL_USER_ID=`id -u` dronecode/dronecode-sdk-ubuntu-18.04 ./tools/travis-docker-build.sh;
-    docker run -it --rm -v $TRAVIS_BUILD_DIR:/home/user/DronecodeSDK:rw -e LOCAL_USER_ID=`id -u` dronecode/dronecode-sdk-ubuntu-18.04 ./tools/create_packages.sh;
   fi
 - if [[ "${BUILD_TARGET}" = "docker_build_fedora_28" ]]; then
     docker run -it --rm -v $TRAVIS_BUILD_DIR:/home/user/DronecodeSDK:rw -e LOCAL_USER_ID=`id -u` dronecode/dronecode-sdk-fedora-28 ./tools/travis-docker-build.sh;
-    docker run -it --rm -v $TRAVIS_BUILD_DIR:/home/user/DronecodeSDK:rw -e LOCAL_USER_ID=`id -u` dronecode/dronecode-sdk-fedora-28 ./tools/create_packages.sh;
   fi
 - if [[ "${BUILD_TARGET}" = "docker_build_fedora_29" ]]; then
     docker run -it --rm -v $TRAVIS_BUILD_DIR:/home/user/DronecodeSDK:rw -e LOCAL_USER_ID=`id -u` dronecode/dronecode-sdk-fedora-29 ./tools/travis-docker-build.sh;
-    docker run -it --rm -v $TRAVIS_BUILD_DIR:/home/user/DronecodeSDK:rw -e LOCAL_USER_ID=`id -u` dronecode/dronecode-sdk-fedora-29 ./tools/create_packages.sh;
   fi
 - if [[ "${BUILD_TARGET}" = "manylinux1-x64" ]]; then
     ./dockcross-manylinux1-x64 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/manylinux1-x64/install -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -DMANYLINUX=TRUE -Bbuild/manylinux1-x64 -H.;
@@ -154,21 +150,21 @@ script:
   fi
 - if [[ "${BUILD_TARGET}" = "osx_build" ]]; then
     cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/release/install -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -Bbuild/release -H.;
-    cmake --build build/release --target install;
+    make -Cbuild/release install -j4;
     ./build/release/src/unit_tests_runner;
     ./build/release/src/backend/test/unit_tests_backend;
   fi
 - if [[ "${BUILD_TARGET}" = "ios_build" ]]; then
-    cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -Bbuild/default -H.;
-    cmake --build build/default;
-    cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=./tools/ios.toolchain.cmake -DPLATFORM=OS -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -Bbuild/ios -H.;
-    cmake --build build/ios;
+    cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -Bbuild/default -H.;
+    make -Cbuild/default -j4;
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=./tools/ios.toolchain.cmake -DPLATFORM=OS -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -Bbuild/ios -H.;
+    make -Cbuild/ios -j4;
   fi
 - if [[ "${BUILD_TARGET}" = "ios_simulator_build" ]]; then
     cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -Bbuild/default -H.;
-    cmake --build build/default;
+    make -Cbuild/default -j4;
     cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=./tools/ios.toolchain.cmake -DPLATFORM=SIMULATOR64 -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -Bbuild/ios_simulator -H.;
-    cmake --build build/ios_simulator;
+    make -Cbuild/ios_simulator -j4;
   fi
 - if [[ "${BUILD_TARGET}" = "windows" ]]; then
     cmake -G "Visual Studio 15 2017" -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/build/debug/install -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -Bbuild/debug -H${TRAVIS_BUILD_DIR};
@@ -227,8 +223,8 @@ deploy:
       secure: hBX3pFWNZiDbz4yKnOjhLg3QS9Ubn1XePxSeIt2Btq5GzbomOPDCgpIFijBppliwj9oKc302EMnZSg2QWeAzFKn9UnmIflJ0E4iymYgwWdTJv+bSnYALJEmO8F6gF9FgRlPk8FCtZiECoTsa75w5TrEZKZpFpmzVYRiDu0eo6sEjW7UJPC0A2KSTXLrBCHSIZy/iasbGmuur4brG7NO0QdMOvDXvhsYfkXDRJFMTtTHvLiKJcqiunPfqARzf1H4x4iczRYscKu5Vn8Kmw3NANGkcIDvEj4ooih831EXxACRZw0VgycgNHOKRXKC9pZ4hLQMon+jxpQX+X8k/K5161oEkF/gCVKyFb31Pk/4Uwe81p1GJY2lAC7MDUxA98RKXhdvVYF2Cp44+IbF0YVoWRUtVAhknXRQ3Weg25kyVSu83q2nN2nZq2qGTnpNIbdN56s/F+uaFtipGEh+vmiv8rNUz+Z5MFrY2FQaSvBTFw9K4tNs9uc+VQd1bE7X5wh0yywEqUEw2nzqTB2xR+OubygUASbk2GLNdc254P0lrzCHbNM62Y7sRX06CM7hPlwhELEkVtUXZWJ0KuhQyLvRh3aPJ3Jj30EswTt/FGT1gzSP1FjjHBRZCK4P2D2rwJ5TMn2JrZKfPxmEd3kVmn6h80+gBbKgonGmZspd2SvPEI5g=
   file_glob: true
   file:
-  - "tools/*.deb"
-  - "tools/*.rpm"
+  - "build/release/*.deb"
+  - "build/release/*.rpm"
   on:
     repo: mavlink/MAVSDK
     tags: true

--- a/tools/create_packages.sh
+++ b/tools/create_packages.sh
@@ -3,80 +3,73 @@
 set -e
 
 echo "Packaging"
+echo "---------"
+
+if [ "$#" -ne 2 ]; then
+  echo "Error: missing path to the 'install' directory (i.e. what was specified as -DCMAKE_INSTALL_PREFIX)" >&2
+  echo "       or output path (where the package will be generated)!" >&2
+  echo "Usage: $0 <path/to/install> <output/path>" >&2
+  exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+install_dir=$1
+output_dir=$2
+
+working_dir=$(mktemp -d)
+mkdir -p ${working_dir}/install
+cp -r ${install_dir} ${working_dir}/install/usr
+
+# We need the relative path of all files.
+library_files=`find ${working_dir}/install -type f | cut -sd / -f 5-`
+echo "Files to be packaged:"
+echo ${library_files}
 
 # This creates a version such as "v1.2.3-5-g123abc".
 version=`git describe --always --tags`
 # We want to extract 1.2.3 from it.
 version=`echo ${version} | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/'`
 
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-working_dir=${script_dir}/install
-install_dir=${working_dir}/usr
+echo "#!/bin/sh" > ${working_dir}/run_ldconfig
+echo "/sbin/ldconfig" >> ${working_dir}/run_ldconfig
 
-rm -rf ${install_dir}
+common_args="--chdir ${working_dir}/install \
+             --input-type dir  \
+             --name mavsdk \
+             --version ${version} \
+             --maintainer julian@oes.ch \
+             --url https://sdk.dronecode.org \
+             --license BSD-3-Clause \
+             --after-install ${working_dir}/run_ldconfig \
+             --after-remove ${working_dir}/run_ldconfig \
+             --force"
 
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${install_dir} -Bbuild/release-package -H.;
-make -Cbuild/release-package install -j4;
-
-common_args="--input-type dir  \
-    --version ${version} \
-    --maintainer julian@oes.ch \
-    --url https://sdk.dronecode.org \
-    --license BSD-3-Clause \
-    --force"
-
-pushd ${working_dir}
-
-# We need the relative path of all files.
-library_files=`find . -type f | cut -sd / -f 2-`
-echo ${library_files}
-
-echo "#!/bin/sh" > run_ldconfig
-
-echo "/sbin/ldconfig" >> run_ldconfig
 if cat /etc/os-release | grep 'Ubuntu'
 then
     echo "Building DEB package"
     fpm ${common_args} \
         --output-type deb \
-        --depends libcurl4-openssl-dev \
         --deb-no-default-config-files \
-        --name libdronecode_sdk-dev \
-        --provides libdronecode_sdk-dev \
-        --after-install run_ldconfig \
-        --after-remove run_ldconfig \
         ${library_files}
 
-    dist_version=$(cat /etc/os-release | grep version_id | sed 's/[^0-9.]*//g')
+    dist_version=$(cat /etc/os-release | grep VERSION_ID | sed 's/[^0-9.]*//g')
 
     for file in *_amd64.deb
     do
-        mv -v "${file}" "${script_dir}/${file%_amd64.deb}_ubuntu${dist_version}_amd64.deb"
+        mv -v "${file}" "${output_dir}/${file%_amd64.deb}_ubuntu${dist_version}_amd64.deb"
     done
-
 elif cat /etc/os-release | grep 'Fedora'
 then
     echo "Building RPM package"
     fpm ${common_args} \
         --output-type rpm \
-        --depends libcurl-devel \
-        --name dronecode_sdk-devel \
-        --provides dronecode_sdk-devel \
-        --after-install run_ldconfig \
-        --after-remove run_ldconfig \
         --rpm-rpmbuild-define "_build_id_links none" \
         ${library_files}
 
-    dist_version=$(cat /etc/os-release | grep version_id | sed 's/[^0-9]*//g')
+    dist_version=$(cat /etc/os-release | grep VERSION_ID | sed 's/[^0-9]*//g')
 
     for file in *.x86_64.rpm
     do
-        mv -v "${file}" "${script_dir}/${file%.x86_64.rpm}.fc${dist_version}-x86_64.rpm"
+        mv -v "${file}" "${output_dir}/${file%.x86_64.rpm}.fc${dist_version}-x86_64.rpm"
     done
 fi
-
-rm run_ldconfig
-
-popd
-
-rm -rf ${install_dir}

--- a/tools/travis-docker-build.sh
+++ b/tools/travis-docker-build.sh
@@ -1,28 +1,24 @@
 #!/usr/bin/env bash
 
-# Note: each build (Release, Debug) is done in its own folder,
-#       hence removing the need to clean between them.
-#       However, the third_parties (which are always built in Release
-#       mode with the superbuild) are reused between the builds.
-
 set -e
 
-# Build and run offline tests in Debug mode
-cmake -DCMAKE_BUILD_TYPE=Debug -Bbuild/debug -H.;
-make -Cbuild/debug -j4;
-./build/debug/src/unit_tests_runner --gtest_filter="-CurlTest.*";
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Build and run offline tests in Release mode
-cmake -DCMAKE_BUILD_TYPE=Release -Bbuild/release -H.;
-make -Cbuild/release -j4;
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/release/install -DBUILD_BACKEND=ON -Bbuild/release -H.;
+make -Cbuild/release -j4 install;
 ./build/release/src/unit_tests_runner --gtest_filter="-CurlTest.*";
+./build/release/src/backend/test/unit_tests_backend;
 
 # Try to build the external plugin example
 cmake -DCMAKE_BUILD_TYPE=Release -DEXTERNAL_DIR=external_example -Bbuild/external-plugin -H.;
 make -Cbuild/external-plugin -j4;
 
 # Check style
-./tools/fix_style.sh .
+${script_dir}/fix_style.sh ${script_dir}/..
 
 # Generate documentation
-./tools/generate_docs.sh
+${script_dir}/generate_docs.sh
+
+# Generate packages
+${script_dir}/create_packages.sh ${script_dir}/../build/release/install ${script_dir}/../build/release


### PR DESCRIPTION
- Deploy manylinux backend binary
- Deploy macos backend binary
- Fix rpm/deb deployment (that I broke when reorganizing the deps)

Notes:
- The rpm/deb packages now include `backend_bin` (which I believe we should rename, e.g. to `mavsdk_backend`, but I will open another PR to discuss that).
- I removed a few `Debug` builds, as it doubles the build time and that's important when building with `-DBUILD_BACKEND=ON`. If we really need to build in Debug mode, we could make a nightly build, IMO.
- `create_packages.sh` is now called by `travis-docker-build.sh`, which IMO makes it cleaner since the later also calls `fix_style.sh` and `generate_docs.sh`.
- `create_packages.sh` takes arguments now. The intent is to make it easier to use without relying on a convention like: "install into `build/default/install/usr`".
- `create_packages.sh` copies the files into a temp dir, and adds `/usr/` there. The benefit of this is that we don't have to build from scratch again just for packaging, improving the CI build time.