### PR TITLE
core: link to libatomic on arm

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -37,6 +37,13 @@ target_link_libraries(mavsdk
     ${CMAKE_THREAD_LIBS_INIT}
 )
 
+if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+    # It seems like on platforms like Raspberry Pi we need to link to libatomic.
+    target_link_libraries(mavsdk
+        atomic
+    )
+endif()
+
 if (IOS)
     target_link_libraries(mavsdk
         PUBLIC


### PR DESCRIPTION
It seems like that's required on platforms like Raspberry Pi.

Fixes #836.