### PR TITLE
CMake changes to support MAVSDK as submodule

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -64,9 +64,12 @@ set_target_properties(mavsdk
     PROPERTIES COMPILE_FLAGS ${warnings}
     )
 
-target_include_directories(mavsdk PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+target_include_directories(mavsdk
+    PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include>
+    PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     )
 
 install(TARGETS mavsdk

--- a/src/integration_tests/CMakeLists.txt
+++ b/src/integration_tests/CMakeLists.txt
@@ -99,13 +99,13 @@ add_test(integration_tests
 add_custom_command(TARGET integration_tests_runner
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_SOURCE_DIR}/tools/start_px4_sitl.sh
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/start_px4_sitl.sh
         ${CMAKE_CURRENT_BINARY_DIR}
 )
 add_custom_command(TARGET integration_tests_runner
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_SOURCE_DIR}/tools/stop_px4_sitl.sh
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stop_px4_sitl.sh
         ${CMAKE_CURRENT_BINARY_DIR}
 )
 


### PR DESCRIPTION
CMakeLists integration_tests: use relative cmake path
CMakeLists core: include binary dir to get version.h