### PR TITLE
core: don't filter from UDP_BRIDGE anymore

### DIFF
--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -195,12 +195,6 @@ void SystemImpl::remove_call_every(const void* cookie)
 
 void SystemImpl::process_heartbeat(const mavlink_message_t& message)
 {
-    // FIXME: for now we ignore heartbeats from UDP_BRIDGE because that's just
-    // confusing since it doesn't mean a vehicle is connected.
-    if (message.compid == MAV_COMP_ID_UDP_BRIDGE) {
-        return;
-    }
-
     mavlink_heartbeat_t heartbeat;
     mavlink_msg_heartbeat_decode(&message, &heartbeat);
 


### PR DESCRIPTION
I think we can remove this because we no longer check for any heartbeat to see if something is connected but we should actually check for `has_autopilot()` or `has_camera` to determine what we have available.

FYI @MatejFranceskin 