### PR TITLE
Add offboard/set_actuator_control to offboard plugin

### DIFF
--- a/src/backend/src/plugins/offboard/offboard_service_impl.h
+++ b/src/backend/src/plugins/offboard/offboard_service_impl.h
@@ -60,6 +60,35 @@ public:
         return grpc::Status::OK;
     }
 
+    grpc::Status SetActuatorControl(grpc::ServerContext * /* context */,
+                             const rpc::offboard::SetActuatorControlRequest *request,
+                             rpc::offboard::SetActuatorControlResponse * /* response */) override
+    {
+        if (request != nullptr) {
+            auto requested_actuator_control = translateRPCActuatorControl(request->actuator_control());
+            _offboard.set_actuator_control(requested_actuator_control);
+        }
+
+        return grpc::Status::OK;
+    }
+
+    static mavsdk::Offboard::ActuatorControl
+    translateRPCActuatorControl(const rpc::offboard::ActuatorControl &rpc_actuator_control)
+    {
+        mavsdk::Offboard::ActuatorControl actuator_control = {};
+
+        actuator_control.actuator_group =
+            static_cast<mavsdk::Offboard::ActuatorControl::ActuatorGroup>(rpc_actuator_control.actuator_group());
+
+        int len = std::min(8, rpc_actuator_control.actuator_values_size());
+        for (int i = 0; i < len; i++) {
+            // https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.repeated_field#
+            actuator_control.actuator_values[i] = rpc_actuator_control.actuator_values(i);
+        }
+
+        return actuator_control;
+    }
+
     grpc::Status SetAttitude(grpc::ServerContext * /* context */,
                              const rpc::offboard::SetAttitudeRequest *request,
                              rpc::offboard::SetAttitudeResponse * /* response */) override

--- a/src/plugins/offboard/include/plugins/offboard/offboard.h
+++ b/src/plugins/offboard/include/plugins/offboard/offboard.h
@@ -132,6 +132,14 @@ public:
     };
 
     /**
+     * @brief Type for actuator control commands
+     *
+     */
+    struct ActuatorControl {
+        std::array<float, 8> actuator_control;
+    };
+
+    /**
      * @brief Start offboard control (synchronous).
      *
      * **Attention:** this is work in progress, use with caution!
@@ -213,6 +221,13 @@ public:
      * @param attitude_rate roll, pitch and yaw angular rate along with thrust in percentage.
      */
     void set_attitude_rate(AttitudeRate attitude_rate);
+
+    /**
+     * @brief Set direct actuator control values
+     *
+     * @param array of 8 values
+     */
+    void set_actuator_control(ActuatorControl actuator_control);
 
     /**
      * @brief Copy constructor (object is not copyable).

--- a/src/plugins/offboard/include/plugins/offboard/offboard.h
+++ b/src/plugins/offboard/include/plugins/offboard/offboard.h
@@ -132,11 +132,23 @@ public:
     };
 
     /**
-     * @brief Type for actuator control commands
+     * @brief Type for actuator control commands.
+     * ActuatorValues members should be normed to -1..+1 where 0 is neutral position.
+     * Throttle for single rotation direction motors is 0..1, negative range for reverse direction.
      *
+     * In PX4 v1.9.0 Only first four Control Groups are supported
+     * (https://github.com/PX4/Firmware/blob/v1.9.0/src/modules/mavlink/mavlink_receiver.cpp#L980).
      */
     struct ActuatorControl {
-        std::array<float, 8> actuator_control;
+        enum ActuatorGroup {
+            FLIGHT_CONTROL = 0, /**< @brief Control Group #0 (Flight Control). */
+            FLIGHT_CONTROL_VTOL = 1, /**< @brief Control Group #1 (Flight Control VTOL/Alternate). */
+            GIMBAL = 2, /**< @brief Control Group #2 (Gimbal). */
+            MANUAL_PASSTHROUGH = 3, /**< @brief Control Group #3 (Manual Passthrough). */
+        };
+
+        ActuatorGroup actuator_group; /**< @brief Actuator group. */
+        float actuator_values[8]; /**< @brief Actuator values array. */
     };
 
     /**
@@ -244,6 +256,13 @@ private:
 };
 
 /**
+ * @brief Equal operator to compare two `Offboard::ActuatorControl` objects.
+ *
+ * @return `true` if items are equal.
+ */
+bool operator==(const Offboard::ActuatorControl &lhs, const Offboard::ActuatorControl &rhs);
+
+/**
  * @brief Equal operator to compare two `Offboard::Attitude` objects.
  *
  * @return `true` if items are equal.
@@ -256,6 +275,13 @@ bool operator==(const Offboard::Attitude &lhs, const Offboard::Attitude &rhs);
  * @return `true` if items are equal.
  */
 bool operator==(const Offboard::AttitudeRate &lhs, const Offboard::AttitudeRate &rhs);
