### PR TITLE
Change callback type name

### DIFF
--- a/examples/offboard_velocity/offboard_velocity.cpp
+++ b/examples/offboard_velocity/offboard_velocity.cpp
@@ -260,7 +260,7 @@ void usage(std::string bin_name)
               << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
 }
 
-Telemetry::landed_state_callback_t
+Telemetry::LandedStateCallback
 landed_state_callback(std::shared_ptr<Telemetry>& telemetry, std::promise<void>& landed_promise)
 {
     return [&landed_promise, &telemetry](Telemetry::LandedState landed) {

--- a/src/backend/test/camera_service_impl_test.cpp
+++ b/src/backend/test/camera_service_impl_test.cpp
@@ -357,7 +357,7 @@ TEST_F(CameraServiceImplTest, setModeSetsVideoMode)
 
 TEST_F(CameraServiceImplTest, registersToCameraMode)
 {
-    mavsdk::Camera::mode_callback_t mode_callback;
+    mavsdk::Camera::ModeCallback mode_callback;
     EXPECT_CALL(_camera, subscribe_mode(_))
         .Times(2)
         .WillOnce(SaveResult(&mode_callback, &_callback_saved_promise))
@@ -401,7 +401,7 @@ void CameraServiceImplTest::checkSendsModes(const std::vector<mavsdk::Camera::Mo
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Camera::mode_callback_t mode_callback;
+    mavsdk::Camera::ModeCallback mode_callback;
     auto context = std::make_shared<grpc::ClientContext>();
     EXPECT_CALL(_camera, subscribe_mode(_))
         .Times(2)
@@ -457,7 +457,7 @@ TEST_F(CameraServiceImplTest, registersToVideoStreamInfo)
     auto rpc_video_stream_info = createArbitraryRPCVideoStreamInfo();
     const auto expected_video_stream_info =
         CameraServiceImpl::translateFromRpcVideoStreamInfo(*rpc_video_stream_info);
-    mavsdk::Camera::video_stream_info_callback_t video_info_callback;
+    mavsdk::Camera::VideoStreamInfoCallback video_info_callback;
     EXPECT_CALL(_camera, subscribe_video_stream_info(_))
         .Times(2)
         .WillOnce(SaveResult(&video_info_callback, &_callback_saved_promise))
@@ -516,7 +516,7 @@ void CameraServiceImplTest::checkSendsVideoStreamInfo(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Camera::video_stream_info_callback_t video_info_callback;
+    mavsdk::Camera::VideoStreamInfoCallback video_info_callback;
     auto context = std::make_shared<grpc::ClientContext>();
     EXPECT_CALL(_camera, subscribe_video_stream_info(_))
         .Times(2)
@@ -547,7 +547,7 @@ TEST_F(CameraServiceImplTest, registersToCaptureInfo)
     auto rpc_capture_info = createArbitraryRPCCaptureInfo();
     const auto expected_capture_info =
         CameraServiceImpl::translateFromRpcCaptureInfo(*rpc_capture_info);
-    mavsdk::Camera::capture_info_callback_t capture_info_callback;
+    mavsdk::Camera::CaptureInfoCallback capture_info_callback;
     EXPECT_CALL(_camera, subscribe_capture_info(_))
         .Times(2)
         .WillOnce(SaveResult(&capture_info_callback, &_callback_saved_promise))
@@ -655,7 +655,7 @@ void CameraServiceImplTest::checkSendsCaptureInfo(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Camera::capture_info_callback_t capture_info_callback;
+    mavsdk::Camera::CaptureInfoCallback capture_info_callback;
     auto context = std::make_shared<grpc::ClientContext>();
     EXPECT_CALL(_camera, subscribe_capture_info(_))
         .Times(2)
@@ -728,7 +728,7 @@ TEST_F(CameraServiceImplTest, registersToStatus)
 {
     const auto expected_camera_status = createStatus(
         false, true, ARBITRARY_CAMERA_STORAGE_STATUS, 3.4f, 12.6f, 16.0f, 0.4f, "100E90HD");
-    mavsdk::Camera::status_callback_t status_callback;
+    mavsdk::Camera::StatusCallback status_callback;
     EXPECT_CALL(_camera, subscribe_status(_))
         .Times(2)
         .WillOnce(SaveResult(&status_callback, &_callback_saved_promise))
@@ -799,7 +799,7 @@ void CameraServiceImplTest::checkSendsStatus(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Camera::status_callback_t camera_status_callback;
+    mavsdk::Camera::StatusCallback camera_status_callback;
     auto context = std::make_shared<grpc::ClientContext>();
     EXPECT_CALL(_camera, subscribe_status(_))
         .Times(2)
@@ -866,7 +866,7 @@ TEST_F(CameraServiceImplTest, registersToCurrentSettings)
         ARBITRARY_SETTING_ID,
         ARBITRARY_SETTING_DESCRIPTION,
         createOption(ARBITRARY_OPTION_ID, ARBITRARY_OPTION_DESCRIPTION)));
-    mavsdk::Camera::current_settings_callback_t current_settings_callback;
+    mavsdk::Camera::CurrentSettingsCallback current_settings_callback;
     EXPECT_CALL(_camera, subscribe_current_settings(_))
         .Times(2)
         .WillOnce(SaveResult(&current_settings_callback, &_callback_saved_promise))
@@ -947,7 +947,7 @@ void CameraServiceImplTest::checkSendsCurrentSettings(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Camera::current_settings_callback_t current_settings_callback;
+    mavsdk::Camera::CurrentSettingsCallback current_settings_callback;
     auto context = std::make_shared<grpc::ClientContext>();
     EXPECT_CALL(_camera, subscribe_current_settings(_))
         .Times(2)
@@ -1025,7 +1025,7 @@ TEST_F(CameraServiceImplTest, registersToPossibleSettings)
     options.push_back(createOption(ARBITRARY_OPTION_ID, ARBITRARY_OPTION_DESCRIPTION));
     possible_settings.push_back(
         createSettingOptions(ARBITRARY_SETTING_ID, ARBITRARY_SETTING_DESCRIPTION, options));
-    mavsdk::Camera::possible_setting_options_callback_t possible_settings_callback;
+    mavsdk::Camera::PossibleSettingOptionsCallback possible_settings_callback;
     EXPECT_CALL(_camera, subscribe_possible_setting_options(_))
         .Times(2)
         .WillOnce(SaveResult(&possible_settings_callback, &_callback_saved_promise))
@@ -1098,7 +1098,7 @@ void CameraServiceImplTest::checkSendsPossibleSettingOptions(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Camera::possible_setting_options_callback_t possible_setting_options_callback;
+    mavsdk::Camera::PossibleSettingOptionsCallback possible_setting_options_callback;
     auto context = std::make_shared<grpc::ClientContext>();
     EXPECT_CALL(_camera, subscribe_possible_setting_options(_))
         .Times(2)
@@ -1210,7 +1210,7 @@ std::unique_ptr<mavsdk::rpc::camera::Setting> CameraServiceImplTest::createRPCSe
 
 TEST_F(CameraServiceImplTest, setsSettingEvenWhenContextAndResponseAreNull)
 {
-    mavsdk::Camera::result_callback_t result_callback;
+    mavsdk::Camera::ResultCallback result_callback;
     mavsdk::rpc::camera::SetSettingRequest request;
     request.set_allocated_setting(createRPCSetting(
                                       ARBITRARY_SETTING_ID,
@@ -1225,7 +1225,7 @@ TEST_F(CameraServiceImplTest, setsSettingEvenWhenContextAndResponseAreNull)
 
 TEST_F(CameraServiceImplTest, setsSettingWithRightParameter)
 {
-    mavsdk::Camera::result_callback_t result_callback;
+    mavsdk::Camera::ResultCallback result_callback;
     mavsdk::rpc::camera::SetSettingRequest request;
     request.set_allocated_setting(createRPCSetting(
                                       ARBITRARY_SETTING_ID,

--- a/src/backend/test/mission_service_impl_test.cpp
+++ b/src/backend/test/mission_service_impl_test.cpp
@@ -150,7 +150,7 @@ protected:
     MissionServiceImpl _mission_service;
 
     /* The mission returns its result through a callback, which is saved in _result_callback. */
-    mavsdk::Mission::result_callback_t _result_callback{};
+    mavsdk::Mission::ResultCallback _result_callback{};
 
     /* The tests need to make sure that _result_callback has been set before calling it, hence the
      * promise. */

--- a/src/backend/test/telemetry_service_impl_test.cpp
+++ b/src/backend/test/telemetry_service_impl_test.cpp
@@ -235,7 +235,7 @@ void TelemetryServiceImplTest::checkSendsPositions(const std::vector<Position>& 
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Telemetry::position_callback_t position_callback;
+    mavsdk::Telemetry::PositionCallback position_callback;
     EXPECT_CALL(*_telemetry, subscribe_position(_))
         .WillOnce(SaveCallback(&position_callback, &subscription_promise));
 
@@ -346,7 +346,7 @@ void TelemetryServiceImplTest::checkSendsHealths(const std::vector<Health>& heal
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Telemetry::health_callback_t health_callback;
+    mavsdk::Telemetry::HealthCallback health_callback;
     EXPECT_CALL(*_telemetry, subscribe_health(_))
         .WillOnce(SaveCallback(&health_callback, &subscription_promise));
 
@@ -451,7 +451,7 @@ void TelemetryServiceImplTest::checkSendsHomePositions(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Telemetry::position_callback_t home_callback;
+    mavsdk::Telemetry::PositionCallback home_callback;
     EXPECT_CALL(*_telemetry, subscribe_home(_))
         .WillOnce(SaveCallback(&home_callback, &subscription_promise));
 
@@ -533,7 +533,7 @@ void TelemetryServiceImplTest::checkSendsInAirEvents(const std::vector<bool>& in
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Telemetry::in_air_callback_t in_air_callback;
+    mavsdk::Telemetry::InAirCallback in_air_callback;
     EXPECT_CALL(*_telemetry, subscribe_in_air(_))
         .WillOnce(SaveCallback(&in_air_callback, &subscription_promise));
 
@@ -615,7 +615,7 @@ void TelemetryServiceImplTest::checkSendsArmedEvents(const std::vector<bool>& ar
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Telemetry::armed_callback_t armed_callback;
+    mavsdk::Telemetry::ArmedCallback armed_callback;
     EXPECT_CALL(*_telemetry, subscribe_armed(_))
         .WillOnce(SaveCallback(&armed_callback, &subscription_promise));
 
@@ -725,7 +725,7 @@ void TelemetryServiceImplTest::checkSendsGpsInfoEvents(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Telemetry::gps_info_callback_t gps_info_callback;
+    mavsdk::Telemetry::GpsInfoCallback gps_info_callback;
     EXPECT_CALL(*_telemetry, subscribe_gps_info(_))
         .WillOnce(SaveCallback(&gps_info_callback, &subscription_promise));
 
@@ -837,7 +837,7 @@ void TelemetryServiceImplTest::checkSendsBatteryEvents(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Telemetry::battery_callback_t battery_callback;
+    mavsdk::Telemetry::BatteryCallback battery_callback;
     EXPECT_CALL(*_telemetry, subscribe_battery(_))
         .WillOnce(SaveCallback(&battery_callback, &subscription_promise));
 
@@ -947,7 +947,7 @@ void TelemetryServiceImplTest::checkSendsFlightModeEvents(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Telemetry::flight_mode_callback_t flight_mode_callback;
+    mavsdk::Telemetry::FlightModeCallback flight_mode_callback;
     EXPECT_CALL(*_telemetry, subscribe_flight_mode(_))
         .WillOnce(SaveCallback(&flight_mode_callback, &subscription_promise));
 
@@ -1123,7 +1123,7 @@ void TelemetryServiceImplTest::checkSendsAttitudeQuaternions(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Telemetry::attitude_quaternion_callback_t attitude_quaternion_callback;
+    mavsdk::Telemetry::AttitudeQuaternionCallback attitude_quaternion_callback;
     EXPECT_CALL(*_telemetry, subscribe_attitude_quaternion(_))
         .WillOnce(SaveCallback(&attitude_quaternion_callback, &subscription_promise));
 
@@ -1147,8 +1147,7 @@ void TelemetryServiceImplTest::checkSendsAttitudeAngularVelocitiesBody(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Telemetry::attitude_angular_velocity_body_callback_t
-        attitude_angular_velocity_body_callback;
+    mavsdk::Telemetry::AttitudeAngularVelocityBodyCallback attitude_angular_velocity_body_callback;
     EXPECT_CALL(*_telemetry, subscribe_attitude_angular_velocity_body(_))
         .WillOnce(SaveCallback(&attitude_angular_velocity_body_callback, &subscription_promise));
 
@@ -1258,7 +1257,7 @@ void TelemetryServiceImplTest::checkSendsAttitudeEulerAngles(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Telemetry::attitude_euler_callback_t attitude_euler_angle_callback;
+    mavsdk::Telemetry::AttitudeEulerCallback attitude_euler_angle_callback;
     EXPECT_CALL(*_telemetry, subscribe_attitude_euler(_))
         .WillOnce(SaveCallback(&attitude_euler_angle_callback, &subscription_promise));
 
@@ -1347,7 +1346,7 @@ void TelemetryServiceImplTest::checkSendsCameraAttitudeQuaternions(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Telemetry::attitude_quaternion_callback_t attitude_quaternion_callback;
+    mavsdk::Telemetry::AttitudeQuaternionCallback attitude_quaternion_callback;
     EXPECT_CALL(*_telemetry, subscribe_camera_attitude_quaternion(_))
         .WillOnce(SaveCallback(&attitude_quaternion_callback, &subscription_promise));
 
@@ -1435,7 +1434,7 @@ void TelemetryServiceImplTest::checkSendsCameraAttitudeEulerAngles(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Telemetry::attitude_euler_callback_t attitude_euler_angle_callback;
+    mavsdk::Telemetry::AttitudeEulerCallback attitude_euler_angle_callback;
     EXPECT_CALL(*_telemetry, subscribe_camera_attitude_euler(_))
         .WillOnce(SaveCallback(&attitude_euler_angle_callback, &subscription_promise));
 
@@ -1535,7 +1534,7 @@ void TelemetryServiceImplTest::checkSendsGroundSpeedEvents(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Telemetry::ground_speed_ned_callback_t ground_speed_ned_callback;
+    mavsdk::Telemetry::GroundSpeedNedCallback ground_speed_ned_callback;
     EXPECT_CALL(*_telemetry, subscribe_ground_speed_ned(_))
         .WillOnce(SaveCallback(&ground_speed_ned_callback, &subscription_promise));
 
@@ -1637,7 +1636,7 @@ void TelemetryServiceImplTest::checkSendsRcStatusEvents(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Telemetry::rc_status_callback_t rc_status_callback;
+    mavsdk::Telemetry::RcStatusCallback rc_status_callback;
     EXPECT_CALL(*_telemetry, subscribe_rc_status(_))
         .WillOnce(SaveCallback(&rc_status_callback, &subscription_promise));
 
@@ -1749,7 +1748,7 @@ void TelemetryServiceImplTest::checkSendsActuatorControlTargetEvents(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Telemetry::actuator_control_target_callback_t actuator_control_target_callback;
+    mavsdk::Telemetry::ActuatorControlTargetCallback actuator_control_target_callback;
     EXPECT_CALL(*_telemetry, subscribe_actuator_control_target(_))
         .WillOnce(SaveCallback(&actuator_control_target_callback, &subscription_promise));
 
@@ -1777,7 +1776,7 @@ void TelemetryServiceImplTest::checkSendsActuatorOutputStatusEvents(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::Telemetry::actuator_output_status_callback_t actuator_output_status_callback;
+    mavsdk::Telemetry::ActuatorOutputStatusCallback actuator_output_status_callback;
     EXPECT_CALL(*_telemetry, subscribe_actuator_output_status(_))
         .WillOnce(SaveCallback(&actuator_output_status_callback, &subscription_promise));
 

--- a/src/core/mavlink_commands.cpp
+++ b/src/core/mavlink_commands.cpp
@@ -66,8 +66,7 @@ MAVLinkCommands::Result MAVLinkCommands::send_command(const MAVLinkCommands::Com
     return res.get();
 }
 
-void MAVLinkCommands::queue_command_async(
-    const CommandInt& command, command_ResultCallback callback)
+void MAVLinkCommands::queue_command_async(const CommandInt& command, commandResultCallback callback)
 {
     // LogDebug() << "Command " << (int)(command.command) << " to send to "
     //  << (int)(command.target_system_id)<< ", " << (int)(command.target_component_id);
@@ -98,7 +97,7 @@ void MAVLinkCommands::queue_command_async(
 }
 
 void MAVLinkCommands::queue_command_async(
-    const CommandLong& command, command_ResultCallback callback)
+    const CommandLong& command, commandResultCallback callback)
 {
     // LogDebug() << "Command " << (int)(command.command) << " to send to "
     //  << (int)(command.target_system_id)<< ", " << (int)(command.target_component_id);
@@ -277,7 +276,7 @@ void MAVLinkCommands::do_work()
 }
 
 void MAVLinkCommands::call_callback(
-    const command_ResultCallback& callback, Result result, float progress)
+    const commandResultCallback& callback, Result result, float progress)
 {
     if (!callback) {
         return;

--- a/src/core/mavlink_commands.cpp
+++ b/src/core/mavlink_commands.cpp
@@ -67,7 +67,7 @@ MAVLinkCommands::Result MAVLinkCommands::send_command(const MAVLinkCommands::Com
 }
 
 void MAVLinkCommands::queue_command_async(
-    const CommandInt& command, command_result_callback_t callback)
+    const CommandInt& command, command_ResultCallback callback)
 {
     // LogDebug() << "Command " << (int)(command.command) << " to send to "
     //  << (int)(command.target_system_id)<< ", " << (int)(command.target_component_id);
@@ -98,7 +98,7 @@ void MAVLinkCommands::queue_command_async(
 }
 
 void MAVLinkCommands::queue_command_async(
-    const CommandLong& command, command_result_callback_t callback)
+    const CommandLong& command, command_ResultCallback callback)
 {
     // LogDebug() << "Command " << (int)(command.command) << " to send to "
     //  << (int)(command.target_system_id)<< ", " << (int)(command.target_component_id);
@@ -277,7 +277,7 @@ void MAVLinkCommands::do_work()
 }
 
 void MAVLinkCommands::call_callback(
-    const command_result_callback_t& callback, Result result, float progress)
+    const command_ResultCallback& callback, Result result, float progress)
 {
     if (!callback) {
         return;

--- a/src/core/mavlink_commands.h
+++ b/src/core/mavlink_commands.h
@@ -28,7 +28,7 @@ public:
         UnknownError
     };
 
-    typedef std::function<void(Result, float)> command_result_callback_t;
+    typedef std::function<void(Result, float)> command_ResultCallback;
 
     struct CommandInt {
         uint8_t target_system_id{0};
@@ -94,8 +94,8 @@ public:
     Result send_command(const CommandInt& command);
     Result send_command(const CommandLong& command);
 
-    void queue_command_async(const CommandInt& command, command_result_callback_t callback);
-    void queue_command_async(const CommandLong& command, command_result_callback_t callback);
+    void queue_command_async(const CommandInt& command, command_ResultCallback callback);
+    void queue_command_async(const CommandLong& command, command_ResultCallback callback);
 
     void do_work();
 
@@ -112,14 +112,14 @@ private:
         uint16_t mavlink_command{0};
         bool already_sent{false};
         mavlink_message_t mavlink_message{};
-        command_result_callback_t callback{};
+        command_ResultCallback callback{};
         dl_time_t time_started{};
     };
 
     void receive_command_ack(mavlink_message_t message);
     void receive_timeout();
 
-    void call_callback(const command_result_callback_t& callback, Result result, float progress);
+    void call_callback(const command_ResultCallback& callback, Result result, float progress);
 
     SystemImpl& _parent;
     LockedQueue<Work> _work_queue{};

--- a/src/core/mavlink_commands.h
+++ b/src/core/mavlink_commands.h
@@ -28,7 +28,7 @@ public:
         UnknownError
     };
 
-    typedef std::function<void(Result, float)> command_ResultCallback;
+    typedef std::function<void(Result, float)> commandResultCallback;
 
     struct CommandInt {
         uint8_t target_system_id{0};
@@ -94,8 +94,8 @@ public:
     Result send_command(const CommandInt& command);
     Result send_command(const CommandLong& command);
 
-    void queue_command_async(const CommandInt& command, command_ResultCallback callback);
-    void queue_command_async(const CommandLong& command, command_ResultCallback callback);
+    void queue_command_async(const CommandInt& command, commandResultCallback callback);
+    void queue_command_async(const CommandLong& command, commandResultCallback callback);
 
     void do_work();
 
@@ -112,14 +112,14 @@ private:
         uint16_t mavlink_command{0};
         bool already_sent{false};
         mavlink_message_t mavlink_message{};
-        command_ResultCallback callback{};
+        commandResultCallback callback{};
         dl_time_t time_started{};
     };
 
     void receive_command_ack(mavlink_message_t message);
     void receive_timeout();
 
-    void call_callback(const command_ResultCallback& callback, Result result, float progress);
+    void call_callback(const commandResultCallback& callback, Result result, float progress);
 
     SystemImpl& _parent;
     LockedQueue<Work> _work_queue{};

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -971,7 +971,7 @@ MAVLinkCommands::Result SystemImpl::set_flight_mode(FlightMode system_mode, uint
 }
 
 void SystemImpl::set_flight_mode_async(
-    FlightMode system_mode, command_result_callback_t callback, uint8_t component_id)
+    FlightMode system_mode, command_ResultCallback callback, uint8_t component_id)
 {
     std::pair<MAVLinkCommands::Result, MAVLinkCommands::CommandLong> result =
         make_command_flight_mode(system_mode, component_id);
@@ -1063,7 +1063,7 @@ MAVLinkCommands::Result SystemImpl::send_command(MAVLinkCommands::CommandInt& co
 }
 
 void SystemImpl::send_command_async(
-    MAVLinkCommands::CommandLong command, const command_result_callback_t callback)
+    MAVLinkCommands::CommandLong command, const command_ResultCallback callback)
 {
     if (target_address.system_id == 0 && _components.size() == 0) {
         if (callback) {
@@ -1077,7 +1077,7 @@ void SystemImpl::send_command_async(
 }
 
 void SystemImpl::send_command_async(
-    MAVLinkCommands::CommandInt command, const command_result_callback_t callback)
+    MAVLinkCommands::CommandInt command, const command_ResultCallback callback)
 {
     if (target_address.system_id == 0 && _components.size() == 0) {
         if (callback) {
@@ -1098,7 +1098,7 @@ SystemImpl::set_msg_rate(uint16_t message_id, double rate_hz, uint8_t component_
 }
 
 void SystemImpl::set_msg_rate_async(
-    uint16_t message_id, double rate_hz, command_result_callback_t callback, uint8_t component_id)
+    uint16_t message_id, double rate_hz, command_ResultCallback callback, uint8_t component_id)
 {
     MAVLinkCommands::CommandLong command = make_command_msg_rate(message_id, rate_hz, component_id);
     send_command_async(command, callback);

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -971,7 +971,7 @@ MAVLinkCommands::Result SystemImpl::set_flight_mode(FlightMode system_mode, uint
 }
 
 void SystemImpl::set_flight_mode_async(
-    FlightMode system_mode, command_ResultCallback callback, uint8_t component_id)
+    FlightMode system_mode, commandResultCallback callback, uint8_t component_id)
 {
     std::pair<MAVLinkCommands::Result, MAVLinkCommands::CommandLong> result =
         make_command_flight_mode(system_mode, component_id);
@@ -1063,7 +1063,7 @@ MAVLinkCommands::Result SystemImpl::send_command(MAVLinkCommands::CommandInt& co
 }
 
 void SystemImpl::send_command_async(
-    MAVLinkCommands::CommandLong command, const command_ResultCallback callback)
+    MAVLinkCommands::CommandLong command, const commandResultCallback callback)
 {
     if (target_address.system_id == 0 && _components.size() == 0) {
         if (callback) {
@@ -1077,7 +1077,7 @@ void SystemImpl::send_command_async(
 }
 
 void SystemImpl::send_command_async(
-    MAVLinkCommands::CommandInt command, const command_ResultCallback callback)
+    MAVLinkCommands::CommandInt command, const commandResultCallback callback)
 {
     if (target_address.system_id == 0 && _components.size() == 0) {
         if (callback) {
@@ -1098,7 +1098,7 @@ SystemImpl::set_msg_rate(uint16_t message_id, double rate_hz, uint8_t component_
 }
 
 void SystemImpl::set_msg_rate_async(
-    uint16_t message_id, double rate_hz, command_ResultCallback callback, uint8_t component_id)
+    uint16_t message_id, double rate_hz, commandResultCallback callback, uint8_t component_id)
 {
     MAVLinkCommands::CommandLong command = make_command_msg_rate(message_id, rate_hz, component_id);
     send_command_async(command, callback);

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -76,15 +76,15 @@ public:
 
     static FlightMode to_flight_mode_from_custom_mode(uint32_t custom_mode);
 
-    typedef std::function<void(MAVLinkCommands::Result, float)> command_result_callback_t;
+    typedef std::function<void(MAVLinkCommands::Result, float)> command_ResultCallback;
 
     MAVLinkCommands::Result send_command(MAVLinkCommands::CommandLong& command);
     MAVLinkCommands::Result send_command(MAVLinkCommands::CommandInt& command);
 
-    void send_command_async(
-        MAVLinkCommands::CommandLong command, const command_result_callback_t callback);
-    void send_command_async(
-        MAVLinkCommands::CommandInt command, const command_result_callback_t callback);
+    void
+    send_command_async(MAVLinkCommands::CommandLong command, const command_ResultCallback callback);
+    void
+    send_command_async(MAVLinkCommands::CommandInt command, const command_ResultCallback callback);
 
     MAVLinkCommands::Result set_msg_rate(
         uint16_t message_id, double rate_hz, uint8_t component_id = MAV_COMP_ID_AUTOPILOT1);
@@ -92,7 +92,7 @@ public:
     void set_msg_rate_async(
         uint16_t message_id,
         double rate_hz,
-        command_result_callback_t callback,
+        command_ResultCallback callback,
         uint8_t component_id = MAV_COMP_ID_AUTOPILOT1);
 
     // Adds unique component ids
@@ -145,7 +145,7 @@ public:
 
     void set_flight_mode_async(
         FlightMode mode,
-        command_result_callback_t callback,
+        command_ResultCallback callback,
         uint8_t component_id = MAV_COMP_ID_AUTOPILOT1);
 
     typedef std::function<void(MAVLinkParameters::Result result, float value)>
@@ -282,7 +282,7 @@ private:
 
     MavsdkImpl& _parent;
 
-    command_result_callback_t _command_result_callback{nullptr};
+    command_ResultCallback _command_result_callback{nullptr};
 
     std::thread* _system_thread{nullptr};
     std::atomic<bool> _should_exit{false};

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -76,15 +76,15 @@ public:
 
     static FlightMode to_flight_mode_from_custom_mode(uint32_t custom_mode);
 
-    typedef std::function<void(MAVLinkCommands::Result, float)> command_ResultCallback;
+    typedef std::function<void(MAVLinkCommands::Result, float)> commandResultCallback;
 
     MAVLinkCommands::Result send_command(MAVLinkCommands::CommandLong& command);
     MAVLinkCommands::Result send_command(MAVLinkCommands::CommandInt& command);
 
     void
-    send_command_async(MAVLinkCommands::CommandLong command, const command_ResultCallback callback);
+    send_command_async(MAVLinkCommands::CommandLong command, const commandResultCallback callback);
     void
-    send_command_async(MAVLinkCommands::CommandInt command, const command_ResultCallback callback);
+    send_command_async(MAVLinkCommands::CommandInt command, const commandResultCallback callback);
 
     MAVLinkCommands::Result set_msg_rate(
         uint16_t message_id, double rate_hz, uint8_t component_id = MAV_COMP_ID_AUTOPILOT1);
@@ -92,7 +92,7 @@ public:
     void set_msg_rate_async(
         uint16_t message_id,
         double rate_hz,
-        command_ResultCallback callback,
+        commandResultCallback callback,
         uint8_t component_id = MAV_COMP_ID_AUTOPILOT1);
 
     // Adds unique component ids
@@ -145,7 +145,7 @@ public:
 
     void set_flight_mode_async(
         FlightMode mode,
-        command_ResultCallback callback,
+        commandResultCallback callback,
         uint8_t component_id = MAV_COMP_ID_AUTOPILOT1);
 
     typedef std::function<void(MAVLinkParameters::Result result, float value)>
@@ -282,7 +282,7 @@ private:
 
     MavsdkImpl& _parent;
 
-    command_ResultCallback _command_result_callback{nullptr};
+    commandResultCallback _command_result_callback{nullptr};
 
     std::thread* _system_thread{nullptr};
     std::atomic<bool> _should_exit{false};

--- a/src/plugins/action/action.cpp
+++ b/src/plugins/action/action.cpp
@@ -13,7 +13,7 @@ Action::Action(System& system) : PluginBase(), _impl{new ActionImpl(system)} {}
 
 Action::~Action() {}
 
-void Action::arm_async(const result_callback_t callback)
+void Action::arm_async(const ResultCallback callback)
 {
     _impl->arm_async(callback);
 }
@@ -23,7 +23,7 @@ Action::Result Action::arm() const
     return _impl->arm();
 }
 
-void Action::disarm_async(const result_callback_t callback)
+void Action::disarm_async(const ResultCallback callback)
 {
     _impl->disarm_async(callback);
 }
@@ -33,7 +33,7 @@ Action::Result Action::disarm() const
     return _impl->disarm();
 }
 
-void Action::takeoff_async(const result_callback_t callback)
+void Action::takeoff_async(const ResultCallback callback)
 {
     _impl->takeoff_async(callback);
 }
@@ -43,7 +43,7 @@ Action::Result Action::takeoff() const
     return _impl->takeoff();
 }
 
-void Action::land_async(const result_callback_t callback)
+void Action::land_async(const ResultCallback callback)
 {
     _impl->land_async(callback);
 }
@@ -53,7 +53,7 @@ Action::Result Action::land() const
     return _impl->land();
 }
 
-void Action::reboot_async(const result_callback_t callback)
+void Action::reboot_async(const ResultCallback callback)
 {
     _impl->reboot_async(callback);
 }
@@ -63,7 +63,7 @@ Action::Result Action::reboot() const
     return _impl->reboot();
 }
 
-void Action::shutdown_async(const result_callback_t callback)
+void Action::shutdown_async(const ResultCallback callback)
 {
     _impl->shutdown_async(callback);
 }
@@ -73,7 +73,7 @@ Action::Result Action::shutdown() const
     return _impl->shutdown();
 }
 
-void Action::kill_async(const result_callback_t callback)
+void Action::kill_async(const ResultCallback callback)
 {
     _impl->kill_async(callback);
 }
@@ -83,7 +83,7 @@ Action::Result Action::kill() const
     return _impl->kill();
 }
 
-void Action::return_to_launch_async(const result_callback_t callback)
+void Action::return_to_launch_async(const ResultCallback callback)
 {
     _impl->return_to_launch_async(callback);
 }
@@ -98,7 +98,7 @@ void Action::goto_location_async(
     double longitude_deg,
     float absolute_altitude_m,
     float yaw_deg,
-    const result_callback_t callback)
+    const ResultCallback callback)
 {
     _impl->goto_location_async(latitude_deg, longitude_deg, absolute_altitude_m, yaw_deg, callback);
 }
@@ -109,7 +109,7 @@ Action::Result Action::goto_location(
     return _impl->goto_location(latitude_deg, longitude_deg, absolute_altitude_m, yaw_deg);
 }
 
-void Action::transition_to_fixedwing_async(const result_callback_t callback)
+void Action::transition_to_fixedwing_async(const ResultCallback callback)
 {
     _impl->transition_to_fixedwing_async(callback);
 }
@@ -119,7 +119,7 @@ Action::Result Action::transition_to_fixedwing() const
     return _impl->transition_to_fixedwing();
 }
 
-void Action::transition_to_multicopter_async(const result_callback_t callback)
+void Action::transition_to_multicopter_async(const ResultCallback callback)
 {
     _impl->transition_to_multicopter_async(callback);
 }
@@ -129,7 +129,7 @@ Action::Result Action::transition_to_multicopter() const
     return _impl->transition_to_multicopter();
 }
 
-void Action::get_takeoff_altitude_async(const get_takeoff_altitude_callback_t callback)
+void Action::get_takeoff_altitude_async(const GetTakeoffAltitudeCallback callback)
 {
     _impl->get_takeoff_altitude_async(callback);
 }
@@ -139,7 +139,7 @@ std::pair<Action::Result, float> Action::get_takeoff_altitude() const
     return _impl->get_takeoff_altitude();
 }
 
-void Action::set_takeoff_altitude_async(float altitude, const result_callback_t callback)
+void Action::set_takeoff_altitude_async(float altitude, const ResultCallback callback)
 {
     _impl->set_takeoff_altitude_async(altitude, callback);
 }
@@ -149,7 +149,7 @@ Action::Result Action::set_takeoff_altitude(float altitude) const
     return _impl->set_takeoff_altitude(altitude);
 }
 
-void Action::get_maximum_speed_async(const get_maximum_speed_callback_t callback)
+void Action::get_maximum_speed_async(const GetMaximumSpeedCallback callback)
 {
     _impl->get_maximum_speed_async(callback);
 }
@@ -159,7 +159,7 @@ std::pair<Action::Result, float> Action::get_maximum_speed() const
     return _impl->get_maximum_speed();
 }
 
-void Action::set_maximum_speed_async(float speed, const result_callback_t callback)
+void Action::set_maximum_speed_async(float speed, const ResultCallback callback)
 {
     _impl->set_maximum_speed_async(speed, callback);
 }
@@ -169,8 +169,7 @@ Action::Result Action::set_maximum_speed(float speed) const
     return _impl->set_maximum_speed(speed);
 }
 
-void Action::get_return_to_launch_altitude_async(
-    const get_return_to_launch_altitude_callback_t callback)
+void Action::get_return_to_launch_altitude_async(const GetReturnToLaunchAltitudeCallback callback)
 {
     _impl->get_return_to_launch_altitude_async(callback);
 }
@@ -181,7 +180,7 @@ std::pair<Action::Result, float> Action::get_return_to_launch_altitude() const
 }
 
 void Action::set_return_to_launch_altitude_async(
-    float relative_altitude_m, const result_callback_t callback)
+    float relative_altitude_m, const ResultCallback callback)
 {
     _impl->set_return_to_launch_altitude_async(relative_altitude_m, callback);
 }

--- a/src/plugins/action/action_impl.cpp
+++ b/src/plugins/action/action_impl.cpp
@@ -165,7 +165,7 @@ Action::Result ActionImpl::transition_to_multicopter() const
     return fut.get();
 }
 
-void ActionImpl::arm_async(const Action::result_callback_t& callback) const
+void ActionImpl::arm_async(const Action::ResultCallback& callback) const
 {
     auto send_arm_command = [this, callback]() {
         MAVLinkCommands::CommandLong command{};
@@ -199,7 +199,7 @@ void ActionImpl::arm_async(const Action::result_callback_t& callback) const
     send_arm_command();
 }
 
-void ActionImpl::disarm_async(const Action::result_callback_t& callback) const
+void ActionImpl::disarm_async(const Action::ResultCallback& callback) const
 {
     Action::Result ret = disarming_allowed();
     if (ret != Action::Result::Success) {
@@ -220,7 +220,7 @@ void ActionImpl::disarm_async(const Action::result_callback_t& callback) const
     });
 }
 
-void ActionImpl::kill_async(const Action::result_callback_t& callback) const
+void ActionImpl::kill_async(const Action::ResultCallback& callback) const
 {
     MAVLinkCommands::CommandLong command{};
 
@@ -234,7 +234,7 @@ void ActionImpl::kill_async(const Action::result_callback_t& callback) const
     });
 }
 
-void ActionImpl::reboot_async(const Action::result_callback_t& callback) const
+void ActionImpl::reboot_async(const Action::ResultCallback& callback) const
 {
     MAVLinkCommands::CommandLong command{};
 
@@ -250,7 +250,7 @@ void ActionImpl::reboot_async(const Action::result_callback_t& callback) const
     });
 }
 
-void ActionImpl::shutdown_async(const Action::result_callback_t& callback) const
+void ActionImpl::shutdown_async(const Action::ResultCallback& callback) const
 {
     MAVLinkCommands::CommandLong command{};
 
@@ -266,7 +266,7 @@ void ActionImpl::shutdown_async(const Action::result_callback_t& callback) const
     });
 }
 
-void ActionImpl::takeoff_async(const Action::result_callback_t& callback) const
+void ActionImpl::takeoff_async(const Action::ResultCallback& callback) const
 {
     MAVLinkCommands::CommandLong command{};
 
@@ -278,7 +278,7 @@ void ActionImpl::takeoff_async(const Action::result_callback_t& callback) const
     });
 }
 
-void ActionImpl::land_async(const Action::result_callback_t& callback) const
+void ActionImpl::land_async(const Action::ResultCallback& callback) const
 {
     MAVLinkCommands::CommandLong command{};
 
@@ -291,7 +291,7 @@ void ActionImpl::land_async(const Action::result_callback_t& callback) const
     });
 }
 
-void ActionImpl::return_to_launch_async(const Action::result_callback_t& callback) const
+void ActionImpl::return_to_launch_async(const Action::ResultCallback& callback) const
 {
     _parent->set_flight_mode_async(
         SystemImpl::FlightMode::ReturnToLaunch,
@@ -305,7 +305,7 @@ void ActionImpl::goto_location_async(
     const double longitude_deg,
     const float altitude_amsl_m,
     const float yaw_deg,
-    const Action::result_callback_t& callback)
+    const Action::ResultCallback& callback)
 {
     MAVLinkCommands::CommandInt command{};
 
@@ -321,7 +321,7 @@ void ActionImpl::goto_location_async(
     });
 }
 
-void ActionImpl::transition_to_fixedwing_async(const Action::result_callback_t& callback) const
+void ActionImpl::transition_to_fixedwing_async(const Action::ResultCallback& callback) const
 {
     if (!_vtol_transition_support_known) {
         if (callback) {
@@ -348,7 +348,7 @@ void ActionImpl::transition_to_fixedwing_async(const Action::result_callback_t& 
     });
 }
 
-void ActionImpl::transition_to_multicopter_async(const Action::result_callback_t& callback) const
+void ActionImpl::transition_to_multicopter_async(const Action::ResultCallback& callback) const
 {
     if (!_vtol_transition_support_known) {
         if (callback) {
@@ -422,7 +422,7 @@ void ActionImpl::process_extended_sys_state(const mavlink_message_t& message)
 }
 
 void ActionImpl::set_takeoff_altitude_async(
-    const float relative_altitude_m, const Action::result_callback_t& callback) const
+    const float relative_altitude_m, const Action::ResultCallback& callback) const
 {
     callback(set_takeoff_altitude(relative_altitude_m));
 }
@@ -436,7 +436,7 @@ Action::Result ActionImpl::set_takeoff_altitude(float relative_altitude_m) const
 }
 
 void ActionImpl::get_takeoff_altitude_async(
-    const Action::get_takeoff_altitude_callback_t& callback) const
+    const Action::GetTakeoffAltitudeCallback& callback) const
 {
     auto altitude_result = get_takeoff_altitude();
     callback(altitude_result.first, altitude_result.second);
@@ -452,7 +452,7 @@ std::pair<Action::Result, float> ActionImpl::get_takeoff_altitude() const
 }
 
 void ActionImpl::set_maximum_speed_async(
-    const float speed_m_s, const Action::result_callback_t& callback) const
+    const float speed_m_s, const Action::ResultCallback& callback) const
 {
     callback(set_maximum_speed(speed_m_s));
 }
@@ -464,7 +464,7 @@ Action::Result ActionImpl::set_maximum_speed(float speed_m_s) const
                                                             Action::Result::ParameterError;
 }
 
-void ActionImpl::get_maximum_speed_async(const Action::get_maximum_speed_callback_t& callback) const
+void ActionImpl::get_maximum_speed_async(const Action::GetMaximumSpeedCallback& callback) const
 {
     auto speed_result = get_maximum_speed();
     callback(speed_result.first, speed_result.second);
@@ -480,7 +480,7 @@ std::pair<Action::Result, float> ActionImpl::get_maximum_speed() const
 }
 
 void ActionImpl::set_return_to_launch_altitude_async(
-    const float relative_altitude_m, const Action::result_callback_t& callback) const
+    const float relative_altitude_m, const Action::ResultCallback& callback) const
 {
     callback(set_return_to_launch_altitude(relative_altitude_m));
 }
@@ -494,7 +494,7 @@ Action::Result ActionImpl::set_return_to_launch_altitude(const float relative_al
 }
 
 void ActionImpl::get_return_to_launch_altitude_async(
-    const Action::get_return_to_launch_altitude_callback_t& callback) const
+    const Action::GetReturnToLaunchAltitudeCallback& callback) const
 {
     const auto get_result = get_return_to_launch_altitude();
     callback(get_result.first, get_result.second);
@@ -530,7 +530,7 @@ Action::Result ActionImpl::action_result_from_command_result(MAVLinkCommands::Re
 }
 
 void ActionImpl::command_result_callback(
-    MAVLinkCommands::Result command_result, const Action::result_callback_t& callback) const
+    MAVLinkCommands::Result command_result, const Action::ResultCallback& callback) const
 {
     Action::Result action_result = action_result_from_command_result(command_result);
 

--- a/src/plugins/action/action_impl.h
+++ b/src/plugins/action/action_impl.h
@@ -35,41 +35,41 @@ public:
     Action::Result transition_to_fixedwing() const;
     Action::Result transition_to_multicopter() const;
 
-    void arm_async(const Action::result_callback_t& callback) const;
-    void disarm_async(const Action::result_callback_t& callback) const;
-    void kill_async(const Action::result_callback_t& callback) const;
-    void reboot_async(const Action::result_callback_t& callback) const;
-    void shutdown_async(const Action::result_callback_t& callback) const;
-    void takeoff_async(const Action::result_callback_t& callback) const;
-    void land_async(const Action::result_callback_t& callback) const;
-    void return_to_launch_async(const Action::result_callback_t& callback) const;
+    void arm_async(const Action::ResultCallback& callback) const;
+    void disarm_async(const Action::ResultCallback& callback) const;
+    void kill_async(const Action::ResultCallback& callback) const;
+    void reboot_async(const Action::ResultCallback& callback) const;
+    void shutdown_async(const Action::ResultCallback& callback) const;
+    void takeoff_async(const Action::ResultCallback& callback) const;
+    void land_async(const Action::ResultCallback& callback) const;
+    void return_to_launch_async(const Action::ResultCallback& callback) const;
     void goto_location_async(
         const double latitude_deg,
         const double longitude_deg,
         const float altitude_amsl_m,
         const float yaw_deg,
-        const Action::result_callback_t& callback);
-    void transition_to_fixedwing_async(const Action::result_callback_t& callback) const;
-    void transition_to_multicopter_async(const Action::result_callback_t& callback) const;
+        const Action::ResultCallback& callback);
+    void transition_to_fixedwing_async(const Action::ResultCallback& callback) const;
+    void transition_to_multicopter_async(const Action::ResultCallback& callback) const;
 
     void set_takeoff_altitude_async(
-        const float relative_altitude_m, const Action::result_callback_t& callback) const;
-    void get_takeoff_altitude_async(const Action::get_takeoff_altitude_callback_t& callback) const;
+        const float relative_altitude_m, const Action::ResultCallback& callback) const;
+    void get_takeoff_altitude_async(const Action::GetTakeoffAltitudeCallback& callback) const;
 
     Action::Result set_takeoff_altitude(float relative_altitude_m) const;
     std::pair<Action::Result, float> get_takeoff_altitude() const;
 
     void
-    set_maximum_speed_async(const float speed_m_s, const Action::result_callback_t& callback) const;
-    void get_maximum_speed_async(const Action::get_maximum_speed_callback_t& callback) const;
+    set_maximum_speed_async(const float speed_m_s, const Action::ResultCallback& callback) const;
+    void get_maximum_speed_async(const Action::GetMaximumSpeedCallback& callback) const;
 
     Action::Result set_maximum_speed(float speed_m_s) const;
     std::pair<Action::Result, float> get_maximum_speed() const;
 
     void set_return_to_launch_altitude_async(
-        const float relative_altitude_m, const Action::result_callback_t& callback) const;
+        const float relative_altitude_m, const Action::ResultCallback& callback) const;
     void get_return_to_launch_altitude_async(
-        const Action::get_return_to_launch_altitude_callback_t& callback) const;
+        const Action::GetReturnToLaunchAltitudeCallback& callback) const;
 
     Action::Result set_return_to_launch_altitude(const float relative_altitude_m) const;
     std::pair<Action::Result, float> get_return_to_launch_altitude() const;
@@ -83,7 +83,7 @@ private:
     static Action::Result action_result_from_command_result(MAVLinkCommands::Result result);
 
     void command_result_callback(
-        MAVLinkCommands::Result command_result, const Action::result_callback_t& callback) const;
+        MAVLinkCommands::Result command_result, const Action::ResultCallback& callback) const;
 
     std::atomic<bool> _in_air_state_known{false};
     std::atomic<bool> _in_air{false};

--- a/src/plugins/action/include/plugins/action/action.h
+++ b/src/plugins/action/include/plugins/action/action.h
@@ -73,7 +73,7 @@ public:
     /**
      * @brief Callback type for asynchronous Action calls.
      */
-    typedef std::function<void(Result)> result_callback_t;
+    typedef std::function<void(Result)> ResultCallback;
 
     /**
      * @brief Send command to arm the drone.
@@ -83,7 +83,7 @@ public:
      *
      * This function is non-blocking. See 'arm' for the blocking counterpart.
      */
-    void arm_async(const result_callback_t callback);
+    void arm_async(const ResultCallback callback);
 
     /**
      * @brief Send command to arm the drone.
@@ -105,7 +105,7 @@ public:
      *
      * This function is non-blocking. See 'disarm' for the blocking counterpart.
      */
-    void disarm_async(const result_callback_t callback);
+    void disarm_async(const ResultCallback callback);
 
     /**
      * @brief Send command to disarm the drone.
@@ -129,7 +129,7 @@ public:
      *
      * This function is non-blocking. See 'takeoff' for the blocking counterpart.
      */
-    void takeoff_async(const result_callback_t callback);
+    void takeoff_async(const ResultCallback callback);
 
     /**
      * @brief Send command to take off and hover.
@@ -152,7 +152,7 @@ public:
      *
      * This function is non-blocking. See 'land' for the blocking counterpart.
      */
-    void land_async(const result_callback_t callback);
+    void land_async(const ResultCallback callback);
 
     /**
      * @brief Send command to land at the current position.
@@ -172,7 +172,7 @@ public:
      *
      * This function is non-blocking. See 'reboot' for the blocking counterpart.
      */
-    void reboot_async(const result_callback_t callback);
+    void reboot_async(const ResultCallback callback);
 
     /**
      * @brief Send command to reboot the drone components.
@@ -194,7 +194,7 @@ public:
      *
      * This function is non-blocking. See 'shutdown' for the blocking counterpart.
      */
-    void shutdown_async(const result_callback_t callback);
+    void shutdown_async(const ResultCallback callback);
 
     /**
      * @brief Send command to shut down the drone components.
@@ -217,7 +217,7 @@ public:
      *
      * This function is non-blocking. See 'kill' for the blocking counterpart.
      */
-    void kill_async(const result_callback_t callback);
+    void kill_async(const ResultCallback callback);
 
     /**
      * @brief Send command to kill the drone.
@@ -241,7 +241,7 @@ public:
      *
      * This function is non-blocking. See 'return_to_launch' for the blocking counterpart.
      */
-    void return_to_launch_async(const result_callback_t callback);
+    void return_to_launch_async(const ResultCallback callback);
 
     /**
      * @brief Send command to return to the launch (takeoff) position and land.
@@ -272,7 +272,7 @@ public:
         double longitude_deg,
         float absolute_altitude_m,
         float yaw_deg,
-        const result_callback_t callback);
+        const ResultCallback callback);
 
     /**
      * @brief Send command to move the vehicle to a specific global position.
@@ -298,7 +298,7 @@ public:
      *
      * This function is non-blocking. See 'transition_to_fixedwing' for the blocking counterpart.
      */
-    void transition_to_fixedwing_async(const result_callback_t callback);
+    void transition_to_fixedwing_async(const ResultCallback callback);
 
     /**
      * @brief Send command to transition the drone to fixedwing.
@@ -323,7 +323,7 @@ public:
      *
      * This function is non-blocking. See 'transition_to_multicopter' for the blocking counterpart.
      */
-    void transition_to_multicopter_async(const result_callback_t callback);
+    void transition_to_multicopter_async(const ResultCallback callback);
 
     /**
      * @brief Send command to transition the drone to multicopter.
@@ -342,14 +342,14 @@ public:
     /**
      * @brief Callback type for get_takeoff_altitude_async.
      */
-    typedef std::function<void(Result, float)> get_takeoff_altitude_callback_t;
+    typedef std::function<void(Result, float)> GetTakeoffAltitudeCallback;
 
     /**
      * @brief Get the takeoff altitude (in meters above ground).
      *
      * This function is non-blocking. See 'get_takeoff_altitude' for the blocking counterpart.
      */
-    void get_takeoff_altitude_async(const get_takeoff_altitude_callback_t callback);
+    void get_takeoff_altitude_async(const GetTakeoffAltitudeCallback callback);
 
     /**
      * @brief Get the takeoff altitude (in meters above ground).
@@ -365,7 +365,7 @@ public:
      *
      * This function is non-blocking. See 'set_takeoff_altitude' for the blocking counterpart.
      */
-    void set_takeoff_altitude_async(float altitude, const result_callback_t callback);
+    void set_takeoff_altitude_async(float altitude, const ResultCallback callback);
 
     /**
      * @brief Set takeoff altitude (in meters above ground).
@@ -379,14 +379,14 @@ public:
     /**
      * @brief Callback type for get_maximum_speed_async.
      */
-    typedef std::function<void(Result, float)> get_maximum_speed_callback_t;
+    typedef std::function<void(Result, float)> GetMaximumSpeedCallback;
 
     /**
      * @brief Get the vehicle maximum speed (in metres/second).
      *
      * This function is non-blocking. See 'get_maximum_speed' for the blocking counterpart.
      */
-    void get_maximum_speed_async(const get_maximum_speed_callback_t callback);
+    void get_maximum_speed_async(const GetMaximumSpeedCallback callback);
 
     /**
      * @brief Get the vehicle maximum speed (in metres/second).
@@ -402,7 +402,7 @@ public:
      *
      * This function is non-blocking. See 'set_maximum_speed' for the blocking counterpart.
      */
-    void set_maximum_speed_async(float speed, const result_callback_t callback);
+    void set_maximum_speed_async(float speed, const ResultCallback callback);
 
     /**
      * @brief Set vehicle maximum speed (in metres/second).
@@ -416,7 +416,7 @@ public:
     /**
      * @brief Callback type for get_return_to_launch_altitude_async.
      */
-    typedef std::function<void(Result, float)> get_return_to_launch_altitude_callback_t;
+    typedef std::function<void(Result, float)> GetReturnToLaunchAltitudeCallback;
 
     /**
      * @brief Get the return to launch minimum return altitude (in meters).
@@ -424,8 +424,7 @@ public:
      * This function is non-blocking. See 'get_return_to_launch_altitude' for the blocking
      * counterpart.
      */
-    void
-    get_return_to_launch_altitude_async(const get_return_to_launch_altitude_callback_t callback);
+    void get_return_to_launch_altitude_async(const GetReturnToLaunchAltitudeCallback callback);
 
     /**
      * @brief Get the return to launch minimum return altitude (in meters).
@@ -443,8 +442,8 @@ public:
      * This function is non-blocking. See 'set_return_to_launch_altitude' for the blocking
      * counterpart.
      */
-    void set_return_to_launch_altitude_async(
-        float relative_altitude_m, const result_callback_t callback);
+    void
+    set_return_to_launch_altitude_async(float relative_altitude_m, const ResultCallback callback);
 
     /**
      * @brief Set the return to launch minimum return altitude (in meters).

--- a/src/plugins/action/include/plugins/action/action.h
+++ b/src/plugins/action/include/plugins/action/action.h
@@ -73,7 +73,7 @@ public:
     /**
      * @brief Callback type for asynchronous Action calls.
      */
-    typedef std::function<void(Result)> ResultCallback;
+    using ResultCallback = std::function<void(Result)>;
 
     /**
      * @brief Send command to arm the drone.
@@ -342,7 +342,7 @@ public:
     /**
      * @brief Callback type for get_takeoff_altitude_async.
      */
-    typedef std::function<void(Result, float)> GetTakeoffAltitudeCallback;
+    using GetTakeoffAltitudeCallback = std::function<void(Result, float)>;
 
     /**
      * @brief Get the takeoff altitude (in meters above ground).
@@ -379,7 +379,7 @@ public:
     /**
      * @brief Callback type for get_maximum_speed_async.
      */
-    typedef std::function<void(Result, float)> GetMaximumSpeedCallback;
+    using GetMaximumSpeedCallback = std::function<void(Result, float)>;
 
     /**
      * @brief Get the vehicle maximum speed (in metres/second).
@@ -416,7 +416,7 @@ public:
     /**
      * @brief Callback type for get_return_to_launch_altitude_async.
      */
-    typedef std::function<void(Result, float)> GetReturnToLaunchAltitudeCallback;
+    using GetReturnToLaunchAltitudeCallback = std::function<void(Result, float)>;
 
     /**
      * @brief Get the return to launch minimum return altitude (in meters).

--- a/src/plugins/calibration/calibration.cpp
+++ b/src/plugins/calibration/calibration.cpp
@@ -15,23 +15,23 @@ Calibration::Calibration(System& system) : PluginBase(), _impl{new CalibrationIm
 
 Calibration::~Calibration() {}
 
-void Calibration::calibrate_gyro_async(calibrate_gyro_callback_t callback)
+void Calibration::calibrate_gyro_async(CalibrateGyroCallback callback)
 {
     _impl->calibrate_gyro_async(callback);
 }
 
-void Calibration::calibrate_accelerometer_async(calibrate_accelerometer_callback_t callback)
+void Calibration::calibrate_accelerometer_async(CalibrateAccelerometerCallback callback)
 {
     _impl->calibrate_accelerometer_async(callback);
 }
 
-void Calibration::calibrate_magnetometer_async(calibrate_magnetometer_callback_t callback)
+void Calibration::calibrate_magnetometer_async(CalibrateMagnetometerCallback callback)
 {
     _impl->calibrate_magnetometer_async(callback);
 }
 
 void Calibration::calibrate_gimbal_accelerometer_async(
-    calibrate_gimbal_accelerometer_callback_t callback)
+    CalibrateGimbalAccelerometerCallback callback)
 {
     _impl->calibrate_gimbal_accelerometer_async(callback);
 }

--- a/src/plugins/calibration/calibration_impl.cpp
+++ b/src/plugins/calibration/calibration_impl.cpp
@@ -36,7 +36,7 @@ void CalibrationImpl::enable() {}
 
 void CalibrationImpl::disable() {}
 
-void CalibrationImpl::calibrate_gyro_async(const calibration_callback_t& callback)
+void CalibrationImpl::calibrate_gyro_async(const CalibrationCallback& callback)
 {
     std::lock_guard<std::mutex> lock(_calibration_mutex);
 
@@ -64,7 +64,7 @@ void CalibrationImpl::calibrate_gyro_async(const calibration_callback_t& callbac
 }
 
 void CalibrationImpl::call_user_callback(
-    const calibration_callback_t& callback,
+    const CalibrationCallback& callback,
     const Calibration::Result& result,
     const Calibration::ProgressData progress_data)
 {
@@ -74,7 +74,7 @@ void CalibrationImpl::call_user_callback(
     }
 }
 
-void CalibrationImpl::calibrate_accelerometer_async(const calibration_callback_t& callback)
+void CalibrationImpl::calibrate_accelerometer_async(const CalibrationCallback& callback)
 {
     std::lock_guard<std::mutex> lock(_calibration_mutex);
 
@@ -101,7 +101,7 @@ void CalibrationImpl::calibrate_accelerometer_async(const calibration_callback_t
         command, std::bind(&CalibrationImpl::command_result_callback, this, _1, _2));
 }
 
-void CalibrationImpl::calibrate_magnetometer_async(const calibration_callback_t& callback)
+void CalibrationImpl::calibrate_magnetometer_async(const CalibrationCallback& callback)
 {
     std::lock_guard<std::mutex> lock(_calibration_mutex);
 
@@ -128,7 +128,7 @@ void CalibrationImpl::calibrate_magnetometer_async(const calibration_callback_t&
         command, std::bind(&CalibrationImpl::command_result_callback, this, _1, _2));
 }
 
-void CalibrationImpl::calibrate_gimbal_accelerometer_async(const calibration_callback_t& callback)
+void CalibrationImpl::calibrate_gimbal_accelerometer_async(const CalibrationCallback& callback)
 {
     std::lock_guard<std::mutex> lock(_calibration_mutex);
 

--- a/src/plugins/calibration/calibration_impl.h
+++ b/src/plugins/calibration/calibration_impl.h
@@ -21,20 +21,18 @@ public:
 
     void cancel() const;
 
-    void calibrate_gyro_async(const Calibration::calibrate_gyro_callback_t& callback);
-    void
-    calibrate_accelerometer_async(const Calibration::calibrate_accelerometer_callback_t& callback);
-    void
-    calibrate_magnetometer_async(const Calibration::calibrate_magnetometer_callback_t& callback);
+    void calibrate_gyro_async(const Calibration::CalibrateGyroCallback& callback);
+    void calibrate_accelerometer_async(const Calibration::CalibrateAccelerometerCallback& callback);
+    void calibrate_magnetometer_async(const Calibration::CalibrateMagnetometerCallback& callback);
     void calibrate_gimbal_accelerometer_async(
-        const Calibration::calibrate_gimbal_accelerometer_callback_t& callback);
+        const Calibration::CalibrateGimbalAccelerometerCallback& callback);
 
 private:
     typedef std::function<void(const Calibration::Result result, const Calibration::ProgressData)>
-        calibration_callback_t;
+        CalibrationCallback;
 
     void call_user_callback(
-        const calibration_callback_t& callback,
+        const CalibrationCallback& callback,
         const Calibration::Result& result,
         const Calibration::ProgressData progress_data);
     void process_statustext(const mavlink_message_t& message);
@@ -72,7 +70,7 @@ private:
         GimbalAccelerometerCalibration
     } _state{State::None};
 
-    calibration_callback_t _calibration_callback{nullptr};
+    CalibrationCallback _calibration_callback{nullptr};
 };
 
 } // namespace mavsdk

--- a/src/plugins/calibration/include/plugins/calibration/calibration.h
+++ b/src/plugins/calibration/include/plugins/calibration/calibration.h
@@ -100,13 +100,13 @@ public:
     /**
      * @brief Callback type for asynchronous Calibration calls.
      */
-    typedef std::function<void(Result)> ResultCallback;
+    using ResultCallback = std::function<void(Result)>;
 
     /**
      * @brief Callback type for calibrate_gyro_async.
      */
 
-    typedef std::function<void(Calibration::Result, ProgressData)> CalibrateGyroCallback;
+    using CalibrateGyroCallback = std::function<void(Calibration::Result, ProgressData)>;
 
     /**
      * @brief Perform gyro calibration.
@@ -117,7 +117,7 @@ public:
      * @brief Callback type for calibrate_accelerometer_async.
      */
 
-    typedef std::function<void(Calibration::Result, ProgressData)> CalibrateAccelerometerCallback;
+    using CalibrateAccelerometerCallback = std::function<void(Calibration::Result, ProgressData)>;
 
     /**
      * @brief Perform accelerometer calibration.
@@ -128,7 +128,7 @@ public:
      * @brief Callback type for calibrate_magnetometer_async.
      */
 
-    typedef std::function<void(Calibration::Result, ProgressData)> CalibrateMagnetometerCallback;
+    using CalibrateMagnetometerCallback = std::function<void(Calibration::Result, ProgressData)>;
 
     /**
      * @brief Perform magnetometer caliration.
@@ -139,8 +139,8 @@ public:
      * @brief Callback type for calibrate_gimbal_accelerometer_async.
      */
 
-    typedef std::function<void(Calibration::Result, ProgressData)>
-        CalibrateGimbalAccelerometerCallback;
+    using CalibrateGimbalAccelerometerCallback =
+        std::function<void(Calibration::Result, ProgressData)>;
 
     /**
      * @brief Perform gimbal accelerometer calibration.

--- a/src/plugins/calibration/include/plugins/calibration/calibration.h
+++ b/src/plugins/calibration/include/plugins/calibration/calibration.h
@@ -100,54 +100,52 @@ public:
     /**
      * @brief Callback type for asynchronous Calibration calls.
      */
-    typedef std::function<void(Result)> result_callback_t;
+    typedef std::function<void(Result)> ResultCallback;
 
     /**
      * @brief Callback type for calibrate_gyro_async.
      */
 
-    typedef std::function<void(Calibration::Result, ProgressData)> calibrate_gyro_callback_t;
+    typedef std::function<void(Calibration::Result, ProgressData)> CalibrateGyroCallback;
 
     /**
      * @brief Perform gyro calibration.
      */
-    void calibrate_gyro_async(calibrate_gyro_callback_t callback);
+    void calibrate_gyro_async(CalibrateGyroCallback callback);
 
     /**
      * @brief Callback type for calibrate_accelerometer_async.
      */
 
-    typedef std::function<void(Calibration::Result, ProgressData)>
-        calibrate_accelerometer_callback_t;
+    typedef std::function<void(Calibration::Result, ProgressData)> CalibrateAccelerometerCallback;
 
     /**
      * @brief Perform accelerometer calibration.
      */
-    void calibrate_accelerometer_async(calibrate_accelerometer_callback_t callback);
+    void calibrate_accelerometer_async(CalibrateAccelerometerCallback callback);
 
     /**
      * @brief Callback type for calibrate_magnetometer_async.
      */
 
-    typedef std::function<void(Calibration::Result, ProgressData)>
-        calibrate_magnetometer_callback_t;
+    typedef std::function<void(Calibration::Result, ProgressData)> CalibrateMagnetometerCallback;
 
     /**
      * @brief Perform magnetometer caliration.
      */
-    void calibrate_magnetometer_async(calibrate_magnetometer_callback_t callback);
+    void calibrate_magnetometer_async(CalibrateMagnetometerCallback callback);
 
     /**
      * @brief Callback type for calibrate_gimbal_accelerometer_async.
      */
 
     typedef std::function<void(Calibration::Result, ProgressData)>
-        calibrate_gimbal_accelerometer_callback_t;
+        CalibrateGimbalAccelerometerCallback;
 
     /**
      * @brief Perform gimbal accelerometer calibration.
      */
-    void calibrate_gimbal_accelerometer_async(calibrate_gimbal_accelerometer_callback_t callback);
+    void calibrate_gimbal_accelerometer_async(CalibrateGimbalAccelerometerCallback callback);
 
     /**
      * @brief Cancel ongoing calibration process.

--- a/src/plugins/camera/camera.cpp
+++ b/src/plugins/camera/camera.cpp
@@ -25,7 +25,7 @@ Camera::Camera(System& system) : PluginBase(), _impl{new CameraImpl(system)} {}
 
 Camera::~Camera() {}
 
-void Camera::take_photo_async(const result_callback_t callback)
+void Camera::take_photo_async(const ResultCallback callback)
 {
     _impl->take_photo_async(callback);
 }
@@ -35,7 +35,7 @@ Camera::Result Camera::take_photo() const
     return _impl->take_photo();
 }
 
-void Camera::start_photo_interval_async(float interval_s, const result_callback_t callback)
+void Camera::start_photo_interval_async(float interval_s, const ResultCallback callback)
 {
     _impl->start_photo_interval_async(interval_s, callback);
 }
@@ -45,7 +45,7 @@ Camera::Result Camera::start_photo_interval(float interval_s) const
     return _impl->start_photo_interval(interval_s);
 }
 
-void Camera::stop_photo_interval_async(const result_callback_t callback)
+void Camera::stop_photo_interval_async(const ResultCallback callback)
 {
     _impl->stop_photo_interval_async(callback);
 }
@@ -55,7 +55,7 @@ Camera::Result Camera::stop_photo_interval() const
     return _impl->stop_photo_interval();
 }
 
-void Camera::start_video_async(const result_callback_t callback)
+void Camera::start_video_async(const ResultCallback callback)
 {
     _impl->start_video_async(callback);
 }
@@ -65,7 +65,7 @@ Camera::Result Camera::start_video() const
     return _impl->start_video();
 }
 
-void Camera::stop_video_async(const result_callback_t callback)
+void Camera::stop_video_async(const ResultCallback callback)
 {
     _impl->stop_video_async(callback);
 }
@@ -85,7 +85,7 @@ Camera::Result Camera::stop_video_streaming() const
     return _impl->stop_video_streaming();
 }
 
-void Camera::set_mode_async(Mode mode, const result_callback_t callback)
+void Camera::set_mode_async(Mode mode, const ResultCallback callback)
 {
     _impl->set_mode_async(mode, callback);
 }
@@ -95,7 +95,7 @@ Camera::Result Camera::set_mode(Mode mode) const
     return _impl->set_mode(mode);
 }
 
-void Camera::subscribe_mode(mode_callback_t callback)
+void Camera::subscribe_mode(ModeCallback callback)
 {
     _impl->mode_async(callback);
 }
@@ -105,7 +105,7 @@ Camera::Mode Camera::mode() const
     return _impl->mode();
 }
 
-void Camera::subscribe_information(information_callback_t callback)
+void Camera::subscribe_information(InformationCallback callback)
 {
     _impl->information_async(callback);
 }
@@ -115,7 +115,7 @@ Camera::Information Camera::information() const
     return _impl->information();
 }
 
-void Camera::subscribe_video_stream_info(video_stream_info_callback_t callback)
+void Camera::subscribe_video_stream_info(VideoStreamInfoCallback callback)
 {
     _impl->video_stream_info_async(callback);
 }
@@ -125,12 +125,12 @@ Camera::VideoStreamInfo Camera::video_stream_info() const
     return _impl->video_stream_info();
 }
 
-void Camera::subscribe_capture_info(capture_info_callback_t callback)
+void Camera::subscribe_capture_info(CaptureInfoCallback callback)
 {
     _impl->capture_info_async(callback);
 }
 
-void Camera::subscribe_status(status_callback_t callback)
+void Camera::subscribe_status(StatusCallback callback)
 {
     _impl->status_async(callback);
 }
@@ -140,12 +140,12 @@ Camera::Status Camera::status() const
     return _impl->status();
 }
 
-void Camera::subscribe_current_settings(current_settings_callback_t callback)
+void Camera::subscribe_current_settings(CurrentSettingsCallback callback)
 {
     _impl->current_settings_async(callback);
 }
 
-void Camera::subscribe_possible_setting_options(possible_setting_options_callback_t callback)
+void Camera::subscribe_possible_setting_options(PossibleSettingOptionsCallback callback)
 {
     _impl->possible_setting_options_async(callback);
 }
@@ -155,7 +155,7 @@ std::vector<Camera::SettingOptions> Camera::possible_setting_options() const
     return _impl->possible_setting_options();
 }
 
-void Camera::set_setting_async(Setting setting, const result_callback_t callback)
+void Camera::set_setting_async(Setting setting, const ResultCallback callback)
 {
     _impl->set_setting_async(setting, callback);
 }
@@ -165,7 +165,7 @@ Camera::Result Camera::set_setting(Setting setting) const
     return _impl->set_setting(setting);
 }
 
-void Camera::get_setting_async(Setting setting, const get_setting_callback_t callback)
+void Camera::get_setting_async(Setting setting, const GetSettingCallback callback)
 {
     _impl->get_setting_async(setting, callback);
 }
@@ -175,7 +175,7 @@ std::pair<Camera::Result, Camera::Setting> Camera::get_setting(Setting setting) 
     return _impl->get_setting(setting);
 }
 
-void Camera::format_storage_async(const result_callback_t callback)
+void Camera::format_storage_async(const ResultCallback callback)
 {
     _impl->format_storage_async(callback);
 }

--- a/src/plugins/camera/camera_impl.cpp
+++ b/src/plugins/camera/camera_impl.cpp
@@ -382,7 +382,7 @@ Camera::Result CameraImpl::stop_video()
     return camera_result_from_command_result(_parent->send_command(cmd_stop_video));
 }
 
-void CameraImpl::take_photo_async(const Camera::result_callback_t& callback)
+void CameraImpl::take_photo_async(const Camera::ResultCallback& callback)
 {
     // TODO: check whether we are in photo mode.
 
@@ -396,7 +396,7 @@ void CameraImpl::take_photo_async(const Camera::result_callback_t& callback)
 }
 
 void CameraImpl::start_photo_interval_async(
-    float interval_s, const Camera::result_callback_t& callback)
+    float interval_s, const Camera::ResultCallback& callback)
 {
     if (!interval_valid(interval_s)) {
         const auto temp_callback = callback;
@@ -416,7 +416,7 @@ void CameraImpl::start_photo_interval_async(
         std::bind(&CameraImpl::receive_command_result, this, _1, callback));
 }
 
-void CameraImpl::stop_photo_interval_async(const Camera::result_callback_t& callback)
+void CameraImpl::stop_photo_interval_async(const Camera::ResultCallback& callback)
 {
     auto cmd_stop_photo_interval = make_command_stop_photo();
 
@@ -425,7 +425,7 @@ void CameraImpl::stop_photo_interval_async(const Camera::result_callback_t& call
         std::bind(&CameraImpl::receive_command_result, this, _1, callback));
 }
 
-void CameraImpl::start_video_async(const Camera::result_callback_t& callback)
+void CameraImpl::start_video_async(const Camera::ResultCallback& callback)
 {
     // TODO: check whether video capture is already in progress.
     // TODO: check whether we are in video mode.
@@ -437,7 +437,7 @@ void CameraImpl::start_video_async(const Camera::result_callback_t& callback)
         cmd_start_video, std::bind(&CameraImpl::receive_command_result, this, _1, callback));
 }
 
-void CameraImpl::stop_video_async(const Camera::result_callback_t& callback)
+void CameraImpl::stop_video_async(const Camera::ResultCallback& callback)
 {
     auto cmd_stop_video = make_command_stop_video();
 
@@ -452,7 +452,7 @@ Camera::Information CameraImpl::information() const
     return _information.data;
 }
 
-void CameraImpl::information_async(const Camera::information_callback_t& callback)
+void CameraImpl::information_async(const Camera::InformationCallback& callback)
 {
     std::lock_guard<std::mutex> lock(_information.mutex);
     _information.subscription_callback = callback;
@@ -513,7 +513,7 @@ Camera::VideoStreamInfo CameraImpl::video_stream_info()
     return _video_stream_info.data;
 }
 
-void CameraImpl::video_stream_info_async(const Camera::video_stream_info_callback_t callback)
+void CameraImpl::video_stream_info_async(const Camera::VideoStreamInfoCallback callback)
 {
     std::lock_guard<std::mutex> lock(_video_stream_info.mutex);
 
@@ -595,7 +595,7 @@ float CameraImpl::to_mavlink_camera_mode(const Camera::Mode mode) const
     }
 }
 
-void CameraImpl::set_mode_async(const Camera::Mode mode, const Camera::result_callback_t& callback)
+void CameraImpl::set_mode_async(const Camera::Mode mode, const Camera::ResultCallback& callback)
 {
     const auto mavlink_mode = to_mavlink_camera_mode(mode);
     auto cmd_set_camera_mode = make_command_set_camera_mode(mavlink_mode);
@@ -614,7 +614,7 @@ Camera::Mode CameraImpl::mode()
     return _mode.data;
 }
 
-void CameraImpl::mode_async(const Camera::mode_callback_t callback)
+void CameraImpl::mode_async(const Camera::ModeCallback callback)
 {
     {
         std::lock_guard<std::mutex> lock(_mode.mutex);
@@ -648,7 +648,7 @@ void CameraImpl::request_status()
     _parent->send_command_async(make_command_request_storage_info(), nullptr);
 }
 
-void CameraImpl::status_async(const Camera::status_callback_t callback)
+void CameraImpl::status_async(const Camera::StatusCallback callback)
 {
     std::lock_guard<std::mutex> lock(_status.mutex);
 
@@ -667,7 +667,7 @@ Camera::Status CameraImpl::status()
     return _status.data;
 }
 
-void CameraImpl::capture_info_async(Camera::capture_info_callback_t callback)
+void CameraImpl::capture_info_async(Camera::CaptureInfoCallback callback)
 {
     std::lock_guard<std::mutex> lock(_capture_info.mutex);
     _capture_info.callback = callback;
@@ -928,7 +928,7 @@ void CameraImpl::check_status()
 }
 
 void CameraImpl::receive_command_result(
-    MAVLinkCommands::Result command_result, const Camera::result_callback_t& callback)
+    MAVLinkCommands::Result command_result, const Camera::ResultCallback& callback)
 {
     Camera::Result camera_result = camera_result_from_command_result(command_result);
 
@@ -939,7 +939,7 @@ void CameraImpl::receive_command_result(
 
 void CameraImpl::receive_set_mode_command_result(
     const MAVLinkCommands::Result command_result,
-    const Camera::result_callback_t callback,
+    const Camera::ResultCallback callback,
     const Camera::Mode mode)
 {
     Camera::Result camera_result = camera_result_from_command_result(command_result);
@@ -1063,8 +1063,7 @@ Camera::Result CameraImpl::set_setting(Camera::Setting setting)
     return ret.get();
 }
 
-void CameraImpl::set_setting_async(
-    Camera::Setting setting, const Camera::result_callback_t callback)
+void CameraImpl::set_setting_async(Camera::Setting setting, const Camera::ResultCallback callback)
 {
     set_option_async(setting.setting_id, setting.option, callback);
 }
@@ -1072,7 +1071,7 @@ void CameraImpl::set_setting_async(
 void CameraImpl::set_option_async(
     const std::string& setting_id,
     const Camera::Option& option,
-    const Camera::result_callback_t& callback)
+    const Camera::ResultCallback& callback)
 {
     if (!_camera_definition) {
         LogWarn() << "Error: no camera defnition available yet.";
@@ -1192,7 +1191,7 @@ void CameraImpl::set_option_async(
 }
 
 void CameraImpl::get_setting_async(
-    Camera::Setting setting, const Camera::get_setting_callback_t callback)
+    Camera::Setting setting, const Camera::GetSettingCallback callback)
 {
     get_option_async(
         setting.setting_id,
@@ -1283,7 +1282,7 @@ void CameraImpl::get_option_async(
     }
 }
 
-void CameraImpl::current_settings_async(const Camera::current_settings_callback_t& callback)
+void CameraImpl::current_settings_async(const Camera::CurrentSettingsCallback& callback)
 {
     {
         std::lock_guard<std::mutex> lock(_subscribe_current_settings.mutex);
@@ -1293,7 +1292,7 @@ void CameraImpl::current_settings_async(const Camera::current_settings_callback_
 }
 
 void CameraImpl::possible_setting_options_async(
-    const Camera::possible_setting_options_callback_t& callback)
+    const Camera::PossibleSettingOptionsCallback& callback)
 {
     {
         std::lock_guard<std::mutex> lock(_subscribe_possible_setting_options.mutex);
@@ -1506,7 +1505,7 @@ Camera::Result CameraImpl::format_storage()
     return ret.get();
 }
 
-void CameraImpl::format_storage_async(Camera::result_callback_t callback)
+void CameraImpl::format_storage_async(Camera::ResultCallback callback)
 {
     MAVLinkCommands::CommandLong cmd_format{};
 

--- a/src/plugins/camera/camera_impl.h
+++ b/src/plugins/camera/camera_impl.h
@@ -29,50 +29,49 @@ public:
     Camera::Result start_video();
     Camera::Result stop_video();
 
-    void take_photo_async(const Camera::result_callback_t& callback);
-    void start_photo_interval_async(float interval_s, const Camera::result_callback_t& callback);
-    void stop_photo_interval_async(const Camera::result_callback_t& callback);
-    void start_video_async(const Camera::result_callback_t& callback);
-    void stop_video_async(const Camera::result_callback_t& callback);
+    void take_photo_async(const Camera::ResultCallback& callback);
+    void start_photo_interval_async(float interval_s, const Camera::ResultCallback& callback);
+    void stop_photo_interval_async(const Camera::ResultCallback& callback);
+    void start_video_async(const Camera::ResultCallback& callback);
+    void stop_video_async(const Camera::ResultCallback& callback);
 
     Camera::Information information() const;
-    void information_async(const Camera::information_callback_t& callback);
+    void information_async(const Camera::InformationCallback& callback);
 
     std::pair<Camera::Result, Camera::VideoStreamInfo> get_video_stream_info();
 
     Camera::VideoStreamInfo video_stream_info();
-    void video_stream_info_async(Camera::video_stream_info_callback_t callback);
+    void video_stream_info_async(Camera::VideoStreamInfoCallback callback);
 
     Camera::Result start_video_streaming();
     Camera::Result stop_video_streaming();
 
     Camera::Result set_mode(const Camera::Mode mode);
-    void set_mode_async(const Camera::Mode mode, const Camera::result_callback_t& callback);
+    void set_mode_async(const Camera::Mode mode, const Camera::ResultCallback& callback);
 
     Camera::Mode mode();
-    void mode_async(const Camera::mode_callback_t callback);
+    void mode_async(const Camera::ModeCallback callback);
 
-    void capture_info_async(Camera::capture_info_callback_t callback);
+    void capture_info_async(Camera::CaptureInfoCallback callback);
 
     Camera::Status status();
-    void status_async(const Camera::status_callback_t callback);
+    void status_async(const Camera::StatusCallback callback);
 
     Camera::Result set_setting(Camera::Setting setting);
-    void set_setting_async(Camera::Setting setting, const Camera::result_callback_t callback);
+    void set_setting_async(Camera::Setting setting, const Camera::ResultCallback callback);
 
-    void get_setting_async(Camera::Setting setting, const Camera::get_setting_callback_t callback);
+    void get_setting_async(Camera::Setting setting, const Camera::GetSettingCallback callback);
     std::pair<Camera::Result, Camera::Setting> get_setting(Camera::Setting setting);
 
     std::vector<Camera::SettingOptions> possible_setting_options();
 
     bool is_setting_range(const std::string& setting_id);
 
-    void current_settings_async(const Camera::current_settings_callback_t& callback);
-    void
-    possible_setting_options_async(const Camera::possible_setting_options_callback_t& callback);
+    void current_settings_async(const Camera::CurrentSettingsCallback& callback);
+    void possible_setting_options_async(const Camera::PossibleSettingOptionsCallback& callback);
 
     Camera::Result format_storage();
-    void format_storage_async(Camera::result_callback_t callback);
+    void format_storage_async(Camera::ResultCallback callback);
 
     CameraImpl(const CameraImpl&) = delete;
     CameraImpl& operator=(const CameraImpl&) = delete;
@@ -84,7 +83,7 @@ private:
     void set_option_async(
         const std::string& setting_id,
         const Camera::Option& option,
-        const Camera::result_callback_t& callback);
+        const Camera::ResultCallback& callback);
 
     Camera::Result get_option(const std::string& setting_id, Camera::Option& option);
     void get_option_async(
@@ -101,14 +100,14 @@ private:
 
     void receive_set_mode_command_result(
         const MAVLinkCommands::Result command_result,
-        const Camera::result_callback_t callback,
+        const Camera::ResultCallback callback,
         const Camera::Mode mode);
 
     static Camera::Result
     camera_result_from_command_result(const MAVLinkCommands::Result command_result);
 
     void receive_command_result(
-        MAVLinkCommands::Result command_result, const Camera::result_callback_t& callback);
+        MAVLinkCommands::Result command_result, const Camera::ResultCallback& callback);
 
     static bool interval_valid(float interval_s);
 
@@ -177,7 +176,7 @@ private:
         bool received_camera_capture_status{false};
         bool received_storage_information{false};
 
-        Camera::status_callback_t subscription_callback{nullptr};
+        Camera::StatusCallback subscription_callback{nullptr};
         void* call_every_cookie{nullptr};
     } _status{};
 
@@ -186,7 +185,7 @@ private:
     struct {
         std::mutex mutex{};
         Camera::Mode data{};
-        Camera::mode_callback_t subscription_callback{nullptr};
+        Camera::ModeCallback subscription_callback{nullptr};
         void* call_every_cookie{nullptr};
     } _mode{};
 
@@ -197,7 +196,7 @@ private:
 
     struct {
         std::mutex mutex{};
-        Camera::capture_info_callback_t callback{nullptr};
+        Camera::CaptureInfoCallback callback{nullptr};
     } _capture_info{};
 
     struct {
@@ -205,23 +204,23 @@ private:
         Camera::VideoStreamInfo data{};
         bool available{false};
         void* call_every_cookie{nullptr};
-        Camera::video_stream_info_callback_t subscription_callback{nullptr};
+        Camera::VideoStreamInfoCallback subscription_callback{nullptr};
     } _video_stream_info{};
 
     struct {
         mutable std::mutex mutex{};
         Camera::Information data{};
-        Camera::information_callback_t subscription_callback{nullptr};
+        Camera::InformationCallback subscription_callback{nullptr};
     } _information{};
 
     struct {
         std::mutex mutex{};
-        Camera::current_settings_callback_t callback{nullptr};
+        Camera::CurrentSettingsCallback callback{nullptr};
     } _subscribe_current_settings{};
 
     struct {
         std::mutex mutex{};
-        Camera::possible_setting_options_callback_t callback{nullptr};
+        Camera::PossibleSettingOptionsCallback callback{nullptr};
     } _subscribe_possible_setting_options{};
 };
 

--- a/src/plugins/camera/include/plugins/camera/camera.h
+++ b/src/plugins/camera/include/plugins/camera/camera.h
@@ -413,14 +413,14 @@ public:
     /**
      * @brief Callback type for asynchronous Camera calls.
      */
-    typedef std::function<void(Result)> result_callback_t;
+    typedef std::function<void(Result)> ResultCallback;
 
     /**
      * @brief Take one photo.
      *
      * This function is non-blocking. See 'take_photo' for the blocking counterpart.
      */
-    void take_photo_async(const result_callback_t callback);
+    void take_photo_async(const ResultCallback callback);
 
     /**
      * @brief Take one photo.
@@ -436,7 +436,7 @@ public:
      *
      * This function is non-blocking. See 'start_photo_interval' for the blocking counterpart.
      */
-    void start_photo_interval_async(float interval_s, const result_callback_t callback);
+    void start_photo_interval_async(float interval_s, const ResultCallback callback);
 
     /**
      * @brief Start photo timelapse with a given interval.
@@ -452,7 +452,7 @@ public:
      *
      * This function is non-blocking. See 'stop_photo_interval' for the blocking counterpart.
      */
-    void stop_photo_interval_async(const result_callback_t callback);
+    void stop_photo_interval_async(const ResultCallback callback);
 
     /**
      * @brief Stop a running photo timelapse.
@@ -468,7 +468,7 @@ public:
      *
      * This function is non-blocking. See 'start_video' for the blocking counterpart.
      */
-    void start_video_async(const result_callback_t callback);
+    void start_video_async(const ResultCallback callback);
 
     /**
      * @brief Start a video recording.
@@ -484,7 +484,7 @@ public:
      *
      * This function is non-blocking. See 'stop_video' for the blocking counterpart.
      */
-    void stop_video_async(const result_callback_t callback);
+    void stop_video_async(const ResultCallback callback);
 
     /**
      * @brief Stop a running video recording.
@@ -518,7 +518,7 @@ public:
      *
      * This function is non-blocking. See 'set_mode' for the blocking counterpart.
      */
-    void set_mode_async(Mode mode, const result_callback_t callback);
+    void set_mode_async(Mode mode, const ResultCallback callback);
 
     /**
      * @brief Set camera mode.
@@ -533,12 +533,12 @@ public:
      * @brief Callback type for subscribe_mode.
      */
 
-    typedef std::function<void(Mode)> mode_callback_t;
+    typedef std::function<void(Mode)> ModeCallback;
 
     /**
      * @brief Subscribe to camera mode updates.
      */
-    void subscribe_mode(mode_callback_t callback);
+    void subscribe_mode(ModeCallback callback);
 
     /**
      * @brief Poll for 'Mode' (blocking).
@@ -551,12 +551,12 @@ public:
      * @brief Callback type for subscribe_information.
      */
 
-    typedef std::function<void(Information)> information_callback_t;
+    typedef std::function<void(Information)> InformationCallback;
 
     /**
      * @brief Subscribe to camera information updates.
      */
-    void subscribe_information(information_callback_t callback);
+    void subscribe_information(InformationCallback callback);
 
     /**
      * @brief Poll for 'Information' (blocking).
@@ -569,12 +569,12 @@ public:
      * @brief Callback type for subscribe_video_stream_info.
      */
 
-    typedef std::function<void(VideoStreamInfo)> video_stream_info_callback_t;
+    typedef std::function<void(VideoStreamInfo)> VideoStreamInfoCallback;
 
     /**
      * @brief Subscribe to video stream info updates.
      */
-    void subscribe_video_stream_info(video_stream_info_callback_t callback);
+    void subscribe_video_stream_info(VideoStreamInfoCallback callback);
 
     /**
      * @brief Poll for 'VideoStreamInfo' (blocking).
@@ -587,23 +587,23 @@ public:
      * @brief Callback type for subscribe_capture_info.
      */
 
-    typedef std::function<void(CaptureInfo)> capture_info_callback_t;
+    typedef std::function<void(CaptureInfo)> CaptureInfoCallback;
 
     /**
      * @brief Subscribe to capture info updates.
      */
-    void subscribe_capture_info(capture_info_callback_t callback);
+    void subscribe_capture_info(CaptureInfoCallback callback);
 
     /**
      * @brief Callback type for subscribe_status.
      */
 
-    typedef std::function<void(Status)> status_callback_t;
+    typedef std::function<void(Status)> StatusCallback;
 
     /**
      * @brief Subscribe to camera status updates.
      */
-    void subscribe_status(status_callback_t callback);
+    void subscribe_status(StatusCallback callback);
 
     /**
      * @brief Poll for 'Status' (blocking).
@@ -616,23 +616,23 @@ public:
      * @brief Callback type for subscribe_current_settings.
      */
 
-    typedef std::function<void(std::vector<Setting>)> current_settings_callback_t;
+    typedef std::function<void(std::vector<Setting>)> CurrentSettingsCallback;
 
     /**
      * @brief Get the list of current camera settings.
      */
-    void subscribe_current_settings(current_settings_callback_t callback);
+    void subscribe_current_settings(CurrentSettingsCallback callback);
 
     /**
      * @brief Callback type for subscribe_possible_setting_options.
      */
 
-    typedef std::function<void(std::vector<SettingOptions>)> possible_setting_options_callback_t;
+    typedef std::function<void(std::vector<SettingOptions>)> PossibleSettingOptionsCallback;
 
     /**
      * @brief Get the list of settings that can be changed.
      */
-    void subscribe_possible_setting_options(possible_setting_options_callback_t callback);
+    void subscribe_possible_setting_options(PossibleSettingOptionsCallback callback);
 
     /**
      * @brief Poll for 'std::vector<SettingOptions>' (blocking).
@@ -648,7 +648,7 @@ public:
      *
      * This function is non-blocking. See 'set_setting' for the blocking counterpart.
      */
-    void set_setting_async(Setting setting, const result_callback_t callback);
+    void set_setting_async(Setting setting, const ResultCallback callback);
 
     /**
      * @brief Set a setting to some value.
@@ -664,7 +664,7 @@ public:
     /**
      * @brief Callback type for get_setting_async.
      */
-    typedef std::function<void(Result, Setting)> get_setting_callback_t;
+    typedef std::function<void(Result, Setting)> GetSettingCallback;
 
     /**
      * @brief Get a setting.
@@ -673,7 +673,7 @@ public:
      *
      * This function is non-blocking. See 'get_setting' for the blocking counterpart.
      */
-    void get_setting_async(Setting setting, const get_setting_callback_t callback);
+    void get_setting_async(Setting setting, const GetSettingCallback callback);
 
     /**
      * @brief Get a setting.
@@ -693,7 +693,7 @@ public:
      *
      * This function is non-blocking. See 'format_storage' for the blocking counterpart.
      */
-    void format_storage_async(const result_callback_t callback);
+    void format_storage_async(const ResultCallback callback);
 
     /**
      * @brief Format storage (e.g. SD card) in camera.

--- a/src/plugins/camera/include/plugins/camera/camera.h
+++ b/src/plugins/camera/include/plugins/camera/camera.h
@@ -413,7 +413,7 @@ public:
     /**
      * @brief Callback type for asynchronous Camera calls.
      */
-    typedef std::function<void(Result)> ResultCallback;
+    using ResultCallback = std::function<void(Result)>;
 
     /**
      * @brief Take one photo.
@@ -533,7 +533,7 @@ public:
      * @brief Callback type for subscribe_mode.
      */
 
-    typedef std::function<void(Mode)> ModeCallback;
+    using ModeCallback = std::function<void(Mode)>;
 
     /**
      * @brief Subscribe to camera mode updates.
@@ -551,7 +551,7 @@ public:
      * @brief Callback type for subscribe_information.
      */
 
-    typedef std::function<void(Information)> InformationCallback;
+    using InformationCallback = std::function<void(Information)>;
 
     /**
      * @brief Subscribe to camera information updates.
@@ -569,7 +569,7 @@ public:
      * @brief Callback type for subscribe_video_stream_info.
      */
 
-    typedef std::function<void(VideoStreamInfo)> VideoStreamInfoCallback;
+    using VideoStreamInfoCallback = std::function<void(VideoStreamInfo)>;
 
     /**
      * @brief Subscribe to video stream info updates.
@@ -587,7 +587,7 @@ public:
      * @brief Callback type for subscribe_capture_info.
      */
 
-    typedef std::function<void(CaptureInfo)> CaptureInfoCallback;
+    using CaptureInfoCallback = std::function<void(CaptureInfo)>;
 
     /**
      * @brief Subscribe to capture info updates.
@@ -598,7 +598,7 @@ public:
      * @brief Callback type for subscribe_status.
      */
 
-    typedef std::function<void(Status)> StatusCallback;
+    using StatusCallback = std::function<void(Status)>;
 
     /**
      * @brief Subscribe to camera status updates.
@@ -616,7 +616,7 @@ public:
      * @brief Callback type for subscribe_current_settings.
      */
 
-    typedef std::function<void(std::vector<Setting>)> CurrentSettingsCallback;
+    using CurrentSettingsCallback = std::function<void(std::vector<Setting>)>;
 
     /**
      * @brief Get the list of current camera settings.
@@ -627,7 +627,7 @@ public:
      * @brief Callback type for subscribe_possible_setting_options.
      */
 
-    typedef std::function<void(std::vector<SettingOptions>)> PossibleSettingOptionsCallback;
+    using PossibleSettingOptionsCallback = std::function<void(std::vector<SettingOptions>)>;
 
     /**
      * @brief Get the list of settings that can be changed.
@@ -664,7 +664,7 @@ public:
     /**
      * @brief Callback type for get_setting_async.
      */
-    typedef std::function<void(Result, Setting)> GetSettingCallback;
+    using GetSettingCallback = std::function<void(Result, Setting)>;
 
     /**
      * @brief Get a setting.

--- a/src/plugins/camera/mocks/camera_mock.h
+++ b/src/plugins/camera/mocks/camera_mock.h
@@ -17,18 +17,17 @@ public:
     MOCK_CONST_METHOD1(set_mode, Camera::Result(Camera::Mode)){};
     MOCK_CONST_METHOD1(set_setting, Camera::Result(Camera::Setting)){};
     MOCK_CONST_METHOD1(get_setting, std::pair<Camera::Result, Camera::Setting>(Camera::Setting)){};
-    MOCK_CONST_METHOD1(subscribe_mode, void(Camera::mode_callback_t)){};
+    MOCK_CONST_METHOD1(subscribe_mode, void(Camera::ModeCallback)){};
     MOCK_CONST_METHOD1(set_video_stream_settings, void(Camera::VideoStreamSettings)){};
-    MOCK_CONST_METHOD1(subscribe_video_stream_info, void(Camera::video_stream_info_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_capture_info, void(Camera::capture_info_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_status, void(Camera::status_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_information, void(Camera::information_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_current_settings, void(Camera::current_settings_callback_t)){};
+    MOCK_CONST_METHOD1(subscribe_video_stream_info, void(Camera::VideoStreamInfoCallback)){};
+    MOCK_CONST_METHOD1(subscribe_capture_info, void(Camera::CaptureInfoCallback)){};
+    MOCK_CONST_METHOD1(subscribe_status, void(Camera::StatusCallback)){};
+    MOCK_CONST_METHOD1(subscribe_information, void(Camera::InformationCallback)){};
+    MOCK_CONST_METHOD1(subscribe_current_settings, void(Camera::CurrentSettingsCallback)){};
     MOCK_CONST_METHOD1(
-        subscribe_possible_setting_options, void(Camera::possible_setting_options_callback_t)){};
+        subscribe_possible_setting_options, void(Camera::PossibleSettingOptionsCallback)){};
     MOCK_CONST_METHOD3(
-        set_option_async,
-        void(Camera::result_callback_t, const std::string&, const Camera::Option)){};
+        set_option_async, void(Camera::ResultCallback, const std::string&, const Camera::Option)){};
     MOCK_CONST_METHOD0(format_storage, Camera::Result()){};
 };
 

--- a/src/plugins/follow_me/include/plugins/follow_me/follow_me.h
+++ b/src/plugins/follow_me/include/plugins/follow_me/follow_me.h
@@ -146,7 +146,7 @@ public:
     /**
      * @brief Callback type for asynchronous FollowMe calls.
      */
-    typedef std::function<void(Result)> result_callback_t;
+    typedef std::function<void(Result)> ResultCallback;
 
     /**
      * @brief Get current configuration.

--- a/src/plugins/follow_me/include/plugins/follow_me/follow_me.h
+++ b/src/plugins/follow_me/include/plugins/follow_me/follow_me.h
@@ -146,7 +146,7 @@ public:
     /**
      * @brief Callback type for asynchronous FollowMe calls.
      */
-    typedef std::function<void(Result)> ResultCallback;
+    using ResultCallback = std::function<void(Result)>;
 
     /**
      * @brief Get current configuration.

--- a/src/plugins/ftp/ftp.cpp
+++ b/src/plugins/ftp/ftp.cpp
@@ -15,45 +15,44 @@ Ftp::Ftp(System& system) : PluginBase(), _impl{new FtpImpl(system)} {}
 
 Ftp::~Ftp() {}
 
-void Ftp::reset_async(const result_callback_t callback)
+void Ftp::reset_async(const ResultCallback callback)
 {
     _impl->reset_async(callback);
 }
 
 void Ftp::download_async(
-    std::string remote_file_path, std::string local_dir, download_callback_t callback)
+    std::string remote_file_path, std::string local_dir, DownloadCallback callback)
 {
     _impl->download_async(remote_file_path, local_dir, callback);
 }
 
-void Ftp::upload_async(
-    std::string local_file_path, std::string remote_dir, upload_callback_t callback)
+void Ftp::upload_async(std::string local_file_path, std::string remote_dir, UploadCallback callback)
 {
     _impl->upload_async(local_file_path, remote_dir, callback);
 }
 
-void Ftp::list_directory_async(std::string remote_dir, const list_directory_callback_t callback)
+void Ftp::list_directory_async(std::string remote_dir, const ListDirectoryCallback callback)
 {
     _impl->list_directory_async(remote_dir, callback);
 }
 
-void Ftp::create_directory_async(std::string remote_dir, const result_callback_t callback)
+void Ftp::create_directory_async(std::string remote_dir, const ResultCallback callback)
 {
     _impl->create_directory_async(remote_dir, callback);
 }
 
-void Ftp::remove_directory_async(std::string remote_dir, const result_callback_t callback)
+void Ftp::remove_directory_async(std::string remote_dir, const ResultCallback callback)
 {
     _impl->remove_directory_async(remote_dir, callback);
 }
 
-void Ftp::remove_file_async(std::string remote_file_path, const result_callback_t callback)
+void Ftp::remove_file_async(std::string remote_file_path, const ResultCallback callback)
 {
     _impl->remove_file_async(remote_file_path, callback);
 }
 
 void Ftp::rename_async(
-    std::string remote_from_path, std::string remote_to_path, const result_callback_t callback)
+    std::string remote_from_path, std::string remote_to_path, const ResultCallback callback)
 {
     _impl->rename_async(remote_from_path, remote_to_path, callback);
 }
@@ -61,7 +60,7 @@ void Ftp::rename_async(
 void Ftp::are_files_identical_async(
     std::string local_file_path,
     std::string remote_file_path,
-    const are_files_identical_callback_t callback)
+    const AreFilesIdenticalCallback callback)
 {
     _impl->are_files_identical_async(local_file_path, remote_file_path, callback);
 }

--- a/src/plugins/ftp/ftp_impl.cpp
+++ b/src/plugins/ftp/ftp_impl.cpp
@@ -269,7 +269,7 @@ Ftp::Result FtpImpl::_translate(ServerResult result)
     }
 }
 
-void FtpImpl::reset_async(Ftp::result_callback_t callback)
+void FtpImpl::reset_async(Ftp::ResultCallback callback)
 {
     std::lock_guard<std::mutex> lock(_curr_op_mutex);
     if (_curr_op != CMD_NONE) {
@@ -289,9 +289,7 @@ void FtpImpl::reset_async(Ftp::result_callback_t callback)
 }
 
 void FtpImpl::download_async(
-    const std::string& remote_path,
-    const std::string& local_folder,
-    Ftp::download_callback_t callback)
+    const std::string& remote_path, const std::string& local_folder, Ftp::DownloadCallback callback)
 {
     std::lock_guard<std::mutex> lock(_curr_op_mutex);
     if (_curr_op != CMD_NONE) {
@@ -352,7 +350,7 @@ void FtpImpl::_read()
 void FtpImpl::upload_async(
     const std::string& local_file_path,
     const std::string& remote_folder,
-    Ftp::upload_callback_t callback)
+    Ftp::UploadCallback callback)
 {
     std::lock_guard<std::mutex> lock(_curr_op_mutex);
     if (_curr_op != CMD_NONE) {
@@ -439,7 +437,7 @@ void FtpImpl::_terminate_session()
 }
 
 void FtpImpl::list_directory_async(
-    const std::string& path, Ftp::list_directory_callback_t callback, uint32_t offset)
+    const std::string& path, Ftp::ListDirectoryCallback callback, uint32_t offset)
 {
     std::lock_guard<std::mutex> lock(_curr_op_mutex);
     if (_curr_op != CMD_NONE && offset == 0) {
@@ -475,7 +473,7 @@ void FtpImpl::_list_directory(uint32_t offset)
 }
 
 void FtpImpl::_generic_command_async(
-    Opcode opcode, uint32_t offset, const std::string& path, Ftp::result_callback_t callback)
+    Opcode opcode, uint32_t offset, const std::string& path, Ftp::ResultCallback callback)
 {
     if (_curr_op != CMD_NONE) {
         callback(Ftp::Result::Busy);
@@ -499,26 +497,26 @@ void FtpImpl::_generic_command_async(
     _send_mavlink_ftp_message(raw_payload);
 }
 
-void FtpImpl::create_directory_async(const std::string& path, Ftp::result_callback_t callback)
+void FtpImpl::create_directory_async(const std::string& path, Ftp::ResultCallback callback)
 {
     std::lock_guard<std::mutex> lock(_curr_op_mutex);
     _generic_command_async(CMD_CREATE_DIRECTORY, 0, path, callback);
 }
 
-void FtpImpl::remove_directory_async(const std::string& path, Ftp::result_callback_t callback)
+void FtpImpl::remove_directory_async(const std::string& path, Ftp::ResultCallback callback)
 {
     std::lock_guard<std::mutex> lock(_curr_op_mutex);
     _generic_command_async(CMD_REMOVE_DIRECTORY, 0, path, callback);
 }
 
-void FtpImpl::remove_file_async(const std::string& path, Ftp::result_callback_t callback)
+void FtpImpl::remove_file_async(const std::string& path, Ftp::ResultCallback callback)
 {
     std::lock_guard<std::mutex> lock(_curr_op_mutex);
     _generic_command_async(CMD_REMOVE_FILE, 0, path, callback);
 }
 
 void FtpImpl::rename_async(
-    const std::string& from_path, const std::string& to_path, Ftp::result_callback_t callback)
+    const std::string& from_path, const std::string& to_path, Ftp::ResultCallback callback)
 {
     std::lock_guard<std::mutex> lock(_curr_op_mutex);
     if (_curr_op != CMD_NONE) {
@@ -550,7 +548,7 @@ void FtpImpl::rename_async(
 void FtpImpl::are_files_identical_async(
     const std::string& local_path,
     const std::string& remote_path,
-    Ftp::are_files_identical_callback_t callback)
+    Ftp::AreFilesIdenticalCallback callback)
 {
     if (!callback) {
         return;
@@ -580,7 +578,7 @@ void FtpImpl::are_files_identical_async(
         });
 }
 
-void FtpImpl::_calc_file_crc32_async(const std::string& path, file_crc32_result_callback_t callback)
+void FtpImpl::_calc_file_crc32_async(const std::string& path, file_crc32_ResultCallback callback)
 {
     std::lock_guard<std::mutex> lock(_curr_op_mutex);
     if (_curr_op != CMD_NONE) {

--- a/src/plugins/ftp/ftp_impl.h
+++ b/src/plugins/ftp/ftp_impl.h
@@ -34,26 +34,26 @@ public:
 
     void send();
 
-    void reset_async(Ftp::result_callback_t callback);
+    void reset_async(Ftp::ResultCallback callback);
     void download_async(
         const std::string& remote_file_path,
         const std::string& local_folder,
-        Ftp::download_callback_t callback);
+        Ftp::DownloadCallback callback);
     void upload_async(
         const std::string& local_file_path,
         const std::string& remote_folder,
-        Ftp::upload_callback_t callback);
+        Ftp::UploadCallback callback);
     void list_directory_async(
-        const std::string& path, Ftp::list_directory_callback_t callback, uint32_t offset = 0);
-    void create_directory_async(const std::string& path, Ftp::result_callback_t callback);
-    void remove_directory_async(const std::string& path, Ftp::result_callback_t callback);
-    void remove_file_async(const std::string& path, Ftp::result_callback_t callback);
+        const std::string& path, Ftp::ListDirectoryCallback callback, uint32_t offset = 0);
+    void create_directory_async(const std::string& path, Ftp::ResultCallback callback);
+    void remove_directory_async(const std::string& path, Ftp::ResultCallback callback);
+    void remove_file_async(const std::string& path, Ftp::ResultCallback callback);
     void rename_async(
-        const std::string& from_path, const std::string& to_path, Ftp::result_callback_t callback);
+        const std::string& from_path, const std::string& to_path, Ftp::ResultCallback callback);
     void are_files_identical_async(
         const std::string& local_path,
         const std::string& remote_path,
-        Ftp::are_files_identical_callback_t callback);
+        Ftp::AreFilesIdenticalCallback callback);
 
     void set_retries(uint32_t retries) { _max_last_command_retries = retries; }
     Ftp::Result set_root_directory(const std::string& root_dir);
@@ -108,7 +108,7 @@ private:
         RSP_NAK ///< Nak response
     };
 
-    typedef std::function<void(Ftp::Result, uint32_t)> file_crc32_result_callback_t;
+    typedef std::function<void(Ftp::Result, uint32_t)> file_crc32_ResultCallback;
 
     static constexpr auto DIRENT_FILE = "F"; ///< Identifies File returned from List command
     static constexpr auto DIRENT_DIR = "D"; ///< Identifies Directory returned from List command
@@ -168,17 +168,17 @@ private:
     uint32_t _file_size = 0;
     std::vector<std::string> _curr_directory_list{};
 
-    Ftp::result_callback_t _curr_op_result_callback{};
+    Ftp::ResultCallback _curr_op_result_callback{};
     // _curr_op_progress_callback is used for download_callback_t as well as upload_callback_t
     static_assert(
-        std::is_same<Ftp::download_callback_t, Ftp::upload_callback_t>::value,
+        std::is_same<Ftp::DownloadCallback, Ftp::UploadCallback>::value,
         "callback types don't match");
-    Ftp::download_callback_t _curr_op_progress_callback{};
-    Ftp::list_directory_callback_t _curr_dir_items_result_callback{};
+    Ftp::DownloadCallback _curr_op_progress_callback{};
+    Ftp::ListDirectoryCallback _curr_dir_items_result_callback{};
 
-    file_crc32_result_callback_t _current_crc32_result_callback{};
+    file_crc32_ResultCallback _current_crc32_result_callback{};
 
-    void _calc_file_crc32_async(const std::string& path, file_crc32_result_callback_t callback);
+    void _calc_file_crc32_async(const std::string& path, file_crc32_ResultCallback callback);
     Ftp::Result _calc_local_file_crc32(const std::string& path, uint32_t& csum);
 
     void _process_ack(PayloadHeader* payload);
@@ -190,7 +190,7 @@ private:
     void _call_dir_items_result_callback(ServerResult result, std::vector<std::string> list);
     void _call_crc32_result_callback(ServerResult result, uint32_t crc32);
     void _generic_command_async(
-        Opcode opcode, uint32_t offset, const std::string& path, Ftp::result_callback_t callback);
+        Opcode opcode, uint32_t offset, const std::string& path, Ftp::ResultCallback callback);
     void _read();
     void _write();
     void _end_read_session();

--- a/src/plugins/ftp/include/plugins/ftp/ftp.h
+++ b/src/plugins/ftp/include/plugins/ftp/ftp.h
@@ -93,71 +93,70 @@ public:
     /**
      * @brief Callback type for asynchronous Ftp calls.
      */
-    typedef std::function<void(Result)> result_callback_t;
+    typedef std::function<void(Result)> ResultCallback;
 
     /**
      * @brief Resets FTP server in case there are stale open sessions.
      *
      * This function is non-blocking.
      */
-    void reset_async(const result_callback_t callback);
+    void reset_async(const ResultCallback callback);
 
     /**
      * @brief Callback type for download_async.
      */
 
-    typedef std::function<void(Ftp::Result, ProgressData)> download_callback_t;
+    typedef std::function<void(Ftp::Result, ProgressData)> DownloadCallback;
 
     /**
      * @brief Downloads a file to local directory.
      */
-    void download_async(
-        std::string remote_file_path, std::string local_dir, download_callback_t callback);
+    void
+    download_async(std::string remote_file_path, std::string local_dir, DownloadCallback callback);
 
     /**
      * @brief Callback type for upload_async.
      */
 
-    typedef std::function<void(Ftp::Result, ProgressData)> upload_callback_t;
+    typedef std::function<void(Ftp::Result, ProgressData)> UploadCallback;
 
     /**
      * @brief Uploads local file to remote directory.
      */
-    void
-    upload_async(std::string local_file_path, std::string remote_dir, upload_callback_t callback);
+    void upload_async(std::string local_file_path, std::string remote_dir, UploadCallback callback);
 
     /**
      * @brief Callback type for list_directory_async.
      */
-    typedef std::function<void(Result, std::vector<std::string>)> list_directory_callback_t;
+    typedef std::function<void(Result, std::vector<std::string>)> ListDirectoryCallback;
 
     /**
      * @brief Lists items from a remote directory.
      *
      * This function is non-blocking.
      */
-    void list_directory_async(std::string remote_dir, const list_directory_callback_t callback);
+    void list_directory_async(std::string remote_dir, const ListDirectoryCallback callback);
 
     /**
      * @brief Creates a remote directory.
      *
      * This function is non-blocking.
      */
-    void create_directory_async(std::string remote_dir, const result_callback_t callback);
+    void create_directory_async(std::string remote_dir, const ResultCallback callback);
 
     /**
      * @brief Removes a remote directory.
      *
      * This function is non-blocking.
      */
-    void remove_directory_async(std::string remote_dir, const result_callback_t callback);
+    void remove_directory_async(std::string remote_dir, const ResultCallback callback);
 
     /**
      * @brief Removes a remote file.
      *
      * This function is non-blocking.
      */
-    void remove_file_async(std::string remote_file_path, const result_callback_t callback);
+    void remove_file_async(std::string remote_file_path, const ResultCallback callback);
 
     /**
      * @brief Renames a remote file or remote directory.
@@ -165,12 +164,12 @@ public:
      * This function is non-blocking.
      */
     void rename_async(
-        std::string remote_from_path, std::string remote_to_path, const result_callback_t callback);
+        std::string remote_from_path, std::string remote_to_path, const ResultCallback callback);
 
     /**
      * @brief Callback type for are_files_identical_async.
      */
-    typedef std::function<void(Result, bool)> are_files_identical_callback_t;
+    typedef std::function<void(Result, bool)> AreFilesIdenticalCallback;
 
     /**
      * @brief Compares a local file to a remote file using a CRC32 checksum.
@@ -180,7 +179,7 @@ public:
     void are_files_identical_async(
         std::string local_file_path,
         std::string remote_file_path,
-        const are_files_identical_callback_t callback);
+        const AreFilesIdenticalCallback callback);
 
     /**
      * @brief Set root directory for MAVLink FTP server.

--- a/src/plugins/ftp/include/plugins/ftp/ftp.h
+++ b/src/plugins/ftp/include/plugins/ftp/ftp.h
@@ -93,7 +93,7 @@ public:
     /**
      * @brief Callback type for asynchronous Ftp calls.
      */
-    typedef std::function<void(Result)> ResultCallback;
+    using ResultCallback = std::function<void(Result)>;
 
     /**
      * @brief Resets FTP server in case there are stale open sessions.
@@ -106,7 +106,7 @@ public:
      * @brief Callback type for download_async.
      */
 
-    typedef std::function<void(Ftp::Result, ProgressData)> DownloadCallback;
+    using DownloadCallback = std::function<void(Ftp::Result, ProgressData)>;
 
     /**
      * @brief Downloads a file to local directory.
@@ -118,7 +118,7 @@ public:
      * @brief Callback type for upload_async.
      */
 
-    typedef std::function<void(Ftp::Result, ProgressData)> UploadCallback;
+    using UploadCallback = std::function<void(Ftp::Result, ProgressData)>;
 
     /**
      * @brief Uploads local file to remote directory.
@@ -128,7 +128,7 @@ public:
     /**
      * @brief Callback type for list_directory_async.
      */
-    typedef std::function<void(Result, std::vector<std::string>)> ListDirectoryCallback;
+    using ListDirectoryCallback = std::function<void(Result, std::vector<std::string>)>;
 
     /**
      * @brief Lists items from a remote directory.
@@ -169,7 +169,7 @@ public:
     /**
      * @brief Callback type for are_files_identical_async.
      */
-    typedef std::function<void(Result, bool)> AreFilesIdenticalCallback;
+    using AreFilesIdenticalCallback = std::function<void(Result, bool)>;
 
     /**
      * @brief Compares a local file to a remote file using a CRC32 checksum.

--- a/src/plugins/geofence/geofence.cpp
+++ b/src/plugins/geofence/geofence.cpp
@@ -16,8 +16,7 @@ Geofence::Geofence(System& system) : PluginBase(), _impl{new GeofenceImpl(system
 
 Geofence::~Geofence() {}
 
-void Geofence::upload_geofence_async(
-    std::vector<Polygon> polygons, const result_callback_t callback)
+void Geofence::upload_geofence_async(std::vector<Polygon> polygons, const ResultCallback callback)
 {
     _impl->upload_geofence_async(polygons, callback);
 }

--- a/src/plugins/geofence/geofence_impl.cpp
+++ b/src/plugins/geofence/geofence_impl.cpp
@@ -33,7 +33,7 @@ Geofence::Result GeofenceImpl::upload_geofence(const std::vector<Geofence::Polyg
 }
 
 void GeofenceImpl::upload_geofence_async(
-    const std::vector<Geofence::Polygon>& polygons, const Geofence::result_callback_t& callback)
+    const std::vector<Geofence::Polygon>& polygons, const Geofence::ResultCallback& callback)
 {
     // We can just create these items on the stack because they get copied
     // later in the MAVLinkMissionTransfer constructor.

--- a/src/plugins/geofence/geofence_impl.h
+++ b/src/plugins/geofence/geofence_impl.h
@@ -25,8 +25,7 @@ public:
     Geofence::Result upload_geofence(const std::vector<Geofence::Polygon>& polygons);
 
     void upload_geofence_async(
-        const std::vector<Geofence::Polygon>& polygons,
-        const Geofence::result_callback_t& callback);
+        const std::vector<Geofence::Polygon>& polygons, const Geofence::ResultCallback& callback);
 
     // Non-copyable
     GeofenceImpl(const GeofenceImpl&) = delete;

--- a/src/plugins/geofence/include/plugins/geofence/geofence.h
+++ b/src/plugins/geofence/include/plugins/geofence/geofence.h
@@ -125,7 +125,7 @@ public:
     /**
      * @brief Callback type for asynchronous Geofence calls.
      */
-    typedef std::function<void(Result)> result_callback_t;
+    typedef std::function<void(Result)> ResultCallback;
 
     /**
      * @brief Upload a geofence.
@@ -135,7 +135,7 @@ public:
      *
      * This function is non-blocking. See 'upload_geofence' for the blocking counterpart.
      */
-    void upload_geofence_async(std::vector<Polygon> polygons, const result_callback_t callback);
+    void upload_geofence_async(std::vector<Polygon> polygons, const ResultCallback callback);
 
     /**
      * @brief Upload a geofence.

--- a/src/plugins/geofence/include/plugins/geofence/geofence.h
+++ b/src/plugins/geofence/include/plugins/geofence/geofence.h
@@ -125,7 +125,7 @@ public:
     /**
      * @brief Callback type for asynchronous Geofence calls.
      */
-    typedef std::function<void(Result)> ResultCallback;
+    using ResultCallback = std::function<void(Result)>;
 
     /**
      * @brief Upload a geofence.

--- a/src/plugins/gimbal/gimbal.cpp
+++ b/src/plugins/gimbal/gimbal.cpp
@@ -13,8 +13,7 @@ Gimbal::Gimbal(System& system) : PluginBase(), _impl{new GimbalImpl(system)} {}
 
 Gimbal::~Gimbal() {}
 
-void Gimbal::set_pitch_and_yaw_async(
-    float pitch_deg, float yaw_deg, const result_callback_t callback)
+void Gimbal::set_pitch_and_yaw_async(float pitch_deg, float yaw_deg, const ResultCallback callback)
 {
     _impl->set_pitch_and_yaw_async(pitch_deg, yaw_deg, callback);
 }
@@ -24,7 +23,7 @@ Gimbal::Result Gimbal::set_pitch_and_yaw(float pitch_deg, float yaw_deg) const
     return _impl->set_pitch_and_yaw(pitch_deg, yaw_deg);
 }
 
-void Gimbal::set_mode_async(GimbalMode gimbal_mode, const result_callback_t callback)
+void Gimbal::set_mode_async(GimbalMode gimbal_mode, const ResultCallback callback)
 {
     _impl->set_mode_async(gimbal_mode, callback);
 }
@@ -35,7 +34,7 @@ Gimbal::Result Gimbal::set_mode(GimbalMode gimbal_mode) const
 }
 
 void Gimbal::set_roi_location_async(
-    double latitude_deg, double longitude_deg, float altitude_m, const result_callback_t callback)
+    double latitude_deg, double longitude_deg, float altitude_m, const ResultCallback callback)
 {
     _impl->set_roi_location_async(latitude_deg, longitude_deg, altitude_m, callback);
 }

--- a/src/plugins/gimbal/gimbal_impl.cpp
+++ b/src/plugins/gimbal/gimbal_impl.cpp
@@ -39,7 +39,7 @@ Gimbal::Result GimbalImpl::set_pitch_and_yaw(float pitch_deg, float yaw_deg)
 }
 
 void GimbalImpl::set_pitch_and_yaw_async(
-    float pitch_deg, float yaw_deg, Gimbal::result_callback_t callback)
+    float pitch_deg, float yaw_deg, Gimbal::ResultCallback callback)
 {
     const float roll_deg = 0.0f;
     MAVLinkCommands::CommandLong command{};
@@ -75,7 +75,7 @@ Gimbal::Result GimbalImpl::set_mode(const Gimbal::GimbalMode gimbal_mode)
 }
 
 void GimbalImpl::set_mode_async(
-    const Gimbal::GimbalMode gimbal_mode, Gimbal::result_callback_t callback)
+    const Gimbal::GimbalMode gimbal_mode, Gimbal::ResultCallback callback)
 {
     MAVLinkCommands::CommandInt command{};
 
@@ -121,7 +121,7 @@ GimbalImpl::set_roi_location(double latitude_deg, double longitude_deg, float al
 }
 
 void GimbalImpl::set_roi_location_async(
-    double latitude_deg, double longitude_deg, float altitude_m, Gimbal::result_callback_t callback)
+    double latitude_deg, double longitude_deg, float altitude_m, Gimbal::ResultCallback callback)
 {
     MAVLinkCommands::CommandInt command{};
 
@@ -136,7 +136,7 @@ void GimbalImpl::set_roi_location_async(
 }
 
 void GimbalImpl::receive_command_result(
-    MAVLinkCommands::Result command_result, const Gimbal::result_callback_t& callback)
+    MAVLinkCommands::Result command_result, const Gimbal::ResultCallback& callback)
 {
     Gimbal::Result gimbal_result = gimbal_result_from_command_result(command_result);
 

--- a/src/plugins/gimbal/gimbal_impl.h
+++ b/src/plugins/gimbal/gimbal_impl.h
@@ -19,12 +19,11 @@ public:
 
     Gimbal::Result set_pitch_and_yaw(float pitch_deg, float yaw_deg);
 
-    void
-    set_pitch_and_yaw_async(float pitch_deg, float yaw_deg, Gimbal::result_callback_t callback);
+    void set_pitch_and_yaw_async(float pitch_deg, float yaw_deg, Gimbal::ResultCallback callback);
 
     Gimbal::Result set_mode(const Gimbal::GimbalMode gimbal_mode);
 
-    void set_mode_async(const Gimbal::GimbalMode gimbal_mode, Gimbal::result_callback_t callback);
+    void set_mode_async(const Gimbal::GimbalMode gimbal_mode, Gimbal::ResultCallback callback);
 
     float to_float_gimbal_mode(const Gimbal::GimbalMode gimbal_mode) const;
 
@@ -34,7 +33,7 @@ public:
         double latitude_deg,
         double longitude_deg,
         float altitude_m,
-        Gimbal::result_callback_t callback);
+        Gimbal::ResultCallback callback);
 
     // Non-copyable
     GimbalImpl(const GimbalImpl&) = delete;
@@ -44,7 +43,7 @@ private:
     static Gimbal::Result gimbal_result_from_command_result(MAVLinkCommands::Result command_result);
 
     static void receive_command_result(
-        MAVLinkCommands::Result command_result, const Gimbal::result_callback_t& callback);
+        MAVLinkCommands::Result command_result, const Gimbal::ResultCallback& callback);
 };
 
 } // namespace mavsdk

--- a/src/plugins/gimbal/include/plugins/gimbal/gimbal.h
+++ b/src/plugins/gimbal/include/plugins/gimbal/gimbal.h
@@ -78,7 +78,7 @@ public:
     /**
      * @brief Callback type for asynchronous Gimbal calls.
      */
-    typedef std::function<void(Result)> ResultCallback;
+    using ResultCallback = std::function<void(Result)>;
 
     /**
      * @brief Set gimbal pitch and yaw angles.

--- a/src/plugins/gimbal/include/plugins/gimbal/gimbal.h
+++ b/src/plugins/gimbal/include/plugins/gimbal/gimbal.h
@@ -78,7 +78,7 @@ public:
     /**
      * @brief Callback type for asynchronous Gimbal calls.
      */
-    typedef std::function<void(Result)> result_callback_t;
+    typedef std::function<void(Result)> ResultCallback;
 
     /**
      * @brief Set gimbal pitch and yaw angles.
@@ -89,7 +89,7 @@ public:
      *
      * This function is non-blocking. See 'set_pitch_and_yaw' for the blocking counterpart.
      */
-    void set_pitch_and_yaw_async(float pitch_deg, float yaw_deg, const result_callback_t callback);
+    void set_pitch_and_yaw_async(float pitch_deg, float yaw_deg, const ResultCallback callback);
 
     /**
      * @brief Set gimbal pitch and yaw angles.
@@ -113,7 +113,7 @@ public:
      *
      * This function is non-blocking. See 'set_mode' for the blocking counterpart.
      */
-    void set_mode_async(GimbalMode gimbal_mode, const result_callback_t callback);
+    void set_mode_async(GimbalMode gimbal_mode, const ResultCallback callback);
 
     /**
      * @brief Set gimbal mode.
@@ -140,10 +140,7 @@ public:
      * This function is non-blocking. See 'set_roi_location' for the blocking counterpart.
      */
     void set_roi_location_async(
-        double latitude_deg,
-        double longitude_deg,
-        float altitude_m,
-        const result_callback_t callback);
+        double latitude_deg, double longitude_deg, float altitude_m, const ResultCallback callback);
 
     /**
      * @brief Set gimbal region of interest (ROI).

--- a/src/plugins/info/include/plugins/info/info.h
+++ b/src/plugins/info/include/plugins/info/info.h
@@ -163,7 +163,7 @@ public:
     /**
      * @brief Callback type for asynchronous Info calls.
      */
-    typedef std::function<void(Result)> ResultCallback;
+    using ResultCallback = std::function<void(Result)>;
 
     /**
      * @brief Get flight information of the system.

--- a/src/plugins/info/include/plugins/info/info.h
+++ b/src/plugins/info/include/plugins/info/info.h
@@ -163,7 +163,7 @@ public:
     /**
      * @brief Callback type for asynchronous Info calls.
      */
-    typedef std::function<void(Result)> result_callback_t;
+    typedef std::function<void(Result)> ResultCallback;
 
     /**
      * @brief Get flight information of the system.

--- a/src/plugins/log_files/include/plugins/log_files/log_files.h
+++ b/src/plugins/log_files/include/plugins/log_files/log_files.h
@@ -112,19 +112,19 @@ public:
     /**
      * @brief Callback type for asynchronous LogFiles calls.
      */
-    typedef std::function<void(Result)> result_callback_t;
+    typedef std::function<void(Result)> ResultCallback;
 
     /**
      * @brief Callback type for get_entries_async.
      */
-    typedef std::function<void(Result, std::vector<Entry>)> get_entries_callback_t;
+    typedef std::function<void(Result, std::vector<Entry>)> GetEntriesCallback;
 
     /**
      * @brief Get List of log files.
      *
      * This function is non-blocking. See 'get_entries' for the blocking counterpart.
      */
-    void get_entries_async(const get_entries_callback_t callback);
+    void get_entries_async(const GetEntriesCallback callback);
 
     /**
      * @brief Get List of log files.
@@ -139,13 +139,12 @@ public:
      * @brief Callback type for download_log_file_async.
      */
 
-    typedef std::function<void(LogFiles::Result, ProgressData)> download_log_file_callback_t;
+    typedef std::function<void(LogFiles::Result, ProgressData)> DownloadLogFileCallback;
 
     /**
      * @brief Download log file.
      */
-    void
-    download_log_file_async(uint32_t id, std::string path, download_log_file_callback_t callback);
+    void download_log_file_async(uint32_t id, std::string path, DownloadLogFileCallback callback);
 
     /**
      * @brief Returns a human-readable English string for a Result.

--- a/src/plugins/log_files/include/plugins/log_files/log_files.h
+++ b/src/plugins/log_files/include/plugins/log_files/log_files.h
@@ -112,12 +112,12 @@ public:
     /**
      * @brief Callback type for asynchronous LogFiles calls.
      */
-    typedef std::function<void(Result)> ResultCallback;
+    using ResultCallback = std::function<void(Result)>;
 
     /**
      * @brief Callback type for get_entries_async.
      */
-    typedef std::function<void(Result, std::vector<Entry>)> GetEntriesCallback;
+    using GetEntriesCallback = std::function<void(Result, std::vector<Entry>)>;
 
     /**
      * @brief Get List of log files.
@@ -139,7 +139,7 @@ public:
      * @brief Callback type for download_log_file_async.
      */
 
-    typedef std::function<void(LogFiles::Result, ProgressData)> DownloadLogFileCallback;
+    using DownloadLogFileCallback = std::function<void(LogFiles::Result, ProgressData)>;
 
     /**
      * @brief Download log file.

--- a/src/plugins/log_files/log_files.cpp
+++ b/src/plugins/log_files/log_files.cpp
@@ -16,7 +16,7 @@ LogFiles::LogFiles(System& system) : PluginBase(), _impl{new LogFilesImpl(system
 
 LogFiles::~LogFiles() {}
 
-void LogFiles::get_entries_async(const get_entries_callback_t callback)
+void LogFiles::get_entries_async(const GetEntriesCallback callback)
 {
     _impl->get_entries_async(callback);
 }
@@ -27,7 +27,7 @@ std::pair<LogFiles::Result, std::vector<LogFiles::Entry>> LogFiles::get_entries(
 }
 
 void LogFiles::download_log_file_async(
-    uint32_t id, std::string path, download_log_file_callback_t callback)
+    uint32_t id, std::string path, DownloadLogFileCallback callback)
 {
     _impl->download_log_file_async(id, path, callback);
 }

--- a/src/plugins/log_files/log_files_impl.cpp
+++ b/src/plugins/log_files/log_files_impl.cpp
@@ -76,7 +76,7 @@ std::pair<LogFiles::Result, std::vector<LogFiles::Entry>> LogFilesImpl::get_entr
     return future_result.get();
 }
 
-void LogFilesImpl::get_entries_async(LogFiles::get_entries_callback_t callback)
+void LogFilesImpl::get_entries_async(LogFiles::GetEntriesCallback callback)
 {
     {
         std::lock_guard<std::mutex> lock(_entries.mutex);
@@ -197,7 +197,7 @@ void LogFilesImpl::list_timeout()
 }
 
 void LogFilesImpl::download_log_file_async(
-    unsigned id, const std::string& file_path, LogFiles::download_log_file_callback_t callback)
+    unsigned id, const std::string& file_path, LogFiles::DownloadLogFileCallback callback)
 {
     unsigned bytes_to_get;
     {

--- a/src/plugins/log_files/log_files_impl.h
+++ b/src/plugins/log_files/log_files_impl.h
@@ -20,10 +20,10 @@ public:
     void disable() override;
 
     std::pair<LogFiles::Result, std::vector<LogFiles::Entry>> get_entries();
-    void get_entries_async(LogFiles::get_entries_callback_t callback);
+    void get_entries_async(LogFiles::GetEntriesCallback callback);
 
     void download_log_file_async(
-        unsigned id, const std::string& file_path, LogFiles::download_log_file_callback_t callback);
+        unsigned id, const std::string& file_path, LogFiles::DownloadLogFileCallback callback);
 
 private:
     void request_end();
@@ -54,7 +54,7 @@ private:
     struct {
         std::mutex mutex{};
         std::map<unsigned, LogFiles::Entry> entry_map{};
-        LogFiles::get_entries_callback_t callback{nullptr};
+        LogFiles::GetEntriesCallback callback{nullptr};
         unsigned max_list_id{0};
         unsigned retries{0};
         void* cookie{nullptr};
@@ -83,7 +83,7 @@ private:
         int last_ofs_rerequested{-1};
         dl_time_t time_started{};
         std::ofstream file{};
-        LogFiles::download_log_file_callback_t callback{nullptr};
+        LogFiles::DownloadLogFileCallback callback{nullptr};
     } _data{};
 };
 

--- a/src/plugins/mission/include/plugins/mission/mission.h
+++ b/src/plugins/mission/include/plugins/mission/mission.h
@@ -177,7 +177,7 @@ public:
     /**
      * @brief Callback type for asynchronous Mission calls.
      */
-    typedef std::function<void(Result)> ResultCallback;
+    using ResultCallback = std::function<void(Result)>;
 
     /**
      * @brief Upload a list of mission items to the system.
@@ -213,7 +213,7 @@ public:
     /**
      * @brief Callback type for download_mission_async.
      */
-    typedef std::function<void(Result, MissionPlan)> DownloadMissionCallback;
+    using DownloadMissionCallback = std::function<void(Result, MissionPlan)>;
 
     /**
      * @brief Download a list of mission items from the system (asynchronous).
@@ -350,7 +350,7 @@ public:
      * @brief Callback type for subscribe_mission_progress.
      */
 
-    typedef std::function<void(MissionProgress)> MissionProgressCallback;
+    using MissionProgressCallback = std::function<void(MissionProgress)>;
 
     /**
      * @brief Subscribe to mission progress updates.
@@ -391,7 +391,7 @@ public:
     /**
      * @brief Callback type for import_qgroundcontrol_mission_async.
      */
-    typedef std::function<void(Result, MissionPlan)> ImportQgroundcontrolMissionCallback;
+    using ImportQgroundcontrolMissionCallback = std::function<void(Result, MissionPlan)>;
 
     /**
      * @brief Import a QGroundControl (QGC) mission plan.

--- a/src/plugins/mission/include/plugins/mission/mission.h
+++ b/src/plugins/mission/include/plugins/mission/mission.h
@@ -177,7 +177,7 @@ public:
     /**
      * @brief Callback type for asynchronous Mission calls.
      */
-    typedef std::function<void(Result)> result_callback_t;
+    typedef std::function<void(Result)> ResultCallback;
 
     /**
      * @brief Upload a list of mission items to the system.
@@ -187,7 +187,7 @@ public:
      *
      * This function is non-blocking. See 'upload_mission' for the blocking counterpart.
      */
-    void upload_mission_async(MissionPlan mission_plan, const result_callback_t callback);
+    void upload_mission_async(MissionPlan mission_plan, const ResultCallback callback);
 
     /**
      * @brief Upload a list of mission items to the system.
@@ -213,7 +213,7 @@ public:
     /**
      * @brief Callback type for download_mission_async.
      */
-    typedef std::function<void(Result, MissionPlan)> download_mission_callback_t;
+    typedef std::function<void(Result, MissionPlan)> DownloadMissionCallback;
 
     /**
      * @brief Download a list of mission items from the system (asynchronous).
@@ -223,7 +223,7 @@ public:
      *
      * This function is non-blocking. See 'download_mission' for the blocking counterpart.
      */
-    void download_mission_async(const download_mission_callback_t callback);
+    void download_mission_async(const DownloadMissionCallback callback);
 
     /**
      * @brief Download a list of mission items from the system (asynchronous).
@@ -253,7 +253,7 @@ public:
      *
      * This function is non-blocking. See 'start_mission' for the blocking counterpart.
      */
-    void start_mission_async(const result_callback_t callback);
+    void start_mission_async(const ResultCallback callback);
 
     /**
      * @brief Start the mission.
@@ -276,7 +276,7 @@ public:
      *
      * This function is non-blocking. See 'pause_mission' for the blocking counterpart.
      */
-    void pause_mission_async(const result_callback_t callback);
+    void pause_mission_async(const ResultCallback callback);
 
     /**
      * @brief Pause the mission.
@@ -297,7 +297,7 @@ public:
      *
      * This function is non-blocking. See 'clear_mission' for the blocking counterpart.
      */
-    void clear_mission_async(const result_callback_t callback);
+    void clear_mission_async(const ResultCallback callback);
 
     /**
      * @brief Clear the mission saved on the vehicle.
@@ -319,7 +319,7 @@ public:
      *
      * This function is non-blocking. See 'set_current_mission_item' for the blocking counterpart.
      */
-    void set_current_mission_item_async(int32_t index, const result_callback_t callback);
+    void set_current_mission_item_async(int32_t index, const ResultCallback callback);
 
     /**
      * @brief Sets the mission item index to go to.
@@ -350,12 +350,12 @@ public:
      * @brief Callback type for subscribe_mission_progress.
      */
 
-    typedef std::function<void(MissionProgress)> mission_progress_callback_t;
+    typedef std::function<void(MissionProgress)> MissionProgressCallback;
 
     /**
      * @brief Subscribe to mission progress updates.
      */
-    void subscribe_mission_progress(mission_progress_callback_t callback);
+    void subscribe_mission_progress(MissionProgressCallback callback);
 
     /**
      * @brief Poll for 'MissionProgress' (blocking).
@@ -391,7 +391,7 @@ public:
     /**
      * @brief Callback type for import_qgroundcontrol_mission_async.
      */
-    typedef std::function<void(Result, MissionPlan)> import_qgroundcontrol_mission_callback_t;
+    typedef std::function<void(Result, MissionPlan)> ImportQgroundcontrolMissionCallback;
 
     /**
      * @brief Import a QGroundControl (QGC) mission plan.
@@ -403,7 +403,7 @@ public:
      * counterpart.
      */
     void import_qgroundcontrol_mission_async(
-        std::string qgc_plan_path, const import_qgroundcontrol_mission_callback_t callback);
+        std::string qgc_plan_path, const ImportQgroundcontrolMissionCallback callback);
 
     /**
      * @brief Import a QGroundControl (QGC) mission plan.

--- a/src/plugins/mission/mission.cpp
+++ b/src/plugins/mission/mission.cpp
@@ -17,7 +17,7 @@ Mission::Mission(System& system) : PluginBase(), _impl{new MissionImpl(system)} 
 
 Mission::~Mission() {}
 
-void Mission::upload_mission_async(MissionPlan mission_plan, const result_callback_t callback)
+void Mission::upload_mission_async(MissionPlan mission_plan, const ResultCallback callback)
 {
     _impl->upload_mission_async(mission_plan, callback);
 }
@@ -32,7 +32,7 @@ Mission::Result Mission::cancel_mission_upload() const
     return _impl->cancel_mission_upload();
 }
 
-void Mission::download_mission_async(const download_mission_callback_t callback)
+void Mission::download_mission_async(const DownloadMissionCallback callback)
 {
     _impl->download_mission_async(callback);
 }
@@ -47,7 +47,7 @@ Mission::Result Mission::cancel_mission_download() const
     return _impl->cancel_mission_download();
 }
 
-void Mission::start_mission_async(const result_callback_t callback)
+void Mission::start_mission_async(const ResultCallback callback)
 {
     _impl->start_mission_async(callback);
 }
@@ -57,7 +57,7 @@ Mission::Result Mission::start_mission() const
     return _impl->start_mission();
 }
 
-void Mission::pause_mission_async(const result_callback_t callback)
+void Mission::pause_mission_async(const ResultCallback callback)
 {
     _impl->pause_mission_async(callback);
 }
@@ -67,7 +67,7 @@ Mission::Result Mission::pause_mission() const
     return _impl->pause_mission();
 }
 
-void Mission::clear_mission_async(const result_callback_t callback)
+void Mission::clear_mission_async(const ResultCallback callback)
 {
     _impl->clear_mission_async(callback);
 }
@@ -77,7 +77,7 @@ Mission::Result Mission::clear_mission() const
     return _impl->clear_mission();
 }
 
-void Mission::set_current_mission_item_async(int32_t index, const result_callback_t callback)
+void Mission::set_current_mission_item_async(int32_t index, const ResultCallback callback)
 {
     _impl->set_current_mission_item_async(index, callback);
 }
@@ -92,7 +92,7 @@ std::pair<Mission::Result, bool> Mission::is_mission_finished() const
     return _impl->is_mission_finished();
 }
 
-void Mission::subscribe_mission_progress(mission_progress_callback_t callback)
+void Mission::subscribe_mission_progress(MissionProgressCallback callback)
 {
     _impl->mission_progress_async(callback);
 }
@@ -113,7 +113,7 @@ Mission::Result Mission::set_return_to_launch_after_mission(bool enable) const
 }
 
 void Mission::import_qgroundcontrol_mission_async(
-    std::string qgc_plan_path, const import_qgroundcontrol_mission_callback_t callback)
+    std::string qgc_plan_path, const ImportQgroundcontrolMissionCallback callback)
 {
     _impl->import_qgroundcontrol_mission_async(qgc_plan_path, callback);
 }

--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -89,7 +89,7 @@ Mission::Result MissionImpl::upload_mission(const Mission::MissionPlan& mission_
 }
 
 void MissionImpl::upload_mission_async(
-    const Mission::MissionPlan& mission_plan, const Mission::result_callback_t& callback)
+    const Mission::MissionPlan& mission_plan, const Mission::ResultCallback& callback)
 {
     if (_mission_data.last_upload.lock()) {
         _parent->call_user_callback([callback]() {
@@ -143,7 +143,7 @@ std::pair<Mission::Result, Mission::MissionPlan> MissionImpl::download_mission()
     return fut.get();
 }
 
-void MissionImpl::download_mission_async(const Mission::download_mission_callback_t& callback)
+void MissionImpl::download_mission_async(const Mission::DownloadMissionCallback& callback)
 {
     if (_mission_data.last_download.lock()) {
         _parent->call_user_callback([callback]() {
@@ -495,7 +495,7 @@ std::pair<Mission::Result, Mission::MissionPlan> MissionImpl::convert_to_result_
         return result_pair;
     }
 
-    Mission::download_mission_callback_t callback;
+    Mission::DownloadMissionCallback callback;
     {
         _enable_return_to_launch_after_mission = false;
 
@@ -616,7 +616,7 @@ Mission::Result MissionImpl::start_mission()
     return fut.get();
 }
 
-void MissionImpl::start_mission_async(const Mission::result_callback_t& callback)
+void MissionImpl::start_mission_async(const Mission::ResultCallback& callback)
 {
     _parent->set_flight_mode_async(
         SystemImpl::FlightMode::Mission, [this, callback](MAVLinkCommands::Result result, float) {
@@ -633,7 +633,7 @@ Mission::Result MissionImpl::pause_mission()
     return fut.get();
 }
 
-void MissionImpl::pause_mission_async(const Mission::result_callback_t& callback)
+void MissionImpl::pause_mission_async(const Mission::ResultCallback& callback)
 {
     _parent->set_flight_mode_async(
         SystemImpl::FlightMode::Hold, [this, callback](MAVLinkCommands::Result result, float) {
@@ -642,7 +642,7 @@ void MissionImpl::pause_mission_async(const Mission::result_callback_t& callback
 }
 
 void MissionImpl::report_flight_mode_change(
-    Mission::result_callback_t callback, MAVLinkCommands::Result result)
+    Mission::ResultCallback callback, MAVLinkCommands::Result result)
 {
     if (!callback) {
         return;
@@ -685,7 +685,7 @@ Mission::Result MissionImpl::clear_mission()
     return fut.get();
 }
 
-void MissionImpl::clear_mission_async(const Mission::result_callback_t& callback)
+void MissionImpl::clear_mission_async(const Mission::ResultCallback& callback)
 {
     _parent->mission_transfer().clear_items_async(
         MAV_MISSION_TYPE_MISSION, [this, callback](MAVLinkMissionTransfer::Result result) {
@@ -709,7 +709,7 @@ Mission::Result MissionImpl::set_current_mission_item(int current)
 }
 
 void MissionImpl::set_current_mission_item_async(
-    int current, const Mission::result_callback_t& callback)
+    int current, const Mission::ResultCallback& callback)
 {
     int mavlink_index = -1;
     {
@@ -854,7 +854,7 @@ Mission::MissionProgress MissionImpl::mission_progress()
     return mission_progress;
 }
 
-void MissionImpl::mission_progress_async(Mission::mission_progress_callback_t callback)
+void MissionImpl::mission_progress_async(Mission::MissionProgressCallback callback)
 {
     std::lock_guard<std::recursive_mutex> lock(_mission_data.mutex);
     _mission_data.mission_progress_callback = callback;
@@ -931,7 +931,7 @@ MissionImpl::import_qgroundcontrol_mission(const std::string& qgc_plan_file)
 }
 
 void MissionImpl::import_qgroundcontrol_mission_async(
-    std::string qgc_plan_path, const Mission::import_qgroundcontrol_mission_callback_t callback)
+    std::string qgc_plan_path, const Mission::ImportQgroundcontrolMissionCallback callback)
 {
     auto fut = std::async([this, callback, qgc_plan_path]() {
         auto result = MissionImpl::import_qgroundcontrol_mission(qgc_plan_path);

--- a/src/plugins/mission/mission_impl.h
+++ b/src/plugins/mission/mission_impl.h
@@ -27,32 +27,32 @@ public:
     Mission::Result upload_mission(const Mission::MissionPlan& mission_plan);
 
     void upload_mission_async(
-        const Mission::MissionPlan& mission_plan, const Mission::result_callback_t& callback);
+        const Mission::MissionPlan& mission_plan, const Mission::ResultCallback& callback);
 
-    void cancel_mission_upload_async(const Mission::result_callback_t callback);
+    void cancel_mission_upload_async(const Mission::ResultCallback callback);
     Mission::Result cancel_mission_upload();
 
     std::pair<Mission::Result, Mission::MissionPlan> download_mission();
-    void download_mission_async(const Mission::download_mission_callback_t& callback);
+    void download_mission_async(const Mission::DownloadMissionCallback& callback);
 
     Mission::Result cancel_mission_download();
-    void cancel_mission_download_async(const Mission::result_callback_t& callback);
+    void cancel_mission_download_async(const Mission::ResultCallback& callback);
 
     Mission::Result set_return_to_launch_after_mission(bool enable_rtl);
 
     std::pair<Mission::Result, bool> get_return_to_launch_after_mission();
 
     Mission::Result start_mission();
-    void start_mission_async(const Mission::result_callback_t& callback);
+    void start_mission_async(const Mission::ResultCallback& callback);
 
     Mission::Result pause_mission();
-    void pause_mission_async(const Mission::result_callback_t& callback);
+    void pause_mission_async(const Mission::ResultCallback& callback);
 
     Mission::Result clear_mission();
-    void clear_mission_async(const Mission::result_callback_t& callback);
+    void clear_mission_async(const Mission::ResultCallback& callback);
 
     Mission::Result set_current_mission_item(int index);
-    void set_current_mission_item_async(int current, const Mission::result_callback_t& callback);
+    void set_current_mission_item_async(int current, const Mission::ResultCallback& callback);
 
     std::pair<Mission::Result, bool> is_mission_finished() const;
 
@@ -60,11 +60,10 @@ public:
     int total_mission_items() const;
 
     Mission::MissionProgress mission_progress();
-    void mission_progress_async(Mission::mission_progress_callback_t callback);
+    void mission_progress_async(Mission::MissionProgressCallback callback);
 
     void import_qgroundcontrol_mission_async(
-        std::string qgc_plan_path,
-        const Mission::import_qgroundcontrol_mission_callback_t callback);
+        std::string qgc_plan_path, const Mission::ImportQgroundcontrolMissionCallback callback);
 
     static std::pair<Mission::Result, Mission::MissionPlan>
     import_qgroundcontrol_mission(const std::string& qgc_plan_path);
@@ -88,7 +87,7 @@ private:
     void reset_mission_progress();
 
     void
-    report_flight_mode_change(Mission::result_callback_t callback, MAVLinkCommands::Result result);
+    report_flight_mode_change(Mission::ResultCallback callback, MAVLinkCommands::Result result);
     static Mission::Result command_result_to_mission_result(MAVLinkCommands::Result result);
 
     // FIXME: make static
@@ -115,9 +114,9 @@ private:
         int num_mission_items_to_download{-1};
         int next_mission_item_to_download{-1};
         int last_mission_item_to_upload{-1};
-        Mission::result_callback_t result_callback{nullptr};
-        Mission::download_mission_callback_t download_mission_callback{nullptr};
-        Mission::mission_progress_callback_t mission_progress_callback{nullptr};
+        Mission::ResultCallback result_callback{nullptr};
+        Mission::DownloadMissionCallback download_mission_callback{nullptr};
+        Mission::MissionProgressCallback mission_progress_callback{nullptr};
         int last_current_reported_mission_item{-1};
         int last_total_reported_mission_item{-1};
         std::weak_ptr<MAVLinkMissionTransfer::WorkItem> last_upload{};

--- a/src/plugins/mission/mocks/mission_mock.h
+++ b/src/plugins/mission/mocks/mission_mock.h
@@ -10,25 +10,25 @@ namespace testing {
 class MockMission {
 public:
     MOCK_CONST_METHOD2(
-        upload_mission_async, void(Mission::MissionPlan&, Mission::result_callback_t)){};
+        upload_mission_async, void(Mission::MissionPlan&, Mission::ResultCallback)){};
     MOCK_CONST_METHOD1(upload_mission, Mission::Result(Mission::MissionPlan)){};
-    MOCK_CONST_METHOD1(download_mission_async, void(Mission::download_mission_callback_t)){};
+    MOCK_CONST_METHOD1(download_mission_async, void(Mission::DownloadMissionCallback)){};
     MOCK_CONST_METHOD0(download_mission, std::pair<Mission::Result, Mission::MissionPlan>()){};
     MOCK_CONST_METHOD0(cancel_mission_upload, Mission::Result()){};
     MOCK_CONST_METHOD0(cancel_mission_download, Mission::Result()){};
-    MOCK_CONST_METHOD1(start_mission_async, void(Mission::result_callback_t)){};
+    MOCK_CONST_METHOD1(start_mission_async, void(Mission::ResultCallback)){};
     MOCK_CONST_METHOD0(start_mission, Mission::Result()){};
-    MOCK_CONST_METHOD1(pause_mission_async, void(Mission::result_callback_t)){};
+    MOCK_CONST_METHOD1(pause_mission_async, void(Mission::ResultCallback)){};
     MOCK_CONST_METHOD0(pause_mission, Mission::Result()){};
-    MOCK_CONST_METHOD1(clear_mission_async, void(Mission::result_callback_t)){};
+    MOCK_CONST_METHOD1(clear_mission_async, void(Mission::ResultCallback)){};
     MOCK_CONST_METHOD0(clear_mission, Mission::Result()){};
     MOCK_CONST_METHOD2(
-        set_current_mission_item_async, void(int current, Mission::result_callback_t)){};
+        set_current_mission_item_async, void(int current, Mission::ResultCallback)){};
     MOCK_CONST_METHOD1(set_current_mission_item, Mission::Result(int current)){};
     MOCK_CONST_METHOD0(current_mission_item, int()){};
     MOCK_CONST_METHOD0(total_mission_items, int()){};
     MOCK_CONST_METHOD0(is_mission_finished, std::pair<Mission::Result, bool>()){};
-    MOCK_CONST_METHOD1(subscribe_mission_progress, void(Mission::mission_progress_callback_t)){};
+    MOCK_CONST_METHOD1(subscribe_mission_progress, void(Mission::MissionProgressCallback)){};
     MOCK_CONST_METHOD0(get_return_to_launch_after_mission, std::pair<Mission::Result, bool>()){};
     MOCK_CONST_METHOD1(set_return_to_launch_after_mission, Mission::Result(bool)){};
 

--- a/src/plugins/mission_raw/include/plugins/mission_raw/mission_raw.h
+++ b/src/plugins/mission_raw/include/plugins/mission_raw/mission_raw.h
@@ -129,7 +129,7 @@ public:
     /**
      * @brief Callback type for asynchronous MissionRaw calls.
      */
