### PR TITLE
Replace IN_PROGRESS and INSTRUCTION by NEXT in finite streams

### DIFF
--- a/src/backend/src/generated/calibration/calibration.pb.cc
+++ b/src/backend/src/generated/calibration/calibration.pb.cc
@@ -380,40 +380,39 @@ const char descriptor_table_protodef_calibration_2fcalibration_2eproto[] PROTOBU
   "\0132).mavsdk.rpc.calibration.CalibrationRe"
   "sult\022;\n\rprogress_data\030\002 \001(\0132$.mavsdk.rpc"
   ".calibration.ProgressData\"\017\n\rCancelReque"
-  "st\"\020\n\016CancelResponse\"\350\002\n\021CalibrationResu"
+  "st\"\020\n\016CancelResponse\"\311\002\n\021CalibrationResu"
   "lt\022@\n\006result\030\001 \001(\01620.mavsdk.rpc.calibrat"
   "ion.CalibrationResult.Result\022\022\n\nresult_s"
-  "tr\030\002 \001(\t\"\374\001\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022"
-  "\022\n\016RESULT_SUCCESS\020\001\022\026\n\022RESULT_IN_PROGRES"
-  "S\020\002\022\026\n\022RESULT_INSTRUCTION\020\003\022\021\n\rRESULT_FA"
-  "ILED\020\004\022\024\n\020RESULT_NO_SYSTEM\020\005\022\033\n\027RESULT_C"
-  "ONNECTION_ERROR\020\006\022\017\n\013RESULT_BUSY\020\007\022\031\n\025RE"
-  "SULT_COMMAND_DENIED\020\010\022\022\n\016RESULT_TIMEOUT\020"
-  "\t\022\024\n\020RESULT_CANCELLED\020\n\"\203\001\n\014ProgressData"
-  "\022\037\n\014has_progress\030\001 \001(\010B\t\202\265\030\005false\022\031\n\010pro"
-  "gress\030\002 \001(\002B\007\202\265\030\003NaN\022\"\n\017has_status_text\030"
-  "\003 \001(\010B\t\202\265\030\005false\022\023\n\013status_text\030\004 \001(\t2\367\005"
-  "\n\022CalibrationService\022\206\001\n\026SubscribeCalibr"
-  "ateGyro\0225.mavsdk.rpc.calibration.Subscri"
-  "beCalibrateGyroRequest\032-.mavsdk.rpc.cali"
-  "bration.CalibrateGyroResponse\"\004\200\265\030\0000\001\022\241\001"
-  "\n\037SubscribeCalibrateAccelerometer\022>.mavs"
-  "dk.rpc.calibration.SubscribeCalibrateAcc"
-  "elerometerRequest\0326.mavsdk.rpc.calibrati"
-  "on.CalibrateAccelerometerResponse\"\004\200\265\030\0000"
-  "\001\022\236\001\n\036SubscribeCalibrateMagnetometer\022=.m"
-  "avsdk.rpc.calibration.SubscribeCalibrate"
-  "MagnetometerRequest\0325.mavsdk.rpc.calibra"
-  "tion.CalibrateMagnetometerResponse\"\004\200\265\030\000"
-  "0\001\022\263\001\n%SubscribeCalibrateGimbalAccelerom"
-  "eter\022D.mavsdk.rpc.calibration.SubscribeC"
-  "alibrateGimbalAccelerometerRequest\032<.mav"
-  "sdk.rpc.calibration.CalibrateGimbalAccel"
-  "erometerResponse\"\004\200\265\030\0000\001\022]\n\006Cancel\022%.mav"
-  "sdk.rpc.calibration.CancelRequest\032&.mavs"
-  "dk.rpc.calibration.CancelResponse\"\004\200\265\030\001B"
-  ")\n\025io.mavsdk.calibrationB\020CalibrationPro"
-  "tob\006proto3"
+  "tr\030\002 \001(\t\"\335\001\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022"
+  "\022\n\016RESULT_SUCCESS\020\001\022\017\n\013RESULT_NEXT\020\002\022\021\n\r"
+  "RESULT_FAILED\020\003\022\024\n\020RESULT_NO_SYSTEM\020\004\022\033\n"
+  "\027RESULT_CONNECTION_ERROR\020\005\022\017\n\013RESULT_BUS"
+  "Y\020\006\022\031\n\025RESULT_COMMAND_DENIED\020\007\022\022\n\016RESULT"
+  "_TIMEOUT\020\010\022\024\n\020RESULT_CANCELLED\020\t\"\203\001\n\014Pro"
+  "gressData\022\037\n\014has_progress\030\001 \001(\010B\t\202\265\030\005fal"
+  "se\022\031\n\010progress\030\002 \001(\002B\007\202\265\030\003NaN\022\"\n\017has_sta"
+  "tus_text\030\003 \001(\010B\t\202\265\030\005false\022\023\n\013status_text"
+  "\030\004 \001(\t2\367\005\n\022CalibrationService\022\206\001\n\026Subscr"
+  "ibeCalibrateGyro\0225.mavsdk.rpc.calibratio"
+  "n.SubscribeCalibrateGyroRequest\032-.mavsdk"
+  ".rpc.calibration.CalibrateGyroResponse\"\004"
+  "\200\265\030\0000\001\022\241\001\n\037SubscribeCalibrateAcceleromet"
+  "er\022>.mavsdk.rpc.calibration.SubscribeCal"
+  "ibrateAccelerometerRequest\0326.mavsdk.rpc."
+  "calibration.CalibrateAccelerometerRespon"
+  "se\"\004\200\265\030\0000\001\022\236\001\n\036SubscribeCalibrateMagneto"
+  "meter\022=.mavsdk.rpc.calibration.Subscribe"
+  "CalibrateMagnetometerRequest\0325.mavsdk.rp"
+  "c.calibration.CalibrateMagnetometerRespo"
+  "nse\"\004\200\265\030\0000\001\022\263\001\n%SubscribeCalibrateGimbal"
+  "Accelerometer\022D.mavsdk.rpc.calibration.S"
+  "ubscribeCalibrateGimbalAccelerometerRequ"
+  "est\032<.mavsdk.rpc.calibration.CalibrateGi"
+  "mbalAccelerometerResponse\"\004\200\265\030\0000\001\022]\n\006Can"
+  "cel\022%.mavsdk.rpc.calibration.CancelReque"
+  "st\032&.mavsdk.rpc.calibration.CancelRespon"
+  "se\"\004\200\265\030\001B)\n\025io.mavsdk.calibrationB\020Calib"
+  "rationProtob\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_calibration_2fcalibration_2eproto_deps[1] = {
   &::descriptor_table_mavsdk_5foptions_2eproto,
