### PR TITLE
Add api to stop `mavsdk_server`

### DIFF
--- a/src/backend/src/backend.cpp
+++ b/src/backend/src/backend.cpp
@@ -6,8 +6,7 @@
 #include "mavsdk.h"
 #include "grpc_server.h"
 
-namespace mavsdk {
-namespace backend {
+using namespace mavsdk::backend;
 
 class MavsdkBackend::Impl {
 public:
@@ -24,15 +23,21 @@ public:
     {
         _server = std::unique_ptr<GRPCServer>(new GRPCServer(_dc));
         _server->set_port(port);
-        return _server->run();
+        _grpc_port = _server->run();
+        return _grpc_port;
     }
 
     void wait() { _server->wait(); }
 
+    void stop() { _server->stop(); }
+
+    int getPort() { return _grpc_port; }
+
 private:
-    Mavsdk _dc;
+    mavsdk::Mavsdk _dc;
     ConnectionInitiator<mavsdk::Mavsdk> _connection_initiator;
     std::unique_ptr<GRPCServer> _server;
+    int _grpc_port;
 };
 
 MavsdkBackend::MavsdkBackend() : _impl(new Impl()) {}
@@ -50,6 +55,12 @@ void MavsdkBackend::wait()
 {
     _impl->wait();
 }
+void MavsdkBackend::stop()
+{
+    _impl->stop();
+}
 
-} // namespace backend
-} // namespace mavsdk
+int MavsdkBackend::getPort()
+{
+    return _impl->getPort();
+}

--- a/src/backend/src/backend.h
+++ b/src/backend/src/backend.h
@@ -3,9 +3,6 @@
 #include <memory>
 #include <string>
 
-namespace mavsdk {
-namespace backend {
-
 class MavsdkBackend {
 public:
     MavsdkBackend();
@@ -16,11 +13,10 @@ public:
     int startGRPCServer(int port);
     void connect(const std::string& connection_url = "udp://");
     void wait();
+    void stop();
+    int getPort();
 
 private:
     class Impl;
     std::unique_ptr<Impl> _impl;
 };
-
-} // namespace backend
-} // namespace mavsdk

--- a/src/backend/src/backend_api.cpp
+++ b/src/backend/src/backend_api.cpp
@@ -2,25 +2,41 @@
 #include "backend.h"
 #include <string>
 
-void runBackend(
-    const char* connection_url,
+MavsdkBackend* runBackend(
+    const char* system_address,
     const int mavsdk_server_port,
     void (*onServerStarted)(void*),
     void* context)
 {
-    mavsdk::backend::MavsdkBackend backend;
+    auto backend = new MavsdkBackend();
 
-    auto grpc_port = backend.startGRPCServer(mavsdk_server_port);
+    auto grpc_port = backend->startGRPCServer(mavsdk_server_port);
     if (grpc_port == 0) {
         // Server failed to start
-        return;
+        return nullptr;
     }
 
-    backend.connect(std::string(connection_url));
+    backend->connect(std::string(system_address));
 
     if (onServerStarted != nullptr) {
         onServerStarted(context);
     }
 
-    backend.wait();
+    return backend;
+}
+
+int getPort(MavsdkBackend* backend)
+{
+    return backend->getPort();
+}
+
+void attach(MavsdkBackend* backend)
+{
+    backend->wait();
+}
+
+void stopBackend(MavsdkBackend* backend)
+{
+    backend->stop();
+    delete backend;
 }

--- a/src/backend/src/backend_api.h
+++ b/src/backend/src/backend_api.h
@@ -10,11 +10,17 @@ extern "C" {
 #define DLLExport __attribute__((visibility("default")))
 #endif
 
-DLLExport void runBackend(
+DLLExport struct MavsdkBackend* runBackend(
     const char* system_address,
     const int mavsdk_server_port,
     void (*onServerStarted)(void*),
     void* context);
+
+DLLExport int getPort(struct MavsdkBackend* backend);
+
+DLLExport void attach(struct MavsdkBackend* backend);
+
+DLLExport void stopBackend(struct MavsdkBackend* backend);
 
 #ifdef __cplusplus
 }

--- a/src/backend/src/grpc_server.cpp
+++ b/src/backend/src/grpc_server.cpp
@@ -53,6 +53,16 @@ void GRPCServer::wait()
     }
 }
 
+void GRPCServer::stop()
+{
+    if (_server != nullptr) {
+        _telemetry_service.stop();
+        _server->Shutdown();
+    } else {
+        LogWarn() << "Calling 'stop()' on a non-existing server. Did you call 'run()' before?";
+    }
+}
+
 void GRPCServer::setup_port(grpc::ServerBuilder& builder)
 {
     const std::string server_address("0.0.0.0:" + std::to_string(_port));

--- a/src/backend/src/grpc_server.h
+++ b/src/backend/src/grpc_server.h
@@ -64,9 +64,10 @@ public:
         _mocap_service(_mocap)
     {}
 
-    void set_port(int port);
     int run();
     void wait();
+    void stop();
+    void set_port(int port);
 
 private:
     void setup_port(grpc::ServerBuilder& builder);

--- a/src/backend/src/mavsdk_server.cpp
+++ b/src/backend/src/mavsdk_server.cpp
@@ -41,7 +41,8 @@ int main(int argc, char** argv)
         }
     }
 
-    runBackend(connection_url.c_str(), mavsdk_server_port, nullptr, nullptr);
+    auto backend = runBackend(connection_url.c_str(), mavsdk_server_port, nullptr, nullptr);
+    attach(backend);
 }
 
 void usage()


### PR DESCRIPTION
This changes the C API from having only `runBackend()` to having `runBackend()`, `getPort()`, `attach()` and `stopBackend()`.

`runBackend()` is not blocking anymore, and that's replaced by `attach()`.

I had to remove the namespaces because that's not working with the C API. The alternative would be to have ifdefs in the API file (to differentiate between `struct MavsdkServer*` and `mavsdk::backend::MavsdkServer*`, and I am not sure what's worse. Here I find the `backend_api.h` file quite clear, at the cost of losing the namespaces only for the API files (`backend_api.*` and `backend.*`).

The limitation now is that if you register to an infinite stream and try to `stopBackend()`, then it will hang forever, waiting for the stream to finish (which won't happen since it is infinite). I fixed the telemetry plugin, so that won't happen here, but it could happen in other plugins. I'm not planning to fix that before the C++ auto-generation, so I would count it as "known issue" :innocent:.

I would also like to do some renaming (backend vs mavsdk_server is a bit confusing right now), but not in this PR.