-    typedef std::function<void(Result)> ResultCallback;
+    using ResultCallback = std::function<void(Result)>;
 
     /**
      * @brief Upload a list of raw mission items to the system.
@@ -166,7 +166,7 @@ public:
     /**
      * @brief Callback type for download_mission_async.
      */
-    typedef std::function<void(Result, std::vector<MissionItem>)> DownloadMissionCallback;
+    using DownloadMissionCallback = std::function<void(Result, std::vector<MissionItem>)>;
 
     /**
      * @brief Download a list of raw mission items from the system (asynchronous).
@@ -282,7 +282,7 @@ public:
      * @brief Callback type for subscribe_mission_progress.
      */
 
-    typedef std::function<void(MissionProgress)> MissionProgressCallback;
+    using MissionProgressCallback = std::function<void(MissionProgress)>;
 
     /**
      * @brief Subscribe to mission progress updates.
@@ -300,7 +300,7 @@ public:
      * @brief Callback type for subscribe_mission_changed.
      */
 
-    typedef std::function<void(bool)> MissionChangedCallback;
+    using MissionChangedCallback = std::function<void(bool)>;
 
     /**
      * @brief *

--- a/src/plugins/mission_raw/include/plugins/mission_raw/mission_raw.h
+++ b/src/plugins/mission_raw/include/plugins/mission_raw/mission_raw.h
@@ -129,7 +129,7 @@ public:
     /**
      * @brief Callback type for asynchronous MissionRaw calls.
      */
