### PR TITLE
Handle the enum prefix logic in the protoc plugin

### DIFF
--- a/templates/mavsdk_server/enum.j2
+++ b/templates/mavsdk_server/enum.j2
@@ -6,11 +6,11 @@ static rpc::{{ plugin_name.lower_snake_case }}::{% if parent_struct %}{{ parent_
         default:
             LogErr() << "Unknown {{ name.lower_snake_case }} enum value: " << static_cast<int>({{ name.lower_snake_case }});
         // FALLTHROUGH
-        case mavsdk::{{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}::{% set value_without_prefix = value.name.lower_camel_case[name.lower_camel_case|length:] %}{{ value_without_prefix }}:
-            return rpc::{{ plugin_name.lower_snake_case }}::{% if parent_struct %}{{ parent_struct.upper_camel_case }}_{{ name.upper_camel_case }}_{% endif %}{{ value.name.uppercase }};
+        case mavsdk::{{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}::{{ value.name.upper_camel_case }}:
+            return rpc::{{ plugin_name.lower_snake_case }}::{% if parent_struct %}{{ parent_struct.upper_camel_case }}_{{ name.upper_camel_case }}_{% endif %}{{ name.uppercase }}_{{ value.name.uppercase }};
         {%- else %}
-        case mavsdk::{{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}::{% set value_without_prefix = value.name.lower_camel_case[name.lower_camel_case|length:] %}{{ value_without_prefix }}:
-            return rpc::{{ plugin_name.lower_snake_case }}::{% if parent_struct %}{{ parent_struct.upper_camel_case }}_{{ name.upper_camel_case }}_{% endif %}{{ value.name.uppercase }};
+        case mavsdk::{{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}::{{ value.name.upper_camel_case }}:
+            return rpc::{{ plugin_name.lower_snake_case }}::{% if parent_struct %}{{ parent_struct.upper_camel_case }}_{{ name.upper_camel_case }}_{% endif %}{{ name.uppercase }}_{{ value.name.uppercase }};
         {%- endif %}
         {%- endfor %}
     }
@@ -24,11 +24,11 @@ static mavsdk::{{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }} t
         default:
             LogErr() << "Unknown {{ name.lower_snake_case }} enum value: " << static_cast<int>({{ name.lower_snake_case }});
         // FALLTHROUGH
-        case rpc::{{ plugin_name.lower_snake_case }}::{% if parent_struct %}{{ parent_struct.upper_camel_case }}_{{ name.upper_camel_case }}_{% endif %}{{ value.name.uppercase }}:
-            return mavsdk::{{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}::{% set value_without_prefix = value.name.lower_camel_case[name.lower_camel_case|length:] %}{{ value_without_prefix }};
+        case rpc::{{ plugin_name.lower_snake_case }}::{% if parent_struct %}{{ parent_struct.upper_camel_case }}_{{ name.upper_camel_case }}_{% endif %}{{ name.uppercase }}_{{ value.name.uppercase }}:
+            return mavsdk::{{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}::{{ value.name.upper_camel_case }};
         {%- else %}
-        case rpc::{{ plugin_name.lower_snake_case }}::{% if parent_struct %}{{ parent_struct.upper_camel_case }}_{{ name.upper_camel_case }}_{% endif %}{{ value.name.uppercase }}:
-            return mavsdk::{{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}::{% set value_without_prefix = value.name.lower_camel_case[name.lower_camel_case|length:] %}{{ value_without_prefix }};
+        case rpc::{{ plugin_name.lower_snake_case }}::{% if parent_struct %}{{ parent_struct.upper_camel_case }}_{{ name.upper_camel_case }}_{% endif %}{{ name.uppercase }}_{{ value.name.uppercase }}:
+            return mavsdk::{{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}::{{ value.name.upper_camel_case }};
         {%- endif %}
         {%- endfor %}
     }

--- a/templates/plugin_cpp/enum.j2
+++ b/templates/plugin_cpp/enum.j2
@@ -3,7 +3,7 @@ const char* {{ plugin_name.upper_camel_case }}::result_str({{ plugin_name.upper_
 {
     switch (result) {
         {%- for value in values %}
-        case {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}::{% set value_without_prefix = value.name.lower_camel_case[name.lower_camel_case|length:] %}{{ value_without_prefix }}:
+        case {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}::{{ value.name.upper_camel_case }}:
             return "{{ value.description[1:].rstrip() }}";
         {%- endfor %}
         default:
@@ -16,8 +16,8 @@ std::ostream& operator<<(std::ostream& str, {{ plugin_name.upper_camel_case }}::
 {
     switch ({{ name.lower_snake_case }}) {
         {%- for value in values %}
-        case {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}::{% set value_without_prefix = value.name.lower_camel_case[name.lower_camel_case|length:] %}{{ value_without_prefix }}:
-            return str << "{{ value.name.upper_readable }}";
+        case {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}::{{ value.name.upper_camel_case }}:
+            return str << "{{ name.upper_readable }} {{ value.name.upper_readable }}";
         {%- endfor %}
         default:
             return str << "Unknown";

--- a/templates/plugin_h/enum.j2
+++ b/templates/plugin_h/enum.j2
@@ -3,7 +3,7 @@
  */
 enum class {{ name.upper_camel_case }} {
 {%- for value in values %}
-    {% set value_without_prefix = value.name.lower_camel_case[name.lower_camel_case|length:] %}{{ value_without_prefix }}, /**< @brief{{ value.description.rstrip() }}. */
+    {{ value.name.upper_camel_case }}, /**< @brief{{ value.description.rstrip() }}. */
 {%- endfor %}
 };
 


### PR DESCRIPTION
This is slightly simplifying the templates, and at least making the whole thing more consistent over all language bindings.