### PR TITLE
Auto-generate action plugin (C++ and mavsdk_server)

### DIFF
--- a/src/backend/src/generated/action/action.grpc.pb.cc
+++ b/src/backend/src/generated/action/action.grpc.pb.cc
@@ -28,9 +28,11 @@ static const char* ActionService_method_names[] = {
   "/mavsdk.rpc.action.ActionService/Takeoff",
   "/mavsdk.rpc.action.ActionService/Land",
   "/mavsdk.rpc.action.ActionService/Reboot",
+  "/mavsdk.rpc.action.ActionService/Shutdown",
   "/mavsdk.rpc.action.ActionService/Kill",
   "/mavsdk.rpc.action.ActionService/ReturnToLaunch",
-  "/mavsdk.rpc.action.ActionService/TransitionToFixedWing",
+  "/mavsdk.rpc.action.ActionService/GotoLocation",
+  "/mavsdk.rpc.action.ActionService/TransitionToFixedwing",
   "/mavsdk.rpc.action.ActionService/TransitionToMulticopter",
   "/mavsdk.rpc.action.ActionService/GetTakeoffAltitude",
   "/mavsdk.rpc.action.ActionService/SetTakeoffAltitude",
@@ -52,16 +54,18 @@ ActionService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& chan
   , rpcmethod_Takeoff_(ActionService_method_names[2], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_Land_(ActionService_method_names[3], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_Reboot_(ActionService_method_names[4], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_Kill_(ActionService_method_names[5], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ReturnToLaunch_(ActionService_method_names[6], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_TransitionToFixedWing_(ActionService_method_names[7], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_TransitionToMulticopter_(ActionService_method_names[8], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_GetTakeoffAltitude_(ActionService_method_names[9], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetTakeoffAltitude_(ActionService_method_names[10], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_GetMaximumSpeed_(ActionService_method_names[11], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetMaximumSpeed_(ActionService_method_names[12], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_GetReturnToLaunchAltitude_(ActionService_method_names[13], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetReturnToLaunchAltitude_(ActionService_method_names[14], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_Shutdown_(ActionService_method_names[5], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_Kill_(ActionService_method_names[6], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ReturnToLaunch_(ActionService_method_names[7], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GotoLocation_(ActionService_method_names[8], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_TransitionToFixedwing_(ActionService_method_names[9], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_TransitionToMulticopter_(ActionService_method_names[10], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetTakeoffAltitude_(ActionService_method_names[11], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetTakeoffAltitude_(ActionService_method_names[12], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetMaximumSpeed_(ActionService_method_names[13], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetMaximumSpeed_(ActionService_method_names[14], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetReturnToLaunchAltitude_(ActionService_method_names[15], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetReturnToLaunchAltitude_(ActionService_method_names[16], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status ActionService::Stub::Arm(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ArmRequest& request, ::mavsdk::rpc::action::ArmResponse* response) {
@@ -204,6 +208,34 @@ void ActionService::Stub::experimental_async::Reboot(::grpc::ClientContext* cont
   return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::mavsdk::rpc::action::RebootResponse>::Create(channel_.get(), cq, rpcmethod_Reboot_, context, request, false);
 }
 
+::grpc::Status ActionService::Stub::Shutdown(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ShutdownRequest& request, ::mavsdk::rpc::action::ShutdownResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_Shutdown_, context, request, response);
+}
+
+void ActionService::Stub::experimental_async::Shutdown(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ShutdownRequest* request, ::mavsdk::rpc::action::ShutdownResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_Shutdown_, context, request, response, std::move(f));
+}
+
+void ActionService::Stub::experimental_async::Shutdown(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::ShutdownResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_Shutdown_, context, request, response, std::move(f));
+}
+
+void ActionService::Stub::experimental_async::Shutdown(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ShutdownRequest* request, ::mavsdk::rpc::action::ShutdownResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_Shutdown_, context, request, response, reactor);
+}
+
+void ActionService::Stub::experimental_async::Shutdown(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::ShutdownResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_Shutdown_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::ShutdownResponse>* ActionService::Stub::AsyncShutdownRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ShutdownRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::mavsdk::rpc::action::ShutdownResponse>::Create(channel_.get(), cq, rpcmethod_Shutdown_, context, request, true);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::ShutdownResponse>* ActionService::Stub::PrepareAsyncShutdownRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ShutdownRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::mavsdk::rpc::action::ShutdownResponse>::Create(channel_.get(), cq, rpcmethod_Shutdown_, context, request, false);
+}
+
 ::grpc::Status ActionService::Stub::Kill(::grpc::ClientContext* context, const ::mavsdk::rpc::action::KillRequest& request, ::mavsdk::rpc::action::KillResponse* response) {
   return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_Kill_, context, request, response);
 }
@@ -260,32 +292,60 @@ void ActionService::Stub::experimental_async::ReturnToLaunch(::grpc::ClientConte
   return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::mavsdk::rpc::action::ReturnToLaunchResponse>::Create(channel_.get(), cq, rpcmethod_ReturnToLaunch_, context, request, false);
 }
 
-::grpc::Status ActionService::Stub::TransitionToFixedWing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest& request, ::mavsdk::rpc::action::TransitionToFixedWingResponse* response) {
-  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_TransitionToFixedWing_, context, request, response);
+::grpc::Status ActionService::Stub::GotoLocation(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest& request, ::mavsdk::rpc::action::GotoLocationResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_GotoLocation_, context, request, response);
 }
 
-void ActionService::Stub::experimental_async::TransitionToFixedWing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest* request, ::mavsdk::rpc::action::TransitionToFixedWingResponse* response, std::function<void(::grpc::Status)> f) {
-  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_TransitionToFixedWing_, context, request, response, std::move(f));
+void ActionService::Stub::experimental_async::GotoLocation(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest* request, ::mavsdk::rpc::action::GotoLocationResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_GotoLocation_, context, request, response, std::move(f));
 }
 
-void ActionService::Stub::experimental_async::TransitionToFixedWing(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::TransitionToFixedWingResponse* response, std::function<void(::grpc::Status)> f) {
-  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_TransitionToFixedWing_, context, request, response, std::move(f));
+void ActionService::Stub::experimental_async::GotoLocation(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::GotoLocationResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_GotoLocation_, context, request, response, std::move(f));
 }
 
-void ActionService::Stub::experimental_async::TransitionToFixedWing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest* request, ::mavsdk::rpc::action::TransitionToFixedWingResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
-  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_TransitionToFixedWing_, context, request, response, reactor);
+void ActionService::Stub::experimental_async::GotoLocation(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest* request, ::mavsdk::rpc::action::GotoLocationResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_GotoLocation_, context, request, response, reactor);
 }
 
-void ActionService::Stub::experimental_async::TransitionToFixedWing(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::TransitionToFixedWingResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
-  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_TransitionToFixedWing_, context, request, response, reactor);
+void ActionService::Stub::experimental_async::GotoLocation(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::GotoLocationResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_GotoLocation_, context, request, response, reactor);
 }
 
-::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::TransitionToFixedWingResponse>* ActionService::Stub::AsyncTransitionToFixedWingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::mavsdk::rpc::action::TransitionToFixedWingResponse>::Create(channel_.get(), cq, rpcmethod_TransitionToFixedWing_, context, request, true);
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationResponse>* ActionService::Stub::AsyncGotoLocationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::mavsdk::rpc::action::GotoLocationResponse>::Create(channel_.get(), cq, rpcmethod_GotoLocation_, context, request, true);
 }
 
-::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::TransitionToFixedWingResponse>* ActionService::Stub::PrepareAsyncTransitionToFixedWingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::mavsdk::rpc::action::TransitionToFixedWingResponse>::Create(channel_.get(), cq, rpcmethod_TransitionToFixedWing_, context, request, false);
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationResponse>* ActionService::Stub::PrepareAsyncGotoLocationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::mavsdk::rpc::action::GotoLocationResponse>::Create(channel_.get(), cq, rpcmethod_GotoLocation_, context, request, false);
+}
+
+::grpc::Status ActionService::Stub::TransitionToFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest& request, ::mavsdk::rpc::action::TransitionToFixedwingResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_TransitionToFixedwing_, context, request, response);
+}
+
+void ActionService::Stub::experimental_async::TransitionToFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest* request, ::mavsdk::rpc::action::TransitionToFixedwingResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_TransitionToFixedwing_, context, request, response, std::move(f));
+}
+
+void ActionService::Stub::experimental_async::TransitionToFixedwing(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::TransitionToFixedwingResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_TransitionToFixedwing_, context, request, response, std::move(f));
+}
+
+void ActionService::Stub::experimental_async::TransitionToFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest* request, ::mavsdk::rpc::action::TransitionToFixedwingResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_TransitionToFixedwing_, context, request, response, reactor);
+}
+
+void ActionService::Stub::experimental_async::TransitionToFixedwing(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::TransitionToFixedwingResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_TransitionToFixedwing_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::TransitionToFixedwingResponse>* ActionService::Stub::AsyncTransitionToFixedwingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::mavsdk::rpc::action::TransitionToFixedwingResponse>::Create(channel_.get(), cq, rpcmethod_TransitionToFixedwing_, context, request, true);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::TransitionToFixedwingResponse>* ActionService::Stub::PrepareAsyncTransitionToFixedwingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::mavsdk::rpc::action::TransitionToFixedwingResponse>::Create(channel_.get(), cq, rpcmethod_TransitionToFixedwing_, context, request, false);
 }
 
 ::grpc::Status ActionService::Stub::TransitionToMulticopter(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToMulticopterRequest& request, ::mavsdk::rpc::action::TransitionToMulticopterResponse* response) {
@@ -513,50 +573,60 @@ ActionService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       ActionService_method_names[5],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::ShutdownRequest, ::mavsdk::rpc::action::ShutdownResponse>(
+          std::mem_fn(&ActionService::Service::Shutdown), this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      ActionService_method_names[6],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::KillRequest, ::mavsdk::rpc::action::KillResponse>(
           std::mem_fn(&ActionService::Service::Kill), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ActionService_method_names[6],
+      ActionService_method_names[7],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::ReturnToLaunchRequest, ::mavsdk::rpc::action::ReturnToLaunchResponse>(
           std::mem_fn(&ActionService::Service::ReturnToLaunch), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ActionService_method_names[7],
-      ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::TransitionToFixedWingRequest, ::mavsdk::rpc::action::TransitionToFixedWingResponse>(
-          std::mem_fn(&ActionService::Service::TransitionToFixedWing), this)));
-  AddMethod(new ::grpc::internal::RpcServiceMethod(
       ActionService_method_names[8],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::GotoLocationRequest, ::mavsdk::rpc::action::GotoLocationResponse>(
+          std::mem_fn(&ActionService::Service::GotoLocation), this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      ActionService_method_names[9],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::TransitionToFixedwingRequest, ::mavsdk::rpc::action::TransitionToFixedwingResponse>(
+          std::mem_fn(&ActionService::Service::TransitionToFixedwing), this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      ActionService_method_names[10],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::TransitionToMulticopterRequest, ::mavsdk::rpc::action::TransitionToMulticopterResponse>(
           std::mem_fn(&ActionService::Service::TransitionToMulticopter), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ActionService_method_names[9],
+      ActionService_method_names[11],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::GetTakeoffAltitudeRequest, ::mavsdk::rpc::action::GetTakeoffAltitudeResponse>(
           std::mem_fn(&ActionService::Service::GetTakeoffAltitude), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ActionService_method_names[10],
+      ActionService_method_names[12],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::SetTakeoffAltitudeRequest, ::mavsdk::rpc::action::SetTakeoffAltitudeResponse>(
           std::mem_fn(&ActionService::Service::SetTakeoffAltitude), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ActionService_method_names[11],
+      ActionService_method_names[13],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::GetMaximumSpeedRequest, ::mavsdk::rpc::action::GetMaximumSpeedResponse>(
           std::mem_fn(&ActionService::Service::GetMaximumSpeed), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ActionService_method_names[12],
+      ActionService_method_names[14],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::SetMaximumSpeedRequest, ::mavsdk::rpc::action::SetMaximumSpeedResponse>(
           std::mem_fn(&ActionService::Service::SetMaximumSpeed), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ActionService_method_names[13],
+      ActionService_method_names[15],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::GetReturnToLaunchAltitudeRequest, ::mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse>(
           std::mem_fn(&ActionService::Service::GetReturnToLaunchAltitude), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ActionService_method_names[14],
+      ActionService_method_names[16],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest, ::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse>(
           std::mem_fn(&ActionService::Service::SetReturnToLaunchAltitude), this)));
@@ -600,6 +670,13 @@ ActionService::Service::~Service() {
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
+::grpc::Status ActionService::Service::Shutdown(::grpc::ServerContext* context, const ::mavsdk::rpc::action::ShutdownRequest* request, ::mavsdk::rpc::action::ShutdownResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
 ::grpc::Status ActionService::Service::Kill(::grpc::ServerContext* context, const ::mavsdk::rpc::action::KillRequest* request, ::mavsdk::rpc::action::KillResponse* response) {
   (void) context;
   (void) request;
@@ -614,7 +691,14 @@ ActionService::Service::~Service() {
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
-::grpc::Status ActionService::Service::TransitionToFixedWing(::grpc::ServerContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest* request, ::mavsdk::rpc::action::TransitionToFixedWingResponse* response) {
+::grpc::Status ActionService::Service::GotoLocation(::grpc::ServerContext* context, const ::mavsdk::rpc::action::GotoLocationRequest* request, ::mavsdk::rpc::action::GotoLocationResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status ActionService::Service::TransitionToFixedwing(::grpc::ServerContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest* request, ::mavsdk::rpc::action::TransitionToFixedwingResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/src/backend/src/generated/action/action.grpc.pb.h
+++ b/src/backend/src/generated/action/action.grpc.pb.h
@@ -110,6 +110,19 @@ class ActionService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::RebootResponse>> PrepareAsyncReboot(::grpc::ClientContext* context, const ::mavsdk::rpc::action::RebootRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::RebootResponse>>(PrepareAsyncRebootRaw(context, request, cq));
     }
+    // *
+    // Send command to shut down the drone components.
+    //
+    // This will shut down the autopilot, onboard computer, camera and gimbal.
+    // This command should only be used when the autopilot is disarmed and autopilots commonly
+    // reject it if they are not already ready to shut down.
+    virtual ::grpc::Status Shutdown(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ShutdownRequest& request, ::mavsdk::rpc::action::ShutdownResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::ShutdownResponse>> AsyncShutdown(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ShutdownRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::ShutdownResponse>>(AsyncShutdownRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::ShutdownResponse>> PrepareAsyncShutdown(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ShutdownRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::ShutdownResponse>>(PrepareAsyncShutdownRaw(context, request, cq));
+    }
     //
     // Send command to kill the drone. 
     //
@@ -135,18 +148,32 @@ class ActionService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::ReturnToLaunchResponse>> PrepareAsyncReturnToLaunch(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ReturnToLaunchRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::ReturnToLaunchResponse>>(PrepareAsyncReturnToLaunchRaw(context, request, cq));
     }
+    // *
+    // Send command to move the vehicle to a specific global position.
+    //
+    // The latitude and longitude are given in degrees (WGS84 frame) and the altitude
+    // in meters AMSL (above mean sea level).
+    //
+    // The yaw angle is in degrees (frame is NED, 0 is North, positive is clockwise).
+    virtual ::grpc::Status GotoLocation(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest& request, ::mavsdk::rpc::action::GotoLocationResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::GotoLocationResponse>> AsyncGotoLocation(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::GotoLocationResponse>>(AsyncGotoLocationRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::GotoLocationResponse>> PrepareAsyncGotoLocation(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::GotoLocationResponse>>(PrepareAsyncGotoLocationRaw(context, request, cq));
+    }
     //
     // Send command to transition the drone to fixedwing.
     //
     // The associated action will only be executed for VTOL vehicles (on other vehicle types the
     // command will fail). The command will succeed if called when the vehicle
     // is already in fixedwing mode.
-    virtual ::grpc::Status TransitionToFixedWing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest& request, ::mavsdk::rpc::action::TransitionToFixedWingResponse* response) = 0;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::TransitionToFixedWingResponse>> AsyncTransitionToFixedWing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::TransitionToFixedWingResponse>>(AsyncTransitionToFixedWingRaw(context, request, cq));
+    virtual ::grpc::Status TransitionToFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest& request, ::mavsdk::rpc::action::TransitionToFixedwingResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::TransitionToFixedwingResponse>> AsyncTransitionToFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::TransitionToFixedwingResponse>>(AsyncTransitionToFixedwingRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::TransitionToFixedWingResponse>> PrepareAsyncTransitionToFixedWing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::TransitionToFixedWingResponse>>(PrepareAsyncTransitionToFixedWingRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::TransitionToFixedwingResponse>> PrepareAsyncTransitionToFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::TransitionToFixedwingResponse>>(PrepareAsyncTransitionToFixedwingRaw(context, request, cq));
     }
     //
     // Send command to transition the drone to multicopter.
@@ -263,6 +290,16 @@ class ActionService final {
       virtual void Reboot(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::RebootResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void Reboot(::grpc::ClientContext* context, const ::mavsdk::rpc::action::RebootRequest* request, ::mavsdk::rpc::action::RebootResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
       virtual void Reboot(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::RebootResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
+      // *
+      // Send command to shut down the drone components.
+      //
+      // This will shut down the autopilot, onboard computer, camera and gimbal.
+      // This command should only be used when the autopilot is disarmed and autopilots commonly
+      // reject it if they are not already ready to shut down.
+      virtual void Shutdown(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ShutdownRequest* request, ::mavsdk::rpc::action::ShutdownResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void Shutdown(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::ShutdownResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void Shutdown(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ShutdownRequest* request, ::mavsdk::rpc::action::ShutdownResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
+      virtual void Shutdown(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::ShutdownResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
       //
       // Send command to kill the drone. 
       //
@@ -282,16 +319,27 @@ class ActionService final {
       virtual void ReturnToLaunch(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::ReturnToLaunchResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void ReturnToLaunch(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ReturnToLaunchRequest* request, ::mavsdk::rpc::action::ReturnToLaunchResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
       virtual void ReturnToLaunch(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::ReturnToLaunchResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
+      // *
+      // Send command to move the vehicle to a specific global position.
+      //
+      // The latitude and longitude are given in degrees (WGS84 frame) and the altitude
+      // in meters AMSL (above mean sea level).
+      //
+      // The yaw angle is in degrees (frame is NED, 0 is North, positive is clockwise).
+      virtual void GotoLocation(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest* request, ::mavsdk::rpc::action::GotoLocationResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void GotoLocation(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::GotoLocationResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void GotoLocation(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest* request, ::mavsdk::rpc::action::GotoLocationResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
+      virtual void GotoLocation(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::GotoLocationResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
       //
       // Send command to transition the drone to fixedwing.
       //
       // The associated action will only be executed for VTOL vehicles (on other vehicle types the
       // command will fail). The command will succeed if called when the vehicle
       // is already in fixedwing mode.
-      virtual void TransitionToFixedWing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest* request, ::mavsdk::rpc::action::TransitionToFixedWingResponse* response, std::function<void(::grpc::Status)>) = 0;
-      virtual void TransitionToFixedWing(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::TransitionToFixedWingResponse* response, std::function<void(::grpc::Status)>) = 0;
-      virtual void TransitionToFixedWing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest* request, ::mavsdk::rpc::action::TransitionToFixedWingResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
-      virtual void TransitionToFixedWing(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::TransitionToFixedWingResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
+      virtual void TransitionToFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest* request, ::mavsdk::rpc::action::TransitionToFixedwingResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void TransitionToFixedwing(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::TransitionToFixedwingResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void TransitionToFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest* request, ::mavsdk::rpc::action::TransitionToFixedwingResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
+      virtual void TransitionToFixedwing(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::TransitionToFixedwingResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
       //
       // Send command to transition the drone to multicopter.
       //
@@ -351,12 +399,16 @@ class ActionService final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::LandResponse>* PrepareAsyncLandRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::LandRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::RebootResponse>* AsyncRebootRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::RebootRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::RebootResponse>* PrepareAsyncRebootRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::RebootRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::ShutdownResponse>* AsyncShutdownRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ShutdownRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::ShutdownResponse>* PrepareAsyncShutdownRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ShutdownRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::KillResponse>* AsyncKillRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::KillRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::KillResponse>* PrepareAsyncKillRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::KillRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::ReturnToLaunchResponse>* AsyncReturnToLaunchRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ReturnToLaunchRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::ReturnToLaunchResponse>* PrepareAsyncReturnToLaunchRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ReturnToLaunchRequest& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::TransitionToFixedWingResponse>* AsyncTransitionToFixedWingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::TransitionToFixedWingResponse>* PrepareAsyncTransitionToFixedWingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::GotoLocationResponse>* AsyncGotoLocationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::GotoLocationResponse>* PrepareAsyncGotoLocationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::TransitionToFixedwingResponse>* AsyncTransitionToFixedwingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::TransitionToFixedwingResponse>* PrepareAsyncTransitionToFixedwingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::TransitionToMulticopterResponse>* AsyncTransitionToMulticopterRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToMulticopterRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::TransitionToMulticopterResponse>* PrepareAsyncTransitionToMulticopterRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToMulticopterRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::GetTakeoffAltitudeResponse>* AsyncGetTakeoffAltitudeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GetTakeoffAltitudeRequest& request, ::grpc::CompletionQueue* cq) = 0;
@@ -410,6 +462,13 @@ class ActionService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::RebootResponse>> PrepareAsyncReboot(::grpc::ClientContext* context, const ::mavsdk::rpc::action::RebootRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::RebootResponse>>(PrepareAsyncRebootRaw(context, request, cq));
     }
+    ::grpc::Status Shutdown(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ShutdownRequest& request, ::mavsdk::rpc::action::ShutdownResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::ShutdownResponse>> AsyncShutdown(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ShutdownRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::ShutdownResponse>>(AsyncShutdownRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::ShutdownResponse>> PrepareAsyncShutdown(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ShutdownRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::ShutdownResponse>>(PrepareAsyncShutdownRaw(context, request, cq));
+    }
     ::grpc::Status Kill(::grpc::ClientContext* context, const ::mavsdk::rpc::action::KillRequest& request, ::mavsdk::rpc::action::KillResponse* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::KillResponse>> AsyncKill(::grpc::ClientContext* context, const ::mavsdk::rpc::action::KillRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::KillResponse>>(AsyncKillRaw(context, request, cq));
@@ -424,12 +483,19 @@ class ActionService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::ReturnToLaunchResponse>> PrepareAsyncReturnToLaunch(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ReturnToLaunchRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::ReturnToLaunchResponse>>(PrepareAsyncReturnToLaunchRaw(context, request, cq));
     }
-    ::grpc::Status TransitionToFixedWing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest& request, ::mavsdk::rpc::action::TransitionToFixedWingResponse* response) override;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::TransitionToFixedWingResponse>> AsyncTransitionToFixedWing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::TransitionToFixedWingResponse>>(AsyncTransitionToFixedWingRaw(context, request, cq));
+    ::grpc::Status GotoLocation(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest& request, ::mavsdk::rpc::action::GotoLocationResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationResponse>> AsyncGotoLocation(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationResponse>>(AsyncGotoLocationRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::TransitionToFixedWingResponse>> PrepareAsyncTransitionToFixedWing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::TransitionToFixedWingResponse>>(PrepareAsyncTransitionToFixedWingRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationResponse>> PrepareAsyncGotoLocation(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationResponse>>(PrepareAsyncGotoLocationRaw(context, request, cq));
+    }
+    ::grpc::Status TransitionToFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest& request, ::mavsdk::rpc::action::TransitionToFixedwingResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::TransitionToFixedwingResponse>> AsyncTransitionToFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::TransitionToFixedwingResponse>>(AsyncTransitionToFixedwingRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::TransitionToFixedwingResponse>> PrepareAsyncTransitionToFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::TransitionToFixedwingResponse>>(PrepareAsyncTransitionToFixedwingRaw(context, request, cq));
     }
     ::grpc::Status TransitionToMulticopter(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToMulticopterRequest& request, ::mavsdk::rpc::action::TransitionToMulticopterResponse* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::TransitionToMulticopterResponse>> AsyncTransitionToMulticopter(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToMulticopterRequest& request, ::grpc::CompletionQueue* cq) {
@@ -503,6 +569,10 @@ class ActionService final {
       void Reboot(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::RebootResponse* response, std::function<void(::grpc::Status)>) override;
       void Reboot(::grpc::ClientContext* context, const ::mavsdk::rpc::action::RebootRequest* request, ::mavsdk::rpc::action::RebootResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
       void Reboot(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::RebootResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
+      void Shutdown(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ShutdownRequest* request, ::mavsdk::rpc::action::ShutdownResponse* response, std::function<void(::grpc::Status)>) override;
+      void Shutdown(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::ShutdownResponse* response, std::function<void(::grpc::Status)>) override;
+      void Shutdown(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ShutdownRequest* request, ::mavsdk::rpc::action::ShutdownResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
+      void Shutdown(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::ShutdownResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
       void Kill(::grpc::ClientContext* context, const ::mavsdk::rpc::action::KillRequest* request, ::mavsdk::rpc::action::KillResponse* response, std::function<void(::grpc::Status)>) override;
       void Kill(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::KillResponse* response, std::function<void(::grpc::Status)>) override;
       void Kill(::grpc::ClientContext* context, const ::mavsdk::rpc::action::KillRequest* request, ::mavsdk::rpc::action::KillResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
@@ -511,10 +581,14 @@ class ActionService final {
       void ReturnToLaunch(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::ReturnToLaunchResponse* response, std::function<void(::grpc::Status)>) override;
       void ReturnToLaunch(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ReturnToLaunchRequest* request, ::mavsdk::rpc::action::ReturnToLaunchResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
       void ReturnToLaunch(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::ReturnToLaunchResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
-      void TransitionToFixedWing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest* request, ::mavsdk::rpc::action::TransitionToFixedWingResponse* response, std::function<void(::grpc::Status)>) override;
-      void TransitionToFixedWing(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::TransitionToFixedWingResponse* response, std::function<void(::grpc::Status)>) override;
-      void TransitionToFixedWing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest* request, ::mavsdk::rpc::action::TransitionToFixedWingResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
-      void TransitionToFixedWing(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::TransitionToFixedWingResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
+      void GotoLocation(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest* request, ::mavsdk::rpc::action::GotoLocationResponse* response, std::function<void(::grpc::Status)>) override;
+      void GotoLocation(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::GotoLocationResponse* response, std::function<void(::grpc::Status)>) override;
+      void GotoLocation(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest* request, ::mavsdk::rpc::action::GotoLocationResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
+      void GotoLocation(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::GotoLocationResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
+      void TransitionToFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest* request, ::mavsdk::rpc::action::TransitionToFixedwingResponse* response, std::function<void(::grpc::Status)>) override;
+      void TransitionToFixedwing(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::TransitionToFixedwingResponse* response, std::function<void(::grpc::Status)>) override;
+      void TransitionToFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest* request, ::mavsdk::rpc::action::TransitionToFixedwingResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
+      void TransitionToFixedwing(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::TransitionToFixedwingResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
       void TransitionToMulticopter(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToMulticopterRequest* request, ::mavsdk::rpc::action::TransitionToMulticopterResponse* response, std::function<void(::grpc::Status)>) override;
       void TransitionToMulticopter(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::mavsdk::rpc::action::TransitionToMulticopterResponse* response, std::function<void(::grpc::Status)>) override;
       void TransitionToMulticopter(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToMulticopterRequest* request, ::mavsdk::rpc::action::TransitionToMulticopterResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
@@ -564,12 +638,16 @@ class ActionService final {
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::LandResponse>* PrepareAsyncLandRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::LandRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::RebootResponse>* AsyncRebootRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::RebootRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::RebootResponse>* PrepareAsyncRebootRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::RebootRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::ShutdownResponse>* AsyncShutdownRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ShutdownRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::ShutdownResponse>* PrepareAsyncShutdownRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ShutdownRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::KillResponse>* AsyncKillRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::KillRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::KillResponse>* PrepareAsyncKillRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::KillRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::ReturnToLaunchResponse>* AsyncReturnToLaunchRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ReturnToLaunchRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::ReturnToLaunchResponse>* PrepareAsyncReturnToLaunchRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ReturnToLaunchRequest& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::TransitionToFixedWingResponse>* AsyncTransitionToFixedWingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::TransitionToFixedWingResponse>* PrepareAsyncTransitionToFixedWingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationResponse>* AsyncGotoLocationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationResponse>* PrepareAsyncGotoLocationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::TransitionToFixedwingResponse>* AsyncTransitionToFixedwingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::TransitionToFixedwingResponse>* PrepareAsyncTransitionToFixedwingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::TransitionToMulticopterResponse>* AsyncTransitionToMulticopterRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToMulticopterRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::TransitionToMulticopterResponse>* PrepareAsyncTransitionToMulticopterRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::TransitionToMulticopterRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GetTakeoffAltitudeResponse>* AsyncGetTakeoffAltitudeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GetTakeoffAltitudeRequest& request, ::grpc::CompletionQueue* cq) override;
@@ -589,9 +667,11 @@ class ActionService final {
     const ::grpc::internal::RpcMethod rpcmethod_Takeoff_;
     const ::grpc::internal::RpcMethod rpcmethod_Land_;
     const ::grpc::internal::RpcMethod rpcmethod_Reboot_;
+    const ::grpc::internal::RpcMethod rpcmethod_Shutdown_;
     const ::grpc::internal::RpcMethod rpcmethod_Kill_;
     const ::grpc::internal::RpcMethod rpcmethod_ReturnToLaunch_;
-    const ::grpc::internal::RpcMethod rpcmethod_TransitionToFixedWing_;
+    const ::grpc::internal::RpcMethod rpcmethod_GotoLocation_;
+    const ::grpc::internal::RpcMethod rpcmethod_TransitionToFixedwing_;
     const ::grpc::internal::RpcMethod rpcmethod_TransitionToMulticopter_;
     const ::grpc::internal::RpcMethod rpcmethod_GetTakeoffAltitude_;
     const ::grpc::internal::RpcMethod rpcmethod_SetTakeoffAltitude_;
@@ -636,6 +716,13 @@ class ActionService final {
     //
     // This will reboot the autopilot, companion computer, camera and gimbal.
     virtual ::grpc::Status Reboot(::grpc::ServerContext* context, const ::mavsdk::rpc::action::RebootRequest* request, ::mavsdk::rpc::action::RebootResponse* response);
+    // *
+    // Send command to shut down the drone components.
+    //
+    // This will shut down the autopilot, onboard computer, camera and gimbal.
+    // This command should only be used when the autopilot is disarmed and autopilots commonly
+    // reject it if they are not already ready to shut down.
+    virtual ::grpc::Status Shutdown(::grpc::ServerContext* context, const ::mavsdk::rpc::action::ShutdownRequest* request, ::mavsdk::rpc::action::ShutdownResponse* response);
     //
     // Send command to kill the drone. 
     //
@@ -649,13 +736,21 @@ class ActionService final {
     // generally means it will rise up to a certain altitude to clear any obstacles before heading
     // back to the launch (takeoff) position and land there.
     virtual ::grpc::Status ReturnToLaunch(::grpc::ServerContext* context, const ::mavsdk::rpc::action::ReturnToLaunchRequest* request, ::mavsdk::rpc::action::ReturnToLaunchResponse* response);
+    // *
+    // Send command to move the vehicle to a specific global position.
+    //
+    // The latitude and longitude are given in degrees (WGS84 frame) and the altitude
+    // in meters AMSL (above mean sea level).
+    //
+    // The yaw angle is in degrees (frame is NED, 0 is North, positive is clockwise).
+    virtual ::grpc::Status GotoLocation(::grpc::ServerContext* context, const ::mavsdk::rpc::action::GotoLocationRequest* request, ::mavsdk::rpc::action::GotoLocationResponse* response);
     //
     // Send command to transition the drone to fixedwing.
     //
     // The associated action will only be executed for VTOL vehicles (on other vehicle types the
     // command will fail). The command will succeed if called when the vehicle
     // is already in fixedwing mode.
-    virtual ::grpc::Status TransitionToFixedWing(::grpc::ServerContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest* request, ::mavsdk::rpc::action::TransitionToFixedWingResponse* response);
+    virtual ::grpc::Status TransitionToFixedwing(::grpc::ServerContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest* request, ::mavsdk::rpc::action::TransitionToFixedwingResponse* response);
     //
     // Send command to transition the drone to multicopter.
     //
@@ -783,12 +878,32 @@ class ActionService final {
     }
   };
   template <class BaseClass>
+  class WithAsyncMethod_Shutdown : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_Shutdown() {
+      ::grpc::Service::MarkMethodAsync(5);
+    }
+    ~WithAsyncMethod_Shutdown() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Shutdown(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::ShutdownRequest* /*request*/, ::mavsdk::rpc::action::ShutdownResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestShutdown(::grpc::ServerContext* context, ::mavsdk::rpc::action::ShutdownRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::ShutdownResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithAsyncMethod_Kill : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_Kill() {
-      ::grpc::Service::MarkMethodAsync(5);
+      ::grpc::Service::MarkMethodAsync(6);
     }
     ~WithAsyncMethod_Kill() override {
       BaseClassMustBeDerivedFromService(this);
@@ -799,7 +914,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestKill(::grpc::ServerContext* context, ::mavsdk::rpc::action::KillRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::KillResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -808,7 +923,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_ReturnToLaunch() {
-      ::grpc::Service::MarkMethodAsync(6);
+      ::grpc::Service::MarkMethodAsync(7);
     }
     ~WithAsyncMethod_ReturnToLaunch() override {
       BaseClassMustBeDerivedFromService(this);
@@ -819,27 +934,47 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestReturnToLaunch(::grpc::ServerContext* context, ::mavsdk::rpc::action::ReturnToLaunchRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::ReturnToLaunchResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
-  class WithAsyncMethod_TransitionToFixedWing : public BaseClass {
+  class WithAsyncMethod_GotoLocation : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithAsyncMethod_TransitionToFixedWing() {
-      ::grpc::Service::MarkMethodAsync(7);
+    WithAsyncMethod_GotoLocation() {
+      ::grpc::Service::MarkMethodAsync(8);
     }
-    ~WithAsyncMethod_TransitionToFixedWing() override {
+    ~WithAsyncMethod_GotoLocation() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status TransitionToFixedWing(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::TransitionToFixedWingRequest* /*request*/, ::mavsdk::rpc::action::TransitionToFixedWingResponse* /*response*/) override {
+    ::grpc::Status GotoLocation(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::GotoLocationRequest* /*request*/, ::mavsdk::rpc::action::GotoLocationResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestTransitionToFixedWing(::grpc::ServerContext* context, ::mavsdk::rpc::action::TransitionToFixedWingRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::TransitionToFixedWingResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
+    void RequestGotoLocation(::grpc::ServerContext* context, ::mavsdk::rpc::action::GotoLocationRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::GotoLocationResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_TransitionToFixedwing : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_TransitionToFixedwing() {
+      ::grpc::Service::MarkMethodAsync(9);
+    }
+    ~WithAsyncMethod_TransitionToFixedwing() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status TransitionToFixedwing(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::TransitionToFixedwingRequest* /*request*/, ::mavsdk::rpc::action::TransitionToFixedwingResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestTransitionToFixedwing(::grpc::ServerContext* context, ::mavsdk::rpc::action::TransitionToFixedwingRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::TransitionToFixedwingResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -848,7 +983,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_TransitionToMulticopter() {
-      ::grpc::Service::MarkMethodAsync(8);
+      ::grpc::Service::MarkMethodAsync(10);
     }
     ~WithAsyncMethod_TransitionToMulticopter() override {
       BaseClassMustBeDerivedFromService(this);
@@ -859,7 +994,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestTransitionToMulticopter(::grpc::ServerContext* context, ::mavsdk::rpc::action::TransitionToMulticopterRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::TransitionToMulticopterResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -868,7 +1003,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_GetTakeoffAltitude() {
-      ::grpc::Service::MarkMethodAsync(9);
+      ::grpc::Service::MarkMethodAsync(11);
     }
     ~WithAsyncMethod_GetTakeoffAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -879,7 +1014,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetTakeoffAltitude(::grpc::ServerContext* context, ::mavsdk::rpc::action::GetTakeoffAltitudeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::GetTakeoffAltitudeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -888,7 +1023,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetTakeoffAltitude() {
-      ::grpc::Service::MarkMethodAsync(10);
+      ::grpc::Service::MarkMethodAsync(12);
     }
     ~WithAsyncMethod_SetTakeoffAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -899,7 +1034,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetTakeoffAltitude(::grpc::ServerContext* context, ::mavsdk::rpc::action::SetTakeoffAltitudeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::SetTakeoffAltitudeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -908,7 +1043,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_GetMaximumSpeed() {
-      ::grpc::Service::MarkMethodAsync(11);
+      ::grpc::Service::MarkMethodAsync(13);
     }
     ~WithAsyncMethod_GetMaximumSpeed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -919,7 +1054,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetMaximumSpeed(::grpc::ServerContext* context, ::mavsdk::rpc::action::GetMaximumSpeedRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::GetMaximumSpeedResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -928,7 +1063,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetMaximumSpeed() {
-      ::grpc::Service::MarkMethodAsync(12);
+      ::grpc::Service::MarkMethodAsync(14);
     }
     ~WithAsyncMethod_SetMaximumSpeed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -939,7 +1074,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetMaximumSpeed(::grpc::ServerContext* context, ::mavsdk::rpc::action::SetMaximumSpeedRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::SetMaximumSpeedResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -948,7 +1083,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_GetReturnToLaunchAltitude() {
-      ::grpc::Service::MarkMethodAsync(13);
+      ::grpc::Service::MarkMethodAsync(15);
     }
     ~WithAsyncMethod_GetReturnToLaunchAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -959,7 +1094,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetReturnToLaunchAltitude(::grpc::ServerContext* context, ::mavsdk::rpc::action::GetReturnToLaunchAltitudeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -968,7 +1103,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetReturnToLaunchAltitude() {
-      ::grpc::Service::MarkMethodAsync(14);
+      ::grpc::Service::MarkMethodAsync(16);
     }
     ~WithAsyncMethod_SetReturnToLaunchAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -979,10 +1114,10 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetReturnToLaunchAltitude(::grpc::ServerContext* context, ::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_Arm<WithAsyncMethod_Disarm<WithAsyncMethod_Takeoff<WithAsyncMethod_Land<WithAsyncMethod_Reboot<WithAsyncMethod_Kill<WithAsyncMethod_ReturnToLaunch<WithAsyncMethod_TransitionToFixedWing<WithAsyncMethod_TransitionToMulticopter<WithAsyncMethod_GetTakeoffAltitude<WithAsyncMethod_SetTakeoffAltitude<WithAsyncMethod_GetMaximumSpeed<WithAsyncMethod_SetMaximumSpeed<WithAsyncMethod_GetReturnToLaunchAltitude<WithAsyncMethod_SetReturnToLaunchAltitude<Service > > > > > > > > > > > > > > > AsyncService;
+  typedef WithAsyncMethod_Arm<WithAsyncMethod_Disarm<WithAsyncMethod_Takeoff<WithAsyncMethod_Land<WithAsyncMethod_Reboot<WithAsyncMethod_Shutdown<WithAsyncMethod_Kill<WithAsyncMethod_ReturnToLaunch<WithAsyncMethod_GotoLocation<WithAsyncMethod_TransitionToFixedwing<WithAsyncMethod_TransitionToMulticopter<WithAsyncMethod_GetTakeoffAltitude<WithAsyncMethod_SetTakeoffAltitude<WithAsyncMethod_GetMaximumSpeed<WithAsyncMethod_SetMaximumSpeed<WithAsyncMethod_GetReturnToLaunchAltitude<WithAsyncMethod_SetReturnToLaunchAltitude<Service > > > > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class ExperimentalWithCallbackMethod_Arm : public BaseClass {
    private:
@@ -1109,18 +1244,43 @@ class ActionService final {
     virtual ::grpc::experimental::ServerUnaryReactor* Reboot(::grpc::experimental::CallbackServerContext* /*context*/, const ::mavsdk::rpc::action::RebootRequest* /*request*/, ::mavsdk::rpc::action::RebootResponse* /*response*/) { return nullptr; }
   };
   template <class BaseClass>
+  class ExperimentalWithCallbackMethod_Shutdown : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    ExperimentalWithCallbackMethod_Shutdown() {
+      ::grpc::Service::experimental().MarkMethodCallback(5,
+        new ::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::ShutdownRequest, ::mavsdk::rpc::action::ShutdownResponse>(
+          [this](::grpc::experimental::CallbackServerContext* context, const ::mavsdk::rpc::action::ShutdownRequest* request, ::mavsdk::rpc::action::ShutdownResponse* response) { return this->Shutdown(context, request, response); }));}
+    void SetMessageAllocatorFor_Shutdown(
+        ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::action::ShutdownRequest, ::mavsdk::rpc::action::ShutdownResponse>* allocator) {
+      static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::ShutdownRequest, ::mavsdk::rpc::action::ShutdownResponse>*>(
+          ::grpc::Service::experimental().GetHandler(5))
+              ->SetMessageAllocator(allocator);
+    }
+    ~ExperimentalWithCallbackMethod_Shutdown() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Shutdown(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::ShutdownRequest* /*request*/, ::mavsdk::rpc::action::ShutdownResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::experimental::ServerUnaryReactor* Shutdown(::grpc::experimental::CallbackServerContext* /*context*/, const ::mavsdk::rpc::action::ShutdownRequest* /*request*/, ::mavsdk::rpc::action::ShutdownResponse* /*response*/) { return nullptr; }
+  };
+  template <class BaseClass>
   class ExperimentalWithCallbackMethod_Kill : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithCallbackMethod_Kill() {
-      ::grpc::Service::experimental().MarkMethodCallback(5,
+      ::grpc::Service::experimental().MarkMethodCallback(6,
         new ::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::KillRequest, ::mavsdk::rpc::action::KillResponse>(
           [this](::grpc::experimental::CallbackServerContext* context, const ::mavsdk::rpc::action::KillRequest* request, ::mavsdk::rpc::action::KillResponse* response) { return this->Kill(context, request, response); }));}
     void SetMessageAllocatorFor_Kill(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::action::KillRequest, ::mavsdk::rpc::action::KillResponse>* allocator) {
       static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::KillRequest, ::mavsdk::rpc::action::KillResponse>*>(
-          ::grpc::Service::experimental().GetHandler(5))
+          ::grpc::Service::experimental().GetHandler(6))
               ->SetMessageAllocator(allocator);
     }
     ~ExperimentalWithCallbackMethod_Kill() override {
@@ -1139,13 +1299,13 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithCallbackMethod_ReturnToLaunch() {
-      ::grpc::Service::experimental().MarkMethodCallback(6,
+      ::grpc::Service::experimental().MarkMethodCallback(7,
         new ::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::ReturnToLaunchRequest, ::mavsdk::rpc::action::ReturnToLaunchResponse>(
           [this](::grpc::experimental::CallbackServerContext* context, const ::mavsdk::rpc::action::ReturnToLaunchRequest* request, ::mavsdk::rpc::action::ReturnToLaunchResponse* response) { return this->ReturnToLaunch(context, request, response); }));}
     void SetMessageAllocatorFor_ReturnToLaunch(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::action::ReturnToLaunchRequest, ::mavsdk::rpc::action::ReturnToLaunchResponse>* allocator) {
       static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::ReturnToLaunchRequest, ::mavsdk::rpc::action::ReturnToLaunchResponse>*>(
-          ::grpc::Service::experimental().GetHandler(6))
+          ::grpc::Service::experimental().GetHandler(7))
               ->SetMessageAllocator(allocator);
     }
     ~ExperimentalWithCallbackMethod_ReturnToLaunch() override {
@@ -1159,29 +1319,54 @@ class ActionService final {
     virtual ::grpc::experimental::ServerUnaryReactor* ReturnToLaunch(::grpc::experimental::CallbackServerContext* /*context*/, const ::mavsdk::rpc::action::ReturnToLaunchRequest* /*request*/, ::mavsdk::rpc::action::ReturnToLaunchResponse* /*response*/) { return nullptr; }
   };
   template <class BaseClass>
-  class ExperimentalWithCallbackMethod_TransitionToFixedWing : public BaseClass {
+  class ExperimentalWithCallbackMethod_GotoLocation : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    ExperimentalWithCallbackMethod_TransitionToFixedWing() {
-      ::grpc::Service::experimental().MarkMethodCallback(7,
-        new ::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::TransitionToFixedWingRequest, ::mavsdk::rpc::action::TransitionToFixedWingResponse>(
-          [this](::grpc::experimental::CallbackServerContext* context, const ::mavsdk::rpc::action::TransitionToFixedWingRequest* request, ::mavsdk::rpc::action::TransitionToFixedWingResponse* response) { return this->TransitionToFixedWing(context, request, response); }));}
-    void SetMessageAllocatorFor_TransitionToFixedWing(
-        ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::action::TransitionToFixedWingRequest, ::mavsdk::rpc::action::TransitionToFixedWingResponse>* allocator) {
-      static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::TransitionToFixedWingRequest, ::mavsdk::rpc::action::TransitionToFixedWingResponse>*>(
-          ::grpc::Service::experimental().GetHandler(7))
+    ExperimentalWithCallbackMethod_GotoLocation() {
+      ::grpc::Service::experimental().MarkMethodCallback(8,
+        new ::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::GotoLocationRequest, ::mavsdk::rpc::action::GotoLocationResponse>(
+          [this](::grpc::experimental::CallbackServerContext* context, const ::mavsdk::rpc::action::GotoLocationRequest* request, ::mavsdk::rpc::action::GotoLocationResponse* response) { return this->GotoLocation(context, request, response); }));}
+    void SetMessageAllocatorFor_GotoLocation(
+        ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::action::GotoLocationRequest, ::mavsdk::rpc::action::GotoLocationResponse>* allocator) {
+      static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::GotoLocationRequest, ::mavsdk::rpc::action::GotoLocationResponse>*>(
+          ::grpc::Service::experimental().GetHandler(8))
               ->SetMessageAllocator(allocator);
     }
-    ~ExperimentalWithCallbackMethod_TransitionToFixedWing() override {
+    ~ExperimentalWithCallbackMethod_GotoLocation() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status TransitionToFixedWing(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::TransitionToFixedWingRequest* /*request*/, ::mavsdk::rpc::action::TransitionToFixedWingResponse* /*response*/) override {
+    ::grpc::Status GotoLocation(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::GotoLocationRequest* /*request*/, ::mavsdk::rpc::action::GotoLocationResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    virtual ::grpc::experimental::ServerUnaryReactor* TransitionToFixedWing(::grpc::experimental::CallbackServerContext* /*context*/, const ::mavsdk::rpc::action::TransitionToFixedWingRequest* /*request*/, ::mavsdk::rpc::action::TransitionToFixedWingResponse* /*response*/) { return nullptr; }
+    virtual ::grpc::experimental::ServerUnaryReactor* GotoLocation(::grpc::experimental::CallbackServerContext* /*context*/, const ::mavsdk::rpc::action::GotoLocationRequest* /*request*/, ::mavsdk::rpc::action::GotoLocationResponse* /*response*/) { return nullptr; }
+  };
+  template <class BaseClass>
+  class ExperimentalWithCallbackMethod_TransitionToFixedwing : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    ExperimentalWithCallbackMethod_TransitionToFixedwing() {
+      ::grpc::Service::experimental().MarkMethodCallback(9,
+        new ::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::TransitionToFixedwingRequest, ::mavsdk::rpc::action::TransitionToFixedwingResponse>(
+          [this](::grpc::experimental::CallbackServerContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest* request, ::mavsdk::rpc::action::TransitionToFixedwingResponse* response) { return this->TransitionToFixedwing(context, request, response); }));}
+    void SetMessageAllocatorFor_TransitionToFixedwing(
+        ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::action::TransitionToFixedwingRequest, ::mavsdk::rpc::action::TransitionToFixedwingResponse>* allocator) {
+      static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::TransitionToFixedwingRequest, ::mavsdk::rpc::action::TransitionToFixedwingResponse>*>(
+          ::grpc::Service::experimental().GetHandler(9))
+              ->SetMessageAllocator(allocator);
+    }
+    ~ExperimentalWithCallbackMethod_TransitionToFixedwing() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status TransitionToFixedwing(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::TransitionToFixedwingRequest* /*request*/, ::mavsdk::rpc::action::TransitionToFixedwingResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::experimental::ServerUnaryReactor* TransitionToFixedwing(::grpc::experimental::CallbackServerContext* /*context*/, const ::mavsdk::rpc::action::TransitionToFixedwingRequest* /*request*/, ::mavsdk::rpc::action::TransitionToFixedwingResponse* /*response*/) { return nullptr; }
   };
   template <class BaseClass>
   class ExperimentalWithCallbackMethod_TransitionToMulticopter : public BaseClass {
@@ -1189,13 +1374,13 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithCallbackMethod_TransitionToMulticopter() {
-      ::grpc::Service::experimental().MarkMethodCallback(8,
+      ::grpc::Service::experimental().MarkMethodCallback(10,
         new ::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::TransitionToMulticopterRequest, ::mavsdk::rpc::action::TransitionToMulticopterResponse>(
           [this](::grpc::experimental::CallbackServerContext* context, const ::mavsdk::rpc::action::TransitionToMulticopterRequest* request, ::mavsdk::rpc::action::TransitionToMulticopterResponse* response) { return this->TransitionToMulticopter(context, request, response); }));}
     void SetMessageAllocatorFor_TransitionToMulticopter(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::action::TransitionToMulticopterRequest, ::mavsdk::rpc::action::TransitionToMulticopterResponse>* allocator) {
       static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::TransitionToMulticopterRequest, ::mavsdk::rpc::action::TransitionToMulticopterResponse>*>(
-          ::grpc::Service::experimental().GetHandler(8))
+          ::grpc::Service::experimental().GetHandler(10))
               ->SetMessageAllocator(allocator);
     }
     ~ExperimentalWithCallbackMethod_TransitionToMulticopter() override {
@@ -1214,13 +1399,13 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithCallbackMethod_GetTakeoffAltitude() {
-      ::grpc::Service::experimental().MarkMethodCallback(9,
+      ::grpc::Service::experimental().MarkMethodCallback(11,
         new ::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::GetTakeoffAltitudeRequest, ::mavsdk::rpc::action::GetTakeoffAltitudeResponse>(
           [this](::grpc::experimental::CallbackServerContext* context, const ::mavsdk::rpc::action::GetTakeoffAltitudeRequest* request, ::mavsdk::rpc::action::GetTakeoffAltitudeResponse* response) { return this->GetTakeoffAltitude(context, request, response); }));}
     void SetMessageAllocatorFor_GetTakeoffAltitude(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::action::GetTakeoffAltitudeRequest, ::mavsdk::rpc::action::GetTakeoffAltitudeResponse>* allocator) {
       static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::GetTakeoffAltitudeRequest, ::mavsdk::rpc::action::GetTakeoffAltitudeResponse>*>(
-          ::grpc::Service::experimental().GetHandler(9))
+          ::grpc::Service::experimental().GetHandler(11))
               ->SetMessageAllocator(allocator);
     }
     ~ExperimentalWithCallbackMethod_GetTakeoffAltitude() override {
@@ -1239,13 +1424,13 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithCallbackMethod_SetTakeoffAltitude() {
-      ::grpc::Service::experimental().MarkMethodCallback(10,
+      ::grpc::Service::experimental().MarkMethodCallback(12,
         new ::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetTakeoffAltitudeRequest, ::mavsdk::rpc::action::SetTakeoffAltitudeResponse>(
           [this](::grpc::experimental::CallbackServerContext* context, const ::mavsdk::rpc::action::SetTakeoffAltitudeRequest* request, ::mavsdk::rpc::action::SetTakeoffAltitudeResponse* response) { return this->SetTakeoffAltitude(context, request, response); }));}
     void SetMessageAllocatorFor_SetTakeoffAltitude(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::action::SetTakeoffAltitudeRequest, ::mavsdk::rpc::action::SetTakeoffAltitudeResponse>* allocator) {
       static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetTakeoffAltitudeRequest, ::mavsdk::rpc::action::SetTakeoffAltitudeResponse>*>(
-          ::grpc::Service::experimental().GetHandler(10))
+          ::grpc::Service::experimental().GetHandler(12))
               ->SetMessageAllocator(allocator);
     }
     ~ExperimentalWithCallbackMethod_SetTakeoffAltitude() override {
@@ -1264,13 +1449,13 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithCallbackMethod_GetMaximumSpeed() {
-      ::grpc::Service::experimental().MarkMethodCallback(11,
+      ::grpc::Service::experimental().MarkMethodCallback(13,
         new ::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::GetMaximumSpeedRequest, ::mavsdk::rpc::action::GetMaximumSpeedResponse>(
           [this](::grpc::experimental::CallbackServerContext* context, const ::mavsdk::rpc::action::GetMaximumSpeedRequest* request, ::mavsdk::rpc::action::GetMaximumSpeedResponse* response) { return this->GetMaximumSpeed(context, request, response); }));}
     void SetMessageAllocatorFor_GetMaximumSpeed(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::action::GetMaximumSpeedRequest, ::mavsdk::rpc::action::GetMaximumSpeedResponse>* allocator) {
       static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::GetMaximumSpeedRequest, ::mavsdk::rpc::action::GetMaximumSpeedResponse>*>(
-          ::grpc::Service::experimental().GetHandler(11))
+          ::grpc::Service::experimental().GetHandler(13))
               ->SetMessageAllocator(allocator);
     }
     ~ExperimentalWithCallbackMethod_GetMaximumSpeed() override {
@@ -1289,13 +1474,13 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithCallbackMethod_SetMaximumSpeed() {
-      ::grpc::Service::experimental().MarkMethodCallback(12,
+      ::grpc::Service::experimental().MarkMethodCallback(14,
         new ::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetMaximumSpeedRequest, ::mavsdk::rpc::action::SetMaximumSpeedResponse>(
           [this](::grpc::experimental::CallbackServerContext* context, const ::mavsdk::rpc::action::SetMaximumSpeedRequest* request, ::mavsdk::rpc::action::SetMaximumSpeedResponse* response) { return this->SetMaximumSpeed(context, request, response); }));}
     void SetMessageAllocatorFor_SetMaximumSpeed(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::action::SetMaximumSpeedRequest, ::mavsdk::rpc::action::SetMaximumSpeedResponse>* allocator) {
       static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetMaximumSpeedRequest, ::mavsdk::rpc::action::SetMaximumSpeedResponse>*>(
-          ::grpc::Service::experimental().GetHandler(12))
+          ::grpc::Service::experimental().GetHandler(14))
               ->SetMessageAllocator(allocator);
     }
     ~ExperimentalWithCallbackMethod_SetMaximumSpeed() override {
@@ -1314,13 +1499,13 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithCallbackMethod_GetReturnToLaunchAltitude() {
-      ::grpc::Service::experimental().MarkMethodCallback(13,
+      ::grpc::Service::experimental().MarkMethodCallback(15,
         new ::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::GetReturnToLaunchAltitudeRequest, ::mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse>(
           [this](::grpc::experimental::CallbackServerContext* context, const ::mavsdk::rpc::action::GetReturnToLaunchAltitudeRequest* request, ::mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse* response) { return this->GetReturnToLaunchAltitude(context, request, response); }));}
     void SetMessageAllocatorFor_GetReturnToLaunchAltitude(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::action::GetReturnToLaunchAltitudeRequest, ::mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse>* allocator) {
       static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::GetReturnToLaunchAltitudeRequest, ::mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse>*>(
-          ::grpc::Service::experimental().GetHandler(13))
+          ::grpc::Service::experimental().GetHandler(15))
               ->SetMessageAllocator(allocator);
     }
     ~ExperimentalWithCallbackMethod_GetReturnToLaunchAltitude() override {
@@ -1339,13 +1524,13 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithCallbackMethod_SetReturnToLaunchAltitude() {
-      ::grpc::Service::experimental().MarkMethodCallback(14,
+      ::grpc::Service::experimental().MarkMethodCallback(16,
         new ::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest, ::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse>(
           [this](::grpc::experimental::CallbackServerContext* context, const ::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest* request, ::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse* response) { return this->SetReturnToLaunchAltitude(context, request, response); }));}
     void SetMessageAllocatorFor_SetReturnToLaunchAltitude(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest, ::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse>* allocator) {
       static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest, ::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse>*>(
-          ::grpc::Service::experimental().GetHandler(14))
+          ::grpc::Service::experimental().GetHandler(16))
               ->SetMessageAllocator(allocator);
     }
     ~ExperimentalWithCallbackMethod_SetReturnToLaunchAltitude() override {
@@ -1358,7 +1543,7 @@ class ActionService final {
     }
     virtual ::grpc::experimental::ServerUnaryReactor* SetReturnToLaunchAltitude(::grpc::experimental::CallbackServerContext* /*context*/, const ::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest* /*request*/, ::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse* /*response*/) { return nullptr; }
   };
-  typedef ExperimentalWithCallbackMethod_Arm<ExperimentalWithCallbackMethod_Disarm<ExperimentalWithCallbackMethod_Takeoff<ExperimentalWithCallbackMethod_Land<ExperimentalWithCallbackMethod_Reboot<ExperimentalWithCallbackMethod_Kill<ExperimentalWithCallbackMethod_ReturnToLaunch<ExperimentalWithCallbackMethod_TransitionToFixedWing<ExperimentalWithCallbackMethod_TransitionToMulticopter<ExperimentalWithCallbackMethod_GetTakeoffAltitude<ExperimentalWithCallbackMethod_SetTakeoffAltitude<ExperimentalWithCallbackMethod_GetMaximumSpeed<ExperimentalWithCallbackMethod_SetMaximumSpeed<ExperimentalWithCallbackMethod_GetReturnToLaunchAltitude<ExperimentalWithCallbackMethod_SetReturnToLaunchAltitude<Service > > > > > > > > > > > > > > > ExperimentalCallbackService;
+  typedef ExperimentalWithCallbackMethod_Arm<ExperimentalWithCallbackMethod_Disarm<ExperimentalWithCallbackMethod_Takeoff<ExperimentalWithCallbackMethod_Land<ExperimentalWithCallbackMethod_Reboot<ExperimentalWithCallbackMethod_Shutdown<ExperimentalWithCallbackMethod_Kill<ExperimentalWithCallbackMethod_ReturnToLaunch<ExperimentalWithCallbackMethod_GotoLocation<ExperimentalWithCallbackMethod_TransitionToFixedwing<ExperimentalWithCallbackMethod_TransitionToMulticopter<ExperimentalWithCallbackMethod_GetTakeoffAltitude<ExperimentalWithCallbackMethod_SetTakeoffAltitude<ExperimentalWithCallbackMethod_GetMaximumSpeed<ExperimentalWithCallbackMethod_SetMaximumSpeed<ExperimentalWithCallbackMethod_GetReturnToLaunchAltitude<ExperimentalWithCallbackMethod_SetReturnToLaunchAltitude<Service > > > > > > > > > > > > > > > > > ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_Arm : public BaseClass {
    private:
@@ -1445,12 +1630,29 @@ class ActionService final {
     }
   };
   template <class BaseClass>
+  class WithGenericMethod_Shutdown : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_Shutdown() {
+      ::grpc::Service::MarkMethodGeneric(5);
+    }
+    ~WithGenericMethod_Shutdown() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Shutdown(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::ShutdownRequest* /*request*/, ::mavsdk::rpc::action::ShutdownResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
   class WithGenericMethod_Kill : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_Kill() {
-      ::grpc::Service::MarkMethodGeneric(5);
+      ::grpc::Service::MarkMethodGeneric(6);
     }
     ~WithGenericMethod_Kill() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1467,7 +1669,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_ReturnToLaunch() {
-      ::grpc::Service::MarkMethodGeneric(6);
+      ::grpc::Service::MarkMethodGeneric(7);
     }
     ~WithGenericMethod_ReturnToLaunch() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1479,18 +1681,35 @@ class ActionService final {
     }
   };
   template <class BaseClass>
-  class WithGenericMethod_TransitionToFixedWing : public BaseClass {
+  class WithGenericMethod_GotoLocation : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithGenericMethod_TransitionToFixedWing() {
-      ::grpc::Service::MarkMethodGeneric(7);
+    WithGenericMethod_GotoLocation() {
+      ::grpc::Service::MarkMethodGeneric(8);
     }
-    ~WithGenericMethod_TransitionToFixedWing() override {
+    ~WithGenericMethod_GotoLocation() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status TransitionToFixedWing(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::TransitionToFixedWingRequest* /*request*/, ::mavsdk::rpc::action::TransitionToFixedWingResponse* /*response*/) override {
+    ::grpc::Status GotoLocation(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::GotoLocationRequest* /*request*/, ::mavsdk::rpc::action::GotoLocationResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_TransitionToFixedwing : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_TransitionToFixedwing() {
+      ::grpc::Service::MarkMethodGeneric(9);
+    }
+    ~WithGenericMethod_TransitionToFixedwing() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status TransitionToFixedwing(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::TransitionToFixedwingRequest* /*request*/, ::mavsdk::rpc::action::TransitionToFixedwingResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -1501,7 +1720,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_TransitionToMulticopter() {
-      ::grpc::Service::MarkMethodGeneric(8);
+      ::grpc::Service::MarkMethodGeneric(10);
     }
     ~WithGenericMethod_TransitionToMulticopter() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1518,7 +1737,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_GetTakeoffAltitude() {
-      ::grpc::Service::MarkMethodGeneric(9);
+      ::grpc::Service::MarkMethodGeneric(11);
     }
     ~WithGenericMethod_GetTakeoffAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1535,7 +1754,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetTakeoffAltitude() {
-      ::grpc::Service::MarkMethodGeneric(10);
+      ::grpc::Service::MarkMethodGeneric(12);
     }
     ~WithGenericMethod_SetTakeoffAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1552,7 +1771,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_GetMaximumSpeed() {
-      ::grpc::Service::MarkMethodGeneric(11);
+      ::grpc::Service::MarkMethodGeneric(13);
     }
     ~WithGenericMethod_GetMaximumSpeed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1569,7 +1788,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetMaximumSpeed() {
-      ::grpc::Service::MarkMethodGeneric(12);
+      ::grpc::Service::MarkMethodGeneric(14);
     }
     ~WithGenericMethod_SetMaximumSpeed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1586,7 +1805,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_GetReturnToLaunchAltitude() {
-      ::grpc::Service::MarkMethodGeneric(13);
+      ::grpc::Service::MarkMethodGeneric(15);
     }
     ~WithGenericMethod_GetReturnToLaunchAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1603,7 +1822,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetReturnToLaunchAltitude() {
-      ::grpc::Service::MarkMethodGeneric(14);
+      ::grpc::Service::MarkMethodGeneric(16);
     }
     ~WithGenericMethod_SetReturnToLaunchAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1715,12 +1934,32 @@ class ActionService final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_Shutdown : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_Shutdown() {
+      ::grpc::Service::MarkMethodRaw(5);
+    }
+    ~WithRawMethod_Shutdown() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Shutdown(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::ShutdownRequest* /*request*/, ::mavsdk::rpc::action::ShutdownResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestShutdown(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithRawMethod_Kill : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_Kill() {
-      ::grpc::Service::MarkMethodRaw(5);
+      ::grpc::Service::MarkMethodRaw(6);
     }
     ~WithRawMethod_Kill() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1731,7 +1970,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestKill(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1740,7 +1979,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_ReturnToLaunch() {
-      ::grpc::Service::MarkMethodRaw(6);
+      ::grpc::Service::MarkMethodRaw(7);
     }
     ~WithRawMethod_ReturnToLaunch() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1751,27 +1990,47 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestReturnToLaunch(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
-  class WithRawMethod_TransitionToFixedWing : public BaseClass {
+  class WithRawMethod_GotoLocation : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithRawMethod_TransitionToFixedWing() {
-      ::grpc::Service::MarkMethodRaw(7);
+    WithRawMethod_GotoLocation() {
+      ::grpc::Service::MarkMethodRaw(8);
     }
-    ~WithRawMethod_TransitionToFixedWing() override {
+    ~WithRawMethod_GotoLocation() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status TransitionToFixedWing(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::TransitionToFixedWingRequest* /*request*/, ::mavsdk::rpc::action::TransitionToFixedWingResponse* /*response*/) override {
+    ::grpc::Status GotoLocation(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::GotoLocationRequest* /*request*/, ::mavsdk::rpc::action::GotoLocationResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestTransitionToFixedWing(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
+    void RequestGotoLocation(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_TransitionToFixedwing : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_TransitionToFixedwing() {
+      ::grpc::Service::MarkMethodRaw(9);
+    }
+    ~WithRawMethod_TransitionToFixedwing() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status TransitionToFixedwing(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::TransitionToFixedwingRequest* /*request*/, ::mavsdk::rpc::action::TransitionToFixedwingResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestTransitionToFixedwing(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1780,7 +2039,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_TransitionToMulticopter() {
-      ::grpc::Service::MarkMethodRaw(8);
+      ::grpc::Service::MarkMethodRaw(10);
     }
     ~WithRawMethod_TransitionToMulticopter() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1791,7 +2050,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestTransitionToMulticopter(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1800,7 +2059,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_GetTakeoffAltitude() {
-      ::grpc::Service::MarkMethodRaw(9);
+      ::grpc::Service::MarkMethodRaw(11);
     }
     ~WithRawMethod_GetTakeoffAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1811,7 +2070,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetTakeoffAltitude(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1820,7 +2079,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetTakeoffAltitude() {
-      ::grpc::Service::MarkMethodRaw(10);
+      ::grpc::Service::MarkMethodRaw(12);
     }
     ~WithRawMethod_SetTakeoffAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1831,7 +2090,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetTakeoffAltitude(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1840,7 +2099,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_GetMaximumSpeed() {
-      ::grpc::Service::MarkMethodRaw(11);
+      ::grpc::Service::MarkMethodRaw(13);
     }
     ~WithRawMethod_GetMaximumSpeed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1851,7 +2110,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetMaximumSpeed(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1860,7 +2119,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetMaximumSpeed() {
-      ::grpc::Service::MarkMethodRaw(12);
+      ::grpc::Service::MarkMethodRaw(14);
     }
     ~WithRawMethod_SetMaximumSpeed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1871,7 +2130,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetMaximumSpeed(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1880,7 +2139,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_GetReturnToLaunchAltitude() {
-      ::grpc::Service::MarkMethodRaw(13);
+      ::grpc::Service::MarkMethodRaw(15);
     }
     ~WithRawMethod_GetReturnToLaunchAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1891,7 +2150,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetReturnToLaunchAltitude(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1900,7 +2159,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetReturnToLaunchAltitude() {
-      ::grpc::Service::MarkMethodRaw(14);
+      ::grpc::Service::MarkMethodRaw(16);
     }
     ~WithRawMethod_SetReturnToLaunchAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1911,7 +2170,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetReturnToLaunchAltitude(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2015,12 +2274,32 @@ class ActionService final {
     virtual ::grpc::experimental::ServerUnaryReactor* Reboot(::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/) { return nullptr; }
   };
   template <class BaseClass>
+  class ExperimentalWithRawCallbackMethod_Shutdown : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    ExperimentalWithRawCallbackMethod_Shutdown() {
+      ::grpc::Service::experimental().MarkMethodRawCallback(5,
+        new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+          [this](::grpc::experimental::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->Shutdown(context, request, response); }));
+    }
+    ~ExperimentalWithRawCallbackMethod_Shutdown() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Shutdown(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::ShutdownRequest* /*request*/, ::mavsdk::rpc::action::ShutdownResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::experimental::ServerUnaryReactor* Shutdown(::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/) { return nullptr; }
+  };
+  template <class BaseClass>
   class ExperimentalWithRawCallbackMethod_Kill : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithRawCallbackMethod_Kill() {
-      ::grpc::Service::experimental().MarkMethodRawCallback(5,
+      ::grpc::Service::experimental().MarkMethodRawCallback(6,
         new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
           [this](::grpc::experimental::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->Kill(context, request, response); }));
     }
@@ -2040,7 +2319,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithRawCallbackMethod_ReturnToLaunch() {
-      ::grpc::Service::experimental().MarkMethodRawCallback(6,
+      ::grpc::Service::experimental().MarkMethodRawCallback(7,
         new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
           [this](::grpc::experimental::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->ReturnToLaunch(context, request, response); }));
     }
@@ -2055,24 +2334,44 @@ class ActionService final {
     virtual ::grpc::experimental::ServerUnaryReactor* ReturnToLaunch(::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/) { return nullptr; }
   };
   template <class BaseClass>
-  class ExperimentalWithRawCallbackMethod_TransitionToFixedWing : public BaseClass {
+  class ExperimentalWithRawCallbackMethod_GotoLocation : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    ExperimentalWithRawCallbackMethod_TransitionToFixedWing() {
-      ::grpc::Service::experimental().MarkMethodRawCallback(7,
+    ExperimentalWithRawCallbackMethod_GotoLocation() {
+      ::grpc::Service::experimental().MarkMethodRawCallback(8,
         new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
-          [this](::grpc::experimental::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->TransitionToFixedWing(context, request, response); }));
+          [this](::grpc::experimental::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->GotoLocation(context, request, response); }));
     }
-    ~ExperimentalWithRawCallbackMethod_TransitionToFixedWing() override {
+    ~ExperimentalWithRawCallbackMethod_GotoLocation() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status TransitionToFixedWing(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::TransitionToFixedWingRequest* /*request*/, ::mavsdk::rpc::action::TransitionToFixedWingResponse* /*response*/) override {
+    ::grpc::Status GotoLocation(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::GotoLocationRequest* /*request*/, ::mavsdk::rpc::action::GotoLocationResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    virtual ::grpc::experimental::ServerUnaryReactor* TransitionToFixedWing(::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/) { return nullptr; }
+    virtual ::grpc::experimental::ServerUnaryReactor* GotoLocation(::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/) { return nullptr; }
+  };
+  template <class BaseClass>
+  class ExperimentalWithRawCallbackMethod_TransitionToFixedwing : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    ExperimentalWithRawCallbackMethod_TransitionToFixedwing() {
+      ::grpc::Service::experimental().MarkMethodRawCallback(9,
+        new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+          [this](::grpc::experimental::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->TransitionToFixedwing(context, request, response); }));
+    }
+    ~ExperimentalWithRawCallbackMethod_TransitionToFixedwing() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status TransitionToFixedwing(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::TransitionToFixedwingRequest* /*request*/, ::mavsdk::rpc::action::TransitionToFixedwingResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::experimental::ServerUnaryReactor* TransitionToFixedwing(::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/) { return nullptr; }
   };
   template <class BaseClass>
   class ExperimentalWithRawCallbackMethod_TransitionToMulticopter : public BaseClass {
@@ -2080,7 +2379,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithRawCallbackMethod_TransitionToMulticopter() {
-      ::grpc::Service::experimental().MarkMethodRawCallback(8,
+      ::grpc::Service::experimental().MarkMethodRawCallback(10,
         new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
           [this](::grpc::experimental::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->TransitionToMulticopter(context, request, response); }));
     }
@@ -2100,7 +2399,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithRawCallbackMethod_GetTakeoffAltitude() {
-      ::grpc::Service::experimental().MarkMethodRawCallback(9,
+      ::grpc::Service::experimental().MarkMethodRawCallback(11,
         new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
           [this](::grpc::experimental::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->GetTakeoffAltitude(context, request, response); }));
     }
@@ -2120,7 +2419,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithRawCallbackMethod_SetTakeoffAltitude() {
-      ::grpc::Service::experimental().MarkMethodRawCallback(10,
+      ::grpc::Service::experimental().MarkMethodRawCallback(12,
         new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
           [this](::grpc::experimental::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetTakeoffAltitude(context, request, response); }));
     }
@@ -2140,7 +2439,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithRawCallbackMethod_GetMaximumSpeed() {
-      ::grpc::Service::experimental().MarkMethodRawCallback(11,
+      ::grpc::Service::experimental().MarkMethodRawCallback(13,
         new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
           [this](::grpc::experimental::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->GetMaximumSpeed(context, request, response); }));
     }
@@ -2160,7 +2459,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithRawCallbackMethod_SetMaximumSpeed() {
-      ::grpc::Service::experimental().MarkMethodRawCallback(12,
+      ::grpc::Service::experimental().MarkMethodRawCallback(14,
         new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
           [this](::grpc::experimental::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetMaximumSpeed(context, request, response); }));
     }
@@ -2180,7 +2479,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithRawCallbackMethod_GetReturnToLaunchAltitude() {
-      ::grpc::Service::experimental().MarkMethodRawCallback(13,
+      ::grpc::Service::experimental().MarkMethodRawCallback(15,
         new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
           [this](::grpc::experimental::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->GetReturnToLaunchAltitude(context, request, response); }));
     }
@@ -2200,7 +2499,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithRawCallbackMethod_SetReturnToLaunchAltitude() {
-      ::grpc::Service::experimental().MarkMethodRawCallback(14,
+      ::grpc::Service::experimental().MarkMethodRawCallback(16,
         new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
           [this](::grpc::experimental::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetReturnToLaunchAltitude(context, request, response); }));
     }
@@ -2315,12 +2614,32 @@ class ActionService final {
     virtual ::grpc::Status StreamedReboot(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::action::RebootRequest,::mavsdk::rpc::action::RebootResponse>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
+  class WithStreamedUnaryMethod_Shutdown : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_Shutdown() {
+      ::grpc::Service::MarkMethodStreamed(5,
+        new ::grpc::internal::StreamedUnaryHandler< ::mavsdk::rpc::action::ShutdownRequest, ::mavsdk::rpc::action::ShutdownResponse>(std::bind(&WithStreamedUnaryMethod_Shutdown<BaseClass>::StreamedShutdown, this, std::placeholders::_1, std::placeholders::_2)));
+    }
+    ~WithStreamedUnaryMethod_Shutdown() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status Shutdown(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::ShutdownRequest* /*request*/, ::mavsdk::rpc::action::ShutdownResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedShutdown(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::action::ShutdownRequest,::mavsdk::rpc::action::ShutdownResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_Kill : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_Kill() {
-      ::grpc::Service::MarkMethodStreamed(5,
+      ::grpc::Service::MarkMethodStreamed(6,
         new ::grpc::internal::StreamedUnaryHandler< ::mavsdk::rpc::action::KillRequest, ::mavsdk::rpc::action::KillResponse>(std::bind(&WithStreamedUnaryMethod_Kill<BaseClass>::StreamedKill, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_Kill() override {
@@ -2340,7 +2659,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_ReturnToLaunch() {
-      ::grpc::Service::MarkMethodStreamed(6,
+      ::grpc::Service::MarkMethodStreamed(7,
         new ::grpc::internal::StreamedUnaryHandler< ::mavsdk::rpc::action::ReturnToLaunchRequest, ::mavsdk::rpc::action::ReturnToLaunchResponse>(std::bind(&WithStreamedUnaryMethod_ReturnToLaunch<BaseClass>::StreamedReturnToLaunch, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_ReturnToLaunch() override {
@@ -2355,24 +2674,44 @@ class ActionService final {
     virtual ::grpc::Status StreamedReturnToLaunch(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::action::ReturnToLaunchRequest,::mavsdk::rpc::action::ReturnToLaunchResponse>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
-  class WithStreamedUnaryMethod_TransitionToFixedWing : public BaseClass {
+  class WithStreamedUnaryMethod_GotoLocation : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithStreamedUnaryMethod_TransitionToFixedWing() {
-      ::grpc::Service::MarkMethodStreamed(7,
-        new ::grpc::internal::StreamedUnaryHandler< ::mavsdk::rpc::action::TransitionToFixedWingRequest, ::mavsdk::rpc::action::TransitionToFixedWingResponse>(std::bind(&WithStreamedUnaryMethod_TransitionToFixedWing<BaseClass>::StreamedTransitionToFixedWing, this, std::placeholders::_1, std::placeholders::_2)));
+    WithStreamedUnaryMethod_GotoLocation() {
+      ::grpc::Service::MarkMethodStreamed(8,
+        new ::grpc::internal::StreamedUnaryHandler< ::mavsdk::rpc::action::GotoLocationRequest, ::mavsdk::rpc::action::GotoLocationResponse>(std::bind(&WithStreamedUnaryMethod_GotoLocation<BaseClass>::StreamedGotoLocation, this, std::placeholders::_1, std::placeholders::_2)));
     }
-    ~WithStreamedUnaryMethod_TransitionToFixedWing() override {
+    ~WithStreamedUnaryMethod_GotoLocation() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable regular version of this method
-    ::grpc::Status TransitionToFixedWing(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::TransitionToFixedWingRequest* /*request*/, ::mavsdk::rpc::action::TransitionToFixedWingResponse* /*response*/) override {
+    ::grpc::Status GotoLocation(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::GotoLocationRequest* /*request*/, ::mavsdk::rpc::action::GotoLocationResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     // replace default version of method with streamed unary
-    virtual ::grpc::Status StreamedTransitionToFixedWing(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::action::TransitionToFixedWingRequest,::mavsdk::rpc::action::TransitionToFixedWingResponse>* server_unary_streamer) = 0;
+    virtual ::grpc::Status StreamedGotoLocation(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::action::GotoLocationRequest,::mavsdk::rpc::action::GotoLocationResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_TransitionToFixedwing : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_TransitionToFixedwing() {
+      ::grpc::Service::MarkMethodStreamed(9,
+        new ::grpc::internal::StreamedUnaryHandler< ::mavsdk::rpc::action::TransitionToFixedwingRequest, ::mavsdk::rpc::action::TransitionToFixedwingResponse>(std::bind(&WithStreamedUnaryMethod_TransitionToFixedwing<BaseClass>::StreamedTransitionToFixedwing, this, std::placeholders::_1, std::placeholders::_2)));
+    }
+    ~WithStreamedUnaryMethod_TransitionToFixedwing() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status TransitionToFixedwing(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::TransitionToFixedwingRequest* /*request*/, ::mavsdk::rpc::action::TransitionToFixedwingResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedTransitionToFixedwing(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::action::TransitionToFixedwingRequest,::mavsdk::rpc::action::TransitionToFixedwingResponse>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
   class WithStreamedUnaryMethod_TransitionToMulticopter : public BaseClass {
@@ -2380,7 +2719,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_TransitionToMulticopter() {
-      ::grpc::Service::MarkMethodStreamed(8,
+      ::grpc::Service::MarkMethodStreamed(10,
         new ::grpc::internal::StreamedUnaryHandler< ::mavsdk::rpc::action::TransitionToMulticopterRequest, ::mavsdk::rpc::action::TransitionToMulticopterResponse>(std::bind(&WithStreamedUnaryMethod_TransitionToMulticopter<BaseClass>::StreamedTransitionToMulticopter, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_TransitionToMulticopter() override {
@@ -2400,7 +2739,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_GetTakeoffAltitude() {
-      ::grpc::Service::MarkMethodStreamed(9,
+      ::grpc::Service::MarkMethodStreamed(11,
         new ::grpc::internal::StreamedUnaryHandler< ::mavsdk::rpc::action::GetTakeoffAltitudeRequest, ::mavsdk::rpc::action::GetTakeoffAltitudeResponse>(std::bind(&WithStreamedUnaryMethod_GetTakeoffAltitude<BaseClass>::StreamedGetTakeoffAltitude, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_GetTakeoffAltitude() override {
@@ -2420,7 +2759,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetTakeoffAltitude() {
-      ::grpc::Service::MarkMethodStreamed(10,
+      ::grpc::Service::MarkMethodStreamed(12,
         new ::grpc::internal::StreamedUnaryHandler< ::mavsdk::rpc::action::SetTakeoffAltitudeRequest, ::mavsdk::rpc::action::SetTakeoffAltitudeResponse>(std::bind(&WithStreamedUnaryMethod_SetTakeoffAltitude<BaseClass>::StreamedSetTakeoffAltitude, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_SetTakeoffAltitude() override {
@@ -2440,7 +2779,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_GetMaximumSpeed() {
-      ::grpc::Service::MarkMethodStreamed(11,
+      ::grpc::Service::MarkMethodStreamed(13,
         new ::grpc::internal::StreamedUnaryHandler< ::mavsdk::rpc::action::GetMaximumSpeedRequest, ::mavsdk::rpc::action::GetMaximumSpeedResponse>(std::bind(&WithStreamedUnaryMethod_GetMaximumSpeed<BaseClass>::StreamedGetMaximumSpeed, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_GetMaximumSpeed() override {
@@ -2460,7 +2799,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetMaximumSpeed() {
-      ::grpc::Service::MarkMethodStreamed(12,
+      ::grpc::Service::MarkMethodStreamed(14,
         new ::grpc::internal::StreamedUnaryHandler< ::mavsdk::rpc::action::SetMaximumSpeedRequest, ::mavsdk::rpc::action::SetMaximumSpeedResponse>(std::bind(&WithStreamedUnaryMethod_SetMaximumSpeed<BaseClass>::StreamedSetMaximumSpeed, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_SetMaximumSpeed() override {
@@ -2480,7 +2819,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_GetReturnToLaunchAltitude() {
-      ::grpc::Service::MarkMethodStreamed(13,
+      ::grpc::Service::MarkMethodStreamed(15,
         new ::grpc::internal::StreamedUnaryHandler< ::mavsdk::rpc::action::GetReturnToLaunchAltitudeRequest, ::mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse>(std::bind(&WithStreamedUnaryMethod_GetReturnToLaunchAltitude<BaseClass>::StreamedGetReturnToLaunchAltitude, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_GetReturnToLaunchAltitude() override {
@@ -2500,7 +2839,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetReturnToLaunchAltitude() {
-      ::grpc::Service::MarkMethodStreamed(14,
+      ::grpc::Service::MarkMethodStreamed(16,
         new ::grpc::internal::StreamedUnaryHandler< ::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest, ::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse>(std::bind(&WithStreamedUnaryMethod_SetReturnToLaunchAltitude<BaseClass>::StreamedSetReturnToLaunchAltitude, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_SetReturnToLaunchAltitude() override {
@@ -2514,9 +2853,9 @@ class ActionService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedSetReturnToLaunchAltitude(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest,::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_Arm<WithStreamedUnaryMethod_Disarm<WithStreamedUnaryMethod_Takeoff<WithStreamedUnaryMethod_Land<WithStreamedUnaryMethod_Reboot<WithStreamedUnaryMethod_Kill<WithStreamedUnaryMethod_ReturnToLaunch<WithStreamedUnaryMethod_TransitionToFixedWing<WithStreamedUnaryMethod_TransitionToMulticopter<WithStreamedUnaryMethod_GetTakeoffAltitude<WithStreamedUnaryMethod_SetTakeoffAltitude<WithStreamedUnaryMethod_GetMaximumSpeed<WithStreamedUnaryMethod_SetMaximumSpeed<WithStreamedUnaryMethod_GetReturnToLaunchAltitude<WithStreamedUnaryMethod_SetReturnToLaunchAltitude<Service > > > > > > > > > > > > > > > StreamedUnaryService;
+  typedef WithStreamedUnaryMethod_Arm<WithStreamedUnaryMethod_Disarm<WithStreamedUnaryMethod_Takeoff<WithStreamedUnaryMethod_Land<WithStreamedUnaryMethod_Reboot<WithStreamedUnaryMethod_Shutdown<WithStreamedUnaryMethod_Kill<WithStreamedUnaryMethod_ReturnToLaunch<WithStreamedUnaryMethod_GotoLocation<WithStreamedUnaryMethod_TransitionToFixedwing<WithStreamedUnaryMethod_TransitionToMulticopter<WithStreamedUnaryMethod_GetTakeoffAltitude<WithStreamedUnaryMethod_SetTakeoffAltitude<WithStreamedUnaryMethod_GetMaximumSpeed<WithStreamedUnaryMethod_SetMaximumSpeed<WithStreamedUnaryMethod_GetReturnToLaunchAltitude<WithStreamedUnaryMethod_SetReturnToLaunchAltitude<Service > > > > > > > > > > > > > > > > > StreamedUnaryService;
   typedef Service SplitStreamedService;
-  typedef WithStreamedUnaryMethod_Arm<WithStreamedUnaryMethod_Disarm<WithStreamedUnaryMethod_Takeoff<WithStreamedUnaryMethod_Land<WithStreamedUnaryMethod_Reboot<WithStreamedUnaryMethod_Kill<WithStreamedUnaryMethod_ReturnToLaunch<WithStreamedUnaryMethod_TransitionToFixedWing<WithStreamedUnaryMethod_TransitionToMulticopter<WithStreamedUnaryMethod_GetTakeoffAltitude<WithStreamedUnaryMethod_SetTakeoffAltitude<WithStreamedUnaryMethod_GetMaximumSpeed<WithStreamedUnaryMethod_SetMaximumSpeed<WithStreamedUnaryMethod_GetReturnToLaunchAltitude<WithStreamedUnaryMethod_SetReturnToLaunchAltitude<Service > > > > > > > > > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_Arm<WithStreamedUnaryMethod_Disarm<WithStreamedUnaryMethod_Takeoff<WithStreamedUnaryMethod_Land<WithStreamedUnaryMethod_Reboot<WithStreamedUnaryMethod_Shutdown<WithStreamedUnaryMethod_Kill<WithStreamedUnaryMethod_ReturnToLaunch<WithStreamedUnaryMethod_GotoLocation<WithStreamedUnaryMethod_TransitionToFixedwing<WithStreamedUnaryMethod_TransitionToMulticopter<WithStreamedUnaryMethod_GetTakeoffAltitude<WithStreamedUnaryMethod_SetTakeoffAltitude<WithStreamedUnaryMethod_GetMaximumSpeed<WithStreamedUnaryMethod_SetMaximumSpeed<WithStreamedUnaryMethod_GetReturnToLaunchAltitude<WithStreamedUnaryMethod_SetReturnToLaunchAltitude<Service > > > > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace action

--- a/src/backend/src/generated/action/action.pb.cc
+++ b/src/backend/src/generated/action/action.pb.cc
@@ -58,6 +58,14 @@ class RebootResponseDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<RebootResponse> _instance;
 } _RebootResponse_default_instance_;
+class ShutdownRequestDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<ShutdownRequest> _instance;
+} _ShutdownRequest_default_instance_;
+class ShutdownResponseDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<ShutdownResponse> _instance;
+} _ShutdownResponse_default_instance_;
 class KillRequestDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<KillRequest> _instance;
@@ -74,14 +82,22 @@ class ReturnToLaunchResponseDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<ReturnToLaunchResponse> _instance;
 } _ReturnToLaunchResponse_default_instance_;
-class TransitionToFixedWingRequestDefaultTypeInternal {
+class GotoLocationRequestDefaultTypeInternal {
  public:
-  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<TransitionToFixedWingRequest> _instance;
-} _TransitionToFixedWingRequest_default_instance_;
-class TransitionToFixedWingResponseDefaultTypeInternal {
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<GotoLocationRequest> _instance;
+} _GotoLocationRequest_default_instance_;
+class GotoLocationResponseDefaultTypeInternal {
  public:
-  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<TransitionToFixedWingResponse> _instance;
-} _TransitionToFixedWingResponse_default_instance_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<GotoLocationResponse> _instance;
+} _GotoLocationResponse_default_instance_;
+class TransitionToFixedwingRequestDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<TransitionToFixedwingRequest> _instance;
+} _TransitionToFixedwingRequest_default_instance_;
+class TransitionToFixedwingResponseDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<TransitionToFixedwingResponse> _instance;
+} _TransitionToFixedwingResponse_default_instance_;
 class TransitionToMulticopterRequestDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<TransitionToMulticopterRequest> _instance;
@@ -304,6 +320,35 @@ static void InitDefaultsscc_info_GetTakeoffAltitudeResponse_action_2faction_2epr
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_GetTakeoffAltitudeResponse_action_2faction_2eproto}, {
       &scc_info_ActionResult_action_2faction_2eproto.base,}};
 
+static void InitDefaultsscc_info_GotoLocationRequest_action_2faction_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::mavsdk::rpc::action::_GotoLocationRequest_default_instance_;
+    new (ptr) ::mavsdk::rpc::action::GotoLocationRequest();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::mavsdk::rpc::action::GotoLocationRequest::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_GotoLocationRequest_action_2faction_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_GotoLocationRequest_action_2faction_2eproto}, {}};
+
+static void InitDefaultsscc_info_GotoLocationResponse_action_2faction_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::mavsdk::rpc::action::_GotoLocationResponse_default_instance_;
+    new (ptr) ::mavsdk::rpc::action::GotoLocationResponse();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::mavsdk::rpc::action::GotoLocationResponse::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_GotoLocationResponse_action_2faction_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_GotoLocationResponse_action_2faction_2eproto}, {
+      &scc_info_ActionResult_action_2faction_2eproto.base,}};
+
 static void InitDefaultsscc_info_KillRequest_action_2faction_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
@@ -507,6 +552,35 @@ static void InitDefaultsscc_info_SetTakeoffAltitudeResponse_action_2faction_2epr
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_SetTakeoffAltitudeResponse_action_2faction_2eproto}, {
       &scc_info_ActionResult_action_2faction_2eproto.base,}};
 
+static void InitDefaultsscc_info_ShutdownRequest_action_2faction_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::mavsdk::rpc::action::_ShutdownRequest_default_instance_;
+    new (ptr) ::mavsdk::rpc::action::ShutdownRequest();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::mavsdk::rpc::action::ShutdownRequest::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_ShutdownRequest_action_2faction_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_ShutdownRequest_action_2faction_2eproto}, {}};
+
+static void InitDefaultsscc_info_ShutdownResponse_action_2faction_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::mavsdk::rpc::action::_ShutdownResponse_default_instance_;
+    new (ptr) ::mavsdk::rpc::action::ShutdownResponse();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::mavsdk::rpc::action::ShutdownResponse::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_ShutdownResponse_action_2faction_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_ShutdownResponse_action_2faction_2eproto}, {
+      &scc_info_ActionResult_action_2faction_2eproto.base,}};
+
 static void InitDefaultsscc_info_TakeoffRequest_action_2faction_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
@@ -536,33 +610,33 @@ static void InitDefaultsscc_info_TakeoffResponse_action_2faction_2eproto() {
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_TakeoffResponse_action_2faction_2eproto}, {
       &scc_info_ActionResult_action_2faction_2eproto.base,}};
 
-static void InitDefaultsscc_info_TransitionToFixedWingRequest_action_2faction_2eproto() {
+static void InitDefaultsscc_info_TransitionToFixedwingRequest_action_2faction_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
   {
-    void* ptr = &::mavsdk::rpc::action::_TransitionToFixedWingRequest_default_instance_;
-    new (ptr) ::mavsdk::rpc::action::TransitionToFixedWingRequest();
+    void* ptr = &::mavsdk::rpc::action::_TransitionToFixedwingRequest_default_instance_;
+    new (ptr) ::mavsdk::rpc::action::TransitionToFixedwingRequest();
     ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::mavsdk::rpc::action::TransitionToFixedWingRequest::InitAsDefaultInstance();
+  ::mavsdk::rpc::action::TransitionToFixedwingRequest::InitAsDefaultInstance();
 }
 
-::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_TransitionToFixedWingRequest_action_2faction_2eproto =
-    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_TransitionToFixedWingRequest_action_2faction_2eproto}, {}};
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_TransitionToFixedwingRequest_action_2faction_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_TransitionToFixedwingRequest_action_2faction_2eproto}, {}};
 
-static void InitDefaultsscc_info_TransitionToFixedWingResponse_action_2faction_2eproto() {
+static void InitDefaultsscc_info_TransitionToFixedwingResponse_action_2faction_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
   {
-    void* ptr = &::mavsdk::rpc::action::_TransitionToFixedWingResponse_default_instance_;
-    new (ptr) ::mavsdk::rpc::action::TransitionToFixedWingResponse();
+    void* ptr = &::mavsdk::rpc::action::_TransitionToFixedwingResponse_default_instance_;
+    new (ptr) ::mavsdk::rpc::action::TransitionToFixedwingResponse();
     ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::mavsdk::rpc::action::TransitionToFixedWingResponse::InitAsDefaultInstance();
+  ::mavsdk::rpc::action::TransitionToFixedwingResponse::InitAsDefaultInstance();
 }
 
-::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_TransitionToFixedWingResponse_action_2faction_2eproto =
-    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_TransitionToFixedWingResponse_action_2faction_2eproto}, {
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_TransitionToFixedwingResponse_action_2faction_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_TransitionToFixedwingResponse_action_2faction_2eproto}, {
       &scc_info_ActionResult_action_2faction_2eproto.base,}};
 
 static void InitDefaultsscc_info_TransitionToMulticopterRequest_action_2faction_2eproto() {
@@ -594,7 +668,7 @@ static void InitDefaultsscc_info_TransitionToMulticopterResponse_action_2faction
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_TransitionToMulticopterResponse_action_2faction_2eproto}, {
       &scc_info_ActionResult_action_2faction_2eproto.base,}};
 
-static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_action_2faction_2eproto[31];
+static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_action_2faction_2eproto[35];
 static const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* file_level_enum_descriptors_action_2faction_2eproto[1];
 static constexpr ::PROTOBUF_NAMESPACE_ID::ServiceDescriptor const** file_level_service_descriptors_action_2faction_2eproto = nullptr;
 
@@ -655,6 +729,17 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_action_2faction_2eproto::offse
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::RebootResponse, action_result_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::ShutdownRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::ShutdownResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::ShutdownResponse, action_result_),
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::KillRequest, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -677,16 +762,31 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_action_2faction_2eproto::offse
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::ReturnToLaunchResponse, action_result_),
   ~0u,  // no _has_bits_
-  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::TransitionToFixedWingRequest, _internal_metadata_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::GotoLocationRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::GotoLocationRequest, latitude_deg_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::GotoLocationRequest, longitude_deg_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::GotoLocationRequest, absolute_altitude_m_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::GotoLocationRequest, yaw_deg_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::GotoLocationResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::GotoLocationResponse, action_result_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::TransitionToFixedwingRequest, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   ~0u,  // no _has_bits_
-  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::TransitionToFixedWingResponse, _internal_metadata_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::TransitionToFixedwingResponse, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::TransitionToFixedWingResponse, action_result_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::TransitionToFixedwingResponse, action_result_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::TransitionToMulticopterRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -789,27 +889,31 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 38, -1, sizeof(::mavsdk::rpc::action::LandResponse)},
   { 44, -1, sizeof(::mavsdk::rpc::action::RebootRequest)},
   { 49, -1, sizeof(::mavsdk::rpc::action::RebootResponse)},
-  { 55, -1, sizeof(::mavsdk::rpc::action::KillRequest)},
-  { 60, -1, sizeof(::mavsdk::rpc::action::KillResponse)},
-  { 66, -1, sizeof(::mavsdk::rpc::action::ReturnToLaunchRequest)},
-  { 71, -1, sizeof(::mavsdk::rpc::action::ReturnToLaunchResponse)},
-  { 77, -1, sizeof(::mavsdk::rpc::action::TransitionToFixedWingRequest)},
-  { 82, -1, sizeof(::mavsdk::rpc::action::TransitionToFixedWingResponse)},
-  { 88, -1, sizeof(::mavsdk::rpc::action::TransitionToMulticopterRequest)},
-  { 93, -1, sizeof(::mavsdk::rpc::action::TransitionToMulticopterResponse)},
-  { 99, -1, sizeof(::mavsdk::rpc::action::GetTakeoffAltitudeRequest)},
-  { 104, -1, sizeof(::mavsdk::rpc::action::GetTakeoffAltitudeResponse)},
-  { 111, -1, sizeof(::mavsdk::rpc::action::SetTakeoffAltitudeRequest)},
-  { 117, -1, sizeof(::mavsdk::rpc::action::SetTakeoffAltitudeResponse)},
-  { 123, -1, sizeof(::mavsdk::rpc::action::GetMaximumSpeedRequest)},
-  { 128, -1, sizeof(::mavsdk::rpc::action::GetMaximumSpeedResponse)},
-  { 135, -1, sizeof(::mavsdk::rpc::action::SetMaximumSpeedRequest)},
-  { 141, -1, sizeof(::mavsdk::rpc::action::SetMaximumSpeedResponse)},
-  { 147, -1, sizeof(::mavsdk::rpc::action::GetReturnToLaunchAltitudeRequest)},
-  { 152, -1, sizeof(::mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse)},
-  { 159, -1, sizeof(::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest)},
-  { 165, -1, sizeof(::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse)},
-  { 171, -1, sizeof(::mavsdk::rpc::action::ActionResult)},
+  { 55, -1, sizeof(::mavsdk::rpc::action::ShutdownRequest)},
+  { 60, -1, sizeof(::mavsdk::rpc::action::ShutdownResponse)},
+  { 66, -1, sizeof(::mavsdk::rpc::action::KillRequest)},
+  { 71, -1, sizeof(::mavsdk::rpc::action::KillResponse)},
+  { 77, -1, sizeof(::mavsdk::rpc::action::ReturnToLaunchRequest)},
+  { 82, -1, sizeof(::mavsdk::rpc::action::ReturnToLaunchResponse)},
+  { 88, -1, sizeof(::mavsdk::rpc::action::GotoLocationRequest)},
+  { 97, -1, sizeof(::mavsdk::rpc::action::GotoLocationResponse)},
+  { 103, -1, sizeof(::mavsdk::rpc::action::TransitionToFixedwingRequest)},
+  { 108, -1, sizeof(::mavsdk::rpc::action::TransitionToFixedwingResponse)},
+  { 114, -1, sizeof(::mavsdk::rpc::action::TransitionToMulticopterRequest)},
+  { 119, -1, sizeof(::mavsdk::rpc::action::TransitionToMulticopterResponse)},
+  { 125, -1, sizeof(::mavsdk::rpc::action::GetTakeoffAltitudeRequest)},
+  { 130, -1, sizeof(::mavsdk::rpc::action::GetTakeoffAltitudeResponse)},
+  { 137, -1, sizeof(::mavsdk::rpc::action::SetTakeoffAltitudeRequest)},
+  { 143, -1, sizeof(::mavsdk::rpc::action::SetTakeoffAltitudeResponse)},
+  { 149, -1, sizeof(::mavsdk::rpc::action::GetMaximumSpeedRequest)},
+  { 154, -1, sizeof(::mavsdk::rpc::action::GetMaximumSpeedResponse)},
+  { 161, -1, sizeof(::mavsdk::rpc::action::SetMaximumSpeedRequest)},
+  { 167, -1, sizeof(::mavsdk::rpc::action::SetMaximumSpeedResponse)},
+  { 173, -1, sizeof(::mavsdk::rpc::action::GetReturnToLaunchAltitudeRequest)},
+  { 178, -1, sizeof(::mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse)},
+  { 185, -1, sizeof(::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest)},
+  { 191, -1, sizeof(::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse)},
+  { 197, -1, sizeof(::mavsdk::rpc::action::ActionResult)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -823,12 +927,16 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action::_LandResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action::_RebootRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action::_RebootResponse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action::_ShutdownRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action::_ShutdownResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action::_KillRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action::_KillResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action::_ReturnToLaunchRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action::_ReturnToLaunchResponse_default_instance_),
-  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action::_TransitionToFixedWingRequest_default_instance_),
-  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action::_TransitionToFixedWingResponse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action::_GotoLocationRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action::_GotoLocationResponse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action::_TransitionToFixedwingRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action::_TransitionToFixedwingResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action::_TransitionToMulticopterRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action::_TransitionToMulticopterResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action::_GetTakeoffAltitudeRequest_default_instance_),
@@ -859,92 +967,104 @@ const char descriptor_table_protodef_action_2faction_2eproto[] PROTOBUF_SECTION_
   "\001(\0132\037.mavsdk.rpc.action.ActionResult\"\017\n\r"
   "RebootRequest\"H\n\016RebootResponse\0226\n\ractio"
   "n_result\030\001 \001(\0132\037.mavsdk.rpc.action.Actio"
-  "nResult\"\r\n\013KillRequest\"F\n\014KillResponse\0226"
-  "\n\raction_result\030\001 \001(\0132\037.mavsdk.rpc.actio"
-  "n.ActionResult\"\027\n\025ReturnToLaunchRequest\""
-  "P\n\026ReturnToLaunchResponse\0226\n\raction_resu"
-  "lt\030\001 \001(\0132\037.mavsdk.rpc.action.ActionResul"
-  "t\"\036\n\034TransitionToFixedWingRequest\"W\n\035Tra"
-  "nsitionToFixedWingResponse\0226\n\raction_res"
-  "ult\030\001 \001(\0132\037.mavsdk.rpc.action.ActionResu"
-  "lt\" \n\036TransitionToMulticopterRequest\"Y\n\037"
-  "TransitionToMulticopterResponse\0226\n\ractio"
-  "n_result\030\001 \001(\0132\037.mavsdk.rpc.action.Actio"
-  "nResult\"\033\n\031GetTakeoffAltitudeRequest\"f\n\032"
-  "GetTakeoffAltitudeResponse\0226\n\raction_res"
-  "ult\030\001 \001(\0132\037.mavsdk.rpc.action.ActionResu"
-  "lt\022\020\n\010altitude\030\002 \001(\002\"-\n\031SetTakeoffAltitu"
-  "deRequest\022\020\n\010altitude\030\001 \001(\002\"T\n\032SetTakeof"
-  "fAltitudeResponse\0226\n\raction_result\030\001 \001(\013"
-  "2\037.mavsdk.rpc.action.ActionResult\"\030\n\026Get"
-  "MaximumSpeedRequest\"`\n\027GetMaximumSpeedRe"
+  "nResult\"\021\n\017ShutdownRequest\"J\n\020ShutdownRe"
   "sponse\0226\n\raction_result\030\001 \001(\0132\037.mavsdk.r"
-  "pc.action.ActionResult\022\r\n\005speed\030\002 \001(\002\"\'\n"
-  "\026SetMaximumSpeedRequest\022\r\n\005speed\030\001 \001(\002\"Q"
-  "\n\027SetMaximumSpeedResponse\0226\n\raction_resu"
-  "lt\030\001 \001(\0132\037.mavsdk.rpc.action.ActionResul"
-  "t\"\"\n GetReturnToLaunchAltitudeRequest\"x\n"
-  "!GetReturnToLaunchAltitudeResponse\0226\n\rac"
+  "pc.action.ActionResult\"\r\n\013KillRequest\"F\n"
+  "\014KillResponse\0226\n\raction_result\030\001 \001(\0132\037.m"
+  "avsdk.rpc.action.ActionResult\"\027\n\025ReturnT"
+  "oLaunchRequest\"P\n\026ReturnToLaunchResponse"
+  "\0226\n\raction_result\030\001 \001(\0132\037.mavsdk.rpc.act"
+  "ion.ActionResult\"p\n\023GotoLocationRequest\022"
+  "\024\n\014latitude_deg\030\001 \001(\001\022\025\n\rlongitude_deg\030\002"
+  " \001(\001\022\033\n\023absolute_altitude_m\030\003 \001(\002\022\017\n\007yaw"
+  "_deg\030\004 \001(\002\"N\n\024GotoLocationResponse\0226\n\rac"
   "tion_result\030\001 \001(\0132\037.mavsdk.rpc.action.Ac"
-  "tionResult\022\033\n\023relative_altitude_m\030\002 \001(\002\""
-  "\?\n SetReturnToLaunchAltitudeRequest\022\033\n\023r"
-  "elative_altitude_m\030\001 \001(\002\"[\n!SetReturnToL"
-  "aunchAltitudeResponse\0226\n\raction_result\030\001"
-  " \001(\0132\037.mavsdk.rpc.action.ActionResult\"\361\002"
-  "\n\014ActionResult\0226\n\006result\030\001 \001(\0162&.mavsdk."
-  "rpc.action.ActionResult.Result\022\022\n\nresult"
-  "_str\030\002 \001(\t\"\224\002\n\006Result\022\013\n\007UNKNOWN\020\000\022\013\n\007SU"
-  "CCESS\020\001\022\r\n\tNO_SYSTEM\020\002\022\024\n\020CONNECTION_ERR"
-  "OR\020\003\022\010\n\004BUSY\020\004\022\022\n\016COMMAND_DENIED\020\005\022\'\n#CO"
-  "MMAND_DENIED_LANDED_STATE_UNKNOWN\020\006\022\035\n\031C"
-  "OMMAND_DENIED_NOT_LANDED\020\007\022\013\n\007TIMEOUT\020\010\022"
-  "#\n\037VTOL_TRANSITION_SUPPORT_UNKNOWN\020\t\022\036\n\032"
-  "NO_VTOL_TRANSITION_SUPPORT\020\n\022\023\n\017PARAMETE"
-  "R_ERROR\020\0132\247\014\n\rActionService\022F\n\003Arm\022\035.mav"
-  "sdk.rpc.action.ArmRequest\032\036.mavsdk.rpc.a"
-  "ction.ArmResponse\"\000\022O\n\006Disarm\022 .mavsdk.r"
-  "pc.action.DisarmRequest\032!.mavsdk.rpc.act"
-  "ion.DisarmResponse\"\000\022R\n\007Takeoff\022!.mavsdk"
-  ".rpc.action.TakeoffRequest\032\".mavsdk.rpc."
-  "action.TakeoffResponse\"\000\022I\n\004Land\022\036.mavsd"
-  "k.rpc.action.LandRequest\032\037.mavsdk.rpc.ac"
-  "tion.LandResponse\"\000\022O\n\006Reboot\022 .mavsdk.r"
-  "pc.action.RebootRequest\032!.mavsdk.rpc.act"
-  "ion.RebootResponse\"\000\022I\n\004Kill\022\036.mavsdk.rp"
-  "c.action.KillRequest\032\037.mavsdk.rpc.action"
-  ".KillResponse\"\000\022g\n\016ReturnToLaunch\022(.mavs"
-  "dk.rpc.action.ReturnToLaunchRequest\032).ma"
-  "vsdk.rpc.action.ReturnToLaunchResponse\"\000"
-  "\022|\n\025TransitionToFixedWing\022/.mavsdk.rpc.a"
-  "ction.TransitionToFixedWingRequest\0320.mav"
-  "sdk.rpc.action.TransitionToFixedWingResp"
-  "onse\"\000\022\202\001\n\027TransitionToMulticopter\0221.mav"
-  "sdk.rpc.action.TransitionToMulticopterRe"
-  "quest\0322.mavsdk.rpc.action.TransitionToMu"
-  "lticopterResponse\"\000\022s\n\022GetTakeoffAltitud"
-  "e\022,.mavsdk.rpc.action.GetTakeoffAltitude"
-  "Request\032-.mavsdk.rpc.action.GetTakeoffAl"
-  "titudeResponse\"\000\022s\n\022SetTakeoffAltitude\022,"
-  ".mavsdk.rpc.action.SetTakeoffAltitudeReq"
-  "uest\032-.mavsdk.rpc.action.SetTakeoffAltit"
-  "udeResponse\"\000\022j\n\017GetMaximumSpeed\022).mavsd"
-  "k.rpc.action.GetMaximumSpeedRequest\032*.ma"
-  "vsdk.rpc.action.GetMaximumSpeedResponse\""
-  "\000\022j\n\017SetMaximumSpeed\022).mavsdk.rpc.action"
-  ".SetMaximumSpeedRequest\032*.mavsdk.rpc.act"
-  "ion.SetMaximumSpeedResponse\"\000\022\210\001\n\031GetRet"
-  "urnToLaunchAltitude\0223.mavsdk.rpc.action."
-  "GetReturnToLaunchAltitudeRequest\0324.mavsd"
-  "k.rpc.action.GetReturnToLaunchAltitudeRe"
-  "sponse\"\000\022\210\001\n\031SetReturnToLaunchAltitude\0223"
-  ".mavsdk.rpc.action.SetReturnToLaunchAlti"
-  "tudeRequest\0324.mavsdk.rpc.action.SetRetur"
-  "nToLaunchAltitudeResponse\"\000B\037\n\020io.mavsdk"
-  ".actionB\013ActionProtob\006proto3"
+  "tionResult\"\036\n\034TransitionToFixedwingReque"
+  "st\"W\n\035TransitionToFixedwingResponse\0226\n\ra"
+  "ction_result\030\001 \001(\0132\037.mavsdk.rpc.action.A"
+  "ctionResult\" \n\036TransitionToMulticopterRe"
+  "quest\"Y\n\037TransitionToMulticopterResponse"
+  "\0226\n\raction_result\030\001 \001(\0132\037.mavsdk.rpc.act"
+  "ion.ActionResult\"\033\n\031GetTakeoffAltitudeRe"
+  "quest\"f\n\032GetTakeoffAltitudeResponse\0226\n\ra"
+  "ction_result\030\001 \001(\0132\037.mavsdk.rpc.action.A"
+  "ctionResult\022\020\n\010altitude\030\002 \001(\002\"-\n\031SetTake"
+  "offAltitudeRequest\022\020\n\010altitude\030\001 \001(\002\"T\n\032"
+  "SetTakeoffAltitudeResponse\0226\n\raction_res"
+  "ult\030\001 \001(\0132\037.mavsdk.rpc.action.ActionResu"
+  "lt\"\030\n\026GetMaximumSpeedRequest\"`\n\027GetMaxim"
+  "umSpeedResponse\0226\n\raction_result\030\001 \001(\0132\037"
+  ".mavsdk.rpc.action.ActionResult\022\r\n\005speed"
+  "\030\002 \001(\002\"\'\n\026SetMaximumSpeedRequest\022\r\n\005spee"
+  "d\030\001 \001(\002\"Q\n\027SetMaximumSpeedResponse\0226\n\rac"
+  "tion_result\030\001 \001(\0132\037.mavsdk.rpc.action.Ac"
+  "tionResult\"\"\n GetReturnToLaunchAltitudeR"
+  "equest\"x\n!GetReturnToLaunchAltitudeRespo"
+  "nse\0226\n\raction_result\030\001 \001(\0132\037.mavsdk.rpc."
+  "action.ActionResult\022\033\n\023relative_altitude"
+  "_m\030\002 \001(\002\"\?\n SetReturnToLaunchAltitudeReq"
+  "uest\022\033\n\023relative_altitude_m\030\001 \001(\002\"[\n!Set"
+  "ReturnToLaunchAltitudeResponse\0226\n\raction"
+  "_result\030\001 \001(\0132\037.mavsdk.rpc.action.Action"
+  "Result\"\361\002\n\014ActionResult\0226\n\006result\030\001 \001(\0162"
+  "&.mavsdk.rpc.action.ActionResult.Result\022"
+  "\022\n\nresult_str\030\002 \001(\t\"\224\002\n\006Result\022\013\n\007UNKNOW"
+  "N\020\000\022\013\n\007SUCCESS\020\001\022\r\n\tNO_SYSTEM\020\002\022\024\n\020CONNE"
+  "CTION_ERROR\020\003\022\010\n\004BUSY\020\004\022\022\n\016COMMAND_DENIE"
+  "D\020\005\022\'\n#COMMAND_DENIED_LANDED_STATE_UNKNO"
+  "WN\020\006\022\035\n\031COMMAND_DENIED_NOT_LANDED\020\007\022\013\n\007T"
+  "IMEOUT\020\010\022#\n\037VTOL_TRANSITION_SUPPORT_UNKN"
+  "OWN\020\t\022\036\n\032NO_VTOL_TRANSITION_SUPPORT\020\n\022\023\n"
+  "\017PARAMETER_ERROR\020\0132\341\r\n\rActionService\022F\n\003"
+  "Arm\022\035.mavsdk.rpc.action.ArmRequest\032\036.mav"
+  "sdk.rpc.action.ArmResponse\"\000\022O\n\006Disarm\022 "
+  ".mavsdk.rpc.action.DisarmRequest\032!.mavsd"
+  "k.rpc.action.DisarmResponse\"\000\022R\n\007Takeoff"
+  "\022!.mavsdk.rpc.action.TakeoffRequest\032\".ma"
+  "vsdk.rpc.action.TakeoffResponse\"\000\022I\n\004Lan"
+  "d\022\036.mavsdk.rpc.action.LandRequest\032\037.mavs"
+  "dk.rpc.action.LandResponse\"\000\022O\n\006Reboot\022 "
+  ".mavsdk.rpc.action.RebootRequest\032!.mavsd"
+  "k.rpc.action.RebootResponse\"\000\022U\n\010Shutdow"
+  "n\022\".mavsdk.rpc.action.ShutdownRequest\032#."
+  "mavsdk.rpc.action.ShutdownResponse\"\000\022I\n\004"
+  "Kill\022\036.mavsdk.rpc.action.KillRequest\032\037.m"
+  "avsdk.rpc.action.KillResponse\"\000\022g\n\016Retur"
+  "nToLaunch\022(.mavsdk.rpc.action.ReturnToLa"
+  "unchRequest\032).mavsdk.rpc.action.ReturnTo"
+  "LaunchResponse\"\000\022a\n\014GotoLocation\022&.mavsd"
+  "k.rpc.action.GotoLocationRequest\032\'.mavsd"
+  "k.rpc.action.GotoLocationResponse\"\000\022|\n\025T"
+  "ransitionToFixedwing\022/.mavsdk.rpc.action"
+  ".TransitionToFixedwingRequest\0320.mavsdk.r"
+  "pc.action.TransitionToFixedwingResponse\""
+  "\000\022\202\001\n\027TransitionToMulticopter\0221.mavsdk.r"
+  "pc.action.TransitionToMulticopterRequest"
+  "\0322.mavsdk.rpc.action.TransitionToMultico"
+  "pterResponse\"\000\022s\n\022GetTakeoffAltitude\022,.m"
+  "avsdk.rpc.action.GetTakeoffAltitudeReque"
+  "st\032-.mavsdk.rpc.action.GetTakeoffAltitud"
+  "eResponse\"\000\022s\n\022SetTakeoffAltitude\022,.mavs"
+  "dk.rpc.action.SetTakeoffAltitudeRequest\032"
+  "-.mavsdk.rpc.action.SetTakeoffAltitudeRe"
+  "sponse\"\000\022j\n\017GetMaximumSpeed\022).mavsdk.rpc"
+  ".action.GetMaximumSpeedRequest\032*.mavsdk."
+  "rpc.action.GetMaximumSpeedResponse\"\000\022j\n\017"
+  "SetMaximumSpeed\022).mavsdk.rpc.action.SetM"
+  "aximumSpeedRequest\032*.mavsdk.rpc.action.S"
+  "etMaximumSpeedResponse\"\000\022\210\001\n\031GetReturnTo"
+  "LaunchAltitude\0223.mavsdk.rpc.action.GetRe"
+  "turnToLaunchAltitudeRequest\0324.mavsdk.rpc"
+  ".action.GetReturnToLaunchAltitudeRespons"
+  "e\"\000\022\210\001\n\031SetReturnToLaunchAltitude\0223.mavs"
+  "dk.rpc.action.SetReturnToLaunchAltitudeR"
+  "equest\0324.mavsdk.rpc.action.SetReturnToLa"
+  "unchAltitudeResponse\"\000B\037\n\020io.mavsdk.acti"
+  "onB\013ActionProtob\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_action_2faction_2eproto_deps[1] = {
 };
-static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_action_2faction_2eproto_sccs[31] = {
+static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_action_2faction_2eproto_sccs[35] = {
   &scc_info_ActionResult_action_2faction_2eproto.base,
   &scc_info_ArmRequest_action_2faction_2eproto.base,
   &scc_info_ArmResponse_action_2faction_2eproto.base,
@@ -956,6 +1076,8 @@ static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_act
   &scc_info_GetReturnToLaunchAltitudeResponse_action_2faction_2eproto.base,
   &scc_info_GetTakeoffAltitudeRequest_action_2faction_2eproto.base,
   &scc_info_GetTakeoffAltitudeResponse_action_2faction_2eproto.base,
+  &scc_info_GotoLocationRequest_action_2faction_2eproto.base,
+  &scc_info_GotoLocationResponse_action_2faction_2eproto.base,
   &scc_info_KillRequest_action_2faction_2eproto.base,
   &scc_info_KillResponse_action_2faction_2eproto.base,
   &scc_info_LandRequest_action_2faction_2eproto.base,
@@ -970,20 +1092,22 @@ static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_act
   &scc_info_SetReturnToLaunchAltitudeResponse_action_2faction_2eproto.base,
   &scc_info_SetTakeoffAltitudeRequest_action_2faction_2eproto.base,
   &scc_info_SetTakeoffAltitudeResponse_action_2faction_2eproto.base,
+  &scc_info_ShutdownRequest_action_2faction_2eproto.base,
+  &scc_info_ShutdownResponse_action_2faction_2eproto.base,
   &scc_info_TakeoffRequest_action_2faction_2eproto.base,
   &scc_info_TakeoffResponse_action_2faction_2eproto.base,
-  &scc_info_TransitionToFixedWingRequest_action_2faction_2eproto.base,
-  &scc_info_TransitionToFixedWingResponse_action_2faction_2eproto.base,
+  &scc_info_TransitionToFixedwingRequest_action_2faction_2eproto.base,
+  &scc_info_TransitionToFixedwingResponse_action_2faction_2eproto.base,
   &scc_info_TransitionToMulticopterRequest_action_2faction_2eproto.base,
   &scc_info_TransitionToMulticopterResponse_action_2faction_2eproto.base,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_action_2faction_2eproto_once;
 static bool descriptor_table_action_2faction_2eproto_initialized = false;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_action_2faction_2eproto = {
-  &descriptor_table_action_2faction_2eproto_initialized, descriptor_table_protodef_action_2faction_2eproto, "action/action.proto", 3748,
-  &descriptor_table_action_2faction_2eproto_once, descriptor_table_action_2faction_2eproto_sccs, descriptor_table_action_2faction_2eproto_deps, 31, 0,
+  &descriptor_table_action_2faction_2eproto_initialized, descriptor_table_protodef_action_2faction_2eproto, "action/action.proto", 4223,
+  &descriptor_table_action_2faction_2eproto_once, descriptor_table_action_2faction_2eproto_sccs, descriptor_table_action_2faction_2eproto_deps, 35, 0,
   schemas, file_default_instances, TableStruct_action_2faction_2eproto::offsets,
-  file_level_metadata_action_2faction_2eproto, 31, file_level_enum_descriptors_action_2faction_2eproto, file_level_service_descriptors_action_2faction_2eproto,
+  file_level_metadata_action_2faction_2eproto, 35, file_level_enum_descriptors_action_2faction_2eproto, file_level_service_descriptors_action_2faction_2eproto,
 };
 
 // Force running AddDescriptors() at dynamic initialization time.
@@ -2825,6 +2949,364 @@ void RebootResponse::InternalSwap(RebootResponse* other) {
 
 // ===================================================================
 
+void ShutdownRequest::InitAsDefaultInstance() {
+}
+class ShutdownRequest::_Internal {
+ public:
+};
+
+ShutdownRequest::ShutdownRequest()
+  : ::PROTOBUF_NAMESPACE_ID::Message(), _internal_metadata_(nullptr) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:mavsdk.rpc.action.ShutdownRequest)
+}
+ShutdownRequest::ShutdownRequest(const ShutdownRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message(),
+      _internal_metadata_(nullptr) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.action.ShutdownRequest)
+}
+
+void ShutdownRequest::SharedCtor() {
+}
+
+ShutdownRequest::~ShutdownRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.action.ShutdownRequest)
+  SharedDtor();
+}
+
+void ShutdownRequest::SharedDtor() {
+}
+
+void ShutdownRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ShutdownRequest& ShutdownRequest::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_ShutdownRequest_action_2faction_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void ShutdownRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action.ShutdownRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _internal_metadata_.Clear();
+}
+
+const char* ShutdownRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag, &_internal_metadata_, ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* ShutdownRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action.ShutdownRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields(), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action.ShutdownRequest)
+  return target;
+}
+
+size_t ShutdownRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action.ShutdownRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ShutdownRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:mavsdk.rpc.action.ShutdownRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ShutdownRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<ShutdownRequest>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:mavsdk.rpc.action.ShutdownRequest)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:mavsdk.rpc.action.ShutdownRequest)
+    MergeFrom(*source);
+  }
+}
+
+void ShutdownRequest::MergeFrom(const ShutdownRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action.ShutdownRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+}
+
+void ShutdownRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:mavsdk.rpc.action.ShutdownRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ShutdownRequest::CopyFrom(const ShutdownRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action.ShutdownRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ShutdownRequest::IsInitialized() const {
+  return true;
+}
+
+void ShutdownRequest::InternalSwap(ShutdownRequest* other) {
+  using std::swap;
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata ShutdownRequest::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+void ShutdownResponse::InitAsDefaultInstance() {
+  ::mavsdk::rpc::action::_ShutdownResponse_default_instance_._instance.get_mutable()->action_result_ = const_cast< ::mavsdk::rpc::action::ActionResult*>(
+      ::mavsdk::rpc::action::ActionResult::internal_default_instance());
+}
+class ShutdownResponse::_Internal {
+ public:
+  static const ::mavsdk::rpc::action::ActionResult& action_result(const ShutdownResponse* msg);
+};
+
+const ::mavsdk::rpc::action::ActionResult&
+ShutdownResponse::_Internal::action_result(const ShutdownResponse* msg) {
+  return *msg->action_result_;
+}
+ShutdownResponse::ShutdownResponse()
+  : ::PROTOBUF_NAMESPACE_ID::Message(), _internal_metadata_(nullptr) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:mavsdk.rpc.action.ShutdownResponse)
+}
+ShutdownResponse::ShutdownResponse(const ShutdownResponse& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message(),
+      _internal_metadata_(nullptr) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  if (from._internal_has_action_result()) {
+    action_result_ = new ::mavsdk::rpc::action::ActionResult(*from.action_result_);
+  } else {
+    action_result_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.action.ShutdownResponse)
+}
+
+void ShutdownResponse::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_ShutdownResponse_action_2faction_2eproto.base);
+  action_result_ = nullptr;
+}
+
+ShutdownResponse::~ShutdownResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.action.ShutdownResponse)
+  SharedDtor();
+}
+
+void ShutdownResponse::SharedDtor() {
+  if (this != internal_default_instance()) delete action_result_;
+}
+
+void ShutdownResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ShutdownResponse& ShutdownResponse::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_ShutdownResponse_action_2faction_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void ShutdownResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action.ShutdownResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArenaNoVirtual() == nullptr && action_result_ != nullptr) {
+    delete action_result_;
+  }
+  action_result_ = nullptr;
+  _internal_metadata_.Clear();
+}
+
+const char* ShutdownResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // .mavsdk.rpc.action.ActionResult action_result = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_action_result(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag, &_internal_metadata_, ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* ShutdownResponse::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action.ShutdownResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.action.ActionResult action_result = 1;
+  if (this->has_action_result()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::action_result(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields(), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action.ShutdownResponse)
+  return target;
+}
+
+size_t ShutdownResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action.ShutdownResponse)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.action.ActionResult action_result = 1;
+  if (this->has_action_result()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *action_result_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ShutdownResponse::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:mavsdk.rpc.action.ShutdownResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ShutdownResponse* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<ShutdownResponse>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:mavsdk.rpc.action.ShutdownResponse)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:mavsdk.rpc.action.ShutdownResponse)
+    MergeFrom(*source);
+  }
+}
+
+void ShutdownResponse::MergeFrom(const ShutdownResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action.ShutdownResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.has_action_result()) {
+    _internal_mutable_action_result()->::mavsdk::rpc::action::ActionResult::MergeFrom(from._internal_action_result());
+  }
+}
+
+void ShutdownResponse::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:mavsdk.rpc.action.ShutdownResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ShutdownResponse::CopyFrom(const ShutdownResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action.ShutdownResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ShutdownResponse::IsInitialized() const {
+  return true;
+}
+
+void ShutdownResponse::InternalSwap(ShutdownResponse* other) {
+  using std::swap;
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  swap(action_result_, other->action_result_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata ShutdownResponse::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
 void KillRequest::InitAsDefaultInstance() {
 }
 class KillRequest::_Internal {
@@ -3541,59 +4023,99 @@ void ReturnToLaunchResponse::InternalSwap(ReturnToLaunchResponse* other) {
 
 // ===================================================================
 
-void TransitionToFixedWingRequest::InitAsDefaultInstance() {
+void GotoLocationRequest::InitAsDefaultInstance() {
 }
-class TransitionToFixedWingRequest::_Internal {
+class GotoLocationRequest::_Internal {
  public:
 };
 
-TransitionToFixedWingRequest::TransitionToFixedWingRequest()
+GotoLocationRequest::GotoLocationRequest()
   : ::PROTOBUF_NAMESPACE_ID::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
-  // @@protoc_insertion_point(constructor:mavsdk.rpc.action.TransitionToFixedWingRequest)
+  // @@protoc_insertion_point(constructor:mavsdk.rpc.action.GotoLocationRequest)
 }
-TransitionToFixedWingRequest::TransitionToFixedWingRequest(const TransitionToFixedWingRequest& from)
+GotoLocationRequest::GotoLocationRequest(const GotoLocationRequest& from)
   : ::PROTOBUF_NAMESPACE_ID::Message(),
       _internal_metadata_(nullptr) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
-  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.action.TransitionToFixedWingRequest)
+  ::memcpy(&latitude_deg_, &from.latitude_deg_,
+    static_cast<size_t>(reinterpret_cast<char*>(&yaw_deg_) -
+    reinterpret_cast<char*>(&latitude_deg_)) + sizeof(yaw_deg_));
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.action.GotoLocationRequest)
 }
 
-void TransitionToFixedWingRequest::SharedCtor() {
+void GotoLocationRequest::SharedCtor() {
+  ::memset(&latitude_deg_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&yaw_deg_) -
+      reinterpret_cast<char*>(&latitude_deg_)) + sizeof(yaw_deg_));
 }
 
-TransitionToFixedWingRequest::~TransitionToFixedWingRequest() {
-  // @@protoc_insertion_point(destructor:mavsdk.rpc.action.TransitionToFixedWingRequest)
+GotoLocationRequest::~GotoLocationRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.action.GotoLocationRequest)
   SharedDtor();
 }
 
-void TransitionToFixedWingRequest::SharedDtor() {
+void GotoLocationRequest::SharedDtor() {
 }
 
-void TransitionToFixedWingRequest::SetCachedSize(int size) const {
+void GotoLocationRequest::SetCachedSize(int size) const {
   _cached_size_.Set(size);
 }
-const TransitionToFixedWingRequest& TransitionToFixedWingRequest::default_instance() {
-  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_TransitionToFixedWingRequest_action_2faction_2eproto.base);
+const GotoLocationRequest& GotoLocationRequest::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_GotoLocationRequest_action_2faction_2eproto.base);
   return *internal_default_instance();
 }
 
 
-void TransitionToFixedWingRequest::Clear() {
-// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action.TransitionToFixedWingRequest)
+void GotoLocationRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action.GotoLocationRequest)
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
+  ::memset(&latitude_deg_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&yaw_deg_) -
+      reinterpret_cast<char*>(&latitude_deg_)) + sizeof(yaw_deg_));
   _internal_metadata_.Clear();
 }
 
-const char* TransitionToFixedWingRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+const char* GotoLocationRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
 #define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
   while (!ctx->Done(&ptr)) {
     ::PROTOBUF_NAMESPACE_ID::uint32 tag;
     ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
     CHK_(ptr);
+    switch (tag >> 3) {
+      // double latitude_deg = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 9)) {
+          latitude_deg_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<double>(ptr);
+          ptr += sizeof(double);
+        } else goto handle_unusual;
+        continue;
+      // double longitude_deg = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 17)) {
+          longitude_deg_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<double>(ptr);
+          ptr += sizeof(double);
+        } else goto handle_unusual;
+        continue;
+      // float absolute_altitude_m = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 29)) {
+          absolute_altitude_m_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<float>(ptr);
+          ptr += sizeof(float);
+        } else goto handle_unusual;
+        continue;
+      // float yaw_deg = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 37)) {
+          yaw_deg_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<float>(ptr);
+          ptr += sizeof(float);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
         if ((tag & 7) == 4 || tag == 0) {
           ctx->SetLastTag(tag);
           goto success;
@@ -3601,6 +4123,8 @@ const char* TransitionToFixedWingRequest::_InternalParse(const char* ptr, ::PROT
         ptr = UnknownFieldParse(tag, &_internal_metadata_, ptr, ctx);
         CHK_(ptr != nullptr);
         continue;
+      }
+    }  // switch
   }  // while
 success:
   return ptr;
@@ -3610,27 +4134,71 @@ failure:
 #undef CHK_
 }
 
-::PROTOBUF_NAMESPACE_ID::uint8* TransitionToFixedWingRequest::_InternalSerialize(
+::PROTOBUF_NAMESPACE_ID::uint8* GotoLocationRequest::_InternalSerialize(
     ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
-  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action.TransitionToFixedWingRequest)
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action.GotoLocationRequest)
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
+
+  // double latitude_deg = 1;
+  if (!(this->latitude_deg() <= 0 && this->latitude_deg() >= 0)) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteDoubleToArray(1, this->_internal_latitude_deg(), target);
+  }
+
+  // double longitude_deg = 2;
+  if (!(this->longitude_deg() <= 0 && this->longitude_deg() >= 0)) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteDoubleToArray(2, this->_internal_longitude_deg(), target);
+  }
+
+  // float absolute_altitude_m = 3;
+  if (!(this->absolute_altitude_m() <= 0 && this->absolute_altitude_m() >= 0)) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteFloatToArray(3, this->_internal_absolute_altitude_m(), target);
+  }
+
+  // float yaw_deg = 4;
+  if (!(this->yaw_deg() <= 0 && this->yaw_deg() >= 0)) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteFloatToArray(4, this->_internal_yaw_deg(), target);
+  }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields(), target, stream);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action.TransitionToFixedWingRequest)
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action.GotoLocationRequest)
   return target;
 }
 
-size_t TransitionToFixedWingRequest::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action.TransitionToFixedWingRequest)
+size_t GotoLocationRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action.GotoLocationRequest)
   size_t total_size = 0;
 
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
+
+  // double latitude_deg = 1;
+  if (!(this->latitude_deg() <= 0 && this->latitude_deg() >= 0)) {
+    total_size += 1 + 8;
+  }
+
+  // double longitude_deg = 2;
+  if (!(this->longitude_deg() <= 0 && this->longitude_deg() >= 0)) {
+    total_size += 1 + 8;
+  }
+
+  // float absolute_altitude_m = 3;
+  if (!(this->absolute_altitude_m() <= 0 && this->absolute_altitude_m() >= 0)) {
+    total_size += 1 + 4;
+  }
+
+  // float yaw_deg = 4;
+  if (!(this->yaw_deg() <= 0 && this->yaw_deg() >= 0)) {
+    total_size += 1 + 4;
+  }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
@@ -3641,79 +4209,95 @@ size_t TransitionToFixedWingRequest::ByteSizeLong() const {
   return total_size;
 }
 
-void TransitionToFixedWingRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:mavsdk.rpc.action.TransitionToFixedWingRequest)
+void GotoLocationRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:mavsdk.rpc.action.GotoLocationRequest)
   GOOGLE_DCHECK_NE(&from, this);
-  const TransitionToFixedWingRequest* source =
-      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<TransitionToFixedWingRequest>(
+  const GotoLocationRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<GotoLocationRequest>(
           &from);
   if (source == nullptr) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:mavsdk.rpc.action.TransitionToFixedWingRequest)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:mavsdk.rpc.action.GotoLocationRequest)
     ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:mavsdk.rpc.action.TransitionToFixedWingRequest)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:mavsdk.rpc.action.GotoLocationRequest)
     MergeFrom(*source);
   }
 }
 
-void TransitionToFixedWingRequest::MergeFrom(const TransitionToFixedWingRequest& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action.TransitionToFixedWingRequest)
+void GotoLocationRequest::MergeFrom(const GotoLocationRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action.GotoLocationRequest)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
+  if (!(from.latitude_deg() <= 0 && from.latitude_deg() >= 0)) {
+    _internal_set_latitude_deg(from._internal_latitude_deg());
+  }
+  if (!(from.longitude_deg() <= 0 && from.longitude_deg() >= 0)) {
+    _internal_set_longitude_deg(from._internal_longitude_deg());
+  }
+  if (!(from.absolute_altitude_m() <= 0 && from.absolute_altitude_m() >= 0)) {
+    _internal_set_absolute_altitude_m(from._internal_absolute_altitude_m());
+  }
+  if (!(from.yaw_deg() <= 0 && from.yaw_deg() >= 0)) {
+    _internal_set_yaw_deg(from._internal_yaw_deg());
+  }
 }
 
-void TransitionToFixedWingRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:mavsdk.rpc.action.TransitionToFixedWingRequest)
+void GotoLocationRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:mavsdk.rpc.action.GotoLocationRequest)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-void TransitionToFixedWingRequest::CopyFrom(const TransitionToFixedWingRequest& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action.TransitionToFixedWingRequest)
+void GotoLocationRequest::CopyFrom(const GotoLocationRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action.GotoLocationRequest)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool TransitionToFixedWingRequest::IsInitialized() const {
+bool GotoLocationRequest::IsInitialized() const {
   return true;
 }
 
-void TransitionToFixedWingRequest::InternalSwap(TransitionToFixedWingRequest* other) {
+void GotoLocationRequest::InternalSwap(GotoLocationRequest* other) {
   using std::swap;
   _internal_metadata_.Swap(&other->_internal_metadata_);
+  swap(latitude_deg_, other->latitude_deg_);
+  swap(longitude_deg_, other->longitude_deg_);
+  swap(absolute_altitude_m_, other->absolute_altitude_m_);
+  swap(yaw_deg_, other->yaw_deg_);
 }
 
-::PROTOBUF_NAMESPACE_ID::Metadata TransitionToFixedWingRequest::GetMetadata() const {
+::PROTOBUF_NAMESPACE_ID::Metadata GotoLocationRequest::GetMetadata() const {
   return GetMetadataStatic();
 }
 
 
 // ===================================================================
 
-void TransitionToFixedWingResponse::InitAsDefaultInstance() {
-  ::mavsdk::rpc::action::_TransitionToFixedWingResponse_default_instance_._instance.get_mutable()->action_result_ = const_cast< ::mavsdk::rpc::action::ActionResult*>(
+void GotoLocationResponse::InitAsDefaultInstance() {
+  ::mavsdk::rpc::action::_GotoLocationResponse_default_instance_._instance.get_mutable()->action_result_ = const_cast< ::mavsdk::rpc::action::ActionResult*>(
       ::mavsdk::rpc::action::ActionResult::internal_default_instance());
 }
-class TransitionToFixedWingResponse::_Internal {
+class GotoLocationResponse::_Internal {
  public:
-  static const ::mavsdk::rpc::action::ActionResult& action_result(const TransitionToFixedWingResponse* msg);
+  static const ::mavsdk::rpc::action::ActionResult& action_result(const GotoLocationResponse* msg);
 };
 
 const ::mavsdk::rpc::action::ActionResult&
-TransitionToFixedWingResponse::_Internal::action_result(const TransitionToFixedWingResponse* msg) {
+GotoLocationResponse::_Internal::action_result(const GotoLocationResponse* msg) {
   return *msg->action_result_;
 }
-TransitionToFixedWingResponse::TransitionToFixedWingResponse()
+GotoLocationResponse::GotoLocationResponse()
   : ::PROTOBUF_NAMESPACE_ID::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
-  // @@protoc_insertion_point(constructor:mavsdk.rpc.action.TransitionToFixedWingResponse)
+  // @@protoc_insertion_point(constructor:mavsdk.rpc.action.GotoLocationResponse)
 }
-TransitionToFixedWingResponse::TransitionToFixedWingResponse(const TransitionToFixedWingResponse& from)
+GotoLocationResponse::GotoLocationResponse(const GotoLocationResponse& from)
   : ::PROTOBUF_NAMESPACE_ID::Message(),
       _internal_metadata_(nullptr) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -3722,34 +4306,34 @@ TransitionToFixedWingResponse::TransitionToFixedWingResponse(const TransitionToF
   } else {
     action_result_ = nullptr;
   }
-  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.action.TransitionToFixedWingResponse)
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.action.GotoLocationResponse)
 }
 
-void TransitionToFixedWingResponse::SharedCtor() {
-  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_TransitionToFixedWingResponse_action_2faction_2eproto.base);
+void GotoLocationResponse::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_GotoLocationResponse_action_2faction_2eproto.base);
   action_result_ = nullptr;
 }
 
-TransitionToFixedWingResponse::~TransitionToFixedWingResponse() {
-  // @@protoc_insertion_point(destructor:mavsdk.rpc.action.TransitionToFixedWingResponse)
+GotoLocationResponse::~GotoLocationResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.action.GotoLocationResponse)
   SharedDtor();
 }
 
-void TransitionToFixedWingResponse::SharedDtor() {
+void GotoLocationResponse::SharedDtor() {
   if (this != internal_default_instance()) delete action_result_;
 }
 
-void TransitionToFixedWingResponse::SetCachedSize(int size) const {
+void GotoLocationResponse::SetCachedSize(int size) const {
   _cached_size_.Set(size);
 }
-const TransitionToFixedWingResponse& TransitionToFixedWingResponse::default_instance() {
-  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_TransitionToFixedWingResponse_action_2faction_2eproto.base);
+const GotoLocationResponse& GotoLocationResponse::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_GotoLocationResponse_action_2faction_2eproto.base);
   return *internal_default_instance();
 }
 
 
-void TransitionToFixedWingResponse::Clear() {
-// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action.TransitionToFixedWingResponse)
+void GotoLocationResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action.GotoLocationResponse)
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -3761,7 +4345,7 @@ void TransitionToFixedWingResponse::Clear() {
   _internal_metadata_.Clear();
 }
 
-const char* TransitionToFixedWingResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+const char* GotoLocationResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
 #define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
   while (!ctx->Done(&ptr)) {
     ::PROTOBUF_NAMESPACE_ID::uint32 tag;
@@ -3795,9 +4379,9 @@ failure:
 #undef CHK_
 }
 
-::PROTOBUF_NAMESPACE_ID::uint8* TransitionToFixedWingResponse::_InternalSerialize(
+::PROTOBUF_NAMESPACE_ID::uint8* GotoLocationResponse::_InternalSerialize(
     ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
-  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action.TransitionToFixedWingResponse)
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action.GotoLocationResponse)
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -3813,12 +4397,12 @@ failure:
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields(), target, stream);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action.TransitionToFixedWingResponse)
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action.GotoLocationResponse)
   return target;
 }
 
-size_t TransitionToFixedWingResponse::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action.TransitionToFixedWingResponse)
+size_t GotoLocationResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action.GotoLocationResponse)
   size_t total_size = 0;
 
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
@@ -3841,23 +4425,23 @@ size_t TransitionToFixedWingResponse::ByteSizeLong() const {
   return total_size;
 }
 
-void TransitionToFixedWingResponse::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:mavsdk.rpc.action.TransitionToFixedWingResponse)
+void GotoLocationResponse::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:mavsdk.rpc.action.GotoLocationResponse)
   GOOGLE_DCHECK_NE(&from, this);
-  const TransitionToFixedWingResponse* source =
-      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<TransitionToFixedWingResponse>(
+  const GotoLocationResponse* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<GotoLocationResponse>(
           &from);
   if (source == nullptr) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:mavsdk.rpc.action.TransitionToFixedWingResponse)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:mavsdk.rpc.action.GotoLocationResponse)
     ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:mavsdk.rpc.action.TransitionToFixedWingResponse)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:mavsdk.rpc.action.GotoLocationResponse)
     MergeFrom(*source);
   }
 }
 
-void TransitionToFixedWingResponse::MergeFrom(const TransitionToFixedWingResponse& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action.TransitionToFixedWingResponse)
+void GotoLocationResponse::MergeFrom(const GotoLocationResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action.GotoLocationResponse)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
@@ -3868,31 +4452,389 @@ void TransitionToFixedWingResponse::MergeFrom(const TransitionToFixedWingRespons
   }
 }
 
-void TransitionToFixedWingResponse::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:mavsdk.rpc.action.TransitionToFixedWingResponse)
+void GotoLocationResponse::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:mavsdk.rpc.action.GotoLocationResponse)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-void TransitionToFixedWingResponse::CopyFrom(const TransitionToFixedWingResponse& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action.TransitionToFixedWingResponse)
+void GotoLocationResponse::CopyFrom(const GotoLocationResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action.GotoLocationResponse)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool TransitionToFixedWingResponse::IsInitialized() const {
+bool GotoLocationResponse::IsInitialized() const {
   return true;
 }
 
-void TransitionToFixedWingResponse::InternalSwap(TransitionToFixedWingResponse* other) {
+void GotoLocationResponse::InternalSwap(GotoLocationResponse* other) {
   using std::swap;
   _internal_metadata_.Swap(&other->_internal_metadata_);
   swap(action_result_, other->action_result_);
 }
 
-::PROTOBUF_NAMESPACE_ID::Metadata TransitionToFixedWingResponse::GetMetadata() const {
+::PROTOBUF_NAMESPACE_ID::Metadata GotoLocationResponse::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+void TransitionToFixedwingRequest::InitAsDefaultInstance() {
+}
+class TransitionToFixedwingRequest::_Internal {
+ public:
+};
+
+TransitionToFixedwingRequest::TransitionToFixedwingRequest()
+  : ::PROTOBUF_NAMESPACE_ID::Message(), _internal_metadata_(nullptr) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:mavsdk.rpc.action.TransitionToFixedwingRequest)
+}
+TransitionToFixedwingRequest::TransitionToFixedwingRequest(const TransitionToFixedwingRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message(),
+      _internal_metadata_(nullptr) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.action.TransitionToFixedwingRequest)
+}
+
+void TransitionToFixedwingRequest::SharedCtor() {
+}
+
+TransitionToFixedwingRequest::~TransitionToFixedwingRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.action.TransitionToFixedwingRequest)
+  SharedDtor();
+}
+
+void TransitionToFixedwingRequest::SharedDtor() {
+}
+
+void TransitionToFixedwingRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const TransitionToFixedwingRequest& TransitionToFixedwingRequest::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_TransitionToFixedwingRequest_action_2faction_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void TransitionToFixedwingRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action.TransitionToFixedwingRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _internal_metadata_.Clear();
+}
+
+const char* TransitionToFixedwingRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag, &_internal_metadata_, ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* TransitionToFixedwingRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action.TransitionToFixedwingRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields(), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action.TransitionToFixedwingRequest)
+  return target;
+}
+
+size_t TransitionToFixedwingRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action.TransitionToFixedwingRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void TransitionToFixedwingRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:mavsdk.rpc.action.TransitionToFixedwingRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const TransitionToFixedwingRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<TransitionToFixedwingRequest>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:mavsdk.rpc.action.TransitionToFixedwingRequest)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:mavsdk.rpc.action.TransitionToFixedwingRequest)
+    MergeFrom(*source);
+  }
+}
+
+void TransitionToFixedwingRequest::MergeFrom(const TransitionToFixedwingRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action.TransitionToFixedwingRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+}
+
+void TransitionToFixedwingRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:mavsdk.rpc.action.TransitionToFixedwingRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void TransitionToFixedwingRequest::CopyFrom(const TransitionToFixedwingRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action.TransitionToFixedwingRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool TransitionToFixedwingRequest::IsInitialized() const {
+  return true;
+}
+
+void TransitionToFixedwingRequest::InternalSwap(TransitionToFixedwingRequest* other) {
+  using std::swap;
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata TransitionToFixedwingRequest::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+void TransitionToFixedwingResponse::InitAsDefaultInstance() {
+  ::mavsdk::rpc::action::_TransitionToFixedwingResponse_default_instance_._instance.get_mutable()->action_result_ = const_cast< ::mavsdk::rpc::action::ActionResult*>(
+      ::mavsdk::rpc::action::ActionResult::internal_default_instance());
+}
+class TransitionToFixedwingResponse::_Internal {
+ public:
+  static const ::mavsdk::rpc::action::ActionResult& action_result(const TransitionToFixedwingResponse* msg);
+};
+
+const ::mavsdk::rpc::action::ActionResult&
+TransitionToFixedwingResponse::_Internal::action_result(const TransitionToFixedwingResponse* msg) {
+  return *msg->action_result_;
+}
+TransitionToFixedwingResponse::TransitionToFixedwingResponse()
+  : ::PROTOBUF_NAMESPACE_ID::Message(), _internal_metadata_(nullptr) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:mavsdk.rpc.action.TransitionToFixedwingResponse)
+}
+TransitionToFixedwingResponse::TransitionToFixedwingResponse(const TransitionToFixedwingResponse& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message(),
+      _internal_metadata_(nullptr) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  if (from._internal_has_action_result()) {
+    action_result_ = new ::mavsdk::rpc::action::ActionResult(*from.action_result_);
+  } else {
+    action_result_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.action.TransitionToFixedwingResponse)
+}
+
+void TransitionToFixedwingResponse::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_TransitionToFixedwingResponse_action_2faction_2eproto.base);
+  action_result_ = nullptr;
+}
+
+TransitionToFixedwingResponse::~TransitionToFixedwingResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.action.TransitionToFixedwingResponse)
+  SharedDtor();
+}
+
+void TransitionToFixedwingResponse::SharedDtor() {
+  if (this != internal_default_instance()) delete action_result_;
+}
+
+void TransitionToFixedwingResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const TransitionToFixedwingResponse& TransitionToFixedwingResponse::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_TransitionToFixedwingResponse_action_2faction_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void TransitionToFixedwingResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action.TransitionToFixedwingResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArenaNoVirtual() == nullptr && action_result_ != nullptr) {
+    delete action_result_;
+  }
+  action_result_ = nullptr;
+  _internal_metadata_.Clear();
+}
+
+const char* TransitionToFixedwingResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // .mavsdk.rpc.action.ActionResult action_result = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_action_result(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag, &_internal_metadata_, ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* TransitionToFixedwingResponse::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action.TransitionToFixedwingResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.action.ActionResult action_result = 1;
+  if (this->has_action_result()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::action_result(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields(), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action.TransitionToFixedwingResponse)
+  return target;
+}
+
+size_t TransitionToFixedwingResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action.TransitionToFixedwingResponse)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.action.ActionResult action_result = 1;
+  if (this->has_action_result()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *action_result_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void TransitionToFixedwingResponse::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:mavsdk.rpc.action.TransitionToFixedwingResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  const TransitionToFixedwingResponse* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<TransitionToFixedwingResponse>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:mavsdk.rpc.action.TransitionToFixedwingResponse)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:mavsdk.rpc.action.TransitionToFixedwingResponse)
+    MergeFrom(*source);
+  }
+}
+
+void TransitionToFixedwingResponse::MergeFrom(const TransitionToFixedwingResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action.TransitionToFixedwingResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.has_action_result()) {
+    _internal_mutable_action_result()->::mavsdk::rpc::action::ActionResult::MergeFrom(from._internal_action_result());
+  }
+}
+
+void TransitionToFixedwingResponse::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:mavsdk.rpc.action.TransitionToFixedwingResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void TransitionToFixedwingResponse::CopyFrom(const TransitionToFixedwingResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action.TransitionToFixedwingResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool TransitionToFixedwingResponse::IsInitialized() const {
+  return true;
+}
+
+void TransitionToFixedwingResponse::InternalSwap(TransitionToFixedwingResponse* other) {
+  using std::swap;
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  swap(action_result_, other->action_result_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata TransitionToFixedwingResponse::GetMetadata() const {
   return GetMetadataStatic();
 }
 
@@ -6833,6 +7775,12 @@ template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action::RebootRequest* Arena::Create
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action::RebootResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::action::RebootResponse >(Arena* arena) {
   return Arena::CreateInternal< ::mavsdk::rpc::action::RebootResponse >(arena);
 }
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action::ShutdownRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::action::ShutdownRequest >(Arena* arena) {
+  return Arena::CreateInternal< ::mavsdk::rpc::action::ShutdownRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action::ShutdownResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::action::ShutdownResponse >(Arena* arena) {
+  return Arena::CreateInternal< ::mavsdk::rpc::action::ShutdownResponse >(arena);
+}
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action::KillRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::action::KillRequest >(Arena* arena) {
   return Arena::CreateInternal< ::mavsdk::rpc::action::KillRequest >(arena);
 }
@@ -6845,11 +7793,17 @@ template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action::ReturnToLaunchRequest* Arena
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action::ReturnToLaunchResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::action::ReturnToLaunchResponse >(Arena* arena) {
   return Arena::CreateInternal< ::mavsdk::rpc::action::ReturnToLaunchResponse >(arena);
 }
-template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action::TransitionToFixedWingRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::action::TransitionToFixedWingRequest >(Arena* arena) {
-  return Arena::CreateInternal< ::mavsdk::rpc::action::TransitionToFixedWingRequest >(arena);
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action::GotoLocationRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::action::GotoLocationRequest >(Arena* arena) {
+  return Arena::CreateInternal< ::mavsdk::rpc::action::GotoLocationRequest >(arena);
 }
-template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action::TransitionToFixedWingResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::action::TransitionToFixedWingResponse >(Arena* arena) {
-  return Arena::CreateInternal< ::mavsdk::rpc::action::TransitionToFixedWingResponse >(arena);
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action::GotoLocationResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::action::GotoLocationResponse >(Arena* arena) {
+  return Arena::CreateInternal< ::mavsdk::rpc::action::GotoLocationResponse >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action::TransitionToFixedwingRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::action::TransitionToFixedwingRequest >(Arena* arena) {
+  return Arena::CreateInternal< ::mavsdk::rpc::action::TransitionToFixedwingRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action::TransitionToFixedwingResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::action::TransitionToFixedwingResponse >(Arena* arena) {
+  return Arena::CreateInternal< ::mavsdk::rpc::action::TransitionToFixedwingResponse >(arena);
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action::TransitionToMulticopterRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::action::TransitionToMulticopterRequest >(Arena* arena) {
   return Arena::CreateInternal< ::mavsdk::rpc::action::TransitionToMulticopterRequest >(arena);

--- a/src/backend/src/generated/action/action.pb.h
+++ b/src/backend/src/generated/action/action.pb.h
@@ -48,7 +48,7 @@ struct TableStruct_action_2faction_2eproto {
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::AuxillaryParseTableField aux[]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
-  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[31]
+  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[35]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::FieldMetadata field_metadata[];
   static const ::PROTOBUF_NAMESPACE_ID::internal::SerializationTable serialization_table[];
@@ -91,6 +91,12 @@ extern GetTakeoffAltitudeRequestDefaultTypeInternal _GetTakeoffAltitudeRequest_d
 class GetTakeoffAltitudeResponse;
 class GetTakeoffAltitudeResponseDefaultTypeInternal;
 extern GetTakeoffAltitudeResponseDefaultTypeInternal _GetTakeoffAltitudeResponse_default_instance_;
+class GotoLocationRequest;
+class GotoLocationRequestDefaultTypeInternal;
+extern GotoLocationRequestDefaultTypeInternal _GotoLocationRequest_default_instance_;
+class GotoLocationResponse;
+class GotoLocationResponseDefaultTypeInternal;
+extern GotoLocationResponseDefaultTypeInternal _GotoLocationResponse_default_instance_;
 class KillRequest;
 class KillRequestDefaultTypeInternal;
 extern KillRequestDefaultTypeInternal _KillRequest_default_instance_;
@@ -133,18 +139,24 @@ extern SetTakeoffAltitudeRequestDefaultTypeInternal _SetTakeoffAltitudeRequest_d
 class SetTakeoffAltitudeResponse;
 class SetTakeoffAltitudeResponseDefaultTypeInternal;
 extern SetTakeoffAltitudeResponseDefaultTypeInternal _SetTakeoffAltitudeResponse_default_instance_;
+class ShutdownRequest;
+class ShutdownRequestDefaultTypeInternal;
+extern ShutdownRequestDefaultTypeInternal _ShutdownRequest_default_instance_;
+class ShutdownResponse;
+class ShutdownResponseDefaultTypeInternal;
+extern ShutdownResponseDefaultTypeInternal _ShutdownResponse_default_instance_;
 class TakeoffRequest;
 class TakeoffRequestDefaultTypeInternal;
 extern TakeoffRequestDefaultTypeInternal _TakeoffRequest_default_instance_;
 class TakeoffResponse;
 class TakeoffResponseDefaultTypeInternal;
 extern TakeoffResponseDefaultTypeInternal _TakeoffResponse_default_instance_;
-class TransitionToFixedWingRequest;
-class TransitionToFixedWingRequestDefaultTypeInternal;
-extern TransitionToFixedWingRequestDefaultTypeInternal _TransitionToFixedWingRequest_default_instance_;
-class TransitionToFixedWingResponse;
-class TransitionToFixedWingResponseDefaultTypeInternal;
-extern TransitionToFixedWingResponseDefaultTypeInternal _TransitionToFixedWingResponse_default_instance_;
+class TransitionToFixedwingRequest;
+class TransitionToFixedwingRequestDefaultTypeInternal;
+extern TransitionToFixedwingRequestDefaultTypeInternal _TransitionToFixedwingRequest_default_instance_;
+class TransitionToFixedwingResponse;
+class TransitionToFixedwingResponseDefaultTypeInternal;
+extern TransitionToFixedwingResponseDefaultTypeInternal _TransitionToFixedwingResponse_default_instance_;
 class TransitionToMulticopterRequest;
 class TransitionToMulticopterRequestDefaultTypeInternal;
 extern TransitionToMulticopterRequestDefaultTypeInternal _TransitionToMulticopterRequest_default_instance_;
@@ -166,6 +178,8 @@ template<> ::mavsdk::rpc::action::GetReturnToLaunchAltitudeRequest* Arena::Creat
 template<> ::mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse>(Arena*);
 template<> ::mavsdk::rpc::action::GetTakeoffAltitudeRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::action::GetTakeoffAltitudeRequest>(Arena*);
 template<> ::mavsdk::rpc::action::GetTakeoffAltitudeResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action::GetTakeoffAltitudeResponse>(Arena*);
+template<> ::mavsdk::rpc::action::GotoLocationRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::action::GotoLocationRequest>(Arena*);
+template<> ::mavsdk::rpc::action::GotoLocationResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action::GotoLocationResponse>(Arena*);
 template<> ::mavsdk::rpc::action::KillRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::action::KillRequest>(Arena*);
 template<> ::mavsdk::rpc::action::KillResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action::KillResponse>(Arena*);
 template<> ::mavsdk::rpc::action::LandRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::action::LandRequest>(Arena*);
@@ -180,10 +194,12 @@ template<> ::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest* Arena::Creat
 template<> ::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse>(Arena*);
 template<> ::mavsdk::rpc::action::SetTakeoffAltitudeRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::action::SetTakeoffAltitudeRequest>(Arena*);
 template<> ::mavsdk::rpc::action::SetTakeoffAltitudeResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action::SetTakeoffAltitudeResponse>(Arena*);
+template<> ::mavsdk::rpc::action::ShutdownRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::action::ShutdownRequest>(Arena*);
+template<> ::mavsdk::rpc::action::ShutdownResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action::ShutdownResponse>(Arena*);
 template<> ::mavsdk::rpc::action::TakeoffRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::action::TakeoffRequest>(Arena*);
 template<> ::mavsdk::rpc::action::TakeoffResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action::TakeoffResponse>(Arena*);
-template<> ::mavsdk::rpc::action::TransitionToFixedWingRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::action::TransitionToFixedWingRequest>(Arena*);
-template<> ::mavsdk::rpc::action::TransitionToFixedWingResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action::TransitionToFixedWingResponse>(Arena*);
+template<> ::mavsdk::rpc::action::TransitionToFixedwingRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::action::TransitionToFixedwingRequest>(Arena*);
+template<> ::mavsdk::rpc::action::TransitionToFixedwingResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action::TransitionToFixedwingResponse>(Arena*);
 template<> ::mavsdk::rpc::action::TransitionToMulticopterRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::action::TransitionToMulticopterRequest>(Arena*);
 template<> ::mavsdk::rpc::action::TransitionToMulticopterResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action::TransitionToMulticopterResponse>(Arena*);
 PROTOBUF_NAMESPACE_CLOSE
@@ -1473,6 +1489,255 @@ class RebootResponse :
 };
 // -------------------------------------------------------------------
 
+class ShutdownRequest :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action.ShutdownRequest) */ {
+ public:
+  ShutdownRequest();
+  virtual ~ShutdownRequest();
+
+  ShutdownRequest(const ShutdownRequest& from);
+  ShutdownRequest(ShutdownRequest&& from) noexcept
+    : ShutdownRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline ShutdownRequest& operator=(const ShutdownRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ShutdownRequest& operator=(ShutdownRequest&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const ShutdownRequest& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const ShutdownRequest* internal_default_instance() {
+    return reinterpret_cast<const ShutdownRequest*>(
+               &_ShutdownRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    10;
+
+  friend void swap(ShutdownRequest& a, ShutdownRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(ShutdownRequest* other) {
+    if (other == this) return;
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ShutdownRequest* New() const final {
+    return CreateMaybeMessage<ShutdownRequest>(nullptr);
+  }
+
+  ShutdownRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<ShutdownRequest>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const ShutdownRequest& from);
+  void MergeFrom(const ShutdownRequest& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ShutdownRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.action.ShutdownRequest";
+  }
+  private:
+  inline ::PROTOBUF_NAMESPACE_ID::Arena* GetArenaNoVirtual() const {
+    return nullptr;
+  }
+  inline void* MaybeArenaPtr() const {
+    return nullptr;
+  }
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_action_2faction_2eproto);
+    return ::descriptor_table_action_2faction_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action.ShutdownRequest)
+ private:
+  class _Internal;
+
+  ::PROTOBUF_NAMESPACE_ID::internal::InternalMetadataWithArena _internal_metadata_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_action_2faction_2eproto;
+};
+// -------------------------------------------------------------------
+
+class ShutdownResponse :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action.ShutdownResponse) */ {
+ public:
+  ShutdownResponse();
+  virtual ~ShutdownResponse();
+
+  ShutdownResponse(const ShutdownResponse& from);
+  ShutdownResponse(ShutdownResponse&& from) noexcept
+    : ShutdownResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline ShutdownResponse& operator=(const ShutdownResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ShutdownResponse& operator=(ShutdownResponse&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const ShutdownResponse& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const ShutdownResponse* internal_default_instance() {
+    return reinterpret_cast<const ShutdownResponse*>(
+               &_ShutdownResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    11;
+
+  friend void swap(ShutdownResponse& a, ShutdownResponse& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(ShutdownResponse* other) {
+    if (other == this) return;
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ShutdownResponse* New() const final {
+    return CreateMaybeMessage<ShutdownResponse>(nullptr);
+  }
+
+  ShutdownResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<ShutdownResponse>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const ShutdownResponse& from);
+  void MergeFrom(const ShutdownResponse& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ShutdownResponse* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.action.ShutdownResponse";
+  }
+  private:
+  inline ::PROTOBUF_NAMESPACE_ID::Arena* GetArenaNoVirtual() const {
+    return nullptr;
+  }
+  inline void* MaybeArenaPtr() const {
+    return nullptr;
+  }
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_action_2faction_2eproto);
+    return ::descriptor_table_action_2faction_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kActionResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.action.ActionResult action_result = 1;
+  bool has_action_result() const;
+  private:
+  bool _internal_has_action_result() const;
+  public:
+  void clear_action_result();
+  const ::mavsdk::rpc::action::ActionResult& action_result() const;
+  ::mavsdk::rpc::action::ActionResult* release_action_result();
+  ::mavsdk::rpc::action::ActionResult* mutable_action_result();
+  void set_allocated_action_result(::mavsdk::rpc::action::ActionResult* action_result);
+  private:
+  const ::mavsdk::rpc::action::ActionResult& _internal_action_result() const;
+  ::mavsdk::rpc::action::ActionResult* _internal_mutable_action_result();
+  public:
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action.ShutdownResponse)
+ private:
+  class _Internal;
+
+  ::PROTOBUF_NAMESPACE_ID::internal::InternalMetadataWithArena _internal_metadata_;
+  ::mavsdk::rpc::action::ActionResult* action_result_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_action_2faction_2eproto;
+};
+// -------------------------------------------------------------------
+
 class KillRequest :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action.KillRequest) */ {
  public:
@@ -1515,7 +1780,7 @@ class KillRequest :
                &_KillRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    10;
+    12;
 
   friend void swap(KillRequest& a, KillRequest& b) {
     a.Swap(&b);
@@ -1630,7 +1895,7 @@ class KillResponse :
                &_KillResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    11;
+    13;
 
   friend void swap(KillResponse& a, KillResponse& b) {
     a.Swap(&b);
@@ -1764,7 +2029,7 @@ class ReturnToLaunchRequest :
                &_ReturnToLaunchRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    12;
+    14;
 
   friend void swap(ReturnToLaunchRequest& a, ReturnToLaunchRequest& b) {
     a.Swap(&b);
@@ -1879,7 +2144,7 @@ class ReturnToLaunchResponse :
                &_ReturnToLaunchResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    13;
+    15;
 
   friend void swap(ReturnToLaunchResponse& a, ReturnToLaunchResponse& b) {
     a.Swap(&b);
@@ -1971,23 +2236,23 @@ class ReturnToLaunchResponse :
 };
 // -------------------------------------------------------------------
 
-class TransitionToFixedWingRequest :
-    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action.TransitionToFixedWingRequest) */ {
+class GotoLocationRequest :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action.GotoLocationRequest) */ {
  public:
-  TransitionToFixedWingRequest();
-  virtual ~TransitionToFixedWingRequest();
+  GotoLocationRequest();
+  virtual ~GotoLocationRequest();
 
-  TransitionToFixedWingRequest(const TransitionToFixedWingRequest& from);
-  TransitionToFixedWingRequest(TransitionToFixedWingRequest&& from) noexcept
-    : TransitionToFixedWingRequest() {
+  GotoLocationRequest(const GotoLocationRequest& from);
+  GotoLocationRequest(GotoLocationRequest&& from) noexcept
+    : GotoLocationRequest() {
     *this = ::std::move(from);
   }
 
-  inline TransitionToFixedWingRequest& operator=(const TransitionToFixedWingRequest& from) {
+  inline GotoLocationRequest& operator=(const GotoLocationRequest& from) {
     CopyFrom(from);
     return *this;
   }
-  inline TransitionToFixedWingRequest& operator=(TransitionToFixedWingRequest&& from) noexcept {
+  inline GotoLocationRequest& operator=(GotoLocationRequest&& from) noexcept {
     if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
       if (this != &from) InternalSwap(&from);
     } else {
@@ -2005,37 +2270,37 @@ class TransitionToFixedWingRequest :
   static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
     return GetMetadataStatic().reflection;
   }
-  static const TransitionToFixedWingRequest& default_instance();
+  static const GotoLocationRequest& default_instance();
 
   static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
-  static inline const TransitionToFixedWingRequest* internal_default_instance() {
-    return reinterpret_cast<const TransitionToFixedWingRequest*>(
-               &_TransitionToFixedWingRequest_default_instance_);
+  static inline const GotoLocationRequest* internal_default_instance() {
+    return reinterpret_cast<const GotoLocationRequest*>(
+               &_GotoLocationRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    14;
+    16;
 
-  friend void swap(TransitionToFixedWingRequest& a, TransitionToFixedWingRequest& b) {
+  friend void swap(GotoLocationRequest& a, GotoLocationRequest& b) {
     a.Swap(&b);
   }
-  inline void Swap(TransitionToFixedWingRequest* other) {
+  inline void Swap(GotoLocationRequest* other) {
     if (other == this) return;
     InternalSwap(other);
   }
 
   // implements Message ----------------------------------------------
 
-  inline TransitionToFixedWingRequest* New() const final {
-    return CreateMaybeMessage<TransitionToFixedWingRequest>(nullptr);
+  inline GotoLocationRequest* New() const final {
+    return CreateMaybeMessage<GotoLocationRequest>(nullptr);
   }
 
-  TransitionToFixedWingRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
-    return CreateMaybeMessage<TransitionToFixedWingRequest>(arena);
+  GotoLocationRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<GotoLocationRequest>(arena);
   }
   void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
   void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
-  void CopyFrom(const TransitionToFixedWingRequest& from);
-  void MergeFrom(const TransitionToFixedWingRequest& from);
+  void CopyFrom(const GotoLocationRequest& from);
+  void MergeFrom(const GotoLocationRequest& from);
   PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
   bool IsInitialized() const final;
 
@@ -2049,10 +2314,10 @@ class TransitionToFixedWingRequest :
   inline void SharedCtor();
   inline void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(TransitionToFixedWingRequest* other);
+  void InternalSwap(GotoLocationRequest* other);
   friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
   static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
-    return "mavsdk.rpc.action.TransitionToFixedWingRequest";
+    return "mavsdk.rpc.action.GotoLocationRequest";
   }
   private:
   inline ::PROTOBUF_NAMESPACE_ID::Arena* GetArenaNoVirtual() const {
@@ -2076,33 +2341,79 @@ class TransitionToFixedWingRequest :
 
   // accessors -------------------------------------------------------
 
-  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action.TransitionToFixedWingRequest)
+  enum : int {
+    kLatitudeDegFieldNumber = 1,
+    kLongitudeDegFieldNumber = 2,
+    kAbsoluteAltitudeMFieldNumber = 3,
+    kYawDegFieldNumber = 4,
+  };
+  // double latitude_deg = 1;
+  void clear_latitude_deg();
+  double latitude_deg() const;
+  void set_latitude_deg(double value);
+  private:
+  double _internal_latitude_deg() const;
+  void _internal_set_latitude_deg(double value);
+  public:
+
+  // double longitude_deg = 2;
+  void clear_longitude_deg();
+  double longitude_deg() const;
+  void set_longitude_deg(double value);
+  private:
+  double _internal_longitude_deg() const;
+  void _internal_set_longitude_deg(double value);
+  public:
+
+  // float absolute_altitude_m = 3;
+  void clear_absolute_altitude_m();
+  float absolute_altitude_m() const;
+  void set_absolute_altitude_m(float value);
+  private:
+  float _internal_absolute_altitude_m() const;
+  void _internal_set_absolute_altitude_m(float value);
+  public:
+
+  // float yaw_deg = 4;
+  void clear_yaw_deg();
+  float yaw_deg() const;
+  void set_yaw_deg(float value);
+  private:
+  float _internal_yaw_deg() const;
+  void _internal_set_yaw_deg(float value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action.GotoLocationRequest)
  private:
   class _Internal;
 
   ::PROTOBUF_NAMESPACE_ID::internal::InternalMetadataWithArena _internal_metadata_;
+  double latitude_deg_;
+  double longitude_deg_;
+  float absolute_altitude_m_;
+  float yaw_deg_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_action_2faction_2eproto;
 };
 // -------------------------------------------------------------------
 
-class TransitionToFixedWingResponse :
-    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action.TransitionToFixedWingResponse) */ {
+class GotoLocationResponse :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action.GotoLocationResponse) */ {
  public:
-  TransitionToFixedWingResponse();
-  virtual ~TransitionToFixedWingResponse();
+  GotoLocationResponse();
+  virtual ~GotoLocationResponse();
 
-  TransitionToFixedWingResponse(const TransitionToFixedWingResponse& from);
-  TransitionToFixedWingResponse(TransitionToFixedWingResponse&& from) noexcept
-    : TransitionToFixedWingResponse() {
+  GotoLocationResponse(const GotoLocationResponse& from);
+  GotoLocationResponse(GotoLocationResponse&& from) noexcept
+    : GotoLocationResponse() {
     *this = ::std::move(from);
   }
 
-  inline TransitionToFixedWingResponse& operator=(const TransitionToFixedWingResponse& from) {
+  inline GotoLocationResponse& operator=(const GotoLocationResponse& from) {
     CopyFrom(from);
     return *this;
   }
-  inline TransitionToFixedWingResponse& operator=(TransitionToFixedWingResponse&& from) noexcept {
+  inline GotoLocationResponse& operator=(GotoLocationResponse&& from) noexcept {
     if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
       if (this != &from) InternalSwap(&from);
     } else {
@@ -2120,37 +2431,37 @@ class TransitionToFixedWingResponse :
   static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
     return GetMetadataStatic().reflection;
   }
-  static const TransitionToFixedWingResponse& default_instance();
+  static const GotoLocationResponse& default_instance();
 
   static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
-  static inline const TransitionToFixedWingResponse* internal_default_instance() {
-    return reinterpret_cast<const TransitionToFixedWingResponse*>(
-               &_TransitionToFixedWingResponse_default_instance_);
+  static inline const GotoLocationResponse* internal_default_instance() {
+    return reinterpret_cast<const GotoLocationResponse*>(
+               &_GotoLocationResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    15;
+    17;
 
-  friend void swap(TransitionToFixedWingResponse& a, TransitionToFixedWingResponse& b) {
+  friend void swap(GotoLocationResponse& a, GotoLocationResponse& b) {
     a.Swap(&b);
   }
-  inline void Swap(TransitionToFixedWingResponse* other) {
+  inline void Swap(GotoLocationResponse* other) {
     if (other == this) return;
     InternalSwap(other);
   }
 
   // implements Message ----------------------------------------------
 
-  inline TransitionToFixedWingResponse* New() const final {
-    return CreateMaybeMessage<TransitionToFixedWingResponse>(nullptr);
+  inline GotoLocationResponse* New() const final {
+    return CreateMaybeMessage<GotoLocationResponse>(nullptr);
   }
 
-  TransitionToFixedWingResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
-    return CreateMaybeMessage<TransitionToFixedWingResponse>(arena);
+  GotoLocationResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<GotoLocationResponse>(arena);
   }
   void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
   void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
-  void CopyFrom(const TransitionToFixedWingResponse& from);
-  void MergeFrom(const TransitionToFixedWingResponse& from);
+  void CopyFrom(const GotoLocationResponse& from);
+  void MergeFrom(const GotoLocationResponse& from);
   PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
   bool IsInitialized() const final;
 
@@ -2164,10 +2475,10 @@ class TransitionToFixedWingResponse :
   inline void SharedCtor();
   inline void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(TransitionToFixedWingResponse* other);
+  void InternalSwap(GotoLocationResponse* other);
   friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
   static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
-    return "mavsdk.rpc.action.TransitionToFixedWingResponse";
+    return "mavsdk.rpc.action.GotoLocationResponse";
   }
   private:
   inline ::PROTOBUF_NAMESPACE_ID::Arena* GetArenaNoVirtual() const {
@@ -2209,7 +2520,256 @@ class TransitionToFixedWingResponse :
   ::mavsdk::rpc::action::ActionResult* _internal_mutable_action_result();
   public:
 
-  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action.TransitionToFixedWingResponse)
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action.GotoLocationResponse)
+ private:
+  class _Internal;
+
+  ::PROTOBUF_NAMESPACE_ID::internal::InternalMetadataWithArena _internal_metadata_;
+  ::mavsdk::rpc::action::ActionResult* action_result_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_action_2faction_2eproto;
+};
+// -------------------------------------------------------------------
+
+class TransitionToFixedwingRequest :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action.TransitionToFixedwingRequest) */ {
+ public:
+  TransitionToFixedwingRequest();
+  virtual ~TransitionToFixedwingRequest();
+
+  TransitionToFixedwingRequest(const TransitionToFixedwingRequest& from);
+  TransitionToFixedwingRequest(TransitionToFixedwingRequest&& from) noexcept
+    : TransitionToFixedwingRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline TransitionToFixedwingRequest& operator=(const TransitionToFixedwingRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline TransitionToFixedwingRequest& operator=(TransitionToFixedwingRequest&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const TransitionToFixedwingRequest& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const TransitionToFixedwingRequest* internal_default_instance() {
+    return reinterpret_cast<const TransitionToFixedwingRequest*>(
+               &_TransitionToFixedwingRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    18;
+
+  friend void swap(TransitionToFixedwingRequest& a, TransitionToFixedwingRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(TransitionToFixedwingRequest* other) {
+    if (other == this) return;
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline TransitionToFixedwingRequest* New() const final {
+    return CreateMaybeMessage<TransitionToFixedwingRequest>(nullptr);
+  }
+
+  TransitionToFixedwingRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<TransitionToFixedwingRequest>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const TransitionToFixedwingRequest& from);
+  void MergeFrom(const TransitionToFixedwingRequest& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(TransitionToFixedwingRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.action.TransitionToFixedwingRequest";
+  }
+  private:
+  inline ::PROTOBUF_NAMESPACE_ID::Arena* GetArenaNoVirtual() const {
+    return nullptr;
+  }
+  inline void* MaybeArenaPtr() const {
+    return nullptr;
+  }
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_action_2faction_2eproto);
+    return ::descriptor_table_action_2faction_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action.TransitionToFixedwingRequest)
+ private:
+  class _Internal;
+
+  ::PROTOBUF_NAMESPACE_ID::internal::InternalMetadataWithArena _internal_metadata_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_action_2faction_2eproto;
+};
+// -------------------------------------------------------------------
+
+class TransitionToFixedwingResponse :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action.TransitionToFixedwingResponse) */ {
+ public:
+  TransitionToFixedwingResponse();
+  virtual ~TransitionToFixedwingResponse();
+
+  TransitionToFixedwingResponse(const TransitionToFixedwingResponse& from);
+  TransitionToFixedwingResponse(TransitionToFixedwingResponse&& from) noexcept
+    : TransitionToFixedwingResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline TransitionToFixedwingResponse& operator=(const TransitionToFixedwingResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline TransitionToFixedwingResponse& operator=(TransitionToFixedwingResponse&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const TransitionToFixedwingResponse& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const TransitionToFixedwingResponse* internal_default_instance() {
+    return reinterpret_cast<const TransitionToFixedwingResponse*>(
+               &_TransitionToFixedwingResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    19;
+
+  friend void swap(TransitionToFixedwingResponse& a, TransitionToFixedwingResponse& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(TransitionToFixedwingResponse* other) {
+    if (other == this) return;
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline TransitionToFixedwingResponse* New() const final {
+    return CreateMaybeMessage<TransitionToFixedwingResponse>(nullptr);
+  }
+
+  TransitionToFixedwingResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<TransitionToFixedwingResponse>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const TransitionToFixedwingResponse& from);
+  void MergeFrom(const TransitionToFixedwingResponse& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(TransitionToFixedwingResponse* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.action.TransitionToFixedwingResponse";
+  }
+  private:
+  inline ::PROTOBUF_NAMESPACE_ID::Arena* GetArenaNoVirtual() const {
+    return nullptr;
+  }
+  inline void* MaybeArenaPtr() const {
+    return nullptr;
+  }
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_action_2faction_2eproto);
+    return ::descriptor_table_action_2faction_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kActionResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.action.ActionResult action_result = 1;
+  bool has_action_result() const;
+  private:
+  bool _internal_has_action_result() const;
+  public:
+  void clear_action_result();
+  const ::mavsdk::rpc::action::ActionResult& action_result() const;
+  ::mavsdk::rpc::action::ActionResult* release_action_result();
+  ::mavsdk::rpc::action::ActionResult* mutable_action_result();
+  void set_allocated_action_result(::mavsdk::rpc::action::ActionResult* action_result);
+  private:
+  const ::mavsdk::rpc::action::ActionResult& _internal_action_result() const;
+  ::mavsdk::rpc::action::ActionResult* _internal_mutable_action_result();
+  public:
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action.TransitionToFixedwingResponse)
  private:
   class _Internal;
 
@@ -2262,7 +2822,7 @@ class TransitionToMulticopterRequest :
                &_TransitionToMulticopterRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    16;
+    20;
 
   friend void swap(TransitionToMulticopterRequest& a, TransitionToMulticopterRequest& b) {
     a.Swap(&b);
@@ -2377,7 +2937,7 @@ class TransitionToMulticopterResponse :
                &_TransitionToMulticopterResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    17;
+    21;
 
   friend void swap(TransitionToMulticopterResponse& a, TransitionToMulticopterResponse& b) {
     a.Swap(&b);
@@ -2511,7 +3071,7 @@ class GetTakeoffAltitudeRequest :
                &_GetTakeoffAltitudeRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    18;
+    22;
 
   friend void swap(GetTakeoffAltitudeRequest& a, GetTakeoffAltitudeRequest& b) {
     a.Swap(&b);
@@ -2626,7 +3186,7 @@ class GetTakeoffAltitudeResponse :
                &_GetTakeoffAltitudeResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    19;
+    23;
 
   friend void swap(GetTakeoffAltitudeResponse& a, GetTakeoffAltitudeResponse& b) {
     a.Swap(&b);
@@ -2771,7 +3331,7 @@ class SetTakeoffAltitudeRequest :
                &_SetTakeoffAltitudeRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    20;
+    24;
 
   friend void swap(SetTakeoffAltitudeRequest& a, SetTakeoffAltitudeRequest& b) {
     a.Swap(&b);
@@ -2899,7 +3459,7 @@ class SetTakeoffAltitudeResponse :
                &_SetTakeoffAltitudeResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    21;
+    25;
 
   friend void swap(SetTakeoffAltitudeResponse& a, SetTakeoffAltitudeResponse& b) {
     a.Swap(&b);
@@ -3033,7 +3593,7 @@ class GetMaximumSpeedRequest :
                &_GetMaximumSpeedRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    22;
+    26;
 
   friend void swap(GetMaximumSpeedRequest& a, GetMaximumSpeedRequest& b) {
     a.Swap(&b);
@@ -3148,7 +3708,7 @@ class GetMaximumSpeedResponse :
                &_GetMaximumSpeedResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    23;
+    27;
 
   friend void swap(GetMaximumSpeedResponse& a, GetMaximumSpeedResponse& b) {
     a.Swap(&b);
@@ -3293,7 +3853,7 @@ class SetMaximumSpeedRequest :
                &_SetMaximumSpeedRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    24;
+    28;
 
   friend void swap(SetMaximumSpeedRequest& a, SetMaximumSpeedRequest& b) {
     a.Swap(&b);
@@ -3421,7 +3981,7 @@ class SetMaximumSpeedResponse :
                &_SetMaximumSpeedResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    25;
+    29;
 
   friend void swap(SetMaximumSpeedResponse& a, SetMaximumSpeedResponse& b) {
     a.Swap(&b);
@@ -3555,7 +4115,7 @@ class GetReturnToLaunchAltitudeRequest :
                &_GetReturnToLaunchAltitudeRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    26;
+    30;
 
   friend void swap(GetReturnToLaunchAltitudeRequest& a, GetReturnToLaunchAltitudeRequest& b) {
     a.Swap(&b);
@@ -3670,7 +4230,7 @@ class GetReturnToLaunchAltitudeResponse :
                &_GetReturnToLaunchAltitudeResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    27;
+    31;
 
   friend void swap(GetReturnToLaunchAltitudeResponse& a, GetReturnToLaunchAltitudeResponse& b) {
     a.Swap(&b);
@@ -3815,7 +4375,7 @@ class SetReturnToLaunchAltitudeRequest :
                &_SetReturnToLaunchAltitudeRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    28;
+    32;
 
   friend void swap(SetReturnToLaunchAltitudeRequest& a, SetReturnToLaunchAltitudeRequest& b) {
     a.Swap(&b);
@@ -3943,7 +4503,7 @@ class SetReturnToLaunchAltitudeResponse :
                &_SetReturnToLaunchAltitudeResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    29;
+    33;
 
   friend void swap(SetReturnToLaunchAltitudeResponse& a, SetReturnToLaunchAltitudeResponse& b) {
     a.Swap(&b);
@@ -4077,7 +4637,7 @@ class ActionResult :
                &_ActionResult_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    30;
+    34;
 
   friend void swap(ActionResult& a, ActionResult& b) {
     a.Swap(&b);
@@ -4578,6 +5138,74 @@ inline void RebootResponse::set_allocated_action_result(::mavsdk::rpc::action::A
 
 // -------------------------------------------------------------------
 
+// ShutdownRequest
+
+// -------------------------------------------------------------------
+
+// ShutdownResponse
+
+// .mavsdk.rpc.action.ActionResult action_result = 1;
+inline bool ShutdownResponse::_internal_has_action_result() const {
+  return this != internal_default_instance() && action_result_ != nullptr;
+}
+inline bool ShutdownResponse::has_action_result() const {
+  return _internal_has_action_result();
+}
+inline void ShutdownResponse::clear_action_result() {
+  if (GetArenaNoVirtual() == nullptr && action_result_ != nullptr) {
+    delete action_result_;
+  }
+  action_result_ = nullptr;
+}
+inline const ::mavsdk::rpc::action::ActionResult& ShutdownResponse::_internal_action_result() const {
+  const ::mavsdk::rpc::action::ActionResult* p = action_result_;
+  return p != nullptr ? *p : *reinterpret_cast<const ::mavsdk::rpc::action::ActionResult*>(
+      &::mavsdk::rpc::action::_ActionResult_default_instance_);
+}
+inline const ::mavsdk::rpc::action::ActionResult& ShutdownResponse::action_result() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action.ShutdownResponse.action_result)
+  return _internal_action_result();
+}
+inline ::mavsdk::rpc::action::ActionResult* ShutdownResponse::release_action_result() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.action.ShutdownResponse.action_result)
+  
+  ::mavsdk::rpc::action::ActionResult* temp = action_result_;
+  action_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::action::ActionResult* ShutdownResponse::_internal_mutable_action_result() {
+  
+  if (action_result_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::action::ActionResult>(GetArenaNoVirtual());
+    action_result_ = p;
+  }
+  return action_result_;
+}
+inline ::mavsdk::rpc::action::ActionResult* ShutdownResponse::mutable_action_result() {
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.action.ShutdownResponse.action_result)
+  return _internal_mutable_action_result();
+}
+inline void ShutdownResponse::set_allocated_action_result(::mavsdk::rpc::action::ActionResult* action_result) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaNoVirtual();
+  if (message_arena == nullptr) {
+    delete action_result_;
+  }
+  if (action_result) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena = nullptr;
+    if (message_arena != submessage_arena) {
+      action_result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, action_result, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  action_result_ = action_result;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.action.ShutdownResponse.action_result)
+}
+
+// -------------------------------------------------------------------
+
 // KillRequest
 
 // -------------------------------------------------------------------
@@ -4714,42 +5342,122 @@ inline void ReturnToLaunchResponse::set_allocated_action_result(::mavsdk::rpc::a
 
 // -------------------------------------------------------------------
 
-// TransitionToFixedWingRequest
+// GotoLocationRequest
+
+// double latitude_deg = 1;
+inline void GotoLocationRequest::clear_latitude_deg() {
+  latitude_deg_ = 0;
+}
+inline double GotoLocationRequest::_internal_latitude_deg() const {
+  return latitude_deg_;
+}
+inline double GotoLocationRequest::latitude_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action.GotoLocationRequest.latitude_deg)
+  return _internal_latitude_deg();
+}
+inline void GotoLocationRequest::_internal_set_latitude_deg(double value) {
+  
+  latitude_deg_ = value;
+}
+inline void GotoLocationRequest::set_latitude_deg(double value) {
+  _internal_set_latitude_deg(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.action.GotoLocationRequest.latitude_deg)
+}
+
+// double longitude_deg = 2;
+inline void GotoLocationRequest::clear_longitude_deg() {
+  longitude_deg_ = 0;
+}
+inline double GotoLocationRequest::_internal_longitude_deg() const {
+  return longitude_deg_;
+}
+inline double GotoLocationRequest::longitude_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action.GotoLocationRequest.longitude_deg)
+  return _internal_longitude_deg();
+}
+inline void GotoLocationRequest::_internal_set_longitude_deg(double value) {
+  
+  longitude_deg_ = value;
+}
+inline void GotoLocationRequest::set_longitude_deg(double value) {
+  _internal_set_longitude_deg(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.action.GotoLocationRequest.longitude_deg)
+}
+
+// float absolute_altitude_m = 3;
+inline void GotoLocationRequest::clear_absolute_altitude_m() {
+  absolute_altitude_m_ = 0;
+}
+inline float GotoLocationRequest::_internal_absolute_altitude_m() const {
+  return absolute_altitude_m_;
+}
+inline float GotoLocationRequest::absolute_altitude_m() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action.GotoLocationRequest.absolute_altitude_m)
+  return _internal_absolute_altitude_m();
+}
+inline void GotoLocationRequest::_internal_set_absolute_altitude_m(float value) {
+  
+  absolute_altitude_m_ = value;
+}
+inline void GotoLocationRequest::set_absolute_altitude_m(float value) {
+  _internal_set_absolute_altitude_m(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.action.GotoLocationRequest.absolute_altitude_m)
+}
+
+// float yaw_deg = 4;
+inline void GotoLocationRequest::clear_yaw_deg() {
+  yaw_deg_ = 0;
+}
+inline float GotoLocationRequest::_internal_yaw_deg() const {
+  return yaw_deg_;
+}
+inline float GotoLocationRequest::yaw_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action.GotoLocationRequest.yaw_deg)
+  return _internal_yaw_deg();
+}
+inline void GotoLocationRequest::_internal_set_yaw_deg(float value) {
+  
+  yaw_deg_ = value;
+}
+inline void GotoLocationRequest::set_yaw_deg(float value) {
+  _internal_set_yaw_deg(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.action.GotoLocationRequest.yaw_deg)
+}
 
 // -------------------------------------------------------------------
 
-// TransitionToFixedWingResponse
+// GotoLocationResponse
 
 // .mavsdk.rpc.action.ActionResult action_result = 1;
-inline bool TransitionToFixedWingResponse::_internal_has_action_result() const {
+inline bool GotoLocationResponse::_internal_has_action_result() const {
   return this != internal_default_instance() && action_result_ != nullptr;
 }
-inline bool TransitionToFixedWingResponse::has_action_result() const {
+inline bool GotoLocationResponse::has_action_result() const {
   return _internal_has_action_result();
 }
-inline void TransitionToFixedWingResponse::clear_action_result() {
+inline void GotoLocationResponse::clear_action_result() {
   if (GetArenaNoVirtual() == nullptr && action_result_ != nullptr) {
     delete action_result_;
   }
   action_result_ = nullptr;
 }
-inline const ::mavsdk::rpc::action::ActionResult& TransitionToFixedWingResponse::_internal_action_result() const {
+inline const ::mavsdk::rpc::action::ActionResult& GotoLocationResponse::_internal_action_result() const {
   const ::mavsdk::rpc::action::ActionResult* p = action_result_;
   return p != nullptr ? *p : *reinterpret_cast<const ::mavsdk::rpc::action::ActionResult*>(
       &::mavsdk::rpc::action::_ActionResult_default_instance_);
 }
-inline const ::mavsdk::rpc::action::ActionResult& TransitionToFixedWingResponse::action_result() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.action.TransitionToFixedWingResponse.action_result)
+inline const ::mavsdk::rpc::action::ActionResult& GotoLocationResponse::action_result() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action.GotoLocationResponse.action_result)
   return _internal_action_result();
 }
-inline ::mavsdk::rpc::action::ActionResult* TransitionToFixedWingResponse::release_action_result() {
-  // @@protoc_insertion_point(field_release:mavsdk.rpc.action.TransitionToFixedWingResponse.action_result)
+inline ::mavsdk::rpc::action::ActionResult* GotoLocationResponse::release_action_result() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.action.GotoLocationResponse.action_result)
   
   ::mavsdk::rpc::action::ActionResult* temp = action_result_;
   action_result_ = nullptr;
   return temp;
 }
-inline ::mavsdk::rpc::action::ActionResult* TransitionToFixedWingResponse::_internal_mutable_action_result() {
+inline ::mavsdk::rpc::action::ActionResult* GotoLocationResponse::_internal_mutable_action_result() {
   
   if (action_result_ == nullptr) {
     auto* p = CreateMaybeMessage<::mavsdk::rpc::action::ActionResult>(GetArenaNoVirtual());
@@ -4757,11 +5465,11 @@ inline ::mavsdk::rpc::action::ActionResult* TransitionToFixedWingResponse::_inte
   }
   return action_result_;
 }
-inline ::mavsdk::rpc::action::ActionResult* TransitionToFixedWingResponse::mutable_action_result() {
-  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.action.TransitionToFixedWingResponse.action_result)
+inline ::mavsdk::rpc::action::ActionResult* GotoLocationResponse::mutable_action_result() {
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.action.GotoLocationResponse.action_result)
   return _internal_mutable_action_result();
 }
-inline void TransitionToFixedWingResponse::set_allocated_action_result(::mavsdk::rpc::action::ActionResult* action_result) {
+inline void GotoLocationResponse::set_allocated_action_result(::mavsdk::rpc::action::ActionResult* action_result) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaNoVirtual();
   if (message_arena == nullptr) {
     delete action_result_;
@@ -4777,7 +5485,75 @@ inline void TransitionToFixedWingResponse::set_allocated_action_result(::mavsdk:
     
   }
   action_result_ = action_result;
-  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.action.TransitionToFixedWingResponse.action_result)
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.action.GotoLocationResponse.action_result)
+}
+
+// -------------------------------------------------------------------
+
+// TransitionToFixedwingRequest
+
+// -------------------------------------------------------------------
+
+// TransitionToFixedwingResponse
+
+// .mavsdk.rpc.action.ActionResult action_result = 1;
+inline bool TransitionToFixedwingResponse::_internal_has_action_result() const {
+  return this != internal_default_instance() && action_result_ != nullptr;
+}
+inline bool TransitionToFixedwingResponse::has_action_result() const {
+  return _internal_has_action_result();
+}
+inline void TransitionToFixedwingResponse::clear_action_result() {
+  if (GetArenaNoVirtual() == nullptr && action_result_ != nullptr) {
+    delete action_result_;
+  }
+  action_result_ = nullptr;
+}
+inline const ::mavsdk::rpc::action::ActionResult& TransitionToFixedwingResponse::_internal_action_result() const {
+  const ::mavsdk::rpc::action::ActionResult* p = action_result_;
+  return p != nullptr ? *p : *reinterpret_cast<const ::mavsdk::rpc::action::ActionResult*>(
+      &::mavsdk::rpc::action::_ActionResult_default_instance_);
+}
+inline const ::mavsdk::rpc::action::ActionResult& TransitionToFixedwingResponse::action_result() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action.TransitionToFixedwingResponse.action_result)
+  return _internal_action_result();
+}
+inline ::mavsdk::rpc::action::ActionResult* TransitionToFixedwingResponse::release_action_result() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.action.TransitionToFixedwingResponse.action_result)
+  
+  ::mavsdk::rpc::action::ActionResult* temp = action_result_;
+  action_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::action::ActionResult* TransitionToFixedwingResponse::_internal_mutable_action_result() {
+  
+  if (action_result_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::action::ActionResult>(GetArenaNoVirtual());
+    action_result_ = p;
+  }
+  return action_result_;
+}
+inline ::mavsdk::rpc::action::ActionResult* TransitionToFixedwingResponse::mutable_action_result() {
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.action.TransitionToFixedwingResponse.action_result)
+  return _internal_mutable_action_result();
+}
+inline void TransitionToFixedwingResponse::set_allocated_action_result(::mavsdk::rpc::action::ActionResult* action_result) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaNoVirtual();
+  if (message_arena == nullptr) {
+    delete action_result_;
+  }
+  if (action_result) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena = nullptr;
+    if (message_arena != submessage_arena) {
+      action_result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, action_result, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  action_result_ = action_result;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.action.TransitionToFixedwingResponse.action_result)
 }
 
 // -------------------------------------------------------------------
@@ -5463,6 +6239,14 @@ inline void ActionResult::set_allocated_result_str(std::string* result_str) {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/src/backend/src/plugins/action/action_service_impl.h
+++ b/src/backend/src/plugins/action/action_service_impl.h
@@ -1,6 +1,8 @@
 #include "action/action.grpc.pb.h"
 #include "plugins/action/action.h"
 
+#include "log.h"
+
 namespace mavsdk {
 namespace backend {
 
@@ -9,30 +11,70 @@ class ActionServiceImpl final : public rpc::action::ActionService::Service {
 public:
     ActionServiceImpl(Action& action) : _action(action) {}
 
-    grpc::Status
-    Arm(grpc::ServerContext* /* context */,
-        const rpc::action::ArmRequest* /* request */,
-        rpc::action::ArmResponse* response) override
-    {
-        auto action_result = _action.arm();
-
-        if (response != nullptr) {
-            fillResponseWithResult(response, action_result);
-        }
-
-        return grpc::Status::OK;
-    }
 
     template<typename ResponseType>
-    void fillResponseWithResult(ResponseType* response, mavsdk::Action::Result& action_result) const
+    void fillResponseWithResult(ResponseType* response, mavsdk::Action::Result& result) const
     {
-        auto rpc_result = static_cast<rpc::action::ActionResult::Result>(action_result);
+        auto rpc_result = translateToRpcResult(result);
 
         auto* rpc_action_result = new rpc::action::ActionResult();
         rpc_action_result->set_result(rpc_result);
-        rpc_action_result->set_result_str(mavsdk::Action::result_str(action_result));
+        rpc_action_result->set_result_str(mavsdk::Action::result_str(result));
 
         response->set_allocated_action_result(rpc_action_result);
+    }
+
+
+
+    static rpc::action::ActionResult::Result translateToRpcResult(const mavsdk::Action::Result& result)
+    {
+        switch (result) {
+            case mavsdk::Action::Result::Unknown:
+                return rpc::action::ActionResult_Result_UNKNOWN;
+            case mavsdk::Action::Result::Success:
+                return rpc::action::ActionResult_Result_SUCCESS;
+            case mavsdk::Action::Result::NoSystem:
+                return rpc::action::ActionResult_Result_NO_SYSTEM;
+            case mavsdk::Action::Result::ConnectionError:
+                return rpc::action::ActionResult_Result_CONNECTION_ERROR;
+            case mavsdk::Action::Result::Busy:
+                return rpc::action::ActionResult_Result_BUSY;
+            case mavsdk::Action::Result::CommandDenied:
+                return rpc::action::ActionResult_Result_COMMAND_DENIED;
+            case mavsdk::Action::Result::CommandDeniedLandedStateUnknown:
+                return rpc::action::ActionResult_Result_COMMAND_DENIED_LANDED_STATE_UNKNOWN;
+            case mavsdk::Action::Result::CommandDeniedNotLanded:
+                return rpc::action::ActionResult_Result_COMMAND_DENIED_NOT_LANDED;
+            case mavsdk::Action::Result::Timeout:
+                return rpc::action::ActionResult_Result_TIMEOUT;
+            case mavsdk::Action::Result::VtolTransitionSupportUnknown:
+                return rpc::action::ActionResult_Result_VTOL_TRANSITION_SUPPORT_UNKNOWN;
+            case mavsdk::Action::Result::NoVtolTransitionSupport:
+                return rpc::action::ActionResult_Result_NO_VTOL_TRANSITION_SUPPORT;
+            case mavsdk::Action::Result::ParameterError:
+                return rpc::action::ActionResult_Result_PARAMETER_ERROR;
+            default:
+                return rpc::action::ActionResult_Result_UNKNOWN;
+        }
+    }
+
+
+
+
+    grpc::Status Arm(
+        grpc::ServerContext* /* context */,
+        const rpc::action::ArmRequest* /* request */,
+        rpc::action::ArmResponse* response) override
+    {
+        
+
+        auto result = _action.arm();
+
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+
+        return grpc::Status::OK;
     }
 
     grpc::Status Disarm(
@@ -40,10 +82,12 @@ public:
         const rpc::action::DisarmRequest* /* request */,
         rpc::action::DisarmResponse* response) override
     {
-        auto action_result = _action.disarm();
+        
+
+        auto result = _action.disarm();
 
         if (response != nullptr) {
-            fillResponseWithResult(response, action_result);
+            fillResponseWithResult(response, result);
         }
 
         return grpc::Status::OK;
@@ -54,10 +98,12 @@ public:
         const rpc::action::TakeoffRequest* /* request */,
         rpc::action::TakeoffResponse* response) override
     {
-        auto action_result = _action.takeoff();
+        
+
+        auto result = _action.takeoff();
 
         if (response != nullptr) {
-            fillResponseWithResult(response, action_result);
+            fillResponseWithResult(response, result);
         }
 
         return grpc::Status::OK;
@@ -68,10 +114,12 @@ public:
         const rpc::action::LandRequest* /* request */,
         rpc::action::LandResponse* response) override
     {
-        auto action_result = _action.land();
+        
+
+        auto result = _action.land();
 
         if (response != nullptr) {
-            fillResponseWithResult(response, action_result);
+            fillResponseWithResult(response, result);
         }
 
         return grpc::Status::OK;
@@ -82,10 +130,28 @@ public:
         const rpc::action::RebootRequest* /* request */,
         rpc::action::RebootResponse* response) override
     {
-        auto action_result = _action.reboot();
+        
+
+        auto result = _action.reboot();
 
         if (response != nullptr) {
-            fillResponseWithResult(response, action_result);
+            fillResponseWithResult(response, result);
+        }
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status Shutdown(
+        grpc::ServerContext* /* context */,
+        const rpc::action::ShutdownRequest* /* request */,
+        rpc::action::ShutdownResponse* response) override
+    {
+        
+
+        auto result = _action.shutdown();
+
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
         }
 
         return grpc::Status::OK;
@@ -96,10 +162,12 @@ public:
         const rpc::action::KillRequest* /* request */,
         rpc::action::KillResponse* response) override
     {
-        auto action_result = _action.kill();
+        
+
+        auto result = _action.kill();
 
         if (response != nullptr) {
-            fillResponseWithResult(response, action_result);
+            fillResponseWithResult(response, result);
         }
 
         return grpc::Status::OK;
@@ -110,24 +178,47 @@ public:
         const rpc::action::ReturnToLaunchRequest* /* request */,
         rpc::action::ReturnToLaunchResponse* response) override
     {
-        auto action_result = _action.return_to_launch();
+        
+
+        auto result = _action.return_to_launch();
 
         if (response != nullptr) {
-            fillResponseWithResult(response, action_result);
+            fillResponseWithResult(response, result);
         }
 
         return grpc::Status::OK;
     }
 
-    grpc::Status TransitionToFixedWing(
+    grpc::Status GotoLocation(
         grpc::ServerContext* /* context */,
-        const rpc::action::TransitionToFixedWingRequest* /* request */,
-        rpc::action::TransitionToFixedWingResponse* response) override
+        const rpc::action::GotoLocationRequest* request,
+        rpc::action::GotoLocationResponse* response) override
     {
-        auto action_result = _action.transition_to_fixedwing();
+        if (request == nullptr) {
+            LogWarn() << "GotoLocation sent with a null request! Ignoring...";
+            return grpc::Status::OK;
+        }
+
+        auto result = _action.goto_location(request->latitude_deg(), request->longitude_deg(), request->absolute_altitude_m(), request->yaw_deg());
 
         if (response != nullptr) {
-            fillResponseWithResult(response, action_result);
+            fillResponseWithResult(response, result);
+        }
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status TransitionToFixedwing(
+        grpc::ServerContext* /* context */,
+        const rpc::action::TransitionToFixedwingRequest* /* request */,
+        rpc::action::TransitionToFixedwingResponse* response) override
+    {
+        
+
+        auto result = _action.transition_to_fixedwing();
+
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
         }
 
         return grpc::Status::OK;
@@ -138,29 +229,28 @@ public:
         const rpc::action::TransitionToMulticopterRequest* /* request */,
         rpc::action::TransitionToMulticopterResponse* response) override
     {
-        auto action_result = _action.transition_to_multicopter();
+        
+
+        auto result = _action.transition_to_multicopter();
 
         if (response != nullptr) {
-            fillResponseWithResult(response, action_result);
+            fillResponseWithResult(response, result);
         }
 
         return grpc::Status::OK;
     }
 
     grpc::Status GetTakeoffAltitude(
-        grpc::ServerContext* /* context */,
+        grpc::ServerContext * /* context */,
         const rpc::action::GetTakeoffAltitudeRequest* /* request */,
         rpc::action::GetTakeoffAltitudeResponse* response) override
     {
+        
+
+        auto result_pair = _action.get_takeoff_altitude();
+
         if (response != nullptr) {
-            auto result_pair = _action.get_takeoff_altitude();
-
-            auto* rpc_action_result = new rpc::action::ActionResult();
-            rpc_action_result->set_result(
-                static_cast<rpc::action::ActionResult::Result>(result_pair.first));
-            rpc_action_result->set_result_str(mavsdk::Action::result_str(result_pair.first));
-
-            response->set_allocated_action_result(rpc_action_result);
+            fillResponseWithResult(response, result_pair.first);
             response->set_altitude(result_pair.second);
         }
 
@@ -172,36 +262,31 @@ public:
         const rpc::action::SetTakeoffAltitudeRequest* request,
         rpc::action::SetTakeoffAltitudeResponse* response) override
     {
-        if (request != nullptr) {
-            const auto requested_altitude = request->altitude();
-            mavsdk::Action::Result action_result = _action.set_takeoff_altitude(requested_altitude);
+        if (request == nullptr) {
+            LogWarn() << "SetTakeoffAltitude sent with a null request! Ignoring...";
+            return grpc::Status::OK;
+        }
 
-            if (response != nullptr) {
-                auto* rpc_action_result = new rpc::action::ActionResult();
-                rpc_action_result->set_result(
-                    static_cast<rpc::action::ActionResult::Result>(action_result));
-                rpc_action_result->set_result_str(mavsdk::Action::result_str(action_result));
-                response->set_allocated_action_result(rpc_action_result);
-            }
+        auto result = _action.set_takeoff_altitude(request->altitude());
+
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
         }
 
         return grpc::Status::OK;
     }
 
     grpc::Status GetMaximumSpeed(
-        grpc::ServerContext* /* context */,
+        grpc::ServerContext * /* context */,
         const rpc::action::GetMaximumSpeedRequest* /* request */,
         rpc::action::GetMaximumSpeedResponse* response) override
     {
+        
+
+        auto result_pair = _action.get_maximum_speed();
+
         if (response != nullptr) {
-            auto result_pair = _action.get_max_speed();
-
-            auto* rpc_action_result = new rpc::action::ActionResult();
-            rpc_action_result->set_result(
-                static_cast<rpc::action::ActionResult::Result>(result_pair.first));
-            rpc_action_result->set_result_str(mavsdk::Action::result_str(result_pair.first));
-
-            response->set_allocated_action_result(rpc_action_result);
+            fillResponseWithResult(response, result_pair.first);
             response->set_speed(result_pair.second);
         }
 
@@ -213,36 +298,31 @@ public:
         const rpc::action::SetMaximumSpeedRequest* request,
         rpc::action::SetMaximumSpeedResponse* response) override
     {
-        if (request != nullptr) {
-            const auto requested_speed = request->speed();
-            mavsdk::Action::Result action_result = _action.set_max_speed(requested_speed);
+        if (request == nullptr) {
+            LogWarn() << "SetMaximumSpeed sent with a null request! Ignoring...";
+            return grpc::Status::OK;
+        }
 
-            if (response != nullptr) {
-                auto* rpc_action_result = new rpc::action::ActionResult();
-                rpc_action_result->set_result(
-                    static_cast<rpc::action::ActionResult::Result>(action_result));
-                rpc_action_result->set_result_str(mavsdk::Action::result_str(action_result));
-                response->set_allocated_action_result(rpc_action_result);
-            }
+        auto result = _action.set_maximum_speed(request->speed());
+
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
         }
 
         return grpc::Status::OK;
     }
 
     grpc::Status GetReturnToLaunchAltitude(
-        grpc::ServerContext* /* context */,
+        grpc::ServerContext * /* context */,
         const rpc::action::GetReturnToLaunchAltitudeRequest* /* request */,
         rpc::action::GetReturnToLaunchAltitudeResponse* response) override
     {
+        
+
+        auto result_pair = _action.get_return_to_launch_altitude();
+
         if (response != nullptr) {
-            auto result_pair = _action.get_return_to_launch_return_altitude();
-
-            auto* rpc_action_result = new rpc::action::ActionResult();
-            rpc_action_result->set_result(
-                static_cast<rpc::action::ActionResult::Result>(result_pair.first));
-            rpc_action_result->set_result_str(mavsdk::Action::result_str(result_pair.first));
-
-            response->set_allocated_action_result(rpc_action_result);
+            fillResponseWithResult(response, result_pair.first);
             response->set_relative_altitude_m(result_pair.second);
         }
 
@@ -254,26 +334,22 @@ public:
         const rpc::action::SetReturnToLaunchAltitudeRequest* request,
         rpc::action::SetReturnToLaunchAltitudeResponse* response) override
     {
-        if (request != nullptr) {
-            const auto requested_altitude = request->relative_altitude_m();
-            const auto action_result =
-                _action.set_return_to_launch_return_altitude(requested_altitude);
+        if (request == nullptr) {
+            LogWarn() << "SetReturnToLaunchAltitude sent with a null request! Ignoring...";
+            return grpc::Status::OK;
+        }
 
-            if (response != nullptr) {
-                auto* rpc_action_result = new rpc::action::ActionResult();
-                rpc_action_result->set_result(
-                    static_cast<rpc::action::ActionResult::Result>(action_result));
-                rpc_action_result->set_result_str(mavsdk::Action::result_str(action_result));
+        auto result = _action.set_return_to_launch_altitude(request->relative_altitude_m());
 
-                response->set_allocated_action_result(rpc_action_result);
-            }
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
         }
 
         return grpc::Status::OK;
     }
 
 private:
-    Action& _action;
+    Action &_action;
 };
 
 } // namespace backend

--- a/src/backend/src/plugins/action/action_service_impl.h
+++ b/src/backend/src/plugins/action/action_service_impl.h
@@ -11,7 +11,6 @@ class ActionServiceImpl final : public rpc::action::ActionService::Service {
 public:
     ActionServiceImpl(Action& action) : _action(action) {}
 
-
     template<typename ResponseType>
     void fillResponseWithResult(ResponseType* response, mavsdk::Action::Result& result) const
     {
@@ -24,9 +23,8 @@ public:
         response->set_allocated_action_result(rpc_action_result);
     }
 
-
-
-    static rpc::action::ActionResult::Result translateToRpcResult(const mavsdk::Action::Result& result)
+    static rpc::action::ActionResult::Result
+    translateToRpcResult(const mavsdk::Action::Result& result)
     {
         switch (result) {
             case mavsdk::Action::Result::Unknown:
@@ -58,16 +56,11 @@ public:
         }
     }
 
-
-
-
-    grpc::Status Arm(
-        grpc::ServerContext* /* context */,
+    grpc::Status
+    Arm(grpc::ServerContext* /* context */,
         const rpc::action::ArmRequest* /* request */,
         rpc::action::ArmResponse* response) override
     {
-        
-
         auto result = _action.arm();
 
         if (response != nullptr) {
@@ -82,8 +75,6 @@ public:
         const rpc::action::DisarmRequest* /* request */,
         rpc::action::DisarmResponse* response) override
     {
-        
-
         auto result = _action.disarm();
 
         if (response != nullptr) {
@@ -98,8 +89,6 @@ public:
         const rpc::action::TakeoffRequest* /* request */,
         rpc::action::TakeoffResponse* response) override
     {
-        
-
         auto result = _action.takeoff();
 
         if (response != nullptr) {
@@ -114,8 +103,6 @@ public:
         const rpc::action::LandRequest* /* request */,
         rpc::action::LandResponse* response) override
     {
-        
-
         auto result = _action.land();
 
         if (response != nullptr) {
@@ -130,8 +117,6 @@ public:
         const rpc::action::RebootRequest* /* request */,
         rpc::action::RebootResponse* response) override
     {
-        
-
         auto result = _action.reboot();
 
         if (response != nullptr) {
@@ -146,8 +131,6 @@ public:
         const rpc::action::ShutdownRequest* /* request */,
         rpc::action::ShutdownResponse* response) override
     {
-        
-
         auto result = _action.shutdown();
 
         if (response != nullptr) {
@@ -162,8 +145,6 @@ public:
         const rpc::action::KillRequest* /* request */,
         rpc::action::KillResponse* response) override
     {
-        
-
         auto result = _action.kill();
 
         if (response != nullptr) {
@@ -178,8 +159,6 @@ public:
         const rpc::action::ReturnToLaunchRequest* /* request */,
         rpc::action::ReturnToLaunchResponse* response) override
     {
-        
-
         auto result = _action.return_to_launch();
 
         if (response != nullptr) {
@@ -199,7 +178,11 @@ public:
             return grpc::Status::OK;
         }
 
-        auto result = _action.goto_location(request->latitude_deg(), request->longitude_deg(), request->absolute_altitude_m(), request->yaw_deg());
+        auto result = _action.goto_location(
+            request->latitude_deg(),
+            request->longitude_deg(),
+            request->absolute_altitude_m(),
+            request->yaw_deg());
 
         if (response != nullptr) {
             fillResponseWithResult(response, result);
@@ -213,8 +196,6 @@ public:
         const rpc::action::TransitionToFixedwingRequest* /* request */,
         rpc::action::TransitionToFixedwingResponse* response) override
     {
-        
-
         auto result = _action.transition_to_fixedwing();
 
         if (response != nullptr) {
@@ -229,8 +210,6 @@ public:
         const rpc::action::TransitionToMulticopterRequest* /* request */,
         rpc::action::TransitionToMulticopterResponse* response) override
     {
-        
-
         auto result = _action.transition_to_multicopter();
 
         if (response != nullptr) {
@@ -241,12 +220,10 @@ public:
     }
 
     grpc::Status GetTakeoffAltitude(
-        grpc::ServerContext * /* context */,
+        grpc::ServerContext* /* context */,
         const rpc::action::GetTakeoffAltitudeRequest* /* request */,
         rpc::action::GetTakeoffAltitudeResponse* response) override
     {
-        
-
         auto result_pair = _action.get_takeoff_altitude();
 
         if (response != nullptr) {
@@ -277,12 +254,10 @@ public:
     }
 
     grpc::Status GetMaximumSpeed(
-        grpc::ServerContext * /* context */,
+        grpc::ServerContext* /* context */,
         const rpc::action::GetMaximumSpeedRequest* /* request */,
         rpc::action::GetMaximumSpeedResponse* response) override
     {
-        
-
         auto result_pair = _action.get_maximum_speed();
 
         if (response != nullptr) {
@@ -313,12 +288,10 @@ public:
     }
 
     grpc::Status GetReturnToLaunchAltitude(
-        grpc::ServerContext * /* context */,
+        grpc::ServerContext* /* context */,
         const rpc::action::GetReturnToLaunchAltitudeRequest* /* request */,
         rpc::action::GetReturnToLaunchAltitudeResponse* response) override
     {
-        
-
         auto result_pair = _action.get_return_to_launch_altitude();
 
         if (response != nullptr) {
@@ -349,7 +322,7 @@ public:
     }
 
 private:
-    Action &_action;
+    Action& _action;
 };
 
 } // namespace backend

--- a/src/backend/test/action_service_impl_test.cpp
+++ b/src/backend/test/action_service_impl_test.cpp
@@ -16,38 +16,34 @@ using MockAction = NiceMock<mavsdk::testing::MockAction>;
 using ActionServiceImpl = mavsdk::backend::ActionServiceImpl<MockAction>;
 
 using ActionResult = mavsdk::rpc::action::ActionResult;
-using InputPair = std::pair<std::string, mavsdk::Action::Result>;
 
 static constexpr float ARBITRARY_ALTITUDE = 42.42f;
 static constexpr float ARBITRARY_SPEED = 8.24f;
 
-std::vector<InputPair> generateInputPairs();
-std::string armAndGetTranslatedResult(mavsdk::Action::Result arm_result);
-std::string disarmAndGetTranslatedResult(mavsdk::Action::Result disarm_result);
-std::string takeoffAndGetTranslatedResult(mavsdk::Action::Result takeoff_result);
-std::string landAndGetTranslatedResult(mavsdk::Action::Result land_result);
-std::string killAndGetTranslatedResult(mavsdk::Action::Result kill_result);
-std::string returnToLaunchAndGetTranslatedResult(mavsdk::Action::Result rtl_result);
-std::string
-transitionToFWAndGetTranslatedResult(const mavsdk::Action::Result transition_to_fw_result);
-std::string
-transitionToMCAndGetTranslatedResult(const mavsdk::Action::Result transition_to_fw_result);
-std::string
-getReturnToLaunchAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result);
-std::string
-setReturnToLaunchAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result);
-std::string getTakeoffAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result);
-std::string setTakeoffAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result);
+std::vector<mavsdk::Action::Result> generateResults();
+mavsdk::Action::Result armAndGetTranslatedResult(mavsdk::Action::Result arm_result);
+mavsdk::Action::Result disarmAndGetTranslatedResult(mavsdk::Action::Result disarm_result);
+mavsdk::Action::Result takeoffAndGetTranslatedResult(mavsdk::Action::Result takeoff_result);
+mavsdk::Action::Result landAndGetTranslatedResult(mavsdk::Action::Result land_result);
+mavsdk::Action::Result killAndGetTranslatedResult(mavsdk::Action::Result kill_result);
+mavsdk::Action::Result returnToLaunchAndGetTranslatedResult(mavsdk::Action::Result rtl_result);
+mavsdk::Action::Result transitionToFWAndGetTranslatedResult(const mavsdk::Action::Result transition_to_fw_result);
+mavsdk::Action::Result transitionToMCAndGetTranslatedResult(const mavsdk::Action::Result transition_to_fw_result);
+mavsdk::Action::Result getReturnToLaunchAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result);
+mavsdk::Action::Result setReturnToLaunchAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result);
+mavsdk::Action::Result getTakeoffAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result);
+mavsdk::Action::Result setTakeoffAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result);
+mavsdk::Action::Result translateFromRpcResult(const mavsdk::rpc::action::ActionResult::Result& result);
 
-class ActionServiceImplTest : public ::testing::TestWithParam<InputPair> {};
+class ActionServiceImplTest : public ::testing::TestWithParam<mavsdk::Action::Result> {};
 
 TEST_P(ActionServiceImplTest, armResultIsTranslatedCorrectly)
 {
-    const auto rpc_result = armAndGetTranslatedResult(GetParam().second);
-    EXPECT_EQ(rpc_result, GetParam().first);
+    const auto result = armAndGetTranslatedResult(GetParam());
+    EXPECT_EQ(result, GetParam());
 }
 
-std::string armAndGetTranslatedResult(const mavsdk::Action::Result arm_result)
+mavsdk::Action::Result armAndGetTranslatedResult(const mavsdk::Action::Result arm_result)
 {
     MockAction action;
     ON_CALL(action, arm()).WillByDefault(Return(arm_result));
@@ -56,7 +52,7 @@ std::string armAndGetTranslatedResult(const mavsdk::Action::Result arm_result)
 
     actionService.Arm(nullptr, nullptr, &response);
 
-    return ActionResult::Result_Name(response.action_result().result());
+    return translateFromRpcResult(response.action_result().result());
 }
 
 TEST_F(ActionServiceImplTest, armsEvenWhenArgsAreNull)
@@ -70,11 +66,11 @@ TEST_F(ActionServiceImplTest, armsEvenWhenArgsAreNull)
 
 TEST_P(ActionServiceImplTest, disarmResultIsTranslatedCorrectly)
 {
-    const auto rpc_result = disarmAndGetTranslatedResult(GetParam().second);
-    EXPECT_EQ(rpc_result, GetParam().first);
+    const auto rpc_result = disarmAndGetTranslatedResult(GetParam());
+    EXPECT_EQ(rpc_result, GetParam());
 }
 
-std::string disarmAndGetTranslatedResult(mavsdk::Action::Result disarm_result)
+mavsdk::Action::Result disarmAndGetTranslatedResult(mavsdk::Action::Result disarm_result)
 {
     MockAction action;
     ON_CALL(action, disarm()).WillByDefault(Return(disarm_result));
@@ -83,7 +79,7 @@ std::string disarmAndGetTranslatedResult(mavsdk::Action::Result disarm_result)
 
     actionService.Disarm(nullptr, nullptr, &response);
 
-    return ActionResult::Result_Name(response.action_result().result());
+    return translateFromRpcResult(response.action_result().result());
 }
 
 TEST_F(ActionServiceImplTest, disarmsEvenWhenArgsAreNull)
@@ -97,11 +93,11 @@ TEST_F(ActionServiceImplTest, disarmsEvenWhenArgsAreNull)
 
 TEST_P(ActionServiceImplTest, takeoffResultIsTranslatedCorrectly)
 {
-    const auto rpc_result = takeoffAndGetTranslatedResult(GetParam().second);
-    EXPECT_EQ(rpc_result, GetParam().first);
+    const auto rpc_result = takeoffAndGetTranslatedResult(GetParam());
+    EXPECT_EQ(rpc_result, GetParam());
 }
 
-std::string takeoffAndGetTranslatedResult(const mavsdk::Action::Result takeoff_result)
+mavsdk::Action::Result takeoffAndGetTranslatedResult(const mavsdk::Action::Result takeoff_result)
 {
     MockAction action;
     ON_CALL(action, takeoff()).WillByDefault(Return(takeoff_result));
@@ -110,7 +106,7 @@ std::string takeoffAndGetTranslatedResult(const mavsdk::Action::Result takeoff_r
 
     actionService.Takeoff(nullptr, nullptr, &response);
 
-    return ActionResult::Result_Name(response.action_result().result());
+    return translateFromRpcResult(response.action_result().result());
 }
 
 TEST_F(ActionServiceImplTest, takeoffEvenWhenArgsAreNull)
@@ -124,11 +120,11 @@ TEST_F(ActionServiceImplTest, takeoffEvenWhenArgsAreNull)
 
 TEST_P(ActionServiceImplTest, landResultIsTranslatedCorrectly)
 {
-    const auto rpc_result = landAndGetTranslatedResult(GetParam().second);
-    EXPECT_EQ(rpc_result, GetParam().first);
+    const auto rpc_result = landAndGetTranslatedResult(GetParam());
+    EXPECT_EQ(rpc_result, GetParam());
 }
 
-std::string landAndGetTranslatedResult(const mavsdk::Action::Result land_result)
+mavsdk::Action::Result landAndGetTranslatedResult(const mavsdk::Action::Result land_result)
 {
     MockAction action;
     ON_CALL(action, land()).WillByDefault(Return(land_result));
@@ -137,7 +133,7 @@ std::string landAndGetTranslatedResult(const mavsdk::Action::Result land_result)
 
     actionService.Land(nullptr, nullptr, &response);
 
-    return ActionResult::Result_Name(response.action_result().result());
+    return translateFromRpcResult(response.action_result().result());
 }
 
 TEST_F(ActionServiceImplTest, landsEvenWhenArgsAreNull)
@@ -151,11 +147,11 @@ TEST_F(ActionServiceImplTest, landsEvenWhenArgsAreNull)
 
 TEST_P(ActionServiceImplTest, killResultIsTranslatedCorrectly)
 {
-    const auto rpc_result = killAndGetTranslatedResult(GetParam().second);
-    EXPECT_EQ(rpc_result, GetParam().first);
+    const auto rpc_result = killAndGetTranslatedResult(GetParam());
+    EXPECT_EQ(rpc_result, GetParam());
 }
 
-std::string killAndGetTranslatedResult(const mavsdk::Action::Result kill_result)
+mavsdk::Action::Result killAndGetTranslatedResult(const mavsdk::Action::Result kill_result)
 {
     MockAction action;
     ON_CALL(action, kill()).WillByDefault(Return(kill_result));
@@ -164,7 +160,7 @@ std::string killAndGetTranslatedResult(const mavsdk::Action::Result kill_result)
 
     actionService.Kill(nullptr, nullptr, &response);
 
-    return ActionResult::Result_Name(response.action_result().result());
+    return translateFromRpcResult(response.action_result().result());
 }
 
 TEST_F(ActionServiceImplTest, killsEvenWhenArgsAreNull)
@@ -178,11 +174,11 @@ TEST_F(ActionServiceImplTest, killsEvenWhenArgsAreNull)
 
 TEST_P(ActionServiceImplTest, rtlResultIsTranslatedCorrectly)
 {
-    const auto rpc_result = returnToLaunchAndGetTranslatedResult(GetParam().second);
-    EXPECT_EQ(rpc_result, GetParam().first);
+    const auto rpc_result = returnToLaunchAndGetTranslatedResult(GetParam());
+    EXPECT_EQ(rpc_result, GetParam());
 }
 
-std::string returnToLaunchAndGetTranslatedResult(const mavsdk::Action::Result rtl_result)
+mavsdk::Action::Result returnToLaunchAndGetTranslatedResult(const mavsdk::Action::Result rtl_result)
 {
     MockAction action;
     ON_CALL(action, return_to_launch()).WillByDefault(Return(rtl_result));
@@ -191,7 +187,7 @@ std::string returnToLaunchAndGetTranslatedResult(const mavsdk::Action::Result rt
 
     actionService.ReturnToLaunch(nullptr, nullptr, &response);
 
-    return ActionResult::Result_Name(response.action_result().result());
+    return translateFromRpcResult(response.action_result().result());
 }
 
 TEST_F(ActionServiceImplTest, rtlsEvenWhenArgsAreNull)
@@ -205,21 +201,21 @@ TEST_F(ActionServiceImplTest, rtlsEvenWhenArgsAreNull)
 
 TEST_P(ActionServiceImplTest, transition2fwResultIsTranslatedCorrectly)
 {
-    const auto rpc_result = transitionToFWAndGetTranslatedResult(GetParam().second);
-    EXPECT_EQ(rpc_result, GetParam().first);
+    const auto rpc_result = transitionToFWAndGetTranslatedResult(GetParam());
+    EXPECT_EQ(rpc_result, GetParam());
 }
 
-std::string
+mavsdk::Action::Result
 transitionToFWAndGetTranslatedResult(const mavsdk::Action::Result transition_to_fw_result)
 {
     MockAction action;
     ON_CALL(action, transition_to_fixedwing()).WillByDefault(Return(transition_to_fw_result));
     ActionServiceImpl actionService(action);
-    mavsdk::rpc::action::TransitionToFixedWingResponse response;
+    mavsdk::rpc::action::TransitionToFixedwingResponse response;
 
-    actionService.TransitionToFixedWing(nullptr, nullptr, &response);
+    actionService.TransitionToFixedwing(nullptr, nullptr, &response);
 
-    return ActionResult::Result_Name(response.action_result().result());
+    return translateFromRpcResult(response.action_result().result());
 }
 
 TEST_F(ActionServiceImplTest, transitions2fwEvenWhenArgsAreNull)
@@ -228,16 +224,16 @@ TEST_F(ActionServiceImplTest, transitions2fwEvenWhenArgsAreNull)
     ActionServiceImpl actionService(action);
     EXPECT_CALL(action, transition_to_fixedwing()).Times(1);
 
-    actionService.TransitionToFixedWing(nullptr, nullptr, nullptr);
+    actionService.TransitionToFixedwing(nullptr, nullptr, nullptr);
 }
 
 TEST_P(ActionServiceImplTest, transition2mcResultIsTranslatedCorrectly)
 {
-    const auto rpc_result = transitionToMCAndGetTranslatedResult(GetParam().second);
-    EXPECT_EQ(rpc_result, GetParam().first);
+    const auto rpc_result = transitionToMCAndGetTranslatedResult(GetParam());
+    EXPECT_EQ(rpc_result, GetParam());
 }
 
-std::string
+mavsdk::Action::Result
 transitionToMCAndGetTranslatedResult(const mavsdk::Action::Result transition_to_mc_result)
 {
     MockAction action;
@@ -247,7 +243,7 @@ transitionToMCAndGetTranslatedResult(const mavsdk::Action::Result transition_to_
 
     actionService.TransitionToMulticopter(nullptr, nullptr, &response);
 
-    return ActionResult::Result_Name(response.action_result().result());
+    return translateFromRpcResult(response.action_result().result());
 }
 
 TEST_F(ActionServiceImplTest, transitions2mcEvenWhenArgsAreNull)
@@ -273,13 +269,13 @@ TEST_P(ActionServiceImplTest, getsCorrectTakeoffAltitude)
 {
     MockAction action;
     ActionServiceImpl actionService(action);
-    const auto expected_pair = std::make_pair<>(GetParam().second, ARBITRARY_ALTITUDE);
+    const auto expected_pair = std::make_pair<>(GetParam(), ARBITRARY_ALTITUDE);
     ON_CALL(action, get_takeoff_altitude()).WillByDefault(Return(expected_pair));
     mavsdk::rpc::action::GetTakeoffAltitudeResponse response;
 
     actionService.GetTakeoffAltitude(nullptr, nullptr, &response);
 
-    EXPECT_EQ(GetParam().first, ActionResult::Result_Name(response.action_result().result()));
+    EXPECT_EQ(GetParam(), translateFromRpcResult(response.action_result().result()));
     EXPECT_EQ(expected_pair.second, response.altitude());
 }
 
@@ -293,11 +289,11 @@ TEST_F(ActionServiceImplTest, getTakeoffAltitudeDoesNotCrashWithNullResponse)
 
 TEST_P(ActionServiceImplTest, getTakeoffAltitudeResultIsTranslatedCorrectly)
 {
-    const auto rpc_result = getTakeoffAltitudeAndGetTranslatedResult(GetParam().second);
-    EXPECT_EQ(rpc_result, GetParam().first);
+    const auto rpc_result = getTakeoffAltitudeAndGetTranslatedResult(GetParam());
+    EXPECT_EQ(rpc_result, GetParam());
 }
 
-std::string getTakeoffAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result)
+mavsdk::Action::Result getTakeoffAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result)
 {
     MockAction action;
     const auto return_pair = std::make_pair<>(action_result, ARBITRARY_ALTITUDE);
@@ -307,7 +303,7 @@ std::string getTakeoffAltitudeAndGetTranslatedResult(const mavsdk::Action::Resul
 
     actionService.GetTakeoffAltitude(nullptr, nullptr, &response);
 
-    return ActionResult::Result_Name(response.action_result().result());
+    return translateFromRpcResult(response.action_result().result());
 }
 
 TEST_F(ActionServiceImplTest, setTakeoffAltitudeDoesNotCrashWithNullRequest)
@@ -342,11 +338,11 @@ TEST_P(ActionServiceImplTest, setTakeoffAltitudeSetsRightValue)
 
 TEST_P(ActionServiceImplTest, setTakeoffAltitudeResultIsTranslatedCorrectly)
 {
-    const auto rpc_result = setTakeoffAltitudeAndGetTranslatedResult(GetParam().second);
-    EXPECT_EQ(rpc_result, GetParam().first);
+    const auto rpc_result = setTakeoffAltitudeAndGetTranslatedResult(GetParam());
+    EXPECT_EQ(rpc_result, GetParam());
 }
 
-std::string setTakeoffAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result)
+mavsdk::Action::Result setTakeoffAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result)
 {
     MockAction action;
     ON_CALL(action, set_takeoff_altitude(_)).WillByDefault(Return(action_result));
@@ -357,7 +353,7 @@ std::string setTakeoffAltitudeAndGetTranslatedResult(const mavsdk::Action::Resul
 
     actionService.SetTakeoffAltitude(nullptr, &request, &response);
 
-    return ActionResult::Result_Name(response.action_result().result());
+    return translateFromRpcResult(response.action_result().result());
 }
 
 TEST_F(ActionServiceImplTest, getMaxSpeedDoesNotCrashWithNullResponse)
@@ -372,7 +368,7 @@ TEST_F(ActionServiceImplTest, getMaxSpeedCallsGetter)
 {
     MockAction action;
     ActionServiceImpl actionService(action);
-    EXPECT_CALL(action, get_max_speed()).Times(1);
+    EXPECT_CALL(action, get_maximum_speed()).Times(1);
     mavsdk::rpc::action::GetMaximumSpeedResponse response;
 
     actionService.GetMaximumSpeed(nullptr, nullptr, &response);
@@ -382,13 +378,13 @@ TEST_P(ActionServiceImplTest, getMaxSpeedGetsRightValue)
 {
     MockAction action;
     ActionServiceImpl actionService(action);
-    const auto expected_pair = std::make_pair<>(GetParam().second, ARBITRARY_SPEED);
-    ON_CALL(action, get_max_speed()).WillByDefault(Return(expected_pair));
+    const auto expected_pair = std::make_pair<>(GetParam(), ARBITRARY_SPEED);
+    ON_CALL(action, get_maximum_speed()).WillByDefault(Return(expected_pair));
     mavsdk::rpc::action::GetMaximumSpeedResponse response;
 
     actionService.GetMaximumSpeed(nullptr, nullptr, &response);
 
-    EXPECT_EQ(GetParam().first, ActionResult::Result_Name(response.action_result().result()));
+    EXPECT_EQ(GetParam(), translateFromRpcResult(response.action_result().result()));
     EXPECT_EQ(expected_pair.second, response.speed());
 }
 
@@ -415,7 +411,7 @@ TEST_F(ActionServiceImplTest, setMaxSpeedCallsSetter)
 {
     MockAction action;
     ActionServiceImpl actionService(action);
-    EXPECT_CALL(action, set_max_speed(_)).Times(1);
+    EXPECT_CALL(action, set_maximum_speed(_)).Times(1);
     mavsdk::rpc::action::SetMaximumSpeedRequest request;
 
     actionService.SetMaximumSpeed(nullptr, &request, nullptr);
@@ -426,7 +422,7 @@ TEST_F(ActionServiceImplTest, setMaxSpeedSetsRightValue)
     MockAction action;
     ActionServiceImpl actionService(action);
     const auto expected_speed = ARBITRARY_SPEED;
-    EXPECT_CALL(action, set_max_speed(expected_speed)).Times(1);
+    EXPECT_CALL(action, set_maximum_speed(expected_speed)).Times(1);
     mavsdk::rpc::action::SetMaximumSpeedRequest request;
     request.set_speed(expected_speed);
 
@@ -435,29 +431,29 @@ TEST_F(ActionServiceImplTest, setMaxSpeedSetsRightValue)
 
 TEST_P(ActionServiceImplTest, getReturnToLaunchAltitudeResultIsTranslatedCorrectly)
 {
-    const auto rpc_result = getReturnToLaunchAltitudeAndGetTranslatedResult(GetParam().second);
-    EXPECT_EQ(rpc_result, GetParam().first);
+    const auto rpc_result = getReturnToLaunchAltitudeAndGetTranslatedResult(GetParam());
+    EXPECT_EQ(rpc_result, GetParam());
 }
 
-std::string
+mavsdk::Action::Result
 getReturnToLaunchAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result)
 {
     MockAction action;
     const auto return_pair = std::make_pair<>(action_result, ARBITRARY_ALTITUDE);
-    ON_CALL(action, get_return_to_launch_return_altitude()).WillByDefault(Return(return_pair));
+    ON_CALL(action, get_return_to_launch_altitude()).WillByDefault(Return(return_pair));
     ActionServiceImpl actionService(action);
     mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse response;
 
     actionService.GetReturnToLaunchAltitude(nullptr, nullptr, &response);
 
-    return ActionResult::Result_Name(response.action_result().result());
+    return translateFromRpcResult(response.action_result().result());
 }
 
 TEST_F(ActionServiceImplTest, getReturnToLaunchAltitudeCallsGetter)
 {
     MockAction action;
     ActionServiceImpl actionService(action);
-    EXPECT_CALL(action, get_return_to_launch_return_altitude()).Times(1);
+    EXPECT_CALL(action, get_return_to_launch_altitude()).Times(1);
     mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse response;
 
     actionService.GetReturnToLaunchAltitude(nullptr, nullptr, &response);
@@ -467,13 +463,13 @@ TEST_P(ActionServiceImplTest, getsCorrectReturnToLaunchAltitude)
 {
     MockAction action;
     ActionServiceImpl actionService(action);
-    const auto expected_pair = std::make_pair<>(GetParam().second, ARBITRARY_ALTITUDE);
-    ON_CALL(action, get_return_to_launch_return_altitude()).WillByDefault(Return(expected_pair));
+    const auto expected_pair = std::make_pair<>(GetParam(), ARBITRARY_ALTITUDE);
+    ON_CALL(action, get_return_to_launch_altitude()).WillByDefault(Return(expected_pair));
     mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse response;
 
     actionService.GetReturnToLaunchAltitude(nullptr, nullptr, &response);
 
-    EXPECT_EQ(GetParam().first, ActionResult::Result_Name(response.action_result().result()));
+    EXPECT_EQ(GetParam(), translateFromRpcResult(response.action_result().result()));
     EXPECT_EQ(expected_pair.second, response.relative_altitude_m());
 }
 
@@ -487,15 +483,15 @@ TEST_F(ActionServiceImplTest, getReturnToLaunchAltitudeDoesNotCrashWithNullRespo
 
 TEST_P(ActionServiceImplTest, setReturnToLaunchAltitudeResultIsTranslatedCorrectly)
 {
-    const auto rpc_result = setReturnToLaunchAltitudeAndGetTranslatedResult(GetParam().second);
-    EXPECT_EQ(rpc_result, GetParam().first);
+    const auto rpc_result = setReturnToLaunchAltitudeAndGetTranslatedResult(GetParam());
+    EXPECT_EQ(rpc_result, GetParam());
 }
 
-std::string
+mavsdk::Action::Result
 setReturnToLaunchAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result)
 {
     MockAction action;
-    ON_CALL(action, set_return_to_launch_return_altitude(_)).WillByDefault(Return(action_result));
+    ON_CALL(action, set_return_to_launch_altitude(_)).WillByDefault(Return(action_result));
     ActionServiceImpl actionService(action);
     mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest request;
     request.set_relative_altitude_m(ARBITRARY_ALTITUDE);
@@ -503,7 +499,7 @@ setReturnToLaunchAltitudeAndGetTranslatedResult(const mavsdk::Action::Result act
 
     actionService.SetReturnToLaunchAltitude(nullptr, &request, &response);
 
-    return ActionResult::Result_Name(response.action_result().result());
+    return translateFromRpcResult(response.action_result().result());
 }
 
 TEST_F(ActionServiceImplTest, setReturnToLaunchAltitudeDoesNotCrashWithNullParams)
@@ -518,7 +514,7 @@ TEST_F(ActionServiceImplTest, setReturnToLaunchAltitudeCallsSetter)
 {
     MockAction action;
     ActionServiceImpl actionService(action);
-    EXPECT_CALL(action, set_return_to_launch_return_altitude(_)).Times(1);
+    EXPECT_CALL(action, set_return_to_launch_altitude(_)).Times(1);
     mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest request;
 
     actionService.SetReturnToLaunchAltitude(nullptr, &request, nullptr);
@@ -529,41 +525,65 @@ TEST_P(ActionServiceImplTest, setReturnToLaunchAltitudeSetsRightValue)
     MockAction action;
     ActionServiceImpl actionService(action);
     float expected_altitude = ARBITRARY_ALTITUDE;
-    EXPECT_CALL(action, set_return_to_launch_return_altitude(expected_altitude)).Times(1);
+    EXPECT_CALL(action, set_return_to_launch_altitude(expected_altitude)).Times(1);
     mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest request;
     request.set_relative_altitude_m(expected_altitude);
 
     actionService.SetReturnToLaunchAltitude(nullptr, &request, nullptr);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    ActionResultCorrespondences, ActionServiceImplTest, ::testing::ValuesIn(generateInputPairs()));
-
-std::vector<InputPair> generateInputPairs()
+mavsdk::Action::Result translateFromRpcResult(const mavsdk::rpc::action::ActionResult::Result& result)
 {
-    std::vector<InputPair> input_pairs;
-    input_pairs.push_back(std::make_pair("SUCCESS", mavsdk::Action::Result::SUCCESS));
-    input_pairs.push_back(std::make_pair("NO_SYSTEM", mavsdk::Action::Result::NO_SYSTEM));
-    input_pairs.push_back(
-        std::make_pair("CONNECTION_ERROR", mavsdk::Action::Result::CONNECTION_ERROR));
-    input_pairs.push_back(std::make_pair("BUSY", mavsdk::Action::Result::BUSY));
-    input_pairs.push_back(std::make_pair("COMMAND_DENIED", mavsdk::Action::Result::COMMAND_DENIED));
-    input_pairs.push_back(std::make_pair(
-        "COMMAND_DENIED_LANDED_STATE_UNKNOWN",
-        mavsdk::Action::Result::COMMAND_DENIED_LANDED_STATE_UNKNOWN));
-    input_pairs.push_back(std::make_pair(
-        "COMMAND_DENIED_NOT_LANDED", mavsdk::Action::Result::COMMAND_DENIED_NOT_LANDED));
-    input_pairs.push_back(std::make_pair("TIMEOUT", mavsdk::Action::Result::TIMEOUT));
-    input_pairs.push_back(std::make_pair(
-        "VTOL_TRANSITION_SUPPORT_UNKNOWN",
-        mavsdk::Action::Result::VTOL_TRANSITION_SUPPORT_UNKNOWN));
-    input_pairs.push_back(std::make_pair(
-        "NO_VTOL_TRANSITION_SUPPORT", mavsdk::Action::Result::NO_VTOL_TRANSITION_SUPPORT));
-    input_pairs.push_back(std::make_pair("UNKNOWN", mavsdk::Action::Result::UNKNOWN));
-    input_pairs.push_back(
-        std::make_pair("PARAMETER_ERROR", mavsdk::Action::Result::PARAMETER_ERROR));
+    switch (result) {
+        case mavsdk::rpc::action::ActionResult_Result_UNKNOWN:
+            return mavsdk::Action::Result::Unknown;
+        case mavsdk::rpc::action::ActionResult_Result_SUCCESS:
+            return mavsdk::Action::Result::Success;
+        case mavsdk::rpc::action::ActionResult_Result_NO_SYSTEM:
+            return mavsdk::Action::Result::NoSystem;
+        case mavsdk::rpc::action::ActionResult_Result_CONNECTION_ERROR:
+            return mavsdk::Action::Result::ConnectionError;
+        case mavsdk::rpc::action::ActionResult_Result_BUSY:
+            return mavsdk::Action::Result::Busy;
+        case mavsdk::rpc::action::ActionResult_Result_COMMAND_DENIED:
+            return mavsdk::Action::Result::CommandDenied;
+        case mavsdk::rpc::action::ActionResult_Result_COMMAND_DENIED_LANDED_STATE_UNKNOWN:
+            return mavsdk::Action::Result::CommandDeniedLandedStateUnknown;
+        case mavsdk::rpc::action::ActionResult_Result_COMMAND_DENIED_NOT_LANDED:
+            return mavsdk::Action::Result::CommandDeniedNotLanded;
+        case mavsdk::rpc::action::ActionResult_Result_TIMEOUT:
+            return mavsdk::Action::Result::Timeout;
+        case mavsdk::rpc::action::ActionResult_Result_VTOL_TRANSITION_SUPPORT_UNKNOWN:
+            return mavsdk::Action::Result::VtolTransitionSupportUnknown;
+        case mavsdk::rpc::action::ActionResult_Result_NO_VTOL_TRANSITION_SUPPORT:
+            return mavsdk::Action::Result::NoVtolTransitionSupport;
+        case mavsdk::rpc::action::ActionResult_Result_PARAMETER_ERROR:
+            return mavsdk::Action::Result::ParameterError;
+        default:
+            return mavsdk::Action::Result::Unknown;
+    }
+}
 
-    return input_pairs;
+INSTANTIATE_TEST_SUITE_P(
+    ActionResultCorrespondences, ActionServiceImplTest, ::testing::ValuesIn(generateResults()));
+
+std::vector<mavsdk::Action::Result> generateResults()
+{
+    std::vector<mavsdk::Action::Result> results;
+    results.push_back(mavsdk::Action::Result::Success);
+    results.push_back(mavsdk::Action::Result::NoSystem);
+    results.push_back(mavsdk::Action::Result::ConnectionError);
+    results.push_back(mavsdk::Action::Result::Busy);
+    results.push_back(mavsdk::Action::Result::CommandDenied);
+    results.push_back(mavsdk::Action::Result::CommandDeniedLandedStateUnknown);
+    results.push_back(mavsdk::Action::Result::CommandDeniedNotLanded);
+    results.push_back(mavsdk::Action::Result::Timeout);
+    results.push_back(mavsdk::Action::Result::VtolTransitionSupportUnknown);
+    results.push_back(mavsdk::Action::Result::NoVtolTransitionSupport);
+    results.push_back(mavsdk::Action::Result::Unknown);
+    results.push_back(mavsdk::Action::Result::ParameterError);
+
+    return results;
 }
 
 } // namespace

--- a/src/backend/test/action_service_impl_test.cpp
+++ b/src/backend/test/action_service_impl_test.cpp
@@ -27,13 +27,20 @@ mavsdk::Action::Result takeoffAndGetTranslatedResult(mavsdk::Action::Result take
 mavsdk::Action::Result landAndGetTranslatedResult(mavsdk::Action::Result land_result);
 mavsdk::Action::Result killAndGetTranslatedResult(mavsdk::Action::Result kill_result);
 mavsdk::Action::Result returnToLaunchAndGetTranslatedResult(mavsdk::Action::Result rtl_result);
-mavsdk::Action::Result transitionToFWAndGetTranslatedResult(const mavsdk::Action::Result transition_to_fw_result);
-mavsdk::Action::Result transitionToMCAndGetTranslatedResult(const mavsdk::Action::Result transition_to_fw_result);
-mavsdk::Action::Result getReturnToLaunchAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result);
-mavsdk::Action::Result setReturnToLaunchAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result);
-mavsdk::Action::Result getTakeoffAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result);
-mavsdk::Action::Result setTakeoffAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result);
-mavsdk::Action::Result translateFromRpcResult(const mavsdk::rpc::action::ActionResult::Result& result);
+mavsdk::Action::Result
+transitionToFWAndGetTranslatedResult(const mavsdk::Action::Result transition_to_fw_result);
+mavsdk::Action::Result
+transitionToMCAndGetTranslatedResult(const mavsdk::Action::Result transition_to_fw_result);
+mavsdk::Action::Result
+getReturnToLaunchAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result);
+mavsdk::Action::Result
+setReturnToLaunchAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result);
+mavsdk::Action::Result
+getTakeoffAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result);
+mavsdk::Action::Result
+setTakeoffAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result);
+mavsdk::Action::Result
+translateFromRpcResult(const mavsdk::rpc::action::ActionResult::Result& result);
 
 class ActionServiceImplTest : public ::testing::TestWithParam<mavsdk::Action::Result> {};
 
@@ -293,7 +300,8 @@ TEST_P(ActionServiceImplTest, getTakeoffAltitudeResultIsTranslatedCorrectly)
     EXPECT_EQ(rpc_result, GetParam());
 }
 
-mavsdk::Action::Result getTakeoffAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result)
+mavsdk::Action::Result
+getTakeoffAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result)
 {
     MockAction action;
     const auto return_pair = std::make_pair<>(action_result, ARBITRARY_ALTITUDE);
@@ -342,7 +350,8 @@ TEST_P(ActionServiceImplTest, setTakeoffAltitudeResultIsTranslatedCorrectly)
     EXPECT_EQ(rpc_result, GetParam());
 }
 
-mavsdk::Action::Result setTakeoffAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result)
+mavsdk::Action::Result
+setTakeoffAltitudeAndGetTranslatedResult(const mavsdk::Action::Result action_result)
 {
     MockAction action;
     ON_CALL(action, set_takeoff_altitude(_)).WillByDefault(Return(action_result));
@@ -532,7 +541,8 @@ TEST_P(ActionServiceImplTest, setReturnToLaunchAltitudeSetsRightValue)
     actionService.SetReturnToLaunchAltitude(nullptr, &request, nullptr);
 }
 
-mavsdk::Action::Result translateFromRpcResult(const mavsdk::rpc::action::ActionResult::Result& result)
+mavsdk::Action::Result
+translateFromRpcResult(const mavsdk::rpc::action::ActionResult::Result& result)
 {
     switch (result) {
         case mavsdk::rpc::action::ActionResult_Result_UNKNOWN:

--- a/src/integration_tests/action_goto.cpp
+++ b/src/integration_tests/action_goto.cpp
@@ -31,11 +31,11 @@ TEST_F(SitlTest, ActionGoto)
 
     auto action = std::make_shared<Action>(system);
     Action::Result action_ret = action->arm();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
+    EXPECT_EQ(action_ret, Action::Result::Success);
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
     action_ret = action->takeoff();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
+    EXPECT_EQ(action_ret, Action::Result::Success);
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
     // Go somewhere
@@ -47,7 +47,7 @@ TEST_F(SitlTest, ActionGoto)
     std::this_thread::sleep_for(std::chrono::seconds(10));
 
     action_ret = action->land();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
+    EXPECT_EQ(action_ret, Action::Result::Success);
 
     iteration = 0;
     while (telemetry->in_air()) {
@@ -59,5 +59,5 @@ TEST_F(SitlTest, ActionGoto)
     }
 
     action_ret = action->disarm();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
+    EXPECT_EQ(action_ret, Action::Result::Success);
 }

--- a/src/integration_tests/action_hover_async.cpp
+++ b/src/integration_tests/action_hover_async.cpp
@@ -49,7 +49,7 @@ TEST_F(SitlTest, ActionHoverAsync)
         std::promise<void> prom;
         std::future<void> fut = prom.get_future();
         action->arm_async([&prom](Action::Result result) {
-            EXPECT_EQ(result, Action::Result::SUCCESS);
+            EXPECT_EQ(result, Action::Result::Success);
             prom.set_value();
         });
         EXPECT_EQ(fut.wait_for(std::chrono::seconds(2)), std::future_status::ready);
@@ -63,7 +63,7 @@ TEST_F(SitlTest, ActionHoverAsync)
         std::promise<void> prom;
         std::future<void> fut = prom.get_future();
         action->takeoff_async([&prom](Action::Result result) {
-            EXPECT_EQ(result, Action::Result::SUCCESS);
+            EXPECT_EQ(result, Action::Result::Success);
             prom.set_value();
         });
         EXPECT_EQ(fut.wait_for(std::chrono::seconds(2)), std::future_status::ready);
@@ -77,7 +77,7 @@ TEST_F(SitlTest, ActionHoverAsync)
         std::promise<void> prom;
         std::future<void> fut = prom.get_future();
         action->land_async([&prom](Action::Result result) {
-            EXPECT_EQ(result, Action::Result::SUCCESS);
+            EXPECT_EQ(result, Action::Result::Success);
             prom.set_value();
         });
         EXPECT_EQ(fut.wait_for(std::chrono::seconds(2)), std::future_status::ready);
@@ -102,7 +102,7 @@ TEST_F(SitlTest, ActionHoverAsync)
         std::promise<void> prom;
         std::future<void> fut = prom.get_future();
         action->disarm_async([&prom](Action::Result result) {
-            EXPECT_EQ(result, Action::Result::SUCCESS);
+            EXPECT_EQ(result, Action::Result::Success);
             prom.set_value();
         });
         EXPECT_EQ(fut.wait_for(std::chrono::seconds(2)), std::future_status::ready);

--- a/src/integration_tests/action_hover_sync.cpp
+++ b/src/integration_tests/action_hover_sync.cpp
@@ -47,15 +47,15 @@ void takeoff_and_hover_at_altitude(float altitude_m)
 
     auto action = std::make_shared<Action>(system);
     Action::Result action_ret = action->arm();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
+    EXPECT_EQ(action_ret, Action::Result::Success);
 
-    EXPECT_EQ(Action::Result::SUCCESS, action->set_takeoff_altitude(altitude_m));
+    EXPECT_EQ(Action::Result::Success, action->set_takeoff_altitude(altitude_m));
     auto takeoff_altitude_result = action->get_takeoff_altitude();
-    EXPECT_EQ(takeoff_altitude_result.first, Action::Result::SUCCESS);
+    EXPECT_EQ(takeoff_altitude_result.first, Action::Result::Success);
     EXPECT_FLOAT_EQ(takeoff_altitude_result.second, altitude_m);
 
     action_ret = action->takeoff();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
+    EXPECT_EQ(action_ret, Action::Result::Success);
 
     // TODO: The wait time should not be hard-coded because the
     //       simulation might run faster.
@@ -68,11 +68,11 @@ void takeoff_and_hover_at_altitude(float altitude_m)
     EXPECT_LT(telemetry->position().relative_altitude_m, altitude_m + 0.25f);
 
     action_ret = action->land();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
+    EXPECT_EQ(action_ret, Action::Result::Success);
 
     EXPECT_TRUE(poll_condition_with_timeout(
         [&telemetry]() { return !telemetry->in_air(); }, std::chrono::seconds(wait_time_s)));
 
     action_ret = action->disarm();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
+    EXPECT_EQ(action_ret, Action::Result::Success);
 }

--- a/src/integration_tests/action_takeoff_and_kill.cpp
+++ b/src/integration_tests/action_takeoff_and_kill.cpp
@@ -50,7 +50,7 @@ TEST_F(SitlTest, ActionTakeoffAndKill)
         std::promise<void> prom;
         std::future<void> fut = prom.get_future();
         action->arm_async([&prom](Action::Result result) {
-            EXPECT_EQ(result, Action::Result::SUCCESS);
+            EXPECT_EQ(result, Action::Result::Success);
             prom.set_value();
         });
         EXPECT_EQ(fut.wait_for(std::chrono::seconds(2)), std::future_status::ready);
@@ -61,7 +61,7 @@ TEST_F(SitlTest, ActionTakeoffAndKill)
         std::promise<void> prom;
         std::future<void> fut = prom.get_future();
         action->takeoff_async([&prom](Action::Result result) {
-            EXPECT_EQ(result, Action::Result::SUCCESS);
+            EXPECT_EQ(result, Action::Result::Success);
             prom.set_value();
         });
         EXPECT_EQ(fut.wait_for(std::chrono::seconds(2)), std::future_status::ready);
@@ -77,7 +77,7 @@ TEST_F(SitlTest, ActionTakeoffAndKill)
         std::promise<void> prom;
         std::future<void> fut = prom.get_future();
         action->kill_async([&prom](Action::Result result) {
-            EXPECT_EQ(result, Action::Result::SUCCESS);
+            EXPECT_EQ(result, Action::Result::Success);
             prom.set_value();
         });
         EXPECT_EQ(fut.wait_for(std::chrono::seconds(2)), std::future_status::ready);

--- a/src/integration_tests/action_transition_multicopter_fixedwing.cpp
+++ b/src/integration_tests/action_transition_multicopter_fixedwing.cpp
@@ -38,7 +38,7 @@ void takeoff_and_transition_to_fixedwing()
 
     LogInfo() << "Transitioning to fixedwing";
     Action::Result transition_result = action->transition_to_fixedwing();
-    EXPECT_EQ(transition_result, Action::Result::SUCCESS);
+    EXPECT_EQ(transition_result, Action::Result::Success);
 
     // Wait a little before the transition back to multicopter,
     // so we can actually see it fly
@@ -46,7 +46,7 @@ void takeoff_and_transition_to_fixedwing()
 
     LogInfo() << "Transitioning to multicopter";
     transition_result = action->transition_to_multicopter();
-    EXPECT_EQ(transition_result, Action::Result::SUCCESS);
+    EXPECT_EQ(transition_result, Action::Result::Success);
 
     std::this_thread::sleep_for(std::chrono::seconds(5));
 
@@ -77,12 +77,12 @@ void takeoff(std::shared_ptr<Action> action, std::shared_ptr<Telemetry> telemetr
     action->set_takeoff_altitude(altitude_m);
 
     Action::Result action_ret = action->arm();
-    ASSERT_EQ(action_ret, Action::Result::SUCCESS);
+    ASSERT_EQ(action_ret, Action::Result::Success);
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
     LogInfo() << "Taking off";
     action_ret = action->takeoff();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
+    EXPECT_EQ(action_ret, Action::Result::Success);
     const int wait_time_s = 15;
     std::this_thread::sleep_for(std::chrono::seconds(wait_time_s));
 

--- a/src/integration_tests/follow_me.cpp
+++ b/src/integration_tests/follow_me.cpp
@@ -43,7 +43,7 @@ TEST_F(SitlTest, FollowMeOneLocation)
     }
 
     Action::Result action_ret = action->arm();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ASSERT_EQ(Action::Result::Success, action_ret);
 
     telemetry->flight_mode_async(std::bind(
         [&](Telemetry::FlightMode flight_mode) {
@@ -56,7 +56,7 @@ TEST_F(SitlTest, FollowMeOneLocation)
         std::placeholders::_1));
 
     action_ret = action->takeoff();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ASSERT_EQ(Action::Result::Success, action_ret);
 
     sleep_for(seconds(5)); // let it reach takeoff altitude
 
@@ -80,7 +80,7 @@ TEST_F(SitlTest, FollowMeOneLocation)
     sleep_for(seconds(2)); // to watch flight mode change from "FollowMe" to default "HOLD"
 
     action_ret = action->land();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ASSERT_EQ(Action::Result::Success, action_ret);
     sleep_for(seconds(2)); // let the system land
 
     while (telemetry->armed()) {
@@ -112,7 +112,7 @@ TEST_F(SitlTest, FollowMeMultiLocationWithConfig)
     }
 
     Action::Result action_ret = action->arm();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ASSERT_EQ(Action::Result::Success, action_ret);
 
     telemetry->flight_mode_async(std::bind(
         [&](Telemetry::FlightMode flight_mode) {
@@ -125,7 +125,7 @@ TEST_F(SitlTest, FollowMeMultiLocationWithConfig)
         std::placeholders::_1));
 
     action_ret = action->takeoff();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ASSERT_EQ(Action::Result::Success, action_ret);
 
     sleep_for(seconds(5));
 
@@ -154,7 +154,7 @@ TEST_F(SitlTest, FollowMeMultiLocationWithConfig)
     sleep_for(seconds(2)); // to watch flight mode change from "FollowMe" to default "HOLD"
 
     action_ret = action->land();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ASSERT_EQ(Action::Result::Success, action_ret);
     sleep_for(seconds(2)); // let it land
 
     while (telemetry->armed()) {

--- a/src/integration_tests/gimbal.cpp
+++ b/src/integration_tests/gimbal.cpp
@@ -70,10 +70,10 @@ TEST(SitlTestGimbal, GimbalTakeoffAndMove)
     }
 
     Action::Result action_result = action->arm();
-    EXPECT_EQ(action_result, Action::Result::SUCCESS);
+    EXPECT_EQ(action_result, Action::Result::Success);
 
     action_result = action->takeoff();
-    EXPECT_EQ(action_result, Action::Result::SUCCESS);
+    EXPECT_EQ(action_result, Action::Result::Success);
 
     telemetry->set_rate_camera_attitude(10.0);
 
@@ -122,10 +122,10 @@ TEST(SitlTestGimbal, GimbalROIOffboard)
         position.absolute_altitude_m + 1.f);
 
     Action::Result action_result = action->arm();
-    EXPECT_EQ(action_result, Action::Result::SUCCESS);
+    EXPECT_EQ(action_result, Action::Result::Success);
 
     action_result = action->takeoff();
-    EXPECT_EQ(action_result, Action::Result::SUCCESS);
+    EXPECT_EQ(action_result, Action::Result::Success);
 
     std::this_thread::sleep_for(std::chrono::seconds(5));
 

--- a/src/integration_tests/mission.cpp
+++ b/src/integration_tests/mission.cpp
@@ -211,7 +211,7 @@ void test_mission(
 
     LogInfo() << "Arming...";
     const Action::Result arm_result = action->arm();
-    EXPECT_EQ(arm_result, Action::Result::SUCCESS);
+    EXPECT_EQ(arm_result, Action::Result::Success);
     LogInfo() << "Armed.";
 
     // Before starting the mission, we want to be sure to subscribe to the mission progress.

--- a/src/integration_tests/mission_change_speed.cpp
+++ b/src/integration_tests/mission_change_speed.cpp
@@ -68,7 +68,7 @@ TEST_F(SitlTest, MissionChangeSpeed)
     ASSERT_TRUE(_mission_sent_ok);
 
     Action::Result result = action->arm();
-    ASSERT_EQ(result, Action::Result::SUCCESS);
+    ASSERT_EQ(result, Action::Result::Success);
 
     mission->subscribe_progress(std::bind(&receive_mission_progress, _1, _2));
 
@@ -106,7 +106,7 @@ TEST_F(SitlTest, MissionChangeSpeed)
     LogInfo() << "mission done";
 
     result = action->return_to_launch();
-    ASSERT_EQ(result, Action::Result::SUCCESS);
+    ASSERT_EQ(result, Action::Result::Success);
 
     while (!mission->mission_finished()) {
         LogDebug() << "waiting until mission is done";
@@ -119,7 +119,7 @@ TEST_F(SitlTest, MissionChangeSpeed)
     }
 
     result = action->disarm();
-    ASSERT_EQ(result, Action::Result::SUCCESS);
+    ASSERT_EQ(result, Action::Result::Success);
 }
 
 void receive_upload_mission_result(Mission::Result result)

--- a/src/integration_tests/mission_rtl.cpp
+++ b/src/integration_tests/mission_rtl.cpp
@@ -75,7 +75,7 @@ void do_mission_with_rtl(float mission_altitude_m, float return_altitude_m)
     }
 
     LogInfo() << "Setting RTL return altitude to " << return_altitude_m;
-    action->set_return_to_launch_return_altitude(return_altitude_m);
+    action->set_return_to_launch_altitude(return_altitude_m);
 
     LogInfo() << "System ready";
     LogInfo() << "Creating and uploading mission";
@@ -109,7 +109,7 @@ void do_mission_with_rtl(float mission_altitude_m, float return_altitude_m)
 
     LogInfo() << "Arming...";
     const Action::Result arm_result = action->arm();
-    ASSERT_EQ(arm_result, Action::Result::SUCCESS);
+    ASSERT_EQ(arm_result, Action::Result::Success);
     LogInfo() << "Armed.";
 
     // Before starting the mission, we want to be sure to subscribe to the mission progress.
@@ -152,7 +152,7 @@ void do_mission_with_rtl(float mission_altitude_m, float return_altitude_m)
         // We are done, and can do RTL to go home.
         LogInfo() << "Commanding RTL...";
         const Action::Result result = action->return_to_launch();
-        EXPECT_EQ(result, Action::Result::SUCCESS);
+        EXPECT_EQ(result, Action::Result::Success);
         LogInfo() << "Commanded RTL.";
     }
 

--- a/src/integration_tests/offboard_attitude.cpp
+++ b/src/integration_tests/offboard_attitude.cpp
@@ -55,11 +55,11 @@ TEST_F(SitlTest, OffboardAttitudeRate)
 
 void arm_and_takeoff(std::shared_ptr<Action> action, std::shared_ptr<Telemetry> telemetry)
 {
-    ASSERT_EQ(action->arm(), Action::Result::SUCCESS);
+    ASSERT_EQ(action->arm(), Action::Result::Success);
 
-    ASSERT_EQ(action->set_takeoff_altitude(5.0f), Action::Result::SUCCESS);
+    ASSERT_EQ(action->set_takeoff_altitude(5.0f), Action::Result::Success);
 
-    ASSERT_EQ(action->takeoff(), Action::Result::SUCCESS);
+    ASSERT_EQ(action->takeoff(), Action::Result::Success);
 
     while (telemetry->position().relative_altitude_m < 4.0f) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/src/integration_tests/offboard_position.cpp
+++ b/src/integration_tests/offboard_position.cpp
@@ -33,10 +33,10 @@ TEST_F(SitlTest, OffboardPositionNED)
     }
 
     Action::Result action_ret = action->arm();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ASSERT_EQ(Action::Result::Success, action_ret);
 
     action_ret = action->takeoff();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ASSERT_EQ(Action::Result::Success, action_ret);
 
     std::this_thread::sleep_for(std::chrono::seconds(5));
 
@@ -106,5 +106,5 @@ TEST_F(SitlTest, OffboardPositionNED)
     EXPECT_EQ(offboard_result, Offboard::Result::SUCCESS);
 
     action_ret = action->land();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
+    EXPECT_EQ(action_ret, Action::Result::Success);
 }

--- a/src/integration_tests/offboard_velocity.cpp
+++ b/src/integration_tests/offboard_velocity.cpp
@@ -32,10 +32,10 @@ TEST_F(SitlTest, OffboardVelocityNED)
     }
 
     Action::Result action_ret = action->arm();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ASSERT_EQ(Action::Result::Success, action_ret);
 
     action_ret = action->takeoff();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ASSERT_EQ(Action::Result::Success, action_ret);
 
     std::this_thread::sleep_for(std::chrono::seconds(5));
 
@@ -103,7 +103,7 @@ TEST_F(SitlTest, OffboardVelocityNED)
     EXPECT_EQ(offboard_result, Offboard::Result::SUCCESS);
 
     action_ret = action->land();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
+    EXPECT_EQ(action_ret, Action::Result::Success);
 }
 
 TEST_F(SitlTest, OffboardVelocityBody)
@@ -129,10 +129,10 @@ TEST_F(SitlTest, OffboardVelocityBody)
     }
 
     Action::Result action_ret = action->arm();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ASSERT_EQ(Action::Result::Success, action_ret);
 
     action_ret = action->takeoff();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ASSERT_EQ(Action::Result::Success, action_ret);
 
     std::this_thread::sleep_for(std::chrono::seconds(5));
 
@@ -175,5 +175,5 @@ TEST_F(SitlTest, OffboardVelocityBody)
     EXPECT_EQ(offboard_result, Offboard::Result::SUCCESS);
 
     action_ret = action->land();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
+    EXPECT_EQ(action_ret, Action::Result::Success);
 }

--- a/src/plugins/action/action.cpp
+++ b/src/plugins/action/action.cpp
@@ -7,7 +7,6 @@ Action::Action(System& system) : PluginBase(), _impl{new ActionImpl(system)} {}
 
 Action::~Action() {}
 
-
 void Action::arm_async(const result_callback_t callback)
 {
     _impl->arm_async(callback);
@@ -88,12 +87,18 @@ Action::Result Action::return_to_launch() const
     return _impl->return_to_launch();
 }
 
-void Action::goto_location_async(double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg, const result_callback_t callback)
+void Action::goto_location_async(
+    double latitude_deg,
+    double longitude_deg,
+    float absolute_altitude_m,
+    float yaw_deg,
+    const result_callback_t callback)
 {
     _impl->goto_location_async(latitude_deg, longitude_deg, absolute_altitude_m, yaw_deg, callback);
 }
 
-Action::Result Action::goto_location(double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg) const
+Action::Result Action::goto_location(
+    double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg) const
 {
     return _impl->goto_location(latitude_deg, longitude_deg, absolute_altitude_m, yaw_deg);
 }
@@ -168,7 +173,8 @@ std::pair<Action::Result, float> Action::get_return_to_launch_altitude() const
     return _impl->get_return_to_launch_altitude();
 }
 
-void Action::set_return_to_launch_altitude_async(float relative_altitude_m, const result_callback_t callback)
+void Action::set_return_to_launch_altitude_async(
+    float relative_altitude_m, const result_callback_t callback)
 {
     _impl->set_return_to_launch_altitude_async(relative_altitude_m, callback);
 }
@@ -177,9 +183,6 @@ Action::Result Action::set_return_to_launch_altitude(float relative_altitude_m) 
 {
     return _impl->set_return_to_launch_altitude(relative_altitude_m);
 }
-
-
-
 
 const char* Action::result_str(Action::Result result)
 {
@@ -212,8 +215,5 @@ const char* Action::result_str(Action::Result result)
             return "Unknown";
     }
 }
-
-
-
 
 } // namespace mavsdk

--- a/src/plugins/action/action.cpp
+++ b/src/plugins/action/action.cpp
@@ -7,9 +7,20 @@ Action::Action(System& system) : PluginBase(), _impl{new ActionImpl(system)} {}
 
 Action::~Action() {}
 
+
+void Action::arm_async(const result_callback_t callback)
+{
+    _impl->arm_async(callback);
+}
+
 Action::Result Action::arm() const
 {
     return _impl->arm();
+}
+
+void Action::disarm_async(const result_callback_t callback)
+{
+    _impl->disarm_async(callback);
 }
 
 Action::Result Action::disarm() const
@@ -17,19 +28,9 @@ Action::Result Action::disarm() const
     return _impl->disarm();
 }
 
-Action::Result Action::kill() const
+void Action::takeoff_async(const result_callback_t callback)
 {
-    return _impl->kill();
-}
-
-Action::Result Action::reboot() const
-{
-    return _impl->reboot();
-}
-
-Action::Result Action::shutdown() const
-{
-    return _impl->shutdown();
+    _impl->takeoff_async(callback);
 }
 
 Action::Result Action::takeoff() const
@@ -37,15 +38,49 @@ Action::Result Action::takeoff() const
     return _impl->takeoff();
 }
 
+void Action::land_async(const result_callback_t callback)
+{
+    _impl->land_async(callback);
+}
+
 Action::Result Action::land() const
 {
     return _impl->land();
 }
 
-Action::Result Action::goto_location(
-    double latitude_deg, double longitude_deg, float altitude_amsl_m, float yaw_deg)
+void Action::reboot_async(const result_callback_t callback)
 {
-    return _impl->goto_location(latitude_deg, longitude_deg, altitude_amsl_m, yaw_deg);
+    _impl->reboot_async(callback);
+}
+
+Action::Result Action::reboot() const
+{
+    return _impl->reboot();
+}
+
+void Action::shutdown_async(const result_callback_t callback)
+{
+    _impl->shutdown_async(callback);
+}
+
+Action::Result Action::shutdown() const
+{
+    return _impl->shutdown();
+}
+
+void Action::kill_async(const result_callback_t callback)
+{
+    _impl->kill_async(callback);
+}
+
+Action::Result Action::kill() const
+{
+    return _impl->kill();
+}
+
+void Action::return_to_launch_async(const result_callback_t callback)
+{
+    _impl->return_to_launch_async(callback);
 }
 
 Action::Result Action::return_to_launch() const
@@ -53,9 +88,29 @@ Action::Result Action::return_to_launch() const
     return _impl->return_to_launch();
 }
 
+void Action::goto_location_async(double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg, const result_callback_t callback)
+{
+    _impl->goto_location_async(latitude_deg, longitude_deg, absolute_altitude_m, yaw_deg, callback);
+}
+
+Action::Result Action::goto_location(double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg) const
+{
+    return _impl->goto_location(latitude_deg, longitude_deg, absolute_altitude_m, yaw_deg);
+}
+
+void Action::transition_to_fixedwing_async(const result_callback_t callback)
+{
+    _impl->transition_to_fixedwing_async(callback);
+}
+
 Action::Result Action::transition_to_fixedwing() const
 {
     return _impl->transition_to_fixedwing();
+}
+
+void Action::transition_to_multicopter_async(const result_callback_t callback)
+{
+    _impl->transition_to_multicopter_async(callback);
 }
 
 Action::Result Action::transition_to_multicopter() const
@@ -63,49 +118,9 @@ Action::Result Action::transition_to_multicopter() const
     return _impl->transition_to_multicopter();
 }
 
-void Action::arm_async(result_callback_t callback)
+void Action::get_takeoff_altitude_async(const altitude_callback_t callback)
 {
-    _impl->arm_async(callback);
-}
-
-void Action::disarm_async(result_callback_t callback)
-{
-    _impl->disarm_async(callback);
-}
-
-void Action::kill_async(result_callback_t callback)
-{
-    _impl->kill_async(callback);
-}
-
-void Action::takeoff_async(result_callback_t callback)
-{
-    _impl->takeoff_async(callback);
-}
-
-void Action::land_async(result_callback_t callback)
-{
-    _impl->land_async(callback);
-}
-
-void Action::return_to_launch_async(result_callback_t callback)
-{
-    _impl->return_to_launch_async(callback);
-}
-
-void Action::transition_to_multicopter_async(result_callback_t callback)
-{
-    _impl->transition_to_multicopter_async(callback);
-}
-
-void Action::transition_to_fixedwing_async(result_callback_t callback)
-{
-    _impl->transition_to_fixedwing_async(callback);
-}
-
-Action::Result Action::set_takeoff_altitude(float relative_altitude_m)
-{
-    return _impl->set_takeoff_altitude(relative_altitude_m);
+    _impl->get_takeoff_altitude_async(callback);
 }
 
 std::pair<Action::Result, float> Action::get_takeoff_altitude() const
@@ -113,55 +128,92 @@ std::pair<Action::Result, float> Action::get_takeoff_altitude() const
     return _impl->get_takeoff_altitude();
 }
 
-Action::Result Action::set_max_speed(float speed_m_s)
+void Action::set_takeoff_altitude_async(float altitude, const result_callback_t callback)
 {
-    return _impl->set_max_speed(speed_m_s);
+    _impl->set_takeoff_altitude_async(altitude, callback);
 }
 
-std::pair<Action::Result, float> Action::get_max_speed() const
+Action::Result Action::set_takeoff_altitude(float altitude) const
 {
-    return _impl->get_max_speed();
+    return _impl->set_takeoff_altitude(altitude);
 }
 
-Action::Result Action::set_return_to_launch_return_altitude(float relative_altitude_m)
+void Action::get_maximum_speed_async(const speed_callback_t callback)
 {
-    return _impl->set_return_to_launch_return_altitude(relative_altitude_m);
+    _impl->get_maximum_speed_async(callback);
 }
 
-std::pair<Action::Result, float> Action::get_return_to_launch_return_altitude() const
+std::pair<Action::Result, float> Action::get_maximum_speed() const
 {
-    return _impl->get_return_to_launch_return_altitude();
+    return _impl->get_maximum_speed();
 }
+
+void Action::set_maximum_speed_async(float speed, const result_callback_t callback)
+{
+    _impl->set_maximum_speed_async(speed, callback);
+}
+
+Action::Result Action::set_maximum_speed(float speed) const
+{
+    return _impl->set_maximum_speed(speed);
+}
+
+void Action::get_return_to_launch_altitude_async(const relative_altitude_m_callback_t callback)
+{
+    _impl->get_return_to_launch_altitude_async(callback);
+}
+
+std::pair<Action::Result, float> Action::get_return_to_launch_altitude() const
+{
+    return _impl->get_return_to_launch_altitude();
+}
+
+void Action::set_return_to_launch_altitude_async(float relative_altitude_m, const result_callback_t callback)
+{
+    _impl->set_return_to_launch_altitude_async(relative_altitude_m, callback);
+}
+
+Action::Result Action::set_return_to_launch_altitude(float relative_altitude_m) const
+{
+    return _impl->set_return_to_launch_altitude(relative_altitude_m);
+}
+
+
+
 
 const char* Action::result_str(Action::Result result)
 {
     switch (result) {
-        case Action::Result::SUCCESS:
-            return "Success";
-        case Action::Result::NO_SYSTEM:
-            return "No system";
-        case Action::Result::CONNECTION_ERROR:
+        case Action::Result::Unknown:
+            return "Unknown error";
+        case Action::Result::Success:
+            return "Success: the action command was accepted by the vehicle";
+        case Action::Result::NoSystem:
+            return "No system is connected";
+        case Action::Result::ConnectionError:
             return "Connection error";
-        case Action::Result::BUSY:
-            return "Busy";
-        case Action::Result::COMMAND_DENIED:
-            return "Command denied";
-        case Action::Result::COMMAND_DENIED_LANDED_STATE_UNKNOWN:
-            return "Command denied, landed state is unknown";
-        case Action::Result::COMMAND_DENIED_NOT_LANDED:
-            return "Command denied, not landed";
-        case Action::Result::TIMEOUT:
-            return "Timeout";
-        case Action::Result::VTOL_TRANSITION_SUPPORT_UNKNOWN:
-            return "VTOL transition unknown";
-        case Action::Result::NO_VTOL_TRANSITION_SUPPORT:
-            return "No VTOL transition support";
-        case Action::Result::PARAMETER_ERROR:
-            return "Parameter error";
-        case Action::Result::UNKNOWN:
+        case Action::Result::Busy:
+            return "Vehicle is busy";
+        case Action::Result::CommandDenied:
+            return "Command refused by vehicle";
+        case Action::Result::CommandDeniedLandedStateUnknown:
+            return "Command refused because landed state is unknown";
+        case Action::Result::CommandDeniedNotLanded:
+            return "Command refused because vehicle not landed";
+        case Action::Result::Timeout:
+            return "Request timed out";
+        case Action::Result::VtolTransitionSupportUnknown:
+            return "Hybrid/VTOL transition refused because VTOL support is unknown";
+        case Action::Result::NoVtolTransitionSupport:
+            return "Vehicle does not support hybrid/VTOL transitions";
+        case Action::Result::ParameterError:
+            return "Error getting or setting parameter";
         default:
             return "Unknown";
     }
 }
+
+
+
 
 } // namespace mavsdk

--- a/src/plugins/action/action_impl.cpp
+++ b/src/plugins/action/action_impl.cpp
@@ -129,12 +129,18 @@ Action::Result ActionImpl::return_to_launch() const
 }
 
 Action::Result ActionImpl::goto_location(
-    const double latitude_deg, const double longitude_deg, const float altitude_amsl_m, const float yaw_deg)
+    const double latitude_deg,
+    const double longitude_deg,
+    const float altitude_amsl_m,
+    const float yaw_deg)
 {
     auto prom = std::promise<Action::Result>();
     auto fut = prom.get_future();
 
-    goto_location_async(latitude_deg, longitude_deg, altitude_amsl_m, yaw_deg, [&prom](Action::Result result) { prom.set_value(result); });
+    goto_location_async(
+        latitude_deg, longitude_deg, altitude_amsl_m, yaw_deg, [&prom](Action::Result result) {
+            prom.set_value(result);
+        });
 
     return fut.get();
 }
@@ -295,7 +301,11 @@ void ActionImpl::return_to_launch_async(const Action::result_callback_t& callbac
 }
 
 void ActionImpl::goto_location_async(
-    const double latitude_deg, const double longitude_deg, const float altitude_amsl_m, const float yaw_deg, const Action::result_callback_t& callback)
+    const double latitude_deg,
+    const double longitude_deg,
+    const float altitude_amsl_m,
+    const float yaw_deg,
+    const Action::result_callback_t& callback)
 {
     MAVLinkCommands::CommandInt command{};
 
@@ -411,7 +421,8 @@ void ActionImpl::process_extended_sys_state(const mavlink_message_t& message)
     _vtol_transition_support_known = true;
 }
 
-void ActionImpl::set_takeoff_altitude_async(const float relative_altitude_m, const Action::result_callback_t& callback) const
+void ActionImpl::set_takeoff_altitude_async(
+    const float relative_altitude_m, const Action::result_callback_t& callback) const
 {
     callback(set_takeoff_altitude(relative_altitude_m));
 }
@@ -424,7 +435,8 @@ Action::Result ActionImpl::set_takeoff_altitude(float relative_altitude_m) const
                                                             Action::Result::ParameterError;
 }
 
-void ActionImpl::get_takeoff_altitude_async(const Action::relative_altitude_m_callback_t& callback) const
+void ActionImpl::get_takeoff_altitude_async(
+    const Action::relative_altitude_m_callback_t& callback) const
 {
     auto altitude_result = get_takeoff_altitude();
     callback(altitude_result.first, altitude_result.second);
@@ -439,7 +451,8 @@ std::pair<Action::Result, float> ActionImpl::get_takeoff_altitude() const
         result.second);
 }
 
-void ActionImpl::set_maximum_speed_async(const float speed_m_s, const Action::result_callback_t& callback) const
+void ActionImpl::set_maximum_speed_async(
+    const float speed_m_s, const Action::result_callback_t& callback) const
 {
     callback(set_maximum_speed(speed_m_s));
 }
@@ -466,7 +479,8 @@ std::pair<Action::Result, float> ActionImpl::get_maximum_speed() const
         result.second);
 }
 
-void ActionImpl::set_return_to_launch_altitude_async(const float relative_altitude_m, const Action::result_callback_t& callback) const
+void ActionImpl::set_return_to_launch_altitude_async(
+    const float relative_altitude_m, const Action::result_callback_t& callback) const
 {
     callback(set_return_to_launch_altitude(relative_altitude_m));
 }
@@ -479,7 +493,8 @@ Action::Result ActionImpl::set_return_to_launch_altitude(const float relative_al
                                                             Action::Result::ParameterError;
 }
 
-void ActionImpl::get_return_to_launch_altitude_async(const Action::relative_altitude_m_callback_t& callback) const
+void ActionImpl::get_return_to_launch_altitude_async(
+    const Action::relative_altitude_m_callback_t& callback) const
 {
     const auto get_result = get_return_to_launch_altitude();
     callback(get_result.first, get_result.second);

--- a/src/plugins/action/action_impl.h
+++ b/src/plugins/action/action_impl.h
@@ -27,8 +27,11 @@ public:
     Action::Result takeoff() const;
     Action::Result land() const;
     Action::Result return_to_launch() const;
-    Action::Result
-    goto_location(const double latitude_deg, const double longitude_deg, const float altitude_amsl_m, const float yaw_deg);
+    Action::Result goto_location(
+        const double latitude_deg,
+        const double longitude_deg,
+        const float altitude_amsl_m,
+        const float yaw_deg);
     Action::Result transition_to_fixedwing() const;
     Action::Result transition_to_multicopter() const;
 
@@ -40,24 +43,33 @@ public:
     void takeoff_async(const Action::result_callback_t& callback) const;
     void land_async(const Action::result_callback_t& callback) const;
     void return_to_launch_async(const Action::result_callback_t& callback) const;
-    void goto_location_async(const double latitude_deg, const double longitude_deg, const float altitude_amsl_m, const float yaw_deg, const Action::result_callback_t& callback);
+    void goto_location_async(
+        const double latitude_deg,
+        const double longitude_deg,
+        const float altitude_amsl_m,
+        const float yaw_deg,
+        const Action::result_callback_t& callback);
     void transition_to_fixedwing_async(const Action::result_callback_t& callback) const;
     void transition_to_multicopter_async(const Action::result_callback_t& callback) const;
 
-    void set_takeoff_altitude_async(const float relative_altitude_m, const Action::result_callback_t& callback) const;
+    void set_takeoff_altitude_async(
+        const float relative_altitude_m, const Action::result_callback_t& callback) const;
     void get_takeoff_altitude_async(const Action::relative_altitude_m_callback_t& callback) const;
 
     Action::Result set_takeoff_altitude(float relative_altitude_m) const;
     std::pair<Action::Result, float> get_takeoff_altitude() const;
 
-    void set_maximum_speed_async(const float speed_m_s, const Action::result_callback_t& callback) const;
+    void
+    set_maximum_speed_async(const float speed_m_s, const Action::result_callback_t& callback) const;
     void get_maximum_speed_async(const Action::speed_callback_t& callback) const;
 
     Action::Result set_maximum_speed(float speed_m_s) const;
     std::pair<Action::Result, float> get_maximum_speed() const;
 
-    void set_return_to_launch_altitude_async(const float relative_altitude_m, const Action::result_callback_t& callback) const;
-    void get_return_to_launch_altitude_async(const Action::relative_altitude_m_callback_t& callback) const;
+    void set_return_to_launch_altitude_async(
+        const float relative_altitude_m, const Action::result_callback_t& callback) const;
+    void get_return_to_launch_altitude_async(
+        const Action::relative_altitude_m_callback_t& callback) const;
 
     Action::Result set_return_to_launch_altitude(const float relative_altitude_m) const;
     std::pair<Action::Result, float> get_return_to_launch_altitude() const;

--- a/src/plugins/action/action_impl.h
+++ b/src/plugins/action/action_impl.h
@@ -28,27 +28,39 @@ public:
     Action::Result land() const;
     Action::Result return_to_launch() const;
     Action::Result
-    goto_location(double latitude_deg, double longitude_deg, float altitude_amsl_m, float yaw_deg);
+    goto_location(const double latitude_deg, const double longitude_deg, const float altitude_amsl_m, const float yaw_deg);
     Action::Result transition_to_fixedwing() const;
     Action::Result transition_to_multicopter() const;
 
     void arm_async(const Action::result_callback_t& callback) const;
     void disarm_async(const Action::result_callback_t& callback) const;
     void kill_async(const Action::result_callback_t& callback) const;
+    void reboot_async(const Action::result_callback_t& callback) const;
+    void shutdown_async(const Action::result_callback_t& callback) const;
     void takeoff_async(const Action::result_callback_t& callback) const;
     void land_async(const Action::result_callback_t& callback) const;
     void return_to_launch_async(const Action::result_callback_t& callback) const;
+    void goto_location_async(const double latitude_deg, const double longitude_deg, const float altitude_amsl_m, const float yaw_deg, const Action::result_callback_t& callback);
     void transition_to_fixedwing_async(const Action::result_callback_t& callback) const;
     void transition_to_multicopter_async(const Action::result_callback_t& callback) const;
 
-    Action::Result set_takeoff_altitude(float relative_altitude_m);
+    void set_takeoff_altitude_async(const float relative_altitude_m, const Action::result_callback_t& callback) const;
+    void get_takeoff_altitude_async(const Action::relative_altitude_m_callback_t& callback) const;
+
+    Action::Result set_takeoff_altitude(float relative_altitude_m) const;
     std::pair<Action::Result, float> get_takeoff_altitude() const;
 
-    Action::Result set_max_speed(float speed_m_s);
-    std::pair<Action::Result, float> get_max_speed() const;
+    void set_maximum_speed_async(const float speed_m_s, const Action::result_callback_t& callback) const;
+    void get_maximum_speed_async(const Action::speed_callback_t& callback) const;
 
-    Action::Result set_return_to_launch_return_altitude(float relative_altitude_m);
-    std::pair<Action::Result, float> get_return_to_launch_return_altitude() const;
+    Action::Result set_maximum_speed(float speed_m_s) const;
+    std::pair<Action::Result, float> get_maximum_speed() const;
+
+    void set_return_to_launch_altitude_async(const float relative_altitude_m, const Action::result_callback_t& callback) const;
+    void get_return_to_launch_altitude_async(const Action::relative_altitude_m_callback_t& callback) const;
+
+    Action::Result set_return_to_launch_altitude(const float relative_altitude_m) const;
+    std::pair<Action::Result, float> get_return_to_launch_altitude() const;
 
 private:
     Action::Result disarming_allowed() const;

--- a/src/plugins/action/include/plugins/action/action.h
+++ b/src/plugins/action/include/plugins/action/action.h
@@ -46,26 +46,20 @@ public:
         ConnectionError, /**< @brief Connection error. */
         Busy, /**< @brief Vehicle is busy. */
         CommandDenied, /**< @brief Command refused by vehicle. */
-        CommandDeniedLandedStateUnknown, /**< @brief Command refused because landed state is unknown. */
+        CommandDeniedLandedStateUnknown, /**< @brief Command refused because landed state is
+                                            unknown. */
         CommandDeniedNotLanded, /**< @brief Command refused because vehicle not landed. */
         Timeout, /**< @brief Request timed out. */
-        VtolTransitionSupportUnknown, /**< @brief Hybrid/VTOL transition refused because VTOL support is unknown. */
+        VtolTransitionSupportUnknown, /**< @brief Hybrid/VTOL transition refused because VTOL
+                                         support is unknown. */
         NoVtolTransitionSupport, /**< @brief Vehicle does not support hybrid/VTOL transitions. */
         ParameterError, /**< @brief Error getting or setting parameter. */
     };
-
-
-
-
-
-
 
     /**
      * @brief Callback type for asynchronous Action calls.
      */
     typedef std::function<void(Result)> result_callback_t;
-
-
 
     /**
      * @brief Send command to arm the drone.
@@ -82,7 +76,6 @@ public:
      */
     Result arm() const;
 
-
     /**
      * @brief Send command to disarm the drone.
      *
@@ -98,11 +91,10 @@ public:
      */
     Result disarm() const;
 
-
     /**
      * @brief Send command to take off and hover.
      *
-     * This switches the drone into position control mode and commands 
+     * This switches the drone into position control mode and commands
      * it to take off and hover at the takeoff altitude.
      *
      * Note that the vehicle must be armed before it can take off.
@@ -115,7 +107,6 @@ public:
      * @return Result of request.
      */
     Result takeoff() const;
-
 
     /**
      * @brief Send command to land at the current position.
@@ -131,7 +122,6 @@ public:
      */
     Result land() const;
 
-
     /**
      * @brief Send command to reboot the drone components.
      *
@@ -145,7 +135,6 @@ public:
      * @return Result of request.
      */
     Result reboot() const;
-
 
     /**
      * @brief *
@@ -164,9 +153,8 @@ public:
      */
     Result shutdown() const;
 
-
     /**
-     * @brief Send command to kill the drone. 
+     * @brief Send command to kill the drone.
      *
      * This will disarm a drone irrespective of whether it is landed or flying.
      * Note that the drone will fall out of the sky if this command is used while flying.
@@ -179,7 +167,6 @@ public:
      * @return Result of request.
      */
     Result kill() const;
-
 
     /**
      * @brief Send command to return to the launch (takeoff) position and land.
@@ -197,7 +184,6 @@ public:
      */
     Result return_to_launch() const;
 
-
     /**
      * @brief *
      * Send command to move the vehicle to a specific global position.
@@ -207,15 +193,20 @@ public:
      *
      * The yaw angle is in degrees (frame is NED, 0 is North, positive is clockwise).
      */
-    void goto_location_async(double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg, const result_callback_t callback);
+    void goto_location_async(
+        double latitude_deg,
+        double longitude_deg,
+        float absolute_altitude_m,
+        float yaw_deg,
+        const result_callback_t callback);
 
     /**
      * @brief Synchronous wrapper for goto_location_async().
      *
      * @return Result of request.
      */
-    Result goto_location(double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg) const;
-
+    Result goto_location(
+        double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg) const;
 
     /**
      * @brief Send command to transition the drone to fixedwing.
@@ -233,7 +224,6 @@ public:
      */
     Result transition_to_fixedwing() const;
 
-
     /**
      * @brief Send command to transition the drone to multicopter.
      *
@@ -250,10 +240,9 @@ public:
      */
     Result transition_to_multicopter() const;
 
-
     /**
-    * @brief Callback type for get_takeoff_altitude_async.
-    */
+     * @brief Callback type for get_takeoff_altitude_async.
+     */
     typedef std::function<void(Result, float)> altitude_callback_t;
 
     /**
@@ -268,7 +257,6 @@ public:
      */
     std::pair<Result, float> get_takeoff_altitude() const;
 
-
     /**
      * @brief Set takeoff altitude (in meters above ground).
      */
@@ -281,10 +269,9 @@ public:
      */
     Result set_takeoff_altitude(float altitude) const;
 
-
     /**
-    * @brief Callback type for get_maximum_speed_async.
-    */
+     * @brief Callback type for get_maximum_speed_async.
+     */
     typedef std::function<void(Result, float)> speed_callback_t;
 
     /**
@@ -299,7 +286,6 @@ public:
      */
     std::pair<Result, float> get_maximum_speed() const;
 
-
     /**
      * @brief Set vehicle maximum speed (in metres/second).
      */
@@ -312,10 +298,9 @@ public:
      */
     Result set_maximum_speed(float speed) const;
 
-
     /**
-    * @brief Callback type for get_return_to_launch_altitude_async.
-    */
+     * @brief Callback type for get_return_to_launch_altitude_async.
+     */
     typedef std::function<void(Result, float)> relative_altitude_m_callback_t;
 
     /**
@@ -330,11 +315,11 @@ public:
      */
     std::pair<Result, float> get_return_to_launch_altitude() const;
 
-
     /**
      * @brief Set the return to launch minimum return altitude (in meters).
      */
-    void set_return_to_launch_altitude_async(float relative_altitude_m, const result_callback_t callback);
+    void set_return_to_launch_altitude_async(
+        float relative_altitude_m, const result_callback_t callback);
 
     /**
      * @brief Synchronous wrapper for set_return_to_launch_altitude_async().
@@ -343,9 +328,6 @@ public:
      */
     Result set_return_to_launch_altitude(float relative_altitude_m) const;
 
-
-
-
     /**
      * @brief Returns a human-readable English string for a Result.
      *
@@ -353,7 +335,6 @@ public:
      * @return Human readable string for the Result.
      */
     static const char* result_str(Result result);
-
 
     /**
      * @brief Copy constructor (object is not copyable).

--- a/src/plugins/action/include/plugins/action/action.h
+++ b/src/plugins/action/include/plugins/action/action.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <array>
 #include <functional>
+#include <limits>
 #include <memory>
+#include <string>
 
 #include "plugin_base.h"
 
@@ -11,16 +14,7 @@ class System;
 class ActionImpl;
 
 /**
- * @brief The Action class enables simple actions for a drone
- * such as arming, taking off, and landing.
- *
- * Synchronous and asynchronous variants of the action methods are supplied.
- *
- * The action methods send their associated MAVLink commands to the vehicle and complete
- * (return synchronously or callback asynchronously) with an Action::Result value
- * indicating whether the vehicle has accepted or rejected the command, or that there has been some
- * error.
- * If the command is accepted, the vehicle will then start to perform the associated action.
+ * @brief Enable simple actions such as arming, taking off, and landing.
  */
 class Action : public PluginBase {
 public:
@@ -43,305 +37,329 @@ public:
     ~Action();
 
     /**
-     * @brief Possible results returned for commanded actions.
-     *
-     * @note Mavsdk does not throw exceptions. Instead a result of this type will be
-     * returned when you execute actions.
+     * @brief Possible results returned for action requests.
      */
     enum class Result {
-        UNKNOWN, /**< @brief Unspecified error. */
-        SUCCESS, /**< @brief Success. The action command was accepted by the vehicle. */
-        NO_SYSTEM, /**< @brief No system is connected error. */
-        CONNECTION_ERROR, /**< @brief %Connection error. */
-        BUSY, /**< @brief Vehicle busy error. */
-        COMMAND_DENIED, /**< @brief Command refused by vehicle. */
-        COMMAND_DENIED_LANDED_STATE_UNKNOWN, /**< @brief Command refused because landed state is
-                                                unknown. */
-        COMMAND_DENIED_NOT_LANDED, /**< @brief Command refused because vehicle not landed. */
-        TIMEOUT, /**< @brief Timeout waiting for command acknowledgement from vehicle. */
-        VTOL_TRANSITION_SUPPORT_UNKNOWN, /**< @brief hybrid/VTOL transition refused because VTOL
-                                            support is unknown. */
-        NO_VTOL_TRANSITION_SUPPORT, /**< @brief Vehicle does not support hybrid/VTOL transitions. */
-        PARAMETER_ERROR /**< @brief Error getting or setting parameter. */
+        Unknown, /**< @brief Unknown error. */
+        Success, /**< @brief Success: the action command was accepted by the vehicle. */
+        NoSystem, /**< @brief No system is connected. */
+        ConnectionError, /**< @brief Connection error. */
+        Busy, /**< @brief Vehicle is busy. */
+        CommandDenied, /**< @brief Command refused by vehicle. */
+        CommandDeniedLandedStateUnknown, /**< @brief Command refused because landed state is unknown. */
+        CommandDeniedNotLanded, /**< @brief Command refused because vehicle not landed. */
+        Timeout, /**< @brief Request timed out. */
+        VtolTransitionSupportUnknown, /**< @brief Hybrid/VTOL transition refused because VTOL support is unknown. */
+        NoVtolTransitionSupport, /**< @brief Vehicle does not support hybrid/VTOL transitions. */
+        ParameterError, /**< @brief Error getting or setting parameter. */
     };
 
-    /**
-     * @brief Send command to *arm* the drone (synchronous).
-     *
-     * @note Arming a drone normally causes motors to spin at idle.
-     * Before arming take all safety precautions and stand clear of the drone!
-     *
-     * @return Result of request.
-     */
-    Result arm() const;
 
-    /**
-     * @brief Send command to *disarm* the drone (synchronous).
-     *
-     * This will disarm a drone that considers itself landed. If flying, the drone should
-     * reject the disarm command. Disarming means that all motors will stop.
-     *
-     * @return Result of request.
-     */
-    Result disarm() const;
 
-    /**
-     * @brief Send command to *kill* the drone (synchronous).
-     *
-     * This will disarm a drone irrespective of whether it is landed or flying.
-     * Note that the drone will fall out of the sky if this command is used while flying.
-     *
-     * @return Result of request.
-     */
-    Result kill() const;
 
-    /**
-     * @brief Send command to *reboot* the drone components.
-     *
-     * This will reboot the autopilot, onboard computer, camera and gimbal.
-     *
-     * @return Action::Result of request.
-     */
-    Result reboot() const;
 
-    /**
-     * @brief Send command to *shut down* the drone components.
-     *
-     * This will shut down the autopilot, onboard computer, camera and gimbal.
-     * This command should only be used when the autopilot is disarmed and autopilots commonly
-     * reject it if they are not already ready to shut down.
-     *
-     * @return Action::Result of request.
-     */
-    Result shutdown() const;
 
-    /**
-     * @brief Send command to *take off and hover* (synchronous).
-     *
-     * This switches the drone into position control mode and commands it to take off and hover at
-     * the takeoff altitude (set using set_takeoff_altitude()).
-     *
-     * Note that the vehicle must be armed before it can take off.
-     *
-     * @return Result of request.
-     */
-    Result takeoff() const;
-
-    /**
-     * @brief Send command to *land* at the current position (synchronous).
-     *
-     * This switches the drone to
-     * [Land mode](https://docs.px4.io/en/flight_modes/land.html).
-     *
-     * @return Result of request.
-     */
-    Result land() const;
-
-    /**
-     * @brief Send command to *return to the launch* (takeoff) position and *land* (asynchronous).
-     *
-     * This switches the drone into [RTL mode](https://docs.px4.io/en/flight_modes/rtl.html) which
-     * generally means it will rise up to a certain altitude to clear any obstacles before heading
-     * back to the launch (takeoff) position and land there.
-     *
-     * @return Result of request.
-     */
-    Result return_to_launch() const;
-
-    /**
-     * @brief Send command to move the vehicle to a specific global position.
-     *
-     * The latitude and longitude are given in degrees (WGS84 frame) and the altitude
-     * in meters AMSL (above mean sea level).
-     *
-     * @param latitude_deg Latitude in degrees.
-     * @param longitude_deg Longitude in degrees.
-     * @param altitude_amsl_m Altitude AMSL in meters.
-     * @param yaw_deg Yaw angle in degrees (Frame is NED, 0 is North, positive is clockwise).
-     *
-     * @return Result of request.
-     */
-    Result
-    goto_location(double latitude_deg, double longitude_deg, float altitude_amsl_m, float yaw_deg);
-
-    /**
-     * @brief Send command to transition the drone to fixedwing.
-     *
-     * The associated action will only be executed for VTOL vehicles (on other vehicle types the
-     * command will fail with an Result). The command will succeed if called when the vehicle
-     * is already in fixedwing mode.
-     *
-     * @return Result of request.
-     */
-    Result transition_to_fixedwing() const;
-
-    /**
-     * @brief Send command to transition the drone to multicopter.
-     *
-     * The associated action will only be executed for VTOL vehicles (on other vehicle types the
-     * command will fail with an Result). The command will succeed if called when the vehicle
-     * is already in multicopter mode.
-     *
-     * @return Result of request.
-     */
-    Result transition_to_multicopter() const;
 
     /**
      * @brief Callback type for asynchronous Action calls.
      */
     typedef std::function<void(Result)> result_callback_t;
 
-    /**
-     * @brief Send command to *arm* the drone (asynchronous).
-     *
-     * Note that arming a drone normally means that the motors will spin at idle.
-     * Therefore, before arming take all safety precautions and stand clear of the drone.
-     *
-     * @param callback Function to call with result of request.
-     */
-    void arm_async(result_callback_t callback);
+
 
     /**
-     * @brief Send command to *disarm* the drone (asynchronous).
+     * @brief Send command to arm the drone.
+     *
+     * Arming a drone normally causes motors to spin at idle.
+     * Before arming take all safety precautions and stand clear of the drone!
+     */
+    void arm_async(const result_callback_t callback);
+
+    /**
+     * @brief Synchronous wrapper for arm_async().
+     *
+     * @return Result of request.
+     */
+    Result arm() const;
+
+
+    /**
+     * @brief Send command to disarm the drone.
      *
      * This will disarm a drone that considers itself landed. If flying, the drone should
      * reject the disarm command. Disarming means that all motors will stop.
-     *
-     * @param callback Function to call with result of request.
      */
-    void disarm_async(result_callback_t callback);
+    void disarm_async(const result_callback_t callback);
 
     /**
-     * @brief Send command to *kill* the drone (asynchronous).
+     * @brief Synchronous wrapper for disarm_async().
      *
-     * This will disarm a drone irrespective of whether it is landed or flying.
-     * Note that the drone will fall out of the sky if you use this command while flying.
-     *
-     * @param callback Function to call with result of request.
+     * @return Result of request.
      */
-    void kill_async(result_callback_t callback);
+    Result disarm() const;
+
 
     /**
-     * @brief Send command to *take off and hover* (asynchronous).
+     * @brief Send command to take off and hover.
      *
-     * This switches the drone into position control mode and commands it to take off and hover at
-     * the takeoff altitude set using set_takeoff_altitude().
+     * This switches the drone into position control mode and commands 
+     * it to take off and hover at the takeoff altitude.
      *
      * Note that the vehicle must be armed before it can take off.
-     *
-     * @param callback Function to call with result of request
      */
-    void takeoff_async(result_callback_t callback);
+    void takeoff_async(const result_callback_t callback);
 
     /**
-     * @brief Send command to *land* at the current position (asynchronous).
+     * @brief Synchronous wrapper for takeoff_async().
      *
-     * This switches the drone to
-     * [Land mode](https://docs.px4.io/en/flight_modes/land.html).
-     *
-     * @param callback Function to call with result of request.
+     * @return Result of request.
      */
-    void land_async(result_callback_t callback);
+    Result takeoff() const;
+
 
     /**
-     * @brief Send command to *return to the launch* (takeoff) position and *land*  (asynchronous).
+     * @brief Send command to land at the current position.
+     *
+     * This switches the drone to 'Land' flight mode.
+     */
+    void land_async(const result_callback_t callback);
+
+    /**
+     * @brief Synchronous wrapper for land_async().
+     *
+     * @return Result of request.
+     */
+    Result land() const;
+
+
+    /**
+     * @brief Send command to reboot the drone components.
+     *
+     * This will reboot the autopilot, companion computer, camera and gimbal.
+     */
+    void reboot_async(const result_callback_t callback);
+
+    /**
+     * @brief Synchronous wrapper for reboot_async().
+     *
+     * @return Result of request.
+     */
+    Result reboot() const;
+
+
+    /**
+     * @brief *
+     * Send command to shut down the drone components.
+     *
+     * This will shut down the autopilot, onboard computer, camera and gimbal.
+     * This command should only be used when the autopilot is disarmed and autopilots commonly
+     * reject it if they are not already ready to shut down.
+     */
+    void shutdown_async(const result_callback_t callback);
+
+    /**
+     * @brief Synchronous wrapper for shutdown_async().
+     *
+     * @return Result of request.
+     */
+    Result shutdown() const;
+
+
+    /**
+     * @brief Send command to kill the drone. 
+     *
+     * This will disarm a drone irrespective of whether it is landed or flying.
+     * Note that the drone will fall out of the sky if this command is used while flying.
+     */
+    void kill_async(const result_callback_t callback);
+
+    /**
+     * @brief Synchronous wrapper for kill_async().
+     *
+     * @return Result of request.
+     */
+    Result kill() const;
+
+
+    /**
+     * @brief Send command to return to the launch (takeoff) position and land.
      *
      * This switches the drone into [RTL mode](https://docs.px4.io/en/flight_modes/rtl.html) which
      * generally means it will rise up to a certain altitude to clear any obstacles before heading
      * back to the launch (takeoff) position and land there.
-     *
-     * @param callback Function to call with result of request.
      */
-    void return_to_launch_async(result_callback_t callback);
+    void return_to_launch_async(const result_callback_t callback);
 
     /**
-     * @brief Send command to transition the drone to fixedwing (asynchronous).
+     * @brief Synchronous wrapper for return_to_launch_async().
      *
-     * The associated action will only be executed for VTOL vehicles (on other vehicle types the
-     * command will fail with an Result). The command will succeed if called when the vehicle
-     * is already in fixedwing mode.
-     *
-     * @param callback Function to call with result of request.
-     */
-    void transition_to_fixedwing_async(result_callback_t callback);
-
-    /**
-     * @brief Send command to transition the drone to multicopter (asynchronous).
-     *
-     * The associated action will only be executed for VTOL vehicles (on other vehicle types the
-     * command will fail with an Result). The command will succeed if called when the vehicle
-     * is already in multicopter mode.
-     *
-     * @param callback Function to call with result of request.
-     */
-    void transition_to_multicopter_async(result_callback_t callback);
-
-    /**
-     * @brief Set takeoff altitude above ground.
-     *
-     * @param relative_altitude_m Takeoff altitude relative to takeoff location, in meters.
      * @return Result of request.
      */
-    Result set_takeoff_altitude(float relative_altitude_m);
+    Result return_to_launch() const;
+
 
     /**
-     * @brief Get the takeoff altitude.
+     * @brief *
+     * Send command to move the vehicle to a specific global position.
      *
-     * @return A pair containing the result of request and if successful, the
-     * takeoff altitude relative to ground/takeoff location, in meters.
+     * The latitude and longitude are given in degrees (WGS84 frame) and the altitude
+     * in meters AMSL (above mean sea level).
+     *
+     * The yaw angle is in degrees (frame is NED, 0 is North, positive is clockwise).
+     */
+    void goto_location_async(double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg, const result_callback_t callback);
+
+    /**
+     * @brief Synchronous wrapper for goto_location_async().
+     *
+     * @return Result of request.
+     */
+    Result goto_location(double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg) const;
+
+
+    /**
+     * @brief Send command to transition the drone to fixedwing.
+     *
+     * The associated action will only be executed for VTOL vehicles (on other vehicle types the
+     * command will fail). The command will succeed if called when the vehicle
+     * is already in fixedwing mode.
+     */
+    void transition_to_fixedwing_async(const result_callback_t callback);
+
+    /**
+     * @brief Synchronous wrapper for transition_to_fixedwing_async().
+     *
+     * @return Result of request.
+     */
+    Result transition_to_fixedwing() const;
+
+
+    /**
+     * @brief Send command to transition the drone to multicopter.
+     *
+     * The associated action will only be executed for VTOL vehicles (on other vehicle types the
+     * command will fail). The command will succeed if called when the vehicle
+     * is already in multicopter mode.
+     */
+    void transition_to_multicopter_async(const result_callback_t callback);
+
+    /**
+     * @brief Synchronous wrapper for transition_to_multicopter_async().
+     *
+     * @return Result of request.
+     */
+    Result transition_to_multicopter() const;
+
+
+    /**
+    * @brief Callback type for get_takeoff_altitude_async.
+    */
+    typedef std::function<void(Result, float)> altitude_callback_t;
+
+    /**
+     * @brief Get the takeoff altitude (in meters above ground).
+     */
+    void get_takeoff_altitude_async(const altitude_callback_t callback);
+
+    /**
+     * @brief Synchronous wrapper for get_takeoff_altitude_async().
+     *
+     * @return Result of request.
      */
     std::pair<Result, float> get_takeoff_altitude() const;
 
+
     /**
-     * @brief Set vehicle maximum speed.
+     * @brief Set takeoff altitude (in meters above ground).
+     */
+    void set_takeoff_altitude_async(float altitude, const result_callback_t callback);
+
+    /**
+     * @brief Synchronous wrapper for set_takeoff_altitude_async().
      *
-     * @param speed_m_s Maximum speed in metres/second.
      * @return Result of request.
      */
-    Result set_max_speed(float speed_m_s);
+    Result set_takeoff_altitude(float altitude) const;
+
 
     /**
-     * @brief Get the vehicle maximum speed.
-     *
-     * @return A pair containing the result of the request and if successful, the
-     * maximum speed in metres/second.
+    * @brief Callback type for get_maximum_speed_async.
+    */
+    typedef std::function<void(Result, float)> speed_callback_t;
+
+    /**
+     * @brief Get the vehicle maximum speed (in metres/second).
      */
-    std::pair<Result, float> get_max_speed() const;
+    void get_maximum_speed_async(const speed_callback_t callback);
 
     /**
-     * @brief Set the return to launch minimum return altitude.
+     * @brief Synchronous wrapper for get_maximum_speed_async().
      *
-     * When return to launch is initiated, the vehicle climbs to the return altitude if it is lower
-     * and stays at the current altitude if higher than the return altitude. Then it returns to the
-     * home location and lands there.
-     *
-     * @param relative_altitude_m Return altitude relative to takeoff location, in meters.
      * @return Result of request.
      */
-    Result set_return_to_launch_return_altitude(float relative_altitude_m);
+    std::pair<Result, float> get_maximum_speed() const;
+
 
     /**
-     * @brief Get the return to launch minimum return altitude.
-     *
-     * @sa `set_return_to_launch_return_altitude`.
-     *
-     * @return A pair containing the result of the request and if successful, the
-     * return altitude relative to takeoff location, in meters.
+     * @brief Set vehicle maximum speed (in metres/second).
      */
-    std::pair<Result, float> get_return_to_launch_return_altitude() const;
+    void set_maximum_speed_async(float speed, const result_callback_t callback);
 
     /**
-     * @brief Returns a human-readable English string for an Result.
+     * @brief Synchronous wrapper for set_maximum_speed_async().
+     *
+     * @return Result of request.
+     */
+    Result set_maximum_speed(float speed) const;
+
+
+    /**
+    * @brief Callback type for get_return_to_launch_altitude_async.
+    */
+    typedef std::function<void(Result, float)> relative_altitude_m_callback_t;
+
+    /**
+     * @brief Get the return to launch minimum return altitude (in meters).
+     */
+    void get_return_to_launch_altitude_async(const relative_altitude_m_callback_t callback);
+
+    /**
+     * @brief Synchronous wrapper for get_return_to_launch_altitude_async().
+     *
+     * @return Result of request.
+     */
+    std::pair<Result, float> get_return_to_launch_altitude() const;
+
+
+    /**
+     * @brief Set the return to launch minimum return altitude (in meters).
+     */
+    void set_return_to_launch_altitude_async(float relative_altitude_m, const result_callback_t callback);
+
+    /**
+     * @brief Synchronous wrapper for set_return_to_launch_altitude_async().
+     *
+     * @return Result of request.
+     */
+    Result set_return_to_launch_altitude(float relative_altitude_m) const;
+
+
+
+
+    /**
+     * @brief Returns a human-readable English string for a Result.
      *
      * @param result The enum value for which a human readable string is required.
      * @return Human readable string for the Result.
      */
     static const char* result_str(Result result);
 
+
     /**
      * @brief Copy constructor (object is not copyable).
      */
     Action(const Action&) = delete;
+
     /**
      * @brief Equality operator (object is not copyable).
      */

--- a/src/plugins/action/mocks/action_mock.h
+++ b/src/plugins/action/mocks/action_mock.h
@@ -12,16 +12,18 @@ public:
     MOCK_CONST_METHOD0(takeoff, Action::Result()){};
     MOCK_CONST_METHOD0(land, Action::Result()){};
     MOCK_CONST_METHOD0(reboot, Action::Result()){};
+    MOCK_CONST_METHOD0(shutdown, Action::Result()){};
+    MOCK_CONST_METHOD4(goto_location, Action::Result(double, double, float, float)){};
     MOCK_CONST_METHOD0(kill, Action::Result()){};
     MOCK_CONST_METHOD0(return_to_launch, Action::Result()){};
     MOCK_CONST_METHOD0(transition_to_fixedwing, Action::Result()){};
     MOCK_CONST_METHOD0(transition_to_multicopter, Action::Result()){};
     MOCK_CONST_METHOD0(get_takeoff_altitude, std::pair<Action::Result, float>()){};
     MOCK_CONST_METHOD1(set_takeoff_altitude, Action::Result(float)){};
-    MOCK_CONST_METHOD0(get_max_speed, std::pair<Action::Result, float>()){};
-    MOCK_CONST_METHOD1(set_max_speed, Action::Result(float)){};
-    MOCK_CONST_METHOD0(get_return_to_launch_return_altitude, std::pair<Action::Result, float>()){};
-    MOCK_CONST_METHOD1(set_return_to_launch_return_altitude, Action::Result(float)){};
+    MOCK_CONST_METHOD0(get_maximum_speed, std::pair<Action::Result, float>()){};
+    MOCK_CONST_METHOD1(set_maximum_speed, Action::Result(float)){};
+    MOCK_CONST_METHOD0(get_return_to_launch_altitude, std::pair<Action::Result, float>()){};
+    MOCK_CONST_METHOD1(set_return_to_launch_altitude, Action::Result(float)){};
 };
 
 } // namespace testing

--- a/templates/mavsdk_server/call.j2
+++ b/templates/mavsdk_server/call.j2
@@ -1,0 +1,20 @@
+grpc::Status {{ name.upper_camel_case }}(
+    grpc::ServerContext* /* context */,
+    const rpc::{{ plugin_name.lower_snake_case }}::{{ name.upper_camel_case }}Request* {% if not params -%} /* request */ {%- else -%} request {%- endif -%},
+    rpc::{{ plugin_name.lower_snake_case }}::{{ name.upper_camel_case }}Response* response) override
+{
+    {% if params -%}
+    if (request == nullptr) {
+        LogWarn() << "{{ name.upper_camel_case }} sent with a null request! Ignoring...";
+        return grpc::Status::OK;
+    }
+    {%- endif %}
+
+    auto result = _{{ plugin_name.lower_snake_case }}.{{ name.lower_snake_case }}({% for param in params %}request->{{ param.name.lower_snake_case }}(){{ ", " if not loop.last }}{% endfor %});
+
+    if (response != nullptr) {
+        fillResponseWithResult(response, result);
+    }
+
+    return grpc::Status::OK;
+}

--- a/templates/mavsdk_server/enum.j2
+++ b/templates/mavsdk_server/enum.j2
@@ -1,0 +1,11 @@
+static rpc::{{ plugin_name.lower_snake_case }}::{% if parent_struct %}{{ parent_struct.upper_camel_case }}::{% endif %}{{ name.upper_camel_case }} translateToRpc{{ name.upper_camel_case }}(const mavsdk::{{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}& {{ name.lower_camel_case }})
+{
+    switch ({{ name.lower_camel_case }}) {
+        {%- for value in values %}
+        case mavsdk::{{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}::{{ value.name.upper_camel_case }}:
+            return rpc::{{ plugin_name.lower_snake_case }}::{% if parent_struct %}{{ parent_struct.upper_camel_case }}_{% endif %}{{ name.upper_camel_case }}_{{ value.name.uppercase }};
+        {%- endfor %}
+        default:
+            return rpc::{{ plugin_name.lower_snake_case }}::{% if parent_struct %}{{ parent_struct.upper_camel_case }}_{% endif %}{{ name.upper_camel_case }}_UNKNOWN;
+    }
+}

--- a/templates/mavsdk_server/file.j2
+++ b/templates/mavsdk_server/file.j2
@@ -1,0 +1,48 @@
+#include "{{ plugin_name.lower_snake_case }}/{{ plugin_name.lower_snake_case }}.grpc.pb.h"
+#include "plugins/{{ plugin_name.lower_snake_case }}/{{ plugin_name.lower_snake_case }}.h"
+
+#include "log.h"
+
+namespace {{ package.lower_snake_case.split('.')[0] }} {
+namespace backend {
+
+template<typename {{ plugin_name.upper_camel_case }} = {{ plugin_name.upper_camel_case }}>
+class {{ plugin_name.upper_camel_case }}ServiceImpl final : public rpc::{{ plugin_name.lower_snake_case }}::{{ plugin_name.upper_camel_case }}Service::Service {
+public:
+    {{ plugin_name.upper_camel_case }}ServiceImpl({{ plugin_name.upper_camel_case }}& {{ plugin_name.lower_snake_case }}) : _{{ plugin_name.lower_snake_case }}({{ plugin_name.lower_snake_case }}) {}
+
+{% if has_result %}
+    template<typename ResponseType>
+    void fillResponseWithResult(ResponseType* response, mavsdk::{{ plugin_name.upper_camel_case }}::Result& result) const
+    {
+        auto rpc_result = translateToRpcResult(result);
+
+        auto* rpc_{{ plugin_name.lower_snake_case }}_result = new rpc::{{ plugin_name.lower_snake_case }}::{{ plugin_name.upper_camel_case }}Result();
+        rpc_{{ plugin_name.lower_snake_case }}_result->set_result(rpc_result);
+        rpc_{{ plugin_name.lower_snake_case }}_result->set_result_str(mavsdk::{{ plugin_name.upper_camel_case }}::result_str(result));
+
+        response->set_allocated_action_result(rpc_{{ plugin_name.lower_snake_case }}_result);
+    }
+{% endif %}
+
+{% for enum in enums -%}
+{{ indent(enum, 1) }}
+
+{% endfor -%}
+
+{% for struct in structs -%}
+{{ indent(struct, 1) }}
+
+{% endfor -%}
+
+{% for method in methods -%}
+{{ indent(method, 1) }}
+
+{% endfor -%}
+
+private:
+    {{ plugin_name.upper_camel_case }} &_{{ plugin_name.lower_snake_case }};
+};
+
+} // namespace backend
+} // namespace {{ package.lower_snake_case.split('.')[0] }}

--- a/templates/mavsdk_server/request.j2
+++ b/templates/mavsdk_server/request.j2
@@ -1,0 +1,21 @@
+grpc::Status {{ name.upper_camel_case }}(
+    grpc::ServerContext * /* context */,
+    const rpc::{{ plugin_name.lower_snake_case }}::{{ name.upper_camel_case }}Request* {% if not params -%} /* request */ {%- else -%} request {%- endif -%},
+    rpc::{{ plugin_name.lower_snake_case }}::{{ name.upper_camel_case }}Response* response) override
+{
+    {% if params -%}
+    if (request == nullptr) {
+        LogWarn() << "{{ name.upper_camel_case }} sent with a null request! Ignoring...";
+        return grpc::Status::OK;
+    }
+    {%- endif %}
+
+    auto result_pair = _{{ plugin_name.lower_snake_case }}.{{ name.lower_snake_case }}({% for param in params %}request->{{ param.name.lower_snake_case() }}(){{ ", " if not loop.last }}{% endfor %});
+
+    if (response != nullptr) {
+        fillResponseWithResult(response, result_pair.first);
+        response->set_{{ return_name.lower_snake_case }}(result_pair.second);
+    }
+
+    return grpc::Status::OK;
+}

--- a/templates/mavsdk_server/stream.j2
+++ b/templates/mavsdk_server/stream.j2
@@ -1,0 +1,21 @@
+grpc::Status {{ name.upper_camel_case }}(grpc::ServerContext * /* context */, const rpc::{{ plugin_name.lower_snake_case }}::{{ name.upper_camel_case }}Request {% if params.empty -%} * /* request */ {%- else -%} *request {%- endif -%}, grpc::ServerWriter<rpc::{{ plugin_name.lower_snake_case }}::{{ name.upper_camel_case }}Response> *writer) override
+{
+    std::promise<void> stream_closed_promise;
+    auto stream_closed_future = stream_closed_promise.get_future();
+
+    bool is_finished = false;
+
+    _{{ plugin_name.lower_snake_case }}.{{ name.lower_snake_case }}_async([this, &writer, &stream_closed_promise, &is_finished](const {{ package.lower_snake_case.split('.')[0] }}::{{ plugin_name.upper_camel_case }}::Result result, const float progress, const std::string &status_text) {
+        rpc::{{ plugin_name.lower_snake_case }}::{{ name.upper_camel_case }}Response rpc_response;
+        rpc_response.set_allocated_{{ plugin_name.lower_snake_case }}_result(translate{{ plugin_name.upper_camel_case }}Result(result).get());
+
+        std::lock_guard<std::mutex> lock(_subscribe_mutex);
+        if (!writer->Write(rpc_response) && !is_finished) {
+            is_finished = true;
+            stream_closed_promise.set_value();
+        }
+    });
+
+    stream_closed_future.wait();
+    return grpc::Status::OK;
+}

--- a/templates/mavsdk_server/struct.j2
+++ b/templates/mavsdk_server/struct.j2
@@ -1,0 +1,16 @@
+{% for nested_enum in nested_enums %}
+{{ nested_enums[nested_enum] }}
+{% endfor %}
+
+{% if not name.upper_camel_case.endswith('Result') -%}
+static std::unique_ptr<rpc::{{ plugin_name.lower_snake_case }}::{{ name.upper_camel_case }}> translate{{ name.upper_camel_case }}(const {{ package.lower_snake_case.split('.')[0] }}::{{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }} &{{ name.lower_snake_case }})
+{
+    auto rpc_{{ name.lower_snake_case }} = std::unique_ptr<rpc::{{ plugin_name.lower_snake_case }}::{{ name.upper_camel_case }}>(new rpc::{{ plugin_name.lower_snake_case }}::{{ name.upper_camel_case }}());
+
+{% for field in fields %}
+    rpc_{{ name.lower_snake_case }}->set_{{ field.name.lower_snake_case }}({{ name.lower_snake_case }}.{{ field.name.lower_snake_case }});
+{%- endfor %}
+
+    return rpc_{{ name.lower_snake_case }};
+}
+{% endif %}

--- a/templates/plugin_cpp/call.j2
+++ b/templates/plugin_cpp/call.j2
@@ -1,0 +1,9 @@
+void {{ plugin_name.upper_camel_case }}::{{ name.lower_snake_case }}_async({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}, {% endfor %}const result_callback_t callback)
+{
+    _impl->{{ name.lower_snake_case }}_async({% for param in params %}{{ param.name.lower_snake_case }}, {% endfor %}callback);
+}
+
+{{ plugin_name.upper_camel_case }}::Result {{ plugin_name.upper_camel_case }}::{{ name.lower_snake_case }}({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}{{ ", " if not loop.last }}{% endfor %}) const
+{
+    return _impl->{{ name.lower_snake_case }}({% for param in params %}{{ param.name.lower_snake_case }}{{ ", " if not loop.last }}{% endfor %});
+}

--- a/templates/plugin_cpp/enum.j2
+++ b/templates/plugin_cpp/enum.j2
@@ -1,0 +1,13 @@
+{% if name.upper_camel_case.endswith('Result') -%}
+const char* {{ plugin_name.upper_camel_case }}::result_str({{ plugin_name.upper_camel_case }}::Result result)
+{
+    switch (result) {
+        {%- for value in values %}
+        case {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}::{{ value.name.upper_camel_case }}:
+            return "{{ value.description[1:].rstrip() }}";
+        {%- endfor %}
+        default:
+            return "Unknown";
+    }
+}
+{% endif %}

--- a/templates/plugin_cpp/file.j2
+++ b/templates/plugin_cpp/file.j2
@@ -1,0 +1,18 @@
+#include "{{ plugin_name.lower_snake_case }}_impl.h"
+#include "plugins/{{ plugin_name.lower_snake_case }}/{{ plugin_name.lower_snake_case }}.h"
+
+namespace mavsdk {
+
+{{ plugin_name.upper_camel_case }}::{{ plugin_name.upper_camel_case }}(System& system) : PluginBase(), _impl{new {{ plugin_name.upper_camel_case }}Impl(system)} {}
+
+{{ plugin_name.upper_camel_case }}::~{{ plugin_name.upper_camel_case }}() {}
+
+{% for method in methods %}
+{{ method }}
+{% endfor %}
+
+{% for struct in structs %}
+{{ struct }}
+{% endfor %}
+
+} // namespace mavsdk

--- a/templates/plugin_cpp/request.j2
+++ b/templates/plugin_cpp/request.j2
@@ -1,0 +1,9 @@
+void {{ plugin_name.upper_camel_case }}::{{ name.lower_snake_case }}_async({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}, {% endfor %}const {{ return_name.lower_snake_case }}_callback_t callback)
+{
+    _impl->{{ name.lower_snake_case }}_async({% for param in params %}{{ param.name.lower_snake_case }}, {% endfor %}callback);
+}
+
+std::pair<{{ plugin_name.upper_camel_case }}::Result, {{ return_type.name }}> {{ plugin_name.upper_camel_case }}::{{ name.lower_snake_case }}({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}{{ ", " if not loop.last }}{% endfor %}) const
+{
+    return _impl->{{ name.lower_snake_case }}({% for param in params %}{{ param.name.lower_snake_case }}{{ ", " if not loop.last }}{% endfor %});
+}

--- a/templates/plugin_cpp/stream.j2
+++ b/templates/plugin_cpp/stream.j2
@@ -1,0 +1,9 @@
+void {{ plugin_name.upper_camel_case }}::{{ name.lower_snake_case }}_async({{ return_name.lower_snake_case }}_callback_t callback)
+{
+    _impl->{{ name.lower_snake_case }}_async(callback);
+}
+
+{{ plugin_name.upper_camel_case }}::{{ return_type.name }} {{ plugin_name.upper_camel_case }}::{{ name.lower_snake_case }}() const
+{
+    return _impl->{{ name.lower_snake_case }}();
+}

--- a/templates/plugin_cpp/struct.j2
+++ b/templates/plugin_cpp/struct.j2
@@ -1,0 +1,3 @@
+{% for nested_enum in nested_enums %}
+{{ nested_enums[nested_enum] }}
+{% endfor %}

--- a/templates/plugin_h/call.j2
+++ b/templates/plugin_h/call.j2
@@ -1,0 +1,11 @@
+/**
+ * @brief {{ method_description | replace('\n', '\n *')}}
+ */
+void {{ name.lower_snake_case }}_async({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}, {% endfor %}const result_callback_t callback);
+
+/**
+ * @brief Synchronous wrapper for {{ name.lower_snake_case }}_async().
+ *
+ * @return Result of request.
+ */
+Result {{ name.lower_snake_case }}({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}{{ ", " if not loop.last }}{% endfor %}) const;

--- a/templates/plugin_h/enum.j2
+++ b/templates/plugin_h/enum.j2
@@ -1,0 +1,8 @@
+/**
+ * @brief {{ enum_description | replace('\n', '\n *')}}
+ */
+enum class {{ name.upper_camel_case }} {
+{%- for value in values %}
+    {{ value.name.upper_camel_case }}, /**< @brief{{ value.description.rstrip() }}. */
+{%- endfor %}
+};

--- a/templates/plugin_h/file.j2
+++ b/templates/plugin_h/file.j2
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <array>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <string>
+
+#include "plugin_base.h"
+
+namespace mavsdk {
+
+class System;
+class {{ plugin_name.upper_camel_case }}Impl;
+
+/**
+ * @brief {{ class_description | replace('\n', '\n *')}}
+ */
+class {{ plugin_name.upper_camel_case }} : public PluginBase {
+public:
+    /**
+     * @brief Constructor. Creates the plugin for a specific System.
+     *
+     * The plugin is typically created as shown below:
+     *
+     *     ```cpp
+     *     auto {{ plugin_name.lower_snake_case }} = std::make_shared<{{ plugin_name.upper_camel_case }}>(system);
+     *     ```
+     *
+     * @param system The specific system associated with this plugin.
+     */
+    explicit {{ plugin_name.upper_camel_case }}(System& system);
+
+    /**
+     * @brief Destructor (internal use only).
+     */
+    ~{{ plugin_name.upper_camel_case }}();
+
+{%- for struct in structs %}
+{{ indent(struct, 1) }}
+
+{% endfor -%}
+
+{% for enum in enums -%}
+{{ indent(enum, 1) }}
+
+{% endfor %}
+
+{% if has_result %}
+    /**
+     * @brief Callback type for asynchronous {{ plugin_name.upper_camel_case }} calls.
+     */
+    typedef std::function<void(Result)> result_callback_t;
+{% endif %}
+
+{% for method in methods %}
+{{ indent(method, 1) }}
+
+{% endfor %}
+
+{% if has_result %}
+    /**
+     * @brief Returns a human-readable English string for a Result.
+     *
+     * @param result The enum value for which a human readable string is required.
+     * @return Human readable string for the Result.
+     */
+    static const char* result_str(Result result);
+{% endif %}
+
+    /**
+     * @brief Copy constructor (object is not copyable).
+     */
+    {{ plugin_name.upper_camel_case }}(const {{ plugin_name.upper_camel_case }}&) = delete;
+
+    /**
+     * @brief Equality operator (object is not copyable).
+     */
+    const {{ plugin_name.upper_camel_case }}& operator=(const {{ plugin_name.upper_camel_case }}&) = delete;
+
+private:
+    /** @private Underlying implementation, set at instantiation */
+    std::unique_ptr<{{ plugin_name.upper_camel_case }}Impl> _impl;
+};
+
+} // namespace mavsdk

--- a/templates/plugin_h/request.j2
+++ b/templates/plugin_h/request.j2
@@ -1,0 +1,16 @@
+/**
+* @brief Callback type for {{ name.lower_snake_case }}_async.
+*/
+typedef std::function<void({% if has_result %}Result, {% endif %}{{ return_type.name }})> {{ return_name.lower_snake_case }}_callback_t;
+
+/**
+ * @brief {{ method_description | replace('\n', '\n *')}}
+ */
+void {{ name.lower_snake_case }}_async({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}, {% endfor %}const {{ return_name.lower_snake_case }}_callback_t callback);
+
+/**
+ * @brief Synchronous wrapper for {{ name.lower_snake_case }}_async().
+ *
+ * @return Result of request.
+ */
+std::pair<Result, {{ return_type.name }}> {{ name.lower_snake_case }}({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}{{ ", " if not loop.last }}{% endfor %}) const;

--- a/templates/plugin_h/stream.j2
+++ b/templates/plugin_h/stream.j2
@@ -1,0 +1,16 @@
+/**
+* @brief Callback type for {{ name.lower_snake_case }}_async.
+*/
+typedef std::function<void({{ return_type.name }})> {{ return_name.lower_snake_case }}_callback_t;
+
+/**
+ * @brief {{ method_description | replace('\n', '\n *')}}
+ */
+void {{ name.lower_snake_case }}_async({{ return_name.lower_snake_case }}_callback_t callback);
+
+/**
+ * @brief Synchronous wrapper getting one {{ return_type.name }} update.
+ *
+ * @return One {{ return_type.name }} update.
+ */
+{{ return_type.name }} {{ name.lower_snake_case }}() const;

--- a/templates/plugin_h/struct.j2
+++ b/templates/plugin_h/struct.j2
@@ -1,0 +1,14 @@
+{% for nested_enum in nested_enums %}
+{{ nested_enums[nested_enum] }}
+{% endfor %}
+
+{% if not name.upper_camel_case.endswith('Result') -%}
+/**
+ * @brief {{ struct_description | replace('\n', '\n *')}}
+ */
+struct {{ name.upper_camel_case }} {
+    {% for field in fields -%}
+    {{ field.type_info.name }} {{ field.name.lower_snake_case }} /**< @brief{{ field.description.rstrip() }} */
+    {% endfor %}
+};
+{% endif %}


### PR DESCRIPTION
This is the first step towards auto-generating the C++ headers and `mavsdk_server`. This PR adds auto-generation for the action plugin.

This PR has been tested by running the `mavsdk_server` unit tests and manually testing control from MAVSDK-Python.