### PR TITLE
Remove superfluous GET_PARAM in action plugin

### DIFF
--- a/src/plugins/action/action_impl.cpp
+++ b/src/plugins/action/action_impl.cpp
@@ -44,10 +44,6 @@ void ActionImpl::enable()
         1.0,
         nullptr,
         MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
-
-    _parent->get_param_float_async(TAKEOFF_ALT_PARAM, nullptr, this);
-    _parent->get_param_float_async(MAX_SPEED_PARAM, nullptr, this);
-    _parent->get_param_float_async(TAKEOFF_ALT_PARAM, nullptr, this);
 }
 
 void ActionImpl::disable() {}


### PR DESCRIPTION
Looking at [`action_impl.cpp`](https://github.com/mavlink/MAVSDK/blob/develop/src/plugins/action/action_impl.cpp#L48-L50), I see:

```cpp
void ActionImpl::enable()
{
   ...

    _parent->get_param_float_async(TAKEOFF_ALT_PARAM, nullptr, this);
    _parent->get_param_float_async(MAX_SPEED_PARAM, nullptr, this);
    _parent->get_param_float_async(TAKEOFF_ALT_PARAM, nullptr, this);
}
```

First, it seems like `TAKEOFF_ALT_PARAM` is called twice :see_no_evil:. Second, I believe that this is superfluous, as it is queried again in [`get_takeoff_altitude`](https://github.com/mavlink/MAVSDK/blob/develop/src/plugins/action/action_impl.cpp#L377).

Maybe that was used to populate the cache in the past, and we forgot to remove it?