### PR TITLE
Refactor mission transfer

### DIFF
--- a/src/backend/test/action_service_impl_test.cpp
+++ b/src/backend/test/action_service_impl_test.cpp
@@ -495,7 +495,7 @@ TEST_P(ActionServiceImplTest, setReturnToLaunchAltitudeSetsRightValue)
     actionService.SetReturnToLaunchAltitude(nullptr, &request, nullptr);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     ActionResultCorrespondences, ActionServiceImplTest, ::testing::ValuesIn(generateInputPairs()));
 
 std::vector<InputPair> generateInputPairs()

--- a/src/backend/test/camera_service_impl_test.cpp
+++ b/src/backend/test/camera_service_impl_test.cpp
@@ -1292,7 +1292,7 @@ TEST_F(CameraServiceImplTest, setSettingDoesNotCrashWhenArgsAreNull)
     _camera_service.SetSetting(nullptr, nullptr, nullptr);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     CameraResultCorrespondences, CameraServiceImplTest, ::testing::ValuesIn(generateInputPairs()));
 
 std::vector<InputPair> generateInputPairs()

--- a/src/backend/test/info_service_impl_test.cpp
+++ b/src/backend/test/info_service_impl_test.cpp
@@ -90,7 +90,7 @@ TEST_F(InfoServiceImplTest, getVersionDoesNotCrashWithNullResponse)
     infoService.GetVersion(nullptr, nullptr, nullptr);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InfoResultCorrespondences, InfoServiceImplTest, ::testing::ValuesIn(generateInputPairs()));
 
 std::vector<InputPair> generateInputPairs()

--- a/src/backend/test/mission_service_impl_test.cpp
+++ b/src/backend/test/mission_service_impl_test.cpp
@@ -179,7 +179,7 @@ protected:
     std::vector<std::shared_ptr<dc::MissionItem>> _uploaded_mission{};
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     MissionResultCorrespondences,
     MissionServiceImplUploadTest,
     ::testing::ValuesIn(generateInputPairs()));
@@ -287,7 +287,7 @@ protected:
     dc::Mission::mission_items_and_result_callback_t _download_callback{};
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     MissionResultCorrespondences,
     MissionServiceImplDownloadTest,
     ::testing::ValuesIn(generateInputPairs()));
@@ -368,7 +368,7 @@ protected:
     std::future<void> startMissionAndSaveParams(std::shared_ptr<StartMissionResponse> response);
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     MissionResultCorrespondences,
     MissionServiceImplStartTest,
     ::testing::ValuesIn(generateInputPairs()));
@@ -446,7 +446,7 @@ protected:
     std::future<void> pauseMissionAndSaveParams(std::shared_ptr<PauseMissionResponse> response);
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     MissionResultCorrespondences,
     MissionServiceImplPauseTest,
     ::testing::ValuesIn(generateInputPairs()));
@@ -485,7 +485,7 @@ TEST_P(MissionServiceImplPauseTest, pauseResultIsTranslatedCorrectly)
 
 class MissionServiceImplSetCurrentTest : public MissionServiceImplTestBase {};
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     MissionResultCorrespondences,
     MissionServiceImplSetCurrentTest,
     ::testing::ValuesIn(generateInputPairs()));

--- a/src/backend/test/offboard_service_impl_test.cpp
+++ b/src/backend/test/offboard_service_impl_test.cpp
@@ -459,7 +459,7 @@ TEST_F(OffboardServiceImplTest, setsVelocityNedCorrectly)
     offboardService.SetVelocityNed(nullptr, &request, nullptr);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     OffboardResultCorrespondences,
     OffboardServiceImplTest,
     ::testing::ValuesIn(generateInputPairs()));

--- a/src/cmake/compiler_flags.cmake
+++ b/src/cmake/compiler_flags.cmake
@@ -28,6 +28,9 @@ else()
 
 
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5)
+            set(warnings "${warnings} -Wno-shadow")
+        endif()
         if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6)
             set(warnings "${warnings} -Wduplicated-cond -Wnull-dereference")
         endif()

--- a/src/cmake/compiler_flags.cmake
+++ b/src/cmake/compiler_flags.cmake
@@ -29,7 +29,7 @@ else()
 
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5)
-            set(warnings "${warnings} -Wno-shadow")
+            set(warnings "${warnings} -Wno-shadow -Wno-effc++")
         endif()
         if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6)
             set(warnings "${warnings} -Wduplicated-cond -Wnull-dereference")

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(mavsdk
     mavlink_mission_transfer.cpp
     mavlink_parameters.cpp
     mavlink_receiver.cpp
+    mavlink_message_handler.cpp
     plugin_impl_base.cpp
     serial_connection.cpp
     tcp_connection.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -16,9 +16,10 @@ add_library(mavsdk
     mavsdk_impl.cpp
     global_include.cpp
     http_loader.cpp
-    mavlink_parameters.cpp
-    mavlink_commands.cpp
     mavlink_channels.cpp
+    mavlink_commands.cpp
+    mavlink_mission_transfer.cpp
+    mavlink_parameters.cpp
     mavlink_receiver.cpp
     plugin_impl_base.cpp
     serial_connection.cpp
@@ -102,6 +103,7 @@ list(APPEND UNIT_TEST_SOURCES
     ${PROJECT_SOURCE_DIR}/core/locked_queue_test.cpp
     ${PROJECT_SOURCE_DIR}/core/thread_pool_test.cpp
     ${PROJECT_SOURCE_DIR}/core/mavsdk_test.cpp
+    ${PROJECT_SOURCE_DIR}/core/mavlink_mission_transfer_test.cpp
     ${PROJECT_SOURCE_DIR}/core/geometry_test.cpp
 )
 set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} PARENT_SCOPE)

--- a/src/core/locked_queue.h
+++ b/src/core/locked_queue.h
@@ -30,6 +30,8 @@ public:
 
     iterator erase(iterator it) { return _queue.erase(it); }
 
