### PR TITLE
Emit the gRPC port on which mavsdk_server listens in onServerStarted

### DIFF
--- a/src/backend/src/backend_api.cpp
+++ b/src/backend/src/backend_api.cpp
@@ -5,7 +5,7 @@
 void runBackend(
     const char* connection_url,
     const int mavsdk_server_port,
-    void (*onServerStarted)(void*),
+    void (*onServerStarted)(void* context, int grpc_port),
     void* context)
 {
     mavsdk::backend::MavsdkBackend backend;
@@ -19,7 +19,7 @@ void runBackend(
     backend.connect(std::string(connection_url));
 
     if (onServerStarted != nullptr) {
-        onServerStarted(context);
+        onServerStarted(context, grpc_port);
     }
 
     backend.wait();

--- a/src/backend/src/backend_api.h
+++ b/src/backend/src/backend_api.h
@@ -13,7 +13,7 @@ extern "C" {
 DLLExport void runBackend(
     const char* system_address,
     const int mavsdk_server_port,
-    void (*onServerStarted)(void*),
+    void (*onServerStarted)(void* context, int grpc_port),
     void* context);
 
 #ifdef __cplusplus


### PR DESCRIPTION
For Android/iOS, we want `mavsdk_server` to start on a random gRPC port, but then we need to advertise it to the Java/Swift client.