### PR TITLE
travis: change name of exe as it's 32 bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,7 @@ before_deploy:
           mv build/release/install/bin/mavsdk_server build/release/install/bin/mavsdk_server_macos;
       fi;
       if [[ "${BUILD_TARGET}" = "windows" ]]; then
-          mv build/release/install/bin/mavsdk_server_bin.exe build/release/install/bin/mavsdk_server_win64.exe;
+          mv build/release/install/bin/mavsdk_server_bin.exe build/release/install/bin/mavsdk_server_win32.exe;
       fi;
   fi
 
@@ -203,7 +203,7 @@ deploy:
       secure: hBX3pFWNZiDbz4yKnOjhLg3QS9Ubn1XePxSeIt2Btq5GzbomOPDCgpIFijBppliwj9oKc302EMnZSg2QWeAzFKn9UnmIflJ0E4iymYgwWdTJv+bSnYALJEmO8F6gF9FgRlPk8FCtZiECoTsa75w5TrEZKZpFpmzVYRiDu0eo6sEjW7UJPC0A2KSTXLrBCHSIZy/iasbGmuur4brG7NO0QdMOvDXvhsYfkXDRJFMTtTHvLiKJcqiunPfqARzf1H4x4iczRYscKu5Vn8Kmw3NANGkcIDvEj4ooih831EXxACRZw0VgycgNHOKRXKC9pZ4hLQMon+jxpQX+X8k/K5161oEkF/gCVKyFb31Pk/4Uwe81p1GJY2lAC7MDUxA98RKXhdvVYF2Cp44+IbF0YVoWRUtVAhknXRQ3Weg25kyVSu83q2nN2nZq2qGTnpNIbdN56s/F+uaFtipGEh+vmiv8rNUz+Z5MFrY2FQaSvBTFw9K4tNs9uc+VQd1bE7X5wh0yywEqUEw2nzqTB2xR+OubygUASbk2GLNdc254P0lrzCHbNM62Y7sRX06CM7hPlwhELEkVtUXZWJ0KuhQyLvRh3aPJ3Jj30EswTt/FGT1gzSP1FjjHBRZCK4P2D2rwJ5TMn2JrZKfPxmEd3kVmn6h80+gBbKgonGmZspd2SvPEI5g=
   file_glob: true
   file:
-  - "build/release/install/bin/mavsdk_server_win64.exe"
+  - "build/release/install/bin/mavsdk_server_win32.exe"
   on:
     repo: mavlink/MAVSDK
     tags: true


### PR DESCRIPTION
It turns out we're currently building a 32 bit Windows exe. It seems to work in Python 64 bit and 32 bit, so for now that's good enough.

```
.\sigcheck64.exe .\mavsdk_server_bin.exe

Sigcheck v2.73 - File version and signature viewer
Copyright (C) 2004-2019 Mark Russinovich
Sysinternals - www.sysinternals.com

C:\Users\MaEtUgR\Downloads\mavsdk_server_bin.exe:
        Verified:       Unsigned
        Link date:      13:39 31.10.2019
        Publisher:      n/a
        Company:        n/a
        Description:    n/a
        Product:        n/a
        Prod version:   n/a
        File version:   n/a
        MachineType:    32-bit
```