+    // This guard serves the purpose to combine a get_front with a pop_front.
+    // Thus, no one can interfere between the two steps.
     class Guard {
     public:
         Guard(LockedQueue& locked_queue) : _locked_queue(locked_queue)

--- a/src/core/locked_queue.h
+++ b/src/core/locked_queue.h
@@ -11,10 +11,10 @@ public:
     LockedQueue(){};
     ~LockedQueue(){};
 
-    void push_back(T item)
+    void push_back(std::shared_ptr<T> item_ptr)
     {
         std::lock_guard<std::mutex> lock(_mutex);
-        _queue.push_back(std::make_shared<T>(item));
+        _queue.push_back(item_ptr);
     }
 
     size_t size()

--- a/src/core/locked_queue_test.cpp
+++ b/src/core/locked_queue_test.cpp
@@ -15,10 +15,10 @@ TEST(LockedQueue, FillAndEmpty)
 
     LockedQueue<int> locked_queue{};
 
-    locked_queue.push_back(one);
+    locked_queue.push_back(std::make_shared<int>(one));
     EXPECT_EQ(locked_queue.size(), 1);
-    locked_queue.push_back(two);
-    locked_queue.push_back(three);
+    locked_queue.push_back(std::make_shared<int>(two));
+    locked_queue.push_back(std::make_shared<int>(three));
     EXPECT_EQ(locked_queue.size(), 3);
 
     {
@@ -45,10 +45,10 @@ TEST(LockedQueue, FillAndIterateAndErase)
 
     LockedQueue<int> locked_queue{};
 
-    locked_queue.push_back(one);
+    locked_queue.push_back(std::make_shared<int>(one));
     EXPECT_EQ(locked_queue.size(), 1);
-    locked_queue.push_back(two);
-    locked_queue.push_back(three);
+    locked_queue.push_back(std::make_shared<int>(two));
+    locked_queue.push_back(std::make_shared<int>(three));
     EXPECT_EQ(locked_queue.size(), 3);
 
     unsigned counter = 0;
@@ -88,9 +88,9 @@ TEST(LockedQueue, GuardAndReturn)
 
     LockedQueue<int> locked_queue{};
 
-    locked_queue.push_back(one);
-    locked_queue.push_back(two);
-    locked_queue.push_back(three);
+    locked_queue.push_back(std::make_shared<int>(one));
+    locked_queue.push_back(std::make_shared<int>(two));
+    locked_queue.push_back(std::make_shared<int>(three));
 
     {
         LockedQueue<int>::Guard guard(locked_queue);
@@ -124,8 +124,8 @@ TEST(LockedQueue, ConcurrantAccess)
 
     LockedQueue<int> locked_queue{};
 
-    locked_queue.push_back(one);
-    locked_queue.push_back(two);
+    locked_queue.push_back(std::make_shared<int>(one));
+    locked_queue.push_back(std::make_shared<int>(two));
 
     auto prom = std::promise<void>();
     auto fut = prom.get_future();
@@ -166,7 +166,7 @@ TEST(LockedQueue, ChangeValue)
 
     Item one;
 
-    locked_queue.push_back(one);
+    locked_queue.push_back(std::make_shared<Item>(one));
 
     {
         LockedQueue<Item>::Guard guard(locked_queue);
@@ -190,8 +190,8 @@ TEST(LockedQueue, Guard)
 
     LockedQueue<int> locked_queue{};
 
-    locked_queue.push_back(one);
-    locked_queue.push_back(two);
+    locked_queue.push_back(std::make_shared<int>(one));
+    locked_queue.push_back(std::make_shared<int>(two));
 
     {
         LockedQueue<int>::Guard guard(locked_queue);

--- a/src/core/mavlink_address.h
+++ b/src/core/mavlink_address.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <cstdint>
+
+struct MAVLinkAddress {
+    uint8_t system_id;
+    uint8_t component_id;
+};

--- a/src/core/mavlink_commands.cpp
+++ b/src/core/mavlink_commands.cpp
@@ -70,7 +70,7 @@ void MAVLinkCommands::queue_command_async(
     const CommandInt& command, command_result_callback_t callback)
 {
     // LogDebug() << "Command " << (int)(command.command) << " to send to "
-    //  << (int)(command.target_system_id)<< ", " << (int)(command.target_component_id;
+    //  << (int)(command.target_system_id)<< ", " << (int)(command.target_component_id);
 
     auto new_work =  std::make_shared<Work>();
 
@@ -101,7 +101,7 @@ void MAVLinkCommands::queue_command_async(
     const CommandLong& command, command_result_callback_t callback)
 {
     // LogDebug() << "Command " << (int)(command.command) << " to send to "
-    //  << (int)(command.target_system_id)<< ", " << (int)(command.target_component_id;
+    //  << (int)(command.target_system_id)<< ", " << (int)(command.target_component_id);
 
     auto new_work = std::make_shared<Work>();
     mavlink_msg_command_long_pack(

--- a/src/core/mavlink_commands.cpp
+++ b/src/core/mavlink_commands.cpp
@@ -72,11 +72,12 @@ void MAVLinkCommands::queue_command_async(
     // LogDebug() << "Command " << (int)(command.command) << " to send to "
     //  << (int)(command.target_system_id)<< ", " << (int)(command.target_component_id;
 
-    Work new_work{};
+    auto new_work =  std::make_shared<Work>();
+
     mavlink_msg_command_int_pack(
         _parent.get_own_system_id(),
         _parent.get_own_component_id(),
-        &new_work.mavlink_message,
+        &new_work->mavlink_message,
         command.target_system_id,
         command.target_component_id,
         command.frame,
@@ -91,8 +92,8 @@ void MAVLinkCommands::queue_command_async(
         command.params.y,
         command.params.z);
 
-    new_work.callback = callback;
-    new_work.mavlink_command = command.command;
+    new_work->callback = callback;
+    new_work->mavlink_command = command.command;
     _work_queue.push_back(new_work);
 }
 
@@ -102,11 +103,11 @@ void MAVLinkCommands::queue_command_async(
     // LogDebug() << "Command " << (int)(command.command) << " to send to "
     //  << (int)(command.target_system_id)<< ", " << (int)(command.target_component_id;
 
-    Work new_work{};
+    auto new_work = std::make_shared<Work>();
     mavlink_msg_command_long_pack(
         _parent.get_own_system_id(),
         _parent.get_own_component_id(),
-        &new_work.mavlink_message,
+        &new_work->mavlink_message,
         command.target_system_id,
         command.target_component_id,
         command.command,
@@ -119,8 +120,8 @@ void MAVLinkCommands::queue_command_async(
         command.params.param6,
         command.params.param7);
 
-    new_work.callback = callback;
-    new_work.mavlink_command = command.command;
+    new_work->callback = callback;
+    new_work->mavlink_command = command.command;
     _work_queue.push_back(new_work);
 }
 

--- a/src/core/mavlink_commands.cpp
+++ b/src/core/mavlink_commands.cpp
@@ -72,7 +72,7 @@ void MAVLinkCommands::queue_command_async(
     // LogDebug() << "Command " << (int)(command.command) << " to send to "
     //  << (int)(command.target_system_id)<< ", " << (int)(command.target_component_id);
 
-    auto new_work =  std::make_shared<Work>();
+    auto new_work = std::make_shared<Work>();
 
     mavlink_msg_command_int_pack(
         _parent.get_own_system_id(),

--- a/src/core/mavlink_commands.cpp
+++ b/src/core/mavlink_commands.cpp
@@ -149,35 +149,35 @@ void MAVLinkCommands::receive_command_ack(mavlink_message_t message)
     switch (command_ack.result) {
         case MAV_RESULT_ACCEPTED:
             _parent.unregister_timeout_handler(_timeout_cookie);
-            work_queue_guard.pop_front();
             call_callback(work->callback, Result::SUCCESS, 1.0f);
+            work_queue_guard.pop_front();
             break;
 
         case MAV_RESULT_DENIED:
             LogWarn() << "command denied (" << work->mavlink_command << ").";
             _parent.unregister_timeout_handler(_timeout_cookie);
-            work_queue_guard.pop_front();
             call_callback(work->callback, Result::COMMAND_DENIED, NAN);
+            work_queue_guard.pop_front();
             break;
 
         case MAV_RESULT_UNSUPPORTED:
             LogWarn() << "command unsupported (" << work->mavlink_command << ").";
             _parent.unregister_timeout_handler(_timeout_cookie);
-            work_queue_guard.pop_front();
             call_callback(work->callback, Result::COMMAND_DENIED, NAN);
+            work_queue_guard.pop_front();
             break;
 
         case MAV_RESULT_TEMPORARILY_REJECTED:
             LogWarn() << "command temporarily rejected (" << work->mavlink_command << ").";
             _parent.unregister_timeout_handler(_timeout_cookie);
-            work_queue_guard.pop_front();
             call_callback(work->callback, Result::COMMAND_DENIED, NAN);
+            work_queue_guard.pop_front();
             break;
 
         case MAV_RESULT_FAILED:
             _parent.unregister_timeout_handler(_timeout_cookie);
-            work_queue_guard.pop_front();
             call_callback(work->callback, Result::COMMAND_DENIED, NAN);
+            work_queue_guard.pop_front();
             break;
 
         case MAV_RESULT_IN_PROGRESS:

--- a/src/core/mavlink_commands.h
+++ b/src/core/mavlink_commands.h
@@ -2,6 +2,7 @@
 
 #include "mavlink_include.h"
 #include "locked_queue.h"
+#include "global_include.h"
 #include <cstdint>
 #include <string>
 #include <functional>
@@ -112,6 +113,7 @@ private:
         bool already_sent{false};
         mavlink_message_t mavlink_message{};
         command_result_callback_t callback{};
+        dl_time_t time_started{};
     };
 
     void receive_command_ack(mavlink_message_t message);

--- a/src/core/mavlink_message_handler.cpp
+++ b/src/core/mavlink_message_handler.cpp
@@ -3,8 +3,7 @@
 
 namespace mavsdk {
 
-void MAVLinkMessageHandler::register_one(
-    uint16_t msg_id, Callback callback, const void* cookie)
+void MAVLinkMessageHandler::register_one(uint16_t msg_id, Callback callback, const void* cookie)
 {
     std::lock_guard<std::mutex> lock(_mutex);
 

--- a/src/core/mavlink_message_handler.cpp
+++ b/src/core/mavlink_message_handler.cpp
@@ -1,0 +1,67 @@
+#include <mutex>
+#include "mavlink_message_handler.h"
+
+namespace mavsdk {
+
+void MAVLinkMessageHandler::register_one(
+    uint16_t msg_id, Callback callback, const void* cookie)
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    Entry entry = {msg_id, callback, cookie};
+    _table.push_back(entry);
+}
+
+void MAVLinkMessageHandler::unregister_one(uint16_t msg_id, const void* cookie)
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    for (auto it = _table.begin(); it != _table.end();
+         /* no ++it */) {
+        if (it->msg_id == msg_id && it->cookie == cookie) {
+            it = _table.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+void MAVLinkMessageHandler::unregister_all(const void* cookie)
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    for (auto it = _table.begin(); it != _table.end();
+         /* no ++it */) {
+        if (it->cookie == cookie) {
+            it = _table.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+void MAVLinkMessageHandler::process_message(const mavlink_message_t& message)
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+
+#if MESSAGE_DEBUGGING == 1
+    bool forwarded = false;
+#endif
+    for (auto it = _table.begin(); it != _table.end(); ++it) {
+        if (it->msg_id == message.msgid) {
+#if MESSAGE_DEBUGGING == 1
+            LogDebug() << "Forwarding msg " << int(message.msgid) << " to " << size_t(it->cookie);
+            forwarded = true;
+#endif
+            it->callback(message);
+        }
+    }
+
+#if MESSAGE_DEBUGGING == 1
+    if (!forwarded) {
+        LogDebug() << "Ignoring msg " << int(message.msgid);
+    }
+#endif
+}
+
+} // namespace mavsdk

--- a/src/core/mavlink_message_handler.h
+++ b/src/core/mavlink_message_handler.h
@@ -23,6 +23,7 @@ public:
     void unregister_one(uint16_t msg_id, const void* cookie);
     void unregister_all(const void* cookie);
     void process_message(const mavlink_message_t& message);
+
 private:
     std::mutex _mutex{};
     std::vector<Entry> _table{};

--- a/src/core/mavlink_message_handler.h
+++ b/src/core/mavlink_message_handler.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <mutex>
+#include <vector>
+#include "mavlink_include.h"
+
+namespace mavsdk {
+
+class MAVLinkMessageHandler {
+public:
+    using Callback = std::function<void(const mavlink_message_t&)>;
+
+    struct Entry {
+        uint16_t msg_id;
+        Callback callback;
+        const void* cookie; // This is the identification to unregister.
+    };
+
+    void register_one(uint16_t msg_id, Callback callback, const void* cookie);
+    void unregister_one(uint16_t msg_id, const void* cookie);
+    void unregister_all(const void* cookie);
+    void process_message(const mavlink_message_t& message);
+private:
+    std::mutex _mutex{};
+    std::vector<Entry> _table{};
+};
+
+} // namespace mavsdk

--- a/src/core/mavlink_mission_transfer.cpp
+++ b/src/core/mavlink_mission_transfer.cpp
@@ -104,6 +104,8 @@ void MAVLinkMissionTransfer::process_mission_request_int(const mavlink_message_t
     mavlink_mission_request_int_t request_int;
     mavlink_msg_mission_request_int_decode(&message, &request_int);
 
+    _timeout_handler.refresh(_cookie);
+
     if (_next_sequence_expected < request_int.seq) {
         LogWarn() << "mission_request_int: sequence incorrect";
         return;

--- a/src/core/mavlink_mission_transfer.cpp
+++ b/src/core/mavlink_mission_transfer.cpp
@@ -32,8 +32,7 @@ MAVLinkMissionTransfer::~MAVLinkMissionTransfer()
 }
 
 void MAVLinkMissionTransfer::upload_items_async(
-    uint8_t type,
-    const std::vector<ItemInt>& items, ResultCallback callback)
+    uint8_t type, const std::vector<ItemInt>& items, ResultCallback callback)
 {
     if (items.size() == 0) {
         if (callback) {
@@ -87,6 +86,26 @@ void MAVLinkMissionTransfer::upload_items_async(
         _config.target_system_id,
         _config.target_component_id,
         items.size(),
+        type);
+
+    if (!_sender.send_message(message)) {
+        _timeout_handler.remove(_cookie);
+        callback_and_reset(Result::ConnectionError);
+        return;
+    }
+}
+
+void MAVLinkMissionTransfer::download_items_async(uint8_t type, ResultAndItemsCallback callback)
+{
+    _callback_download = callback;
+
+    mavlink_message_t message;
+    mavlink_msg_mission_request_list_pack(
+        _config.own_system_id,
+        _config.own_component_id,
+        &message,
+        _config.target_system_id,
+        _config.target_component_id,
         type);
 
     if (!_sender.send_message(message)) {

--- a/src/core/mavlink_mission_transfer.cpp
+++ b/src/core/mavlink_mission_transfer.cpp
@@ -1,0 +1,23 @@
+#include "mavlink_mission_transfer.h"
+
+namespace mavsdk {
+
+void MAVLinkMissionTransfer::upload_items_async(
+        const std::vector<ItemInt> &items, ResultCallback callback)
+{
+    mavlink_message_t message;
+    mavlink_msg_mission_count_pack(
+        0,
+        0,
+        &message,
+        0,
+        0,
+        items.size(),
+        MAV_MISSION_TYPE_MISSION);
+
+    _sender.send_message(message);
+
+    (void)callback;
+}
+
+} // namespace mavsdk

--- a/src/core/mavlink_mission_transfer.cpp
+++ b/src/core/mavlink_mission_transfer.cpp
@@ -32,6 +32,7 @@ MAVLinkMissionTransfer::~MAVLinkMissionTransfer()
 }
 
 void MAVLinkMissionTransfer::upload_items_async(
+    uint8_t type,
     const std::vector<ItemInt>& items, ResultCallback callback)
 {
     if (items.size() == 0) {
@@ -62,10 +63,8 @@ void MAVLinkMissionTransfer::upload_items_async(
         return;
     }
 
-    auto first_mission_type = items[0].mission_type;
-
-    if (std::any_of(items.cbegin(), items.cend(), [first_mission_type](const ItemInt& item) {
-            return item.mission_type != first_mission_type;
+    if (std::any_of(items.cbegin(), items.cend(), [type](const ItemInt& item) {
+            return item.mission_type != type;
         })) {
         if (callback) {
             callback(Result::MissionTypeNotConsistent);
@@ -88,7 +87,7 @@ void MAVLinkMissionTransfer::upload_items_async(
         _config.target_system_id,
         _config.target_component_id,
         items.size(),
-        first_mission_type);
+        type);
 
     if (!_sender.send_message(message)) {
         _timeout_handler.remove(_cookie);

--- a/src/core/mavlink_mission_transfer.cpp
+++ b/src/core/mavlink_mission_transfer.cpp
@@ -133,10 +133,17 @@ void MAVLinkMissionTransfer::UploadWorkItem::start()
         return;
     }
 
+    _retries_done = 0;
+    _step = Step::SendCount;
     _timeout_handler.add([this]() { process_timeout(); }, timeout_s, &_cookie);
 
-    _next_sequence_expected = 0;
+    _next_sequence = 0;
 
+    send_count();
+}
+
+void MAVLinkMissionTransfer::UploadWorkItem::send_count()
+{
     mavlink_message_t message;
     mavlink_msg_mission_count_pack(
         _config.own_system_id,
@@ -152,6 +159,8 @@ void MAVLinkMissionTransfer::UploadWorkItem::start()
         callback_and_reset(Result::ConnectionError);
         return;
     }
+
+    ++_retries_done;
 }
 
 void MAVLinkMissionTransfer::UploadWorkItem::process_mission_request_int(
@@ -160,10 +169,37 @@ void MAVLinkMissionTransfer::UploadWorkItem::process_mission_request_int(
     mavlink_mission_request_int_t request_int;
     mavlink_msg_mission_request_int_decode(&message, &request_int);
 
+    _step = Step::SendItems;
+
+    if (_next_sequence < request_int.seq) {
+        // We should not go back to a previous one.
+        // TODO: figure out if we should error here.
+        LogWarn() << "mission_request_int: sequence incorrect";
+        return;
+
+    } else if (_next_sequence > request_int.seq) {
+        // We have already sent that one before.
+        if (_retries_done >= retries) {
+            _timeout_handler.remove(_cookie);
+            callback_and_reset(Result::Timeout);
+            return;
+        }
+
+    } else {
+        // Correct one, sending it the first time.
+        _retries_done = 0;
+    }
+
     _timeout_handler.refresh(_cookie);
 
-    if (_next_sequence_expected < request_int.seq) {
-        LogWarn() << "mission_request_int: sequence incorrect";
+    _next_sequence = request_int.seq;
+    send_mission_item();
+}
+
+void MAVLinkMissionTransfer::UploadWorkItem::send_mission_item()
+{
+    if (_next_sequence >= _items.size()) {
+        LogErr() << "send_mission_item: sequence out of bounds";
         return;
     }
 
@@ -174,27 +210,30 @@ void MAVLinkMissionTransfer::UploadWorkItem::process_mission_request_int(
         &new_message,
         _config.target_system_id,
         _config.target_component_id,
-        request_int.seq,
-        _items[request_int.seq].frame,
-        _items[request_int.seq].command,
-        _items[request_int.seq].current,
-        _items[request_int.seq].autocontinue,
-        _items[request_int.seq].param1,
-        _items[request_int.seq].param2,
-        _items[request_int.seq].param3,
-        _items[request_int.seq].param4,
-        _items[request_int.seq].x,
-        _items[request_int.seq].y,
-        _items[request_int.seq].z,
+        _next_sequence,
+        _items[_next_sequence].frame,
+        _items[_next_sequence].command,
+        _items[_next_sequence].current,
+        _items[_next_sequence].autocontinue,
+        _items[_next_sequence].param1,
+        _items[_next_sequence].param2,
+        _items[_next_sequence].param3,
+        _items[_next_sequence].param4,
+        _items[_next_sequence].x,
+        _items[_next_sequence].y,
+        _items[_next_sequence].z,
         MAV_MISSION_TYPE_MISSION);
+    // TODO: above type lacking test
 
-    _next_sequence_expected = request_int.seq + 1;
+    ++_next_sequence;
 
     if (!_sender.send_message(new_message)) {
         _timeout_handler.remove(_cookie);
         callback_and_reset(Result::ConnectionError);
         return;
     }
+
+    ++_retries_done;
 }
 
 void MAVLinkMissionTransfer::UploadWorkItem::process_mission_ack(const mavlink_message_t& message)
@@ -245,7 +284,7 @@ void MAVLinkMissionTransfer::UploadWorkItem::process_mission_ack(const mavlink_m
             return;
     }
 
-    if (_next_sequence_expected == static_cast<int>(_items.size())) {
+    if (_next_sequence == _items.size()) {
         callback_and_reset(Result::Success);
     } else {
         callback_and_reset(Result::ProtocolError);
@@ -254,7 +293,21 @@ void MAVLinkMissionTransfer::UploadWorkItem::process_mission_ack(const mavlink_m
 
 void MAVLinkMissionTransfer::UploadWorkItem::process_timeout()
 {
-    callback_and_reset(Result::Timeout);
+    if (_retries_done >= retries) {
+        callback_and_reset(Result::Timeout);
+        return;
+    }
+
+    switch (_step) {
+        case Step::SendCount:
+            _timeout_handler.add([this]() { process_timeout(); }, timeout_s, &_cookie);
+            send_count();
+            break;
+
+        case Step::SendItems:
+            callback_and_reset(Result::Timeout);
+            break;
+    }
 }
 
 void MAVLinkMissionTransfer::UploadWorkItem::callback_and_reset(Result result)
@@ -262,9 +315,12 @@ void MAVLinkMissionTransfer::UploadWorkItem::callback_and_reset(Result result)
     if (_callback) {
         _callback(result);
     }
+
+    _retries_done = 0;
+    _step = Step::SendCount;
     _callback = nullptr;
     _items.clear();
-    _next_sequence_expected = -1;
+    _next_sequence = 0;
 }
 
 MAVLinkMissionTransfer::DownloadWorkItem::DownloadWorkItem(
@@ -276,7 +332,17 @@ MAVLinkMissionTransfer::DownloadWorkItem::DownloadWorkItem(
     ResultAndItemsCallback callback) :
     WorkItem(config, sender, message_handler, timeout_handler, type),
     _callback(callback)
-{}
+{
+    _message_handler.register_one(
+        MAVLINK_MSG_ID_MISSION_COUNT,
+        [this](const mavlink_message_t& message) { process_mission_count(message); },
+        this);
+
+    _message_handler.register_one(
+        MAVLINK_MSG_ID_MISSION_ITEM_INT,
+        [this](const mavlink_message_t& message) { process_mission_item_int(message); },
+        this);
+}
 
 MAVLinkMissionTransfer::DownloadWorkItem::~DownloadWorkItem()
 {
@@ -286,7 +352,9 @@ MAVLinkMissionTransfer::DownloadWorkItem::~DownloadWorkItem()
 
 void MAVLinkMissionTransfer::DownloadWorkItem::start()
 {
+    _items.clear();
     _started = true;
+    _retries_done = 0;
     _timeout_handler.add([this]() { process_timeout(); }, timeout_s, &_cookie);
     request_list();
 }
@@ -307,12 +375,123 @@ void MAVLinkMissionTransfer::DownloadWorkItem::request_list()
         callback_and_reset(Result::ConnectionError);
         return;
     }
+
+    ++_retries_done;
+}
+
+void MAVLinkMissionTransfer::DownloadWorkItem::request_item()
+{
+    mavlink_message_t message;
+    mavlink_msg_mission_request_int_pack(
+        _config.own_system_id,
+        _config.own_component_id,
+        &message,
+        _config.target_system_id,
+        _config.target_component_id,
+        _next_sequence,
+        _type);
+
+    if (!_sender.send_message(message)) {
+        _timeout_handler.remove(_cookie);
+        callback_and_reset(Result::ConnectionError);
+        return;
+    }
+
+    ++_retries_done;
+}
+
+void MAVLinkMissionTransfer::DownloadWorkItem::send_ack_and_finish()
+{
+    mavlink_message_t message;
+    mavlink_msg_mission_ack_pack(
+        _config.own_system_id,
+        _config.own_component_id,
+        &message,
+        _config.target_system_id,
+        _config.target_component_id,
+        MAV_MISSION_ACCEPTED,
+        _type);
+
+    if (!_sender.send_message(message)) {
+        callback_and_reset(Result::ConnectionError);
+        return;
+    }
+
+    // We do not wait on anything coming back after this.
+    callback_and_reset(Result::Success);
+}
+
+void MAVLinkMissionTransfer::DownloadWorkItem::process_mission_count(
+    const mavlink_message_t& message)
+{
+    mavlink_mission_count_t count;
+    mavlink_msg_mission_count_decode(&message, &count);
+
+    if (count.count == 0) {
+        send_ack_and_finish();
+        _timeout_handler.remove(_cookie);
+        return;
+    }
+
+    _timeout_handler.refresh(_cookie);
+    _next_sequence = 0;
+    _step = Step::RequestItem;
+    _retries_done = 0;
+    _expected_count = count.count;
+    request_item();
+}
+
+void MAVLinkMissionTransfer::DownloadWorkItem::process_mission_item_int(
+    const mavlink_message_t& message)
+{
+    _timeout_handler.refresh(_cookie);
+
+    mavlink_mission_item_int_t item_int;
+    mavlink_msg_mission_item_int_decode(&message, &item_int);
+
+    _items.push_back(ItemInt{item_int.seq,
+                             item_int.frame,
+                             item_int.command,
+                             item_int.current,
+                             item_int.autocontinue,
+                             item_int.param1,
+                             item_int.param2,
+                             item_int.param3,
+                             item_int.param4,
+                             item_int.x,
+                             item_int.y,
+                             item_int.z,
+                             item_int.mission_type});
+
+    if (_next_sequence + 1 == _expected_count) {
+        _timeout_handler.remove(_cookie);
+        send_ack_and_finish();
+
+    } else {
+        _next_sequence = item_int.seq + 1;
+        _retries_done = 0;
+        request_item();
+    }
 }
 
 void MAVLinkMissionTransfer::DownloadWorkItem::process_timeout()
 {
-    LogWarn() << "Timeout!";
-    request_list();
+    if (_retries_done >= retries) {
+        callback_and_reset(Result::Timeout);
+        return;
+    }
+
+    switch (_step) {
+        case Step::RequestList:
+            _timeout_handler.add([this]() { process_timeout(); }, timeout_s, &_cookie);
+            request_list();
+            break;
+
+        case Step::RequestItem:
+            _timeout_handler.add([this]() { process_timeout(); }, timeout_s, &_cookie);
+            request_item();
+            break;
+    }
 }
 
 void MAVLinkMissionTransfer::DownloadWorkItem::callback_and_reset(Result result)

--- a/src/core/mavlink_mission_transfer.cpp
+++ b/src/core/mavlink_mission_transfer.cpp
@@ -116,13 +116,13 @@ void MAVLinkMissionTransfer::process_mission_request_int(const mavlink_message_t
         _items[request_int.seq].command,
         _items[request_int.seq].current,
         _items[request_int.seq].autocontinue,
-        1.0f,
-        NAN,
-        -1.0f,
-        0.0f,
-        0,
-        0,
-        NAN,
+        _items[request_int.seq].param1,
+        _items[request_int.seq].param2,
+        _items[request_int.seq].param3,
+        _items[request_int.seq].param4,
+        _items[request_int.seq].x,
+        _items[request_int.seq].y,
+        _items[request_int.seq].z,
         MAV_MISSION_TYPE_MISSION);
     LogWarn() << "sending: " << new_message.msgid;
 

--- a/src/core/mavlink_mission_transfer.cpp
+++ b/src/core/mavlink_mission_transfer.cpp
@@ -229,8 +229,7 @@ void MAVLinkMissionTransfer::UploadWorkItem::send_mission_item()
         _items[_next_sequence].x,
         _items[_next_sequence].y,
         _items[_next_sequence].z,
-        MAV_MISSION_TYPE_MISSION);
-    // TODO: above type lacking test
+        _type);
 
     ++_next_sequence;
 

--- a/src/core/mavlink_mission_transfer.cpp
+++ b/src/core/mavlink_mission_transfer.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "mavlink_mission_transfer.h"
 
 namespace mavsdk {
@@ -8,6 +9,16 @@ void MAVLinkMissionTransfer::upload_items_async(
     if (items.size() == 0) {
         if (callback) {
             callback(Result::NoMissionAvailable);
+        }
+        return;
+    }
+
+    auto first_mission_type = items[0].mission_type;
+
+    if (std::any_of(items.cbegin(), items.cend(), [first_mission_type](const ItemInt& item) {
+            return item.mission_type != first_mission_type; })) {
+        if (callback) {
+            callback(Result::MissionTypeNotConsistent);
         }
         return;
     }

--- a/src/core/mavlink_mission_transfer.cpp
+++ b/src/core/mavlink_mission_transfer.cpp
@@ -34,13 +34,13 @@ void MAVLinkMissionTransfer::upload_items_async(
 
     mavlink_message_t message;
     mavlink_msg_mission_count_pack(
-        0,
-        0,
+        _config.own_system_id,
+        _config.own_component_id,
         &message,
-        0,
-        0,
+        _config.target_system_id,
+        _config.target_component_id,
         items.size(),
-        MAV_MISSION_TYPE_MISSION);
+        first_mission_type);
 
     if (!_sender.send_message(message)) {
         _timeout_handler.remove(cookie);

--- a/src/core/mavlink_mission_transfer.cpp
+++ b/src/core/mavlink_mission_transfer.cpp
@@ -68,7 +68,6 @@ MAVLinkMissionTransfer::WorkItem::WorkItem(
 
 MAVLinkMissionTransfer::WorkItem::~WorkItem() {}
 
-
 bool MAVLinkMissionTransfer::WorkItem::has_started()
 {
     return _started;

--- a/src/core/mavlink_mission_transfer.cpp
+++ b/src/core/mavlink_mission_transfer.cpp
@@ -1,10 +1,33 @@
 #include <algorithm>
 #include "mavlink_mission_transfer.h"
+#include "log.h"
 
 namespace mavsdk {
 
+MAVLinkMissionTransfer::MAVLinkMissionTransfer(
+    Config config,
+    Sender& sender,
+    MAVLinkMessageHandler& message_handler,
+    TimeoutHandler& timeout_handler) :
+    _config(config),
+    _sender(sender),
+    _message_handler(message_handler),
+    _timeout_handler(timeout_handler)
+{
+    _message_handler.register_one(
+        MAVLINK_MSG_ID_MISSION_REQUEST_INT,
+        [this](const mavlink_message_t& message) { process_mission_request_int(message); },
+        this);
+}
+
+MAVLinkMissionTransfer::~MAVLinkMissionTransfer()
+{
+    _message_handler.unregister_all(this);
+    _timeout_handler.remove(_cookie);
+}
+
 void MAVLinkMissionTransfer::upload_items_async(
-        const std::vector<ItemInt> &items, ResultCallback callback)
+    const std::vector<ItemInt>& items, ResultCallback callback)
 {
     if (items.size() == 0) {
         if (callback) {
@@ -13,24 +36,44 @@ void MAVLinkMissionTransfer::upload_items_async(
         return;
     }
 
+    int count = 0;
+    for (const auto& item : items) {
+        if (count++ != item.seq) {
+            if (callback) {
+                callback(Result::WrongSequence);
+            }
+            return;
+        }
+    }
+
+    int num_currents = 0;
+    std::for_each(items.cbegin(), items.cend(), [&num_currents](const ItemInt& item) {
+        num_currents += item.current;
+    });
+    if (num_currents != 1) {
+        if (callback) {
+            callback(Result::CurrentInvalid);
+        }
+        return;
+    }
+
     auto first_mission_type = items[0].mission_type;
 
     if (std::any_of(items.cbegin(), items.cend(), [first_mission_type](const ItemInt& item) {
-            return item.mission_type != first_mission_type; })) {
+            return item.mission_type != first_mission_type;
+        })) {
         if (callback) {
             callback(Result::MissionTypeNotConsistent);
         }
         return;
     }
 
-    void* cookie = nullptr;
+    _callback = callback;
+    _items = items;
 
-    _timeout_handler.add(
-        [this, callback]() {
-            if (callback) {
-                callback(Result::Timeout);
-            }
-        }, timeout_s, &cookie);
+    _timeout_handler.add([this]() { process_timeout(); }, timeout_s, &_cookie);
+
+    _next_sequence_expected = 0;
 
     mavlink_message_t message;
     mavlink_msg_mission_count_pack(
@@ -43,12 +86,61 @@ void MAVLinkMissionTransfer::upload_items_async(
         first_mission_type);
 
     if (!_sender.send_message(message)) {
-        _timeout_handler.remove(cookie);
+        _timeout_handler.remove(_cookie);
         if (callback) {
             callback(Result::ConnectionError);
         }
         return;
     }
+}
+
+void MAVLinkMissionTransfer::process_mission_request_int(const mavlink_message_t& message)
+{
+    mavlink_mission_request_int_t request_int;
+    mavlink_msg_mission_request_int_decode(&message, &request_int);
+
+    if (_next_sequence_expected != request_int.seq) {
+        LogWarn() << "mission_request_int: sequence incorrect";
+        return;
+    }
+
+    mavlink_message_t new_message;
+    mavlink_msg_mission_item_int_pack(
+        _config.own_system_id,
+        _config.own_component_id,
+        &new_message,
+        _config.target_system_id,
+        _config.target_component_id,
+        request_int.seq,
+        _items[request_int.seq].frame,
+        _items[request_int.seq].command,
+        _items[request_int.seq].current,
+        _items[request_int.seq].autocontinue,
+        1.0f,
+        NAN,
+        -1.0f,
+        0.0f,
+        0,
+        0,
+        NAN,
+        MAV_MISSION_TYPE_MISSION);
+    LogWarn() << "sending: " << new_message.msgid;
+
+    if (!_sender.send_message(new_message)) {
+        _timeout_handler.remove(_cookie);
+        if (_callback) {
+            _callback(Result::ConnectionError);
+        }
+        return;
+    }
+}
+
+void MAVLinkMissionTransfer::process_timeout()
+{
+    if (!_callback) {
+        return;
+    }
+    _callback(Result::Timeout);
 }
 
 } // namespace mavsdk

--- a/src/core/mavlink_mission_transfer.cpp
+++ b/src/core/mavlink_mission_transfer.cpp
@@ -5,6 +5,13 @@ namespace mavsdk {
 void MAVLinkMissionTransfer::upload_items_async(
         const std::vector<ItemInt> &items, ResultCallback callback)
 {
+    if (items.size() == 0) {
+        if (callback) {
+            callback(Result::NoMissionAvailable);
+        }
+        return;
+    }
+
     mavlink_message_t message;
     mavlink_msg_mission_count_pack(
         0,
@@ -15,9 +22,12 @@ void MAVLinkMissionTransfer::upload_items_async(
         items.size(),
         MAV_MISSION_TYPE_MISSION);
 
-    _sender.send_message(message);
-
-    (void)callback;
+    if (!_sender.send_message(message)) {
+        if (callback) {
+            callback(Result::ConnectionError);
+        }
+        return;
+    }
 }
 
 } // namespace mavsdk

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -39,24 +39,19 @@ public:
     };
 
     struct ItemInt {
-        uint8_t target_system; /**< @brief System ID. */
-        uint8_t target_component; /**< @brief Component ID. */
-        uint16_t seq; /**< @brief Sequence. */
-        uint8_t frame; /**< @brief The coordinate system of the waypoint. */
-        uint16_t command; /**< @brief The scheduled action for the waypoint. */
-        uint8_t current; /**< @brief false:0, true:1. */
-        uint8_t autocontinue; /**< @brief Autocontinue to next waypoint. */
-        float param1; /**< @brief PARAM1, see MAV_CMD enum. */
-        float param2; /**< @brief PARAM2, see MAV_CMD enum. */
-        float param3; /**< @brief PARAM3, see MAV_CMD enum. */
-        float param4; /**< @brief PARAM4, see MAV_CMD enum. */
-        int32_t x; /**< @brief PARAM5 / local: x position in meters * 1e4, global: latitude in
-                      degrees * 10^7. */
-        int32_t y; /**< @brief PARAM6 / y position: local: x position in meters * 1e4, global:
-                      longitude in degrees *10^7. */
-        float z; /**< @brief PARAM7 / local: Z coordinate, global: altitude (relative or absolute,
-                    depending on frame). */
-        uint8_t mission_type; /**< @brief Mission type. */
+        uint16_t seq;
+        uint8_t frame;
+        uint16_t command;
+        uint8_t current;
+        uint8_t autocontinue;
+        float param1;
+        float param2;
+        float param3;
+        float param4;
+        int32_t x;
+        int32_t y;
+        float z;
+        uint8_t mission_type;
     };
 
     static constexpr double timeout_s = 1.0;

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -74,6 +74,7 @@ public:
 
 private:
     void process_mission_request_int(const mavlink_message_t& message);
+    void process_mission_ack(const mavlink_message_t& message);
     void process_timeout();
 
     Config _config;

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -60,7 +60,6 @@ public:
 
     static constexpr double timeout_s = 1.0;
 
-    using ResultCallback = std::function<void(Result result)>;
 
     MAVLinkMissionTransfer(
         Config config,
@@ -70,7 +69,8 @@ public:
 
     ~MAVLinkMissionTransfer();
 
-    void upload_items_async(const std::vector<ItemInt>& items, ResultCallback callback);
+    using ResultCallback = std::function<void(Result result)>;
+    void upload_items_async(uint8_t type, const std::vector<ItemInt>& items, ResultCallback callback);
 
     // Non-copyable
     MAVLinkMissionTransfer(const MAVLinkMissionTransfer&) = delete;

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -181,6 +181,35 @@ public:
         unsigned _retries_done{0};
     };
 
+    class ClearWorkItem : public WorkItem {
+    public:
+        ClearWorkItem(
+            Sender& sender,
+            MAVLinkMessageHandler& message_handler,
+            TimeoutHandler& timeout_handler,
+            uint8_t type,
+            ResultCallback callback);
+
+        virtual ~ClearWorkItem();
+        void start() override;
+        void cancel() override;
+
+        ClearWorkItem(const ClearWorkItem&) = delete;
+        ClearWorkItem(ClearWorkItem&&) = delete;
+        ClearWorkItem& operator=(const ClearWorkItem&) = delete;
+        ClearWorkItem& operator=(ClearWorkItem&&) = delete;
+
+    private:
+        void send_clear();
+        void process_mission_ack(const mavlink_message_t& message);
+        void process_timeout();
+        void callback_and_reset(Result result);
+
+        ResultCallback _callback{nullptr};
+        void* _cookie{nullptr};
+        unsigned _retries_done{0};
+    };
+
     static constexpr double timeout_s = 0.5;
     static constexpr unsigned retries = 4;
 
@@ -193,6 +222,8 @@ public:
     upload_items_async(uint8_t type, const std::vector<ItemInt>& items, ResultCallback callback);
 
     std::weak_ptr<WorkItem> download_items_async(uint8_t type, ResultAndItemsCallback callback);
+
+    void clear_items_async(uint8_t type, ResultCallback callback);
 
     void do_work();
     bool is_idle();

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -60,7 +60,6 @@ public:
 
     static constexpr double timeout_s = 1.0;
 
-
     MAVLinkMissionTransfer(
         Config config,
         Sender& sender,
@@ -70,7 +69,11 @@ public:
     ~MAVLinkMissionTransfer();
 
     using ResultCallback = std::function<void(Result result)>;
-    void upload_items_async(uint8_t type, const std::vector<ItemInt>& items, ResultCallback callback);
+    void
+    upload_items_async(uint8_t type, const std::vector<ItemInt>& items, ResultCallback callback);
+
+    using ResultAndItemsCallback = std::function<void(Result result, std::vector<ItemInt> items)>;
+    void download_items_async(uint8_t type, ResultAndItemsCallback callback);
 
     // Non-copyable
     MAVLinkMissionTransfer(const MAVLinkMissionTransfer&) = delete;
@@ -90,6 +93,7 @@ private:
     int _next_sequence_expected{-1};
     void* _cookie{nullptr};
     ResultCallback _callback{nullptr};
+    ResultAndItemsCallback _callback_download{nullptr};
     std::vector<ItemInt> _items{};
 };
 

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -1,0 +1,112 @@
+#include <cstdint>
+#include <vector>
+#include "mavlink_include.h"
+
+namespace mavsdk {
+
+class Sender {
+public:
+    virtual ~Sender() = default;
+    virtual bool send_message(const mavlink_message_t& message) = 0;
+};
+
+class FakeSender : public Sender {
+public:
+    virtual ~FakeSender() = default;
+
+    bool send_message(const mavlink_message_t& message) override
+    {
+        if (able_to_send) {
+            _last_message = message;
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    const mavlink_message_t& last_message() const
+    {
+        return _last_message;
+    }
+
+    bool able_to_send {true};
+
+private:
+    mavlink_message_t _last_message {};
+};
+
+class Receiver {
+public:
+    virtual ~Receiver() = default;
+};
+
+class FakeReceiver : public Receiver {
+public:
+    virtual ~FakeReceiver() = default;
+};
+
+class Timeouter {
+public:
+    virtual ~Timeouter() = default;
+
+};
+
+class FakeTimeouter : public Timeouter {
+public:
+    virtual ~FakeTimeouter() = default;
+};
+
+class MAVLinkMissionTransfer {
+public:
+
+    enum class Result {
+        Success,
+        ConnectionError,
+        TooManyMissionItems,
+        Timeout,
+        Unsupported,
+        NoMissionAvailable,
+        Cancelled
+    };
+
+    struct ItemInt {
+        uint8_t target_system; /**< @brief System ID. */
+        uint8_t target_component; /**< @brief Component ID. */
+        uint16_t seq; /**< @brief Sequence. */
+        uint8_t frame; /**< @brief The coordinate system of the waypoint. */
+        uint16_t command; /**< @brief The scheduled action for the waypoint. */
+        uint8_t current; /**< @brief false:0, true:1. */
+        uint8_t autocontinue; /**< @brief Autocontinue to next waypoint. */
+        float param1; /**< @brief PARAM1, see MAV_CMD enum. */
+        float param2; /**< @brief PARAM2, see MAV_CMD enum. */
+        float param3; /**< @brief PARAM3, see MAV_CMD enum. */
+        float param4; /**< @brief PARAM4, see MAV_CMD enum. */
+        int32_t x; /**< @brief PARAM5 / local: x position in meters * 1e4, global: latitude in
+                      degrees * 10^7. */
+        int32_t y; /**< @brief PARAM6 / y position: local: x position in meters * 1e4, global:
+                      longitude in degrees *10^7. */
+        float z; /**< @brief PARAM7 / local: Z coordinate, global: altitude (relative or absolute,
+                    depending on frame). */
+        uint8_t mission_type; /**< @brief Mission type. */
+    };
+
+    using ResultCallback = void(Result result);
+
+    MAVLinkMissionTransfer(Sender& sender, Receiver& receiver, Timeouter& timeouter) :
+        _sender(sender),
+        _receiver(receiver),
+        _timeouter(timeouter)
+    {}
+
+
+    void upload_items_async(const std::vector<ItemInt>& items, ResultCallback callback);
+
+
+private:
+    Sender& _sender;
+    Receiver& _receiver;
+    Timeouter& _timeouter;
+};
+
+
+} // namespace mavsdk

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -15,9 +15,9 @@ namespace mavsdk {
 
 class Sender {
 public:
-    Sender(MAVLinkAddress& own_address, MAVLinkAddress& target_address) :
-        own_address(own_address),
-        target_address(target_address)
+    Sender(MAVLinkAddress& new_own_address, MAVLinkAddress& new_target_address) :
+        own_address(new_own_address),
+        target_address(new_target_address)
     {}
     virtual ~Sender() = default;
     virtual bool send_message(mavlink_message_t& message) = 0;

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -35,7 +35,8 @@ public:
         Timeout,
         Unsupported,
         NoMissionAvailable,
-        Cancelled
+        Cancelled,
+        MissionTypeNotConsistent
     };
 
     struct ItemInt {

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -27,6 +27,12 @@ public:
 
 class MAVLinkMissionTransfer {
 public:
+    struct Config {
+        uint8_t own_system_id;
+        uint8_t own_component_id;
+        uint8_t target_system_id;
+        uint8_t target_component_id;
+    };
 
     enum class Result {
         Success,
@@ -64,7 +70,8 @@ public:
 
     using ResultCallback = std::function<void(Result result)>;
 
-    MAVLinkMissionTransfer(Sender& sender, Receiver& receiver, TimeoutHandler& timeout_handler) :
+    MAVLinkMissionTransfer(Config config, Sender& sender, Receiver& receiver, TimeoutHandler& timeout_handler) :
+        _config(config),
         _sender(sender),
         _receiver(receiver),
         _timeout_handler(timeout_handler)
@@ -75,6 +82,7 @@ public:
 
 
 private:
+    Config _config;
     Sender& _sender;
     Receiver& _receiver;
     TimeoutHandler& _timeout_handler;

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <vector>
 #include "mavlink_address.h"
 #include "mavlink_include.h"
@@ -98,6 +99,7 @@ public:
         uint8_t _type;
         bool _started{false};
         bool _done{false};
+        std::mutex _mutex{};
     };
 
     class UploadWorkItem : public WorkItem {

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -1,4 +1,7 @@
+#pragma once
+
 #include <cstdint>
+#include <functional>
 #include <vector>
 #include "mavlink_include.h"
 
@@ -90,7 +93,7 @@ public:
         uint8_t mission_type; /**< @brief Mission type. */
     };
 
-    using ResultCallback = void(Result result);
+    using ResultCallback = std::function<void(Result result)>;
 
     MAVLinkMissionTransfer(Sender& sender, Receiver& receiver, Timeouter& timeouter) :
         _sender(sender),

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -13,31 +13,6 @@ public:
     virtual bool send_message(const mavlink_message_t& message) = 0;
 };
 
-class FakeSender : public Sender {
-public:
-    virtual ~FakeSender() = default;
-
-    bool send_message(const mavlink_message_t& message) override
-    {
-        if (able_to_send) {
-            _last_message = message;
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    const mavlink_message_t& last_message() const
-    {
-        return _last_message;
-    }
-
-    bool able_to_send {true};
-
-private:
-    mavlink_message_t _last_message {};
-};
-
 class Receiver {
 public:
     virtual ~Receiver() = default;

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -123,6 +123,8 @@ public:
         void send_count();
         void send_mission_item();
         void send_cancel_and_finish();
+
+        void process_mission_request(const mavlink_message_t& message);
         void process_mission_request_int(const mavlink_message_t& message);
         void process_mission_ack(const mavlink_message_t& message);
         void process_timeout();

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -80,6 +80,7 @@ private:
     void process_mission_request_int(const mavlink_message_t& message);
     void process_mission_ack(const mavlink_message_t& message);
     void process_timeout();
+    void callback_and_reset(Result result);
 
     Config _config;
     Sender& _sender;

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -57,6 +57,16 @@ public:
         int32_t y;
         float z;
         uint8_t mission_type;
+
+        bool operator==(const ItemInt& other) const
+        {
+            return (
+                seq == other.seq && frame == other.frame && command == other.command &&
+                current == other.current && autocontinue == other.autocontinue &&
+                param1 == other.param1 && param2 == other.param2 && param3 == other.param3 &&
+                param4 == other.param4 && x == other.x && y == other.y && z == other.z &&
+                mission_type == other.mission_type);
+        }
     };
 
     static constexpr double timeout_s = 0.5;

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -7,6 +7,7 @@
 #include "mavlink_include.h"
 #include "mavlink_message_handler.h"
 #include "timeout_handler.h"
+#include "locked_queue.h"
 
 namespace mavsdk {
 
@@ -75,37 +76,106 @@ public:
     using ResultAndItemsCallback = std::function<void(Result result, std::vector<ItemInt> items)>;
     void download_items_async(uint8_t type, ResultAndItemsCallback callback);
 
+    void do_work();
+
     // Non-copyable
     MAVLinkMissionTransfer(const MAVLinkMissionTransfer&) = delete;
     const MAVLinkMissionTransfer& operator=(const MAVLinkMissionTransfer&) = delete;
 
 private:
-    void request_list();
-    void process_mission_request_int(const mavlink_message_t& message);
-    void process_mission_ack(const mavlink_message_t& message);
-    void process_timeout();
-    void callback_and_reset(Result result);
+    class WorkItem {
+    public:
+        WorkItem(
+            Config config,
+            Sender& sender,
+            MAVLinkMessageHandler& message_handler,
+            TimeoutHandler& timeout_handler,
+            uint8_t type);
+        virtual ~WorkItem();
+        virtual void start() = 0;
+        bool has_started();
+        bool is_done();
+
+        WorkItem(const WorkItem&) = default;
+        WorkItem(WorkItem&&) = default;
+        WorkItem& operator=(const WorkItem&) = default;
+        WorkItem& operator=(WorkItem&&) = default;
+
+    protected:
+        Config _config;
+        Sender& _sender;
+        MAVLinkMessageHandler& _message_handler;
+        TimeoutHandler& _timeout_handler;
+        uint8_t _type;
+        bool _started{false};
+        bool _done{false};
+    };
+
+    class UploadWorkItem : public WorkItem {
+    public:
+        UploadWorkItem(
+            Config config,
+            Sender& sender,
+            MAVLinkMessageHandler& message_handler,
+            TimeoutHandler& timeout_handler,
+            uint8_t type,
+            const std::vector<ItemInt>& items,
+            ResultCallback callback);
+
+        virtual ~UploadWorkItem();
+        void start() override;
+
+        UploadWorkItem(const UploadWorkItem&) = default;
+        UploadWorkItem(UploadWorkItem&&) = default;
+        UploadWorkItem& operator=(const UploadWorkItem&) = default;
+        UploadWorkItem& operator=(UploadWorkItem&&) = default;
+
+    private:
+        void process_mission_request_int(const mavlink_message_t& message);
+        void process_mission_ack(const mavlink_message_t& message);
+        void process_timeout();
+        void callback_and_reset(Result result);
+
+        std::vector<ItemInt> _items{};
+        ResultCallback _callback{nullptr};
+        int _next_sequence_expected{-1};
+        void* _cookie{nullptr};
+    };
+
+    class DownloadWorkItem : public WorkItem {
+    public:
+        DownloadWorkItem(
+            Config config,
+            Sender& sender,
+            MAVLinkMessageHandler& message_handler,
+            TimeoutHandler& timeout_handler,
+            uint8_t type,
+            ResultAndItemsCallback callback);
+
+        virtual ~DownloadWorkItem();
+        void start() override;
+
+        DownloadWorkItem(const DownloadWorkItem&) = default;
+        DownloadWorkItem(DownloadWorkItem&&) = default;
+        DownloadWorkItem& operator=(const DownloadWorkItem&) = default;
+        DownloadWorkItem& operator=(DownloadWorkItem&&) = default;
+
+    private:
+        void request_list();
+        void process_timeout();
+        void callback_and_reset(Result result);
+
+        std::vector<ItemInt> _items{};
+        ResultAndItemsCallback _callback{nullptr};
+        void* _cookie{nullptr};
+    };
 
     Config _config;
     Sender& _sender;
     MAVLinkMessageHandler& _message_handler;
     TimeoutHandler& _timeout_handler;
 
-    enum class Activity {
-        None,
-        Upload,
-        Download,
-    };
-
-    Activity _activity {Activity::None};
-
-    int _next_sequence_expected{-1};
-    void* _cookie{nullptr};
-    ResultCallback _callback{nullptr};
-    std::vector<ItemInt> _items{};
-
-    ResultAndItemsCallback _callback_download{nullptr};
-    uint8_t _type {0};
+    LockedQueue<WorkItem> _work_queue{};
 };
 
 } // namespace mavsdk

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -78,6 +78,7 @@ public:
     void download_items_async(uint8_t type, ResultAndItemsCallback callback);
 
     void do_work();
+    bool is_idle();
 
     // Non-copyable
     MAVLinkMissionTransfer(const MAVLinkMissionTransfer&) = delete;

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -20,8 +20,8 @@ public:
     {}
     virtual ~Sender() = default;
     virtual bool send_message(mavlink_message_t& message) = 0;
-    MAVLinkAddress own_address;
-    MAVLinkAddress target_address;
+    MAVLinkAddress& own_address;
+    MAVLinkAddress& target_address;
 };
 
 class MAVLinkMissionTransfer {

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -28,14 +28,18 @@ public:
     enum class Result {
         Success,
         ConnectionError,
+        Denied,
         TooManyMissionItems,
         Timeout,
         Unsupported,
+        UnsupportedFrame,
         NoMissionAvailable,
         Cancelled,
         MissionTypeNotConsistent,
-        WrongSequence,
+        InvalidSequence,
         CurrentInvalid,
+        ProtocolError,
+        InvalidParam,
     };
 
     struct ItemInt {

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 #include <functional>
 #include <vector>
 #include "mavlink_include.h"
+#include "timeout_handler.h"
 
 namespace mavsdk {
 
@@ -21,17 +23,6 @@ public:
 class FakeReceiver : public Receiver {
 public:
     virtual ~FakeReceiver() = default;
-};
-
-class Timeouter {
-public:
-    virtual ~Timeouter() = default;
-
-};
-
-class FakeTimeouter : public Timeouter {
-public:
-    virtual ~FakeTimeouter() = default;
 };
 
 class MAVLinkMissionTransfer {
@@ -68,12 +59,14 @@ public:
         uint8_t mission_type; /**< @brief Mission type. */
     };
 
+    static constexpr double timeout_s = 1.0;
+
     using ResultCallback = std::function<void(Result result)>;
 
-    MAVLinkMissionTransfer(Sender& sender, Receiver& receiver, Timeouter& timeouter) :
+    MAVLinkMissionTransfer(Sender& sender, Receiver& receiver, TimeoutHandler& timeout_handler) :
         _sender(sender),
         _receiver(receiver),
-        _timeouter(timeouter)
+        _timeout_handler(timeout_handler)
     {}
 
 
@@ -83,7 +76,7 @@ public:
 private:
     Sender& _sender;
     Receiver& _receiver;
-    Timeouter& _timeouter;
+    TimeoutHandler& _timeout_handler;
 };
 
 

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -80,6 +80,7 @@ public:
     const MAVLinkMissionTransfer& operator=(const MAVLinkMissionTransfer&) = delete;
 
 private:
+    void request_list();
     void process_mission_request_int(const mavlink_message_t& message);
     void process_mission_ack(const mavlink_message_t& message);
     void process_timeout();
@@ -90,11 +91,21 @@ private:
     MAVLinkMessageHandler& _message_handler;
     TimeoutHandler& _timeout_handler;
 
+    enum class Activity {
+        None,
+        Upload,
+        Download,
+    };
+
+    Activity _activity {Activity::None};
+
     int _next_sequence_expected{-1};
     void* _cookie{nullptr};
     ResultCallback _callback{nullptr};
-    ResultAndItemsCallback _callback_download{nullptr};
     std::vector<ItemInt> _items{};
+
+    ResultAndItemsCallback _callback_download{nullptr};
+    uint8_t _type {0};
 };
 
 } // namespace mavsdk

--- a/src/core/mavlink_mission_transfer_test.cpp
+++ b/src/core/mavlink_mission_transfer_test.cpp
@@ -16,47 +16,37 @@ using MockSender = NiceMock<mavsdk::testing::MockSender>;
 
 using Result = MAVLinkMissionTransfer::Result;
 
-const static MAVLinkMissionTransfer::Config config {
-    .own_system_id = 42,
-    .own_component_id = 16,
-    .target_system_id = 99,
-    .target_component_id = 101 };
-
+const static MAVLinkMissionTransfer::Config config{.own_system_id = 42,
+                                                   .own_component_id = 16,
+                                                   .target_system_id = 99,
+                                                   .target_component_id = 101};
 
 #define ONCE_ONLY \
     static bool called = false; \
     EXPECT_FALSE(called); \
     called = true;
 
-MAVLinkMissionTransfer::ItemInt make_mission_item()
+MAVLinkMissionTransfer::ItemInt make_item(int type, int sequence)
 {
-    MAVLinkMissionTransfer::ItemInt item;
-    item.mission_type = MAV_MISSION_TYPE_MISSION;
-    return item;
-}
-
-MAVLinkMissionTransfer::ItemInt make_geofence_item()
-{
-    MAVLinkMissionTransfer::ItemInt item;
-    item.mission_type = MAV_MISSION_TYPE_FENCE;
-    return item;
-}
-
-MAVLinkMissionTransfer::ItemInt make_rally_item()
-{
-    MAVLinkMissionTransfer::ItemInt item;
-    item.mission_type = MAV_MISSION_TYPE_RALLY;
+    MAVLinkMissionTransfer::ItemInt item{};
+    item.mission_type = type;
+    item.seq = sequence;
+    if (sequence == 0) {
+        item.current = 1;
+    } else {
+        item.current = 0;
+    }
     return item;
 }
 
 TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutNoItems)
 {
     MockSender mock_sender;
-    FakeReceiver fake_receiver;
+    MAVLinkMessageHandler message_handler;
     FakeTime time;
     TimeoutHandler timeout_handler(time);
 
-    MAVLinkMissionTransfer mmt(config, mock_sender, fake_receiver, timeout_handler);
+    MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
     std::vector<MAVLinkMissionTransfer::ItemInt> items;
 
@@ -72,19 +62,44 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutNoItems)
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 }
 
-TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutInconsistentMissionTypes)
+TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutWrongSequence)
 {
     MockSender mock_sender;
-    FakeReceiver fake_receiver;
+    MAVLinkMessageHandler message_handler;
     FakeTime time;
     TimeoutHandler timeout_handler(time);
 
-    MAVLinkMissionTransfer mmt(config, mock_sender, fake_receiver, timeout_handler);
+    MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
     std::vector<MAVLinkMissionTransfer::ItemInt> items;
-    items.push_back(make_mission_item());
-    items.push_back(make_geofence_item());
-    items.push_back(make_mission_item());
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 2));
+
+    std::promise<void> prom;
+    auto fut = prom.get_future();
+
+    mmt.upload_items_async(items, [&prom](Result result) {
+        EXPECT_EQ(result, Result::WrongSequence);
+        ONCE_ONLY;
+        prom.set_value();
+    });
+
+    EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+}
+
+TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutInconsistentMissionTypes)
+{
+    MockSender mock_sender;
+    MAVLinkMessageHandler message_handler;
+    FakeTime time;
+    TimeoutHandler timeout_handler(time);
+
+    MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
+
+    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_FENCE, 1));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 2));
 
     std::promise<void> prom;
     auto fut = prom.get_future();
@@ -98,42 +113,101 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutInconsistentMissionTy
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 }
 
-TEST(MAVLinkMissionTransfer, UploadMissionDoesNotCrashIfCallbackIsNull)
+TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutNoCurrent)
 {
     MockSender mock_sender;
-    FakeReceiver fake_receiver;
+    MAVLinkMessageHandler message_handler;
     FakeTime time;
     TimeoutHandler timeout_handler(time);
 
-    MAVLinkMissionTransfer mmt(config, mock_sender, fake_receiver, timeout_handler);
+    MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
-    ON_CALL(mock_sender, send_message(_))
-        .WillByDefault(Return(false));
+    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 2));
+    // Remove the current flag again.
+    items[0].current = 0;
 
+    std::promise<void> prom;
+    auto fut = prom.get_future();
+
+    mmt.upload_items_async(items, [&prom](Result result) {
+        EXPECT_EQ(result, Result::CurrentInvalid);
+        ONCE_ONLY;
+        prom.set_value();
+    });
+
+    EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+}
+
+TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutTwoCurrents)
+{
+    MockSender mock_sender;
+    MAVLinkMessageHandler message_handler;
+    FakeTime time;
+    TimeoutHandler timeout_handler(time);
+
+    MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
+
+    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 2));
+    // Add another current.
+    items[1].current = 1;
+
+    std::promise<void> prom;
+    auto fut = prom.get_future();
+
+    mmt.upload_items_async(items, [&prom](Result result) {
+        EXPECT_EQ(result, Result::CurrentInvalid);
+        ONCE_ONLY;
+        prom.set_value();
+    });
+
+    EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+}
+
+TEST(MAVLinkMissionTransfer, UploadMissionDoesNotCrashIfCallbackIsNull)
+{
+    MockSender mock_sender;
+    MAVLinkMessageHandler message_handler;
+    FakeTime time;
+    TimeoutHandler timeout_handler(time);
+
+    MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
+
+    ON_CALL(mock_sender, send_message(_)).WillByDefault(Return(false));
+
+    // Catch the empty case
     std::vector<MAVLinkMissionTransfer::ItemInt> items;
     mmt.upload_items_async(items, nullptr);
 
-    items.push_back(make_mission_item());
-    items.push_back(make_mission_item());
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
 
+    mmt.upload_items_async(items, nullptr);
+
+    // Catch the WrongSequence case as well.
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 3));
     mmt.upload_items_async(items, nullptr);
 }
 
 TEST(MAVLinkMissionTransfer, UploadMissionReturnsConnectionErrorWhenSendMessageFails)
 {
     MockSender mock_sender;
-    FakeReceiver fake_receiver;
+    MAVLinkMessageHandler message_handler;
     FakeTime time;
     TimeoutHandler timeout_handler(time);
 
-    MAVLinkMissionTransfer mmt(config, mock_sender, fake_receiver, timeout_handler);
+    MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
-    ON_CALL(mock_sender, send_message(_))
-        .WillByDefault(Return(false));
+    ON_CALL(mock_sender, send_message(_)).WillByDefault(Return(false));
 
     std::vector<MAVLinkMissionTransfer::ItemInt> items;
-    items.push_back(make_mission_item());
-    items.push_back(make_mission_item());
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
 
     std::promise<void> prom;
     auto fut = prom.get_future();
@@ -147,42 +221,39 @@ TEST(MAVLinkMissionTransfer, UploadMissionReturnsConnectionErrorWhenSendMessageF
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     // We want to be sure a timeout is not still triggered later.
-    time.sleep_for(
-        std::chrono::milliseconds(
-            static_cast<int>(MAVLinkMissionTransfer::timeout_s * 1.1) * 1000));
+    time.sleep_for(std::chrono::milliseconds(
+        static_cast<int>(MAVLinkMissionTransfer::timeout_s * 1.1) * 1000));
     timeout_handler.run_once();
 }
 
 TEST(MAVLinkMissionTransfer, UploadMissionSendsCount)
 {
     MockSender mock_sender;
-    FakeReceiver fake_receiver;
+    MAVLinkMessageHandler message_handler;
     FakeTime time;
     TimeoutHandler timeout_handler(time);
 
-    MAVLinkMissionTransfer mmt(config, mock_sender, fake_receiver, timeout_handler);
+    MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
     std::vector<MAVLinkMissionTransfer::ItemInt> items;
-    items.push_back(make_geofence_item());
-    items.push_back(make_geofence_item());
+    items.push_back(make_item(MAV_MISSION_TYPE_FENCE, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_FENCE, 1));
 
-    ON_CALL(mock_sender, send_message(_))
-        .WillByDefault(Return(true));
+    ON_CALL(mock_sender, send_message(_)).WillByDefault(Return(true));
 
-    EXPECT_CALL(mock_sender, send_message(Truly(
-                    [&items](const mavlink_message_t& message) {
+    EXPECT_CALL(mock_sender, send_message(Truly([&items](const mavlink_message_t& message) {
+                    mavlink_mission_count_t mission_count;
+                    mavlink_msg_mission_count_decode(&message, &mission_count);
 
-        mavlink_mission_count_t mission_count;
-        mavlink_msg_mission_count_decode(&message, &mission_count);
-
-        return (message.msgid == MAVLINK_MSG_ID_MISSION_COUNT &&
-                message.sysid == config.own_system_id &&
-                message.compid == config.own_component_id &&
-                mission_count.target_system == config.target_system_id &&
-                mission_count.target_component == config.target_component_id &&
-                mission_count.count == items.size() &&
-                mission_count.mission_type == items[0].mission_type);
-    })));
+                    return (
+                        message.msgid == MAVLINK_MSG_ID_MISSION_COUNT &&
+                        message.sysid == config.own_system_id &&
+                        message.compid == config.own_component_id &&
+                        mission_count.target_system == config.target_system_id &&
+                        mission_count.target_component == config.target_component_id &&
+                        mission_count.count == items.size() &&
+                        mission_count.mission_type == items[0].mission_type);
+                })));
 
     mmt.upload_items_async(items, [](Result result) {
         UNUSED(result);
@@ -193,18 +264,17 @@ TEST(MAVLinkMissionTransfer, UploadMissionSendsCount)
 TEST(MAVLinkMissionTransfer, UploadMissionTimeoutAfterSendCount)
 {
     MockSender mock_sender;
-    FakeReceiver fake_receiver;
+    MAVLinkMessageHandler message_handler;
     FakeTime time;
     TimeoutHandler timeout_handler(time);
 
-    MAVLinkMissionTransfer mmt(config, mock_sender, fake_receiver, timeout_handler);
+    MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
     std::vector<MAVLinkMissionTransfer::ItemInt> items;
-    items.push_back(make_mission_item());
-    items.push_back(make_mission_item());
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
 
-    ON_CALL(mock_sender, send_message(_))
-        .WillByDefault(Return(true));
+    ON_CALL(mock_sender, send_message(_)).WillByDefault(Return(true));
 
     std::promise<void> prom;
     auto fut = prom.get_future();
@@ -217,10 +287,75 @@ TEST(MAVLinkMissionTransfer, UploadMissionTimeoutAfterSendCount)
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(0)), std::future_status::timeout);
 
-    time.sleep_for(
-        std::chrono::milliseconds(
-            static_cast<int>(MAVLinkMissionTransfer::timeout_s * 1.1) * 1000));
+    time.sleep_for(std::chrono::milliseconds(
+        static_cast<int>(MAVLinkMissionTransfer::timeout_s * 1.1) * 1000));
     timeout_handler.run_once();
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+}
+
+mavlink_message_t make_mission_item_request(int sequence)
+{
+    mavlink_message_t message;
+    mavlink_msg_mission_request_int_pack(
+        config.own_system_id,
+        config.own_component_id,
+        &message,
+        config.target_system_id,
+        config.target_component_id,
+        sequence,
+        MAV_MISSION_TYPE_MISSION);
+    return message;
+}
+
+TEST(MAVLinkMissionTransfer, UploadMissionSendsMissionItems)
+{
+    MockSender mock_sender;
+    MAVLinkMessageHandler message_handler;
+    FakeTime time;
+    TimeoutHandler timeout_handler(time);
+
+    MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
+
+    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
+
+    ON_CALL(mock_sender, send_message(_)).WillByDefault(Return(true));
+
+    std::promise<void> prom;
+    auto fut = prom.get_future();
+
+    mmt.upload_items_async(items, [&prom](Result result) {
+        EXPECT_EQ(result, Result::Success);
+        ONCE_ONLY;
+        prom.set_value();
+    });
+
+    EXPECT_CALL(mock_sender, send_message(Truly([&items](const mavlink_message_t& message) {
+                    mavlink_mission_item_int_t mission_item_int;
+                    mavlink_msg_mission_item_int_decode(&message, &mission_item_int);
+
+                    return (
+                        message.msgid == MAVLINK_MSG_ID_MISSION_ITEM_INT &&
+                        message.sysid == config.own_system_id &&
+                        message.compid == config.own_component_id &&
+                        mission_item_int.target_system == config.target_system_id &&
+                        mission_item_int.target_component == config.target_component_id &&
+                        mission_item_int.seq == 0 &&
+                        mission_item_int.mission_type == items[0].mission_type &&
+                        mission_item_int.frame == items[0].frame &&
+                        mission_item_int.command == items[0].command);
+                })));
+
+    message_handler.process_message(make_mission_item_request(0));
+
+    // EXPECT_EQ(fut.wait_for(std::chrono::seconds(0)), std::future_status::timeout);
+
+    // time.sleep_for(
+    //    std::chrono::milliseconds(
+    //        static_cast<int>(MAVLinkMissionTransfer::timeout_s * 1.1) * 1000));
+    // timeout_handler.run_once();
+
+    // EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 }

--- a/src/core/mavlink_mission_transfer_test.cpp
+++ b/src/core/mavlink_mission_transfer_test.cpp
@@ -1,8 +1,17 @@
+#include <chrono>
+#include <future>
 #include <gtest/gtest.h>
-#include "mavlink_mission_transfer.h"
+
 #include "global_include.h"
+#include "mavlink_mission_transfer.h"
+#include "mocks/sender_mock.h"
 
 using namespace mavsdk;
+
+using ::testing::_;
+using ::testing::NiceMock;
+using ::testing::Return;
+using MockSender = NiceMock<mavsdk::testing::MockSender>;
 
 using Result = MAVLinkMissionTransfer::Result;
 
@@ -11,31 +20,79 @@ using Result = MAVLinkMissionTransfer::Result;
     EXPECT_FALSE(called); \
     called = true;
 
-
 MAVLinkMissionTransfer::ItemInt make_item()
 {
     MAVLinkMissionTransfer::ItemInt item;
     return item;
 }
 
-TEST(MAVLinkMissionTransfer, UploadMissionUnableToSend)
+TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutNoItems)
 {
-    FakeSender fake_sender;
+    MockSender mock_sender;
     FakeReceiver fake_receiver;
     FakeTimeouter fake_timeouter;
 
-    MAVLinkMissionTransfer mmt(fake_sender, fake_receiver, fake_timeouter);
+    MAVLinkMissionTransfer mmt(mock_sender, fake_receiver, fake_timeouter);
+
+    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+
+    std::promise<void> prom;
+    auto fut = prom.get_future();
+
+    mmt.upload_items_async(items, [&prom](Result result) {
+        EXPECT_EQ(result, Result::NoMissionAvailable);
+        ONCE_ONLY;
+        prom.set_value();
+    });
+
+    EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+}
+
+TEST(MAVLinkMissionTransfer, UploadMissionDoesNotCrashIfCallbackIsNull)
+{
+    MockSender mock_sender;
+    FakeReceiver fake_receiver;
+    FakeTimeouter fake_timeouter;
+
+    MAVLinkMissionTransfer mmt(mock_sender, fake_receiver, fake_timeouter);
+
+    ON_CALL(mock_sender, send_message(_))
+        .WillByDefault(Return(false));
+
+    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    mmt.upload_items_async(items, nullptr);
+
+    items.push_back(make_item());
+    items.push_back(make_item());
+
+    mmt.upload_items_async(items, nullptr);
+}
+
+TEST(MAVLinkMissionTransfer, UploadMissionReturnsConnectionErrorWhenSendMessageFails)
+{
+    MockSender mock_sender;
+    FakeReceiver fake_receiver;
+    FakeTimeouter fake_timeouter;
+
+    MAVLinkMissionTransfer mmt(mock_sender, fake_receiver, fake_timeouter);
+
+    ON_CALL(mock_sender, send_message(_))
+        .WillByDefault(Return(false));
 
     std::vector<MAVLinkMissionTransfer::ItemInt> items;
     items.push_back(make_item());
     items.push_back(make_item());
 
-    fake_sender.able_to_send = false;
+    std::promise<void> prom;
+    auto fut = prom.get_future();
 
-    mmt.upload_items_async(items, [](Result result) {
+    mmt.upload_items_async(items, [&prom](Result result) {
         EXPECT_EQ(result, Result::ConnectionError);
         ONCE_ONLY;
+        prom.set_value();
     });
+
+    EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 }
 
 TEST(MAVLinkMissionTransfer, UploadMissionSendsCount)

--- a/src/core/mavlink_mission_transfer_test.cpp
+++ b/src/core/mavlink_mission_transfer_test.cpp
@@ -17,10 +17,7 @@ using MockSender = NiceMock<mavsdk::testing::MockSender>;
 using Result = MAVLinkMissionTransfer::Result;
 using ItemInt = MAVLinkMissionTransfer::ItemInt;
 
-const static MAVLinkMissionTransfer::Config config{.own_system_id = 42,
-                                                   .own_component_id = 16,
-                                                   .target_system_id = 99,
-                                                   .target_component_id = 101};
+static MAVLinkMissionTransfer::Config config {42, 16, 99, 101};
 
 #define ONCE_ONLY \
     static bool called = false; \
@@ -29,21 +26,22 @@ const static MAVLinkMissionTransfer::Config config{.own_system_id = 42,
 
 ItemInt make_item(uint8_t type, uint16_t sequence)
 {
-    ItemInt item{
-        .seq = sequence,
-        .frame = MAV_FRAME_MISSION,
-        .command = MAV_CMD_NAV_WAYPOINT,
-        .current = uint8_t(sequence == 0 ? 1 : 0),
-        .autocontinue = 1,
-        .param1 = 1.0f,
-        .param2 = 2.0f,
-        .param3 = 3.0f,
-        .param4 = 4.0f,
-        .x = 5,
-        .y = 6,
-        .z = 7.0f,
-        .mission_type = type,
-    };
+    ItemInt item;
+
+    item.seq = sequence;
+    item.frame = MAV_FRAME_MISSION;
+    item.command = MAV_CMD_NAV_WAYPOINT;
+    item.current = uint8_t(sequence == 0 ? 1 : 0);
+    item.autocontinue = 1;
+    item.param1 = 1.0f;
+    item.param2 = 2.0f;
+    item.param3 = 3.0f;
+    item.param4 = 4.0f;
+    item.x = 5;
+    item.y = 6;
+    item.z = 7.0f;
+    item.mission_type = type;
+
     return item;
 }
 

--- a/src/core/mavlink_mission_transfer_test.cpp
+++ b/src/core/mavlink_mission_transfer_test.cpp
@@ -26,16 +26,23 @@ const static MAVLinkMissionTransfer::Config config{.own_system_id = 42,
     EXPECT_FALSE(called); \
     called = true;
 
-MAVLinkMissionTransfer::ItemInt make_item(int type, int sequence)
+MAVLinkMissionTransfer::ItemInt make_item(uint8_t type, uint16_t sequence)
 {
-    MAVLinkMissionTransfer::ItemInt item{};
-    item.mission_type = type;
-    item.seq = sequence;
-    if (sequence == 0) {
-        item.current = 1;
-    } else {
-        item.current = 0;
-    }
+    MAVLinkMissionTransfer::ItemInt item{
+        .seq = sequence,
+        .frame = MAV_FRAME_MISSION,
+        .command = MAV_CMD_NAV_WAYPOINT,
+        .current = uint8_t(sequence == 0 ? 1 : 0),
+        .autocontinue = 1,
+        .param1 = 1.0f,
+        .param2 = 2.0f,
+        .param3 = 3.0f,
+        .param4 = 4.0f,
+        .x = 5,
+        .y = 6,
+        .z = 7.0f,
+        .mission_type = type,
+    };
     return item;
 }
 
@@ -342,10 +349,19 @@ TEST(MAVLinkMissionTransfer, UploadMissionSendsMissionItems)
                         message.compid == config.own_component_id &&
                         mission_item_int.target_system == config.target_system_id &&
                         mission_item_int.target_component == config.target_component_id &&
-                        mission_item_int.seq == 0 &&
-                        mission_item_int.mission_type == items[0].mission_type &&
+                        mission_item_int.seq == 0 && // style
                         mission_item_int.frame == items[0].frame &&
-                        mission_item_int.command == items[0].command);
+                        mission_item_int.command == items[0].command &&
+                        mission_item_int.current == items[0].current &&
+                        mission_item_int.autocontinue == items[0].autocontinue &&
+                        mission_item_int.param1 == items[0].param1 &&
+                        mission_item_int.param2 == items[0].param2 &&
+                        mission_item_int.param3 == items[0].param3 &&
+                        mission_item_int.param4 == items[0].param4 &&
+                        mission_item_int.x == items[0].x && // style
+                        mission_item_int.y == items[0].y && // style
+                        mission_item_int.z == items[0].z &&
+                        mission_item_int.mission_type == items[0].mission_type);
                 })));
 
     message_handler.process_message(make_mission_item_request(0));

--- a/src/core/mavlink_mission_transfer_test.cpp
+++ b/src/core/mavlink_mission_transfer_test.cpp
@@ -67,6 +67,9 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutNoItems)
     mmt.do_work();
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }
 
 TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutWrongSequence)
@@ -93,6 +96,9 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutWrongSequence)
     mmt.do_work();
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }
 
 TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutInconsistentMissionTypesInAPI)
@@ -120,6 +126,9 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutInconsistentMissionTy
     mmt.do_work();
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }
 
 TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutInconsistentMissionTypesInItems)
@@ -147,6 +156,9 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutInconsistentMissionTy
     mmt.do_work();
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }
 
 TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutNoCurrent)
@@ -176,6 +188,9 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutNoCurrent)
     mmt.do_work();
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }
 
 TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutTwoCurrents)
@@ -205,6 +220,9 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutTwoCurrents)
     mmt.do_work();
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }
 
 TEST(MAVLinkMissionTransfer, UploadMissionDoesNotCrashIfCallbackIsNull)
@@ -233,6 +251,9 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesNotCrashIfCallbackIsNull)
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 3));
     mmt.upload_items_async(MAV_MISSION_TYPE_MISSION, items, nullptr);
     mmt.do_work();
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }
 
 TEST(MAVLinkMissionTransfer, UploadMissionReturnsConnectionErrorWhenSendMessageFails)
