### PR TITLE
core: fix segfault on register_plugin

### DIFF
--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -311,8 +311,6 @@ private:
 
     ThreadPool _thread_pool{3};
 
-    bool _iterator_invalidated{false};
-
     std::mutex _param_changed_callbacks_mutex{};
     std::map<const void*, param_changed_callback_t> _param_changed_callbacks{};
 


### PR DESCRIPTION
This should fix a segfault due to a race which seldomly happened, about 1/100 or 1/1000 cases.

The events leading to the segfault are as follows:
1. A plugin is constructed and calls register_plugin.
2. register_plugin calls enable() of the plugin which does all message registrations/subscriptions.
3. While the plugin is still initializing, MAVLink messages are already being received and distributed to the plugins.
4. Before the callbacks are called from the _mavlink_handler_table the lock is released and acquired again after the callback.
5. If it now happens that a new message is registered right at the moment after the unlock before the callback is called, the iterator might be invalidated. (For instance if the vector data is moved
   because its capacity needs to be doubled.)
6. We then call the callback of the invalid iterator and segfault.

The patch fixes the problem by never unlocking during the callback. This means that it is not possible to register new message handlers inside a message handler callback. It will deadlock. However, this
should be found during development and can be documented. Also, plugins usually subscribe to everything required in the initialization and don't tend to change this later. I don't know of any plugin which would currently do that.

Presumably fixes #932.