### PR TITLE
core: add geometry file for global/local frames

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(mavsdk
     log.cpp
     cli_arg.cpp
     thread_pool.cpp
+    geometry.cpp
 )
 
 target_link_libraries(mavsdk
@@ -82,6 +83,7 @@ install(FILES
     system.h
     mavsdk.h
     plugin_base.h
+    geometry.h
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/mavsdk"
 )
 
@@ -99,5 +101,6 @@ list(APPEND UNIT_TEST_SOURCES
     ${PROJECT_SOURCE_DIR}/core/locked_queue_test.cpp
     ${PROJECT_SOURCE_DIR}/core/thread_pool_test.cpp
     ${PROJECT_SOURCE_DIR}/core/mavsdk_test.cpp
+    ${PROJECT_SOURCE_DIR}/core/geometry_test.cpp
 )
 set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} PARENT_SCOPE)

--- a/src/core/geometry.cpp
+++ b/src/core/geometry.cpp
@@ -1,0 +1,86 @@
+#include "geometry.h"
+#include "global_include.h"
+#include <cmath>
+
+namespace mavsdk {
+namespace geometry {
+
+CoordinateTransformation::CoordinateTransformation(GlobalCoordinate reference) :
+    _ref_lat_rad(rad(reference.latitude_deg)),
+    _ref_lon_rad(rad(reference.longitude_deg))
+{}
+
+CoordinateTransformation::LocalCoordinate
+CoordinateTransformation::local_from_global(GlobalCoordinate global_coordinate) const
+{
+    const double lat_rad = rad(global_coordinate.latitude_deg);
+    const double lon_rad = rad(global_coordinate.longitude_deg);
+
+    const double sin_lat = sin(lat_rad);
+    const double cos_lat = cos(lat_rad);
+
+    const double cos_d_lon = cos(lon_rad - _ref_lon_rad);
+
+    const double ref_sin_lat = sin(_ref_lat_rad);
+    const double ref_cos_lat = cos(_ref_lat_rad);
+
+    const double arg =
+        constrain(ref_sin_lat * sin_lat + ref_cos_lat * cos_lat * cos_d_lon, -1.0, 1.0);
+    const double c = acos(arg);
+
+    const double k = (fabs(c) > 0) ? (c / sin(c)) : 1.0;
+
+    return LocalCoordinate{k * (ref_cos_lat * sin_lat - ref_sin_lat * cos_lat * cos_d_lon) *
+                               world_radius_m,
+                           k * cos_lat * sin(lon_rad - _ref_lon_rad) * world_radius_m};
+}
+
+CoordinateTransformation::GlobalCoordinate
+CoordinateTransformation::global_from_local(LocalCoordinate local_coordinate) const
+{
+    const double x_rad = local_coordinate.north_m / world_radius_m;
+    const double y_rad = local_coordinate.east_m / world_radius_m;
+    const double c = sqrt(x_rad * x_rad + y_rad * y_rad);
+
+    GlobalCoordinate global{};
+
+    if (fabs(c) > 0) {
+        const double sin_c = sin(c);
+        const double cos_c = cos(c);
+
+        const double ref_sin_lat = sin(_ref_lat_rad);
+        const double ref_cos_lat = cos(_ref_lat_rad);
+
+        const double lat_rad = asin(cos_c * ref_sin_lat + (x_rad * sin_c * ref_cos_lat) / c);
+        const double lon_rad =
+            (_ref_lon_rad +
+             atan2(y_rad * sin_c, c * ref_cos_lat * cos_c - x_rad * ref_sin_lat * sin_c));
+
+        global.latitude_deg = deg(lat_rad);
+        global.longitude_deg = deg(lon_rad);
+
+    } else {
+        global.latitude_deg = deg(_ref_lat_rad);
+        global.longitude_deg = deg(_ref_lon_rad);
+    }
+
+    return global;
+}
+
+constexpr double CoordinateTransformation::rad(double deg)
+{
+    return M_PI / 180.0 * deg;
+}
+
+constexpr double CoordinateTransformation::deg(double rad)
+{
+    return 180.0 / M_PI * rad;
+}
+
+constexpr double CoordinateTransformation::constrain(double input, double min, double max)
+{
+    return (input > max) ? max : (input < min) ? min : input;
+}
+
+} // namespace geometry
+} // namespace mavsdk

