### PR TITLE
Adding DISTANCE_SENSOR and possibly other raw sensor messages.

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(mavsdk
     cli_arg.cpp
     thread_pool.cpp
     geometry.cpp
+    timesync.cpp
 )
 
 target_link_libraries(mavsdk

--- a/src/core/global_include.cpp
+++ b/src/core/global_include.cpp
@@ -4,10 +4,12 @@
 #include <cstdint>
 #include <limits>
 #include <cmath>
+#include <chrono>
 
 namespace mavsdk {
 
 using std::chrono::steady_clock;
+using std::chrono::system_clock;
 
 Time::Time() {}
 Time::~Time() {}
@@ -15,6 +17,11 @@ Time::~Time() {}
 dl_time_t Time::steady_time()
 {
     return steady_clock::now();
+}
+
+dl_system_time_t Time::system_time()
+{
+    return system_clock::now();
 }
 
 double Time::elapsed_s()
@@ -157,5 +164,33 @@ bool are_equal(double one, double two)
 {
     return (std::fabs(one - two) < std::numeric_limits<double>::epsilon());
 }
+
+AutopilotTime::AutopilotTime() {}
+AutopilotTime::~AutopilotTime() {}
+
+dl_system_time_t AutopilotTime::system_time()
+{
+    return system_clock::now();
+}
+
+dl_autopilot_time_t AutopilotTime::now()
+{
+    std::lock_guard<std::mutex> lock(_autopilot_system_time_offset_mutex);
+    return dl_autopilot_time_t(std::chrono::duration_cast<std::chrono::microseconds>(
+        system_time().time_since_epoch() + _autopilot_time_offset));
+}
+
+void AutopilotTime::shift_time_by(std::chrono::nanoseconds offset)
+{
+    std::lock_guard<std::mutex> lock(_autopilot_system_time_offset_mutex);
+    _autopilot_time_offset = offset;
+};
+
+dl_autopilot_time_t AutopilotTime::time_in(dl_system_time_t local_system_time_point)
+{
+    std::lock_guard<std::mutex> lock(_autopilot_system_time_offset_mutex);
+    return dl_autopilot_time_t(std::chrono::duration_cast<std::chrono::microseconds>(
+        local_system_time_point.time_since_epoch() + _autopilot_time_offset));
+};
 
 } // namespace mavsdk

--- a/src/core/mavsdk.h
+++ b/src/core/mavsdk.h
@@ -135,6 +135,7 @@ public:
      * @brief Possible configurations.
      */
     enum class Configuration {
+        Autopilot, /**< @brief SDK is used as an autopilot. */
         GroundStation, /**< @brief SDK is used as a ground station. */
         CompanionComputer /**< @brief SDK is used on a companion computer onboard the system (e.g.
                              drone). */

--- a/src/core/mavsdk_impl.cpp
+++ b/src/core/mavsdk_impl.cpp
@@ -311,6 +311,9 @@ System& MavsdkImpl::get_system(const uint64_t uuid)
 uint8_t MavsdkImpl::get_own_system_id() const
 {
     switch (_configuration.load()) {
+        case Mavsdk::Configuration::Autopilot:
+            return 1;
+
         case Mavsdk::Configuration::GroundStation:
             return MAV_COMP_ID_MISSIONPLANNER;
 
@@ -328,6 +331,9 @@ uint8_t MavsdkImpl::get_own_system_id() const
 uint8_t MavsdkImpl::get_own_component_id() const
 {
     switch (_configuration.load()) {
+        case Mavsdk::Configuration::Autopilot:
+            return MAV_COMP_ID_AUTOPILOT1;
+
         case Mavsdk::Configuration::GroundStation:
             // FIXME: For now we increment by 1 to avoid conflicts with others.
             return MAV_COMP_ID_MISSIONPLANNER + 1;
@@ -345,10 +351,15 @@ uint8_t MavsdkImpl::get_own_component_id() const
 uint8_t MavsdkImpl::get_mav_type() const
 {
     switch (_configuration.load()) {
+        case Mavsdk::Configuration::Autopilot:
+            return MAV_TYPE_GENERIC;
+
         case Mavsdk::Configuration::GroundStation:
             return MAV_TYPE_GCS;
+
         case Mavsdk::Configuration::CompanionComputer:
             return MAV_TYPE_ONBOARD_CONTROLLER;
+
         default:
             LogErr() << "Unknown configuration";
             return 0;

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -21,6 +21,7 @@ SystemImpl::SystemImpl(MavsdkImpl& parent, uint8_t system_id, uint8_t comp_id, b
     _parent(parent),
     _params(*this),
     _commands(*this),
+    _timesync(*this),
     _timeout_handler(_time),
     _call_every_handler(_time)
 {
@@ -330,6 +331,7 @@ void SystemImpl::system_thread()
         _timeout_handler.run_once();
         _params.do_work();
         _commands.do_work();
+        _timesync.do_work();
 
         if (_connected) {
             // Work fairly fast if we're connected.

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -7,6 +7,7 @@
 #include "timeout_handler.h"
 #include "call_every_handler.h"
 #include "thread_pool.h"
+#include "timesync.h"
 #include "system.h"
 #include <cstdint>
 #include <functional>
@@ -192,6 +193,7 @@ public:
     bool is_connected() const;
 
     Time& get_time() { return _time; };
+    AutopilotTime& get_autopilot_time() { return _autopilot_time; };
 
     void register_plugin(PluginImplBase* plugin_impl);
     void unregister_plugin(PluginImplBase* plugin_impl);
@@ -293,10 +295,13 @@ private:
 
     MAVLinkCommands _commands;
 
+    Timesync _timesync;
+
     TimeoutHandler _timeout_handler;
     CallEveryHandler _call_every_handler;
 
     Time _time{};
+    AutopilotTime _autopilot_time{};
 
     std::mutex _plugin_impls_mutex{};
     std::vector<PluginImplBase*> _plugin_impls{};

--- a/src/core/timesync.cpp
+++ b/src/core/timesync.cpp
@@ -1,0 +1,94 @@
+#include "timesync.h"
+#include "log.h"
+#include "system_impl.h"
+
+// Partially based on: https://github.com/mavlink/mavros/blob/master/mavros/src/plugins/sys_time.cpp
+
+namespace mavsdk {
+
+Timesync::Timesync(SystemImpl& parent) : _parent(parent)
+{
+    using namespace std::placeholders; // for `_1`
+
+    _parent.register_mavlink_message_handler(
+        MAVLINK_MSG_ID_TIMESYNC, std::bind(&Timesync::process_timesync, this, _1), this);
+}
+
+Timesync::~Timesync()
+{
+    _parent.unregister_all_mavlink_message_handlers(this);
+}
+
+void Timesync::do_work()
+{
+    if (_parent.get_time().elapsed_since_s(_last_time) >= _TIMESYNC_SEND_INTERVAL_S) {
+        if (_parent.is_connected()) {
+            uint64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                  _parent.get_time().system_time().time_since_epoch())
+                                  .count();
+            send_timesync(0, now_ns);
+        }
+        _last_time = _parent.get_time().steady_time();
+    }
+}
+
+void Timesync::process_timesync(const mavlink_message_t& message)
+{
+    mavlink_timesync_t timesync;
+
+    mavlink_msg_timesync_decode(&message, &timesync);
+
+    int64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                         _parent.get_time().system_time().time_since_epoch())
+                         .count();
+
+    if (timesync.tc1 == 0) {
+        send_timesync(now_ns, timesync.ts1);
+    } else if (timesync.tc1 > 0) {
+        // Time offset between this system and the remote system is calculated assuming RTT for
+        // the timesync packet is roughly equal both ways.
+        set_timesync_offset((timesync.tc1 * 2 - (timesync.ts1 + now_ns)) / 2, timesync.ts1);
+    }
+}
+
+void Timesync::send_timesync(uint64_t tc1, uint64_t ts1)
+{
+    mavlink_message_t message;
+
+    mavlink_msg_timesync_pack(
+        _parent.get_own_system_id(), _parent.get_own_component_id(), &message, tc1, ts1);
+    _parent.send_message(message);
+}
+
+void Timesync::set_timesync_offset(int64_t offset_ns, uint64_t start_transfer_local_time_ns)
+{
+    uint64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                          _parent.get_time().system_time().time_since_epoch())
+                          .count();
+
+    // Calculate the round trip time (RTT) it took the timesync packet to bounce back to us from
+    // remote system
+    uint64_t rtt_ns = now_ns - start_transfer_local_time_ns;
+
+    if (rtt_ns < _MAX_RTT_SAMPLE_MS * 1000000ULL) { // Only use samples with low RTT
+
+        // Save time offset for other components to use
+        _parent.get_autopilot_time().shift_time_by(std::chrono::nanoseconds(offset_ns));
+
+        // Reset high RTT count after filter update
+        _high_rtt_count = 0;
+    } else {
+        // Increment counter if round trip time is too high for accurate timesync
+        _high_rtt_count++;
+
+        if (_high_rtt_count > _MAX_CONS_HIGH_RTT) {
+            // Issue a warning to the user if the RTT is constantly high
+            LogWarn() << "RTT too high for timesync: " << rtt_ns / 1000000.0 << " ms.";
+
+            // Reset counter
+            _high_rtt_count = 0;
+        }
+    }
+}
+
+} // namespace mavsdk

--- a/src/core/timesync.h
+++ b/src/core/timesync.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "global_include.h"
+#include "mavlink_include.h"
+
+namespace mavsdk {
+
+class SystemImpl;
+
+class Timesync {
+public:
+    Timesync(SystemImpl& parent);
+    ~Timesync();
+
+    void do_work();
+
+    Timesync(const Timesync&) = delete;
+    Timesync& operator=(const Timesync&) = delete;
+
+private:
+    SystemImpl& _parent;
+
+    void process_timesync(const mavlink_message_t& message);
+    void send_timesync(uint64_t tc1, uint64_t ts1);
+    void set_timesync_offset(int64_t offset_ns, uint64_t start_transfer_local_time_ns);
+
+    static constexpr double _TIMESYNC_SEND_INTERVAL_S = 5.0;
+    dl_time_t _last_time{};
+
+    static constexpr uint64_t _MAX_CONS_HIGH_RTT = 5;
+    static constexpr uint64_t _MAX_RTT_SAMPLE_MS = 10;
+    uint64_t _high_rtt_count{};
+};
+} // namespace mavsdk

--- a/src/core/udp_connection.cpp
+++ b/src/core/udp_connection.cpp
@@ -195,7 +195,7 @@ void UdpConnection::add_remote_with_remote_sysid(
         });
 
     if (existing_remote == _remotes.end()) {
-        LogInfo() << "New system on: " << new_remote.ip << ":" << new_remote.port_number;
+        LogInfo() << "New system on: " << new_remote.ip << ":" << new_remote.port_number << " (with sysid: " << (int)new_remote.system_id << ")";
         _remotes.push_back(new_remote);
     } else if (existing_remote->system_id != new_remote.system_id) {
         LogWarn() << "System on: " << new_remote.ip << ":" << new_remote.port_number


### PR DESCRIPTION
**Moved to Issues**
-------------------
For offboard work I feel it would be useful to have access to the the raw sensor data. For example I am using Attitude+Lidar Rangefinder+Thermal Sensor  to create a heat map during a survey. 

**Suggestions/Ideas:**

A telemetry subclass ie `telemetry.raw()` that gathers sensor information and current readings available through mavlink. Also, IMO the sensor reading timestamp "time_boot_ms" (ex: https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR) is especially useful from my perspective for sensor fusion and filtering to approximate vehicle state.  