### PR TITLE
cmake: remove -Werror

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install lcov
         run: sudo apt-get install -y lcov
       - name: configure
-        run: cmake -DCMAKE_BUILD_TYPE=Coverage -DASAN=ON -DUBSAN=ON -DLSAN=ON -j 2 -Bbuild -H.
+        run: cmake -DCMAKE_BUILD_TYPE=Coverage -DASAN=ON -DUBSAN=ON -DLSAN=ON -DWERROR=ON -j 2 -Bbuild -H.
       - name: build
         run: cmake --build build -j 2
       - name: test
@@ -46,7 +46,7 @@ jobs:
       - name: install
         run: sudo apt-get update && sudo apt-get install -y libjsoncpp-dev libcurl4-openssl-dev libtinyxml2-dev
       - name: configure
-        run: cmake -DCMAKE_BUILD_TYPE=Release -DSUPERBUILD=OFF -j 2 -Bbuild/release -H.
+        run: cmake -DCMAKE_BUILD_TYPE=Release -DSUPERBUILD=OFF -DWERROR=ON -j 2 -Bbuild/release -H.
       - name: build
         run: cmake --build build/release -j 2
       - name: test
@@ -60,7 +60,7 @@ jobs:
         with:
           submodules: recursive
       - name: configure
-        run: cmake -DCMAKE_BUILD_TYPE=Release -DSUPERBUILD=ON -DBUILD_BACKEND=ON -j 2 -Bbuild/release -H.
+        run: cmake -DCMAKE_BUILD_TYPE=Release -DSUPERBUILD=ON -DBUILD_BACKEND=ON -DWERROR=ON -j 2 -Bbuild/release -H.
       - name: build
         run: cmake --build build/release -j 2
       - name: install
@@ -68,7 +68,7 @@ jobs:
       - name: install examples dependencies
         run: sudo apt-get install -y libsdl2-dev
       - name: configure examples
-        run: (cd examples && cmake -DCMAKE_BUILD_TYPE=Release -j 2 -Bbuild -H.)
+        run: (cd examples && cmake -DCMAKE_BUILD_TYPE=Release -DWERROR=ON -j 2 -Bbuild -H.)
       - name: build examples
         run: (cd examples && cmake --build build -j 2)
       - name: test
@@ -123,7 +123,7 @@ jobs:
         with:
           submodules: recursive
       - name: configure
-        run: cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=install -Bbuild/release -H.
+        run: cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=install -DWERROR=ON -j 2 -Bbuild/release -H.
       - name: build
         run: cmake --build build/release --target install -- -j2
       - name: test
@@ -171,7 +171,7 @@ jobs:
         with:
           submodules: recursive
       - name: configure
-        run: cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_BACKEND=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=install -Bbuild/release -H.
+        run: cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_BACKEND=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=install -DWERROR=ON -j 2 -Bbuild/release -H.
       - name: build
         run: cmake --build build/release --target install -- -j2
       - name: Package
@@ -199,7 +199,7 @@ jobs:
         with:
           submodules: recursive
       - name: configure
-        run: cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_BACKEND=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=install -Bbuild/release -H.
+        run: cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_BACKEND=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=install -DWERROR=ON  -j 2 -Bbuild/release -H.
       - name: build
         run: cmake --build build/release --target install -- -j2
       - name: Package
@@ -228,7 +228,7 @@ jobs:
       - name: setup dockcross
         run: docker run --rm dockcross/${{ matrix.arch_name }} > ./dockcross-${{ matrix.arch_name }}; chmod +x ./dockcross-${{ matrix.arch_name }}
       - name: configure
-        run: ./dockcross-${{ matrix.arch_name }} cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/${{ matrix.arch_name }}/install -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -j 2 -Bbuild/${{ matrix.arch_name }} -H.
+        run: ./dockcross-${{ matrix.arch_name }} cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/${{ matrix.arch_name }}/install -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -DWERROR=ON -j 2 -Bbuild/${{ matrix.arch_name }} -H.
       - name: build
         run: ./dockcross-${{ matrix.arch_name }} cmake --build build/${{ matrix.arch_name }} -j 2 --target install
       - name: Publish artefacts
@@ -251,7 +251,7 @@ jobs:
       - name: setup dockcross
         run: docker run --rm dockcross/android-arm > ./dockcross-android-arm; chmod +x ./dockcross-android-arm
       - name: configure
-        run: ./dockcross-android-arm cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/android-arm/install -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -j 2 -Bbuild/android-arm -H.
+        run: ./dockcross-android-arm cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/android-arm/install -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -DWERROR=ON -j 2 -Bbuild/android-arm -H.
       - name: build
         run: ./dockcross-android-arm cmake --build build/android-arm -j 2 --target install
       - name: create tar with header and library
@@ -276,7 +276,7 @@ jobs:
       - name: setup dockcross
         run: docker run --rm dockcross/android-arm64 > ./dockcross-android-arm64; chmod +x ./dockcross-android-arm64
       - name: configure
