### PR TITLE
Add configuration to run MAVSDK on the autopilot side

### DIFF
--- a/src/core/mavsdk.h
+++ b/src/core/mavsdk.h
@@ -135,6 +135,7 @@ public:
      * @brief Possible configurations.
      */
     enum class Configuration {
+        Autopilot, /**< @brief SDK is used as an autopilot. */
         GroundStation, /**< @brief SDK is used as a ground station. */
         CompanionComputer /**< @brief SDK is used on a companion computer onboard the system (e.g.
                              drone). */

--- a/src/core/mavsdk_impl.cpp
+++ b/src/core/mavsdk_impl.cpp
@@ -311,6 +311,9 @@ System& MavsdkImpl::get_system(const uint64_t uuid)
 uint8_t MavsdkImpl::get_own_system_id() const
 {
     switch (_configuration.load()) {
+        case Mavsdk::Configuration::Autopilot:
+            return 1;
+
         case Mavsdk::Configuration::GroundStation:
             return MAV_COMP_ID_MISSIONPLANNER;
 
@@ -328,6 +331,9 @@ uint8_t MavsdkImpl::get_own_system_id() const
 uint8_t MavsdkImpl::get_own_component_id() const
 {
     switch (_configuration.load()) {
+        case Mavsdk::Configuration::Autopilot:
+            return MAV_COMP_ID_AUTOPILOT1;
+
         case Mavsdk::Configuration::GroundStation:
             // FIXME: For now we increment by 1 to avoid conflicts with others.
             return MAV_COMP_ID_MISSIONPLANNER + 1;
@@ -345,10 +351,15 @@ uint8_t MavsdkImpl::get_own_component_id() const
 uint8_t MavsdkImpl::get_mav_type() const
 {
     switch (_configuration.load()) {
+        case Mavsdk::Configuration::Autopilot:
+            return MAV_TYPE_GENERIC;
+
         case Mavsdk::Configuration::GroundStation:
             return MAV_TYPE_GCS;
+
         case Mavsdk::Configuration::CompanionComputer:
             return MAV_TYPE_ONBOARD_CONTROLLER;
+
         default:
             LogErr() << "Unknown configuration";
             return 0;

--- a/src/core/udp_connection.cpp
+++ b/src/core/udp_connection.cpp
@@ -195,7 +195,7 @@ void UdpConnection::add_remote_with_remote_sysid(
         });
 
     if (existing_remote == _remotes.end()) {
-        LogInfo() << "New system on: " << new_remote.ip << ":" << new_remote.port_number;
+        LogInfo() << "New system on: " << new_remote.ip << ":" << new_remote.port_number << " (with sysid: " << (int)new_remote.system_id << ")";
         _remotes.push_back(new_remote);
     } else if (existing_remote->system_id != new_remote.system_id) {
         LogWarn() << "System on: " << new_remote.ip << ":" << new_remote.port_number


### PR DESCRIPTION
This adds a way for MAVSDK to advertise itself as an autopilot.

@julianoes: I hardcoded the system id to 1. Is that a valid first implementation, or should I look into having it as a parameter somewhere?