### PR TITLE
Set listening port of mavsdk_server in order to run multiple instances in parallel

### DIFF
--- a/src/backend/src/backend.cpp
+++ b/src/backend/src/backend.cpp
@@ -20,10 +20,11 @@ public:
         _connection_initiator.wait();
     }
 
-    void startGRPCServer()
+    int startGRPCServer(const int port)
     {
         _server = std::unique_ptr<GRPCServer>(new GRPCServer(_dc));
-        _server->run();
+        _server->set_port(port);
+        return _server->run();
     }
 
     void wait() { _server->wait(); }
@@ -37,9 +38,9 @@ private:
 MavsdkBackend::MavsdkBackend() : _impl(new Impl()) {}
 MavsdkBackend::~MavsdkBackend() = default;
 
-void MavsdkBackend::startGRPCServer()
+int MavsdkBackend::startGRPCServer(const int port)
 {
-    _impl->startGRPCServer();
+    return _impl->startGRPCServer(port);
 }
 void MavsdkBackend::connect(const std::string& connection_url)
 {

--- a/src/backend/src/backend.h
+++ b/src/backend/src/backend.h
@@ -13,7 +13,7 @@ public:
     MavsdkBackend(MavsdkBackend&&) = delete;
     MavsdkBackend& operator=(MavsdkBackend&&) = delete;
 
-    void startGRPCServer();
+    int startGRPCServer(int port);
     void connect(const std::string& connection_url = "udp://");
     void wait();
 

--- a/src/backend/src/backend_api.cpp
+++ b/src/backend/src/backend_api.cpp
@@ -2,10 +2,16 @@
 #include "backend.h"
 #include <string>
 
-void runBackend(const char* connection_url, void (*onServerStarted)(void*), void* context)
+void runBackend(const char* connection_url, const int mavsdk_server_port, void (*onServerStarted)(void*), void* context)
 {
     mavsdk::backend::MavsdkBackend backend;
-    backend.startGRPCServer();
+
+    auto grpc_port = backend.startGRPCServer(mavsdk_server_port);
+    if (grpc_port == 0) {
+        // Server failed to start
+        return;
+    }
+
     backend.connect(std::string(connection_url));
 
     if (onServerStarted != nullptr) {

--- a/src/backend/src/backend_api.h
+++ b/src/backend/src/backend_api.h
@@ -11,7 +11,7 @@ extern "C" {
 #endif
 
 DLLExport void
-runBackend(const char* connection_url, void (*onServerStarted)(void*), void* context);
+runBackend(const char* system_address, const int mavsdk_server_port, void (*onServerStarted)(void*), void* context);
 
 #ifdef __cplusplus
 }

--- a/src/backend/src/connection_initiator.h
+++ b/src/backend/src/connection_initiator.h
@@ -19,6 +19,7 @@ public:
         init_mutex();
         init_timeout_logging(dc);
 
+        LogInfo() << "Waiting to discover system on " << connection_url << "...";
         _discovery_future = wrapped_register_on_discover(dc);
 
         if (!add_any_connection(dc, connection_url)) {
@@ -54,8 +55,6 @@ private:
     std::future<uint64_t> wrapped_register_on_discover(Mavsdk& dc)
     {
         auto future = _discovery_promise->get_future();
-
-        LogInfo() << "Waiting to discover system...";
 
         dc.register_on_discover([this](uint64_t uuid) {
             std::call_once(_discovery_flag, [this, uuid]() {

--- a/src/backend/src/grpc_server.h
+++ b/src/backend/src/grpc_server.h
@@ -35,6 +35,7 @@ namespace backend {
 class GRPCServer {
 public:
     GRPCServer(Mavsdk& dc) :
+        _port(0),
         _dc(dc),
         _core(_dc),
         _action(_dc.system()),
@@ -63,7 +64,8 @@ public:
         _mocap_service(_mocap)
     {}
 
-    void run();
+    void set_port(int port);
+    int run();
     void wait();
 
 private:
@@ -98,6 +100,9 @@ private:
     MocapServiceImpl<> _mocap_service;
 
     std::unique_ptr<grpc::Server> _server;
+
+    int _port;
+    int _bound_port = 0;
 };
 
 } // namespace backend


### PR DESCRIPTION
The new default is to leave `mavsdk_server` choose a free port for the gRPC server.

The port can be set with `-p <port>`, for instance:

```
./mavsdk_server -p 50051 udp://:14540
```

The next step would be to send the port over the callback of `runBackend(...)`, so that bindings like Swift or Python can actually directly know it and easily start multiple instances of `mavsdk_server`.