-        run: ./dockcross-android-arm64 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/android-arm64/install -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -j 2 -Bbuild/android-arm64 -H.
+        run: ./dockcross-android-arm64 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/android-arm64/install -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -DWERROR=ON -j 2 -Bbuild/android-arm64 -H.
       - name: build
         run: ./dockcross-android-arm64 cmake --build build/android-arm64 -j 2 --target install
       - name: create tar with header and library
@@ -314,7 +314,7 @@ jobs:
         with:
           submodules: recursive
       - name: configure
-        run: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/release/install -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -j 2 -Bbuild/release -H.
+        run: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/release/install -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -DWERROR=ON -j 2 -Bbuild/release -H.
       - name: build
         run: cmake --build build/release -j 2 --target install
       - name: test (core)
@@ -339,11 +339,11 @@ jobs:
         with:
           submodules: recursive
       - name: configure (ios)
-        run: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$(pwd)/tools/ios.toolchain.cmake -DPLATFORM=OS -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -j 2 -Bbuild/ios -H.
+        run: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$(pwd)/tools/ios.toolchain.cmake -DPLATFORM=OS -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -DWERROR=ON -j 2 -Bbuild/ios -H.
       - name: build (ios)
         run: cmake --build build/ios -j 2
       - name: configure (ios_simulator)
-        run: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$(pwd)/tools/ios.toolchain.cmake -DPLATFORM=SIMULATOR64 -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -j 2 -Bbuild/ios_simulator -H.
+        run: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$(pwd)/tools/ios.toolchain.cmake -DPLATFORM=SIMULATOR64 -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -DWERROR=ON -j 2 -Bbuild/ios_simulator -H.
       - name: build (ios_simulator)
         run: cmake --build build/ios_simulator -j 2
       - name: Package
@@ -367,7 +367,7 @@ jobs:
         with:
           submodules: recursive
       - name: configure
-        run: cmake -G "Visual Studio 16 2019" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/release/install -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -j 2 -Bbuild/release -S.
+        run: cmake -G "Visual Studio 16 2019" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/release/install -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -DWERROR=ON -j 2 -Bbuild/release -S.
       - name: build
         run: cmake --build build/release -j 2 --config Release --target install
       - name: Publish artefacts

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,6 +3,10 @@ project(mavsdk_examples)
 
 # This allows to build all examples at once.
 
+if (WERROR)
+    add_compile_options(-Werror)
+endif()
+
 add_subdirectory(battery)
 add_subdirectory(calibrate)
 add_subdirectory(fly_mission)

--- a/examples/battery/CMakeLists.txt
+++ b/examples/battery/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.8.12)
 project(battery)
 
 if(NOT MSVC)
-    add_definitions("-std=c++11 -Wall -Wextra -Werror ")
+    add_definitions("-std=c++11 -Wall -Wextra ")
     # This warning is triggered by the MAVLink includes.
     add_definitions("-Wno-address-of-packed-member")
 else()

--- a/examples/calibrate/CMakeLists.txt
+++ b/examples/calibrate/CMakeLists.txt
@@ -5,7 +5,7 @@ project(calibrate)
 find_package(Threads REQUIRED)
 
 if(NOT MSVC)
-    add_definitions("-std=c++11 -Wall -Wextra -Werror")
+    add_definitions("-std=c++11 -Wall -Wextra")
 else()
     add_definitions("-std=c++11 -WX -W2")
 endif()

--- a/examples/fly_mission/CMakeLists.txt
+++ b/examples/fly_mission/CMakeLists.txt
@@ -5,7 +5,7 @@ project(fly_mission)
 find_package(Threads REQUIRED)
 
 if(NOT MSVC)
-    add_definitions("-std=c++11 -Wall -Wextra -Werror")
+    add_definitions("-std=c++11 -Wall -Wextra")
 else()
     add_definitions("-std=c++11 -WX -W2")
 endif()

--- a/examples/fly_multiple_drones/CMakeLists.txt
+++ b/examples/fly_multiple_drones/CMakeLists.txt
@@ -5,7 +5,7 @@ project(fly_multiple_drones)
 find_package(Threads REQUIRED)
 
 if(NOT MSVC)
-    add_definitions("-std=c++11 -Wall -Wextra -Werror")
+    add_definitions("-std=c++11 -Wall -Wextra")
 else()
     add_definitions("-std=c++11 -WX -W2")
 endif()

--- a/examples/fly_qgc_mission/CMakeLists.txt
+++ b/examples/fly_qgc_mission/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.8.12)
 project(fly_qgc_mission)
 
 if(NOT MSVC)
-    add_definitions("-std=c++11 -Wall -Wextra -Werror")
+    add_definitions("-std=c++11 -Wall -Wextra")
 else()
     add_definitions("-std=c++11 -WX -W2")
 endif()

--- a/examples/follow_me/CMakeLists.txt
+++ b/examples/follow_me/CMakeLists.txt
@@ -5,7 +5,7 @@ project(follow_me)
 find_package(Threads REQUIRED)
 
 if(NOT MSVC)
