### PR TITLE
tools: consistently use cmake -H

### DIFF
--- a/tools/generate_camera_definitions.sh
+++ b/tools/generate_camera_definitions.sh
@@ -14,7 +14,7 @@ echo "* Building cpp_rsc binary..."
 curl -L https://github.com/JonasVautherin/cpp_rsc/archive/master.tar.gz | tar -xvz -C ${tmp_dir}
 clone_dir=${tmp_dir}/cpp_rsc-master
 
-cmake -B${clone_dir}/build -S${clone_dir}
+cmake -B${clone_dir}/build -H${clone_dir}
 cmake --build ${clone_dir}/build
 
 cpp_rsc=${clone_dir}/build/src/cpp_rsc

--- a/tools/generate_from_protos.sh
+++ b/tools/generate_from_protos.sh
@@ -25,7 +25,7 @@ command -v ${protoc_binary} && command -v ${protoc_grpc_binary} || {
     echo >&2 ""
     echo >&2 "You may want to run the CMake configure step first:"
     echo >&2 ""
-    echo >&2 "    $ cmake -DBUILD_BACKEND=ON -Bbuild/default -S."
+    echo >&2 "    $ cmake -DBUILD_BACKEND=ON -Bbuild/default -H."
     exit 1
 }
 


### PR DESCRIPTION
Follow up to #1090.
This is because -S is not supported yet with cmake 3.5.1 on Ubuntu 16.04.

Found by @TSC21.