### PR TITLE
fixed SetTakeoffAltitude to include action result in response

### DIFF
--- a/src/backend/src/plugins/action/action_service_impl.h
+++ b/src/backend/src/plugins/action/action_service_impl.h
@@ -174,7 +174,15 @@ public:
     {
         if (request != nullptr) {
             const auto requested_altitude = request->altitude();
-            _action.set_takeoff_altitude(requested_altitude);
+            mavsdk::Action::Result action_result = _action.set_takeoff_altitude(requested_altitude);
+
+            if (response != nullptr) {
+                auto* rpc_action_result = new rpc::action::ActionResult();
+                rpc_action_result->set_result(
+                    static_cast<rpc::action::ActionResult::Result>(action_result));
+                rpc_action_result->set_result_str(mavsdk::Action::result_str(action_result));
+                response->set_allocated_action_result(rpc_action_result);
+            }
         }
 
         return grpc::Status::OK;

--- a/src/backend/src/plugins/action/action_service_impl.h
+++ b/src/backend/src/plugins/action/action_service_impl.h
@@ -170,7 +170,7 @@ public:
     grpc::Status SetTakeoffAltitude(
         grpc::ServerContext* /* context */,
         const rpc::action::SetTakeoffAltitudeRequest* request,
-        rpc::action::SetTakeoffAltitudeResponse* /* response */) override
+        rpc::action::SetTakeoffAltitudeResponse* response) override
     {
         if (request != nullptr) {
             const auto requested_altitude = request->altitude();


### PR DESCRIPTION
In response to [this issue](https://github.com/mavlink/MAVSDK-Python/issues/85) in mavsdk-python.

I'm not entirely sure what's the contributing flow here.
Are there any unit tests to be updated?
Should I just compile & check if it works? @JonasVautherin 