@@ -266,6 +287,9 @@ TEST(MAVLinkMissionTransfer, UploadMissionReturnsConnectionErrorWhenSendMessageF
     time.sleep_for(std::chrono::milliseconds(
         static_cast<int>(MAVLinkMissionTransfer::timeout_s * 1.1 * 1000.)));
     timeout_handler.run_once();
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }
 
 bool is_correct_mission_send_count(uint8_t type, unsigned count, const mavlink_message_t& message)
@@ -488,6 +512,9 @@ TEST(MAVLinkMissionTransfer, UploadMissionSendsMissionItems)
     time.sleep_for(std::chrono::milliseconds(
         static_cast<int>(MAVLinkMissionTransfer::timeout_s * 1.1 * 1000.)));
     timeout_handler.run_once();
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }
 
 TEST(MAVLinkMissionTransfer, UploadMissionResendsMissionItems)
@@ -539,6 +566,9 @@ TEST(MAVLinkMissionTransfer, UploadMissionResendsMissionItems)
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }
 
 TEST(MAVLinkMissionTransfer, UploadMissionResendsMissionItemsButGivesUpAfterSomeRetries)
@@ -581,6 +611,9 @@ TEST(MAVLinkMissionTransfer, UploadMissionResendsMissionItemsButGivesUpAfterSome
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }
 
 TEST(MAVLinkMissionTransfer, UploadMissionAckArrivesTooEarly)
