### PR TITLE
Remove switching to HOLD mode before arm and takeoff

### DIFF
--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -28,13 +28,15 @@ class PluginImplBase;
 class SystemImpl {
 public:
     enum class FlightMode {
-        HOLD = 0,
-        RETURN_TO_LAUNCH,
+        UNKNOWN,
+        READY,
         TAKEOFF,
-        LAND,
+        HOLD,
         MISSION,
-        FOLLOW_ME,
+        RETURN_TO_LAUNCH,
+        LAND,
         OFFBOARD,
+        FOLLOW_ME,
     };
 
     explicit SystemImpl(
@@ -61,6 +63,8 @@ public:
     void remove_call_every(const void* cookie);
 
     bool send_message(mavlink_message_t& message);
+
+    static FlightMode to_flight_mode_from_custom_mode(uint32_t custom_mode);
 
     typedef std::function<void(MAVLinkCommands::Result, float)> command_result_callback_t;
 
@@ -123,6 +127,8 @@ public:
         const std::string& name, float value, success_t callback, const void* cookie);
     void set_param_ext_int_async(
         const std::string& name, int32_t value, success_t callback, const void* cookie);
+
+    FlightMode get_flight_mode() const;
 
     MAVLinkCommands::Result
     set_flight_mode(FlightMode mode, uint8_t component_id = MAV_COMP_ID_AUTOPILOT1);
@@ -306,6 +312,8 @@ private:
 
     std::function<bool(mavlink_message_t&)> _incoming_messages_intercept_callback{nullptr};
     std::function<bool(mavlink_message_t&)> _outgoing_messages_intercept_callback{nullptr};
+
+    std::atomic<FlightMode> _flight_mode{FlightMode::UNKNOWN};
 };
 
 } // namespace mavsdk

--- a/src/plugins/action/action_impl.h
+++ b/src/plugins/action/action_impl.h
@@ -51,8 +51,6 @@ public:
 
 private:
     void loiter_before_takeoff_async(const Action::result_callback_t& callback);
-    void loiter_before_arm_async(const Action::result_callback_t& callback);
-
     void takeoff_async_continued(
         MAVLinkCommands::Result previous_result, const Action::result_callback_t& callback);
     void arm_async_continued(

--- a/src/plugins/action/action_impl.h
+++ b/src/plugins/action/action_impl.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <cstdint>
-
 #include "mavlink_include.h"
 #include "plugins/action/action.h"
 #include "plugin_impl_base.h"
+#include <atomic>
+#include <cstdint>
 
 namespace mavsdk {
 
@@ -31,14 +31,14 @@ public:
     Action::Result transition_to_fixedwing() const;
     Action::Result transition_to_multicopter() const;
 
-    void arm_async(const Action::result_callback_t& callback);
-    void disarm_async(const Action::result_callback_t& callback);
-    void kill_async(const Action::result_callback_t& callback);
-    void takeoff_async(const Action::result_callback_t& callback);
-    void land_async(const Action::result_callback_t& callback);
-    void return_to_launch_async(const Action::result_callback_t& callback);
-    void transition_to_fixedwing_async(const Action::result_callback_t& callback);
-    void transition_to_multicopter_async(const Action::result_callback_t& callback);
+    void arm_async(const Action::result_callback_t& callback) const;
+    void disarm_async(const Action::result_callback_t& callback) const;
+    void kill_async(const Action::result_callback_t& callback) const;
+    void takeoff_async(const Action::result_callback_t& callback) const;
+    void land_async(const Action::result_callback_t& callback) const;
+    void return_to_launch_async(const Action::result_callback_t& callback) const;
+    void transition_to_fixedwing_async(const Action::result_callback_t& callback) const;
+    void transition_to_multicopter_async(const Action::result_callback_t& callback) const;
 
     Action::Result set_takeoff_altitude(float relative_altitude_m);
     std::pair<Action::Result, float> get_takeoff_altitude() const;
@@ -50,10 +50,6 @@ public:
     std::pair<Action::Result, float> get_return_to_launch_return_altitude() const;
 
 private:
-    void arm_async_continued(
-        MAVLinkCommands::Result previous_result, const Action::result_callback_t& callback);
-
-    Action::Result arming_allowed() const;
     Action::Result disarming_allowed() const;
     Action::Result taking_off_allowed() const;
 
@@ -61,8 +57,8 @@ private:
 
     static Action::Result action_result_from_command_result(MAVLinkCommands::Result result);
 
-    static void command_result_callback(
-        MAVLinkCommands::Result command_result, const Action::result_callback_t& callback);
+    void command_result_callback(
+        MAVLinkCommands::Result command_result, const Action::result_callback_t& callback) const;
 
     std::atomic<bool> _in_air_state_known{false};
     std::atomic<bool> _in_air{false};

--- a/src/plugins/action/action_impl.h
+++ b/src/plugins/action/action_impl.h
@@ -50,9 +50,6 @@ public:
     std::pair<Action::Result, float> get_return_to_launch_return_altitude() const;
 
 private:
-    void loiter_before_takeoff_async(const Action::result_callback_t& callback);
-    void takeoff_async_continued(
-        MAVLinkCommands::Result previous_result, const Action::result_callback_t& callback);
     void arm_async_continued(
         MAVLinkCommands::Result previous_result, const Action::result_callback_t& callback);
 

--- a/src/plugins/telemetry/telemetry_impl.h
+++ b/src/plugins/telemetry/telemetry_impl.h
@@ -130,7 +130,6 @@ private:
     void set_imu_reading_ned(Telemetry::IMUReadingNED imu_reading_ned);
     void set_gps_info(Telemetry::GPSInfo gps_info);
     void set_battery(Telemetry::Battery battery);
-    void set_flight_mode(Telemetry::FlightMode flight_mode);
     void set_health_local_position(bool ok);
     void set_health_global_position(bool ok);
     void set_health_home_position(bool ok);
@@ -180,9 +179,10 @@ private:
     static void command_result_callback(
         MAVLinkCommands::Result command_result, const Telemetry::result_callback_t& callback);
 
-    static Telemetry::FlightMode to_flight_mode_from_custom_mode(uint32_t custom_mode);
-
     static Telemetry::LandedState to_landed_state(mavlink_extended_sys_state_t extended_sys_state);
+
+    static Telemetry::FlightMode
+    telemetry_flight_mode_from_flight_mode(SystemImpl::FlightMode flight_mode);
 
     // Make all fields thread-safe using mutexs
     // The mutexs are mutable so that the lock can get aqcuired in
@@ -224,9 +224,6 @@ private:
 
     mutable std::mutex _battery_mutex{};
     Telemetry::Battery _battery{NAN, NAN};
-
-    mutable std::mutex _flight_mode_mutex{};
-    Telemetry::FlightMode _flight_mode{Telemetry::FlightMode::UNKNOWN};
 
     mutable std::mutex _health_mutex{};
     Telemetry::Health _health{false, false, false, false, false, false, false};


### PR DESCRIPTION
This removes most of the workaround where we switch to HOLD before arming. This was mostly out of precaution but as discussed in #50 it can hopefully safely get dropped now.

This also includes some refactoring and cleanup of the action plugin.

For reviewing, please check the individual commits and messages.

Fixes #50, fixes #614, fixes #855.