--- a/src/core/geometry.h
+++ b/src/core/geometry.h
@@ -14,14 +14,20 @@ namespace geometry {
  */
 class CoordinateTransformation {
 public:
+    /**
+     * @brief Type for global coordinate in latitude/longitude in degrees.
+     */
     struct GlobalCoordinate {
-        double latitude_deg;
-        double longitude_deg;
+        double latitude_deg; /**< @brief Latitude in degrees. */
+        double longitude_deg; /**< @brief Longitude in degrees. */
     };
 
+    /**
+     * @brief Type for local coordinate relative to reference in meters.
+     */
     struct LocalCoordinate {
-        double north_m;
-        double east_m;
+        double north_m; /**< @brief Position in North direction in meters. */
+        double east_m; /**< @brief Position in East direction in meters. */
     };
 
     /**

--- a/src/core/geometry.h
+++ b/src/core/geometry.h
@@ -1,0 +1,69 @@
+#pragma once
+
+namespace mavsdk {
+namespace geometry {
+
+/**
+ * @brief This is a utility class for coordinate transformations.
+ *
+ * The projections used to transform from global (lat/lon) to local (meter)
+ * coordinates are taken from:
+ * http://mathworld.wolfram.com/AzimuthalEquidistantProjection.html
+ * and inspired by the implementations in:
+ * https://github.com/PX4/ecl/blob/master/geo/geo.cpp
+ */
+class CoordinateTransformation {
+public:
+    struct GlobalCoordinate {
+        double latitude_deg;
+        double longitude_deg;
+    };
+
+    struct LocalCoordinate {
+        double north_m;
+        double east_m;
+    };
+
+    /**
+     * @brief Default constructor not available.
+     */
+    CoordinateTransformation() = delete;
+
+    /**
+     * @brief Constructor to initialize projection reference.
+     *
+     * @param reference Reference coordinate to project from.
+     */
+    explicit CoordinateTransformation(GlobalCoordinate reference);
+
+    /**
+     * @brief Calculate local coordinates from global coordinates.
+     *
+     * @param global_coordinate The global coordinate to project from.
+     */
+    LocalCoordinate local_from_global(GlobalCoordinate global_coordinate) const;
+
+    /**
+     * @brief Calculate global coordinates from local coordinates.
+     *
+     * @param local_coordinate The local coordinate to project from.
+     */
+    GlobalCoordinate global_from_local(LocalCoordinate local_coordinate) const;
+
+    /**
+     * @brief Destructor.
+     */
+    ~CoordinateTransformation() = default;
+
+private:
+    static constexpr double rad(double deg);
+    static constexpr double deg(double rad);
+    static constexpr double constrain(double input, double min, double max);
+
+    double _ref_lat_rad;
+    double _ref_lon_rad;
+    static constexpr double world_radius_m{6371000.0};
+};
+
+} // namespace geometry
+} // namespace mavsdk

--- a/src/core/geometry_test.cpp
+++ b/src/core/geometry_test.cpp
@@ -1,0 +1,50 @@
+#include "geometry.h"
+#include <gtest/gtest.h>
+
+using namespace mavsdk::geometry;
+
+// Note the tests are quite coarse due to lack of better ground
+// truth. This is mostly to get the ballpark and signs right.
+
+TEST(Geometry, GlobalToLocal)
+{
+    CoordinateTransformation ct({47.356042, 8.519031});
+
+    auto a_bit_south = ct.local_from_global({47.353697, 8.519124});
+    EXPECT_NEAR(a_bit_south.north_m, -263.0, 5.0);
+    EXPECT_NEAR(a_bit_south.east_m, 5.0, 5.0);
+
+    auto further_west = ct.local_from_global({47.354218, 8.536610});
+    EXPECT_NEAR(further_west.north_m, -207.0, 5.0);
+    EXPECT_NEAR(further_west.east_m, 1320.0, 5.0);
+}
+
+TEST(Geometry, LocalToGlobal)
+{
+    CoordinateTransformation ct({32.812984, -117.251033});
+    auto south_west = ct.global_from_local({-778.0, -1370.0});
+
+    EXPECT_NEAR(south_west.latitude_deg, 32.805920, 0.0005);
+    EXPECT_NEAR(south_west.longitude_deg, -117.265296, 0.0005);
+}
+
+TEST(Geometry, GlobalToLocalAndBack)
+{
+    CoordinateTransformation::GlobalCoordinate spot{-26.668028, 153.108583};
+    CoordinateTransformation ct({-26.693518, 153.104172});
+    auto spot_again = ct.global_from_local(ct.local_from_global(spot));
+
+    EXPECT_NEAR(spot.latitude_deg, spot_again.latitude_deg, 1e-9);
+    EXPECT_NEAR(spot.longitude_deg, spot_again.longitude_deg, 1e-9);
+}
+
+TEST(Geoemtry, LocalToGlobalAndBack)
+{
+    CoordinateTransformation::GlobalCoordinate spot{-38.227562, 176.506076};
+    CoordinateTransformation ct(spot);
+    CoordinateTransformation::LocalCoordinate location{-140.0, 240.0};
+    auto location_again = ct.local_from_global(ct.global_from_local(location));
+
+    EXPECT_NEAR(location.north_m, location_again.north_m, 1e-9);
+    EXPECT_NEAR(location.east_m, location_again.east_m, 1e-9);
+}


### PR DESCRIPTION
This adds functionality to convert from local coordinates in meters to global latitude/longitude and back.

This will be used to easily create tests missions without hard-coded latitude/longitude coordinates.