@@ -618,6 +651,9 @@ TEST(MAVLinkMissionTransfer, UploadMissionAckArrivesTooEarly)
     message_handler.process_message(make_mission_ack(MAV_MISSION_ACCEPTED));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }
 
 TEST(MAVLinkMissionTransfer, UploadMissionNacksAreHandled)
@@ -673,6 +709,9 @@ TEST(MAVLinkMissionTransfer, UploadMissionNacksAreHandled)
         message_handler.process_message(make_mission_ack(nack_case.first));
 
         EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+        mmt.do_work();
+        EXPECT_TRUE(mmt.is_idle());
     }
 }
 
@@ -737,6 +776,9 @@ TEST(MAVLinkMissionTransfer, UploadMissionTimeoutNotTriggeredDuringTransfer)
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }
 
 TEST(MAVLinkMissionTransfer, UploadMissionTimeoutAfterSendMissionItem)
@@ -778,6 +820,9 @@ TEST(MAVLinkMissionTransfer, UploadMissionTimeoutAfterSendMissionItem)
 
     // Ignore later (wrong) ack.
     message_handler.process_message(make_mission_ack(MAV_MISSION_ACCEPTED));
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }
 
 TEST(MAVLinkMissionTransfer, UploadMissionDoesNotCrashOnRandomMessages)