-    typedef std::function<void(Result)> result_callback_t;
+    typedef std::function<void(Result)> ResultCallback;
 
     /**
      * @brief Upload a list of raw mission items to the system.
@@ -140,7 +140,7 @@ public:
      * This function is non-blocking. See 'upload_mission' for the blocking counterpart.
      */
     void
-    upload_mission_async(std::vector<MissionItem> mission_items, const result_callback_t callback);
+    upload_mission_async(std::vector<MissionItem> mission_items, const ResultCallback callback);
 
     /**
      * @brief Upload a list of raw mission items to the system.
@@ -166,14 +166,14 @@ public:
     /**
      * @brief Callback type for download_mission_async.
      */
-    typedef std::function<void(Result, std::vector<MissionItem>)> download_mission_callback_t;
+    typedef std::function<void(Result, std::vector<MissionItem>)> DownloadMissionCallback;
 
     /**
      * @brief Download a list of raw mission items from the system (asynchronous).
      *
      * This function is non-blocking. See 'download_mission' for the blocking counterpart.
      */
-    void download_mission_async(const download_mission_callback_t callback);
+    void download_mission_async(const DownloadMissionCallback callback);
 
     /**
      * @brief Download a list of raw mission items from the system (asynchronous).
@@ -200,7 +200,7 @@ public:
      *
      * This function is non-blocking. See 'start_mission' for the blocking counterpart.
      */
