### PR TITLE
Upload mission raw

### DIFF
--- a/src/integration_tests/mission_raw_mission_changed.cpp
+++ b/src/integration_tests/mission_raw_mission_changed.cpp
@@ -50,9 +50,7 @@ TEST_F(SitlTest, MissionRawMissionChanged)
     std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>> mission_raw_items;
 
     for (unsigned i = 0; i < NUM_SOME_ITEMS; ++i) {
-        auto new_raw_item_nav = std::make_shared<
-            MissionRaw::
-                MavlinkMissionItemInt>(); // std::make_shared<MissionRaw::MavlinkMissionItemInt>();
+        auto new_raw_item_nav = std::make_shared<MissionRaw::MavlinkMissionItemInt>();
         new_raw_item_nav->seq = (i * 2);
         new_raw_item_nav->frame = 6; // MAV_FRAME_GLOBAL_RELATIVE_ALT_INT
         new_raw_item_nav->command = 16; // MAV_CMD_NAV_WAYPOINT
@@ -62,14 +60,13 @@ TEST_F(SitlTest, MissionRawMissionChanged)
         new_raw_item_nav->param2 = 1.0; // Accept Radius
         new_raw_item_nav->param3 = 1.0; // Pass Radius
         new_raw_item_nav->param4 = NAN; // Yaw
-        new_raw_item_nav->x = std::round(SOME_LATITUDES[i] * 1e7);
-        new_raw_item_nav->y = std::round(SOME_LONGITUDES[i] * 1e7);
+        new_raw_item_nav->x = int32_t(std::round(SOME_LATITUDES[i] * 1e7));
+        new_raw_item_nav->y = int32_t(std::round(SOME_LONGITUDES[i] * 1e7));
         new_raw_item_nav->z = SOME_ALTITUDES[i];
         new_raw_item_nav->mission_type = 0; // MAV_MISSION_TYPE_MISSION
 
-        std::shared_ptr<MissionRaw::MavlinkMissionItemInt> new_raw_item_speed = std::make_shared<
-            MissionRaw::
-                MavlinkMissionItemInt>(); // std::make_shared<MissionRaw::MavlinkMissionItemInt>();
+        std::shared_ptr<MissionRaw::MavlinkMissionItemInt> new_raw_item_speed =
+            std::make_shared<MissionRaw::MavlinkMissionItemInt>();
         new_raw_item_speed->seq = (i * 2) + 1;
         new_raw_item_speed->frame = 2; // MAV_FRAME_MISSION
         new_raw_item_speed->command = 178; // MAV_CMD_DO_CHANGE_SPEED

--- a/src/plugins/mission_raw/include/plugins/mission_raw/mission_raw.h
+++ b/src/plugins/mission_raw/include/plugins/mission_raw/mission_raw.h
@@ -21,9 +21,6 @@ class System;
  *
  * For a tested, simpler subset in mission functionality, it is recommended
  * to use the `Mission` plugin.
- *
- * @note Currently, only downloading the mission items is implemented,
- *       uploading could be added in the future if required.
  */
 class MissionRaw : public PluginBase {
 public:
@@ -54,6 +51,7 @@ public:
         ERROR, /**< @brief Error. */
         BUSY, /**< @brief %Vehicle busy. */
         TIMEOUT, /**< @brief Request timed out. */
+        UNSUPPORTED, /**< @brief The mission downloaded from the system is not supported. */
         INVALID_ARGUMENT, /**< @brief Invalid argument. */
         NO_MISSION_AVAILABLE, /**< @brief No mission available on system. */
         CANCELLED /**< @brief Mission upload or download has been cancelled. */
@@ -88,6 +86,14 @@ public:
                     depending on frame). */
         uint8_t mission_type; /**< @brief Mission type. */
 
+        /**
+         * @brief Equality between two MavlinkMissionItemInt
+         *
+         * @param other Another MavlinkMissionItemInt object
+         *
+         * @return 'true'  If the two MavlinkMissionItemInts are equal
+         *         'false' Otherwise
+         */
         bool operator==(const MavlinkMissionItemInt& other) const
         {
             return (
@@ -134,19 +140,12 @@ public:
      * The mission raw are uploaded to a drone. Once uploaded the mission can be started and
      * executed even if a connection is lost.
      *
-     * @param mission_items Reference to vector of mission items.
+     * @param mission_raw Reference to vector of mission raw.
      * @param callback Callback to receive result of this request.
      */
-    void upload_mission_async(const std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>>& mission_raw,
-            result_callback_t callback);
-
-    /**
-     * @brief Cancel a mission upload (asynchronous).
-     *
-     * This cancels an ongoing mission upload. The mission upload will fail
-     * with the result `Result::CANCELLED`.
-     */
-    //TODO void upload_mission_cancel();
+    void upload_mission_async(
+        const std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>>& mission_raw,
+        result_callback_t callback);
 
     /**
      * @brief Callback type to signal if the mission has changed.

--- a/src/plugins/mission_raw/include/plugins/mission_raw/mission_raw.h
+++ b/src/plugins/mission_raw/include/plugins/mission_raw/mission_raw.h
@@ -68,7 +68,7 @@ public:
     static const char* result_str(Result result);
 
     /**
-     * @brief Mission item mostly identical to MAVLink MISSION_ITEM_INT.
+     * @brief Mission item exactly identical to MAVLink MISSION_ITEM_INT.
      */
     struct MavlinkMissionItemInt {
         uint16_t seq; /**< @brief Sequence. */
@@ -87,7 +87,22 @@ public:
         float z; /**< @brief PARAM7 / local: Z coordinate, global: altitude (relative or absolute,
                     depending on frame). */
         uint8_t mission_type; /**< @brief Mission type. */
+
+        bool operator==(const MavlinkMissionItemInt& other) const
+        {
+            return (
+                seq == other.seq && frame == other.frame && command == other.command &&
+                current == other.current && autocontinue == other.autocontinue &&
+                param1 == other.param1 && param2 == other.param2 && param3 == other.param3 &&
+                param4 == other.param4 && x == other.x && y == other.y && z == other.z &&
+                mission_type == other.mission_type);
+        }
     };
+
+    /**
+     * @brief Callback type for async mission calls.
+     */
+    typedef std::function<void(Result)> result_callback_t;
 
     /**
      * @brief Type for vector of mission items.
@@ -112,6 +127,26 @@ public:
      * with the result `Result::CANCELLED`.
      */
     void download_mission_cancel();
+
+    /**
+     * @brief Uploads a vector of mission raw to the system (asynchronous).
+     *
+     * The mission raw are uploaded to a drone. Once uploaded the mission can be started and
+     * executed even if a connection is lost.
+     *
+     * @param mission_items Reference to vector of mission items.
+     * @param callback Callback to receive result of this request.
+     */
+    void upload_mission_async(const std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>>& mission_raw,
+            result_callback_t callback);
+
+    /**
+     * @brief Cancel a mission upload (asynchronous).
+     *
+     * This cancels an ongoing mission upload. The mission upload will fail
+     * with the result `Result::CANCELLED`.
+     */
+    //TODO void upload_mission_cancel();
 
     /**
      * @brief Callback type to signal if the mission has changed.

--- a/src/plugins/mission_raw/mission_raw.cpp
+++ b/src/plugins/mission_raw/mission_raw.cpp
@@ -19,6 +19,12 @@ void MissionRaw::download_mission_cancel()
     _impl->download_mission_cancel();
 }
 
+void MissionRaw::upload_mission_async(
+    const std::vector<std::shared_ptr<MavlinkMissionItemInt> > &mission_raw, result_callback_t callback)
+{
+    _impl->upload_mission_async(mission_raw, callback);
+}
+
 const char* MissionRaw::result_str(Result result)
 {
     switch (result) {

--- a/src/plugins/mission_raw/mission_raw.cpp
+++ b/src/plugins/mission_raw/mission_raw.cpp
@@ -20,7 +20,8 @@ void MissionRaw::download_mission_cancel()
 }
 
 void MissionRaw::upload_mission_async(
-    const std::vector<std::shared_ptr<MavlinkMissionItemInt> > &mission_raw, result_callback_t callback)
+    const std::vector<std::shared_ptr<MavlinkMissionItemInt>>& mission_raw,
+    result_callback_t callback)
 {
     _impl->upload_mission_async(mission_raw, callback);
 }
@@ -34,6 +35,8 @@ const char* MissionRaw::result_str(Result result)
             return "Busy";
         case Result::ERROR:
             return "Error";
+        case Result::UNSUPPORTED:
+            return "Unsupported";
         case Result::INVALID_ARGUMENT:
             return "Invalid argument";
         case Result::TIMEOUT:

--- a/src/plugins/mission_raw/mission_raw_impl.h
+++ b/src/plugins/mission_raw/mission_raw_impl.h
@@ -23,6 +23,10 @@ public:
     void download_mission_async(const MissionRaw::mission_items_and_result_callback_t& callback);
     void download_mission_cancel();
 
+    void upload_mission_async(const std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>>& mission_raw,
+        const MissionRaw::result_callback_t &callback);
+    //TODO void upload_mission_cancel();
+
     void subscribe_mission_changed(MissionRaw::mission_changed_callback_t callback);
 
     MissionRawImpl(const MissionRawImpl&) = delete;
@@ -30,6 +34,11 @@ public:
 
 private:
     void process_mission_ack(const mavlink_message_t& message);
+
+    std::vector<MAVLinkMissionTransfer::ItemInt>
+    convert_to_int_items(const std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>>& mission_raw);
+    MAVLinkMissionTransfer::ItemInt convert_mission_raw(const std::shared_ptr<MissionRaw::MavlinkMissionItemInt> transfer_mission_raw);
+
 
     static MissionRaw::Result convert_result(MAVLinkMissionTransfer::Result result);
     MissionRaw::MavlinkMissionItemInt static convert_item(

--- a/src/plugins/mission_raw/mission_raw_impl.h
+++ b/src/plugins/mission_raw/mission_raw_impl.h
@@ -23,9 +23,9 @@ public:
     void download_mission_async(const MissionRaw::mission_items_and_result_callback_t& callback);
     void download_mission_cancel();
 
-    void upload_mission_async(const std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>>& mission_raw,
-        const MissionRaw::result_callback_t &callback);
-    //TODO void upload_mission_cancel();
+    void upload_mission_async(
+        const std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>>& mission_raw,
+        const MissionRaw::result_callback_t& callback);
 
     void subscribe_mission_changed(MissionRaw::mission_changed_callback_t callback);
 
@@ -35,10 +35,10 @@ public:
 private:
     void process_mission_ack(const mavlink_message_t& message);
 
-    std::vector<MAVLinkMissionTransfer::ItemInt>
-    convert_to_int_items(const std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>>& mission_raw);
-    MAVLinkMissionTransfer::ItemInt convert_mission_raw(const std::shared_ptr<MissionRaw::MavlinkMissionItemInt> transfer_mission_raw);
-
+    std::vector<MAVLinkMissionTransfer::ItemInt> convert_to_int_items(
+        const std::vector<std::shared_ptr<MissionRaw::MavlinkMissionItemInt>>& mission_raw);
+    MAVLinkMissionTransfer::ItemInt convert_mission_raw(
+        const std::shared_ptr<MissionRaw::MavlinkMissionItemInt> transfer_mission_raw);
 
     static MissionRaw::Result convert_result(MAVLinkMissionTransfer::Result result);
     MissionRaw::MavlinkMissionItemInt static convert_item(


### PR DESCRIPTION
This is a first draft and it just compiles yet but it bothers me that it is just copy/paste (but not exactly) from Mission....

I feel it would do more sense to do a `MissionRawItem` rather than `MissionRaw`. For me, `MissionRaw` is just a lower level than `MissionItem`. And `MissionItem` would just use `MissionRawItem`. If we want high level functionalities we'll use `MissionItem` and for more advanced settings like I need we can work with `MissionRawItem`.

also the `MavlinkMissionItemInt` is exactly a `MAVLinkMissionTransfer::ItemInt` so I don't get the purpose to create another struct for that 