### PR TITLE
Add lossy mission transfer test to CI

### DIFF
--- a/tools/run-sitl-tests.sh
+++ b/tools/run-sitl-tests.sh
@@ -10,6 +10,6 @@ fi
 PX4_FIRMWARE_DIR=$1
 NPROCS=$(nproc --all)
 
-cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_BACKEND=OFF -DBUILD_SHARED_LIBS=ON -Bbuild/debug -H.;
-cmake --build build/debug -- -j$NPROCS;
+cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_BACKEND=OFF -DBUILD_SHARED_LIBS=ON -j $NPROCS -Bbuild/debug -H.;
+cmake --build build/debug -- -j $NPROCS;
 PX4_SIM_SPEED_FACTOR=10 AUTOSTART_SITL=1 PX4_FIRMWARE_DIR=$PX4_FIRMWARE_DIR HEADLESS=1 build/debug/src/integration_tests/integration_tests_runner --gtest_filter="SitlTest.*"

--- a/tools/run-sitl-tests.sh
+++ b/tools/run-sitl-tests.sh
@@ -10,6 +10,6 @@ fi
 PX4_FIRMWARE_DIR=$1
 NPROCS=$(nproc --all)
 
-cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_BACKEND=OFF -DBUILD_SHARED_LIBS=ON -j $NPROCS -Bbuild/debug -H.;
+cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_BACKEND=OFF -DBUILD_SHARED_LIBS=ON -DENABLE_MAVLINK_PASSTHROUGH=1 -j $NPROCS -Bbuild/debug -H.;
 cmake --build build/debug -- -j $NPROCS;
 PX4_SIM_SPEED_FACTOR=10 AUTOSTART_SITL=1 PX4_FIRMWARE_DIR=$PX4_FIRMWARE_DIR HEADLESS=1 build/debug/src/integration_tests/integration_tests_runner --gtest_filter="SitlTest.*"


### PR DESCRIPTION
We need to include the passthrough plugin for the lossy mission transfer test.