### PR TITLE
Add build and tests in github actions (no deployment)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,138 @@
+name: C/C++ CI
+
+on: [push]
+
+jobs:
+  coverage:
+    name: coverage (ubuntu-18.04)
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: recursive
+      - name: configure
+        run: cmake -DCMAKE_BUILD_TYPE=Coverage -j 2 -Bbuild -H.
+      - name: build
+        run: cmake --build build -j 2
+
+  ubuntu18-non-superbuild:
+    name: ubuntu-18.04 (non-backend, non-superbuild)
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: recursive
+      - name: install
+        run: sudo apt-get install -y libjsoncpp-dev libcurl4-openssl-dev libtinyxml2-dev
+      - name: configure
+        run: cmake -DCMAKE_BUILD_TYPE=Release -DSUPERBUILD=OFF -j 2 -Bbuild/release -H.
+      - name: build
+        run: cmake --build build/release -j 2
+      - name: test
+        run: ./build/release/src/unit_tests_runner
+
+  ubuntu18-superbuild:
+    name: ubuntu-18.04 (backend, superbuild)
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: recursive
+      - name: configure
+        run: cmake -DCMAKE_BUILD_TYPE=Release -DSUPERBUILD=ON -DBUILD_BACKEND=ON -j 2 -Bbuild/release -H.
+      - name: build
+        run: cmake --build build/release -j 2
+      - name: test
+        run: ./build/release/src/unit_tests_runner
+
+  px4-sitl:
+    name: PX4 SITL (ubuntu-18.04)
+    runs-on: ubuntu-18.04
+    container: mavsdk/mavsdk-ubuntu-18.04-px4-sitl
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: recursive
+      - name: test
+        run: tools/run-sitl-tests.sh /home/user/Firmware
+
+  deb-rpm-package:
+    name: ${{ matrix.container_name }} (package, non-backend)
+    runs-on: ubuntu-18.04
+    container: mavsdk/mavsdk-${{ matrix.container_name }}
+    strategy:
+      matrix:
+        container_name: [ubuntu-16.04, ubuntu-18.04, fedora-29, fedora-30]
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: recursive
+      - name: configure
+        run: cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_BACKEND=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=install -Bbuild/release -H.
+      - name: build
+        run: cmake --build build/release --target install -- -j2
+      - name: package
+        run: tools/create_packages.sh ./install .
+
+  dockcross:
+    name: ${{ matrix.arch_name }}
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        arch_name: [android-arm64, android-arm, linux-armv6, linux-armv7, linux-arm64, manylinux2010-x64]
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: recursive
+      - name: setup dockcross
+        run: docker run --rm dockcross/${{ matrix.arch_name }} > ./dockcross-${{ matrix.arch_name }}; chmod +x ./dockcross-${{ matrix.arch_name }}
+      - name: configure
+        run: ./dockcross-${{ matrix.arch_name }} cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/${{ matrix.arch_name }}/install -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -j 2 -Bbuild/${{ matrix.arch_name }} -H.
+      - name: build
+        run: ./dockcross-${{ matrix.arch_name }} cmake --build build/${{ matrix.arch_name }} -j 2 --target install
+
+  macOS:
+    name: macOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: recursive
+      - name: configure
+        run: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/release/install -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -j 2 -Bbuild/release -H.
+      - name: build
+        run: cmake --build build/release -j 2 --target install
+      - name: test (core)
+        run: ./build/release/src/unit_tests_runner
+      - name: test (mavsdk_server)
+        run: ./build/release/src/backend/test/unit_tests_backend
+
+  iOS:
+    name: iOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: recursive
+      - name: configure (ios)
+        run: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$(pwd)/tools/ios.toolchain.cmake -DPLATFORM=OS -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -j 2 -Bbuild/ios -H.
+      - name: build (ios)
+        run: cmake --build build/ios -j 2
+      - name: configure (ios_simulator)
+        run: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$(pwd)/tools/ios.toolchain.cmake -DPLATFORM=SIMULATOR64 -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -j 2 -Bbuild/ios_simulator -H.
+      - name: build (ios_simulator)
+        run: cmake --build build/ios_simulator -j 2
+      - name: package
+        run: bash ./src/backend/tools/package_backend_framework.bash
+
+  Windows:
+    name: Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: recursive
+      - name: configure
+        run: cmake -G "Visual Studio 16 2019" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/release/install -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -j 2 -Bbuild/release -S.
+      - name: build
+        run: cmake --build build/release -j 2 --config Release --target install

--- a/.travis.yml
+++ b/.travis.yml
@@ -166,7 +166,7 @@ script:
     ./build/src/unit_tests_runner;
   fi
 - if [[ "${BUILD_TARGET}" = "px4-sitl" ]]; then
-    docker run -it -v $TRAVIS_BUILD_DIR:/home/user/MAVSDK:rw ${DOCKER_REPO} tools/run-sitl-tests.sh;
+    docker run -it -v $TRAVIS_BUILD_DIR:/home/user/MAVSDK:rw ${DOCKER_REPO} tools/run-sitl-tests.sh /home/user/Firmware;
   fi
 - if [[ "${BUILD_TARGET}" = "deb-x64" ]]; then
     docker run -it -v $TRAVIS_BUILD_DIR:/home/user/MAVSDK:rw ${DOCKER_REPO} cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_BACKEND=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=./install -Bbuild/release -H.;

--- a/tools/run-sitl-tests.sh
+++ b/tools/run-sitl-tests.sh
@@ -2,12 +2,12 @@
 
 set -e
 
-PWD=$(pwd)
-
-if [ -z ${PX4_FIRMWARE_DIR+x} ]; then
-    PX4_FIRMWARE_DIR=$PWD/../Firmware
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <path/to/Firmware>"
+    exit 1
 fi
 
+PX4_FIRMWARE_DIR=$1
 NPROCS=$(nproc --all)
 
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_BACKEND=OFF -DBUILD_SHARED_LIBS=ON -Bbuild/debug -H.;


### PR DESCRIPTION
All our Travis jobs are here except for manylinux1-x64, which requires a custom image (because of perl). I believe we could move to manylinux2010-x64 for the next release, and it should not affect our python users. Also, I am not sure about the coverage (maybe more work is needed there).

In my limited experience with github actions, I'm quite impressed. Jobs are always starting directly, all in parallel, the config syntax is actually pretty nice (I find it even more compact than Travis), and it is more integrated into github (e.g.  deployment [seems fairly easy](https://github.com/marketplace/actions/github-action-publish-binaries)). Moreover, it apparently allows self-hosted nodes, but I haven't tried that.

I believe that this will allow us to deploy `mavsdk_server.framework` from the CI (for iOS). It already creates the package, which we could not do in Travis because it would time out.

@julianoes: If you agree, I believe we could merge this and test github actions while keeping Travis as the sole "required" test. And to test deployment, I could add iOS to the github actions, since Travis doesn't do it.