-    void start_mission_async(const result_callback_t callback);
+    void start_mission_async(const ResultCallback callback);
 
     /**
      * @brief Start the mission.
@@ -223,7 +223,7 @@ public:
      *
      * This function is non-blocking. See 'pause_mission' for the blocking counterpart.
      */
-    void pause_mission_async(const result_callback_t callback);
+    void pause_mission_async(const ResultCallback callback);
 
     /**
      * @brief Pause the mission.
@@ -244,7 +244,7 @@ public:
      *
      * This function is non-blocking. See 'clear_mission' for the blocking counterpart.
      */
-    void clear_mission_async(const result_callback_t callback);
+    void clear_mission_async(const ResultCallback callback);
 
     /**
      * @brief Clear the mission saved on the vehicle.
@@ -263,7 +263,7 @@ public:
      *
      * This function is non-blocking. See 'set_current_mission_item' for the blocking counterpart.
      */
-    void set_current_mission_item_async(int32_t index, const result_callback_t callback);
+    void set_current_mission_item_async(int32_t index, const ResultCallback callback);
 
     /**
      * @brief Sets the raw mission item index to go to.
@@ -282,12 +282,12 @@ public:
      * @brief Callback type for subscribe_mission_progress.
      */
 
-    typedef std::function<void(MissionProgress)> mission_progress_callback_t;
+    typedef std::function<void(MissionProgress)> MissionProgressCallback;
 
     /**
      * @brief Subscribe to mission progress updates.
      */
