### PR TITLE
Don't respond to timesync until time known

### DIFF
--- a/src/core/timesync.cpp
+++ b/src/core/timesync.cpp
@@ -42,7 +42,7 @@ void Timesync::process_timesync(const mavlink_message_t& message)
                          _parent.get_autopilot_time().now().time_since_epoch())
                          .count();
 
-    if (timesync.tc1 == 0) {
+    if (timesync.tc1 == 0 && _autopilot_timesync_acquired) {
         // Send synced time to remote system
         send_timesync(now_ns, timesync.ts1);
     } else if (timesync.tc1 > 0) {
@@ -75,6 +75,7 @@ void Timesync::set_timesync_offset(int64_t offset_ns, uint64_t start_transfer_lo
 
         // Save time offset for other components to use
         _parent.get_autopilot_time().shift_time_by(std::chrono::nanoseconds(offset_ns));
+        _autopilot_timesync_acquired = true;
 
         // Reset high RTT count after filter update
         _high_rtt_count = 0;

--- a/src/core/timesync.cpp
+++ b/src/core/timesync.cpp
@@ -27,6 +27,8 @@ void Timesync::do_work()
                                   _parent.get_autopilot_time().now().time_since_epoch())
                                   .count();
             send_timesync(0, now_ns);
+        } else {
+            _autopilot_timesync_acquired = false;
         }
         _last_time = _parent.get_time().steady_time();
     }

--- a/src/core/timesync.h
+++ b/src/core/timesync.h
@@ -30,5 +30,6 @@ private:
     static constexpr uint64_t _MAX_CONS_HIGH_RTT = 5;
     static constexpr uint64_t _MAX_RTT_SAMPLE_MS = 10;
     uint64_t _high_rtt_count{};
+    bool _autopilot_timesync_acquired = false;
 };
 } // namespace mavsdk


### PR DESCRIPTION
The timesync protocol expects clock offsets to be constant (or at least have constant skew), however the MAVSDK has an initial big change when syncing with the flight controller. This can confuse other systems on the mavlink network.

This prevents the MAVSDK from responding to other timesync messages until its own timesync with the autopilot time has been determined.

This is a ~~fix~~ cover up for #1033 . The real fix is to allow the flight controller, MAVROS, etc to have multiple different external systems timesynced at the same time.

FYI @irsdkv  @DanielePettenuzzo @JonasVautherin 

Fixes #1033.