### PR TITLE
integration_tests: fix intermittent test fail

### DIFF
--- a/src/integration_tests/mavlink_passthrough.cpp
+++ b/src/integration_tests/mavlink_passthrough.cpp
@@ -60,7 +60,7 @@ TEST_F(SitlTest, MavlinkPassthrough)
 
                 LogInfo() << "HIGHRES_IMU.temperature [1] (" << counter << ")"
                           << highres_imu.temperature << " degrees C";
-                if (++counter > 100) {
+                if (++counter == 100) {
                     EXPECT_FALSE(stopped);
                     if (!stopped) {
                         stopped = true;


### PR DESCRIPTION
Depending on timing, we sometimes tried to fulfil the promise twice which leads to an abort.

This should fix the intermittent CI failure for the MavlinkPassthrough test:

```
HIGHRES_IMU.temperature [1] (100)32 degrees C (mavlink_passthrough.cpp:61)
terminate called after throwing an instance of 'std::system_error'
  what():  Resource deadlock avoided
```

This happened for instance here: http://ci.px4.io:8080/blue/organizations/jenkins/mavlink%2FMAVSDK/detail/PR-881/2/pipeline/#step-354-log-2082