### PR TITLE
core/plugins: workaround clang-format bug

### DIFF
--- a/src/core/mavlink_parameters.cpp
+++ b/src/core/mavlink_parameters.cpp
@@ -30,9 +30,9 @@ MAVLinkParameters::~MAVLinkParameters()
 
 void MAVLinkParameters::set_param_async(const std::string &name,
                                         const ParamValue &value,
-                                        set_param_callback_t callback,
                                         const void *cookie,
-                                        bool extended)
+                                        bool extended,
+                                        set_param_callback_t callback)
 {
     // if (value.is_float()) {
     //     LogDebug() << "setting param " << name << " to " << value.get_float();
@@ -66,16 +66,16 @@ MAVLinkParameters::set_param(const std::string &name, const ParamValue &value, b
     auto res = prom.get_future();
 
     set_param_async(
-        name, value, [&prom](Result result) { prom.set_value(result); }, this, extended);
+        name, value, this, extended, [&prom](Result result) { prom.set_value(result); });
 
     return res.get();
 }
 
 void MAVLinkParameters::get_param_async(const std::string &name,
                                         ParamValue value_type,
-                                        get_param_callback_t callback,
                                         const void *cookie,
-                                        bool extended)
+                                        bool extended,
+                                        get_param_callback_t callback)
 {
     // LogDebug() << "getting param " << name << ", extended: " << (extended ? "yes" : "no");
 
@@ -114,13 +114,9 @@ MAVLinkParameters::get_param(const std::string &name, ParamValue value_type, boo
     auto prom = std::promise<std::pair<Result, MAVLinkParameters::ParamValue>>();
     auto res = prom.get_future();
 
-    get_param_async(name,
-                    value_type,
-                    [&prom](Result result, ParamValue value) {
-                        prom.set_value(std::make_pair<>(result, value));
-                    },
-                    this,
-                    extended);
+    get_param_async(name, value_type, this, extended, [&prom](Result result, ParamValue value) {
+        prom.set_value(std::make_pair<>(result, value));
+    });
 
     return res.get();
 }

--- a/src/core/mavlink_parameters.h
+++ b/src/core/mavlink_parameters.h
@@ -483,18 +483,18 @@ public:
 
     void set_param_async(const std::string &name,
                          const ParamValue &value,
-                         set_param_callback_t callback,
-                         const void *cookie = nullptr,
-                         bool extended = false);
+                         const void *cookie,
+                         bool extended,
+                         set_param_callback_t callback);
 
     std::pair<Result, ParamValue>
     get_param(const std::string &name, ParamValue value_type, bool extended);
     typedef std::function<void(Result, ParamValue value)> get_param_callback_t;
     void get_param_async(const std::string &name,
                          ParamValue value_type,
-                         get_param_callback_t callback,
                          const void *cookie,
-                         bool extended = false);
+                         bool extended,
+                         get_param_callback_t callback);
 
     void cancel_all_param(const void *cookie);
 

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -173,18 +173,18 @@ public:
 
     void set_param_async(const std::string &name,
                          MAVLinkParameters::ParamValue value,
-                         success_t callback,
                          const void *cookie,
-                         bool extended = false);
+                         bool extended,
+                         success_t callback);
 
     MAVLinkParameters::Result
     set_param(const std::string &name, MAVLinkParameters::ParamValue value, bool extended = false);
 
     void get_param_async(const std::string &name,
                          MAVLinkParameters::ParamValue value_type,
-                         get_param_callback_t callback,
                          const void *cookie,
-                         bool extended);
+                         bool extended,
+                         get_param_callback_t callback);
 
     void cancel_all_param(const void *cookie);
 