-    void subscribe_mission_progress(mission_progress_callback_t callback);
+    void subscribe_mission_progress(MissionProgressCallback callback);
 
     /**
      * @brief Poll for 'MissionProgress' (blocking).
@@ -300,7 +300,7 @@ public:
      * @brief Callback type for subscribe_mission_changed.
      */
 
-    typedef std::function<void(bool)> mission_changed_callback_t;
+    typedef std::function<void(bool)> MissionChangedCallback;
 
     /**
      * @brief *
@@ -311,7 +311,7 @@ public:
      *
      * @param callback Callback to notify about change.
      */
-    void subscribe_mission_changed(mission_changed_callback_t callback);
+    void subscribe_mission_changed(MissionChangedCallback callback);
 
     /**
      * @brief Returns a human-readable English string for a Result.

--- a/src/plugins/mission_raw/mission_raw.cpp
+++ b/src/plugins/mission_raw/mission_raw.cpp
@@ -17,7 +17,7 @@ MissionRaw::MissionRaw(System& system) : PluginBase(), _impl{new MissionRawImpl(
 MissionRaw::~MissionRaw() {}
 
 void MissionRaw::upload_mission_async(
-    std::vector<MissionItem> mission_items, const result_callback_t callback)
+    std::vector<MissionItem> mission_items, const ResultCallback callback)
 {
     _impl->upload_mission_async(mission_items, callback);
 }
@@ -32,7 +32,7 @@ MissionRaw::Result MissionRaw::cancel_mission_upload() const
     return _impl->cancel_mission_upload();
 }
 
-void MissionRaw::download_mission_async(const download_mission_callback_t callback)
+void MissionRaw::download_mission_async(const DownloadMissionCallback callback)
 {
     _impl->download_mission_async(callback);
 }
@@ -48,7 +48,7 @@ MissionRaw::Result MissionRaw::cancel_mission_download() const
     return _impl->cancel_mission_download();
 }
 
-void MissionRaw::start_mission_async(const result_callback_t callback)
+void MissionRaw::start_mission_async(const ResultCallback callback)
 {
     _impl->start_mission_async(callback);
 }
@@ -58,7 +58,7 @@ MissionRaw::Result MissionRaw::start_mission() const
     return _impl->start_mission();
 }
 
-void MissionRaw::pause_mission_async(const result_callback_t callback)
+void MissionRaw::pause_mission_async(const ResultCallback callback)
 {
     _impl->pause_mission_async(callback);
 }
@@ -68,7 +68,7 @@ MissionRaw::Result MissionRaw::pause_mission() const
     return _impl->pause_mission();
 }
 
-void MissionRaw::clear_mission_async(const result_callback_t callback)
+void MissionRaw::clear_mission_async(const ResultCallback callback)
 {
     _impl->clear_mission_async(callback);
 }
@@ -78,7 +78,7 @@ MissionRaw::Result MissionRaw::clear_mission() const
     return _impl->clear_mission();
 }
 
-void MissionRaw::set_current_mission_item_async(int32_t index, const result_callback_t callback)
+void MissionRaw::set_current_mission_item_async(int32_t index, const ResultCallback callback)
 {
     _impl->set_current_mission_item_async(index, callback);
 }
@@ -88,7 +88,7 @@ MissionRaw::Result MissionRaw::set_current_mission_item(int32_t index) const
     return _impl->set_current_mission_item(index);
 }
 
-void MissionRaw::subscribe_mission_progress(mission_progress_callback_t callback)
+void MissionRaw::subscribe_mission_progress(MissionProgressCallback callback)
 {
     _impl->mission_progress_async(callback);
 }
@@ -98,7 +98,7 @@ MissionRaw::MissionProgress MissionRaw::mission_progress() const
     return _impl->mission_progress();
 }
 
-void MissionRaw::subscribe_mission_changed(mission_changed_callback_t callback)
+void MissionRaw::subscribe_mission_changed(MissionChangedCallback callback)
 {
     _impl->mission_changed_async(callback);
 }

--- a/src/plugins/mission_raw/mission_raw_impl.cpp
+++ b/src/plugins/mission_raw/mission_raw_impl.cpp
@@ -113,7 +113,7 @@ MissionRawImpl::upload_mission(std::vector<MissionRaw::MissionItem> mission_item
 
 void MissionRawImpl::upload_mission_async(
     const std::vector<MissionRaw::MissionItem>& mission_raw,
-    const MissionRaw::result_callback_t& callback)
+    const MissionRaw::ResultCallback& callback)
 {
     if (_last_upload.lock()) {
         _parent->call_user_callback([callback]() {
@@ -173,7 +173,7 @@ MissionRawImpl::download_mission()
     return fut.get();
 }
 
-void MissionRawImpl::download_mission_async(const MissionRaw::download_mission_callback_t& callback)
+void MissionRawImpl::download_mission_async(const MissionRaw::DownloadMissionCallback& callback)
 {
     if (_last_download.lock()) {
         _parent->call_user_callback([callback]() {
@@ -293,7 +293,7 @@ MissionRaw::Result MissionRawImpl::start_mission()
     return fut.get();
 }
 
-void MissionRawImpl::start_mission_async(const MissionRaw::result_callback_t& callback)
+void MissionRawImpl::start_mission_async(const MissionRaw::ResultCallback& callback)
 {
     _parent->set_flight_mode_async(
         SystemImpl::FlightMode::Mission, [this, callback](MAVLinkCommands::Result result, float) {
@@ -310,7 +310,7 @@ MissionRaw::Result MissionRawImpl::pause_mission()
     return fut.get();
 }
 
-void MissionRawImpl::pause_mission_async(const MissionRaw::result_callback_t& callback)
+void MissionRawImpl::pause_mission_async(const MissionRaw::ResultCallback& callback)
 {
     _parent->set_flight_mode_async(
         SystemImpl::FlightMode::Hold, [this, callback](MAVLinkCommands::Result result, float) {
@@ -319,7 +319,7 @@ void MissionRawImpl::pause_mission_async(const MissionRaw::result_callback_t& ca
 }
 
 void MissionRawImpl::report_flight_mode_change(
-    MissionRaw::result_callback_t callback, MAVLinkCommands::Result result)
+    MissionRaw::ResultCallback callback, MAVLinkCommands::Result result)
 {
     if (!callback) {
         return;
@@ -362,7 +362,7 @@ MissionRaw::Result MissionRawImpl::clear_mission()
     return fut.get();
 }
 
-void MissionRawImpl::clear_mission_async(const MissionRaw::result_callback_t& callback)
+void MissionRawImpl::clear_mission_async(const MissionRaw::ResultCallback& callback)
 {
     _parent->mission_transfer().clear_items_async(
         MAV_MISSION_TYPE_MISSION, [this, callback](MAVLinkMissionTransfer::Result result) {
@@ -386,7 +386,7 @@ MissionRaw::Result MissionRawImpl::set_current_mission_item(int index)
 }
 
 void MissionRawImpl::set_current_mission_item_async(
-    int index, const MissionRaw::result_callback_t& callback)
+    int index, const MissionRaw::ResultCallback& callback)
 {
     if (index < 0 && index >= _mission_progress.last.total) {
         _parent->call_user_callback([callback]() {
@@ -435,7 +435,7 @@ void MissionRawImpl::report_progress_current()
     }
 }
 
-void MissionRawImpl::mission_progress_async(MissionRaw::mission_progress_callback_t callback)
+void MissionRawImpl::mission_progress_async(MissionRaw::MissionProgressCallback callback)
 {
     std::lock_guard<std::mutex> lock(_mission_progress.mutex);
     _mission_progress.callback = callback;
@@ -447,7 +447,7 @@ MissionRaw::MissionProgress MissionRawImpl::mission_progress()
     return _mission_progress.last;
 }
 
-void MissionRawImpl::mission_changed_async(MissionRaw::mission_changed_callback_t callback)
+void MissionRawImpl::mission_changed_async(MissionRaw::MissionChangedCallback callback)
 {
     std::lock_guard<std::mutex> lock(_mission_changed.mutex);
     _mission_changed.callback = callback;

--- a/src/plugins/mission_raw/mission_raw_impl.h
+++ b/src/plugins/mission_raw/mission_raw_impl.h
@@ -21,32 +21,32 @@ public:
     void disable() override;
 
     std::pair<MissionRaw::Result, std::vector<MissionRaw::MissionItem>> download_mission();
-    void download_mission_async(const MissionRaw::download_mission_callback_t& callback);
+    void download_mission_async(const MissionRaw::DownloadMissionCallback& callback);
     MissionRaw::Result cancel_mission_download();
 
     MissionRaw::Result upload_mission(std::vector<MissionRaw::MissionItem> mission_items);
     void upload_mission_async(
         const std::vector<MissionRaw::MissionItem>& mission_raw,
-        const MissionRaw::result_callback_t& callback);
+        const MissionRaw::ResultCallback& callback);
     MissionRaw::Result cancel_mission_upload();
 
-    void mission_changed_async(MissionRaw::mission_changed_callback_t callback);
+    void mission_changed_async(MissionRaw::MissionChangedCallback callback);
 
     MissionRaw::Result start_mission();
-    void start_mission_async(const MissionRaw::result_callback_t& callback);
+    void start_mission_async(const MissionRaw::ResultCallback& callback);
     MissionRaw::Result pause_mission();
-    void pause_mission_async(const MissionRaw::result_callback_t& callback);
+    void pause_mission_async(const MissionRaw::ResultCallback& callback);
     MissionRaw::Result clear_mission();
-    void clear_mission_async(const MissionRaw::result_callback_t& callback);
+    void clear_mission_async(const MissionRaw::ResultCallback& callback);
 
     MissionRaw::Result set_current_mission_item(int index);
-    void set_current_mission_item_async(int index, const MissionRaw::result_callback_t& callback);
+    void set_current_mission_item_async(int index, const MissionRaw::ResultCallback& callback);
 
     int current_mavlink_mission_item() const;
     int total_mavlink_mission_items() const;
 
     MissionRaw::MissionProgress mission_progress();
-    void mission_progress_async(MissionRaw::mission_progress_callback_t callback);
+    void mission_progress_async(MissionRaw::MissionProgressCallback callback);
 
     MissionRawImpl(const MissionRawImpl&) = delete;
     const MissionRawImpl& operator=(const MissionRawImpl&) = delete;
@@ -60,8 +60,8 @@ private:
 
     void report_progress_current();
 
-    void report_flight_mode_change(
-        MissionRaw::result_callback_t callback, MAVLinkCommands::Result result);
+    void
+    report_flight_mode_change(MissionRaw::ResultCallback callback, MAVLinkCommands::Result result);
     static MissionRaw::Result command_result_to_mission_result(MAVLinkCommands::Result result);
 
     std::vector<MAVLinkMissionTransfer::ItemInt>
@@ -84,12 +84,12 @@ private:
         std::mutex mutex{};
         MissionRaw::MissionProgress last{};
         MissionRaw::MissionProgress last_reported{};
-        MissionRaw::mission_progress_callback_t callback{nullptr};
+        MissionRaw::MissionProgressCallback callback{nullptr};
     } _mission_progress{};
 
     struct {
         std::mutex mutex{};
-        MissionRaw::mission_changed_callback_t callback{nullptr};
+        MissionRaw::MissionChangedCallback callback{nullptr};
     } _mission_changed{};
 };
 

--- a/src/plugins/mocap/include/plugins/mocap/mocap.h
+++ b/src/plugins/mocap/include/plugins/mocap/mocap.h
@@ -320,7 +320,7 @@ public:
     /**
      * @brief Callback type for asynchronous Mocap calls.
      */
-    typedef std::function<void(Result)> result_callback_t;
+    typedef std::function<void(Result)> ResultCallback;
 
     /**
      * @brief Send Global position/attitude estimate from a vision source.

--- a/src/plugins/mocap/include/plugins/mocap/mocap.h
+++ b/src/plugins/mocap/include/plugins/mocap/mocap.h
@@ -320,7 +320,7 @@ public:
     /**
      * @brief Callback type for asynchronous Mocap calls.
      */
-    typedef std::function<void(Result)> ResultCallback;
+    using ResultCallback = std::function<void(Result)>;
 
     /**
      * @brief Send Global position/attitude estimate from a vision source.

--- a/src/plugins/offboard/include/plugins/offboard/offboard.h
+++ b/src/plugins/offboard/include/plugins/offboard/offboard.h
@@ -269,7 +269,7 @@ public:
     /**
      * @brief Callback type for asynchronous Offboard calls.
      */
-    typedef std::function<void(Result)> ResultCallback;
+    using ResultCallback = std::function<void(Result)>;
 
     /**
      * @brief Start offboard control.

--- a/src/plugins/offboard/include/plugins/offboard/offboard.h
+++ b/src/plugins/offboard/include/plugins/offboard/offboard.h
@@ -269,14 +269,14 @@ public:
     /**
      * @brief Callback type for asynchronous Offboard calls.
      */
-    typedef std::function<void(Result)> result_callback_t;
+    typedef std::function<void(Result)> ResultCallback;
 
     /**
      * @brief Start offboard control.
      *
      * This function is non-blocking. See 'start' for the blocking counterpart.
      */
-    void start_async(const result_callback_t callback);
+    void start_async(const ResultCallback callback);
 
     /**
      * @brief Start offboard control.
@@ -294,7 +294,7 @@ public:
      *
      * This function is non-blocking. See 'stop' for the blocking counterpart.
      */
-    void stop_async(const result_callback_t callback);
+    void stop_async(const ResultCallback callback);
 
     /**
      * @brief Stop offboard control.

--- a/src/plugins/offboard/offboard.cpp
+++ b/src/plugins/offboard/offboard.cpp
@@ -21,7 +21,7 @@ Offboard::Offboard(System& system) : PluginBase(), _impl{new OffboardImpl(system
 
 Offboard::~Offboard() {}
 
-void Offboard::start_async(const result_callback_t callback)
+void Offboard::start_async(const ResultCallback callback)
 {
     _impl->start_async(callback);
 }
@@ -31,7 +31,7 @@ Offboard::Result Offboard::start() const
     return _impl->start();
 }
 
-void Offboard::stop_async(const result_callback_t callback)
+void Offboard::stop_async(const ResultCallback callback)
 {
     _impl->stop_async(callback);
 }

--- a/src/plugins/offboard/offboard_impl.cpp
+++ b/src/plugins/offboard/offboard_impl.cpp
@@ -62,7 +62,7 @@ Offboard::Result OffboardImpl::stop()
         _parent->set_flight_mode(SystemImpl::FlightMode::Hold));
 }
 
-void OffboardImpl::start_async(Offboard::result_callback_t callback)
+void OffboardImpl::start_async(Offboard::ResultCallback callback)
 {
     {
         std::lock_guard<std::mutex> lock(_mutex);
@@ -81,7 +81,7 @@ void OffboardImpl::start_async(Offboard::result_callback_t callback)
         std::bind(&OffboardImpl::receive_command_result, this, std::placeholders::_1, callback));
 }
 
-void OffboardImpl::stop_async(Offboard::result_callback_t callback)
+void OffboardImpl::stop_async(Offboard::ResultCallback callback)
 {
     {
         std::lock_guard<std::mutex> lock(_mutex);
@@ -102,7 +102,7 @@ bool OffboardImpl::is_active()
 }
 
 void OffboardImpl::receive_command_result(
-    MAVLinkCommands::Result result, const Offboard::result_callback_t& callback)
+    MAVLinkCommands::Result result, const Offboard::ResultCallback& callback)
 {
     Offboard::Result offboard_result = offboard_result_from_command_result(result);
     if (callback) {

--- a/src/plugins/offboard/offboard_impl.h
+++ b/src/plugins/offboard/offboard_impl.h
@@ -23,8 +23,8 @@ public:
     Offboard::Result start();
     Offboard::Result stop();
 
-    void start_async(Offboard::result_callback_t callback);
-    void stop_async(Offboard::result_callback_t callback);
+    void start_async(Offboard::ResultCallback callback);
+    void stop_async(Offboard::ResultCallback callback);
 
     bool is_active();
 
@@ -49,7 +49,7 @@ private:
 
     void process_heartbeat(const mavlink_message_t& message);
     void receive_command_result(
-        MAVLinkCommands::Result result, const Offboard::result_callback_t& callback);
+        MAVLinkCommands::Result result, const Offboard::ResultCallback& callback);
 
     static Offboard::Result offboard_result_from_command_result(MAVLinkCommands::Result result);
 

--- a/src/plugins/param/include/plugins/param/param.h
+++ b/src/plugins/param/include/plugins/param/param.h
@@ -65,7 +65,7 @@ public:
     /**
      * @brief Callback type for asynchronous Param calls.
      */
-    typedef std::function<void(Result)> result_callback_t;
+    typedef std::function<void(Result)> ResultCallback;
 
     /**
      * @brief Get an int parameter.

--- a/src/plugins/param/include/plugins/param/param.h
+++ b/src/plugins/param/include/plugins/param/param.h
@@ -65,7 +65,7 @@ public:
     /**
      * @brief Callback type for asynchronous Param calls.
      */