+
+/**
+ * @brief Stream operator to print information about a `Offboard::ActuatorControl`.
+ *
+ * @return A reference to the stream.
+ */
+std::ostream &operator<<(std::ostream &str, Offboard::ActuatorControl const &actuator_control);
 
 /**
  * @brief Stream operator to print information about a `Offboard::Attitude`.

--- a/src/plugins/offboard/mocks/offboard_mock.h
+++ b/src/plugins/offboard/mocks/offboard_mock.h
@@ -15,6 +15,7 @@ public:
     MOCK_CONST_METHOD1(set_position_ned, void(Offboard::PositionNEDYaw)){};
     MOCK_CONST_METHOD1(set_velocity_body, void(Offboard::VelocityBodyYawspeed)){};
     MOCK_CONST_METHOD1(set_velocity_ned, void(Offboard::VelocityNEDYaw)){};
+    MOCK_CONST_METHOD1(set_actuator_control, void(Offboard::ActuatorControl)){};
 };
 
 } // namespace testing

--- a/src/plugins/offboard/offboard.cpp
+++ b/src/plugins/offboard/offboard.cpp
@@ -57,6 +57,11 @@ void Offboard::set_attitude_rate(Offboard::AttitudeRate attitude_rate)
     return _impl->set_attitude_rate(attitude_rate);
 }
 
+void Offboard::set_actuator_control(Offboard::ActuatorControl actuator_control)
+{
+    return _impl->set_actuator_control(actuator_control);
+}
+
 const char *Offboard::result_str(Result result)
 {
     switch (result) {

--- a/src/plugins/offboard/offboard.cpp
+++ b/src/plugins/offboard/offboard.cpp
@@ -85,6 +85,29 @@ const char *Offboard::result_str(Result result)
     }
 }
 
+bool operator==(const Offboard::ActuatorControl &lhs, const Offboard::ActuatorControl &rhs)
+{
+    if (lhs.actuator_group != rhs.actuator_group)
+        return false;
+    for (int i = 0; i < 8; i++)
+        if (lhs.actuator_values[i] != rhs.actuator_values[i])
+            return false;
+    return true;
+}
+
+std::ostream &operator<<(std::ostream &str, Offboard::ActuatorControl const &actuator_control)
+{
+    return str << "[group: " << actuator_control.actuator_group
+               << ", Command port 0: " << actuator_control.actuator_values[0]
+               << ", Command port 1: " << actuator_control.actuator_values[1]
+               << ", Command port 2: " << actuator_control.actuator_values[2]
+               << ", Command port 3: " << actuator_control.actuator_values[3]
+               << ", Command port 4: " << actuator_control.actuator_values[4]
+               << ", Command port 5: " << actuator_control.actuator_values[5]
+               << ", Command port 6: " << actuator_control.actuator_values[6]
+               << ", Command port 7: " << actuator_control.actuator_values[7] << "]";
+}
+
 bool operator==(const Offboard::Attitude &lhs, const Offboard::Attitude &rhs)
 {
     return lhs.roll_deg == rhs.roll_deg && lhs.pitch_deg == rhs.pitch_deg &&

--- a/src/plugins/offboard/offboard_impl.cpp
+++ b/src/plugins/offboard/offboard_impl.cpp
@@ -264,6 +264,7 @@ void OffboardImpl::set_actuator_control(Offboard::ActuatorControl actuator_contr
     }
     _mutex.unlock();
 
+    // also send it right now to reduce latency
     send_actuator_control();
 }
 
@@ -513,11 +514,7 @@ void OffboardImpl::send_attitude_rate()
 void OffboardImpl::send_actuator_control()
 {
     _mutex.lock();
-    float actuator_control[8] = {};
-
-    std::copy(_actuator_control.actuator_control.begin(),
-              _actuator_control.actuator_control.end(),
-              actuator_control);
+    const Offboard::ActuatorControl actuator_control = _actuator_control;
     _mutex.unlock();
 
     mavlink_message_t message;
@@ -526,10 +523,10 @@ void OffboardImpl::send_actuator_control()
         _parent->get_own_component_id(),
         &message,
         static_cast<uint32_t>(_parent->get_time().elapsed_s() * 1e3),
-        0,
+        actuator_control.actuator_group,
         _parent->get_system_id(),
         _parent->get_autopilot_id(),
-        actuator_control);
+        actuator_control.actuator_values);
     _parent->send_message(message);
 }
 

--- a/src/plugins/offboard/offboard_impl.h
+++ b/src/plugins/offboard/offboard_impl.h
@@ -33,6 +33,7 @@ public:
     void set_velocity_body(Offboard::VelocityBodyYawspeed velocity_body_yawspeed);
     void set_attitude(Offboard::Attitude attitude);
     void set_attitude_rate(Offboard::AttitudeRate attitude_rate);
+    void set_actuator_control(Offboard::ActuatorControl actuator_control);
 
     OffboardImpl(const OffboardImpl &) = delete;
     OffboardImpl &operator=(const OffboardImpl &) = delete;
@@ -43,6 +44,7 @@ private:
     void send_velocity_body();
     void send_attitude_rate();
     void send_attitude();
+    void send_actuator_control();
 
     void process_heartbeat(const mavlink_message_t &message);
     void receive_command_result(MAVLinkCommands::Result result,
@@ -59,13 +61,15 @@ private:
         VELOCITY_NED,
         VELOCITY_BODY,
         ATTITUDE,
-        ATTITUDE_RATE
+        ATTITUDE_RATE,
+        ACTUATOR_CONTROL
     } _mode = Mode::NOT_ACTIVE;
     Offboard::PositionNEDYaw _position_ned_yaw{};
     Offboard::VelocityNEDYaw _velocity_ned_yaw{};
     Offboard::VelocityBodyYawspeed _velocity_body_yawspeed{};
     Offboard::Attitude _attitude{};
     Offboard::AttitudeRate _attitude_rate{};
+    Offboard::ActuatorControl _actuator_control{};
 
     void *_call_every_cookie = nullptr;
 


### PR DESCRIPTION
`set_actuator_control` method was added recently to `offboard` plugin and it is not supported in resent offboard grpc backend introduced with [great pull request](https://github.com/Dronecode/DronecodeSDK/pull/735) So this adds set_actuator_control support.

The corresponding MAVSDK-Proto PR is [here](https://github.com/mavlink/MAVSDK-Proto/pull/87).