--- a/src/plugins/camera/camera_impl.cpp
+++ b/src/plugins/camera/camera_impl.cpp
@@ -1240,6 +1240,8 @@ void CameraImpl::set_option_async(const std::string &setting_id,
 
     _parent->set_param_async(setting_id,
                              value,
+                             this,
+                             true,
                              [this, callback, setting_id, value](MAVLinkParameters::Result result) {
                                  if (result == MAVLinkParameters::Result::SUCCESS) {
                                      if (this->_camera_definition) {
@@ -1254,9 +1256,7 @@ void CameraImpl::set_option_async(const std::string &setting_id,
                                          callback(Camera::Result::ERROR);
                                      }
                                  }
-                             },
-                             this,
-                             true);
+                             });
 }
 
 Camera::Result CameraImpl::get_option(const std::string &setting_id, Camera::Option &option)
@@ -1438,6 +1438,8 @@ void CameraImpl::refresh_params()
         const bool is_last = (count + 1 == params.size());
         _parent->get_param_async(param_name,
                                  param_value_type,
+                                 this,
+                                 true,
                                  [param_name, is_last, this](MAVLinkParameters::Result result,
                                                              MAVLinkParameters::ParamValue value) {
                                      if (result != MAVLinkParameters::Result::SUCCESS) {
@@ -1453,9 +1455,7 @@ void CameraImpl::refresh_params()
                                          notify_current_settings();
                                          notify_possible_setting_options();
                                      }
-                                 },
-                                 this,
-                                 true);
+                                 });
         ++count;
     }
 }

--- a/src/plugins/follow_me/follow_me_impl.cpp
+++ b/src/plugins/follow_me/follow_me_impl.cpp
@@ -34,35 +34,38 @@ void FollowMeImpl::deinit()
 
 void FollowMeImpl::enable()
 {
-    _parent->get_param_float_async("NAV_MIN_FT_HT",
-                                   [this](MAVLinkParameters::Result result, float value) {
-                                       if (result == MAVLinkParameters::Result::SUCCESS) {
-                                           _config.min_height_m = value;
-                                       }
-                                   },
-                                   this);
-    _parent->get_param_float_async("NAV_FT_DST",
-                                   [this](MAVLinkParameters::Result result, float value) {
-                                       if (result == MAVLinkParameters::Result::SUCCESS) {
-                                           _config.follow_distance_m = value;
-                                       }
-                                   },
-                                   this);
-    _parent->get_param_int_async("NAV_FT_FS",
-                                 [this](MAVLinkParameters::Result result, int32_t value) {
-                                     if (result == MAVLinkParameters::Result::SUCCESS) {
-                                         _config.follow_direction =
-                                             static_cast<FollowMe::Config::FollowDirection>(value);
-                                     }
-                                 },
-                                 this);
-    _parent->get_param_float_async("NAV_FT_RS",
-                                   [this](MAVLinkParameters::Result result, float value) {
-                                       if (result == MAVLinkParameters::Result::SUCCESS) {
-                                           _config.responsiveness = value;
-                                       }
-                                   },
-                                   this);
+    _parent->get_param_float_async(
+        "NAV_MIN_FT_HT",
+        [this](MAVLinkParameters::Result result, float value) {
+            if (result == MAVLinkParameters::Result::SUCCESS) {
+                _config.min_height_m = value;
+            }
+        },
+        this);
+    _parent->get_param_float_async(
+        "NAV_FT_DST",
+        [this](MAVLinkParameters::Result result, float value) {
+            if (result == MAVLinkParameters::Result::SUCCESS) {
+                _config.follow_distance_m = value;
+            }
+        },
+        this);
+    _parent->get_param_int_async(
+        "NAV_FT_FS",
+        [this](MAVLinkParameters::Result result, int32_t value) {
+            if (result == MAVLinkParameters::Result::SUCCESS) {
+                _config.follow_direction = static_cast<FollowMe::Config::FollowDirection>(value);
+            }
+        },
+        this);
+    _parent->get_param_float_async(
+        "NAV_FT_RS",
+        [this](MAVLinkParameters::Result result, float value) {
+            if (result == MAVLinkParameters::Result::SUCCESS) {
+                _config.responsiveness = value;
+            }
+        },
+        this);
 }
 
 void FollowMeImpl::disable()


### PR DESCRIPTION
We move the callback to the last argument to workaround a bug in clang-format 8.

See bug report:
https://bugs.llvm.org/show_bug.cgi?id=41676