-    typedef std::function<void(Result)> ResultCallback;
+    using ResultCallback = std::function<void(Result)>;
 
     /**
      * @brief Get an int parameter.

--- a/src/plugins/shell/include/plugins/shell/shell.h
+++ b/src/plugins/shell/include/plugins/shell/shell.h
@@ -66,7 +66,7 @@ public:
     /**
      * @brief Callback type for asynchronous Shell calls.
      */
-    typedef std::function<void(Result)> result_callback_t;
+    typedef std::function<void(Result)> ResultCallback;
 
     /**
      * @brief Send a command line.
@@ -81,7 +81,7 @@ public:
      * @brief Callback type for subscribe_receive.
      */
 
-    typedef std::function<void(std::string)> receive_callback_t;
+    typedef std::function<void(std::string)> ReceiveCallback;
 
     /**
      * @brief Receive feedback from a sent command line.
@@ -89,7 +89,7 @@ public:
      * This subscription needs to be made before a command line is sent, otherwise, no response will
      * be sent.
      */
-    void subscribe_receive(receive_callback_t callback);
+    void subscribe_receive(ReceiveCallback callback);
 
     /**
      * @brief Returns a human-readable English string for a Result.

--- a/src/plugins/shell/include/plugins/shell/shell.h
+++ b/src/plugins/shell/include/plugins/shell/shell.h
@@ -66,7 +66,7 @@ public:
     /**
      * @brief Callback type for asynchronous Shell calls.
      */
-    typedef std::function<void(Result)> ResultCallback;
+    using ResultCallback = std::function<void(Result)>;
 
     /**
      * @brief Send a command line.
@@ -81,7 +81,7 @@ public:
      * @brief Callback type for subscribe_receive.
      */
 
-    typedef std::function<void(std::string)> ReceiveCallback;
+    using ReceiveCallback = std::function<void(std::string)>;
 
     /**
      * @brief Receive feedback from a sent command line.

--- a/src/plugins/shell/shell.cpp
+++ b/src/plugins/shell/shell.cpp
@@ -18,7 +18,7 @@ Shell::Result Shell::send(std::string command) const
     return _impl->send(command);
 }
 
-void Shell::subscribe_receive(receive_callback_t callback)
+void Shell::subscribe_receive(ReceiveCallback callback)
 {
     _impl->receive_async(callback);
 }

--- a/src/plugins/shell/shell_impl.cpp
+++ b/src/plugins/shell/shell_impl.cpp
@@ -48,7 +48,7 @@ Shell::Result ShellImpl::send(std::string command)
     return Shell::Result::Success;
 }
 
-void ShellImpl::receive_async(Shell::receive_callback_t callback)
+void ShellImpl::receive_async(Shell::ReceiveCallback callback)
 {
     std::lock_guard<std::mutex> lock(_receive.mutex);
     _receive.callback = callback;

--- a/src/plugins/shell/shell_impl.h
+++ b/src/plugins/shell/shell_impl.h
@@ -23,7 +23,7 @@ public:
     void disable() override;
 
     Shell::Result send(std::string command);
-    void receive_async(Shell::receive_callback_t callback);
+    void receive_async(Shell::ReceiveCallback callback);
 
     ShellImpl(const ShellImpl&) = delete;
     ShellImpl& operator=(const ShellImpl&) = delete;
@@ -36,7 +36,7 @@ private:
 
     struct {
         std::mutex mutex{};
-        Shell::receive_callback_t callback{nullptr};
+        Shell::ReceiveCallback callback{nullptr};
     } _receive{};
 };
 } // namespace mavsdk

--- a/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -820,13 +820,13 @@ public:
     /**
      * @brief Callback type for asynchronous Telemetry calls.
      */
-    typedef std::function<void(Result)> ResultCallback;
+    using ResultCallback = std::function<void(Result)>;
 
     /**
      * @brief Callback type for subscribe_position.
      */
 
-    typedef std::function<void(Position)> PositionCallback;
+    using PositionCallback = std::function<void(Position)>;
 
     /**
      * @brief Subscribe to 'position' updates.
@@ -844,7 +844,7 @@ public:
      * @brief Callback type for subscribe_home.
      */
 
-    typedef std::function<void(Position)> HomeCallback;
+    using HomeCallback = std::function<void(Position)>;
 
     /**
      * @brief Subscribe to 'home position' updates.
@@ -862,7 +862,7 @@ public:
      * @brief Callback type for subscribe_in_air.
      */
 
-    typedef std::function<void(bool)> InAirCallback;
+    using InAirCallback = std::function<void(bool)>;
 
     /**
      * @brief Subscribe to in-air updates.
@@ -880,7 +880,7 @@ public:
      * @brief Callback type for subscribe_landed_state.
      */
 
-    typedef std::function<void(LandedState)> LandedStateCallback;
+    using LandedStateCallback = std::function<void(LandedState)>;
 
     /**
      * @brief Subscribe to landed state updates
@@ -898,7 +898,7 @@ public:
      * @brief Callback type for subscribe_armed.
      */
 
-    typedef std::function<void(bool)> ArmedCallback;
+    using ArmedCallback = std::function<void(bool)>;
 
     /**
      * @brief Subscribe to armed updates.
@@ -916,7 +916,7 @@ public:
      * @brief Callback type for subscribe_attitude_quaternion.
      */
 
-    typedef std::function<void(Quaternion)> AttitudeQuaternionCallback;
+    using AttitudeQuaternionCallback = std::function<void(Quaternion)>;
 
     /**
      * @brief Subscribe to 'attitude' updates (quaternion).
@@ -934,7 +934,7 @@ public:
      * @brief Callback type for subscribe_attitude_euler.
      */
 
-    typedef std::function<void(EulerAngle)> AttitudeEulerCallback;
+    using AttitudeEulerCallback = std::function<void(EulerAngle)>;
 
     /**
      * @brief Subscribe to 'attitude' updates (Euler).
@@ -952,7 +952,7 @@ public:
      * @brief Callback type for subscribe_attitude_angular_velocity_body.
      */
 
-    typedef std::function<void(AngularVelocityBody)> AttitudeAngularVelocityBodyCallback;
+    using AttitudeAngularVelocityBodyCallback = std::function<void(AngularVelocityBody)>;
 
     /**
      * @brief Subscribe to 'attitude' updates (angular velocity)
@@ -970,7 +970,7 @@ public:
      * @brief Callback type for subscribe_camera_attitude_quaternion.
      */
 
-    typedef std::function<void(Quaternion)> CameraAttitudeQuaternionCallback;
+    using CameraAttitudeQuaternionCallback = std::function<void(Quaternion)>;
 
     /**
      * @brief Subscribe to 'camera attitude' updates (quaternion).
@@ -988,7 +988,7 @@ public:
      * @brief Callback type for subscribe_camera_attitude_euler.
      */
 
-    typedef std::function<void(EulerAngle)> CameraAttitudeEulerCallback;
+    using CameraAttitudeEulerCallback = std::function<void(EulerAngle)>;
 
     /**
      * @brief Subscribe to 'camera attitude' updates (Euler).
@@ -1006,7 +1006,7 @@ public:
      * @brief Callback type for subscribe_ground_speed_ned.
      */
 
-    typedef std::function<void(SpeedNed)> GroundSpeedNedCallback;
+    using GroundSpeedNedCallback = std::function<void(SpeedNed)>;
 
     /**
      * @brief Subscribe to 'ground speed' updates (NED).
@@ -1024,7 +1024,7 @@ public:
      * @brief Callback type for subscribe_gps_info.
      */
 
-    typedef std::function<void(GpsInfo)> GpsInfoCallback;
+    using GpsInfoCallback = std::function<void(GpsInfo)>;
 
     /**
      * @brief Subscribe to 'GPS info' updates.
@@ -1042,7 +1042,7 @@ public:
      * @brief Callback type for subscribe_battery.
      */
 
-    typedef std::function<void(Battery)> BatteryCallback;
+    using BatteryCallback = std::function<void(Battery)>;
 
     /**
      * @brief Subscribe to 'battery' updates.
@@ -1060,7 +1060,7 @@ public:
      * @brief Callback type for subscribe_flight_mode.
      */
 
-    typedef std::function<void(FlightMode)> FlightModeCallback;
+    using FlightModeCallback = std::function<void(FlightMode)>;
 
     /**
      * @brief Subscribe to 'flight mode' updates.
@@ -1078,7 +1078,7 @@ public:
      * @brief Callback type for subscribe_health.
      */
 
-    typedef std::function<void(Health)> HealthCallback;
+    using HealthCallback = std::function<void(Health)>;
 
     /**
      * @brief Subscribe to 'health' updates.
@@ -1096,7 +1096,7 @@ public:
      * @brief Callback type for subscribe_rc_status.
      */
 
-    typedef std::function<void(RcStatus)> RcStatusCallback;
+    using RcStatusCallback = std::function<void(RcStatus)>;
 
     /**
      * @brief Subscribe to 'RC status' updates.
@@ -1114,7 +1114,7 @@ public:
      * @brief Callback type for subscribe_status_text.
      */
 
-    typedef std::function<void(StatusText)> StatusTextCallback;
+    using StatusTextCallback = std::function<void(StatusText)>;
 
     /**
      * @brief Subscribe to 'status text' updates.
@@ -1132,7 +1132,7 @@ public:
      * @brief Callback type for subscribe_actuator_control_target.
      */
 
-    typedef std::function<void(ActuatorControlTarget)> ActuatorControlTargetCallback;
+    using ActuatorControlTargetCallback = std::function<void(ActuatorControlTarget)>;
 
     /**
      * @brief Subscribe to 'actuator control target' updates.
@@ -1150,7 +1150,7 @@ public:
      * @brief Callback type for subscribe_actuator_output_status.
      */
 
-    typedef std::function<void(ActuatorOutputStatus)> ActuatorOutputStatusCallback;
+    using ActuatorOutputStatusCallback = std::function<void(ActuatorOutputStatus)>;
 
     /**
      * @brief Subscribe to 'actuator output status' updates.
@@ -1168,7 +1168,7 @@ public:
      * @brief Callback type for subscribe_odometry.
      */
 
-    typedef std::function<void(Odometry)> OdometryCallback;
+    using OdometryCallback = std::function<void(Odometry)>;
 
     /**
      * @brief Subscribe to 'odometry' updates.
@@ -1186,7 +1186,7 @@ public:
      * @brief Callback type for subscribe_position_velocity_ned.
      */
 
-    typedef std::function<void(PositionVelocityNed)> PositionVelocityNedCallback;
+    using PositionVelocityNedCallback = std::function<void(PositionVelocityNed)>;
 
     /**
      * @brief Subscribe to 'position velocity' updates.
@@ -1204,7 +1204,7 @@ public:
      * @brief Callback type for subscribe_ground_truth.
      */
 
-    typedef std::function<void(GroundTruth)> GroundTruthCallback;
+    using GroundTruthCallback = std::function<void(GroundTruth)>;
 
     /**
      * @brief Subscribe to 'ground truth' updates.
@@ -1222,7 +1222,7 @@ public:
      * @brief Callback type for subscribe_fixedwing_metrics.
      */
 
-    typedef std::function<void(FixedwingMetrics)> FixedwingMetricsCallback;
+    using FixedwingMetricsCallback = std::function<void(FixedwingMetrics)>;
 
     /**
      * @brief Subscribe to 'fixedwing metrics' updates.
@@ -1240,7 +1240,7 @@ public:
      * @brief Callback type for subscribe_imu.
      */
 
-    typedef std::function<void(Imu)> ImuCallback;
+    using ImuCallback = std::function<void(Imu)>;
 
     /**
      * @brief Subscribe to 'IMU' updates.
@@ -1258,7 +1258,7 @@ public:
      * @brief Callback type for subscribe_health_all_ok.
      */
 
-    typedef std::function<void(bool)> HealthAllOkCallback;
+    using HealthAllOkCallback = std::function<void(bool)>;
 
     /**
      * @brief Subscribe to 'HealthAllOk' updates.
@@ -1276,7 +1276,7 @@ public:
      * @brief Callback type for subscribe_unix_epoch_time.
      */
 
-    typedef std::function<void(uint64_t)> UnixEpochTimeCallback;
+    using UnixEpochTimeCallback = std::function<void(uint64_t)>;
 
     /**
      * @brief Subscribe to 'unix epoch time' updates.

--- a/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -820,18 +820,18 @@ public:
     /**
      * @brief Callback type for asynchronous Telemetry calls.
      */
-    typedef std::function<void(Result)> result_callback_t;
+    typedef std::function<void(Result)> ResultCallback;
 
     /**
      * @brief Callback type for subscribe_position.
      */
 
-    typedef std::function<void(Position)> position_callback_t;
+    typedef std::function<void(Position)> PositionCallback;
 
     /**
      * @brief Subscribe to 'position' updates.
      */
-    void subscribe_position(position_callback_t callback);
+    void subscribe_position(PositionCallback callback);
 
     /**
      * @brief Poll for 'Position' (blocking).
@@ -844,12 +844,12 @@ public:
      * @brief Callback type for subscribe_home.
      */
 
-    typedef std::function<void(Position)> home_callback_t;
+    typedef std::function<void(Position)> HomeCallback;
 
     /**
      * @brief Subscribe to 'home position' updates.
      */
-    void subscribe_home(home_callback_t callback);
+    void subscribe_home(HomeCallback callback);
 
     /**
      * @brief Poll for 'Position' (blocking).
@@ -862,12 +862,12 @@ public:
      * @brief Callback type for subscribe_in_air.
      */
 
-    typedef std::function<void(bool)> in_air_callback_t;
+    typedef std::function<void(bool)> InAirCallback;
 
     /**
      * @brief Subscribe to in-air updates.
      */
-    void subscribe_in_air(in_air_callback_t callback);
+    void subscribe_in_air(InAirCallback callback);
 
     /**
      * @brief Poll for 'bool' (blocking).
@@ -880,12 +880,12 @@ public:
      * @brief Callback type for subscribe_landed_state.
      */
 
-    typedef std::function<void(LandedState)> landed_state_callback_t;
+    typedef std::function<void(LandedState)> LandedStateCallback;
 
     /**
      * @brief Subscribe to landed state updates
      */
-    void subscribe_landed_state(landed_state_callback_t callback);
+    void subscribe_landed_state(LandedStateCallback callback);
 
     /**
      * @brief Poll for 'LandedState' (blocking).
@@ -898,12 +898,12 @@ public:
      * @brief Callback type for subscribe_armed.
      */
 
-    typedef std::function<void(bool)> armed_callback_t;
+    typedef std::function<void(bool)> ArmedCallback;
 
     /**
      * @brief Subscribe to armed updates.
      */
-    void subscribe_armed(armed_callback_t callback);
+    void subscribe_armed(ArmedCallback callback);
 
     /**
      * @brief Poll for 'bool' (blocking).
@@ -916,12 +916,12 @@ public:
      * @brief Callback type for subscribe_attitude_quaternion.
      */
 
-    typedef std::function<void(Quaternion)> attitude_quaternion_callback_t;
+    typedef std::function<void(Quaternion)> AttitudeQuaternionCallback;
 
     /**
      * @brief Subscribe to 'attitude' updates (quaternion).
      */
-    void subscribe_attitude_quaternion(attitude_quaternion_callback_t callback);
+    void subscribe_attitude_quaternion(AttitudeQuaternionCallback callback);
 
     /**
      * @brief Poll for 'Quaternion' (blocking).
@@ -934,12 +934,12 @@ public:
      * @brief Callback type for subscribe_attitude_euler.
      */
 
-    typedef std::function<void(EulerAngle)> attitude_euler_callback_t;
+    typedef std::function<void(EulerAngle)> AttitudeEulerCallback;
 
     /**
      * @brief Subscribe to 'attitude' updates (Euler).
      */
-    void subscribe_attitude_euler(attitude_euler_callback_t callback);
+    void subscribe_attitude_euler(AttitudeEulerCallback callback);
 
     /**
      * @brief Poll for 'EulerAngle' (blocking).
@@ -952,13 +952,12 @@ public:
      * @brief Callback type for subscribe_attitude_angular_velocity_body.
      */
 
-    typedef std::function<void(AngularVelocityBody)> attitude_angular_velocity_body_callback_t;
+    typedef std::function<void(AngularVelocityBody)> AttitudeAngularVelocityBodyCallback;
 
     /**
      * @brief Subscribe to 'attitude' updates (angular velocity)
      */
-    void
-    subscribe_attitude_angular_velocity_body(attitude_angular_velocity_body_callback_t callback);
+    void subscribe_attitude_angular_velocity_body(AttitudeAngularVelocityBodyCallback callback);
 
     /**
      * @brief Poll for 'AngularVelocityBody' (blocking).
@@ -971,12 +970,12 @@ public:
      * @brief Callback type for subscribe_camera_attitude_quaternion.
      */
 
-    typedef std::function<void(Quaternion)> camera_attitude_quaternion_callback_t;
+    typedef std::function<void(Quaternion)> CameraAttitudeQuaternionCallback;
 
     /**
      * @brief Subscribe to 'camera attitude' updates (quaternion).
      */
-    void subscribe_camera_attitude_quaternion(camera_attitude_quaternion_callback_t callback);
+    void subscribe_camera_attitude_quaternion(CameraAttitudeQuaternionCallback callback);
 
     /**
      * @brief Poll for 'Quaternion' (blocking).
@@ -989,12 +988,12 @@ public:
      * @brief Callback type for subscribe_camera_attitude_euler.
      */
 
-    typedef std::function<void(EulerAngle)> camera_attitude_euler_callback_t;
+    typedef std::function<void(EulerAngle)> CameraAttitudeEulerCallback;
 
     /**
      * @brief Subscribe to 'camera attitude' updates (Euler).
      */
-    void subscribe_camera_attitude_euler(camera_attitude_euler_callback_t callback);
+    void subscribe_camera_attitude_euler(CameraAttitudeEulerCallback callback);
 
     /**
      * @brief Poll for 'EulerAngle' (blocking).
@@ -1007,12 +1006,12 @@ public:
      * @brief Callback type for subscribe_ground_speed_ned.
      */
 
-    typedef std::function<void(SpeedNed)> ground_speed_ned_callback_t;
+    typedef std::function<void(SpeedNed)> GroundSpeedNedCallback;
 
     /**
      * @brief Subscribe to 'ground speed' updates (NED).
      */
-    void subscribe_ground_speed_ned(ground_speed_ned_callback_t callback);
+    void subscribe_ground_speed_ned(GroundSpeedNedCallback callback);
 
     /**
      * @brief Poll for 'SpeedNed' (blocking).
@@ -1025,12 +1024,12 @@ public:
      * @brief Callback type for subscribe_gps_info.
      */
 
-    typedef std::function<void(GpsInfo)> gps_info_callback_t;
+    typedef std::function<void(GpsInfo)> GpsInfoCallback;
 
     /**
      * @brief Subscribe to 'GPS info' updates.
      */
-    void subscribe_gps_info(gps_info_callback_t callback);
+    void subscribe_gps_info(GpsInfoCallback callback);
 
     /**
      * @brief Poll for 'GpsInfo' (blocking).
@@ -1043,12 +1042,12 @@ public:
      * @brief Callback type for subscribe_battery.
      */
 
-    typedef std::function<void(Battery)> battery_callback_t;
+    typedef std::function<void(Battery)> BatteryCallback;
 
     /**
      * @brief Subscribe to 'battery' updates.
      */
-    void subscribe_battery(battery_callback_t callback);
+    void subscribe_battery(BatteryCallback callback);
 
     /**
      * @brief Poll for 'Battery' (blocking).
@@ -1061,12 +1060,12 @@ public:
      * @brief Callback type for subscribe_flight_mode.
      */
 
-    typedef std::function<void(FlightMode)> flight_mode_callback_t;
+    typedef std::function<void(FlightMode)> FlightModeCallback;
 
     /**
      * @brief Subscribe to 'flight mode' updates.
      */
-    void subscribe_flight_mode(flight_mode_callback_t callback);
+    void subscribe_flight_mode(FlightModeCallback callback);
 
     /**
      * @brief Poll for 'FlightMode' (blocking).
@@ -1079,12 +1078,12 @@ public:
      * @brief Callback type for subscribe_health.
      */
 
-    typedef std::function<void(Health)> health_callback_t;
+    typedef std::function<void(Health)> HealthCallback;
 
     /**
      * @brief Subscribe to 'health' updates.
      */
-    void subscribe_health(health_callback_t callback);
+    void subscribe_health(HealthCallback callback);
 
     /**
      * @brief Poll for 'Health' (blocking).
@@ -1097,12 +1096,12 @@ public:
      * @brief Callback type for subscribe_rc_status.
      */
 
-    typedef std::function<void(RcStatus)> rc_status_callback_t;
+    typedef std::function<void(RcStatus)> RcStatusCallback;
 
     /**
      * @brief Subscribe to 'RC status' updates.
      */
-    void subscribe_rc_status(rc_status_callback_t callback);
+    void subscribe_rc_status(RcStatusCallback callback);
 
     /**
      * @brief Poll for 'RcStatus' (blocking).
@@ -1115,12 +1114,12 @@ public:
      * @brief Callback type for subscribe_status_text.
      */
 
-    typedef std::function<void(StatusText)> status_text_callback_t;
+    typedef std::function<void(StatusText)> StatusTextCallback;
 
     /**
      * @brief Subscribe to 'status text' updates.
      */
-    void subscribe_status_text(status_text_callback_t callback);
+    void subscribe_status_text(StatusTextCallback callback);
 
     /**
      * @brief Poll for 'StatusText' (blocking).
@@ -1133,12 +1132,12 @@ public:
      * @brief Callback type for subscribe_actuator_control_target.
      */
 
-    typedef std::function<void(ActuatorControlTarget)> actuator_control_target_callback_t;
+    typedef std::function<void(ActuatorControlTarget)> ActuatorControlTargetCallback;
 
     /**
      * @brief Subscribe to 'actuator control target' updates.
      */
-    void subscribe_actuator_control_target(actuator_control_target_callback_t callback);
+    void subscribe_actuator_control_target(ActuatorControlTargetCallback callback);
 
     /**
      * @brief Poll for 'ActuatorControlTarget' (blocking).
@@ -1151,12 +1150,12 @@ public:
      * @brief Callback type for subscribe_actuator_output_status.
      */
 
-    typedef std::function<void(ActuatorOutputStatus)> actuator_output_status_callback_t;
+    typedef std::function<void(ActuatorOutputStatus)> ActuatorOutputStatusCallback;
 
     /**
      * @brief Subscribe to 'actuator output status' updates.
      */
-    void subscribe_actuator_output_status(actuator_output_status_callback_t callback);
+    void subscribe_actuator_output_status(ActuatorOutputStatusCallback callback);
 
     /**
      * @brief Poll for 'ActuatorOutputStatus' (blocking).
@@ -1169,12 +1168,12 @@ public:
      * @brief Callback type for subscribe_odometry.
      */
 
-    typedef std::function<void(Odometry)> odometry_callback_t;
+    typedef std::function<void(Odometry)> OdometryCallback;
 
     /**
      * @brief Subscribe to 'odometry' updates.
      */
-    void subscribe_odometry(odometry_callback_t callback);
+    void subscribe_odometry(OdometryCallback callback);
 
     /**
      * @brief Poll for 'Odometry' (blocking).
@@ -1187,12 +1186,12 @@ public:
      * @brief Callback type for subscribe_position_velocity_ned.
      */
 
-    typedef std::function<void(PositionVelocityNed)> position_velocity_ned_callback_t;
+    typedef std::function<void(PositionVelocityNed)> PositionVelocityNedCallback;
 
     /**
      * @brief Subscribe to 'position velocity' updates.
      */
-    void subscribe_position_velocity_ned(position_velocity_ned_callback_t callback);
+    void subscribe_position_velocity_ned(PositionVelocityNedCallback callback);
 
     /**
      * @brief Poll for 'PositionVelocityNed' (blocking).
@@ -1205,12 +1204,12 @@ public:
      * @brief Callback type for subscribe_ground_truth.
      */
 
-    typedef std::function<void(GroundTruth)> ground_truth_callback_t;
+    typedef std::function<void(GroundTruth)> GroundTruthCallback;
 
     /**
      * @brief Subscribe to 'ground truth' updates.
      */
-    void subscribe_ground_truth(ground_truth_callback_t callback);
+    void subscribe_ground_truth(GroundTruthCallback callback);
 
     /**
      * @brief Poll for 'GroundTruth' (blocking).
@@ -1223,12 +1222,12 @@ public:
      * @brief Callback type for subscribe_fixedwing_metrics.
      */
 
-    typedef std::function<void(FixedwingMetrics)> fixedwing_metrics_callback_t;
+    typedef std::function<void(FixedwingMetrics)> FixedwingMetricsCallback;
 
     /**
      * @brief Subscribe to 'fixedwing metrics' updates.
      */
-    void subscribe_fixedwing_metrics(fixedwing_metrics_callback_t callback);
+    void subscribe_fixedwing_metrics(FixedwingMetricsCallback callback);
 
     /**
      * @brief Poll for 'FixedwingMetrics' (blocking).
@@ -1241,12 +1240,12 @@ public:
      * @brief Callback type for subscribe_imu.
      */
 
-    typedef std::function<void(Imu)> imu_callback_t;
+    typedef std::function<void(Imu)> ImuCallback;
 
     /**
      * @brief Subscribe to 'IMU' updates.
      */
-    void subscribe_imu(imu_callback_t callback);
+    void subscribe_imu(ImuCallback callback);
 
     /**
      * @brief Poll for 'Imu' (blocking).
@@ -1259,12 +1258,12 @@ public:
      * @brief Callback type for subscribe_health_all_ok.
      */
 
-    typedef std::function<void(bool)> health_all_ok_callback_t;
+    typedef std::function<void(bool)> HealthAllOkCallback;
 
     /**
      * @brief Subscribe to 'HealthAllOk' updates.
      */
-    void subscribe_health_all_ok(health_all_ok_callback_t callback);
+    void subscribe_health_all_ok(HealthAllOkCallback callback);
 
     /**
      * @brief Poll for 'bool' (blocking).
@@ -1277,12 +1276,12 @@ public:
      * @brief Callback type for subscribe_unix_epoch_time.
      */
 
-    typedef std::function<void(uint64_t)> unix_epoch_time_callback_t;
+    typedef std::function<void(uint64_t)> UnixEpochTimeCallback;
 
     /**
      * @brief Subscribe to 'unix epoch time' updates.
      */
-    void subscribe_unix_epoch_time(unix_epoch_time_callback_t callback);
+    void subscribe_unix_epoch_time(UnixEpochTimeCallback callback);
 
     /**
      * @brief Poll for 'uint64_t' (blocking).
@@ -1296,7 +1295,7 @@ public:
      *
      * This function is non-blocking. See 'set_rate_position' for the blocking counterpart.
      */
-    void set_rate_position_async(double rate_hz, const result_callback_t callback);
+    void set_rate_position_async(double rate_hz, const ResultCallback callback);
 
     /**
      * @brief Set rate to 'position' updates.
@@ -1312,7 +1311,7 @@ public:
      *
      * This function is non-blocking. See 'set_rate_home' for the blocking counterpart.
      */
-    void set_rate_home_async(double rate_hz, const result_callback_t callback);
+    void set_rate_home_async(double rate_hz, const ResultCallback callback);
 
     /**
      * @brief Set rate to 'home position' updates.
@@ -1328,7 +1327,7 @@ public:
      *
      * This function is non-blocking. See 'set_rate_in_air' for the blocking counterpart.
      */
-    void set_rate_in_air_async(double rate_hz, const result_callback_t callback);
+    void set_rate_in_air_async(double rate_hz, const ResultCallback callback);
 
     /**
      * @brief Set rate to in-air updates.
@@ -1344,7 +1343,7 @@ public:
      *
      * This function is non-blocking. See 'set_rate_landed_state' for the blocking counterpart.
      */
-    void set_rate_landed_state_async(double rate_hz, const result_callback_t callback);
+    void set_rate_landed_state_async(double rate_hz, const ResultCallback callback);
 
     /**
      * @brief Set rate to landed state updates
@@ -1361,7 +1360,7 @@ public:
      *
      * This function is non-blocking. See 'set_rate_attitude' for the blocking counterpart.
      */
-    void set_rate_attitude_async(double rate_hz, const result_callback_t callback);
+    void set_rate_attitude_async(double rate_hz, const ResultCallback callback);
 
     /**
      * @brief Set rate to 'attitude' updates.
@@ -1377,7 +1376,7 @@ public:
      *
      * This function is non-blocking. See 'set_rate_camera_attitude' for the blocking counterpart.
      */
-    void set_rate_camera_attitude_async(double rate_hz, const result_callback_t callback);
+    void set_rate_camera_attitude_async(double rate_hz, const ResultCallback callback);
 
     /**
      * @brief Set rate of camera attitude updates.
@@ -1394,7 +1393,7 @@ public:
      *
      * This function is non-blocking. See 'set_rate_ground_speed_ned' for the blocking counterpart.
      */
-    void set_rate_ground_speed_ned_async(double rate_hz, const result_callback_t callback);
+    void set_rate_ground_speed_ned_async(double rate_hz, const ResultCallback callback);
 
     /**
      * @brief Set rate to 'ground speed' updates (NED).
@@ -1411,7 +1410,7 @@ public:
      *
      * This function is non-blocking. See 'set_rate_gps_info' for the blocking counterpart.
      */
-    void set_rate_gps_info_async(double rate_hz, const result_callback_t callback);
+    void set_rate_gps_info_async(double rate_hz, const ResultCallback callback);
 
     /**
      * @brief Set rate to 'GPS info' updates.
@@ -1427,7 +1426,7 @@ public:
      *
      * This function is non-blocking. See 'set_rate_battery' for the blocking counterpart.
      */
-    void set_rate_battery_async(double rate_hz, const result_callback_t callback);
+    void set_rate_battery_async(double rate_hz, const ResultCallback callback);
 
     /**
      * @brief Set rate to 'battery' updates.
@@ -1443,7 +1442,7 @@ public:
      *
      * This function is non-blocking. See 'set_rate_rc_status' for the blocking counterpart.
      */
-    void set_rate_rc_status_async(double rate_hz, const result_callback_t callback);
+    void set_rate_rc_status_async(double rate_hz, const ResultCallback callback);
 
     /**
      * @brief Set rate to 'RC status' updates.
@@ -1460,7 +1459,7 @@ public:
      * This function is non-blocking. See 'set_rate_actuator_control_target' for the blocking
      * counterpart.
      */
-    void set_rate_actuator_control_target_async(double rate_hz, const result_callback_t callback);
+    void set_rate_actuator_control_target_async(double rate_hz, const ResultCallback callback);
 
     /**
      * @brief Set rate to 'actuator control target' updates.
@@ -1478,7 +1477,7 @@ public:
      * This function is non-blocking. See 'set_rate_actuator_output_status' for the blocking
      * counterpart.
      */
-    void set_rate_actuator_output_status_async(double rate_hz, const result_callback_t callback);
+    void set_rate_actuator_output_status_async(double rate_hz, const ResultCallback callback);
 
     /**
      * @brief Set rate to 'actuator output status' updates.
@@ -1495,7 +1494,7 @@ public:
      *
      * This function is non-blocking. See 'set_rate_odometry' for the blocking counterpart.
      */
-    void set_rate_odometry_async(double rate_hz, const result_callback_t callback);
+    void set_rate_odometry_async(double rate_hz, const ResultCallback callback);
 
     /**
      * @brief Set rate to 'odometry' updates.
@@ -1512,7 +1511,7 @@ public:
      * This function is non-blocking. See 'set_rate_position_velocity_ned' for the blocking
      * counterpart.
      */
-    void set_rate_position_velocity_ned_async(double rate_hz, const result_callback_t callback);
+    void set_rate_position_velocity_ned_async(double rate_hz, const ResultCallback callback);
 
     /**
      * @brief Set rate to 'position velocity' updates.
@@ -1529,7 +1528,7 @@ public:
      *
      * This function is non-blocking. See 'set_rate_ground_truth' for the blocking counterpart.
      */
-    void set_rate_ground_truth_async(double rate_hz, const result_callback_t callback);
+    void set_rate_ground_truth_async(double rate_hz, const ResultCallback callback);
 
     /**
      * @brief Set rate to 'ground truth' updates.
@@ -1546,7 +1545,7 @@ public:
      *
      * This function is non-blocking. See 'set_rate_fixedwing_metrics' for the blocking counterpart.
      */
-    void set_rate_fixedwing_metrics_async(double rate_hz, const result_callback_t callback);
+    void set_rate_fixedwing_metrics_async(double rate_hz, const ResultCallback callback);
 
     /**
      * @brief Set rate to 'fixedwing metrics' updates.
@@ -1563,7 +1562,7 @@ public:
      *
      * This function is non-blocking. See 'set_rate_imu' for the blocking counterpart.
      */
-    void set_rate_imu_async(double rate_hz, const result_callback_t callback);
+    void set_rate_imu_async(double rate_hz, const ResultCallback callback);
 
     /**
      * @brief Set rate to 'IMU' updates.
@@ -1579,7 +1578,7 @@ public:
      *
      * This function is non-blocking. See 'set_rate_unix_epoch_time' for the blocking counterpart.
      */
