### PR TITLE
tools: force usage of clang-format version 9

### DIFF
--- a/tools/fix_style.sh
+++ b/tools/fix_style.sh
@@ -26,7 +26,17 @@ semver_regex="(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)"
 if [[ $version =~ $semver_regex ]]; then
 version_major=${BASH_REMATCH[1]}
 if [ "$version_required_major" -gt "$version_major" ]; then
-    echo "Clang version $version_major too old (required >= $version_required_major)"
+    echo "Clang version $version_major too old (required: $version_required_major)"
+    echo "You can use clang-format-9 from docker:"
+    echo ""
+    echo "    'tools/run-docker.sh tools/fix_style.sh .'"
+    exit 1
+
+elif [ "$version_required_major" -lt "$version_major" ]; then
+    echo "Clang version $version_major too new (required: $version_required_major)"
+    echo "You can use clang-format-9 from docker:"
+    echo ""
+    echo "    'tools/run-docker.sh tools/fix_style.sh .'"
     exit 1
 fi
 


### PR DESCRIPTION
If not available on the system, the suggestion is to use it from docker.

This is required because Arch Linux already went to clang-format 10 and these versions don't ever seem to be backward compatible :angry:.