### PR TITLE
Add mavlink parameter retry (follow up)

### DIFF
--- a/src/core/mavlink_parameters.cpp
+++ b/src/core/mavlink_parameters.cpp
@@ -194,7 +194,9 @@ void MAVLinkParameters::do_work()
 
             // We want to get notified if a timeout happens
             _parent.register_timeout_handler(
-                std::bind(&MAVLinkParameters::receive_timeout, this), work->timeout_s, &_timeout_cookie);
+                std::bind(&MAVLinkParameters::receive_timeout, this),
+                work->timeout_s,
+                &_timeout_cookie);
 
         } break;
 
@@ -245,7 +247,9 @@ void MAVLinkParameters::do_work()
 
             // We want to get notified if a timeout happens
             _parent.register_timeout_handler(
-                std::bind(&MAVLinkParameters::receive_timeout, this), work->timeout_s, &_timeout_cookie);
+                std::bind(&MAVLinkParameters::receive_timeout, this),
+                work->timeout_s,
+                &_timeout_cookie);
 
         } break;
     }
@@ -454,15 +458,18 @@ void MAVLinkParameters::receive_timeout()
             if (work->retries_to_do > 0) {
                 // We're not sure the command arrived, let's retransmit.
                 LogWarn() << "sending again, retries to do: " << work->retries_to_do << "  ("
-                        << work->param_name << ").";
+                          << work->param_name << ").";
                 if (!_parent.send_message(work->mavlink_message)) {
                     LogErr() << "connection send error in retransmit (" << work->param_name << ").";
                     work_queue_guard.pop_front();
-                    work->get_param_callback(MAVLinkParameters::Result::CONNECTION_ERROR, empty_value);
+                    work->get_param_callback(
+                        MAVLinkParameters::Result::CONNECTION_ERROR, empty_value);
                 } else {
                     --work->retries_to_do;
                     _parent.register_timeout_handler(
-                        std::bind(&MAVLinkParameters::receive_timeout, this), work->timeout_s, &_timeout_cookie);
+                        std::bind(&MAVLinkParameters::receive_timeout, this),
+                        work->timeout_s,
+                        &_timeout_cookie);
                 }
             } else {
                 // We have tried retransmitting, giving up now.
@@ -477,15 +484,17 @@ void MAVLinkParameters::receive_timeout()
             if (work->retries_to_do > 0) {
                 // We're not sure the command arrived, let's retransmit.
                 LogWarn() << "sending again, retries to do: " << work->retries_to_do << "  ("
-                        << work->param_name << ").";
+                          << work->param_name << ").";
                 if (!_parent.send_message(work->mavlink_message)) {
                     LogErr() << "connection send error in retransmit (" << work->param_name << ").";
                     work_queue_guard.pop_front();
-                     work->set_param_callback(MAVLinkParameters::Result::CONNECTION_ERROR);
+                    work->set_param_callback(MAVLinkParameters::Result::CONNECTION_ERROR);
                 } else {
                     --work->retries_to_do;
                     _parent.register_timeout_handler(
-                        std::bind(&MAVLinkParameters::receive_timeout, this), work->timeout_s, &_timeout_cookie);
+                        std::bind(&MAVLinkParameters::receive_timeout, this),
+                        work->timeout_s,
+                        &_timeout_cookie);
                 }
             } else {
                 // We have tried retransmitting, giving up now.

--- a/src/core/mavlink_parameters.cpp
+++ b/src/core/mavlink_parameters.cpp
@@ -149,8 +149,6 @@ void MAVLinkParameters::do_work()
     char param_id[PARAM_ID_LEN + 1] = {};
     STRNCPY(param_id, work->param_name.c_str(), sizeof(param_id) - 1);
 
-    mavlink_message_t message{};
-
     switch (work->type) {
         case WorkItem::Type::Set: {
             if (work->extended) {
@@ -161,7 +159,7 @@ void MAVLinkParameters::do_work()
                 mavlink_msg_param_ext_set_pack(
                     _parent.get_own_system_id(),
                     _parent.get_own_component_id(),
-                    &message,
+                    &work->mavlink_message,
                     _parent.get_system_id(),
                     MAV_COMP_ID_CAMERA,
                     param_id,
@@ -172,7 +170,7 @@ void MAVLinkParameters::do_work()
                 mavlink_msg_param_set_pack(
                     _parent.get_own_system_id(),
                     _parent.get_own_component_id(),
-                    &message,
+                    &work->mavlink_message,
                     _parent.get_system_id(),
                     _parent.get_autopilot_id(),
                     param_id,
@@ -180,7 +178,7 @@ void MAVLinkParameters::do_work()
                     work->param_value.get_mav_param_type());
             }
 
-            if (!_parent.send_message(message)) {
+            if (!_parent.send_message(work->mavlink_message)) {
                 LogErr() << "Error: Send message failed";
                 if (work->set_param_callback) {
                     work->set_param_callback(MAVLinkParameters::Result::CONNECTION_ERROR);
@@ -206,7 +204,7 @@ void MAVLinkParameters::do_work()
                 mavlink_msg_param_ext_request_read_pack(
                     _parent.get_own_system_id(),
                     _parent.get_own_component_id(),
-                    &message,
+                    &work->mavlink_message,
                     _parent.get_system_id(),
                     MAV_COMP_ID_CAMERA,
                     param_id,
@@ -223,14 +221,14 @@ void MAVLinkParameters::do_work()
                 mavlink_msg_param_request_read_pack(
                     _parent.get_own_system_id(),
                     _parent.get_own_component_id(),
-                    &message,
+                    &work->mavlink_message,
                     _parent.get_system_id(),
                     _parent.get_autopilot_id(),
                     param_id,
                     -1);
             }
 
-            if (!_parent.send_message(message)) {
+            if (!_parent.send_message(work->mavlink_message)) {
                 LogErr() << "Error: Send message failed";
                 if (work->get_param_callback) {
                     ParamValue empty_param;

--- a/src/core/mavlink_parameters.h
+++ b/src/core/mavlink_parameters.h
@@ -635,6 +635,9 @@ private:
         int retries_done{0};
         bool already_requested{false};
         const void* cookie{nullptr};
+        int retries_to_do{3};
+        double timeout_s{1.0};
+        mavlink_message_t mavlink_message{};
     };
     LockedQueue<WorkItem> _work_queue{};
 

--- a/src/plugins/telemetry/telemetry_impl.cpp
+++ b/src/plugins/telemetry/telemetry_impl.cpp
@@ -674,10 +674,9 @@ void TelemetryImpl::process_ground_truth(const mavlink_message_t& message)
     mavlink_hil_state_quaternion_t hil_state_quaternion;
     mavlink_msg_hil_state_quaternion_decode(&message, &hil_state_quaternion);
 
-    set_ground_truth(
-    Telemetry::GroundTruth({hil_state_quaternion.lat * 1e-7,
-                            hil_state_quaternion.lon * 1e-7,
-                            hil_state_quaternion.alt * 1e-3f}));
+    set_ground_truth(Telemetry::GroundTruth({hil_state_quaternion.lat * 1e-7,
+                                             hil_state_quaternion.lon * 1e-7,
+                                             hil_state_quaternion.alt * 1e-3f}));
 
     if (_ground_truth_subscription) {
         auto callback = _ground_truth_subscription;


### PR DESCRIPTION
Follow up to #970.

Manually tested against SITL with a lossy link.