### PR TITLE
backend: added missing server part for LandedState

### DIFF
--- a/src/backend/src/plugins/telemetry/telemetry_service_impl.h
+++ b/src/backend/src/plugins/telemetry/telemetry_service_impl.h
@@ -113,6 +113,44 @@ public:
         return grpc::Status::OK;
     }
 
+    grpc::Status SubscribeLandedState(
+        grpc::ServerContext* /* context */,
+        const mavsdk::rpc::telemetry::SubscribeLandedStateRequest* /* request */,
+        grpc::ServerWriter<rpc::telemetry::LandedStateResponse>* writer) override
+    {
+        std::mutex landed_state_mutex{};
+
+        _telemetry.landed_state_async(
+            [this, &writer, &landed_state_mutex](mavsdk::Telemetry::LandedState landed_state) {
+                mavsdk::rpc::telemetry::LandedStateResponse rpc_landed_state_response;
+                rpc_landed_state_response.set_landed_state(translateLandedState(landed_state));
+
+                std::lock_guard<std::mutex> lock(landed_state_mutex);
+                writer->Write(rpc_landed_state_response);
+            });
+
+        _stop_future.wait();
+        return grpc::Status::OK;
+    }
+
+    rpc::telemetry::LandedState
+    translateLandedState(const mavsdk::Telemetry::LandedState landed_state) const
+    {
+        switch (landed_state) {
+            default:
+            case mavsdk::Telemetry::LandedState::UNKNOWN:
+                return rpc::telemetry::LandedState::LANDED_STATE_UNKNOWN;
+            case mavsdk::Telemetry::LandedState::ON_GROUND:
+                return rpc::telemetry::LandedState::LANDED_STATE_ON_GROUND;
+            case mavsdk::Telemetry::LandedState::IN_AIR:
+                return rpc::telemetry::LandedState::LANDED_STATE_IN_AIR;
+            case mavsdk::Telemetry::LandedState::TAKING_OFF:
+                return rpc::telemetry::LandedState::LANDED_STATE_TAKING_OFF;
+            case mavsdk::Telemetry::LandedState::LANDING:
+                return rpc::telemetry::LandedState::LANDED_STATE_LANDING;
+        }
+    }
+
     grpc::Status SubscribeStatusText(
         grpc::ServerContext* /* context */,
         const mavsdk::rpc::telemetry::SubscribeStatusTextRequest* /* request */,

--- a/src/plugins/telemetry/mocks/telemetry_mock.h
+++ b/src/plugins/telemetry/mocks/telemetry_mock.h
@@ -16,6 +16,7 @@ public:
     MOCK_CONST_METHOD1(gps_info_async, void(Telemetry::gps_info_callback_t)){};
     MOCK_CONST_METHOD1(battery_async, void(Telemetry::battery_callback_t)){};
     MOCK_CONST_METHOD1(flight_mode_async, void(Telemetry::flight_mode_callback_t)){};
+    MOCK_CONST_METHOD1(landed_state_async, void(Telemetry::landed_state_callback_t)){};
     MOCK_CONST_METHOD1(
         attitude_quaternion_async, void(Telemetry::attitude_quaternion_callback_t)){};
     MOCK_CONST_METHOD1(


### PR DESCRIPTION
This was missing. Fixes https://github.com/mavlink/MAVSDK-Python/issues/135.