@@ -796,6 +841,9 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesNotCrashOnRandomMessages)
     time.sleep_for(std::chrono::milliseconds(
         static_cast<int>(MAVLinkMissionTransfer::timeout_s * 1.1 * 1000.)));
     timeout_handler.run_once();
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }
 
 TEST(MAVLinkMissionTransfer, DownloadMissionSendsRequestList)
@@ -912,6 +960,9 @@ TEST(MAVLinkMissionTransfer, DownloadMissionResendsRequestListButGivesUpAfterSom
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }
 
 bool is_correct_mission_request_int(
@@ -1016,6 +1067,9 @@ TEST(MAVLinkMissionTransfer, DownloadMissionResendsMissionRequestsAndTimesOutEve
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }
 
 bool is_correct_mission_ack(uint8_t type, uint8_t result, const mavlink_message_t& message)
@@ -1110,6 +1164,9 @@ TEST(MAVLinkMissionTransfer, DownloadMissionSendsAllMissionRequestsAndAck)
     message_handler.process_message(make_mission_item(items, 2));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }
 
 TEST(MAVLinkMissionTransfer, DownloadMissionResendsRequestItemAgainForSecondItem)
@@ -1167,6 +1224,9 @@ TEST(MAVLinkMissionTransfer, DownloadMissionResendsRequestItemAgainForSecondItem
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }
 
 TEST(MAVLinkMissionTransfer, DownloadMissionEmptyList)
@@ -1203,6 +1263,9 @@ TEST(MAVLinkMissionTransfer, DownloadMissionEmptyList)
     time.sleep_for(std::chrono::milliseconds(
         static_cast<int>(MAVLinkMissionTransfer::timeout_s * 1.1 * 1000.)));
     timeout_handler.run_once();
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }
 
 TEST(MAVLinkMissionTransfer, DownloadMissionTimeoutNotTriggeredDuringTransfer)
@@ -1257,4 +1320,7 @@ TEST(MAVLinkMissionTransfer, DownloadMissionTimeoutNotTriggeredDuringTransfer)
     message_handler.process_message(make_mission_item(items, 2));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
 }

--- a/src/core/mavlink_mission_transfer_test.cpp
+++ b/src/core/mavlink_mission_transfer_test.cpp
@@ -15,6 +15,7 @@ using ::testing::Truly;
 using MockSender = NiceMock<mavsdk::testing::MockSender>;
 
 using Result = MAVLinkMissionTransfer::Result;
+using ItemInt = MAVLinkMissionTransfer::ItemInt;
 
 const static MAVLinkMissionTransfer::Config config{.own_system_id = 42,
                                                    .own_component_id = 16,
@@ -26,9 +27,9 @@ const static MAVLinkMissionTransfer::Config config{.own_system_id = 42,
     EXPECT_FALSE(called); \
     called = true;
 
-MAVLinkMissionTransfer::ItemInt make_item(uint8_t type, uint16_t sequence)
+ItemInt make_item(uint8_t type, uint16_t sequence)
 {
-    MAVLinkMissionTransfer::ItemInt item{
+    ItemInt item{
         .seq = sequence,
         .frame = MAV_FRAME_MISSION,
         .command = MAV_CMD_NAV_WAYPOINT,
@@ -55,7 +56,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutNoItems)
 
     MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
-    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    std::vector<ItemInt> items;
 
     std::promise<void> prom;
     auto fut = prom.get_future();
@@ -78,7 +79,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutWrongSequence)
 
     MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
-    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    std::vector<ItemInt> items;
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 2));
 
@@ -103,7 +104,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutInconsistentMissionTy
 
     MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
-    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    std::vector<ItemInt> items;
     items.push_back(make_item(MAV_MISSION_TYPE_FENCE, 0));
     items.push_back(make_item(MAV_MISSION_TYPE_FENCE, 1));
     items.push_back(make_item(MAV_MISSION_TYPE_FENCE, 2));
@@ -129,7 +130,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutInconsistentMissionTy
 
     MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
-    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    std::vector<ItemInt> items;
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
     items.push_back(make_item(MAV_MISSION_TYPE_FENCE, 1));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 2));
@@ -155,7 +156,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutNoCurrent)
 
     MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
-    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    std::vector<ItemInt> items;
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 2));
@@ -183,7 +184,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutTwoCurrents)
 
     MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
-    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    std::vector<ItemInt> items;
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 2));
@@ -214,7 +215,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesNotCrashIfCallbackIsNull)
     ON_CALL(mock_sender, send_message(_)).WillByDefault(Return(false));
 
     // Catch the empty case
-    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    std::vector<ItemInt> items;
     mmt.upload_items_async(MAV_MISSION_TYPE_MISSION, items, nullptr);
 
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
@@ -238,7 +239,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionReturnsConnectionErrorWhenSendMessageF
 
     ON_CALL(mock_sender, send_message(_)).WillByDefault(Return(false));
 
-    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    std::vector<ItemInt> items;
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
 
@@ -268,7 +269,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionSendsCount)
 
     MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
-    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    std::vector<ItemInt> items;
     items.push_back(make_item(MAV_MISSION_TYPE_FENCE, 0));
     items.push_back(make_item(MAV_MISSION_TYPE_FENCE, 1));
 
@@ -303,7 +304,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionTimeoutAfterSendCount)
 
     MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
-    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    std::vector<ItemInt> items;
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
 
@@ -355,7 +356,7 @@ mavlink_message_t make_mission_ack(uint8_t result)
     return message;
 }
 
-bool is_the_same(const MAVLinkMissionTransfer::ItemInt& item, const mavlink_message_t& message)
+bool is_the_same(const ItemInt& item, const mavlink_message_t& message)
 {
     if (message.msgid != MAVLINK_MSG_ID_MISSION_ITEM_INT) {
         return false;
@@ -392,7 +393,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionSendsMissionItems)
 
     MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
-    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    std::vector<ItemInt> items;
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
 
@@ -439,7 +440,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionRetransmitsMissionItems)
 
     MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
-    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    std::vector<ItemInt> items;
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
 
@@ -489,7 +490,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionAckArrivesTooEarly)
 
     MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
-    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    std::vector<ItemInt> items;
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
 
@@ -544,7 +545,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionNacksAreHandled)
 
         MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
-        std::vector<MAVLinkMissionTransfer::ItemInt> items;
+        std::vector<ItemInt> items;
         items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
         items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
 
@@ -580,7 +581,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionTimeoutNotTriggeredDuringTransfer)
 
     MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
-    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    std::vector<ItemInt> items;
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 2));
@@ -642,7 +643,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionTimeoutAfterSendMissionItem)
 
     MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
-    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    std::vector<ItemInt> items;
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
 
@@ -689,4 +690,36 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesNotCrashOnRandomMessages)
     time.sleep_for(std::chrono::milliseconds(
         static_cast<int>(MAVLinkMissionTransfer::timeout_s * 1.1 * 1000.)));
     timeout_handler.run_once();
+}
+
+TEST(MAVLinkMissionTransfer, DownloadMissionSendsRequestList)
+{
+    MockSender mock_sender;
+    MAVLinkMessageHandler message_handler;
+    FakeTime time;
+    TimeoutHandler timeout_handler(time);
+
+    MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
+
+    ON_CALL(mock_sender, send_message(_)).WillByDefault(Return(true));
+
+    EXPECT_CALL(mock_sender, send_message(Truly([](const mavlink_message_t& message) {
+                    mavlink_mission_request_list_t mission_request_list;
+                    mavlink_msg_mission_request_list_decode(&message, &mission_request_list);
+
+                    return (
+                        message.msgid == MAVLINK_MSG_ID_MISSION_REQUEST_LIST &&
+                        message.sysid == config.own_system_id &&
+                        message.compid == config.own_component_id &&
+                        mission_request_list.target_system == config.target_system_id &&
+                        mission_request_list.target_component == config.target_component_id &&
+                        mission_request_list.mission_type == MAV_MISSION_TYPE_MISSION);
+                })));
+
+    mmt.download_items_async(
+        MAV_MISSION_TYPE_MISSION, [](Result result, std::vector<ItemInt> items) {
+            UNUSED(result);
+            UNUSED(items);
+            EXPECT_TRUE(false);
+        });
 }

--- a/src/core/mavlink_mission_transfer_test.cpp
+++ b/src/core/mavlink_mission_transfer_test.cpp
@@ -581,15 +581,15 @@ TEST(MAVLinkMissionTransfer, UploadMissionResendsMissionItemsButGivesUpAfterSome
     MAVLinkMissionTransfer mmt(config, mock_sender, message_handler, timeout_handler);
 
     std::vector<ItemInt> items;
-    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
-    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
+    items.push_back(make_item(MAV_MISSION_TYPE_FENCE, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_FENCE, 1));
 
     ON_CALL(mock_sender, send_message(_)).WillByDefault(Return(true));
 
     std::promise<void> prom;
     auto fut = prom.get_future();
 
-    mmt.upload_items_async(MAV_MISSION_TYPE_MISSION, items, [&prom](Result result) {
+    mmt.upload_items_async(MAV_MISSION_TYPE_FENCE, items, [&prom](Result result) {
         EXPECT_EQ(result, Result::Timeout);
         ONCE_ONLY;
         prom.set_value();

--- a/src/core/mavlink_mission_transfer_test.cpp
+++ b/src/core/mavlink_mission_transfer_test.cpp
@@ -64,6 +64,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutNoItems)
         ONCE_ONLY;
         prom.set_value();
     });
+    mmt.do_work();
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 }
@@ -89,6 +90,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutWrongSequence)
         ONCE_ONLY;
         prom.set_value();
     });
+    mmt.do_work();
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 }
@@ -115,6 +117,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutInconsistentMissionTy
         ONCE_ONLY;
         prom.set_value();
     });
