### PR TITLE
shell: fix docs build

### DIFF
--- a/src/plugins/shell/include/plugins/shell/shell.h
+++ b/src/plugins/shell/include/plugins/shell/shell.h
@@ -68,7 +68,7 @@ public:
     /**
      * @brief Send the shell message.
      *
-     * If shell_message.data string have not trailing '\n' symbol - it will be added.
+     * If shell_message.data string have not trailing newline - it will be added.
      *
      * If response data looks like not completed try to increase timeout value in request.
      *


### PR DESCRIPTION
The docs build took the '\n' to literal.