### PR TITLE
offboard: fix crash on plugin destruction

### DIFF
--- a/src/plugins/offboard/offboard_impl.cpp
+++ b/src/plugins/offboard/offboard_impl.cpp
@@ -27,6 +27,7 @@ void OffboardImpl::init()
 
 void OffboardImpl::deinit()
 {
+    stop_sending_setpoints();
     _parent->unregister_all_mavlink_message_handlers(this);
 }
 


### PR DESCRIPTION
If we don't stop the call_every calls before destruction, we can run into segfaults where the method is destructed but still called.