+    mmt.do_work();
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 }
@@ -141,6 +144,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutInconsistentMissionTy
         ONCE_ONLY;
         prom.set_value();
     });
+    mmt.do_work();
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 }
@@ -169,6 +173,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutNoCurrent)
         ONCE_ONLY;
         prom.set_value();
     });
+    mmt.do_work();
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 }
@@ -197,6 +202,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesComplainAboutTwoCurrents)
         ONCE_ONLY;
         prom.set_value();
     });
+    mmt.do_work();
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 }
@@ -215,15 +221,18 @@ TEST(MAVLinkMissionTransfer, UploadMissionDoesNotCrashIfCallbackIsNull)
     // Catch the empty case
     std::vector<ItemInt> items;
     mmt.upload_items_async(MAV_MISSION_TYPE_MISSION, items, nullptr);
+    mmt.do_work();
 
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
 
     mmt.upload_items_async(MAV_MISSION_TYPE_MISSION, items, nullptr);
+    mmt.do_work();
 
     // Catch the WrongSequence case as well.
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 3));
     mmt.upload_items_async(MAV_MISSION_TYPE_MISSION, items, nullptr);
+    mmt.do_work();
 }
 
 TEST(MAVLinkMissionTransfer, UploadMissionReturnsConnectionErrorWhenSendMessageFails)
@@ -249,6 +258,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionReturnsConnectionErrorWhenSendMessageF
         ONCE_ONLY;
         prom.set_value();
     });
+    mmt.do_work();
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
@@ -291,6 +301,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionSendsCount)
         UNUSED(result);
         EXPECT_TRUE(false);
     });
+    mmt.do_work();
 }
 
 TEST(MAVLinkMissionTransfer, UploadMissionTimeoutAfterSendCount)
@@ -316,6 +327,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionTimeoutAfterSendCount)
         ONCE_ONLY;
         prom.set_value();
     });
+    mmt.do_work();
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(0)), std::future_status::timeout);
 
@@ -405,6 +417,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionSendsMissionItems)
         ONCE_ONLY;
         prom.set_value();
     });
