### PR TITLE
add flight information to Info plugin

### DIFF
--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -551,6 +551,18 @@ void SystemImpl::send_autopilot_version_request()
     send_command_async(command, nullptr);
 }
 
+void SystemImpl::send_flight_information_request()
+{
+    // We don't care about an answer, we mostly care about receiving FLIGHT_INFORMATION.
+    MAVLinkCommands::CommandLong command{};
+
+    command.command = MAV_CMD_REQUEST_FLIGHT_INFORMATION;
+    command.params.param1 = 1.0f;
+    command.target_component_id = get_autopilot_id();
+
+    send_command_async(command, nullptr);
+}
+
 void SystemImpl::set_connected()
 {
     bool enable_needed = false;

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -199,6 +199,7 @@ public:
     void call_user_callback(const std::function<void()>& func);
 
     void send_autopilot_version_request();
+    void send_flight_information_request();
 
     void intercept_incoming_messages(std::function<bool(mavlink_message_t&)> callback);
     void intercept_outgoing_messages(std::function<bool(mavlink_message_t&)> callback);

--- a/src/integration_tests/info.cpp
+++ b/src/integration_tests/info.cpp
@@ -76,6 +76,18 @@ TEST_F(SitlTest, Info)
                       << Info::result_str(identification_result.first);
         }
 
+        std::pair<Info::Result, Info::FlightInfo> flight_info_result =
+            info->get_flight_information();
+        EXPECT_EQ(flight_info_result.first, Info::Result::SUCCESS);
+
+        if (flight_info_result.first == Info::Result::SUCCESS) {
+            std::cout << "Time since boot (ms): "
+                      << std::to_string(flight_info_result.second.time_boot_ms) << std::endl;
+            std::cout << "Flight UID: " << flight_info_result.second.flight_uid << std::endl;
+        } else {
+            LogWarn() << "Product request result: " << Info::result_str(flight_info_result.first);
+        }
+
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 }

--- a/src/plugins/info/include/plugins/info/info.h
+++ b/src/plugins/info/include/plugins/info/info.h
@@ -83,6 +83,15 @@ public:
     };
 
     /**
+     * @brief Type containing system flight information.
+     */
+    struct FlightInfo {
+        uint32_t time_boot_ms; /**< @brief Time since system boot. */
+        uint64_t flight_uid; /**< @brief Flight counter. Starts from zero, is incremented by 1
+                                  at every disarm and is never reset even after reboots.*/
+    };
+
+    /**
      * @brief Type containing identification.
      */
     struct Identification {
@@ -115,6 +124,14 @@ public:
      * the product information about the system.
      */
     std::pair<Result, Product> get_product() const;
+
+    /**
+     * @brief Get system flight information.
+     *
+     * @return a pair containing the result of the request and if successful,
+     * the flight information about the system.
+     */
+    std::pair<Result, FlightInfo> get_flight_information() const;
 
     /**
      * @brief Returns a human-readable English string for an Result.

--- a/src/plugins/info/info.cpp
+++ b/src/plugins/info/info.cpp
@@ -22,6 +22,11 @@ std::pair<Info::Result, Info::Product> Info::get_product() const
     return _impl->get_product();
 }
 
+std::pair<Info::Result, Info::FlightInfo> Info::get_flight_information() const
+{
+    return _impl->get_flight_information();
+}
+
 std::string Info::result_str(Result result)
 {
     switch (result) {

--- a/src/plugins/info/info_impl.h
+++ b/src/plugins/info/info_impl.h
@@ -22,23 +22,30 @@ public:
     std::pair<Info::Result, Info::Identification> get_identification() const;
     std::pair<Info::Result, Info::Version> get_version() const;
     std::pair<Info::Result, Info::Product> get_product() const;
+    std::pair<Info::Result, Info::FlightInfo> get_flight_information() const;
 
     InfoImpl(const InfoImpl&) = delete;
     InfoImpl& operator=(const InfoImpl&) = delete;
 
 private:
     void request_version_again();
+    void request_flight_information();
     void process_heartbeat(const mavlink_message_t& message);
     void process_autopilot_version(const mavlink_message_t& message);
+    void process_flight_information(const mavlink_message_t& message);
 
     mutable std::mutex _mutex{};
 
     Info::Version _version{};
     Info::Product _product{};
     Info::Identification _identification{};
+    Info::FlightInfo _flight_info{};
     bool _information_received{false};
+    bool _flight_information_received{false};
+    bool _was_armed{false};
 
     void* _call_every_cookie{nullptr};
+    void* _flight_info_call_every_cookie{nullptr};
 
     static const char* vendor_id_str(uint16_t vendor_id);
     static const char* product_id_str(uint16_t product_id);


### PR DESCRIPTION
The flight information mavlink message was so far available only in the camera plugin. In this plugin the user can extract the flight_uuid as part of the folder name that the SDK creates for your photos. This will only work if you have a camera hooked up. 

This pr adds the flight information to the info plugin. The plugin automatically starts and periodically sends the mavlink command to get the flight information. The use can then pull out this info with the get_flight_information()  method. 

@julianoes if you confirm that this makes sense I will add comments everywhere to keep the same structure as the other oomments in the header files.