### PR TITLE
Fix deployment after backend_bin got renamed to mavsdk_server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -189,10 +189,10 @@ before_deploy:
       export BEFORE_DEPLOY_RUN=1;
 
       if [[ "${BUILD_TARGET}" = "manylinux1-x64" ]]; then
-          mv build/manylinux1-x64/install/bin/backend_bin build/manylinux1-x64/install/bin/mavsdk_backend_manylinux1-x64;
+          mv build/manylinux1-x64/install/bin/mavsdk_server build/manylinux1-x64/install/bin/mavsdk_server_manylinux1-x64;
       fi;
       if [[ "${BUILD_TARGET}" = "osx_build" ]]; then
-          mv build/release/install/bin/backend_bin build/release/install/bin/mavsdk_backend_macos;
+          mv build/release/install/bin/mavsdk_server build/release/install/bin/mavsdk_server_macos;
       fi;
   fi
 
@@ -202,7 +202,7 @@ deploy:
   api_key:
       secure: hBX3pFWNZiDbz4yKnOjhLg3QS9Ubn1XePxSeIt2Btq5GzbomOPDCgpIFijBppliwj9oKc302EMnZSg2QWeAzFKn9UnmIflJ0E4iymYgwWdTJv+bSnYALJEmO8F6gF9FgRlPk8FCtZiECoTsa75w5TrEZKZpFpmzVYRiDu0eo6sEjW7UJPC0A2KSTXLrBCHSIZy/iasbGmuur4brG7NO0QdMOvDXvhsYfkXDRJFMTtTHvLiKJcqiunPfqARzf1H4x4iczRYscKu5Vn8Kmw3NANGkcIDvEj4ooih831EXxACRZw0VgycgNHOKRXKC9pZ4hLQMon+jxpQX+X8k/K5161oEkF/gCVKyFb31Pk/4Uwe81p1GJY2lAC7MDUxA98RKXhdvVYF2Cp44+IbF0YVoWRUtVAhknXRQ3Weg25kyVSu83q2nN2nZq2qGTnpNIbdN56s/F+uaFtipGEh+vmiv8rNUz+Z5MFrY2FQaSvBTFw9K4tNs9uc+VQd1bE7X5wh0yywEqUEw2nzqTB2xR+OubygUASbk2GLNdc254P0lrzCHbNM62Y7sRX06CM7hPlwhELEkVtUXZWJ0KuhQyLvRh3aPJ3Jj30EswTt/FGT1gzSP1FjjHBRZCK4P2D2rwJ5TMn2JrZKfPxmEd3kVmn6h80+gBbKgonGmZspd2SvPEI5g=
   file_glob: true
-  file: "build/manylinux1-x64/install/bin/mavsdk_backend_manylinux1-x64"
+  file: "build/manylinux1-x64/install/bin/mavsdk_server_manylinux1-x64"
   on:
     condition: ${BUILD_TARGET} = manylinux1-x64
     repo: mavlink/MAVSDK
@@ -212,7 +212,7 @@ deploy:
   api_key:
       secure: hBX3pFWNZiDbz4yKnOjhLg3QS9Ubn1XePxSeIt2Btq5GzbomOPDCgpIFijBppliwj9oKc302EMnZSg2QWeAzFKn9UnmIflJ0E4iymYgwWdTJv+bSnYALJEmO8F6gF9FgRlPk8FCtZiECoTsa75w5TrEZKZpFpmzVYRiDu0eo6sEjW7UJPC0A2KSTXLrBCHSIZy/iasbGmuur4brG7NO0QdMOvDXvhsYfkXDRJFMTtTHvLiKJcqiunPfqARzf1H4x4iczRYscKu5Vn8Kmw3NANGkcIDvEj4ooih831EXxACRZw0VgycgNHOKRXKC9pZ4hLQMon+jxpQX+X8k/K5161oEkF/gCVKyFb31Pk/4Uwe81p1GJY2lAC7MDUxA98RKXhdvVYF2Cp44+IbF0YVoWRUtVAhknXRQ3Weg25kyVSu83q2nN2nZq2qGTnpNIbdN56s/F+uaFtipGEh+vmiv8rNUz+Z5MFrY2FQaSvBTFw9K4tNs9uc+VQd1bE7X5wh0yywEqUEw2nzqTB2xR+OubygUASbk2GLNdc254P0lrzCHbNM62Y7sRX06CM7hPlwhELEkVtUXZWJ0KuhQyLvRh3aPJ3Jj30EswTt/FGT1gzSP1FjjHBRZCK4P2D2rwJ5TMn2JrZKfPxmEd3kVmn6h80+gBbKgonGmZspd2SvPEI5g=
   file_glob: true
-  file: "build/release/install/bin/mavsdk_backend_macos"
+  file: "build/release/install/bin/mavsdk_server_macos"
   on:
     condition: ${BUILD_TARGET} = osx_build
     repo: mavlink/MAVSDK


### PR DESCRIPTION
Otherwise Travis tries to deploy `backend_bin`, which does not exist anymore.