### PR TITLE
integration_tests: only sleep if required

### DIFF
--- a/src/integration_tests/integration_test_helper.h
+++ b/src/integration_tests/integration_test_helper.h
@@ -65,7 +65,7 @@ template<typename Rep, typename Period>
 bool poll_condition_with_timeout(
     std::function<bool()> fun, std::chrono::duration<Rep, Period> duration)
 {
-    // We need at millisecond resolution for sleeping.
+    // We need millisecond resolution for sleeping.
     const std::chrono::milliseconds duration_ms(duration);
 
     unsigned iteration = 0;

--- a/src/integration_tests/integration_test_helper.h
+++ b/src/integration_tests/integration_test_helper.h
@@ -20,8 +20,6 @@ protected:
             mavsdk::LogErr() << "./tools/start_px4_sitl.sh failed, giving up.";
             abort();
         }
-        // We need to wait a bit until it's up and running.
-        std::this_thread::sleep_for(std::chrono::seconds(10));
 #else
         UNUSED(model);
         mavsdk::LogErr() << "Auto-starting SITL not supported on Windows.";
@@ -31,8 +29,6 @@ protected:
     void StopPX4()
     {
 #ifndef WINDOWS
-        // Don't rush this either.
-        std::this_thread::sleep_for(std::chrono::seconds(1));
         const int ret = system("./tools/stop_px4_sitl.sh");
         if (ret != 0) {
             mavsdk::LogErr() << "./tools/stop_px4_sitl.sh failed, giving up.";

--- a/tools/start_px4_sitl.sh
+++ b/tools/start_px4_sitl.sh
@@ -66,4 +66,6 @@ $px4_firmware_dir/Tools/sitl_run.sh \
 # Go back to dir where we started
 popd
 
+echo "waiting for SITL to be running"
+sleep 10
 echo "done"

--- a/tools/stop_px4_sitl.sh
+++ b/tools/stop_px4_sitl.sh
@@ -2,6 +2,9 @@
 
 # This script shuts the Gazebo PX4 software in the loop (SITL) simulation down again.
 
+# Prevent any potential races by waiting a bit.
+sleep 1
+
 if [[ $AUTOSTART_SITL != 1 ]]; then
     exit 0
 fi


### PR DESCRIPTION
We should not sleep and wait for the simulator if we're not even using the start/stop scripts.