### PR TITLE
Add shutdown action

### DIFF
--- a/src/plugins/action/action.cpp
+++ b/src/plugins/action/action.cpp
@@ -27,6 +27,11 @@ Action::Result Action::reboot() const
     return _impl->reboot();
 }
 
+Action::Result Action::shutdown() const
+{
+    return _impl->shutdown();
+}
+
 Action::Result Action::takeoff() const
 {
     return _impl->takeoff();

--- a/src/plugins/action/action_impl.cpp
+++ b/src/plugins/action/action_impl.cpp
@@ -92,6 +92,20 @@ Action::Result ActionImpl::reboot() const
     return action_result_from_command_result(_parent->send_command(command));
 }
 
+Action::Result ActionImpl::shutdown() const
+{
+    MAVLinkCommands::CommandLong command{};
+
+    command.command = MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN;
+    command.params.param1 = 2.0f; // shutdown autopilot
+    command.params.param2 = 2.0f; // shutdown onboard computer
+    command.params.param3 = 2.0f; // shutdown camera
+    command.params.param4 = 2.0f; // shutdown gimbal
+    command.target_component_id = _parent->get_autopilot_id();
+
+    return action_result_from_command_result(_parent->send_command(command));
+}
+
 Action::Result ActionImpl::takeoff() const
 {
     auto prom = std::promise<Action::Result>();

--- a/src/plugins/action/action_impl.h
+++ b/src/plugins/action/action_impl.h
@@ -23,6 +23,7 @@ public:
     Action::Result disarm() const;
     Action::Result kill() const;
     Action::Result reboot() const;
+    Action::Result shutdown() const;
     Action::Result takeoff() const;
     Action::Result land() const;
     Action::Result return_to_launch() const;

--- a/src/plugins/action/include/plugins/action/action.h
+++ b/src/plugins/action/include/plugins/action/action.h
@@ -102,7 +102,18 @@ public:
      *
      * @return Action::Result of request.
      */
-    Action::Result reboot() const;
+    Result reboot() const;
+
+    /**
+     * @brief Send command to *shut down* the drone components.
+     *
+     * This will shut down the autopilot, onboard computer, camera and gimbal.
+     * This command should only be used when the autopilot is disarmed and autopilots commonly
+     * reject it if they are not already ready to shut down.
+     *
+     * @return Action::Result of request.
+     */
+    Result shutdown() const;
 
     /**
      * @brief Send command to *take off and hover* (synchronous).


### PR DESCRIPTION
This allows to shut an autopilot (including additional onboard components) cleanly down. As the existing reboot action has the same corner cases (regarding an in-flight state) the overall expected design pattern is that the autopilot has authority over wether it reboots / shuts down or not in safety critical conditions (e.g. while being armed).