### PR TITLE
generate mavsdk_server_bin.exe instead of mavsdk_server.exe with MSVC

### DIFF
--- a/src/backend/src/CMakeLists.txt
+++ b/src/backend/src/CMakeLists.txt
@@ -83,9 +83,14 @@ else()
         mavsdk
     )
 
-    set_target_properties(mavsdk_server_bin PROPERTIES
-        OUTPUT_NAME mavsdk_server
-    )
+    # MSVC fails to generate the `mavsdk_server` binary while having
+    # a library called `mavsdk_server` as well. This means that with
+    # MSVC, we build `mavsdk_server_bin.exe`.
+    if(NOT MSVC)
+        set_target_properties(mavsdk_server_bin PROPERTIES
+            OUTPUT_NAME mavsdk_server
+        )
+    endif()
 
     install(TARGETS mavsdk_server_bin
         EXPORT mavsdk-targets


### PR DESCRIPTION
For some reason, MSVC is the only one not allowing us to generate `mavsdk_server` as both an executable and a library.

Resolves #814.