### PR TITLE
telemetry_impl: Add process_attitude call

### DIFF
--- a/src/plugins/telemetry/telemetry_impl.h
+++ b/src/plugins/telemetry/telemetry_impl.h
@@ -146,6 +146,7 @@ private:
     void process_position_velocity_ned(const mavlink_message_t& message);
     void process_global_position_int(const mavlink_message_t& message);
     void process_home_position(const mavlink_message_t& message);
+    void process_attitude(const mavlink_message_t& message);
     void process_attitude_quaternion(const mavlink_message_t& message);
     void process_mount_orientation(const mavlink_message_t& message);
     void process_imu_reading_ned(const mavlink_message_t& message);


### PR DESCRIPTION
It's only possible to get attitude information via quaternion messages with the actual implementation.
There is vehicles that the default attitude message is ATTITUDE and not ATTITUDE_QUATERNION.
This patch allow both messages to be used. 

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>