### PR TITLE
Enable cmake build option to build without cURL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,20 @@ matrix:
             - gcc-5
             - g++-5
     - os: linux
+      name: "ubuntu 14.04 - gcc 6 without curl"
+      dist: trusty
+      sudo: false
+      compiler: gcc
+      env:
+      - MATRIX_EVAL="BUILD_TARGET=no_curl_build && CC=gcc-6 && CXX=g++-6"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-6
+            - g++-6
+    - os: linux
       name: "ubuntu 14.04 - gcc 6"
       dist: trusty
       sudo: false
@@ -129,6 +143,11 @@ script:
   fi
 - if [[ "${BUILD_TARGET}" = "coverage_build" ]]; then
     cmake -DCMAKE_BUILD_TYPE=Coverage -Bbuild -H.;
+    cmake --build build;
+    ./build/src/unit_tests_runner;
+  fi
+- if [[ "${BUILD_TARGET}" = "no_curl_build" ]]; then
+    cmake -DBUILD_CURL=Off -Bbuild -H.;
     cmake --build build;
     ./build/src/unit_tests_runner;
   fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(mavsdk_superbuild)
 
 option(SUPERBUILD "Build dependencies" ON)
 option(BUILD_BACKEND "Build gRPC backend server" OFF)
+option(BUILD_CURL "Build cURL" ON)
 option(BUILD_SHARED_LIBS "Build core as shared libraries instead of static ones" ON)
 option(MANYLINUX "Build for manylinux. Required because gRPC doesn't detect it automatically." FALSE)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,10 @@ option(CMAKE_POSITION_INDEPENDENT_CODE "Position independent code" ON)
 
 include(cmake/compiler_flags.cmake)
 
-find_package(CURL REQUIRED CONFIG)
+if(${BUILD_CURL})
+    find_package(CURL REQUIRED CONFIG)
+endif()
+
 find_package(tinyxml2 REQUIRED)
 
 if(NOT MSVC AND NOT MINGW)

--- a/src/cmake/unit_tests.cmake
+++ b/src/cmake/unit_tests.cmake
@@ -16,11 +16,16 @@ target_link_libraries(unit_tests_runner
     mavsdk_mission
     mavsdk_camera
     mavsdk_calibration
-    CURL::libcurl
     tinyxml2::tinyxml2
     gtest
     gtest_main
     gmock
 )
+
+if(${BUILD_CURL})
+    target_link_libraries(unit_tests_runner
+        CURL::libcurl
+    )
+endif()
 
 add_test(unit_tests unit_tests_runner)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -6,16 +6,23 @@ include_directories(
 
 configure_file(version.h.in version.h)
 
+set(maybe_curl_sources "")
+if(${BUILD_CURL})
+    set(maybe_curl_sources
+        curl_wrapper.cpp
+        http_loader.cpp
+    )
+    add_definitions(-DBUILD_CURL=1)
+endif()
+
 add_library(mavsdk
     call_every_handler.cpp
     connection.cpp
-    curl_wrapper.cpp
     system.cpp
     system_impl.cpp
     mavsdk.cpp
     mavsdk_impl.cpp
     global_include.cpp
-    http_loader.cpp
     mavlink_parameters.cpp
     mavlink_commands.cpp
     mavlink_channels.cpp
@@ -28,14 +35,21 @@ add_library(mavsdk
     log.cpp
     cli_arg.cpp
     thread_pool.cpp
+    ${maybe_curl_sources}
 )
 
 target_link_libraries(mavsdk
     PRIVATE
     tinyxml2::tinyxml2
-    CURL::libcurl
     ${CMAKE_THREAD_LIBS_INIT}
 )
+
+if(${BUILD_CURL})
+    target_link_libraries(mavsdk
+        PRIVATE
+        CURL::libcurl
+    )
+endif()
 
 if (IOS)
     target_link_libraries(mavsdk
@@ -90,15 +104,21 @@ list(APPEND UNIT_TEST_SOURCES
     ${PROJECT_SOURCE_DIR}/core/global_include_test.cpp
     ${PROJECT_SOURCE_DIR}/core/mavlink_channels_test.cpp
     ${PROJECT_SOURCE_DIR}/core/unittests_main.cpp
-    # TODO: add this again
-    #${PROJECT_SOURCE_DIR}/core/http_loader_test.cpp
     ${PROJECT_SOURCE_DIR}/core/timeout_handler_test.cpp
     ${PROJECT_SOURCE_DIR}/core/call_every_handler_test.cpp
-    ${PROJECT_SOURCE_DIR}/core/curl_test.cpp
     ${PROJECT_SOURCE_DIR}/core/any_test.cpp
     ${PROJECT_SOURCE_DIR}/core/cli_arg_test.cpp
     ${PROJECT_SOURCE_DIR}/core/locked_queue_test.cpp
     ${PROJECT_SOURCE_DIR}/core/thread_pool_test.cpp
     ${PROJECT_SOURCE_DIR}/core/mavsdk_test.cpp
 )
+
+if(${BUILD_CURL})
+    list(APPEND UNIT_TEST_SOURCES
+        ${PROJECT_SOURCE_DIR}/core/curl_test.cpp
+        # TODO: add this again
+        #${PROJECT_SOURCE_DIR}/core/http_loader_test.cpp
+    )
+endif()
+
 set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} PARENT_SCOPE)

--- a/src/plugins/camera/CMakeLists.txt
+++ b/src/plugins/camera/CMakeLists.txt
@@ -23,8 +23,14 @@ target_link_libraries(mavsdk_camera
     mavsdk
     PRIVATE
     tinyxml2::tinyxml2
-    CURL::libcurl
 )
+
+if(${BUILD_CURL})
+    target_link_libraries(mavsdk_camera
+        PRIVATE
+        CURL::libcurl
+    )
+endif()
 
 set_target_properties(mavsdk_camera
     PROPERTIES COMPILE_FLAGS ${warnings}

--- a/src/plugins/camera/camera_impl.cpp
+++ b/src/plugins/camera/camera_impl.cpp
@@ -1167,6 +1167,7 @@ void CameraImpl::get_mode_timeout_happened()
 
 bool CameraImpl::load_definition_file(const std::string& uri, std::string& content)
 {
+#if BUILD_CURL == 1
     HttpLoader http_loader;
     LogInfo() << "Downloading camera definition from: " << uri;
     if (!http_loader.download_text_sync(uri, content)) {
@@ -1175,6 +1176,11 @@ bool CameraImpl::load_definition_file(const std::string& uri, std::string& conte
     }
 
     return true;
+#else
+    UNUSED(content);
+    LogErr() << "Curl not built, can't download camera definition from: " << uri;
+    return false;
+#endif
 }
 
 bool CameraImpl::get_possible_setting_options(std::vector<std::string>& settings)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -13,7 +13,10 @@ build_target(tinyxml2)
 if(NOT IOS)
 build_target(zlib)
 endif()
-build_target(curl)
+
+if(${BUILD_CURL})
+    build_target(curl)
+endif()
 
 if(${BUILD_BACKEND})
     build_target(libressl)


### PR DESCRIPTION
This adds the cmake build option BUILD_CURL which can be set to off to disable building and including libcURL in the MAVSDK build.

@JonasVautherin do you think that's bearable?

Fixes #830.