@@ -435,7 +434,7 @@ static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_cal
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_calibration_2fcalibration_2eproto_once;
 static bool descriptor_table_calibration_2fcalibration_2eproto_initialized = false;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_calibration_2fcalibration_2eproto = {
-  &descriptor_table_calibration_2fcalibration_2eproto_initialized, descriptor_table_protodef_calibration_2fcalibration_2eproto, "calibration/calibration.proto", 2250,
+  &descriptor_table_calibration_2fcalibration_2eproto_initialized, descriptor_table_protodef_calibration_2fcalibration_2eproto, "calibration/calibration.proto", 2219,
   &descriptor_table_calibration_2fcalibration_2eproto_once, descriptor_table_calibration_2fcalibration_2eproto_sccs, descriptor_table_calibration_2fcalibration_2eproto_deps, 12, 1,
   schemas, file_default_instances, TableStruct_calibration_2fcalibration_2eproto::offsets,
   file_level_metadata_calibration_2fcalibration_2eproto, 12, file_level_enum_descriptors_calibration_2fcalibration_2eproto, file_level_service_descriptors_calibration_2fcalibration_2eproto,
@@ -462,7 +461,6 @@ bool CalibrationResult_Result_IsValid(int value) {
     case 7:
     case 8:
     case 9:
-    case 10:
       return true;
     default:
       return false;
@@ -472,8 +470,7 @@ bool CalibrationResult_Result_IsValid(int value) {
 #if (__cplusplus < 201703) && (!defined(_MSC_VER) || _MSC_VER >= 1900)
 constexpr CalibrationResult_Result CalibrationResult::RESULT_UNKNOWN;
 constexpr CalibrationResult_Result CalibrationResult::RESULT_SUCCESS;
-constexpr CalibrationResult_Result CalibrationResult::RESULT_IN_PROGRESS;
-constexpr CalibrationResult_Result CalibrationResult::RESULT_INSTRUCTION;
+constexpr CalibrationResult_Result CalibrationResult::RESULT_NEXT;
 constexpr CalibrationResult_Result CalibrationResult::RESULT_FAILED;
 constexpr CalibrationResult_Result CalibrationResult::RESULT_NO_SYSTEM;
 constexpr CalibrationResult_Result CalibrationResult::RESULT_CONNECTION_ERROR;

--- a/src/backend/src/generated/calibration/calibration.pb.h
+++ b/src/backend/src/generated/calibration/calibration.pb.h
@@ -119,15 +119,14 @@ namespace calibration {
 enum CalibrationResult_Result : int {
   CalibrationResult_Result_RESULT_UNKNOWN = 0,
   CalibrationResult_Result_RESULT_SUCCESS = 1,
-  CalibrationResult_Result_RESULT_IN_PROGRESS = 2,
-  CalibrationResult_Result_RESULT_INSTRUCTION = 3,
-  CalibrationResult_Result_RESULT_FAILED = 4,
-  CalibrationResult_Result_RESULT_NO_SYSTEM = 5,
-  CalibrationResult_Result_RESULT_CONNECTION_ERROR = 6,
-  CalibrationResult_Result_RESULT_BUSY = 7,
-  CalibrationResult_Result_RESULT_COMMAND_DENIED = 8,
-  CalibrationResult_Result_RESULT_TIMEOUT = 9,
-  CalibrationResult_Result_RESULT_CANCELLED = 10,
+  CalibrationResult_Result_RESULT_NEXT = 2,
+  CalibrationResult_Result_RESULT_FAILED = 3,
+  CalibrationResult_Result_RESULT_NO_SYSTEM = 4,
+  CalibrationResult_Result_RESULT_CONNECTION_ERROR = 5,
+  CalibrationResult_Result_RESULT_BUSY = 6,
+  CalibrationResult_Result_RESULT_COMMAND_DENIED = 7,
+  CalibrationResult_Result_RESULT_TIMEOUT = 8,
+  CalibrationResult_Result_RESULT_CANCELLED = 9,
   CalibrationResult_Result_CalibrationResult_Result_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::min(),
   CalibrationResult_Result_CalibrationResult_Result_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::max()
 };
@@ -1554,10 +1553,8 @@ class CalibrationResult :
     CalibrationResult_Result_RESULT_UNKNOWN;
   static constexpr Result RESULT_SUCCESS =
     CalibrationResult_Result_RESULT_SUCCESS;
-  static constexpr Result RESULT_IN_PROGRESS =
-    CalibrationResult_Result_RESULT_IN_PROGRESS;
-  static constexpr Result RESULT_INSTRUCTION =
-    CalibrationResult_Result_RESULT_INSTRUCTION;
+  static constexpr Result RESULT_NEXT =
+    CalibrationResult_Result_RESULT_NEXT;
   static constexpr Result RESULT_FAILED =
     CalibrationResult_Result_RESULT_FAILED;
   static constexpr Result RESULT_NO_SYSTEM =

--- a/src/backend/src/plugins/calibration/calibration_service_impl.h
+++ b/src/backend/src/plugins/calibration/calibration_service_impl.h
@@ -44,10 +44,8 @@ public:
                 return rpc::calibration::CalibrationResult_Result_RESULT_UNKNOWN;
             case mavsdk::Calibration::Result::Success:
                 return rpc::calibration::CalibrationResult_Result_RESULT_SUCCESS;
-            case mavsdk::Calibration::Result::InProgress:
-                return rpc::calibration::CalibrationResult_Result_RESULT_IN_PROGRESS;
-            case mavsdk::Calibration::Result::Instruction:
-                return rpc::calibration::CalibrationResult_Result_RESULT_INSTRUCTION;
+            case mavsdk::Calibration::Result::Next:
+                return rpc::calibration::CalibrationResult_Result_RESULT_NEXT;
             case mavsdk::Calibration::Result::Failed:
                 return rpc::calibration::CalibrationResult_Result_RESULT_FAILED;
             case mavsdk::Calibration::Result::NoSystem:
@@ -76,10 +74,8 @@ public:
                 return mavsdk::Calibration::Result::Unknown;
             case rpc::calibration::CalibrationResult_Result_RESULT_SUCCESS:
                 return mavsdk::Calibration::Result::Success;
-            case rpc::calibration::CalibrationResult_Result_RESULT_IN_PROGRESS:
-                return mavsdk::Calibration::Result::InProgress;
-            case rpc::calibration::CalibrationResult_Result_RESULT_INSTRUCTION:
-                return mavsdk::Calibration::Result::Instruction;
+            case rpc::calibration::CalibrationResult_Result_RESULT_NEXT:
+                return mavsdk::Calibration::Result::Next;
             case rpc::calibration::CalibrationResult_Result_RESULT_FAILED:
                 return mavsdk::Calibration::Result::Failed;
             case rpc::calibration::CalibrationResult_Result_RESULT_NO_SYSTEM:

--- a/src/integration_tests/calibration.cpp
+++ b/src/integration_tests/calibration.cpp
@@ -203,9 +203,9 @@ void receive_calibration_callback(
     const std::string& calibration_type,
     std::promise<Calibration::Result>& prom)
 {
-    if (result == Calibration::Result::InProgress) {
+    if (result == Calibration::Result::Next && progress_data.has_progress) {
         LogInfo() << calibration_type << " calibration in progress: " << progress_data.progress;
-    } else if (result == Calibration::Result::Instruction) {
+    } else if (result == Calibration::Result::Next && progress_data.has_status_text) {
         LogInfo() << calibration_type << " calibration instruction: " << progress_data.status_text;
     } else {
         prom.set_value(result);

--- a/src/plugins/calibration/calibration.cpp
+++ b/src/plugins/calibration/calibration.cpp
@@ -48,10 +48,8 @@ const char* Calibration::result_str(Calibration::Result result)
             return "Unknown error";
         case Calibration::Result::Success:
             return "The calibration process succeeded";
-        case Calibration::Result::InProgress:
-            return "Intermediate message showing progress of the calibration process";
-        case Calibration::Result::Instruction:
-            return "Intermediate message giving instructions on the next steps required by the process";
+        case Calibration::Result::Next:
+            return "Intermediate message showing progress or instructions on the next steps required by the process";
         case Calibration::Result::Failed:
             return "Calibration failed";
         case Calibration::Result::NoSystem:
@@ -78,10 +76,8 @@ std::ostream& operator<<(std::ostream& str, Calibration::Result const& result)
             return str << "Result Unknown";
         case Calibration::Result::Success:
             return str << "Result Success";
-        case Calibration::Result::InProgress:
-            return str << "Result In Progress";
-        case Calibration::Result::Instruction:
-            return str << "Result Instruction";
+        case Calibration::Result::Next:
+            return str << "Result Next";
         case Calibration::Result::Failed:
             return str << "Result Failed";
         case Calibration::Result::NoSystem:

--- a/src/plugins/calibration/calibration_impl.cpp
+++ b/src/plugins/calibration/calibration_impl.cpp
@@ -252,7 +252,7 @@ CalibrationImpl::calibration_result_from_command_result(MAVLinkCommands::Result 
         case MAVLinkCommands::Result::TIMEOUT:
             return Calibration::Result::Timeout;
         case MAVLinkCommands::Result::IN_PROGRESS:
-            return Calibration::Result::InProgress;
+            return Calibration::Result::Next;
         default:
             return Calibration::Result::Unknown;
     }
@@ -367,7 +367,7 @@ void CalibrationImpl::report_progress(float progress)
     Calibration::ProgressData progress_data;
     progress_data.has_progress = true;
     progress_data.progress = progress;
-    call_user_callback(_calibration_callback, Calibration::Result::InProgress, progress_data);
+    call_user_callback(_calibration_callback, Calibration::Result::Next, progress_data);
 }
 
 void CalibrationImpl::report_instruction(const std::string& instruction)
@@ -375,7 +375,7 @@ void CalibrationImpl::report_instruction(const std::string& instruction)
     Calibration::ProgressData progress_data;
     progress_data.has_status_text = true;
     progress_data.status_text = instruction;
-    call_user_callback(_calibration_callback, Calibration::Result::Instruction, progress_data);
+    call_user_callback(_calibration_callback, Calibration::Result::Next, progress_data);
 }
 
 } // namespace mavsdk

--- a/src/plugins/calibration/include/plugins/calibration/calibration.h
+++ b/src/plugins/calibration/include/plugins/calibration/calibration.h
@@ -49,9 +49,8 @@ public:
     enum class Result {
         Unknown, /**< @brief Unknown error. */
         Success, /**< @brief The calibration process succeeded. */
-        InProgress, /**< @brief Intermediate message showing progress of the calibration process. */
-        Instruction, /**< @brief Intermediate message giving instructions on the next steps required
-                        by the process. */
+        Next, /**< @brief Intermediate message showing progress or instructions on the next steps
+                 required by the process. */
         Failed, /**< @brief Calibration failed. */
         NoSystem, /**< @brief No system is connected. */
         ConnectionError, /**< @brief Connection error. */


### PR DESCRIPTION
This makes the streams more generic: 

* SUCCESS means that the stream ended successfully
* NEXT means that a new element is being sent (hence the stream is continuing)
* Everything else is an error and raises/throws an exception