### PR TITLE
third_party: update gRPC

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ include(cmake/compiler_flags.cmake)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 
+find_package(Threads REQUIRED)
 find_package(CURL REQUIRED)
 find_package(tinyxml2 REQUIRED)
 

--- a/third_party/grpc/CMakeLists.txt
+++ b/third_party/grpc/CMakeLists.txt
@@ -44,4 +44,5 @@ ExternalProject_add(
     GIT_TAG v1.28.1
     PREFIX grpc
     CMAKE_ARGS "${CMAKE_ARGS}"
+    PATCH_COMMAND git apply ${PROJECT_SOURCE_DIR}/absl-workaround.patch
     )

--- a/third_party/grpc/CMakeLists.txt
+++ b/third_party/grpc/CMakeLists.txt
@@ -41,7 +41,7 @@ endforeach()
 ExternalProject_add(
     grpc
     GIT_REPOSITORY https://github.com/grpc/grpc
-    GIT_TAG v1.26.0
+    GIT_TAG v1.28.1
     PREFIX grpc
     CMAKE_ARGS "${CMAKE_ARGS}"
     )

--- a/third_party/grpc/absl-workaround.patch
+++ b/third_party/grpc/absl-workaround.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f7d6191519..60d2c92965 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -188,6 +188,9 @@ else()
+   set(_gRPC_CORE_NOSTDCXX_FLAGS "")
+ endif()
+ 
++# Workaround for https://github.com/abseil/abseil-cpp/issues/626
++add_definitions(-DABSL_NO_XRAY_ATTRIBUTES)
++
+ include(cmake/abseil-cpp.cmake)
+ include(cmake/address_sorting.cmake)
+ include(cmake/benchmark.cmake)


### PR DESCRIPTION
This should fix a stall that we have seen in the backend unit test.

Now really fixes #977.