### PR TITLE
workflows: build PRs from forks too

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,14 @@
 name: C/C++ CI
 
-on: [push]
+on:
+  push:
+    branches:
+    - 'master'
+    - 'develop'
+  pull_request:
+    branches:
+    - '*'
+
 
 jobs:
   coverage:


### PR DESCRIPTION
If we don't build on pull_request, then pull requests from forks are not built. By only building pushes to master and develop though we get rid of the duplicate builds otherwise.