### PR TITLE
mavlink_parameters: workaround for param mismatch

### DIFF
--- a/src/core/mavlink_parameters.cpp
+++ b/src/core/mavlink_parameters.cpp
@@ -372,6 +372,15 @@ void MAVLinkParameters::process_param_ext_value(const mavlink_message_t& message
                     work->get_param_callback(
                         MAVLinkParameters::Result::SUCCESS, correct_type_value);
                 }
+            } else if (value.is_uint8() && work->param_value.is_uint32()) {
+                // FIXME: workaround for mismatching type uint8_t which should be uint32_t.
+                ParamValue correct_type_value;
+                correct_type_value.set_uint32(static_cast<uint32_t>(value.get_uint8()));
+                _cache[work->param_name] = correct_type_value;
+                if (work->get_param_callback) {
+                    work->get_param_callback(
+                                             MAVLinkParameters::Result::SUCCESS, correct_type_value);
+                }
             } else {
                 LogErr() << "Param types don't match";
                 ParamValue no_value;

--- a/src/core/mavlink_parameters.cpp
+++ b/src/core/mavlink_parameters.cpp
@@ -363,6 +363,14 @@ void MAVLinkParameters::process_param_ext_value(const mavlink_message_t& message
                 if (work->get_param_callback) {
                     work->get_param_callback(MAVLinkParameters::Result::SUCCESS, value);
                 }
+            } else if (value.is_uint8() && work->param_value.is_uint16()) {
+                // FIXME: workaround for mismatching type uint8_t which should be uint16_t.
+                ParamValue correct_type_value;
+                correct_type_value.set_uint16(uint16_t(value.get_uint8()));
+                _cache[work->param_name] = correct_type_value;
+                if (work->get_param_callback) {
+                    work->get_param_callback(MAVLinkParameters::Result::SUCCESS, correct_type_value);
+                }
             } else {
                 LogErr() << "Param types don't match";
                 ParamValue no_value;

--- a/src/core/mavlink_parameters.cpp
+++ b/src/core/mavlink_parameters.cpp
@@ -379,7 +379,7 @@ void MAVLinkParameters::process_param_ext_value(const mavlink_message_t& message
                 _cache[work->param_name] = correct_type_value;
                 if (work->get_param_callback) {
                     work->get_param_callback(
-                                             MAVLinkParameters::Result::SUCCESS, correct_type_value);
+                        MAVLinkParameters::Result::SUCCESS, correct_type_value);
                 }
             } else {
                 LogErr() << "Param types don't match";

--- a/src/core/mavlink_parameters.cpp
+++ b/src/core/mavlink_parameters.cpp
@@ -366,10 +366,11 @@ void MAVLinkParameters::process_param_ext_value(const mavlink_message_t& message
             } else if (value.is_uint8() && work->param_value.is_uint16()) {
                 // FIXME: workaround for mismatching type uint8_t which should be uint16_t.
                 ParamValue correct_type_value;
-                correct_type_value.set_uint16(uint16_t(value.get_uint8()));
+                correct_type_value.set_uint16(static_cast<uint16_t>(value.get_uint8()));
                 _cache[work->param_name] = correct_type_value;
                 if (work->get_param_callback) {
-                    work->get_param_callback(MAVLinkParameters::Result::SUCCESS, correct_type_value);
+                    work->get_param_callback(
+                        MAVLinkParameters::Result::SUCCESS, correct_type_value);
                 }
             } else {
                 LogErr() << "Param types don't match";


### PR DESCRIPTION
This could workaround a potential problem with E90 where the MAVLink parameter type does not match the xml type.

@byuarus please test. I ran out of time to test this against an E90 but I thought it was worth a shot.