### PR TITLE
fix to include the last byte in the uid2 in the hardware_uid string

### DIFF
--- a/src/plugins/info/info_impl.cpp
+++ b/src/plugins/info/info_impl.cpp
@@ -172,12 +172,13 @@ std::string InfoImpl::swap_and_translate_binary_to_str(uint8_t* binary, unsigned
 
 std::string InfoImpl::translate_binary_to_str(uint8_t* binary, unsigned binary_len)
 {
-    std::string str(binary_len * 2, '0');
+    std::string str(binary_len * 2 + 1, '0');
 
     for (unsigned i = 0; i < binary_len; ++i) {
         // One hex number occupies 2 chars.
-        snprintf(&str[i * 2], str.length() - i * 2 + 2, "%02x", binary[i]);
+        snprintf(&str[i * 2], str.length() - i * 2, "%02x", binary[i]);
     }
+    snprintf(&str[binary_len * 2], str.length() - binary_len * 2 - 1, "%x", '\0');
 
     return str;
 }

--- a/src/plugins/info/info_impl.cpp
+++ b/src/plugins/info/info_impl.cpp
@@ -178,7 +178,6 @@ std::string InfoImpl::translate_binary_to_str(uint8_t* binary, unsigned binary_l
         // One hex number occupies 2 chars.
         snprintf(&str[i * 2], str.length() - i * 2, "%02x", binary[i]);
     }
-    snprintf(&str[binary_len * 2], str.length() - binary_len * 2 - 1, "%x", '\0');
 
     return str;
 }

--- a/src/plugins/info/info_impl.cpp
+++ b/src/plugins/info/info_impl.cpp
@@ -176,7 +176,7 @@ std::string InfoImpl::translate_binary_to_str(uint8_t* binary, unsigned binary_l
 
     for (unsigned i = 0; i < binary_len; ++i) {
         // One hex number occupies 2 chars.
-        snprintf(&str[i * 2], str.length() - i * 2, "%02x", binary[i]);
+        snprintf(&str[i * 2], str.length() - i * 2 + 2, "%02x", binary[i]);
     }
 
     return str;


### PR DESCRIPTION
I had this issue that when I update to the latest mavsdk the last character in my uid2 was not included in the hardware_uid in the info plugin. This is because snprintf doesn n-1 in the length argument. 

FYI @JonasVautherin 