### PR TITLE
mavlink_passthrough: re-use mavlink_include.h

### DIFF
--- a/src/core/mavlink_include.h
+++ b/src/core/mavlink_include.h
@@ -4,4 +4,4 @@
 #pragma GCC system_header
 #endif
 
-#include <mavlink/v2.0/common/mavlink.h>
+#include "mavlink/v2.0/common/mavlink.h"

--- a/src/plugins/mavlink_passthrough/CMakeLists.txt
+++ b/src/plugins/mavlink_passthrough/CMakeLists.txt
@@ -24,6 +24,7 @@ install(TARGETS mavsdk_mavlink_passthrough
 
 install(FILES
     include/plugins/mavlink_passthrough/mavlink_passthrough.h
+    ../../core/mavlink_include.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mavsdk/plugins/mavlink_passthrough
 )
 

--- a/src/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.h
+++ b/src/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.h
@@ -5,7 +5,7 @@
 #include <functional>
 
 // This plugin provides/includes the mavlink 2.0 header files.
-#include "mavlink/v2.0/common/mavlink.h"
+#include "mavlink_include.h"
 #include "plugin_base.h"
 
 namespace mavsdk {


### PR DESCRIPTION
The mavlink_include.h file contains a pragma to ignore warnings which is helpful when the MAVLink include is used by library users through the mavlink_passthrough plugin.

This came up in https://github.com/Auterion/mavlink-testing-suite/pull/23#discussion_r305914857.