+    mmt.do_work();
 
     EXPECT_CALL(mock_sender, send_message(Truly([&items](const mavlink_message_t& message) {
                     return is_the_same_mission_item_int(items[0], message);
@@ -452,6 +465,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionRetransmitsMissionItems)
         ONCE_ONLY;
         prom.set_value();
     });
+    mmt.do_work();
 
     EXPECT_CALL(mock_sender, send_message(Truly([&items](const mavlink_message_t& message) {
                     return is_the_same_mission_item_int(items[0], message);
@@ -502,6 +516,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionAckArrivesTooEarly)
         ONCE_ONLY;
         prom.set_value();
     });
+    mmt.do_work();
 
     EXPECT_CALL(mock_sender, send_message(Truly([&items](const mavlink_message_t& message) {
                     return is_the_same_mission_item_int(items[0], message);
@@ -556,6 +571,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionNacksAreHandled)
             EXPECT_EQ(result, nack_case.second);
             prom.set_value();
         });
+        mmt.do_work();
 
         EXPECT_CALL(mock_sender, send_message(Truly([&items](const mavlink_message_t& message) {
                         return is_the_same_mission_item_int(items[0], message);
@@ -594,6 +610,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionTimeoutNotTriggeredDuringTransfer)
         ONCE_ONLY;
         prom.set_value();
     });
+    mmt.do_work();
 
     EXPECT_CALL(mock_sender, send_message(Truly([&items](const mavlink_message_t& message) {
                     return is_the_same_mission_item_int(items[0], message);
@@ -655,6 +672,7 @@ TEST(MAVLinkMissionTransfer, UploadMissionTimeoutAfterSendMissionItem)
         ONCE_ONLY;
         prom.set_value();
     });
+    mmt.do_work();
 
     EXPECT_CALL(mock_sender, send_message(Truly([&items](const mavlink_message_t& message) {
                     return is_the_same_mission_item_int(items[0], message);
@@ -720,6 +738,7 @@ TEST(MAVLinkMissionTransfer, DownloadMissionSendsRequestList)
             UNUSED(items);
             EXPECT_TRUE(false);
         });
+    mmt.do_work();
 }
 
 bool is_correct_mission_request_list(const mavlink_message_t& message)
@@ -756,6 +775,7 @@ TEST(MAVLinkMissionTransfer, DownloadMissionRetransmitsRequestList)
             UNUSED(items);
             EXPECT_TRUE(false);
         });
+    mmt.do_work();
 
     // We want to be sure a timeout is not still triggered later.
     time.sleep_for(std::chrono::milliseconds(

--- a/src/core/mavlink_mission_transfer_test.cpp
+++ b/src/core/mavlink_mission_transfer_test.cpp
@@ -1,0 +1,80 @@
+#include <gtest/gtest.h>
+#include "mavlink_mission_transfer.h"
+#include "global_include.h"
+
+using namespace mavsdk;
+
+using Result = MAVLinkMissionTransfer::Result;
+
+#define ONCE_ONLY \
+    static bool called = false; \
+    EXPECT_FALSE(called); \
+    called = true;
+
+
+MAVLinkMissionTransfer::ItemInt make_item()
+{
+    MAVLinkMissionTransfer::ItemInt item;
+    return item;
+}
+
+TEST(MAVLinkMissionTransfer, UploadMissionUnableToSend)
+{
+    FakeSender fake_sender;
+    FakeReceiver fake_receiver;
+    FakeTimeouter fake_timeouter;
+
+    MAVLinkMissionTransfer mmt(fake_sender, fake_receiver, fake_timeouter);
+
+    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    items.push_back(make_item());
+    items.push_back(make_item());
+
+    fake_sender.able_to_send = false;
+
+    mmt.upload_items_async(items, [](Result result) {
+        EXPECT_EQ(result, Result::ConnectionError);
+        ONCE_ONLY;
+    });
+}
+
+TEST(MAVLinkMissionTransfer, UploadMissionSendsCount)
+{
+    FakeSender fake_sender;
+    FakeReceiver fake_receiver;
+    FakeTimeouter fake_timeouter;
+
+    MAVLinkMissionTransfer mmt(fake_sender, fake_receiver, fake_timeouter);
+
+    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    items.push_back(make_item());
+    items.push_back(make_item());
+    mmt.upload_items_async(items, [](Result result) {
+        UNUSED(result);
+        EXPECT_TRUE(false);
+    });
+    EXPECT_EQ(fake_sender.last_message().msgid, MAVLINK_MSG_ID_MISSION_COUNT);
+}
+
+
+#if 0
+TEST(MAVLinkMissionTransfer, UploadMissionTimeoutAfterSendCount)
+{
+    FakeSender fake_sender;
+    FakeReceiver fake_receiver;
+    FakeTimeouter fake_timeouter;
+
+    MAVLinkMissionTransfer mmt(fake_sender, fake_receiver, fake_timeouter);
+
+    std::vector<MAVLinkMissionTransfer::ItemInt> items;
+    items.push_back(make_item());
+    items.push_back(make_item());
+    mmt.upload_items_async(items, [](Result result) {
+        EXPECT_EQ(result, Result::Timeout);
+        ONCE_ONLY;
+    });
+
+    fake_timeouter.set_expired();
+}
+
+#endif

--- a/src/core/mavlink_parameters.cpp
+++ b/src/core/mavlink_parameters.cpp
@@ -49,13 +49,13 @@ void MAVLinkParameters::set_param_async(
         return;
     }
 
-    WorkItem new_work{};
-    new_work.type = WorkItem::Type::Set;
-    new_work.set_param_callback = callback;
-    new_work.param_name = name;
-    new_work.param_value = value;
-    new_work.extended = extended;
-    new_work.cookie = cookie;
+    auto new_work = std::make_shared<WorkItem>();
+    new_work->type = WorkItem::Type::Set;
+    new_work->set_param_callback = callback;
+    new_work->param_name = name;
+    new_work->param_value = value;
+    new_work->extended = extended;
+    new_work->cookie = cookie;
 
     _work_queue.push_back(new_work);
 }
@@ -91,13 +91,13 @@ void MAVLinkParameters::get_param_async(
     }
 
     // Otherwise push work onto queue.
-    WorkItem new_work{};
-    new_work.type = WorkItem::Type::Get;
-    new_work.get_param_callback = callback;
-    new_work.param_name = name;
-    new_work.param_value = value_type;
-    new_work.extended = extended;
-    new_work.cookie = cookie;
+    auto new_work = std::make_shared<WorkItem>();
+    new_work->type = WorkItem::Type::Get;
+    new_work->get_param_callback = callback;
+    new_work->param_name = name;
+    new_work->param_value = value_type;
+    new_work->extended = extended;
+    new_work->cookie = cookie;
 
     _work_queue.push_back(new_work);
 }
@@ -125,7 +125,7 @@ void MAVLinkParameters::cancel_all_param(const void* cookie)
     LockedQueue<WorkItem>::Guard work_queue_guard(_work_queue);
 
     for (auto item = _work_queue.begin(); item != _work_queue.end(); /* manual incrementation */) {
-        if (item->get()->cookie == cookie) {
+        if ((*item)->cookie == cookie) {
             item = _work_queue.erase(item);
         } else {
             ++item;

--- a/src/core/mavsdk_impl.cpp
+++ b/src/core/mavsdk_impl.cpp
@@ -245,7 +245,32 @@ void MavsdkImpl::add_connection(std::shared_ptr<Connection> new_connection)
 
 void MavsdkImpl::set_configuration(Mavsdk::Configuration configuration)
 {
-    _configuration = configuration;
+    switch (configuration) {
+        case Mavsdk::Configuration::Autopilot:
+            own_address.system_id = 1;
+            own_address.component_id = MAV_COMP_ID_AUTOPILOT1;
+            break;
+
+        case Mavsdk::Configuration::GroundStation:
+            // FIXME: this is wrong. It should not be equal to a component ID.
+            own_address.system_id = MAV_COMP_ID_MISSIONPLANNER;
+            // FIXME: For now we increment by 1 to avoid conflicts with others.
+            own_address.component_id = MAV_COMP_ID_MISSIONPLANNER + 1;
+            break;
+
+        case Mavsdk::Configuration::CompanionComputer:
+            // FIXME: This should be the same as the drone but we need to
+            // add auto detection for it.
+            own_address.system_id = 1;
+            own_address.component_id = MAV_COMP_ID_UDP_BRIDGE;
+            break;
+
+        default:
+            LogErr() << "Unknown configuration";
+            own_address.system_id = 0;
+            own_address.component_id = 0;
+            break;
+    }
 }
 
 std::vector<uint64_t> MavsdkImpl::get_system_uuids() const
@@ -310,42 +335,14 @@ System& MavsdkImpl::get_system(const uint64_t uuid)
 
 uint8_t MavsdkImpl::get_own_system_id() const
 {
-    switch (_configuration.load()) {
-        case Mavsdk::Configuration::Autopilot:
-            return 1;
-
-        case Mavsdk::Configuration::GroundStation:
-            return MAV_COMP_ID_MISSIONPLANNER;
-
-        case Mavsdk::Configuration::CompanionComputer:
-            // FIXME: This should be the same as the drone but we need to
-            // add auto detection for it.
-            return 1;
-
-        default:
-            LogErr() << "Unknown configuration";
-            return 0;
-    }
+    // TODO: To be deprecated.
+    return own_address.system_id;
 }
 
 uint8_t MavsdkImpl::get_own_component_id() const
 {
-    switch (_configuration.load()) {
-        case Mavsdk::Configuration::Autopilot:
-            return MAV_COMP_ID_AUTOPILOT1;
-
-        case Mavsdk::Configuration::GroundStation:
-            // FIXME: For now we increment by 1 to avoid conflicts with others.
-            return MAV_COMP_ID_MISSIONPLANNER + 1;
-
-        case Mavsdk::Configuration::CompanionComputer:
-            // It's at least a possibility that we are bridging MAVLink traffic.
-            return MAV_COMP_ID_UDP_BRIDGE;
-
-        default:
-            LogErr() << "Unknown configuration";
-            return 0;
-    }
+    // TODO: To be deprecated.
+    return own_address.component_id;
 }
 
 uint8_t MavsdkImpl::get_mav_type() const

--- a/src/core/mavsdk_impl.cpp
+++ b/src/core/mavsdk_impl.cpp
@@ -23,6 +23,7 @@ MavsdkImpl::MavsdkImpl() :
     _on_timeout_callback(nullptr)
 {
     LogInfo() << "MAVSDK version: " << mavsdk_version;
+    set_configuration(Mavsdk::Configuration::GroundStation);
 }
 
 MavsdkImpl::~MavsdkImpl()

--- a/src/core/mavsdk_impl.h
+++ b/src/core/mavsdk_impl.h
@@ -9,6 +9,7 @@
 #include "mavsdk.h"
 #include "system.h"
 #include "mavlink_include.h"
+#include "mavlink_address.h"
 
 namespace mavsdk {
 
@@ -48,6 +49,8 @@ public:
 
     void notify_on_discover(uint64_t uuid);
     void notify_on_timeout(uint64_t uuid);
+
+    MAVLinkAddress own_address{};
 
 private:
     void add_connection(std::shared_ptr<Connection>);

--- a/src/core/mocks/sender_mock.h
+++ b/src/core/mocks/sender_mock.h
@@ -1,0 +1,13 @@
+#include <gmock/gmock.h>
+#include "mavlink_mission_transfer.h"
+
+namespace mavsdk {
+namespace testing {
+
+class MockSender : public Sender {
+public:
+    MOCK_METHOD(bool, send_message, (const mavlink_message_t&), (override)) {};
+};
+
+} // namespace testing
+} // namespace mavsdk

--- a/src/core/mocks/sender_mock.h
+++ b/src/core/mocks/sender_mock.h
@@ -6,7 +6,7 @@ namespace testing {
 
 class MockSender : public Sender {
 public:
-    MOCK_METHOD(bool, send_message, (const mavlink_message_t&), (override)) {};
+    MOCK_METHOD(bool, send_message, (const mavlink_message_t&), (override)){};
 };
 
 } // namespace testing

--- a/src/core/mocks/sender_mock.h
+++ b/src/core/mocks/sender_mock.h
@@ -6,7 +6,10 @@ namespace testing {
 
 class MockSender : public Sender {
 public:
-    MOCK_METHOD(bool, send_message, (const mavlink_message_t&), (override)){};
+    MockSender(MAVLinkAddress& own_address, MAVLinkAddress& target_address) :
+        Sender(own_address, target_address)
+    {}
+    MOCK_METHOD(bool, send_message, (mavlink_message_t&), (override)){};
 };
 
 } // namespace testing

--- a/src/core/mocks/sender_mock.h
+++ b/src/core/mocks/sender_mock.h
@@ -6,8 +6,8 @@ namespace testing {
 
 class MockSender : public Sender {
 public:
-    MockSender(MAVLinkAddress& own_address, MAVLinkAddress& target_address) :
-        Sender(own_address, target_address)
+    MockSender(MAVLinkAddress& new_own_address, MAVLinkAddress& new_target_address) :
+        Sender(new_own_address, new_target_address)
     {}
     MOCK_METHOD(bool, send_message, (mavlink_message_t&), (override)){};
 };

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -275,6 +275,7 @@ void SystemImpl::system_thread()
         _params.do_work();
         _commands.do_work();
         _timesync.do_work();
+        //_mission_transfer.do_work();
 
         if (_connected) {
             // Work fairly fast if we're connected.

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -1093,30 +1093,18 @@ void SystemImpl::send_command_async(
 MAVLinkCommands::Result
 SystemImpl::set_msg_rate(uint16_t message_id, double rate_hz, uint8_t component_id)
 {
-    std::pair<MAVLinkCommands::Result, MAVLinkCommands::CommandLong> result =
-        make_command_msg_rate(message_id, rate_hz, component_id);
-    if (result.first == MAVLinkCommands::Result::SUCCESS) {
-        return send_command(result.second);
-    }
-
-    return result.first;
+    MAVLinkCommands::CommandLong command = make_command_msg_rate(message_id, rate_hz, component_id);
+    return send_command(command);
 }
 
 void SystemImpl::set_msg_rate_async(
     uint16_t message_id, double rate_hz, command_result_callback_t callback, uint8_t component_id)
 {
-    std::pair<MAVLinkCommands::Result, MAVLinkCommands::CommandLong> result =
-        make_command_msg_rate(message_id, rate_hz, component_id);
-    if (result.first == MAVLinkCommands::Result::SUCCESS) {
-        send_command_async(result.second, callback);
-    } else {
-        if (callback) {
-            callback(result.first, NAN);
-        }
-    }
+    MAVLinkCommands::CommandLong command = make_command_msg_rate(message_id, rate_hz, component_id);
+    send_command_async(command, callback);
 }
 
-std::pair<MAVLinkCommands::Result, MAVLinkCommands::CommandLong>
+MAVLinkCommands::CommandLong
 SystemImpl::make_command_msg_rate(uint16_t message_id, double rate_hz, uint8_t component_id)
 {
     MAVLinkCommands::CommandLong command{};
@@ -1136,7 +1124,7 @@ SystemImpl::make_command_msg_rate(uint16_t message_id, double rate_hz, uint8_t c
     command.params.param2 = interval_us;
     command.target_component_id = component_id;
 
-    return std::make_pair<>(MAVLinkCommands::Result::SUCCESS, command);
+    return command;
 }
 
 void SystemImpl::register_plugin(PluginImplBase* plugin_impl)

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -24,7 +24,7 @@ SystemImpl::SystemImpl(MavsdkImpl& parent, uint8_t system_id, uint8_t comp_id, b
     _timesync(*this),
     _timeout_handler(_time),
     _call_every_handler(_time),
-    mission_transfer(*this, _message_handler, _timeout_handler)
+    _mission_transfer(*this, _message_handler, _timeout_handler)
 {
     target_address.system_id = system_id;
     // FIXME: for now use this as a default.
@@ -280,7 +280,7 @@ void SystemImpl::system_thread()
         _params.do_work();
         _commands.do_work();
         _timesync.do_work();
-        //_mission_transfer.do_work();
+        _mission_transfer.do_work();
 
         if (_connected) {
             // Work fairly fast if we're connected.

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -4,6 +4,7 @@
 #include "mavlink_include.h"
 #include "mavlink_parameters.h"
 #include "mavlink_commands.h"
+#include "mavlink_message_handler.h"
 #include "timeout_handler.h"
 #include "call_every_handler.h"
 #include "thread_pool.h"
@@ -258,15 +259,6 @@ private:
     std::mutex _component_discovered_callback_mutex{};
     discover_callback_t _component_discovered_callback{nullptr};
 
-    struct MAVLinkHandlerTableEntry {
-        uint16_t msg_id;
-        mavlink_message_handler_t callback;
-        const void* cookie; // This is the identification to unregister.
-    };
-
-    std::mutex _mavlink_handler_table_mutex{};
-    std::vector<MAVLinkHandlerTableEntry> _mavlink_handler_table{};
-
     std::atomic<uint8_t> _system_id;
 
     uint64_t _uuid{0};
@@ -300,6 +292,8 @@ private:
     MAVLinkParameters _params;
 
     MAVLinkCommands _commands;
+
+    MAVLinkMessageHandler _message_handler{};
 
     Timesync _timesync;
 

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -259,6 +259,9 @@ private:
     std::mutex _component_discovered_callback_mutex{};
     discover_callback_t _component_discovered_callback{nullptr};
 
+    // Needs to be before anything else because they can depend on it.
+    MAVLinkMessageHandler _message_handler{};
+
     std::atomic<uint8_t> _system_id;
 
     uint64_t _uuid{0};
@@ -290,10 +293,7 @@ private:
     static constexpr double _HEARTBEAT_SEND_INTERVAL_S = 1.0;
 
     MAVLinkParameters _params;
-
     MAVLinkCommands _commands;
-
-    MAVLinkMessageHandler _message_handler{};
 
     Timesync _timesync;
 

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -212,6 +212,8 @@ public:
     void send_autopilot_version_request();
     void send_flight_information_request();
 
+    MAVLinkMissionTransfer& mission_transfer() { return _mission_transfer; };
+
     void intercept_incoming_messages(std::function<bool(mavlink_message_t&)> callback);
     void intercept_outgoing_messages(std::function<bool(mavlink_message_t&)> callback);
 
@@ -305,7 +307,7 @@ private:
     TimeoutHandler _timeout_handler;
     CallEveryHandler _call_every_handler;
 
-    MAVLinkMissionTransfer mission_transfer;
+    MAVLinkMissionTransfer _mission_transfer;
 
     std::mutex _plugin_impls_mutex{};
     std::vector<PluginImplBase*> _plugin_impls{};

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -249,8 +249,7 @@ private:
     std::pair<MAVLinkCommands::Result, MAVLinkCommands::CommandLong>
     make_command_flight_mode(FlightMode mode, uint8_t component_id);
 
-    // We use std::pair instead of a std::optional.
-    std::pair<MAVLinkCommands::Result, MAVLinkCommands::CommandLong>
+    MAVLinkCommands::CommandLong
     make_command_msg_rate(uint16_t message_id, double rate_hz, uint8_t component_id);
 
     static void receive_float_param(

--- a/src/integration_tests/mission_cancellation.cpp
+++ b/src/integration_tests/mission_cancellation.cpp
@@ -62,6 +62,9 @@ TEST_F(SitlTest, MissionUploadCancellation)
     EXPECT_EQ(future_status, std::future_status::ready);
     auto future_result = fut.get();
     EXPECT_EQ(future_result, Mission::Result::CANCELLED);
+
+    // FIXME: older PX4 versions don't support CANCEL and need time to timeout.
+    std::this_thread::sleep_for(std::chrono::seconds(5));
 }
 
 TEST_F(SitlTest, MissionDownloadCancellation)
@@ -126,6 +129,9 @@ TEST_F(SitlTest, MissionDownloadCancellation)
         auto future_result = fut.get();
         EXPECT_EQ(future_result, Mission::Result::CANCELLED);
     }
+
+    // FIXME: older PX4 versions don't support CANCEL and need time to timeout.
+    std::this_thread::sleep_for(std::chrono::seconds(5));
 }
 
 std::shared_ptr<MissionItem> add_waypoint(

--- a/src/plugins/action/action_impl.cpp
+++ b/src/plugins/action/action_impl.cpp
@@ -452,7 +452,7 @@ void ActionImpl::command_result_callback(
     if (callback) {
         auto temp_callback = callback;
         _parent->call_user_callback(
-            [this, temp_callback, action_result]() { temp_callback(action_result); });
+            [temp_callback, action_result]() { temp_callback(action_result); });
     }
 }
 

--- a/src/plugins/geofence/geofence_impl.cpp
+++ b/src/plugins/geofence/geofence_impl.cpp
@@ -5,9 +5,7 @@
 
 namespace mavsdk {
 
-GeofenceImpl::GeofenceImpl(System& system) :
-    PluginImplBase(system),
-    _mavlink_geofence_item_messages()
+GeofenceImpl::GeofenceImpl(System& system) : PluginImplBase(system)
 {
     _parent->register_plugin(this);
 }
@@ -17,28 +15,9 @@ GeofenceImpl::~GeofenceImpl()
     _parent->unregister_plugin(this);
 }
 
-void GeofenceImpl::init()
-{
-    using namespace std::placeholders; // for `_1`
+void GeofenceImpl::init() {}
 
-    _parent->register_mavlink_message_handler(
-        MAVLINK_MSG_ID_MISSION_REQUEST,
-        std::bind(&GeofenceImpl::process_mission_request, this, _1),
-        this);
-
-    _parent->register_mavlink_message_handler(
-        MAVLINK_MSG_ID_MISSION_REQUEST_INT,
-        std::bind(&GeofenceImpl::process_mission_request_int, this, _1),
-        this);
-
-    _parent->register_mavlink_message_handler(
-        MAVLINK_MSG_ID_MISSION_ACK, std::bind(&GeofenceImpl::process_mission_ack, this, _1), this);
-}
-
-void GeofenceImpl::deinit()
-{
-    _parent->unregister_all_mavlink_message_handlers(this);
-}
+void GeofenceImpl::deinit() {}
 
 void GeofenceImpl::enable() {}
 
@@ -48,131 +27,24 @@ void GeofenceImpl::send_geofence_async(
     const std::vector<std::shared_ptr<Geofence::Polygon>>& polygons,
     const Geofence::result_callback_t& callback)
 {
-    if (_active) {
-        report_geofence_result(callback, Geofence::Result::BUSY);
-        return;
-    }
+    // We can just create these items on the stack because they get copied
+    // later in the MAVLinkMissionTransfer constructor.
+    const auto items = assemble_items(polygons);
 
-    if (!_parent->does_support_mission_int()) {
-        LogDebug() << "Mission int messages not supported";
-        report_geofence_result(callback, Geofence::Result::ERROR);
-        return;
-    }
-
-    _active = true;
-
-    assemble_mavlink_messages(polygons);
-
-    LogDebug() << "size afterwards is: " << _mavlink_geofence_item_messages.size();
-
-    mavlink_message_t message;
-    mavlink_msg_mission_count_pack(
-        _parent->get_own_system_id(),
-        _parent->get_own_component_id(),
-        &message,
-        _parent->get_system_id(),
-        _parent->get_autopilot_id(),
-        _mavlink_geofence_item_messages.size(),
-        MAV_MISSION_TYPE_FENCE);
-
-    LogDebug() << "About to send " << _mavlink_geofence_item_messages.size() << " geofence items";
-
-    if (!_parent->send_message(message)) {
-        report_geofence_result(callback, Geofence::Result::ERROR);
-    }
-
-    _result_callback = callback;
-
-    _parent->register_timeout_handler(
-        std::bind(&GeofenceImpl::timeout_happened, this), 2.0, &_timeout_cookie);
+    _parent->mission_transfer().upload_items_async(
+        MAV_MISSION_TYPE_FENCE, items, [this, callback](MAVLinkMissionTransfer::Result result) {
+            auto converted_result = convert_result(result);
+            _parent->call_user_callback(
+                [callback, converted_result]() { callback(converted_result); });
+        });
 }
 
-void GeofenceImpl::process_mission_request(const mavlink_message_t& unused)
+std::vector<MAVLinkMissionTransfer::ItemInt>
+GeofenceImpl::assemble_items(const std::vector<std::shared_ptr<Geofence::Polygon>>& polygons)
 {
-    // We only support int, so we nack this and thus tell the autopilot to use int.
-    UNUSED(unused);
+    std::vector<MAVLinkMissionTransfer::ItemInt> items;
 
-    mavlink_message_t message;
-    mavlink_msg_mission_ack_pack(
-        _parent->get_own_system_id(),
-        _parent->get_own_component_id(),
-        &message,
-        _parent->get_system_id(),
-        _parent->get_autopilot_id(),
-        MAV_MISSION_UNSUPPORTED,
-        MAV_MISSION_TYPE_FENCE);
-
-    _parent->send_message(message);
-
-    // Reset the timeout because we're still communicating.
-    _parent->refresh_timeout_handler(this);
-}
-
-void GeofenceImpl::process_mission_request_int(const mavlink_message_t& message)
-{
-    if (!_active) {
-        LogDebug() << "Ignore geofence request, currently inactive";
-        return;
-    }
-
-    mavlink_mission_request_int_t mission_request_int;
-    mavlink_msg_mission_request_int_decode(&message, &mission_request_int);
-
-    if (mission_request_int.target_system != _parent->get_own_system_id() &&
-        mission_request_int.target_component != _parent->get_own_component_id()) {
-        LogDebug() << "Ignore geofence request int that is not for us";
-        return;
-    }
-
-    if (mission_request_int.mission_type != MAV_MISSION_TYPE_FENCE) {
-        LogDebug() << "Ignore mission request that is not a geofence";
-        return;
-    }
-
-    send_geofence_item(mission_request_int.seq);
-
-    // Reset the timeout because we're still communicating.
-    _parent->refresh_timeout_handler(this);
-}
-
-void GeofenceImpl::process_mission_ack(const mavlink_message_t& message)
-{
-    if (!_active) {
-        LogDebug() << "Ignore mission ack because not active";
-        return;
-    }
-
-    mavlink_mission_ack_t mission_ack;
-    mavlink_msg_mission_ack_decode(&message, &mission_ack);
-
-    if (mission_ack.target_system != _parent->get_own_system_id() &&
-        mission_ack.target_component != _parent->get_own_component_id()) {
-        LogDebug() << "Ignore geofence ack that is not for us";
-        return;
-    }
-
-    // We got some response, so it wasn't a timeout and we can remove it.
-    _parent->unregister_timeout_handler(this);
-
-    if (mission_ack.type == MAV_MISSION_ACCEPTED) {
-        report_geofence_result(_result_callback, Geofence::Result::SUCCESS);
-        LogDebug() << "Sucess, done";
-
-    } else if (mission_ack.type == MAV_MISSION_NO_SPACE) {
-        LogDebug() << "Error: too many geofence items: " << int(mission_ack.type);
-        report_geofence_result(_result_callback, Geofence::Result::TOO_MANY_GEOFENCE_ITEMS);
-    } else {
-        LogDebug() << "Error: unknown geofence ack: " << int(mission_ack.type);
-        report_geofence_result(_result_callback, Geofence::Result::ERROR);
-    }
-}
-
-void GeofenceImpl::assemble_mavlink_messages(
-    const std::vector<std::shared_ptr<Geofence::Polygon>>& polygons)
-{
-    // TODO: delete all entries first
-    _mavlink_geofence_item_messages.clear();
-
+    uint16_t sequence = 0;
     for (auto& polygon : polygons) {
         uint16_t command;
         switch (polygon->type) {
@@ -183,64 +55,70 @@ void GeofenceImpl::assemble_mavlink_messages(
                 command = MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION;
                 break;
             default:
-                LogDebug() << "Unknown type";
-                return;
+                LogErr() << "Unknown type";
+                continue;
         }
 
         for (auto& point : polygon->points) {
-            std::shared_ptr<mavlink_message_t> message(new mavlink_message_t());
-            mavlink_msg_mission_item_int_pack(
-                _parent->get_own_system_id(),
-                _parent->get_own_component_id(),
-                message.get(),
-                _parent->get_system_id(),
-                _parent->get_autopilot_id(),
-                _mavlink_geofence_item_messages.size(),
-                MAV_FRAME_GLOBAL_INT,
-                command,
-                0, // current
-                0, // autocontinue
-                float(polygon->points.size()), // vertex count
-                0.0f,
-                0.0f,
-                0.0f,
-                int32_t(std::round(point.latitude_deg * 1e7)),
-                int32_t(std::round(point.longitude_deg * 1e7)),
-                0.0f,
-                MAV_MISSION_TYPE_FENCE);
-            _mavlink_geofence_item_messages.push_back(message);
+            // FIXME: check if these two  make sense.
+            const uint8_t current = (sequence == 0 ? 1 : 0);
+            const uint8_t autocontinue = 0;
+            const float param1 = float(polygon->points.size());
+
+            items.push_back(
+                MAVLinkMissionTransfer::ItemInt{sequence,
+                                                MAV_FRAME_GLOBAL_INT,
+                                                command,
+                                                current,
+                                                autocontinue,
+                                                param1,
+                                                0.0f,
+                                                0.0f,
+                                                0.0f,
+                                                int32_t(std::round(point.latitude_deg * 1e7)),
+                                                int32_t(std::round(point.longitude_deg * 1e7)),
+                                                0.0f,
+                                                MAV_MISSION_TYPE_FENCE});
+            ++sequence;
         }
     }
+    return items;
 }
 
-void GeofenceImpl::timeout_happened()
+Geofence::Result GeofenceImpl::convert_result(MAVLinkMissionTransfer::Result result)
 {
-    LogDebug() << "timeout happened";
-    _active = false;
-
-    report_geofence_result(_result_callback, Geofence::Result::TIMEOUT);
-}
-
-void GeofenceImpl::send_geofence_item(uint16_t seq)
-{
-    LogDebug() << "Send geofence item " << int(seq);
-    if (seq >= _mavlink_geofence_item_messages.size()) {
-        LogDebug() << "Geofence item requested out of bounds.";
-        return;
+    switch (result) {
+        case MAVLinkMissionTransfer::Result::Success:
+            return Geofence::Result::SUCCESS;
+        case MAVLinkMissionTransfer::Result::ConnectionError:
+            return Geofence::Result::ERROR; // FIXME
+        case MAVLinkMissionTransfer::Result::Denied:
+            return Geofence::Result::ERROR; // FIXME
+        case MAVLinkMissionTransfer::Result::TooManyMissionItems:
+            return Geofence::Result::TOO_MANY_GEOFENCE_ITEMS;
+        case MAVLinkMissionTransfer::Result::Timeout:
+            return Geofence::Result::TIMEOUT;
+        case MAVLinkMissionTransfer::Result::Unsupported:
+            return Geofence::Result::ERROR; // FIXME
+        case MAVLinkMissionTransfer::Result::UnsupportedFrame:
+            return Geofence::Result::ERROR; // FIXME
+        case MAVLinkMissionTransfer::Result::NoMissionAvailable:
+            return Geofence::Result::INVALID_ARGUMENT; // FIXME
+        case MAVLinkMissionTransfer::Result::Cancelled:
+            return Geofence::Result::ERROR; // FIXME
+        case MAVLinkMissionTransfer::Result::MissionTypeNotConsistent:
+            return Geofence::Result::INVALID_ARGUMENT; // FIXME
+        case MAVLinkMissionTransfer::Result::InvalidSequence:
+            return Geofence::Result::INVALID_ARGUMENT; // FIXME
+        case MAVLinkMissionTransfer::Result::CurrentInvalid:
+            return Geofence::Result::INVALID_ARGUMENT; // FIXME
+        case MAVLinkMissionTransfer::Result::ProtocolError:
+            return Geofence::Result::ERROR; // FIXME
+        case MAVLinkMissionTransfer::Result::InvalidParam:
+            return Geofence::Result::INVALID_ARGUMENT; // FIXME
+        default:
+            return Geofence::Result::UNKNOWN;
     }
-
-    _parent->send_message(*_mavlink_geofence_item_messages.at(seq));
-}
-
-void GeofenceImpl::report_geofence_result(
-    const Geofence::result_callback_t& callback, Geofence::Result result)
-{
-    if (callback == nullptr) {
-        LogDebug() << "Callback is not set";
-        return;
-    }
-
-    callback(result);
 }
 
 } // namespace mavsdk

--- a/src/plugins/geofence/geofence_impl.h
+++ b/src/plugins/geofence/geofence_impl.h
@@ -31,27 +31,10 @@ public:
     const GeofenceImpl& operator=(const GeofenceImpl&) = delete;
 
 private:
-    void assemble_mavlink_messages(const std::vector<std::shared_ptr<Geofence::Polygon>>& polygons);
+    std::vector<MAVLinkMissionTransfer::ItemInt>
+    assemble_items(const std::vector<std::shared_ptr<Geofence::Polygon>>& polygons);
 
-    void timeout_happened();
-
-    void process_mission_request(const mavlink_message_t& message);
-    void process_mission_request_int(const mavlink_message_t& message);
-    void process_mission_ack(const mavlink_message_t& message);
-    void send_geofence_item(uint16_t seq);
-
-    static void
-    report_geofence_result(const Geofence::result_callback_t& callback, Geofence::Result result);
-
-    void receive_command_result(
-        MAVLinkCommands::Result command_result, const Geofence::result_callback_t& callback);
-
-    Geofence::result_callback_t _result_callback = nullptr;
-
-    std::vector<std::shared_ptr<mavlink_message_t>> _mavlink_geofence_item_messages;
-
-    void* _timeout_cookie{nullptr};
-    std::atomic<bool> _active{false};
+    static Geofence::Result convert_result(MAVLinkMissionTransfer::Result result);
 };
 
 } // namespace mavsdk

--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -618,8 +618,16 @@ Mission::Result MissionImpl::command_result_to_mission_result(MAVLinkCommands::R
 
 void MissionImpl::clear_mission_async(const Mission::result_callback_t& callback)
 {
-    UNUSED(callback);
-    // TODO: implement clear
+    _parent->mission_transfer().clear_items_async(
+        MAV_MISSION_TYPE_MISSION,
+        [this, callback](MAVLinkMissionTransfer::Result result) {
+            auto converted_result = convert_result(result);
+            _parent->call_user_callback([callback, converted_result]() {
+                if (callback) {
+                    callback(converted_result);
+                }
+            });
+        });
 }
 
 void MissionImpl::set_current_mission_item_async(int current, Mission::result_callback_t& callback)

--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -137,6 +137,16 @@ void MissionImpl::upload_mission_cancel()
 void MissionImpl::download_mission_async(
     const Mission::mission_items_and_result_callback_t& callback)
 {
+    if (_mission_data.last_download.lock()) {
+        _parent->call_user_callback([callback]() {
+            if (callback) {
+                std::vector<std::shared_ptr<MissionItem>> empty_items;
+                callback(Mission::Result::BUSY, empty_items);
+            }
+        });
+        return;
+    }
+
     _parent->mission_transfer().download_items_async(
         MAV_MISSION_TYPE_MISSION,
         [this, callback](

--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -147,7 +147,7 @@ void MissionImpl::download_mission_async(
         return;
     }
 
-    _parent->mission_transfer().download_items_async(
+    _mission_data.last_download = _parent->mission_transfer().download_items_async(
         MAV_MISSION_TYPE_MISSION,
         [this, callback](
             MAVLinkMissionTransfer::Result result,

--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -765,7 +765,8 @@ int MissionImpl::current_mission_item() const
 int MissionImpl::total_mission_items() const
 {
     std::lock_guard<std::recursive_mutex> lock(_mission_data.mutex);
-    return static_cast<int>(_mission_data.mavlink_mission_item_to_mission_item_indices.size());
+    return static_cast<int>(
+        _mission_data.mavlink_mission_item_to_mission_item_indices.rbegin()->second + 1);
 }
 
 void MissionImpl::subscribe_progress(Mission::progress_callback_t callback)

--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -619,8 +619,7 @@ Mission::Result MissionImpl::command_result_to_mission_result(MAVLinkCommands::R
 void MissionImpl::clear_mission_async(const Mission::result_callback_t& callback)
 {
     _parent->mission_transfer().clear_items_async(
-        MAV_MISSION_TYPE_MISSION,
-        [this, callback](MAVLinkMissionTransfer::Result result) {
+        MAV_MISSION_TYPE_MISSION, [this, callback](MAVLinkMissionTransfer::Result result) {
             auto converted_result = convert_result(result);
             _parent->call_user_callback([callback, converted_result]() {
                 if (callback) {

--- a/src/plugins/mission_raw/include/plugins/mission_raw/mission_raw.h
+++ b/src/plugins/mission_raw/include/plugins/mission_raw/mission_raw.h
@@ -68,11 +68,9 @@ public:
     static const char* result_str(Result result);
 
     /**
-     * @brief Mission item identical to MAVLink MISSION_ITEM_INT.
+     * @brief Mission item mostly identical to MAVLink MISSION_ITEM_INT.
      */
     struct MavlinkMissionItemInt {
-        uint8_t target_system; /**< @brief System ID. */
-        uint8_t target_component; /**< @brief Component ID. */
         uint16_t seq; /**< @brief Sequence. */
         uint8_t frame; /**< @brief The coordinate system of the waypoint. */
         uint16_t command; /**< @brief The scheduled action for the waypoint. */

--- a/src/plugins/mission_raw/mission_raw_impl.cpp
+++ b/src/plugins/mission_raw/mission_raw_impl.cpp
@@ -1,9 +1,6 @@
 #include "mission_raw_impl.h"
 #include "system.h"
 #include "global_include.h"
-#include <fstream> // for `std::ifstream`
-#include <sstream> // for `std::stringstream`
-#include <cmath>
 
 namespace mavsdk {
 
@@ -25,16 +22,6 @@ void MissionRawImpl::init()
         MAVLINK_MSG_ID_MISSION_ACK,
         std::bind(&MissionRawImpl::process_mission_ack, this, _1),
         this);
-
-    _parent->register_mavlink_message_handler(
-        MAVLINK_MSG_ID_MISSION_COUNT,
-        std::bind(&MissionRawImpl::process_mission_count, this, _1),
-        this);
-
-    _parent->register_mavlink_message_handler(
-        MAVLINK_MSG_ID_MISSION_ITEM_INT,
-        std::bind(&MissionRawImpl::process_mission_item_int, this, _1),
-        this);
 }
 
 void MissionRawImpl::deinit()
@@ -51,7 +38,8 @@ void MissionRawImpl::process_mission_ack(const mavlink_message_t& message)
     mavlink_mission_ack_t mission_ack;
     mavlink_msg_mission_ack_decode(&message, &mission_ack);
 
-    if (mission_ack.type != MAV_MISSION_ACCEPTED) {
+    if (mission_ack.type != MAV_MISSION_ACCEPTED ||
+        mission_ack.mission_type != MAV_MISSION_TYPE_MISSION) {
         return;
     }
 
@@ -65,269 +53,98 @@ void MissionRawImpl::process_mission_ack(const mavlink_message_t& message)
     }
 }
 
+MissionRaw::Result MissionRawImpl::convert_result(MAVLinkMissionTransfer::Result result)
+{
+    switch (result) {
+        case MAVLinkMissionTransfer::Result::Success:
+            return MissionRaw::Result::SUCCESS;
+        case MAVLinkMissionTransfer::Result::ConnectionError:
+            return MissionRaw::Result::ERROR; // FIXME
+        case MAVLinkMissionTransfer::Result::Denied:
+            return MissionRaw::Result::ERROR; // FIXME
+        case MAVLinkMissionTransfer::Result::TooManyMissionItems:
+            return MissionRaw::Result::ERROR; // FIXME
+        case MAVLinkMissionTransfer::Result::Timeout:
+            return MissionRaw::Result::TIMEOUT;
+        case MAVLinkMissionTransfer::Result::Unsupported:
+            return MissionRaw::Result::ERROR; // FIXME
+        case MAVLinkMissionTransfer::Result::UnsupportedFrame:
+            return MissionRaw::Result::ERROR; // FIXME
+        case MAVLinkMissionTransfer::Result::NoMissionAvailable:
+            return MissionRaw::Result::NO_MISSION_AVAILABLE;
+        case MAVLinkMissionTransfer::Result::Cancelled:
+            return MissionRaw::Result::CANCELLED;
+        case MAVLinkMissionTransfer::Result::MissionTypeNotConsistent:
+            return MissionRaw::Result::INVALID_ARGUMENT; // FIXME
+        case MAVLinkMissionTransfer::Result::InvalidSequence:
+            return MissionRaw::Result::INVALID_ARGUMENT; // FIXME
+        case MAVLinkMissionTransfer::Result::CurrentInvalid:
+            return MissionRaw::Result::INVALID_ARGUMENT; // FIXME
+        case MAVLinkMissionTransfer::Result::ProtocolError:
+            return MissionRaw::Result::ERROR; // FIXME
+        case MAVLinkMissionTransfer::Result::InvalidParam:
+            return MissionRaw::Result::INVALID_ARGUMENT; // FIXME
+        default:
+            return MissionRaw::Result::UNKNOWN;
+    }
+}
+
+MissionRaw::MavlinkMissionItemInt
+MissionRawImpl::convert_item(const MAVLinkMissionTransfer::ItemInt& transfer_item)
+{
+    MissionRaw::MavlinkMissionItemInt new_item;
+
+    new_item.seq = transfer_item.seq;
+    new_item.frame = transfer_item.frame;
+    new_item.command = transfer_item.command;
+    new_item.current = transfer_item.current;
+    new_item.autocontinue = transfer_item.autocontinue;
+    new_item.param1 = transfer_item.param1;
+    new_item.param2 = transfer_item.param2;
+    new_item.param3 = transfer_item.param3;
+    new_item.param4 = transfer_item.param4;
+    new_item.x = transfer_item.x;
+    new_item.y = transfer_item.y;
+    new_item.z = transfer_item.z;
+    new_item.mission_type = transfer_item.mission_type;
+
+    return new_item;
+}
+
+std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>>
+MissionRawImpl::convert_items(const std::vector<MAVLinkMissionTransfer::ItemInt>& transfer_items)
+{
+    std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>> new_items;
+    new_items.reserve(transfer_items.size());
+
+    for (const auto& transfer_item : transfer_items) {
+        new_items.push_back(
+            std::make_shared<MissionRaw::MavlinkMissionItemInt>(convert_item(transfer_item)));
+    }
+
+    return new_items;
+}
+
 void MissionRawImpl::download_mission_async(
     const MissionRaw::mission_items_and_result_callback_t& callback)
 {
-    {
-        std::lock_guard<std::mutex> lock(_mission_download.mutex);
-        if (_mission_download.state != MissionDownload::State::NONE) {
-            if (callback) {
-                std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>> empty_vec{};
-                _parent->call_user_callback(
-                    [callback, empty_vec]() { callback(MissionRaw::Result::BUSY, empty_vec); });
-            }
-            return;
-        }
-
-        _mission_download.state = MissionDownload::State::REQUEST_LIST;
-        _mission_download.retries = 0;
-        _mission_download.mavlink_mission_items_downloaded.clear();
-        _mission_download.callback = callback;
-    }
-
-    _parent->register_timeout_handler(
-        std::bind(&MissionRawImpl::do_download_step, this), 0.0, nullptr);
+    _parent->mission_transfer().download_items_async(
+        MAV_MISSION_TYPE_MISSION,
+        [this, callback](
+            MAVLinkMissionTransfer::Result result,
+            std::vector<MAVLinkMissionTransfer::ItemInt> items) {
+            auto converted_result = convert_result(result);
+            auto converted_items = convert_items(items);
+            _parent->call_user_callback([callback, converted_result, converted_items]() {
+                callback(converted_result, converted_items);
+            });
+        });
 }
 
-void MissionRawImpl::do_download_step()
+void MissionRawImpl::download_mission_cancel()
 {
-    std::lock_guard<std::mutex> lock(_mission_download.mutex);
-    switch (_mission_download.state) {
-        case MissionDownload::State::NONE:
-            LogWarn() << "Invalid state: do_download_step and State::NONE";
-            break;
-        case MissionDownload::State::REQUEST_LIST:
-            request_list();
-            break;
-        case MissionDownload::State::REQUEST_ITEM:
-            request_item();
-            break;
-        case MissionDownload::State::SHOULD_ACK:
-            send_ack();
-            break;
-    }
+    // TODO: Implement cancel.
 }
-
-void MissionRawImpl::request_list()
-{
-    // Requires _mission_download.mutex.
-
-    if (_mission_download.retries++ >= 3) {
-        // We tried multiple times without success, let's give up.
-        _mission_download.state = MissionDownload::State::NONE;
-        if (_mission_download.callback) {
-            std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>> empty_vec{};
-            auto callback = _mission_download.callback;
-            _parent->call_user_callback(
-                [callback, empty_vec]() { callback(MissionRaw::Result::TIMEOUT, empty_vec); });
-        }
-        return;
-    }
-
-    // LogDebug() << "Requesting mission list (" << _mission_download.retries << ")";
-
-    mavlink_message_t message;
-    mavlink_msg_mission_request_list_pack(
-        _parent->get_own_system_id(),
-        _parent->get_own_component_id(),
-        &message,
-        _parent->get_system_id(),
-        _parent->get_autopilot_id(),
-        MAV_MISSION_TYPE_MISSION);
-
-    if (!_parent->send_message(message)) {
-        // This is a terrible and unexpected error. Therefore we don't even
-        // retry but just give up.
-        _mission_download.state = MissionDownload::State::NONE;
-        if (_mission_download.callback) {
-            std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>> empty_vec{};
-            auto callback = _mission_download.callback;
-            _parent->call_user_callback(
-                [callback, empty_vec]() { callback(MissionRaw::Result::ERROR, empty_vec); });
-        }
-        return;
-    }
-
-    // We retry the list request and mission item request, so we use the lower timeout.
-    _parent->register_timeout_handler(
-        std::bind(&MissionRawImpl::do_download_step, this), RETRY_TIMEOUT_S, &_timeout_cookie);
-}
-
-void MissionRawImpl::process_mission_count(const mavlink_message_t& message)
-{
-    // LogDebug() << "Received mission count";
-
-    std::lock_guard<std::mutex> lock(_mission_download.mutex);
-    if (_mission_download.state != MissionDownload::State::REQUEST_LIST) {
-        return;
-    }
-
-    mavlink_mission_count_t mission_count;
-    mavlink_msg_mission_count_decode(&message, &mission_count);
-
-    _mission_download.num_mission_items_to_download = mission_count.count;
-    _mission_download.next_mission_item_to_download = 0;
-    _mission_download.retries = 0;
-
-    // We can get rid of the timeout and schedule and do the next step straightaway.
-    _parent->unregister_timeout_handler(_timeout_cookie);
-
-    _mission_download.state = MissionDownload::State::REQUEST_ITEM;
-
-    if (mission_count.count == 0) {
-        _mission_download.state = MissionDownload::State::SHOULD_ACK;
-    }
-
-    // Let's just add this to the queue, this way we don't block the receive thread
-    // and let go of the mutex as well.
-    _parent->register_timeout_handler(
-        std::bind(&MissionRawImpl::do_download_step, this), 0.0, nullptr);
-}
-
-void MissionRawImpl::request_item()
-{
-    // Requires _mission_download.mutex.
-
-    if (_mission_download.retries++ >= 3) {
-        // We tried multiple times without success, let's give up.
-        _mission_download.state = MissionDownload::State::NONE;
-        if (_mission_download.callback) {
-            std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>> empty_vec{};
-            auto callback = _mission_download.callback;
-            _parent->call_user_callback(
-                [callback, empty_vec]() { callback(MissionRaw::Result::TIMEOUT, empty_vec); });
-        }
-        return;
-    }
-
-    // LogDebug() << "Requesting mission item " << _mission_download.next_mission_item_to_download
-    //            << " (" << _mission_download.retries << ")";
-
-    mavlink_message_t message;
-    mavlink_msg_mission_request_int_pack(
-        _parent->get_own_system_id(),
-        _parent->get_own_component_id(),
-        &message,
-        _parent->get_system_id(),
-        _parent->get_autopilot_id(),
-        _mission_download.next_mission_item_to_download,
-        MAV_MISSION_TYPE_MISSION);
-
-    if (!_parent->send_message(message)) {
-        // This is a terrible and unexpected error. Therefore we don't even
-        // retry but just give up.
-        _mission_download.state = MissionDownload::State::NONE;
-        if (_mission_download.callback) {
-            std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>> empty_vec{};
-            auto callback = _mission_download.callback;
-            _parent->call_user_callback(
-                [callback, empty_vec]() { callback(MissionRaw::Result::ERROR, empty_vec); });
-        }
-        return;
-    }
-
-    // We retry the list request and mission item request, so we use the lower timeout.
-    _parent->register_timeout_handler(
-        std::bind(&MissionRawImpl::do_download_step, this), RETRY_TIMEOUT_S, &_timeout_cookie);
-}
-
-void MissionRawImpl::process_mission_item_int(const mavlink_message_t& message)
-{
-    // LogDebug() << "Received mission item int";
-
-    std::lock_guard<std::mutex> lock(_mission_download.mutex);
-    if (_mission_download.state != MissionDownload::State::REQUEST_ITEM) {
-        return;
-    }
-
-    mavlink_mission_item_int_t mission_item_int;
-    mavlink_msg_mission_item_int_decode(&message, &mission_item_int);
-
-    if (mission_item_int.seq != _mission_download.next_mission_item_to_download) {
-        LogWarn() << "Received mission item " << int(mission_item_int.seq) << " instead of "
-                  << _mission_download.next_mission_item_to_download << " (ignored)";
-
-        // The timeout will happen anyway and retry for this case.
-        return;
-    }
-
-    auto new_item = std::make_shared<MissionRaw::MavlinkMissionItemInt>();
-
-    new_item->target_system = mission_item_int.target_system;
-    new_item->target_component = mission_item_int.target_component;
-    new_item->seq = mission_item_int.seq;
-    new_item->frame = mission_item_int.frame;
-    new_item->command = mission_item_int.command;
-    new_item->current = mission_item_int.current;
-    new_item->autocontinue = mission_item_int.autocontinue;
-    new_item->param1 = mission_item_int.param1;
-    new_item->param2 = mission_item_int.param2;
-    new_item->param3 = mission_item_int.param3;
-    new_item->param4 = mission_item_int.param4;
-    new_item->x = mission_item_int.x;
-    new_item->y = mission_item_int.y;
-    new_item->z = mission_item_int.z;
-    new_item->mission_type = mission_item_int.mission_type;
-
-    _mission_download.mavlink_mission_items_downloaded.push_back(new_item);
-    ++_mission_download.next_mission_item_to_download;
-    _mission_download.retries = 0;
-
-    if (_mission_download.next_mission_item_to_download ==
-        _mission_download.num_mission_items_to_download) {
-        _mission_download.state = MissionDownload::State::SHOULD_ACK;
-    }
-
-    // We can remove timeout.
-    _parent->unregister_timeout_handler(_timeout_cookie);
-
-    // And schedule the next request.
-    _parent->register_timeout_handler(
-        std::bind(&MissionRawImpl::do_download_step, this), 0.0, nullptr);
-}
-
-void MissionRawImpl::send_ack()
-{
-    // Requires _mission_download.mutex.
-
-    // LogDebug() << "Sending ack";
-
-    mavlink_message_t message;
-    mavlink_msg_mission_ack_pack(
-        _parent->get_own_system_id(),
-        _parent->get_own_component_id(),
-        &message,
-        _parent->get_system_id(),
-        _parent->get_autopilot_id(),
-        MAV_MISSION_ACCEPTED,
-        MAV_MISSION_TYPE_MISSION);
-
-    if (!_parent->send_message(message)) {
-        // This is a terrible and unexpected error. Therefore we don't even
-        // retry but just give up.
-        _mission_download.state = MissionDownload::State::NONE;
-        if (_mission_download.callback) {
-            std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>> empty_vec{};
-            auto callback = _mission_download.callback;
-            _parent->call_user_callback(
-                [callback, empty_vec]() { callback(MissionRaw::Result::ERROR, empty_vec); });
-        }
-        return;
-    }
-
-    // We did it, we are done.
-    _mission_download.state = MissionDownload::State::NONE;
-
-    if (_mission_download.callback) {
-        std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>> vec_copy =
-            _mission_download.mavlink_mission_items_downloaded;
-        auto callback = _mission_download.callback;
-        _parent->call_user_callback(
-            [callback, vec_copy]() { callback(MissionRaw::Result::SUCCESS, vec_copy); });
-    }
-}
-
-void MissionRawImpl::download_mission_cancel() {}
 
 void MissionRawImpl::subscribe_mission_changed(MissionRaw::mission_changed_callback_t callback)
 {

--- a/src/plugins/mission_raw/mission_raw_impl.h
+++ b/src/plugins/mission_raw/mission_raw_impl.h
@@ -30,31 +30,16 @@ public:
 
 private:
     void process_mission_ack(const mavlink_message_t& message);
-    void process_mission_count(const mavlink_message_t& message);
-    void process_mission_item_int(const mavlink_message_t& message);
-    void do_download_step();
-    void request_list();
-    void request_item();
-    void send_ack();
+    MissionRaw::Result convert_result(MAVLinkMissionTransfer::Result result);
+    MissionRaw::MavlinkMissionItemInt
+    convert_item(const MAVLinkMissionTransfer::ItemInt& transfer_item);
+    std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>>
+    convert_items(const std::vector<MAVLinkMissionTransfer::ItemInt>& transfer_items);
 
     struct MissionChanged {
         std::mutex mutex{};
         MissionRaw::mission_changed_callback_t callback{nullptr};
     } _mission_changed{};
-
-    struct MissionDownload {
-        std::mutex mutex{};
-        enum class State { NONE, REQUEST_LIST, REQUEST_ITEM, SHOULD_ACK } state{State::NONE};
-        unsigned retries{0};
-        std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>>
-            mavlink_mission_items_downloaded{};
-        MissionRaw::mission_items_and_result_callback_t callback{nullptr};
-        unsigned num_mission_items_to_download{0};
-        unsigned next_mission_item_to_download{0};
-    } _mission_download{};
-
-    void* _timeout_cookie{nullptr};
-    static constexpr double RETRY_TIMEOUT_S = 0.250;
 };
 
 } // namespace mavsdk

--- a/src/plugins/mission_raw/mission_raw_impl.h
+++ b/src/plugins/mission_raw/mission_raw_impl.h
@@ -30,11 +30,12 @@ public:
 
 private:
     void process_mission_ack(const mavlink_message_t& message);
-    MissionRaw::Result convert_result(MAVLinkMissionTransfer::Result result);
-    MissionRaw::MavlinkMissionItemInt
-    convert_item(const MAVLinkMissionTransfer::ItemInt& transfer_item);
-    std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>>
-    convert_items(const std::vector<MAVLinkMissionTransfer::ItemInt>& transfer_items);
+
+    static MissionRaw::Result convert_result(MAVLinkMissionTransfer::Result result);
+    MissionRaw::MavlinkMissionItemInt static convert_item(
+        const MAVLinkMissionTransfer::ItemInt& transfer_item);
+    std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>> static convert_items(
+        const std::vector<MAVLinkMissionTransfer::ItemInt>& transfer_items);
 
     struct MissionChanged {
         std::mutex mutex{};


### PR DESCRIPTION
This moves mission/geofence/rally point transfer into core which means the work that has to be done in the plugins can be simplified