-    void set_rate_unix_epoch_time_async(double rate_hz, const result_callback_t callback);
+    void set_rate_unix_epoch_time_async(double rate_hz, const ResultCallback callback);
 
     /**
      * @brief Set rate to 'unix epoch time' updates.

--- a/src/plugins/telemetry/mocks/telemetry_mock.h
+++ b/src/plugins/telemetry/mocks/telemetry_mock.h
@@ -7,41 +7,39 @@ namespace testing {
 
 class MockTelemetry {
 public:
-    MOCK_CONST_METHOD1(subscribe_position, void(Telemetry::position_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_health, void(Telemetry::health_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_home, void(Telemetry::position_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_in_air, void(Telemetry::in_air_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_status_text, void(Telemetry::status_text_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_armed, void(Telemetry::armed_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_gps_info, void(Telemetry::gps_info_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_battery, void(Telemetry::battery_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_flight_mode, void(Telemetry::flight_mode_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_landed_state, void(Telemetry::landed_state_callback_t)){};
+    MOCK_CONST_METHOD1(subscribe_position, void(Telemetry::PositionCallback)){};
+    MOCK_CONST_METHOD1(subscribe_health, void(Telemetry::HealthCallback)){};
+    MOCK_CONST_METHOD1(subscribe_home, void(Telemetry::PositionCallback)){};
+    MOCK_CONST_METHOD1(subscribe_in_air, void(Telemetry::InAirCallback)){};
+    MOCK_CONST_METHOD1(subscribe_status_text, void(Telemetry::StatusTextCallback)){};
+    MOCK_CONST_METHOD1(subscribe_armed, void(Telemetry::ArmedCallback)){};
+    MOCK_CONST_METHOD1(subscribe_gps_info, void(Telemetry::GpsInfoCallback)){};
+    MOCK_CONST_METHOD1(subscribe_battery, void(Telemetry::BatteryCallback)){};
+    MOCK_CONST_METHOD1(subscribe_flight_mode, void(Telemetry::FlightModeCallback)){};
+    MOCK_CONST_METHOD1(subscribe_landed_state, void(Telemetry::LandedStateCallback)){};
     MOCK_CONST_METHOD1(
-        subscribe_attitude_quaternion, void(Telemetry::attitude_quaternion_callback_t)){};
+        subscribe_attitude_quaternion, void(Telemetry::AttitudeQuaternionCallback)){};
     MOCK_CONST_METHOD1(
         subscribe_attitude_angular_velocity_body,
-        void(Telemetry::attitude_angular_velocity_body_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_attitude_euler, void(Telemetry::attitude_euler_callback_t)){};
+        void(Telemetry::AttitudeAngularVelocityBodyCallback)){};
+    MOCK_CONST_METHOD1(subscribe_attitude_euler, void(Telemetry::AttitudeEulerCallback)){};
     MOCK_CONST_METHOD1(
-        subscribe_camera_attitude_quaternion, void(Telemetry::attitude_quaternion_callback_t)){};
+        subscribe_camera_attitude_quaternion, void(Telemetry::AttitudeQuaternionCallback)){};
+    MOCK_CONST_METHOD1(subscribe_camera_attitude_euler, void(Telemetry::AttitudeEulerCallback)){};
+    MOCK_CONST_METHOD1(subscribe_ground_speed_ned, void(Telemetry::GroundSpeedNedCallback)){};
+    MOCK_CONST_METHOD1(subscribe_rc_status, void(Telemetry::RcStatusCallback)){};
     MOCK_CONST_METHOD1(
-        subscribe_camera_attitude_euler, void(Telemetry::attitude_euler_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_ground_speed_ned, void(Telemetry::ground_speed_ned_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_rc_status, void(Telemetry::rc_status_callback_t)){};
+        subscribe_actuator_control_target, void(Telemetry::ActuatorControlTargetCallback)){};
     MOCK_CONST_METHOD1(
-        subscribe_actuator_control_target, void(Telemetry::actuator_control_target_callback_t)){};
+        subscribe_actuator_output_status, void(Telemetry::ActuatorOutputStatusCallback)){};
+    MOCK_CONST_METHOD1(subscribe_odometry, void(Telemetry::OdometryCallback)){};
     MOCK_CONST_METHOD1(
-        subscribe_actuator_output_status, void(Telemetry::actuator_output_status_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_odometry, void(Telemetry::odometry_callback_t)){};
-    MOCK_CONST_METHOD1(
-        subscribe_position_velocity_ned, void(Telemetry::position_velocity_ned_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_ground_truth, void(Telemetry::ground_truth_callback_t)){};
-    MOCK_CONST_METHOD1(
-        subscribe_fixedwing_metrics, void(Telemetry::fixedwing_metrics_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_imu, void(Telemetry::imu_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_health_all_ok, void(Telemetry::health_all_ok_callback_t)){};
-    MOCK_CONST_METHOD1(subscribe_unix_epoch_time, void(Telemetry::unix_epoch_time_callback_t)){};
+        subscribe_position_velocity_ned, void(Telemetry::PositionVelocityNedCallback)){};
+    MOCK_CONST_METHOD1(subscribe_ground_truth, void(Telemetry::GroundTruthCallback)){};
+    MOCK_CONST_METHOD1(subscribe_fixedwing_metrics, void(Telemetry::FixedwingMetricsCallback)){};
+    MOCK_CONST_METHOD1(subscribe_imu, void(Telemetry::ImuCallback)){};
+    MOCK_CONST_METHOD1(subscribe_health_all_ok, void(Telemetry::HealthAllOkCallback)){};
+    MOCK_CONST_METHOD1(subscribe_unix_epoch_time, void(Telemetry::UnixEpochTimeCallback)){};
 
     MOCK_METHOD1(set_rate_position, Telemetry::Result(double)){};
     MOCK_METHOD1(set_rate_home, Telemetry::Result(double)){};
@@ -62,31 +60,27 @@ public:
     MOCK_METHOD1(set_rate_imu, Telemetry::Result(double)){};
     MOCK_METHOD1(set_rate_unix_epoch_time, Telemetry::Result(double)){};
 
-    MOCK_CONST_METHOD2(set_rate_position_async, void(double, Telemetry::result_callback_t)){};
-    MOCK_CONST_METHOD2(set_rate_home_async, void(double, Telemetry::result_callback_t)){};
-    MOCK_CONST_METHOD2(set_rate_in_air_async, void(double, Telemetry::result_callback_t)){};
-    MOCK_CONST_METHOD2(set_rate_landed_state_async, void(double, Telemetry::result_callback_t)){};
-    MOCK_CONST_METHOD2(set_rate_attitude_async, void(double, Telemetry::result_callback_t)){};
+    MOCK_CONST_METHOD2(set_rate_position_async, void(double, Telemetry::ResultCallback)){};
+    MOCK_CONST_METHOD2(set_rate_home_async, void(double, Telemetry::ResultCallback)){};
+    MOCK_CONST_METHOD2(set_rate_in_air_async, void(double, Telemetry::ResultCallback)){};
+    MOCK_CONST_METHOD2(set_rate_landed_state_async, void(double, Telemetry::ResultCallback)){};
+    MOCK_CONST_METHOD2(set_rate_attitude_async, void(double, Telemetry::ResultCallback)){};
+    MOCK_CONST_METHOD2(set_rate_camera_attitude_async, void(double, Telemetry::ResultCallback)){};
+    MOCK_CONST_METHOD2(set_rate_ground_speed_ned_async, void(double, Telemetry::ResultCallback)){};
+    MOCK_CONST_METHOD2(set_rate_gps_info_async, void(double, Telemetry::ResultCallback)){};
+    MOCK_CONST_METHOD2(set_rate_battery_async, void(double, Telemetry::ResultCallback)){};
+    MOCK_CONST_METHOD2(set_rate_rc_status_async, void(double, Telemetry::ResultCallback)){};
     MOCK_CONST_METHOD2(
-        set_rate_camera_attitude_async, void(double, Telemetry::result_callback_t)){};
+        set_rate_actuator_control_target_async, void(double, Telemetry::ResultCallback)){};
     MOCK_CONST_METHOD2(
-        set_rate_ground_speed_ned_async, void(double, Telemetry::result_callback_t)){};
-    MOCK_CONST_METHOD2(set_rate_gps_info_async, void(double, Telemetry::result_callback_t)){};
-    MOCK_CONST_METHOD2(set_rate_battery_async, void(double, Telemetry::result_callback_t)){};
-    MOCK_CONST_METHOD2(set_rate_rc_status_async, void(double, Telemetry::result_callback_t)){};
+        set_rate_actuator_output_status_async, void(double, Telemetry::ResultCallback)){};
+    MOCK_CONST_METHOD2(set_rate_odometry_async, void(double, Telemetry::ResultCallback)){};
     MOCK_CONST_METHOD2(
-        set_rate_actuator_control_target_async, void(double, Telemetry::result_callback_t)){};
-    MOCK_CONST_METHOD2(
-        set_rate_actuator_output_status_async, void(double, Telemetry::result_callback_t)){};
-    MOCK_CONST_METHOD2(set_rate_odometry_async, void(double, Telemetry::result_callback_t)){};
-    MOCK_CONST_METHOD2(
-        set_rate_position_velocity_ned_async, void(double, Telemetry::result_callback_t)){};
-    MOCK_CONST_METHOD2(set_rate_ground_truth_async, void(double, Telemetry::result_callback_t)){};
-    MOCK_CONST_METHOD2(
-        set_rate_fixedwing_metrics_async, void(double, Telemetry::result_callback_t)){};
-    MOCK_CONST_METHOD2(set_rate_imu_async, void(double, Telemetry::result_callback_t)){};
-    MOCK_CONST_METHOD2(
-        set_rate_unix_epoch_time_async, void(double, Telemetry::result_callback_t)){};
+        set_rate_position_velocity_ned_async, void(double, Telemetry::ResultCallback)){};
+    MOCK_CONST_METHOD2(set_rate_ground_truth_async, void(double, Telemetry::ResultCallback)){};
+    MOCK_CONST_METHOD2(set_rate_fixedwing_metrics_async, void(double, Telemetry::ResultCallback)){};
+    MOCK_CONST_METHOD2(set_rate_imu_async, void(double, Telemetry::ResultCallback)){};
+    MOCK_CONST_METHOD2(set_rate_unix_epoch_time_async, void(double, Telemetry::ResultCallback)){};
 };
 
 } // namespace testing

--- a/src/plugins/telemetry/telemetry.cpp
+++ b/src/plugins/telemetry/telemetry.cpp
@@ -39,7 +39,7 @@ Telemetry::Telemetry(System& system) : PluginBase(), _impl{new TelemetryImpl(sys
 
 Telemetry::~Telemetry() {}
 
-void Telemetry::subscribe_position(position_callback_t callback)
+void Telemetry::subscribe_position(PositionCallback callback)
 {
     _impl->position_async(callback);
 }
@@ -49,7 +49,7 @@ Telemetry::Position Telemetry::position() const
     return _impl->position();
 }
 
-void Telemetry::subscribe_home(home_callback_t callback)
+void Telemetry::subscribe_home(HomeCallback callback)
 {
     _impl->home_async(callback);
 }
@@ -59,7 +59,7 @@ Telemetry::Position Telemetry::home() const
     return _impl->home();
 }
 
-void Telemetry::subscribe_in_air(in_air_callback_t callback)
+void Telemetry::subscribe_in_air(InAirCallback callback)
 {
     _impl->in_air_async(callback);
 }
@@ -69,7 +69,7 @@ bool Telemetry::in_air() const
     return _impl->in_air();
 }
 
-void Telemetry::subscribe_landed_state(landed_state_callback_t callback)
+void Telemetry::subscribe_landed_state(LandedStateCallback callback)
 {
     _impl->landed_state_async(callback);
 }
@@ -79,7 +79,7 @@ Telemetry::LandedState Telemetry::landed_state() const
     return _impl->landed_state();
 }
 
-void Telemetry::subscribe_armed(armed_callback_t callback)
+void Telemetry::subscribe_armed(ArmedCallback callback)
 {
     _impl->armed_async(callback);
 }
@@ -89,7 +89,7 @@ bool Telemetry::armed() const
     return _impl->armed();
 }
 
-void Telemetry::subscribe_attitude_quaternion(attitude_quaternion_callback_t callback)
+void Telemetry::subscribe_attitude_quaternion(AttitudeQuaternionCallback callback)
 {
     _impl->attitude_quaternion_async(callback);
 }
@@ -99,7 +99,7 @@ Telemetry::Quaternion Telemetry::attitude_quaternion() const
     return _impl->attitude_quaternion();
 }
 
-void Telemetry::subscribe_attitude_euler(attitude_euler_callback_t callback)
+void Telemetry::subscribe_attitude_euler(AttitudeEulerCallback callback)
 {
     _impl->attitude_euler_async(callback);
 }
@@ -110,7 +110,7 @@ Telemetry::EulerAngle Telemetry::attitude_euler() const
 }
 
 void Telemetry::subscribe_attitude_angular_velocity_body(
-    attitude_angular_velocity_body_callback_t callback)
+    AttitudeAngularVelocityBodyCallback callback)
 {
     _impl->attitude_angular_velocity_body_async(callback);
 }
@@ -120,7 +120,7 @@ Telemetry::AngularVelocityBody Telemetry::attitude_angular_velocity_body() const
     return _impl->attitude_angular_velocity_body();
 }
 
-void Telemetry::subscribe_camera_attitude_quaternion(camera_attitude_quaternion_callback_t callback)
+void Telemetry::subscribe_camera_attitude_quaternion(CameraAttitudeQuaternionCallback callback)
 {
     _impl->camera_attitude_quaternion_async(callback);
 }
@@ -130,7 +130,7 @@ Telemetry::Quaternion Telemetry::camera_attitude_quaternion() const
     return _impl->camera_attitude_quaternion();
 }
 
-void Telemetry::subscribe_camera_attitude_euler(camera_attitude_euler_callback_t callback)
+void Telemetry::subscribe_camera_attitude_euler(CameraAttitudeEulerCallback callback)
 {
     _impl->camera_attitude_euler_async(callback);
 }
@@ -140,7 +140,7 @@ Telemetry::EulerAngle Telemetry::camera_attitude_euler() const
     return _impl->camera_attitude_euler();
 }
 
-void Telemetry::subscribe_ground_speed_ned(ground_speed_ned_callback_t callback)
+void Telemetry::subscribe_ground_speed_ned(GroundSpeedNedCallback callback)
 {
     _impl->ground_speed_ned_async(callback);
 }
@@ -150,7 +150,7 @@ Telemetry::SpeedNed Telemetry::ground_speed_ned() const
     return _impl->ground_speed_ned();
 }
 
-void Telemetry::subscribe_gps_info(gps_info_callback_t callback)
+void Telemetry::subscribe_gps_info(GpsInfoCallback callback)
 {
     _impl->gps_info_async(callback);
 }
@@ -160,7 +160,7 @@ Telemetry::GpsInfo Telemetry::gps_info() const
     return _impl->gps_info();
 }
 
-void Telemetry::subscribe_battery(battery_callback_t callback)
+void Telemetry::subscribe_battery(BatteryCallback callback)
 {
     _impl->battery_async(callback);
 }
@@ -170,7 +170,7 @@ Telemetry::Battery Telemetry::battery() const
     return _impl->battery();
 }
 
-void Telemetry::subscribe_flight_mode(flight_mode_callback_t callback)
+void Telemetry::subscribe_flight_mode(FlightModeCallback callback)
 {
     _impl->flight_mode_async(callback);
 }
@@ -180,7 +180,7 @@ Telemetry::FlightMode Telemetry::flight_mode() const
     return _impl->flight_mode();
 }
 
-void Telemetry::subscribe_health(health_callback_t callback)
+void Telemetry::subscribe_health(HealthCallback callback)
 {
     _impl->health_async(callback);
 }
@@ -190,7 +190,7 @@ Telemetry::Health Telemetry::health() const
     return _impl->health();
 }
 
-void Telemetry::subscribe_rc_status(rc_status_callback_t callback)
+void Telemetry::subscribe_rc_status(RcStatusCallback callback)
 {
     _impl->rc_status_async(callback);
 }
@@ -200,7 +200,7 @@ Telemetry::RcStatus Telemetry::rc_status() const
     return _impl->rc_status();
 }
 
-void Telemetry::subscribe_status_text(status_text_callback_t callback)
+void Telemetry::subscribe_status_text(StatusTextCallback callback)
 {
     _impl->status_text_async(callback);
 }
@@ -210,7 +210,7 @@ Telemetry::StatusText Telemetry::status_text() const
     return _impl->status_text();
 }
 
-void Telemetry::subscribe_actuator_control_target(actuator_control_target_callback_t callback)
+void Telemetry::subscribe_actuator_control_target(ActuatorControlTargetCallback callback)
 {
     _impl->actuator_control_target_async(callback);
 }
@@ -220,7 +220,7 @@ Telemetry::ActuatorControlTarget Telemetry::actuator_control_target() const
     return _impl->actuator_control_target();
 }
 
-void Telemetry::subscribe_actuator_output_status(actuator_output_status_callback_t callback)
+void Telemetry::subscribe_actuator_output_status(ActuatorOutputStatusCallback callback)
 {
     _impl->actuator_output_status_async(callback);
 }
@@ -230,7 +230,7 @@ Telemetry::ActuatorOutputStatus Telemetry::actuator_output_status() const
     return _impl->actuator_output_status();
 }
 
-void Telemetry::subscribe_odometry(odometry_callback_t callback)
+void Telemetry::subscribe_odometry(OdometryCallback callback)
 {
     _impl->odometry_async(callback);
 }
@@ -240,7 +240,7 @@ Telemetry::Odometry Telemetry::odometry() const
     return _impl->odometry();
 }
 
-void Telemetry::subscribe_position_velocity_ned(position_velocity_ned_callback_t callback)
+void Telemetry::subscribe_position_velocity_ned(PositionVelocityNedCallback callback)
 {
     _impl->position_velocity_ned_async(callback);
 }
@@ -250,7 +250,7 @@ Telemetry::PositionVelocityNed Telemetry::position_velocity_ned() const
     return _impl->position_velocity_ned();
 }
 
-void Telemetry::subscribe_ground_truth(ground_truth_callback_t callback)
+void Telemetry::subscribe_ground_truth(GroundTruthCallback callback)
 {
     _impl->ground_truth_async(callback);
 }
@@ -260,7 +260,7 @@ Telemetry::GroundTruth Telemetry::ground_truth() const
     return _impl->ground_truth();
 }
 
-void Telemetry::subscribe_fixedwing_metrics(fixedwing_metrics_callback_t callback)
+void Telemetry::subscribe_fixedwing_metrics(FixedwingMetricsCallback callback)
 {
     _impl->fixedwing_metrics_async(callback);
 }
@@ -270,7 +270,7 @@ Telemetry::FixedwingMetrics Telemetry::fixedwing_metrics() const
     return _impl->fixedwing_metrics();
 }
 
-void Telemetry::subscribe_imu(imu_callback_t callback)
+void Telemetry::subscribe_imu(ImuCallback callback)
 {
     _impl->imu_async(callback);
 }
@@ -280,7 +280,7 @@ Telemetry::Imu Telemetry::imu() const
     return _impl->imu();
 }
 
-void Telemetry::subscribe_health_all_ok(health_all_ok_callback_t callback)
+void Telemetry::subscribe_health_all_ok(HealthAllOkCallback callback)
 {
     _impl->health_all_ok_async(callback);
 }
@@ -290,7 +290,7 @@ bool Telemetry::health_all_ok() const
     return _impl->health_all_ok();
 }
 
-void Telemetry::subscribe_unix_epoch_time(unix_epoch_time_callback_t callback)
+void Telemetry::subscribe_unix_epoch_time(UnixEpochTimeCallback callback)
 {
     _impl->unix_epoch_time_async(callback);
 }
@@ -300,7 +300,7 @@ uint64_t Telemetry::unix_epoch_time() const
     return _impl->unix_epoch_time();
 }
 
-void Telemetry::set_rate_position_async(double rate_hz, const result_callback_t callback)
+void Telemetry::set_rate_position_async(double rate_hz, const ResultCallback callback)
 {
     _impl->set_rate_position_async(rate_hz, callback);
 }
@@ -310,7 +310,7 @@ Telemetry::Result Telemetry::set_rate_position(double rate_hz) const
     return _impl->set_rate_position(rate_hz);
 }
 
-void Telemetry::set_rate_home_async(double rate_hz, const result_callback_t callback)
+void Telemetry::set_rate_home_async(double rate_hz, const ResultCallback callback)
 {
     _impl->set_rate_home_async(rate_hz, callback);
 }
@@ -320,7 +320,7 @@ Telemetry::Result Telemetry::set_rate_home(double rate_hz) const
     return _impl->set_rate_home(rate_hz);
 }
 
-void Telemetry::set_rate_in_air_async(double rate_hz, const result_callback_t callback)
+void Telemetry::set_rate_in_air_async(double rate_hz, const ResultCallback callback)
 {
     _impl->set_rate_in_air_async(rate_hz, callback);
 }
@@ -330,7 +330,7 @@ Telemetry::Result Telemetry::set_rate_in_air(double rate_hz) const
     return _impl->set_rate_in_air(rate_hz);
 }
 
-void Telemetry::set_rate_landed_state_async(double rate_hz, const result_callback_t callback)
+void Telemetry::set_rate_landed_state_async(double rate_hz, const ResultCallback callback)
 {
     _impl->set_rate_landed_state_async(rate_hz, callback);
 }
@@ -340,7 +340,7 @@ Telemetry::Result Telemetry::set_rate_landed_state(double rate_hz) const
     return _impl->set_rate_landed_state(rate_hz);
 }
 
-void Telemetry::set_rate_attitude_async(double rate_hz, const result_callback_t callback)
+void Telemetry::set_rate_attitude_async(double rate_hz, const ResultCallback callback)
 {
     _impl->set_rate_attitude_async(rate_hz, callback);
 }
@@ -350,7 +350,7 @@ Telemetry::Result Telemetry::set_rate_attitude(double rate_hz) const
     return _impl->set_rate_attitude(rate_hz);
 }
 
-void Telemetry::set_rate_camera_attitude_async(double rate_hz, const result_callback_t callback)
+void Telemetry::set_rate_camera_attitude_async(double rate_hz, const ResultCallback callback)
 {
     _impl->set_rate_camera_attitude_async(rate_hz, callback);
 }
@@ -360,7 +360,7 @@ Telemetry::Result Telemetry::set_rate_camera_attitude(double rate_hz) const
     return _impl->set_rate_camera_attitude(rate_hz);
 }
 
-void Telemetry::set_rate_ground_speed_ned_async(double rate_hz, const result_callback_t callback)
+void Telemetry::set_rate_ground_speed_ned_async(double rate_hz, const ResultCallback callback)
 {
     _impl->set_rate_ground_speed_ned_async(rate_hz, callback);
 }
@@ -370,7 +370,7 @@ Telemetry::Result Telemetry::set_rate_ground_speed_ned(double rate_hz) const
     return _impl->set_rate_ground_speed_ned(rate_hz);
 }
 
-void Telemetry::set_rate_gps_info_async(double rate_hz, const result_callback_t callback)
+void Telemetry::set_rate_gps_info_async(double rate_hz, const ResultCallback callback)
 {
     _impl->set_rate_gps_info_async(rate_hz, callback);
 }
@@ -380,7 +380,7 @@ Telemetry::Result Telemetry::set_rate_gps_info(double rate_hz) const
     return _impl->set_rate_gps_info(rate_hz);
 }
 
-void Telemetry::set_rate_battery_async(double rate_hz, const result_callback_t callback)
+void Telemetry::set_rate_battery_async(double rate_hz, const ResultCallback callback)
 {
     _impl->set_rate_battery_async(rate_hz, callback);
 }
@@ -390,7 +390,7 @@ Telemetry::Result Telemetry::set_rate_battery(double rate_hz) const
     return _impl->set_rate_battery(rate_hz);
 }
 
-void Telemetry::set_rate_rc_status_async(double rate_hz, const result_callback_t callback)
+void Telemetry::set_rate_rc_status_async(double rate_hz, const ResultCallback callback)
 {
     _impl->set_rate_rc_status_async(rate_hz, callback);
 }
@@ -401,7 +401,7 @@ Telemetry::Result Telemetry::set_rate_rc_status(double rate_hz) const
 }
 
 void Telemetry::set_rate_actuator_control_target_async(
-    double rate_hz, const result_callback_t callback)
+    double rate_hz, const ResultCallback callback)
 {
     _impl->set_rate_actuator_control_target_async(rate_hz, callback);
 }
@@ -411,8 +411,7 @@ Telemetry::Result Telemetry::set_rate_actuator_control_target(double rate_hz) co
     return _impl->set_rate_actuator_control_target(rate_hz);
 }
 
-void Telemetry::set_rate_actuator_output_status_async(
-    double rate_hz, const result_callback_t callback)
+void Telemetry::set_rate_actuator_output_status_async(double rate_hz, const ResultCallback callback)
 {
     _impl->set_rate_actuator_output_status_async(rate_hz, callback);
 }
@@ -422,7 +421,7 @@ Telemetry::Result Telemetry::set_rate_actuator_output_status(double rate_hz) con
     return _impl->set_rate_actuator_output_status(rate_hz);
 }
 
-void Telemetry::set_rate_odometry_async(double rate_hz, const result_callback_t callback)
+void Telemetry::set_rate_odometry_async(double rate_hz, const ResultCallback callback)
 {
     _impl->set_rate_odometry_async(rate_hz, callback);
 }
@@ -432,8 +431,7 @@ Telemetry::Result Telemetry::set_rate_odometry(double rate_hz) const
     return _impl->set_rate_odometry(rate_hz);
 }
 
-void Telemetry::set_rate_position_velocity_ned_async(
-    double rate_hz, const result_callback_t callback)
+void Telemetry::set_rate_position_velocity_ned_async(double rate_hz, const ResultCallback callback)
 {
     _impl->set_rate_position_velocity_ned_async(rate_hz, callback);
 }
@@ -443,7 +441,7 @@ Telemetry::Result Telemetry::set_rate_position_velocity_ned(double rate_hz) cons
     return _impl->set_rate_position_velocity_ned(rate_hz);
 }
 
-void Telemetry::set_rate_ground_truth_async(double rate_hz, const result_callback_t callback)
+void Telemetry::set_rate_ground_truth_async(double rate_hz, const ResultCallback callback)
 {
     _impl->set_rate_ground_truth_async(rate_hz, callback);
 }
@@ -453,7 +451,7 @@ Telemetry::Result Telemetry::set_rate_ground_truth(double rate_hz) const
     return _impl->set_rate_ground_truth(rate_hz);
 }
 
-void Telemetry::set_rate_fixedwing_metrics_async(double rate_hz, const result_callback_t callback)
+void Telemetry::set_rate_fixedwing_metrics_async(double rate_hz, const ResultCallback callback)
 {
     _impl->set_rate_fixedwing_metrics_async(rate_hz, callback);
 }
@@ -463,7 +461,7 @@ Telemetry::Result Telemetry::set_rate_fixedwing_metrics(double rate_hz) const
     return _impl->set_rate_fixedwing_metrics(rate_hz);
 }
 
-void Telemetry::set_rate_imu_async(double rate_hz, const result_callback_t callback)
+void Telemetry::set_rate_imu_async(double rate_hz, const ResultCallback callback)
 {
     _impl->set_rate_imu_async(rate_hz, callback);
 }
@@ -473,7 +471,7 @@ Telemetry::Result Telemetry::set_rate_imu(double rate_hz) const
     return _impl->set_rate_imu(rate_hz);
 }
 
-void Telemetry::set_rate_unix_epoch_time_async(double rate_hz, const result_callback_t callback)
+void Telemetry::set_rate_unix_epoch_time_async(double rate_hz, const ResultCallback callback)
 {
     _impl->set_rate_unix_epoch_time_async(rate_hz, callback);
 }

--- a/src/plugins/telemetry/telemetry_impl.cpp
+++ b/src/plugins/telemetry/telemetry_impl.cpp
@@ -300,7 +300,7 @@ Telemetry::Result TelemetryImpl::set_rate_unix_epoch_time(double rate_hz)
 }
 
 void TelemetryImpl::set_rate_position_velocity_ned_async(
-    double rate_hz, Telemetry::result_callback_t callback)
+    double rate_hz, Telemetry::ResultCallback callback)
 {
     _parent->set_msg_rate_async(
         MAVLINK_MSG_ID_LOCAL_POSITION_NED,
@@ -308,7 +308,7 @@ void TelemetryImpl::set_rate_position_velocity_ned_async(
         std::bind(&TelemetryImpl::command_result_callback, std::placeholders::_1, callback));
 }
 
-void TelemetryImpl::set_rate_position_async(double rate_hz, Telemetry::result_callback_t callback)
+void TelemetryImpl::set_rate_position_async(double rate_hz, Telemetry::ResultCallback callback)
 {
     _position_rate_hz = rate_hz;
     double max_rate_hz = std::max(_position_rate_hz, _ground_speed_ned_rate_hz);
@@ -319,7 +319,7 @@ void TelemetryImpl::set_rate_position_async(double rate_hz, Telemetry::result_ca
         std::bind(&TelemetryImpl::command_result_callback, std::placeholders::_1, callback));
 }
 
-void TelemetryImpl::set_rate_home_async(double rate_hz, Telemetry::result_callback_t callback)
+void TelemetryImpl::set_rate_home_async(double rate_hz, Telemetry::ResultCallback callback)
 {
     _parent->set_msg_rate_async(
         MAVLINK_MSG_ID_HOME_POSITION,
@@ -327,13 +327,12 @@ void TelemetryImpl::set_rate_home_async(double rate_hz, Telemetry::result_callba
         std::bind(&TelemetryImpl::command_result_callback, std::placeholders::_1, callback));
 }
 
-void TelemetryImpl::set_rate_in_air_async(double rate_hz, Telemetry::result_callback_t callback)
+void TelemetryImpl::set_rate_in_air_async(double rate_hz, Telemetry::ResultCallback callback)
 {
     set_rate_landed_state_async(rate_hz, callback);
 }
 
-void TelemetryImpl::set_rate_landed_state_async(
-    double rate_hz, Telemetry::result_callback_t callback)
+void TelemetryImpl::set_rate_landed_state_async(double rate_hz, Telemetry::ResultCallback callback)
 {
     _parent->set_msg_rate_async(
         MAVLINK_MSG_ID_EXTENDED_SYS_STATE,
@@ -341,7 +340,7 @@ void TelemetryImpl::set_rate_landed_state_async(
         std::bind(&TelemetryImpl::command_result_callback, std::placeholders::_1, callback));
 }
 
-void TelemetryImpl::set_rate_attitude_async(double rate_hz, Telemetry::result_callback_t callback)
+void TelemetryImpl::set_rate_attitude_async(double rate_hz, Telemetry::ResultCallback callback)
 {
     _parent->set_msg_rate_async(
         MAVLINK_MSG_ID_ATTITUDE_QUATERNION,
@@ -350,7 +349,7 @@ void TelemetryImpl::set_rate_attitude_async(double rate_hz, Telemetry::result_ca
 }
 
 void TelemetryImpl::set_rate_camera_attitude_async(
-    double rate_hz, Telemetry::result_callback_t callback)
+    double rate_hz, Telemetry::ResultCallback callback)
 {
     _parent->set_msg_rate_async(
         MAVLINK_MSG_ID_MOUNT_ORIENTATION,
@@ -359,7 +358,7 @@ void TelemetryImpl::set_rate_camera_attitude_async(
 }
 
 void TelemetryImpl::set_rate_ground_speed_ned_async(
-    double rate_hz, Telemetry::result_callback_t callback)
+    double rate_hz, Telemetry::ResultCallback callback)
 {
     _ground_speed_ned_rate_hz = rate_hz;
     double max_rate_hz = std::max(_position_rate_hz, _ground_speed_ned_rate_hz);
@@ -370,7 +369,7 @@ void TelemetryImpl::set_rate_ground_speed_ned_async(
         std::bind(&TelemetryImpl::command_result_callback, std::placeholders::_1, callback));
 }
 
-void TelemetryImpl::set_rate_imu_async(double rate_hz, Telemetry::result_callback_t callback)
+void TelemetryImpl::set_rate_imu_async(double rate_hz, Telemetry::ResultCallback callback)
 {
     _parent->set_msg_rate_async(
         MAVLINK_MSG_ID_HIGHRES_IMU,
@@ -379,7 +378,7 @@ void TelemetryImpl::set_rate_imu_async(double rate_hz, Telemetry::result_callbac
 }
 
 void TelemetryImpl::set_rate_fixedwing_metrics_async(
-    double rate_hz, Telemetry::result_callback_t callback)
+    double rate_hz, Telemetry::ResultCallback callback)
 {
     _parent->set_msg_rate_async(
         MAVLINK_MSG_ID_VFR_HUD,
@@ -387,8 +386,7 @@ void TelemetryImpl::set_rate_fixedwing_metrics_async(
         std::bind(&TelemetryImpl::command_result_callback, std::placeholders::_1, callback));
 }
 
-void TelemetryImpl::set_rate_ground_truth_async(
-    double rate_hz, Telemetry::result_callback_t callback)
+void TelemetryImpl::set_rate_ground_truth_async(double rate_hz, Telemetry::ResultCallback callback)
 {
     _parent->set_msg_rate_async(
         MAVLINK_MSG_ID_HIL_STATE_QUATERNION,
@@ -396,7 +394,7 @@ void TelemetryImpl::set_rate_ground_truth_async(
         std::bind(&TelemetryImpl::command_result_callback, std::placeholders::_1, callback));
 }
 
-void TelemetryImpl::set_rate_gps_info_async(double rate_hz, Telemetry::result_callback_t callback)
+void TelemetryImpl::set_rate_gps_info_async(double rate_hz, Telemetry::ResultCallback callback)
 {
     _parent->set_msg_rate_async(
         MAVLINK_MSG_ID_GPS_RAW_INT,
@@ -404,7 +402,7 @@ void TelemetryImpl::set_rate_gps_info_async(double rate_hz, Telemetry::result_ca
         std::bind(&TelemetryImpl::command_result_callback, std::placeholders::_1, callback));
 }
 
-void TelemetryImpl::set_rate_battery_async(double rate_hz, Telemetry::result_callback_t callback)
+void TelemetryImpl::set_rate_battery_async(double rate_hz, Telemetry::ResultCallback callback)
 {
     _parent->set_msg_rate_async(
         MAVLINK_MSG_ID_SYS_STATUS,
@@ -412,7 +410,7 @@ void TelemetryImpl::set_rate_battery_async(double rate_hz, Telemetry::result_cal
         std::bind(&TelemetryImpl::command_result_callback, std::placeholders::_1, callback));
 }
 
-void TelemetryImpl::set_rate_rc_status_async(double rate_hz, Telemetry::result_callback_t callback)
+void TelemetryImpl::set_rate_rc_status_async(double rate_hz, Telemetry::ResultCallback callback)
 {
     _parent->set_msg_rate_async(
         MAVLINK_MSG_ID_RC_CHANNELS,
@@ -421,7 +419,7 @@ void TelemetryImpl::set_rate_rc_status_async(double rate_hz, Telemetry::result_c
 }
 
 void TelemetryImpl::set_rate_unix_epoch_time_async(
-    double rate_hz, Telemetry::result_callback_t callback)
+    double rate_hz, Telemetry::ResultCallback callback)
 {
     _parent->set_msg_rate_async(
         MAVLINK_MSG_ID_UTM_GLOBAL_POSITION,
@@ -430,7 +428,7 @@ void TelemetryImpl::set_rate_unix_epoch_time_async(
 }
 
 void TelemetryImpl::set_rate_actuator_control_target_async(
-    double rate_hz, Telemetry::result_callback_t callback)
+    double rate_hz, Telemetry::ResultCallback callback)
 {
     _parent->set_msg_rate_async(
         MAVLINK_MSG_ID_ACTUATOR_CONTROL_TARGET,
@@ -439,7 +437,7 @@ void TelemetryImpl::set_rate_actuator_control_target_async(
 }
 
 void TelemetryImpl::set_rate_actuator_output_status_async(
-    double rate_hz, Telemetry::result_callback_t callback)
+    double rate_hz, Telemetry::ResultCallback callback)
 {
     _parent->set_msg_rate_async(
         MAVLINK_MSG_ID_ACTUATOR_OUTPUT_STATUS,
@@ -447,7 +445,7 @@ void TelemetryImpl::set_rate_actuator_output_status_async(
         std::bind(&TelemetryImpl::command_result_callback, std::placeholders::_1, callback));
 }
 
-void TelemetryImpl::set_rate_odometry_async(double rate_hz, Telemetry::result_callback_t callback)
+void TelemetryImpl::set_rate_odometry_async(double rate_hz, Telemetry::ResultCallback callback)
 {
     _parent->set_msg_rate_async(
         MAVLINK_MSG_ID_ODOMETRY,
@@ -477,7 +475,7 @@ TelemetryImpl::telemetry_result_from_command_result(MAVLinkCommands::Result comm
 }
 
 void TelemetryImpl::command_result_callback(
-    MAVLinkCommands::Result command_result, const Telemetry::result_callback_t& callback)
+    MAVLinkCommands::Result command_result, const Telemetry::ResultCallback& callback)
 {
     Telemetry::Result action_result = telemetry_result_from_command_result(command_result);
 
@@ -1524,137 +1522,135 @@ void TelemetryImpl::set_odometry(Telemetry::Odometry& odometry)
     _odometry = odometry;
 }
 
-void TelemetryImpl::position_velocity_ned_async(
-    Telemetry::position_velocity_ned_callback_t& callback)
+void TelemetryImpl::position_velocity_ned_async(Telemetry::PositionVelocityNedCallback& callback)
 {
     _position_velocity_ned_subscription = callback;
 }
 
-void TelemetryImpl::position_async(Telemetry::position_callback_t& callback)
+void TelemetryImpl::position_async(Telemetry::PositionCallback& callback)
 {
     _position_subscription = callback;
 }
 
-void TelemetryImpl::home_async(Telemetry::position_callback_t& callback)
+void TelemetryImpl::home_async(Telemetry::PositionCallback& callback)
 {
     _home_position_subscription = callback;
 }
 
-void TelemetryImpl::in_air_async(Telemetry::in_air_callback_t& callback)
+void TelemetryImpl::in_air_async(Telemetry::InAirCallback& callback)
 {
     _in_air_subscription = callback;
 }
 
-void TelemetryImpl::status_text_async(Telemetry::status_text_callback_t& callback)
+void TelemetryImpl::status_text_async(Telemetry::StatusTextCallback& callback)
 {
     _status_text_subscription = callback;
 }
 
-void TelemetryImpl::armed_async(Telemetry::armed_callback_t& callback)
+void TelemetryImpl::armed_async(Telemetry::ArmedCallback& callback)
 {
     _armed_subscription = callback;
 }
 
-void TelemetryImpl::attitude_quaternion_async(Telemetry::attitude_quaternion_callback_t& callback)
+void TelemetryImpl::attitude_quaternion_async(Telemetry::AttitudeQuaternionCallback& callback)
 {
     _attitude_quaternion_angle_subscription = callback;
 }
 
-void TelemetryImpl::attitude_euler_async(Telemetry::attitude_euler_callback_t& callback)
+void TelemetryImpl::attitude_euler_async(Telemetry::AttitudeEulerCallback& callback)
 {
     _attitude_euler_angle_subscription = callback;
 }
 
 void TelemetryImpl::attitude_angular_velocity_body_async(
-    Telemetry::attitude_angular_velocity_body_callback_t& callback)
+    Telemetry::AttitudeAngularVelocityBodyCallback& callback)
 {
     _attitude_angular_velocity_body_subscription = callback;
 }
 
-void TelemetryImpl::fixedwing_metrics_async(Telemetry::fixedwing_metrics_callback_t& callback)
+void TelemetryImpl::fixedwing_metrics_async(Telemetry::FixedwingMetricsCallback& callback)
 {
     _fixedwing_metrics_subscription = callback;
 }
 
-void TelemetryImpl::ground_truth_async(Telemetry::ground_truth_callback_t& callback)
+void TelemetryImpl::ground_truth_async(Telemetry::GroundTruthCallback& callback)
 {
     _ground_truth_subscription = callback;
 }
 
 void TelemetryImpl::camera_attitude_quaternion_async(
-    Telemetry::attitude_quaternion_callback_t& callback)
+    Telemetry::AttitudeQuaternionCallback& callback)
 {
     _camera_attitude_quaternion_subscription = callback;
 }
 
-void TelemetryImpl::camera_attitude_euler_async(Telemetry::attitude_euler_callback_t& callback)
+void TelemetryImpl::camera_attitude_euler_async(Telemetry::AttitudeEulerCallback& callback)
 {
     _camera_attitude_euler_angle_subscription = callback;
 }
 
-void TelemetryImpl::ground_speed_ned_async(Telemetry::ground_speed_ned_callback_t& callback)
+void TelemetryImpl::ground_speed_ned_async(Telemetry::GroundSpeedNedCallback& callback)
 {
     _ground_speed_ned_subscription = callback;
 }
 
-void TelemetryImpl::imu_async(Telemetry::imu_callback_t& callback)
+void TelemetryImpl::imu_async(Telemetry::ImuCallback& callback)
 {
     _imu_reading_ned_subscription = callback;
 }
 
-void TelemetryImpl::gps_info_async(Telemetry::gps_info_callback_t& callback)
+void TelemetryImpl::gps_info_async(Telemetry::GpsInfoCallback& callback)
 {
     _gps_info_subscription = callback;
 }
 
-void TelemetryImpl::battery_async(Telemetry::battery_callback_t& callback)
+void TelemetryImpl::battery_async(Telemetry::BatteryCallback& callback)
 {
     _battery_subscription = callback;
 }
 
-void TelemetryImpl::flight_mode_async(Telemetry::flight_mode_callback_t& callback)
+void TelemetryImpl::flight_mode_async(Telemetry::FlightModeCallback& callback)
 {
     _flight_mode_subscription = callback;
 }
 
-void TelemetryImpl::health_async(Telemetry::health_callback_t& callback)
+void TelemetryImpl::health_async(Telemetry::HealthCallback& callback)
 {
     _health_subscription = callback;
 }
 
-void TelemetryImpl::health_all_ok_async(Telemetry::health_all_ok_callback_t& callback)
+void TelemetryImpl::health_all_ok_async(Telemetry::HealthAllOkCallback& callback)
 {
     _health_all_ok_subscription = callback;
 }
 
-void TelemetryImpl::landed_state_async(Telemetry::landed_state_callback_t& callback)
+void TelemetryImpl::landed_state_async(Telemetry::LandedStateCallback& callback)
 {
     _landed_state_subscription = callback;
 }
 
-void TelemetryImpl::rc_status_async(Telemetry::rc_status_callback_t& callback)
+void TelemetryImpl::rc_status_async(Telemetry::RcStatusCallback& callback)
 {
     _rc_status_subscription = callback;
 }
 
-void TelemetryImpl::unix_epoch_time_async(Telemetry::unix_epoch_time_callback_t& callback)
+void TelemetryImpl::unix_epoch_time_async(Telemetry::UnixEpochTimeCallback& callback)
 {
     _unix_epoch_time_subscription = callback;
 }
 
 void TelemetryImpl::actuator_control_target_async(
-    Telemetry::actuator_control_target_callback_t& callback)
+    Telemetry::ActuatorControlTargetCallback& callback)
 {
     _actuator_control_target_subscription = callback;
 }
 
-void TelemetryImpl::actuator_output_status_async(
-    Telemetry::actuator_output_status_callback_t& callback)
+void TelemetryImpl::actuator_output_status_async(Telemetry::ActuatorOutputStatusCallback& callback)
 {
     _actuator_output_status_subscription = callback;
 }
 
-void TelemetryImpl::odometry_async(Telemetry::odometry_callback_t& callback)
+void TelemetryImpl::odometry_async(Telemetry::OdometryCallback& callback)
 {
     _odometry_subscription = callback;
 }

--- a/src/plugins/telemetry/telemetry_impl.h
+++ b/src/plugins/telemetry/telemetry_impl.h
@@ -46,27 +46,24 @@ public:
     Telemetry::Result set_rate_odometry(double rate_hz);
     Telemetry::Result set_rate_unix_epoch_time(double rate_hz);
 
-    void
-    set_rate_position_velocity_ned_async(double rate_hz, Telemetry::result_callback_t callback);
-    void set_rate_position_async(double rate_hz, Telemetry::result_callback_t callback);
-    void set_rate_home_async(double rate_hz, Telemetry::result_callback_t callback);
-    void set_rate_in_air_async(double rate_hz, Telemetry::result_callback_t callback);
-    void set_rate_landed_state_async(double rate_hz, Telemetry::result_callback_t callback);
-    void set_rate_attitude_async(double rate_hz, Telemetry::result_callback_t callback);
-    void set_rate_camera_attitude_async(double rate_hz, Telemetry::result_callback_t callback);
-    void set_rate_ground_speed_ned_async(double rate_hz, Telemetry::result_callback_t callback);
-    void set_rate_imu_async(double rate_hz, Telemetry::result_callback_t callback);
-    void set_rate_fixedwing_metrics_async(double rate_hz, Telemetry::result_callback_t callback);
-    void set_rate_ground_truth_async(double rate_hz, Telemetry::result_callback_t callback);
-    void set_rate_gps_info_async(double rate_hz, Telemetry::result_callback_t callback);
-    void set_rate_battery_async(double rate_hz, Telemetry::result_callback_t callback);
-    void set_rate_rc_status_async(double rate_hz, Telemetry::result_callback_t callback);
-    void
-    set_rate_actuator_control_target_async(double rate_hz, Telemetry::result_callback_t callback);
-    void
-    set_rate_actuator_output_status_async(double rate_hz, Telemetry::result_callback_t callback);
-    void set_rate_odometry_async(double rate_hz, Telemetry::result_callback_t callback);
-    void set_rate_unix_epoch_time_async(double rate_hz, Telemetry::result_callback_t callback);
+    void set_rate_position_velocity_ned_async(double rate_hz, Telemetry::ResultCallback callback);
+    void set_rate_position_async(double rate_hz, Telemetry::ResultCallback callback);
+    void set_rate_home_async(double rate_hz, Telemetry::ResultCallback callback);
+    void set_rate_in_air_async(double rate_hz, Telemetry::ResultCallback callback);
+    void set_rate_landed_state_async(double rate_hz, Telemetry::ResultCallback callback);
+    void set_rate_attitude_async(double rate_hz, Telemetry::ResultCallback callback);
+    void set_rate_camera_attitude_async(double rate_hz, Telemetry::ResultCallback callback);
+    void set_rate_ground_speed_ned_async(double rate_hz, Telemetry::ResultCallback callback);
+    void set_rate_imu_async(double rate_hz, Telemetry::ResultCallback callback);
+    void set_rate_fixedwing_metrics_async(double rate_hz, Telemetry::ResultCallback callback);
+    void set_rate_ground_truth_async(double rate_hz, Telemetry::ResultCallback callback);
+    void set_rate_gps_info_async(double rate_hz, Telemetry::ResultCallback callback);
+    void set_rate_battery_async(double rate_hz, Telemetry::ResultCallback callback);
+    void set_rate_rc_status_async(double rate_hz, Telemetry::ResultCallback callback);
+    void set_rate_actuator_control_target_async(double rate_hz, Telemetry::ResultCallback callback);
+    void set_rate_actuator_output_status_async(double rate_hz, Telemetry::ResultCallback callback);
+    void set_rate_odometry_async(double rate_hz, Telemetry::ResultCallback callback);
+    void set_rate_unix_epoch_time_async(double rate_hz, Telemetry::ResultCallback callback);
 
     Telemetry::PositionVelocityNed position_velocity_ned() const;
     Telemetry::Position position() const;
@@ -95,33 +92,33 @@ public:
     Telemetry::Odometry odometry() const;
     uint64_t unix_epoch_time() const;
 
-    void position_velocity_ned_async(Telemetry::position_velocity_ned_callback_t& callback);
-    void position_async(Telemetry::position_callback_t& callback);
-    void home_async(Telemetry::position_callback_t& callback);
-    void in_air_async(Telemetry::in_air_callback_t& callback);
-    void status_text_async(Telemetry::status_text_callback_t& callback);
-    void armed_async(Telemetry::armed_callback_t& callback);
-    void attitude_quaternion_async(Telemetry::attitude_quaternion_callback_t& callback);
-    void attitude_euler_async(Telemetry::attitude_euler_callback_t& callback);
-    void attitude_angular_velocity_body_async(
-        Telemetry::attitude_angular_velocity_body_callback_t& callback);
-    void fixedwing_metrics_async(Telemetry::fixedwing_metrics_callback_t& callback);
-    void ground_truth_async(Telemetry::ground_truth_callback_t& callback);
-    void camera_attitude_quaternion_async(Telemetry::attitude_quaternion_callback_t& callback);
-    void camera_attitude_euler_async(Telemetry::attitude_euler_callback_t& callback);
-    void ground_speed_ned_async(Telemetry::ground_speed_ned_callback_t& callback);
-    void imu_async(Telemetry::imu_callback_t& callback);
-    void gps_info_async(Telemetry::gps_info_callback_t& callback);
-    void battery_async(Telemetry::battery_callback_t& callback);
-    void flight_mode_async(Telemetry::flight_mode_callback_t& callback);
-    void health_async(Telemetry::health_callback_t& callback);
-    void health_all_ok_async(Telemetry::health_all_ok_callback_t& callback);
-    void landed_state_async(Telemetry::landed_state_callback_t& callback);
-    void rc_status_async(Telemetry::rc_status_callback_t& callback);
-    void unix_epoch_time_async(Telemetry::unix_epoch_time_callback_t& callback);
-    void actuator_control_target_async(Telemetry::actuator_control_target_callback_t& callback);
-    void actuator_output_status_async(Telemetry::actuator_output_status_callback_t& callback);
-    void odometry_async(Telemetry::odometry_callback_t& callback);
+    void position_velocity_ned_async(Telemetry::PositionVelocityNedCallback& callback);
+    void position_async(Telemetry::PositionCallback& callback);
+    void home_async(Telemetry::PositionCallback& callback);
+    void in_air_async(Telemetry::InAirCallback& callback);
+    void status_text_async(Telemetry::StatusTextCallback& callback);
+    void armed_async(Telemetry::ArmedCallback& callback);
+    void attitude_quaternion_async(Telemetry::AttitudeQuaternionCallback& callback);
+    void attitude_euler_async(Telemetry::AttitudeEulerCallback& callback);
+    void
+    attitude_angular_velocity_body_async(Telemetry::AttitudeAngularVelocityBodyCallback& callback);
+    void fixedwing_metrics_async(Telemetry::FixedwingMetricsCallback& callback);
+    void ground_truth_async(Telemetry::GroundTruthCallback& callback);
+    void camera_attitude_quaternion_async(Telemetry::AttitudeQuaternionCallback& callback);
+    void camera_attitude_euler_async(Telemetry::AttitudeEulerCallback& callback);
+    void ground_speed_ned_async(Telemetry::GroundSpeedNedCallback& callback);
+    void imu_async(Telemetry::ImuCallback& callback);
+    void gps_info_async(Telemetry::GpsInfoCallback& callback);
+    void battery_async(Telemetry::BatteryCallback& callback);
+    void flight_mode_async(Telemetry::FlightModeCallback& callback);
+    void health_async(Telemetry::HealthCallback& callback);
+    void health_all_ok_async(Telemetry::HealthAllOkCallback& callback);
+    void landed_state_async(Telemetry::LandedStateCallback& callback);
+    void rc_status_async(Telemetry::RcStatusCallback& callback);
+    void unix_epoch_time_async(Telemetry::UnixEpochTimeCallback& callback);
+    void actuator_control_target_async(Telemetry::ActuatorControlTargetCallback& callback);
+    void actuator_output_status_async(Telemetry::ActuatorOutputStatusCallback& callback);
+    void odometry_async(Telemetry::OdometryCallback& callback);
 
     TelemetryImpl(const TelemetryImpl&) = delete;
     TelemetryImpl& operator=(const TelemetryImpl&) = delete;
@@ -193,7 +190,7 @@ private:
     telemetry_result_from_command_result(MAVLinkCommands::Result command_result);
 
     static void command_result_callback(
-        MAVLinkCommands::Result command_result, const Telemetry::result_callback_t& callback);
+        MAVLinkCommands::Result command_result, const Telemetry::ResultCallback& callback);
 
     static Telemetry::LandedState to_landed_state(mavlink_extended_sys_state_t extended_sys_state);
 
@@ -269,33 +266,33 @@ private:
 
     std::atomic<bool> _hitl_enabled{false};
 
-    Telemetry::position_velocity_ned_callback_t _position_velocity_ned_subscription{nullptr};
-    Telemetry::position_callback_t _position_subscription{nullptr};
-    Telemetry::position_callback_t _home_position_subscription{nullptr};
-    Telemetry::in_air_callback_t _in_air_subscription{nullptr};
-    Telemetry::status_text_callback_t _status_text_subscription{nullptr};
-    Telemetry::armed_callback_t _armed_subscription{nullptr};
-    Telemetry::attitude_quaternion_callback_t _attitude_quaternion_angle_subscription{nullptr};
-    Telemetry::attitude_angular_velocity_body_callback_t
-        _attitude_angular_velocity_body_subscription{nullptr};
-    Telemetry::ground_truth_callback_t _ground_truth_subscription{nullptr};
-    Telemetry::fixedwing_metrics_callback_t _fixedwing_metrics_subscription{nullptr};
-    Telemetry::attitude_euler_callback_t _attitude_euler_angle_subscription{nullptr};
-    Telemetry::attitude_quaternion_callback_t _camera_attitude_quaternion_subscription{nullptr};
-    Telemetry::attitude_euler_callback_t _camera_attitude_euler_angle_subscription{nullptr};
-    Telemetry::ground_speed_ned_callback_t _ground_speed_ned_subscription{nullptr};
-    Telemetry::imu_callback_t _imu_reading_ned_subscription{nullptr};
-    Telemetry::gps_info_callback_t _gps_info_subscription{nullptr};
-    Telemetry::battery_callback_t _battery_subscription{nullptr};
-    Telemetry::flight_mode_callback_t _flight_mode_subscription{nullptr};
-    Telemetry::health_callback_t _health_subscription{nullptr};
-    Telemetry::health_all_ok_callback_t _health_all_ok_subscription{nullptr};
-    Telemetry::landed_state_callback_t _landed_state_subscription{nullptr};
-    Telemetry::rc_status_callback_t _rc_status_subscription{nullptr};
-    Telemetry::unix_epoch_time_callback_t _unix_epoch_time_subscription{nullptr};
-    Telemetry::actuator_control_target_callback_t _actuator_control_target_subscription{nullptr};
-    Telemetry::actuator_output_status_callback_t _actuator_output_status_subscription{nullptr};
-    Telemetry::odometry_callback_t _odometry_subscription{nullptr};
+    Telemetry::PositionVelocityNedCallback _position_velocity_ned_subscription{nullptr};
+    Telemetry::PositionCallback _position_subscription{nullptr};
+    Telemetry::PositionCallback _home_position_subscription{nullptr};
+    Telemetry::InAirCallback _in_air_subscription{nullptr};
+    Telemetry::StatusTextCallback _status_text_subscription{nullptr};
+    Telemetry::ArmedCallback _armed_subscription{nullptr};
+    Telemetry::AttitudeQuaternionCallback _attitude_quaternion_angle_subscription{nullptr};
+    Telemetry::AttitudeAngularVelocityBodyCallback _attitude_angular_velocity_body_subscription{
+        nullptr};
+    Telemetry::GroundTruthCallback _ground_truth_subscription{nullptr};
+    Telemetry::FixedwingMetricsCallback _fixedwing_metrics_subscription{nullptr};
+    Telemetry::AttitudeEulerCallback _attitude_euler_angle_subscription{nullptr};
+    Telemetry::AttitudeQuaternionCallback _camera_attitude_quaternion_subscription{nullptr};
+    Telemetry::AttitudeEulerCallback _camera_attitude_euler_angle_subscription{nullptr};
+    Telemetry::GroundSpeedNedCallback _ground_speed_ned_subscription{nullptr};
+    Telemetry::ImuCallback _imu_reading_ned_subscription{nullptr};
+    Telemetry::GpsInfoCallback _gps_info_subscription{nullptr};
+    Telemetry::BatteryCallback _battery_subscription{nullptr};
+    Telemetry::FlightModeCallback _flight_mode_subscription{nullptr};
+    Telemetry::HealthCallback _health_subscription{nullptr};
+    Telemetry::HealthAllOkCallback _health_all_ok_subscription{nullptr};
+    Telemetry::LandedStateCallback _landed_state_subscription{nullptr};
+    Telemetry::RcStatusCallback _rc_status_subscription{nullptr};
+    Telemetry::UnixEpochTimeCallback _unix_epoch_time_subscription{nullptr};
+    Telemetry::ActuatorControlTargetCallback _actuator_control_target_subscription{nullptr};
+    Telemetry::ActuatorOutputStatusCallback _actuator_output_status_subscription{nullptr};
+    Telemetry::OdometryCallback _odometry_subscription{nullptr};
 
     // The ground speed and position are coupled to the same message, therefore, we just use
     // the faster between the two.

--- a/src/plugins/tune/include/plugins/tune/tune.h
+++ b/src/plugins/tune/include/plugins/tune/tune.h
@@ -121,7 +121,7 @@ public:
     /**
      * @brief Callback type for asynchronous Tune calls.
      */
