### PR TITLE
Remove caching in params module

### DIFF
--- a/src/core/mavlink_parameters.cpp
+++ b/src/core/mavlink_parameters.cpp
@@ -342,7 +342,6 @@ void MAVLinkParameters::process_param_ext_value(const mavlink_message_t& message
                 // FIXME: workaround for mismatching type uint8_t which should be uint16_t.
                 ParamValue correct_type_value;
                 correct_type_value.set_uint16(static_cast<uint16_t>(value.get_uint8()));
-                _cache[work->param_name] = correct_type_value;
                 if (work->get_param_callback) {
                     work->get_param_callback(
                         MAVLinkParameters::Result::SUCCESS, correct_type_value);
@@ -351,7 +350,6 @@ void MAVLinkParameters::process_param_ext_value(const mavlink_message_t& message
                 // FIXME: workaround for mismatching type uint8_t which should be uint32_t.
                 ParamValue correct_type_value;
                 correct_type_value.set_uint32(static_cast<uint32_t>(value.get_uint8()));
-                _cache[work->param_name] = correct_type_value;
                 if (work->get_param_callback) {
                     work->get_param_callback(
                         MAVLinkParameters::Result::SUCCESS, correct_type_value);

--- a/src/core/mavlink_parameters.cpp
+++ b/src/core/mavlink_parameters.cpp
@@ -90,14 +90,6 @@ void MAVLinkParameters::get_param_async(
         return;
     }
 
-    // Use cached value if available.
-    if (_cache.find(name) != _cache.end()) {
-        if (callback) {
-            callback(MAVLinkParameters::Result::SUCCESS, _cache[name]);
-        }
-        return;
-    }
-
     // Otherwise push work onto queue.
     WorkItem new_work{};
     new_work.type = WorkItem::Type::Get;
@@ -259,20 +251,6 @@ void MAVLinkParameters::do_work()
     }
 }
 
-void MAVLinkParameters::remove_from_cache(const std::string& name)
-{
-    const auto& it = _cache.find(name);
-    if (it == _cache.end()) {
-        return;
-    }
-    _cache.erase(it);
-}
-
-void MAVLinkParameters::reset_cache()
-{
-    _cache.clear();
-}
-
 void MAVLinkParameters::process_param_value(const mavlink_message_t& message)
 {
     mavlink_param_value_t param_value;
@@ -301,7 +279,6 @@ void MAVLinkParameters::process_param_value(const mavlink_message_t& message)
             ParamValue value;
             value.set_from_mavlink_param_value(param_value);
             if (value.is_same_type(work->param_value)) {
-                _cache[work->param_name] = value;
                 if (work->get_param_callback) {
                     work->get_param_callback(MAVLinkParameters::Result::SUCCESS, value);
                 }
@@ -319,7 +296,6 @@ void MAVLinkParameters::process_param_value(const mavlink_message_t& message)
         } break;
         case WorkItem::Type::Set: {
             // We are done, inform caller and go back to idle
-            _cache[work->param_name] = work->param_value;
             if (work->set_param_callback) {
                 work->set_param_callback(MAVLinkParameters::Result::SUCCESS);
             }
@@ -359,7 +335,6 @@ void MAVLinkParameters::process_param_ext_value(const mavlink_message_t& message
             ParamValue value;
             value.set_from_mavlink_param_ext_value(param_ext_value);
             if (value.is_same_type(work->param_value)) {
-                _cache[work->param_name] = value;
                 if (work->get_param_callback) {
                     work->get_param_callback(MAVLinkParameters::Result::SUCCESS, value);
                 }
@@ -413,7 +388,6 @@ void MAVLinkParameters::process_param_ext_ack(const mavlink_message_t& message)
         case WorkItem::Type::Set: {
             if (param_ext_ack.param_result == PARAM_ACK_ACCEPTED) {
                 // We are done, inform caller and go back to idle
-                _cache[work->param_name] = work->param_value;
                 if (work->set_param_callback) {
                     work->set_param_callback(MAVLinkParameters::Result::SUCCESS);
                 }

--- a/src/core/mavlink_parameters.h
+++ b/src/core/mavlink_parameters.h
@@ -605,9 +605,6 @@ public:
 
     void do_work();
 
-    void reset_cache();
-    void remove_from_cache(const std::string& name);
-
     friend std::ostream& operator<<(std::ostream&, const ParamValue&);
 
     // Non-copyable
@@ -640,8 +637,6 @@ private:
         const void* cookie{nullptr};
     };
     LockedQueue<WorkItem> _work_queue{};
-
-    std::map<std::string, ParamValue> _cache{};
 
     void* _timeout_cookie = nullptr;
 

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -1143,8 +1143,6 @@ void SystemImpl::call_user_callback(const std::function<void()>& func)
 
 void SystemImpl::param_changed(const std::string& name)
 {
-    _params.remove_from_cache(name);
-
     std::lock_guard<std::mutex> lock(_param_changed_callbacks_mutex);
 
     for (auto& callback : _param_changed_callbacks) {


### PR DESCRIPTION
Due to [this](https://github.com/mavlink/MAVSDK/issues/736#issuecomment-522110195) conversation:

- Seems that MAVSDK has no way to know that parameter was changed on UAV after reboot or using console or QGC, for example
- Use cases of MAVSDK probably does not include real necessity of fast frequency parameters values polling (which may require cache using)