### PR TITLE
core: fix destruction of serial connection

### DIFF
--- a/src/core/serial_connection.cpp
+++ b/src/core/serial_connection.cpp
@@ -127,8 +127,8 @@ ConnectionResult SerialConnection::setup_port()
     tc.c_cflag &= ~(CSIZE | PARENB | CRTSCTS);
     tc.c_cflag |= CS8;
 
-    tc.c_cc[VMIN] = 1; // We want at least 1 byte to be available.
-    tc.c_cc[VTIME] = 0; // We don't timeout but wait indefinitely.
+    tc.c_cc[VMIN] = 0; // We are ok with 0 bytes.
+    tc.c_cc[VTIME] = 10; // Timeout after 1 second.
 #endif
 
 #if defined(LINUX) || defined(APPLE)


### PR DESCRIPTION
When nothing weas being received over serial the destruction of the serial connection hung waiting for a read to complete.

By using a timeout every second, we can recover after one second. It's not optimal but better than stalling completely.