-    typedef std::function<void(Result)> ResultCallback;
+    using ResultCallback = std::function<void(Result)>;
 
     /**
      * @brief Send a tune to be played by the system.

--- a/src/plugins/tune/include/plugins/tune/tune.h
+++ b/src/plugins/tune/include/plugins/tune/tune.h
@@ -121,14 +121,14 @@ public:
     /**
      * @brief Callback type for asynchronous Tune calls.
      */
-    typedef std::function<void(Result)> result_callback_t;
+    typedef std::function<void(Result)> ResultCallback;
 
     /**
      * @brief Send a tune to be played by the system.
      *
      * This function is non-blocking.
      */
-    void play_tune_async(TuneDescription description, const result_callback_t callback);
+    void play_tune_async(TuneDescription description, const ResultCallback callback);
 
     /**
      * @brief Returns a human-readable English string for a Result.

--- a/src/plugins/tune/tune.cpp
+++ b/src/plugins/tune/tune.cpp
@@ -15,7 +15,7 @@ Tune::Tune(System& system) : PluginBase(), _impl{new TuneImpl(system)} {}
 
 Tune::~Tune() {}
 
-void Tune::play_tune_async(TuneDescription description, const result_callback_t callback)
+void Tune::play_tune_async(TuneDescription description, const ResultCallback callback)
 {
     _impl->play_tune_async(description, callback);
 }

--- a/src/plugins/tune/tune_impl.cpp
+++ b/src/plugins/tune/tune_impl.cpp
@@ -23,7 +23,7 @@ void TuneImpl::enable() {}
 void TuneImpl::disable() {}
 
 void TuneImpl::play_tune_async(
-    const Tune::TuneDescription& tune, const Tune::result_callback_t& callback)
+    const Tune::TuneDescription& tune, const Tune::ResultCallback& callback)
 {
     const auto song_elements = tune.song_elements;
     const int tempo = tune.tempo;
@@ -137,7 +137,7 @@ void TuneImpl::play_tune_async(
     report_tune_result(callback, Tune::Result::Success);
 }
 
-void TuneImpl::report_tune_result(const Tune::result_callback_t& callback, Tune::Result result)
+void TuneImpl::report_tune_result(const Tune::ResultCallback& callback, Tune::Result result)
 {
     if (callback == nullptr) {
         LogWarn() << "Callback is not set";

--- a/src/plugins/tune/tune_impl.h
+++ b/src/plugins/tune/tune_impl.h
@@ -18,8 +18,7 @@ public:
     void enable() override;
     void disable() override;
 
-    void
-    play_tune_async(const Tune::TuneDescription& tune, const Tune::result_callback_t& callback);
+    void play_tune_async(const Tune::TuneDescription& tune, const Tune::ResultCallback& callback);
 
     // Non-copyable
     TuneImpl(const TuneImpl&) = delete;
@@ -28,12 +27,12 @@ public:
 private:
     void timeout_happened();
 
-    void report_tune_result(const Tune::result_callback_t& callback, Tune::Result result);
+    void report_tune_result(const Tune::ResultCallback& callback, Tune::Result result);
 
     void receive_command_result(
-        MAVLinkCommands::Result command_result, const Tune::result_callback_t& callback);
+        MAVLinkCommands::Result command_result, const Tune::ResultCallback& callback);
 
-    Tune::result_callback_t _result_callback = nullptr;
+    Tune::ResultCallback _result_callback = nullptr;
 
     std::vector<std::shared_ptr<mavlink_message_t>> _mavlink_tune_item_messages;
 };

--- a/templates/plugin_cpp/call.j2
+++ b/templates/plugin_cpp/call.j2
@@ -1,5 +1,5 @@
 {% if is_async %}
-void {{ plugin_name.upper_camel_case }}::{{ name.lower_snake_case }}_async({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}, {% endfor %}const result_callback_t callback)
+void {{ plugin_name.upper_camel_case }}::{{ name.lower_snake_case }}_async({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}, {% endfor %}const ResultCallback callback)
 {
     _impl->{{ name.lower_snake_case }}_async({% for param in params %}{{ param.name.lower_snake_case }}, {% endfor %}callback);
 }

--- a/templates/plugin_cpp/request.j2
+++ b/templates/plugin_cpp/request.j2
@@ -1,5 +1,5 @@
 {% if is_async %}
-void {{ plugin_name.upper_camel_case }}::{{ name.lower_snake_case }}_async({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}, {% endfor %}const {{ name.lower_snake_case }}_callback_t callback)
+void {{ plugin_name.upper_camel_case }}::{{ name.lower_snake_case }}_async({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}, {% endfor %}const {{ name.upper_camel_case }}Callback callback)
 {
     _impl->{{ name.lower_snake_case }}_async({% for param in params %}{{ param.name.lower_snake_case }}, {% endfor %}callback);
 }

--- a/templates/plugin_cpp/stream.j2
+++ b/templates/plugin_cpp/stream.j2
@@ -1,5 +1,5 @@
 {% if is_async %}
-void {{ plugin_name.upper_camel_case }}::{% if not is_finite %}subscribe_{% endif %}{{ name.lower_snake_case }}{% if is_finite %}_async{% endif %}({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}, {% endfor %}{{ name.lower_snake_case }}_callback_t callback)
+void {{ plugin_name.upper_camel_case }}::{% if not is_finite %}subscribe_{% endif %}{{ name.lower_snake_case }}{% if is_finite %}_async{% endif %}({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}, {% endfor %}{{ name.upper_camel_case }}Callback callback)
 {
     _impl->{{ name.lower_snake_case }}_async({% for param in params %}{{ param.name.lower_snake_case }}, {% endfor %}callback);
 }

--- a/templates/plugin_h/call.j2
+++ b/templates/plugin_h/call.j2
@@ -4,7 +4,7 @@
  *
  * This function is non-blocking.{% if is_sync %} See '{{ name.lower_snake_case }}' for the blocking counterpart.{% endif %}
  */
-void {{ name.lower_snake_case }}_async({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}, {% endfor %}const result_callback_t callback);
+void {{ name.lower_snake_case }}_async({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}, {% endfor %}const ResultCallback callback);
 {% endif %}
 
 {% if is_sync %}

--- a/templates/plugin_h/file.j2
+++ b/templates/plugin_h/file.j2
@@ -54,7 +54,7 @@ public:
     /**
      * @brief Callback type for asynchronous {{ plugin_name.upper_camel_case }} calls.
      */
-    typedef std::function<void(Result)> result_callback_t;
+    typedef std::function<void(Result)> ResultCallback;
 {% endif %}
 
 {% for method in methods %}

--- a/templates/plugin_h/file.j2
+++ b/templates/plugin_h/file.j2
@@ -54,7 +54,7 @@ public:
     /**
      * @brief Callback type for asynchronous {{ plugin_name.upper_camel_case }} calls.
      */
-    typedef std::function<void(Result)> ResultCallback;
+    using ResultCallback = std::function<void(Result)>;
 {% endif %}
 
 {% for method in methods %}

--- a/templates/plugin_h/request.j2
+++ b/templates/plugin_h/request.j2
@@ -2,14 +2,14 @@
 /**
 * @brief Callback type for {{ name.lower_snake_case }}_async.
 */
-typedef std::function<void({% if has_result %}Result, {% endif %}{{ return_type.name }})> {{ name.lower_snake_case }}_callback_t;
+typedef std::function<void({% if has_result %}Result, {% endif %}{{ return_type.name }})> {{ name.upper_camel_case }}Callback;
 
 /**
  * @brief {{ method_description | replace('\n', '\n *')}}
  *
  * This function is non-blocking.{% if is_sync %} See '{{ name.lower_snake_case }}' for the blocking counterpart.{% endif %}
  */
-void {{ name.lower_snake_case }}_async({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}, {% endfor %}const {{ name.lower_snake_case }}_callback_t callback);
+void {{ name.lower_snake_case }}_async({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}, {% endfor %}const {{ name.upper_camel_case }}Callback callback);
 {% endif %}
 
 {% if is_sync %}

--- a/templates/plugin_h/request.j2
+++ b/templates/plugin_h/request.j2
@@ -2,7 +2,7 @@
 /**
 * @brief Callback type for {{ name.lower_snake_case }}_async.
 */
-typedef std::function<void({% if has_result %}Result, {% endif %}{{ return_type.name }})> {{ name.upper_camel_case }}Callback;
+using {{ name.upper_camel_case }}Callback = std::function<void({% if has_result %}Result, {% endif %}{{ return_type.name }})>;
 
 /**
  * @brief {{ method_description | replace('\n', '\n *')}}

--- a/templates/plugin_h/stream.j2
+++ b/templates/plugin_h/stream.j2
@@ -8,7 +8,7 @@
 * @brief Callback type for subscribe_{{ name.lower_snake_case }}.
 */
     {% endif %}
-typedef std::function<void({% if has_result %}{{ plugin_name.upper_camel_case }}::Result, {% endif %}{{ return_type.name }})> {{ name.upper_camel_case }}Callback;
+using {{ name.upper_camel_case }}Callback = std::function<void({% if has_result %}{{ plugin_name.upper_camel_case }}::Result, {% endif %}{{ return_type.name }})>;
 
 /**
  * @brief {{ method_description | replace('\n', '\n *')}}

--- a/templates/plugin_h/stream.j2
+++ b/templates/plugin_h/stream.j2
@@ -8,12 +8,12 @@
 * @brief Callback type for subscribe_{{ name.lower_snake_case }}.
 */
     {% endif %}
-typedef std::function<void({% if has_result %}{{ plugin_name.upper_camel_case }}::Result, {% endif %}{{ return_type.name }})> {{ name.lower_snake_case }}_callback_t;
+typedef std::function<void({% if has_result %}{{ plugin_name.upper_camel_case }}::Result, {% endif %}{{ return_type.name }})> {{ name.upper_camel_case }}Callback;
 
 /**
  * @brief {{ method_description | replace('\n', '\n *')}}
  */
-void {% if not is_finite %}subscribe_{% endif %}{{ name.lower_snake_case }}{% if is_finite %}_async{% endif %}({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}, {% endfor %}{{ name.lower_snake_case }}_callback_t callback);
+void {% if not is_finite %}subscribe_{% endif %}{{ name.lower_snake_case }}{% if is_finite %}_async{% endif %}({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}, {% endfor %}{{ name.upper_camel_case }}Callback callback);
 {% endif %}
 
 {% if is_sync %}


### PR DESCRIPTION
This changes all callbacks from:

```
typedef std::function<void(int, double)> foo_callback_t;
```

to:
```
using FooCallback = std::function<void(int, double)>;
```
which is more in line with modern C++ rather than old style C typedefs.

I'm not sure it is worth the churn though. However, the time to do it is probably now because we changed most callback types already through the auto-generation.