### PR TITLE
Fix an unnecessary use of set_allocated 

### DIFF
--- a/src/backend/src/core/core_service_impl.h
+++ b/src/backend/src/core/core_service_impl.h
@@ -83,12 +83,11 @@ private:
     static mavsdk::rpc::core::ConnectionStateResponse
     createRpcConnectionStateResponse(const uint64_t uuid, const bool is_connected)
     {
-        auto rpc_connection_state = new rpc::core::ConnectionState();
+        mavsdk::rpc::core::ConnectionStateResponse rpc_connection_state_response;
+
+        auto* rpc_connection_state = rpc_connection_state_response.mutable_connection_state();
         rpc_connection_state->set_uuid(uuid);
         rpc_connection_state->set_is_connected(is_connected);
-
-        mavsdk::rpc::core::ConnectionStateResponse rpc_connection_state_response;
-        rpc_connection_state_response.set_allocated_connection_state(rpc_connection_state);
 
         return rpc_connection_state_response;
     }

--- a/src/backend/src/plugins/shell/shell_service_impl.h
+++ b/src/backend/src/plugins/shell/shell_service_impl.h
@@ -28,7 +28,6 @@ public:
         mavsdk::Shell::Result set_callback_result = _shell.shell_command_response_async(
             [this, &response, &response_message_received_promise, is_finished](
                 mavsdk::Shell::Result result, mavsdk::Shell::ShellMessage shell_response) {
-
                 std::lock_guard<std::mutex> lock(_subscribe_mutex);
                 if (!*is_finished) {
                     auto rpc_shell_result = get_allocated_shell_result(result);


### PR DESCRIPTION
`set_allocated_*` and `release_*` should only be used in rare cases as their usage is error-prone.

My intuition is that there is not currently a valid use-case for these functions in MAVSDK.

Protos can also be returned by value, which can avoid some heap allocations compared to `unique_ptr`-wrapped values and will use move assignment for things like this:
```C++
MySubMessage build_submessage();

MyMessage build_message() {
  MyMessage result;
  *result.mutable_submessage() = build_submessage();
  return result;
}
```