### PR TITLE
workaround for the problem with E10T where the MAVLink the MAVLink pa…

### DIFF
--- a/src/core/mavlink_parameters.cpp
+++ b/src/core/mavlink_parameters.cpp
@@ -372,6 +372,15 @@ void MAVLinkParameters::process_param_ext_value(const mavlink_message_t& message
                     work->get_param_callback(
                         MAVLinkParameters::Result::SUCCESS, correct_type_value);
                 }
+            } else if (value.is_uint8() && work->param_value.is_uint32()) {
+                // FIXME: workaround for mismatching type uint8_t which should be uint32_t.
+                ParamValue correct_type_value;
+                correct_type_value.set_uint32(static_cast<uint32_t>(value.get_uint8()));
+                _cache[work->param_name] = correct_type_value;
+                if (work->get_param_callback) {
+                    work->get_param_callback(
+                                             MAVLinkParameters::Result::SUCCESS, correct_type_value);
+                }
             } else {
                 LogErr() << "Param types don't match";
                 ParamValue no_value;


### PR DESCRIPTION
Extended the workaround for the problem with E10T
> Comparison type mismatch between uint8_t and uint32_t (mavlink_parameters.h:407)