### PR TITLE
add compiler definition for Android

### DIFF
--- a/src/cmake/compiler_flags.cmake
+++ b/src/cmake/compiler_flags.cmake
@@ -61,6 +61,10 @@ if(IOS)
     add_definitions("-DIOS")
 endif()
 
+if(ANDROID)
+    add_definitions("-DANDROID")
+endif()
+
 if(UNIX AND NOT APPLE)
     add_definitions("-DLINUX")
 endif()


### PR DESCRIPTION
This is required for `log.h` to enable logcat (I probably removed that when refactoring a while ago).