### PR TITLE
Stream callback may need to return a result 

### DIFF
--- a/templates/plugin_h/stream.j2
+++ b/templates/plugin_h/stream.j2
@@ -1,7 +1,7 @@
 /**
 * @brief Callback type for {{ name.lower_snake_case }}_async.
 */
-typedef std::function<void({{ return_type.name }})> {{ name.lower_snake_case }}_callback_t;
+typedef std::function<void({% if has_result %}{{ plugin_name.upper_camel_case }}::Result, {% endif %}{{ return_type.name }})> {{ name.lower_snake_case }}_callback_t;
 
 /**
  * @brief {{ method_description | replace('\n', '\n *')}}


### PR DESCRIPTION
That's typically the case if it is a finite stream (e.g. in the `calibration` plugin)