### PR TITLE
Camera: add is_range flag

### DIFF
--- a/src/core/mavlink_parameters.h
+++ b/src/core/mavlink_parameters.h
@@ -235,6 +235,35 @@ public:
             }
         }
 
+        bool set_as_same_type(const std::string& value_str)
+        {
+            if (_value.is<uint8_t>()) {
+                _value = uint8_t(std::stoi(value_str.c_str()));
+            } else if (_value.is<int8_t>()) {
+                _value = int8_t(std::stoi(value_str.c_str()));
+            } else if (_value.is<uint16_t>()) {
+                _value = uint16_t(std::stoi(value_str.c_str()));
+            } else if (_value.is<int16_t>()) {
+                _value = int16_t(std::stoi(value_str.c_str()));
+            } else if (_value.is<uint32_t>()) {
+                _value = uint32_t(std::stoi(value_str.c_str()));
+            } else if (_value.is<int32_t>()) {
+                _value = int32_t(std::stoi(value_str.c_str()));
+            } else if (_value.is<uint64_t>()) {
+                _value = uint64_t(std::stoll(value_str.c_str()));
+            } else if (_value.is<int64_t>()) {
+                _value = int64_t(std::stoll(value_str.c_str()));
+            } else if (_value.is<float>()) {
+                _value = float(std::stof(value_str.c_str()));
+            } else if (_value.is<double>()) {
+                _value = double(std::stod(value_str.c_str()));
+            } else {
+                LogErr() << "Unknown type";
+                return false;
+            }
+            return true;
+        }
+
         float get_4_float_bytes() const
         {
             if (_value.is<float>()) {

--- a/src/plugins/camera/camera.cpp
+++ b/src/plugins/camera/camera.cpp
@@ -154,6 +154,11 @@ bool Camera::get_possible_options(
     return _impl->get_possible_options(setting_id, options);
 }
 
+bool Camera::is_setting_range(const std::string& setting_id)
+{
+    return _impl->is_setting_range(setting_id);
+}
+
 void Camera::subscribe_current_settings(const subscribe_current_settings_callback_t& callback)
 {
     _impl->subscribe_current_settings(callback);

--- a/src/plugins/camera/camera_definition.cpp
+++ b/src/plugins/camera/camera_definition.cpp
@@ -753,6 +753,16 @@ void CameraDefinition::set_all_params_unknown()
     }
 }
 
+bool CameraDefinition::is_setting_range(const std::string& name)
+{
+    if (_parameter_map.find(name) == _parameter_map.end()) {
+        LogWarn() << "Setting " << name << " not found.";
+        return false;
+    }
+
+    return _parameter_map[name]->is_range;
+}
+
 bool CameraDefinition::get_setting_str(const std::string& name, std::string& description)
 {
     std::lock_guard<std::recursive_mutex> lock(_mutex);

--- a/src/plugins/camera/camera_definition.h
+++ b/src/plugins/camera/camera_definition.h
@@ -44,6 +44,8 @@ public:
     bool get_possible_options(
         const std::string& name, std::vector<MAVLinkParameters::ParamValue>& values);
 
+    bool is_setting_range(const std::string& name);
+
     bool get_setting_str(const std::string& setting_name, std::string& description);
     bool get_option_str(
         const std::string& setting_name, const std::string& option_name, std::string& description);

--- a/src/plugins/camera/camera_definition_test.cpp
+++ b/src/plugins/camera/camera_definition_test.cpp
@@ -521,6 +521,9 @@ TEST(CameraDefinition, UVCCheckDefaultSettings)
     EXPECT_TRUE(cd.get_all_settings(settings));
     EXPECT_EQ(settings.size(), 13);
 
+    EXPECT_TRUE(cd.is_setting_range("brightness"));
+    EXPECT_FALSE(cd.is_setting_range("exp-mode"));
+
     EXPECT_EQ(settings["camera-mode"].get_uint32(), 1);
     EXPECT_EQ(settings["brightness"].get_int32(), 128);
     EXPECT_EQ(settings["contrast"].get_int32(), 32);

--- a/src/plugins/camera/camera_impl.cpp
+++ b/src/plugins/camera/camera_impl.cpp
@@ -1387,6 +1387,7 @@ void CameraImpl::notify_current_settings()
         if (_camera_definition->get_setting(possible_setting, value)) {
             Camera::Setting setting{};
             setting.setting_id = possible_setting;
+            setting.is_range = _camera_definition->is_setting_range(possible_setting);
             get_setting_str(setting.setting_id, setting.setting_description);
             setting.option.option_id = value.get_string();
             get_option_str(
@@ -1428,6 +1429,7 @@ void CameraImpl::notify_possible_setting_options()
     for (auto& possible_setting : possible_settings) {
         Camera::SettingOptions setting_options{};
         setting_options.setting_id = possible_setting;
+        setting_options.is_range = _camera_definition->is_setting_range(possible_setting);
         get_setting_str(setting_options.setting_id, setting_options.setting_description);
         get_possible_options(possible_setting, setting_options.options);
         possible_setting_options.push_back(setting_options);

--- a/src/plugins/camera/camera_impl.cpp
+++ b/src/plugins/camera/camera_impl.cpp
@@ -1221,7 +1221,9 @@ bool CameraImpl::get_possible_options(
         ss << value;
         Camera::Option option{};
         option.option_id = ss.str();
-        get_option_str(setting_id, option.option_id, option.option_description);
+        if (!is_setting_range(setting_id)) {
+            get_option_str(setting_id, option.option_id, option.option_description);
+        }
         options.push_back(option);
     }
 
@@ -1248,27 +1250,60 @@ void CameraImpl::set_option_async(
 
     // We get it first so that we have the type of the param value.
     MAVLinkParameters::ParamValue value;
-    if (!_camera_definition->get_option_value(setting_id, option.option_id, value)) {
-        if (callback) {
-            callback(Camera::Result::ERROR);
-        }
-        return;
-    }
 
-    std::vector<MAVLinkParameters::ParamValue> possible_values;
-    _camera_definition->get_possible_options(setting_id, possible_values);
-    bool allowed = false;
-    for (const auto& possible_value : possible_values) {
-        if (value == possible_value) {
-            allowed = true;
+    if (_camera_definition->is_setting_range(setting_id)) {
+        // TODO: Get type from minimum.
+        std::vector<MAVLinkParameters::ParamValue> all_values;
+        if (!_camera_definition->get_all_options(setting_id, all_values)) {
+            if (callback) {
+                LogErr() << "Could not get all options to get type for range param.";
+                callback(Camera::Result::ERROR);
+            }
+            return;
         }
-    }
-    if (!allowed) {
-        LogErr() << "Setting " << setting_id << "(" << option.option_id << ") not allowed";
-        if (callback) {
-            callback(Camera::Result::ERROR);
+
+        if (all_values.size() == 0) {
+            if (callback) {
+                LogErr() << "Could not get any options to get type for range param.";
+                callback(Camera::Result::ERROR);
+            }
+            return;
         }
-        return;
+        value = all_values[0];
+        // Now re-use that type.
+        // FIXME: this is quite ugly, we should do better than that.
+        if (!value.set_as_same_type(option.option_id)) {
+            if (callback) {
+                LogErr() << "Could not set option value to given type.";
+                callback(Camera::Result::ERROR);
+            }
+            return;
+        }
+
+    } else {
+        if (!_camera_definition->get_option_value(setting_id, option.option_id, value)) {
+            if (callback) {
+                LogErr() << "Could not get option value.";
+                callback(Camera::Result::ERROR);
+            }
+            return;
+        }
+
+        std::vector<MAVLinkParameters::ParamValue> possible_values;
+        _camera_definition->get_possible_options(setting_id, possible_values);
+        bool allowed = false;
+        for (const auto& possible_value : possible_values) {
+            if (value == possible_value) {
+                allowed = true;
+            }
+        }
+        if (!allowed) {
+            LogErr() << "Setting " << setting_id << "(" << option.option_id << ") not allowed";
+            if (callback) {
+                callback(Camera::Result::ERROR);
+            }
+            return;
+        }
     }
 
     _parent->set_param_async(
@@ -1333,7 +1368,9 @@ void CameraImpl::get_option_async(
         if (callback) {
             Camera::Option new_option{};
             new_option.option_id = value.get_string();
-            get_option_str(setting_id, new_option.option_id, new_option.option_description);
+            if (!is_setting_range(setting_id)) {
+                get_option_str(setting_id, new_option.option_id, new_option.option_description);
+            }
             callback(Camera::Result::SUCCESS, new_option);
         }
     } else {
@@ -1392,11 +1429,15 @@ void CameraImpl::notify_current_settings()
         if (_camera_definition->get_setting(possible_setting, value)) {
             Camera::Setting setting{};
             setting.setting_id = possible_setting;
-            setting.is_range = _camera_definition->is_setting_range(possible_setting);
+            setting.is_range = is_setting_range(possible_setting);
             get_setting_str(setting.setting_id, setting.setting_description);
             setting.option.option_id = value.get_string();
-            get_option_str(
-                setting.setting_id, setting.option.option_id, setting.option.option_description);
+            if (!is_setting_range(possible_setting)) {
+                get_option_str(
+                    setting.setting_id,
+                    setting.option.option_id,
+                    setting.option.option_description);
+            }
             current_settings.push_back(setting);
         }
     }

--- a/src/plugins/camera/camera_impl.cpp
+++ b/src/plugins/camera/camera_impl.cpp
@@ -1228,6 +1228,11 @@ bool CameraImpl::get_possible_options(
     return options.size() > 0;
 }
 
+bool CameraImpl::is_setting_range(const std::string& setting_id)
+{
+    return _camera_definition->is_setting_range(setting_id);
+}
+
 void CameraImpl::set_option_async(
     const std::string& setting_id,
     const Camera::Option& option,

--- a/src/plugins/camera/camera_impl.h
+++ b/src/plugins/camera/camera_impl.h
@@ -66,6 +66,8 @@ public:
     bool get_possible_setting_options(std::vector<std::string>& settings);
     bool get_possible_options(const std::string& setting_id, std::vector<Camera::Option>& options);
 
+    bool is_setting_range(const std::string& setting_id);
+
     bool get_setting_str(const std::string& setting_id, std::string& description);
     bool get_option_str(
         const std::string& setting_id, const std::string& option_id, std::string& description);

--- a/src/plugins/camera/include/plugins/camera/camera.h
+++ b/src/plugins/camera/include/plugins/camera/camera.h
@@ -504,6 +504,17 @@ public:
     bool get_possible_options(const std::string& setting_id, std::vector<Camera::Option>& options);
 
     /**
+     * @brief Query if setting is a range setting.
+     *
+     * A range setting is not given by possible options but rather by [min, max] or [min, max,
+     * interval].
+     *
+     * @param setting_id Name of setting (machine readable).
+     * @return true if it is a range setting.
+     */
+    bool is_setting_range(const std::string& setting_id);
+
+    /**
      * @brief Get an option of a setting (synchronous).
      *
      * @param setting_id The machine readable name of the setting.

--- a/src/plugins/camera/include/plugins/camera/camera.h
+++ b/src/plugins/camera/include/plugins/camera/camera.h
@@ -472,6 +472,7 @@ public:
         std::string setting_id{}; /**< Name of the setting (machine readable). */
         std::string setting_description{}; /**< Description of the setting (human readable). */
         Option option{}; /**< Selected option. */
+        bool is_range{false}; /**< If Option is given as a range. */
     };
 
     /**


### PR DESCRIPTION
The information whether a parameter is a range parameter was not yet properly exposed. This makes sure we don't just expose it in `SettingOptions` but also in `Setting`.