### PR TITLE
Fix mission progress edge case

### DIFF
--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -170,6 +170,8 @@ void MissionImpl::process_mission_ack(const mavlink_message_t& message)
             report_mission_result(temp_callback, Mission::Result::SUCCESS);
             LogInfo() << "Mission accepted";
 
+            reset_mission_progress();
+
         } else if (mission_ack.type == MAV_MISSION_NO_SPACE) {
             LogErr() << "Error: too many waypoints: " << int(mission_ack.type);
             report_mission_result(temp_callback, Mission::Result::TOO_MANY_MISSION_ITEMS);
@@ -187,6 +189,15 @@ void MissionImpl::process_mission_ack(const mavlink_message_t& message)
         // We need to stop after this, no matter what.
         _activity.state = Activity::State::NONE;
     }
+}
+
+void MissionImpl::reset_mission_progress()
+{
+    std::lock_guard<std::recursive_mutex> lock(_mission_data.mutex);
+    _mission_data.last_current_mavlink_mission_item = -1;
+    _mission_data.last_reached_mavlink_mission_item = -1;
+    _mission_data.last_current_reported_mission_item = -1;
+    _mission_data.last_total_reported_mission_item = -1;
 }
 
 void MissionImpl::process_mission_current(const mavlink_message_t& message)

--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -158,6 +158,11 @@ void MissionImpl::process_mission_ack(const mavlink_message_t& message)
             return;
         }
 
+        if (_activity.state == Activity::State::NONE) {
+            LogWarn() << "Mission ack ignored";
+            return;
+        }
+
         // We got some response, so it wasn't a timeout and we can remove it.
         _parent->unregister_timeout_handler(_timeout_cookie);
 

--- a/src/plugins/mission/mission_impl.h
+++ b/src/plugins/mission/mission_impl.h
@@ -87,6 +87,8 @@ private:
 
     void assemble_mission_items();
 
+    void reset_mission_progress();
+
     static Mission::Result
     import_mission_items(Mission::mission_items_t& mission_items, const Json& mission_json);
     static Mission::Result build_mission_items(


### PR DESCRIPTION
This solves an edge case where we thought a mission was already finished because we still had the previous mission progress stored.

Also, this adds a change so we don't act on mission acks that we did not expect.

@douglaswsilva I found this while debugging `mission_clear`.