-    add_definitions("-std=c++11 -Wall -Wextra -Werror")
+    add_definitions("-std=c++11 -Wall -Wextra")
 else()
     add_definitions("-std=c++11 -WX -W2")
 endif()

--- a/examples/ftp_client/CMakeLists.txt
+++ b/examples/ftp_client/CMakeLists.txt
@@ -5,7 +5,7 @@ project(ftp_client)
 find_package(Threads REQUIRED)
 
 if(NOT MSVC)
-    add_definitions("-std=c++11 -Wall -Wextra -Werror")
+    add_definitions("-std=c++11 -Wall -Wextra")
 else()
     add_definitions("-std=c++11 -WX -W2")
 endif()

--- a/examples/ftp_server/CMakeLists.txt
+++ b/examples/ftp_server/CMakeLists.txt
@@ -5,7 +5,7 @@ project(ftp_server)
 find_package(Threads REQUIRED)
 
 if(NOT MSVC)
-    add_definitions("-std=c++11 -Wall -Wextra -Werror")
+    add_definitions("-std=c++11 -Wall -Wextra")
 else()
     add_definitions("-std=c++11 -WX -W2")
 endif()

--- a/examples/geofence_inclusion/CMakeLists.txt
+++ b/examples/geofence_inclusion/CMakeLists.txt
@@ -5,7 +5,7 @@ project(geofence_inclusion)
 if(MSVC)
     add_definitions("-std=c++11 -WX -W2")
 else()
-    add_definitions("-std=c++11 -Wall -Wextra -Werror")
+    add_definitions("-std=c++11 -Wall -Wextra")
 endif()
 
 find_package(MAVSDK REQUIRED)

--- a/examples/multiple_drones/CMakeLists.txt
+++ b/examples/multiple_drones/CMakeLists.txt
@@ -5,7 +5,7 @@ project(multiple_drones)
 find_package(Threads REQUIRED)
 
 if(NOT MSVC)
-    add_definitions("-std=c++11 -Wall -Wextra -Werror")
+    add_definitions("-std=c++11 -Wall -Wextra")
 else()
     add_definitions("-std=c++11 -WX -W2")
 endif()

--- a/examples/offboard_velocity/CMakeLists.txt
+++ b/examples/offboard_velocity/CMakeLists.txt
@@ -10,7 +10,7 @@ if(MSVC)
     add_definitions("-std=c++11 -WX -W2")
     add_definitions("-D_USE_MATH_DEFINES") # For M_PI
 else()
-    add_definitions("-std=c++11 -Wall -Wextra -Werror")
+    add_definitions("-std=c++11 -Wall -Wextra")
 endif()
 
 find_package(MAVSDK REQUIRED)

--- a/examples/takeoff_land/CMakeLists.txt
+++ b/examples/takeoff_land/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.8.12)
 project(takeoff_and_land)
 
 if(NOT MSVC)
-    add_definitions("-std=c++11 -Wall -Wextra -Werror")
+    add_definitions("-std=c++11 -Wall -Wextra")
 else()
     add_definitions("-std=c++11 -WX -W2")
 endif()

--- a/examples/transition_vtol_fixed_wing/CMakeLists.txt
+++ b/examples/transition_vtol_fixed_wing/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.8.12)
 project(transition_vtol_fixed_wing)
 
 if(NOT MSVC)
-    add_definitions("-std=c++11 -Wall -Wextra -Werror")
+    add_definitions("-std=c++11 -Wall -Wextra")
 else()
     add_definitions("-std=c++11 -WX -W2")
 endif()

--- a/examples/tune/CMakeLists.txt
+++ b/examples/tune/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5.1)
 project(tune)
 
 if(NOT MSVC)
-    add_definitions("-std=c++11 -Wall -Wextra -Werror")
+    add_definitions("-std=c++11 -Wall -Wextra")
 else()
     add_definitions("-std=c++11 -WX -W2")
 endif()

--- a/src/cmake/compiler_flags.cmake
+++ b/src/cmake/compiler_flags.cmake
@@ -26,7 +26,10 @@ else()
         set(warnings "-Wall -Wextra -Wshadow -Wno-strict-aliasing -Wold-style-cast -Wdouble-promotion")
     else()
         add_definitions(-fno-exceptions)
-        set(warnings "-Wall -Wextra -Werror -Wshadow -Wno-strict-aliasing -Wold-style-cast -Wdouble-promotion -Wformat=2 -Weffc++")
+        set(warnings "-Wall -Wextra -Wshadow -Wno-strict-aliasing -Wold-style-cast -Wdouble-promotion -Wformat=2 -Weffc++")
+        if (WERROR)
+            set(warnings "${warnings} -Werror")
+        endif()
     endif()
 
 


### PR DESCRIPTION
I think it's a better idea to only use -Werror in CI because:
- This way the build is more robust when built for unknown environments with unknown compilers and compiler versions.
- Many developers get confused by warnings and are blocked assuming they are actual errors.

Fixes #611.