### PR TITLE
Additional Flight Modes

### DIFF
--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -905,6 +905,24 @@ SystemImpl::make_command_flight_mode(FlightMode flight_mode, uint8_t component_i
         case FlightMode::OFFBOARD:
             custom_mode = px4::PX4_CUSTOM_MAIN_MODE_OFFBOARD;
             break;
+        case FlightMode::MANUAL:
+            custom_mode = px4::PX4_CUSTOM_MAIN_MODE_MANUAL;
+            break;
+        case FlightMode::POSITION:
+            custom_mode = px4::PX4_CUSTOM_MAIN_MODE_POSCTL;
+            break;
+        case FlightMode::ALTITUDE:
+            custom_mode = px4::PX4_CUSTOM_MAIN_MODE_ALTCTL;
+            break;
+        case FlightMode::RATTITUDE:
+            custom_mode = px4::PX4_CUSTOM_MAIN_MODE_RATTITUDE;
+            break;
+        case FlightMode::ACRO:
+            custom_mode = px4::PX4_CUSTOM_MAIN_MODE_ACRO;
+            break;
+        case FlightMode::STABILIZED:
+            custom_mode = px4::PX4_CUSTOM_MAIN_MODE_STABILIZED;
+            break;
         default:
             LogErr() << "Unknown Flight mode.";
             MAVLinkCommands::CommandLong empty_command{};
@@ -935,6 +953,18 @@ SystemImpl::FlightMode SystemImpl::to_flight_mode_from_custom_mode(uint32_t cust
     switch (px4_custom_mode.main_mode) {
         case px4::PX4_CUSTOM_MAIN_MODE_OFFBOARD:
             return FlightMode::OFFBOARD;
+        case px4::PX4_CUSTOM_MAIN_MODE_MANUAL:
+            return Telemetry::FlightMode::MANUAL;
+        case px4::PX4_CUSTOM_MAIN_MODE_POSCTL:
+            return Telemetry::FlightMode::POSCTL;
+        case px4::PX4_CUSTOM_MAIN_MODE_ALTCTL:
+            return Telemetry::FlightMode::ALTCTL;
+        case px4::PX4_CUSTOM_MAIN_MODE_RATTITUDE:
+            return Telemetry::FlightMode::RATTITUDE;
+        case px4::PX4_CUSTOM_MAIN_MODE_ACRO:
+            return Telemetry::FlightMode::ACRO;
+        case px4::PX4_CUSTOM_MAIN_MODE_STABILIZED:
+            return Telemetry::FlightMode::STABILIZED;
         case px4::PX4_CUSTOM_MAIN_MODE_AUTO:
             switch (px4_custom_mode.sub_mode) {
                 case px4::PX4_CUSTOM_SUB_MODE_AUTO_READY:

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -954,17 +954,17 @@ SystemImpl::FlightMode SystemImpl::to_flight_mode_from_custom_mode(uint32_t cust
         case px4::PX4_CUSTOM_MAIN_MODE_OFFBOARD:
             return FlightMode::OFFBOARD;
         case px4::PX4_CUSTOM_MAIN_MODE_MANUAL:
-            return Telemetry::FlightMode::MANUAL;
-        case px4::PX4_CUSTOM_MAIN_MODE_POSCTL:
-            return Telemetry::FlightMode::POSCTL;
-        case px4::PX4_CUSTOM_MAIN_MODE_ALTCTL:
-            return Telemetry::FlightMode::ALTCTL;
-        case px4::PX4_CUSTOM_MAIN_MODE_RATTITUDE:
-            return Telemetry::FlightMode::RATTITUDE;
-        case px4::PX4_CUSTOM_MAIN_MODE_ACRO:
-            return Telemetry::FlightMode::ACRO;
-        case px4::PX4_CUSTOM_MAIN_MODE_STABILIZED:
-            return Telemetry::FlightMode::STABILIZED;
+           return FlightMode::MANUAL;
+       case px4::PX4_CUSTOM_MAIN_MODE_POSCTL:
+           return FlightMode::POSCTL;
+       case px4::PX4_CUSTOM_MAIN_MODE_ALTCTL:
+           return FlightMode::ALTCTL;
+       case px4::PX4_CUSTOM_MAIN_MODE_RATTITUDE:
+           return FlightMode::RATTITUDE;
+       case px4::PX4_CUSTOM_MAIN_MODE_ACRO:
+           return FlightMode::ACRO;
+       case px4::PX4_CUSTOM_MAIN_MODE_STABILIZED:
+           return FlightMode::STABILIZED;
         case px4::PX4_CUSTOM_MAIN_MODE_AUTO:
             switch (px4_custom_mode.sub_mode) {
                 case px4::PX4_CUSTOM_SUB_MODE_AUTO_READY:

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -908,10 +908,10 @@ SystemImpl::make_command_flight_mode(FlightMode flight_mode, uint8_t component_i
         case FlightMode::MANUAL:
             custom_mode = px4::PX4_CUSTOM_MAIN_MODE_MANUAL;
             break;
-        case FlightMode::POSITION:
+        case FlightMode::POSCTL:
             custom_mode = px4::PX4_CUSTOM_MAIN_MODE_POSCTL;
             break;
-        case FlightMode::ALTITUDE:
+        case FlightMode::ALTCTL:
             custom_mode = px4::PX4_CUSTOM_MAIN_MODE_ALTCTL;
             break;
         case FlightMode::RATTITUDE:

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -38,6 +38,12 @@ public:
         LAND,
         OFFBOARD,
         FOLLOW_ME,
+        MANUAL,
+        POSITION,
+        ALTITUDE,
+        RATTITUDE,
+        ACRO,
+        STABILIZED,
     };
 
     explicit SystemImpl(

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -44,6 +44,8 @@ public:
         RATTITUDE,
         ACRO,
         STABILIZED,
+        ALTCTL,
+        POSCTL
     };
 
     explicit SystemImpl(

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -39,13 +39,11 @@ public:
         OFFBOARD,
         FOLLOW_ME,
         MANUAL,
-        POSITION,
-        ALTITUDE,
-        RATTITUDE,
-        ACRO,
-        STABILIZED,
         ALTCTL,
-        POSCTL
+        POSCTL,
+        ACRO,
+        RATTITUDE,
+        STABILIZED,
     };
 
     explicit SystemImpl(

--- a/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -223,6 +223,7 @@ public:
      * https://docs.px4.io/en/config/flight_mode.html.
      */
     enum class FlightMode {
+        UNKNOWN, /**< @brief Mode not known. */
         READY, /**< @brief Armed and ready to take off. */
         TAKEOFF, /**< @brief Taking off. */
         HOLD, /**< @brief Hold mode (hovering in place (or circling for fixed-wing vehicles). */
@@ -231,13 +232,12 @@ public:
         LAND, /**< @brief Landing. */
         OFFBOARD, /**< @brief Offboard mode. */
         FOLLOW_ME, /**< @brief FollowMe mode. */
-        UNKNOWN, /**< @brief Mode not known. */
         MANUAL, /**< @brief Manual mode. */
-        POSCTL, /**< @brief Position mode. */
         ALTCTL, /**< @brief Altitude mode. */
-        RATTITUDE, /**< @brief Mode not known. */
+        POSCTL, /**< @brief Position mode. */
         ACRO, /**< @brief Acro mode. */
-        STABILIZED /**< @brief Stabilize mode. */
+        STABILIZED, /**< @brief Stabilize mode. */
+        RATTITUDE /**< @brief Rattitude mode. */
     };
 
     /**

--- a/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -231,7 +231,13 @@ public:
         LAND, /**< @brief Landing. */
         OFFBOARD, /**< @brief Offboard mode. */
         FOLLOW_ME, /**< @brief FollowMe mode. */
-        UNKNOWN /**< @brief Mode not known. */
+        UNKNOWN, /**< @brief Mode not known. */
+        MANUAL, /**< @brief Manual mode. */
+        POSCTL, /**< @brief Position mode. */
+        ALTCTL, /**< @brief Altitude mode. */
+        RATTITUDE, /**< @brief Mode not known. */
+        ACRO, /**< @brief Acro mode. */
+        STABILIZED /**< @brief Stabilize mode. */
     };
 
     /**

--- a/src/plugins/telemetry/telemetry.cpp
+++ b/src/plugins/telemetry/telemetry.cpp
@@ -402,7 +402,20 @@ std::string Telemetry::flight_mode_str(FlightMode flight_mode)
             return "Offboard";
         case FlightMode::FOLLOW_ME:
             return "FollowMe";
+        case FlightMode::MANUAL:
+            return "Manual";
+        case FlightMode::POSCTL:
+            return "Position";
+        case FlightMode::ALTCTL:
+            return "Altitude";
+        case FlightMode::RATTITUDE:
+            return "Rattitude";
+        case FlightMode::ACRO:
+            return "Acro";
+        case FlightMode::STABILIZED:
+            return "Stabilize";
         case FlightMode::UNKNOWN:
+            return "Unknown";
         default:
             return "Unknown";
     }

--- a/src/plugins/telemetry/telemetry.cpp
+++ b/src/plugins/telemetry/telemetry.cpp
@@ -413,7 +413,7 @@ std::string Telemetry::flight_mode_str(FlightMode flight_mode)
         case FlightMode::ACRO:
             return "Acro";
         case FlightMode::STABILIZED:
-            return "Stabilize";
+            return "Stabilized";
         case FlightMode::UNKNOWN:
             return "Unknown";
         default:

--- a/src/plugins/telemetry/telemetry_impl.cpp
+++ b/src/plugins/telemetry/telemetry_impl.cpp
@@ -902,6 +902,18 @@ TelemetryImpl::telemetry_flight_mode_from_flight_mode(SystemImpl::FlightMode fli
             return Telemetry::FlightMode::OFFBOARD;
         case SystemImpl::FlightMode::FOLLOW_ME:
             return Telemetry::FlightMode::FOLLOW_ME;
+        case SystemImpl::FlightMode::MANUAL:
+            return Telemetry::FlightMode::MANUAL;
+        case SystemImpl::FlightMode::POSCTL:
+            return Telemetry::FlightMode::POSCTL;
+        case SystemImpl::FlightMode::ALTCTL:
+            return Telemetry::FlightMode::ALTCTL;
+        case SystemImpl::FlightMode::RATTITUDE:
+            return Telemetry::FlightMode::RATTITUDE;
+        case SystemImpl::FlightMode::ACRO:
+            return Telemetry::FlightMode::ACRO;
+        case SystemImpl::FlightMode::STABILIZED:
+            return Telemetry::FlightMode::STABILIZED;
         default:
             return Telemetry::FlightMode::UNKNOWN;
     }


### PR DESCRIPTION
Hello,
Based on this #912 , there is a gap for PX4 modes to get flight modes from telemetry plugin. I added on PR but there is also problem about this PR. I'm using very old version (about 5 months ago), so there are some changes for implementation in current version. 

For example;

https://github.com/bozkurthan/MAVSDK/blob/782022d72be38ed30e77308e0336de511245733a/src/plugins/telemetry/telemetry_impl.cpp#L885-L908

I didn't change this function. I can also add these lines and test this on SiTL. But currently it's working for me.

![Screenshot from 2019-12-19 14-41-05](https://user-images.githubusercontent.com/44507545/71170948-a0a26b80-226d-11ea-9961-722d9181fa6a.png)
