### PR TITLE
Update examples based on recent Action class renaming

### DIFF
--- a/examples/fly_mission/fly_mission.cpp
+++ b/examples/fly_mission/fly_mission.cpp
@@ -274,7 +274,7 @@ int main(int argc, char** argv)
         // We are done, and can do RTL to go home.
         std::cout << "Commanding RTL..." << std::endl;
         const Action::Result result = action->return_to_launch();
-        if (result != Action::Result::SUCCESS) {
+        if (result != Action::Result::Success) {
             std::cout << "Failed to command RTL (" << Action::result_str(result) << ")"
                       << std::endl;
         } else {
@@ -314,7 +314,7 @@ std::shared_ptr<MissionItem> make_mission_item(
 
 inline void handle_action_err_exit(Action::Result result, const std::string& message)
 {
-    if (result != Action::Result::SUCCESS) {
+    if (result != Action::Result::Success) {
         std::cerr << ERROR_CONSOLE_TEXT << message << Action::result_str(result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);

--- a/examples/fly_multiple_drones/fly_multiple_drones.cpp
+++ b/examples/fly_multiple_drones/fly_multiple_drones.cpp
@@ -249,7 +249,7 @@ void complete_mission(std::string qgc_plan, System& system)
         // Mission complete. Command RTL to go home.
         std::cout << "Commanding RTL..." << std::endl;
         const Action::Result result = action->return_to_launch();
-        if (result != Action::Result::SUCCESS) {
+        if (result != Action::Result::Success) {
             std::cout << "Failed to command RTL (" << Action::result_str(result) << ")"
                       << std::endl;
         } else {
@@ -260,7 +260,7 @@ void complete_mission(std::string qgc_plan, System& system)
 
 static void handle_action_err_exit(Action::Result result, const std::string& message)
 {
-    if (result != Action::Result::SUCCESS) {
+    if (result != Action::Result::Success) {
         std::cerr << ERROR_CONSOLE_TEXT << message << Action::result_str(result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);

--- a/examples/fly_qgc_mission/fly_qgc_mission.cpp
+++ b/examples/fly_qgc_mission/fly_qgc_mission.cpp
@@ -178,7 +178,7 @@ int main(int argc, char** argv)
         // Mission complete. Command RTL to go home.
         std::cout << "Commanding RTL..." << std::endl;
         const Action::Result result = action->return_to_launch();
-        if (result != Action::Result::SUCCESS) {
+        if (result != Action::Result::Success) {
             std::cout << "Failed to command RTL (" << Action::result_str(result) << ")"
                       << std::endl;
         } else {
@@ -191,7 +191,7 @@ int main(int argc, char** argv)
 
 inline void handle_action_err_exit(Action::Result result, const std::string& message)
 {
-    if (result != Action::Result::SUCCESS) {
+    if (result != Action::Result::Success) {
         std::cerr << ERROR_CONSOLE_TEXT << message << Action::result_str(result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);

--- a/examples/follow_me/follow_me.cpp
+++ b/examples/follow_me/follow_me.cpp
@@ -148,7 +148,7 @@ int main(int argc, char** argv)
 // Handles Action's result
 inline void action_error_exit(Action::Result result, const std::string& message)
 {
-    if (result != Action::Result::SUCCESS) {
+    if (result != Action::Result::Success) {
         std::cerr << ERROR_CONSOLE_TEXT << message << Action::result_str(result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);

--- a/examples/mavlink_ftp_server/mavlink_ftp_server.cpp
+++ b/examples/mavlink_ftp_server/mavlink_ftp_server.cpp
@@ -38,7 +38,8 @@ int main(int argc, char** argv)
     }
 
     Mavsdk mavsdk;
-    mavsdk.set_configuration(Mavsdk::Configuration::CompanionComputer);
+    Mavsdk::Configuration configuration(Mavsdk::Configuration::UsageType::CompanionComputer);
+    mavsdk.set_configuration(configuration);
     ConnectionResult connection_result = mavsdk.setup_udp_remote(argv[1], std::stoi(argv[2]));
     if (connection_result != ConnectionResult::SUCCESS) {
         std::cout << ERROR_CONSOLE_TEXT << "Error setting up Mavlink FTP server." << std::endl;

--- a/examples/multiple_drones/multiple_drones.cpp
+++ b/examples/multiple_drones/multiple_drones.cpp
@@ -112,7 +112,7 @@ void takeoff_and_land(System& system)
     std::cout << "Arming..." << std::endl;
     const Action::Result arm_result = action->arm();
 
-    if (arm_result != Action::Result::SUCCESS) {
+    if (arm_result != Action::Result::Success) {
         std::cerr << ERROR_CONSOLE_TEXT << "Arming failed:" << Action::result_str(arm_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
     }
@@ -120,7 +120,7 @@ void takeoff_and_land(System& system)
     // Take off
     std::cout << "Taking off..." << std::endl;
     const Action::Result takeoff_result = action->takeoff();
-    if (takeoff_result != Action::Result::SUCCESS) {
+    if (takeoff_result != Action::Result::Success) {
         std::cerr << ERROR_CONSOLE_TEXT << "Takeoff failed:" << Action::result_str(takeoff_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
     }
@@ -130,7 +130,7 @@ void takeoff_and_land(System& system)
 
     std::cout << "Landing..." << std::endl;
     const Action::Result land_result = action->land();
-    if (land_result != Action::Result::SUCCESS) {
+    if (land_result != Action::Result::Success) {
         std::cerr << ERROR_CONSOLE_TEXT << "Land failed:" << Action::result_str(land_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
     }

--- a/examples/offboard_velocity/offboard_velocity.cpp
+++ b/examples/offboard_velocity/offboard_velocity.cpp
@@ -31,7 +31,7 @@ using std::this_thread::sleep_for;
 // Handles Action's result
 inline void action_error_exit(Action::Result result, const std::string& message)
 {
-    if (result != Action::Result::SUCCESS) {
+    if (result != Action::Result::Success) {
         std::cerr << ERROR_CONSOLE_TEXT << message << Action::result_str(result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);

--- a/examples/takeoff_land/takeoff_and_land.cpp
+++ b/examples/takeoff_land/takeoff_and_land.cpp
@@ -112,7 +112,7 @@ int main(int argc, char** argv)
     std::cout << "Arming..." << std::endl;
     const Action::Result arm_result = action->arm();
 
-    if (arm_result != Action::Result::SUCCESS) {
+    if (arm_result != Action::Result::Success) {
         std::cout << ERROR_CONSOLE_TEXT << "Arming failed:" << Action::result_str(arm_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
@@ -121,7 +121,7 @@ int main(int argc, char** argv)
     // Take off
     std::cout << "Taking off..." << std::endl;
     const Action::Result takeoff_result = action->takeoff();
-    if (takeoff_result != Action::Result::SUCCESS) {
+    if (takeoff_result != Action::Result::Success) {
         std::cout << ERROR_CONSOLE_TEXT << "Takeoff failed:" << Action::result_str(takeoff_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
@@ -132,7 +132,7 @@ int main(int argc, char** argv)
 
     std::cout << "Landing..." << std::endl;
     const Action::Result land_result = action->land();
-    if (land_result != Action::Result::SUCCESS) {
+    if (land_result != Action::Result::Success) {
         std::cout << ERROR_CONSOLE_TEXT << "Land failed:" << Action::result_str(land_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;

--- a/examples/transition_vtol_fixed_wing/transition_vtol_fixed_wing.cpp
+++ b/examples/transition_vtol_fixed_wing/transition_vtol_fixed_wing.cpp
@@ -74,7 +74,7 @@ int main(int argc, char** argv)
     std::cout << "Arming." << std::endl;
     const Action::Result arm_result = action->arm();
 
-    if (arm_result != Action::Result::SUCCESS) {
+    if (arm_result != Action::Result::Success) {
         std::cout << ERROR_CONSOLE_TEXT << "Arming failed: " << Action::result_str(arm_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
@@ -83,7 +83,7 @@ int main(int argc, char** argv)
     // Take off
     std::cout << "Taking off." << std::endl;
     const Action::Result takeoff_result = action->takeoff();
-    if (takeoff_result != Action::Result::SUCCESS) {
+    if (takeoff_result != Action::Result::Success) {
         std::cout << ERROR_CONSOLE_TEXT << "Takeoff failed:n" << Action::result_str(takeoff_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
@@ -95,7 +95,7 @@ int main(int argc, char** argv)
     std::cout << "Transition to fixedwing." << std::endl;
     const Action::Result fw_result = action->transition_to_fixedwing();
 
-    if (fw_result != Action::Result::SUCCESS) {
+    if (fw_result != Action::Result::Success) {
         std::cout << ERROR_CONSOLE_TEXT
                   << "Transition to fixed wing failed: " << Action::result_str(fw_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
@@ -109,7 +109,7 @@ int main(int argc, char** argv)
     std::cout << "Sending it to location." << std::endl;
     // We pass latitude and longitude but leave altitude and yaw unset by passing NAN.
     const Action::Result goto_result = action->goto_location(47.3633001, 8.5428515, NAN, NAN);
-    if (goto_result != Action::Result::SUCCESS) {
+    if (goto_result != Action::Result::Success) {
         std::cout << ERROR_CONSOLE_TEXT
                   << "Goto command failed: " << Action::result_str(goto_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
@@ -122,7 +122,7 @@ int main(int argc, char** argv)
     // Let's stop before reaching the goto point and go back to hover.
     std::cout << "Transition back to multicopter..." << std::endl;
     const Action::Result mc_result = action->transition_to_multicopter();
-    if (mc_result != Action::Result::SUCCESS) {
+    if (mc_result != Action::Result::Success) {
         std::cout << ERROR_CONSOLE_TEXT
                   << "Transition to multi copter failed: " << Action::result_str(mc_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
@@ -135,7 +135,7 @@ int main(int argc, char** argv)
     // Now just land here.
     std::cout << "Landing..." << std::endl;
     const Action::Result land_result = action->land();
-    if (land_result != Action::Result::SUCCESS) {
+    if (land_result != Action::Result::Success) {
         std::cout << ERROR_CONSOLE_TEXT << "Land failed: " << Action::result_str(land_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;

--- a/src/plugins/follow_me/include/plugins/follow_me/follow_me.h
+++ b/src/plugins/follow_me/include/plugins/follow_me/follow_me.h
@@ -21,7 +21,7 @@ class System;
  * the vehicle. Applications must get target position information from the underlying platform (or
  * some other source).
  *
- * @sa [Follow Me Mode](https://docs.px4.io/en/flight_modes/follow_me.html) (PX4 User Guide)
+ * @sa [Follow Me Mode](https://docs.px4.io/master/en/flight_modes/follow_me.html) (PX4 User Guide)
  *
  */
 class FollowMe : public PluginBase {
@@ -64,7 +64,7 @@ public:
      * @brief FollowMe Configuration.
      * @sa get_config(), set_config()
      * @sa [Parameter
-     * Reference](https://docs.px4.io/en/advanced_config/parameter_reference.html#follow-target)
+     * Reference](https://docs.px4.io/master/en/advanced_config/parameter_reference.html#follow-target)
      * (PX4 User Guide)
      */
     struct Config {


### PR DESCRIPTION
When Action got changed with the autogeneration of gRPC bindings, etc, Action::Result enum values changed from uppercase to title case - this PR reflects those changes in the examples. It also fixes the mavlink_ftp_server example, which was broken when I implemented the new Configuration system a short while back.