### PR TITLE
camera: fixes to prevent deadlocks

### DIFF
--- a/src/plugins/camera/camera_impl.h
+++ b/src/plugins/camera/camera_impl.h
@@ -97,7 +97,7 @@ private:
     static Camera::Result
     camera_result_from_command_result(const MAVLinkCommands::Result command_result);
 
-    static void receive_command_result(
+    void receive_command_result(
         MAVLinkCommands::Result command_result, const Camera::result_callback_t& callback);
 
     static bool interval_valid(float interval_s);


### PR DESCRIPTION
We have been seeing deadlocks connected with the camera plugin presumably due to deadlocks which then block the receiving thread.

On inspection I found a couple of callbacks from the camera plugin which had not been using the thread pool. Hopefully fixing these to all use the thread pool might fix the issues.

Hopefully fixes: https://github.com/mavlink/MAVSDK-Swift/issues/138.