### PR TITLE
clang-format: prevent style changes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,6 +6,7 @@ AlignEscapedNewlines: DontAlign
 AlignOperands: true
 AlignTrailingComments: false
 AllowAllParametersOfDeclarationOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline


### PR DESCRIPTION
This seems to be necessary with Clang 9.