### PR TITLE
backend: fix race condition for unlock

### DIFF
--- a/src/backend/src/plugins/calibration/calibration_service_impl.h
+++ b/src/backend/src/plugins/calibration/calibration_service_impl.h
@@ -159,11 +159,12 @@ public:
                 rpc_calibration_result->set_result_str(ss.str());
                 rpc_response.set_allocated_calibration_result(rpc_calibration_result);
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _calibration.calibrate_gyro_async(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -202,11 +203,12 @@ public:
                 rpc_calibration_result->set_result_str(ss.str());
                 rpc_response.set_allocated_calibration_result(rpc_calibration_result);
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _calibration.calibrate_accelerometer_async(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -245,11 +247,12 @@ public:
                 rpc_calibration_result->set_result_str(ss.str());
                 rpc_response.set_allocated_calibration_result(rpc_calibration_result);
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _calibration.calibrate_magnetometer_async(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -288,11 +291,12 @@ public:
                 rpc_calibration_result->set_result_str(ss.str());
                 rpc_response.set_allocated_calibration_result(rpc_calibration_result);
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _calibration.calibrate_gimbal_accelerometer_async(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });

--- a/src/backend/src/plugins/camera/camera_service_impl.h
+++ b/src/backend/src/plugins/camera/camera_service_impl.h
@@ -687,11 +687,12 @@ public:
 
                 rpc_response.set_mode(translateToRpcMode(mode));
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _camera.subscribe_mode(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -721,11 +722,12 @@ public:
                 rpc_response.set_allocated_information(
                     translateToRpcInformation(information).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _camera.subscribe_information(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -755,11 +757,12 @@ public:
                 rpc_response.set_allocated_video_stream_info(
                     translateToRpcVideoStreamInfo(video_stream_info).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _camera.subscribe_video_stream_info(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -789,11 +792,12 @@ public:
                 rpc_response.set_allocated_capture_info(
                     translateToRpcCaptureInfo(capture_info).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _camera.subscribe_capture_info(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -822,11 +826,12 @@ public:
 
                 rpc_response.set_allocated_camera_status(translateToRpcStatus(status).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _camera.subscribe_status(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -858,11 +863,12 @@ public:
                     ptr->CopyFrom(*translateToRpcSetting(elem).release());
                 }
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _camera.subscribe_current_settings(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -894,11 +900,12 @@ public:
                     ptr->CopyFrom(*translateToRpcSettingOptions(elem).release());
                 }
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _camera.subscribe_possible_setting_options(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });

--- a/src/backend/src/plugins/ftp/ftp_service_impl.h
+++ b/src/backend/src/plugins/ftp/ftp_service_impl.h
@@ -168,11 +168,12 @@ public:
                 rpc_ftp_result->set_result_str(ss.str());
                 rpc_response.set_allocated_ftp_result(rpc_ftp_result);
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _ftp.download_async(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -208,11 +209,12 @@ public:
             rpc_ftp_result->set_result_str(ss.str());
             rpc_response.set_allocated_ftp_result(rpc_ftp_result);
 
-            std::lock_guard<std::mutex> lock(subscribe_mutex);
+            std::unique_lock<std::mutex> lock(subscribe_mutex);
             if (!*is_finished && !writer->Write(rpc_response)) {
                 _ftp.upload_async(nullptr);
                 *is_finished = true;
                 unregister_stream_stop_promise(stream_closed_promise);
+                lock.unlock();
                 stream_closed_promise->set_value();
             }
         });

--- a/src/backend/src/plugins/log_files/log_files_service_impl.h
+++ b/src/backend/src/plugins/log_files/log_files_service_impl.h
@@ -176,11 +176,12 @@ public:
                 rpc_log_files_result->set_result_str(ss.str());
                 rpc_response.set_allocated_log_files_result(rpc_log_files_result);
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _log_files.download_log_file_async(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });

--- a/src/backend/src/plugins/mission/mission_service_impl.h
+++ b/src/backend/src/plugins/mission/mission_service_impl.h
@@ -417,11 +417,12 @@ public:
                 rpc_response.set_allocated_mission_progress(
                     translateToRpcMissionProgress(mission_progress).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _mission.subscribe_mission_progress(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });

--- a/src/backend/src/plugins/mission_raw/mission_raw_service_impl.h
+++ b/src/backend/src/plugins/mission_raw/mission_raw_service_impl.h
@@ -339,11 +339,12 @@ public:
                 rpc_response.set_allocated_mission_progress(
                     translateToRpcMissionProgress(mission_progress).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _mission_raw.subscribe_mission_progress(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -372,11 +373,12 @@ public:
 
                 rpc_response.set_mission_changed(mission_changed);
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _mission_raw.subscribe_mission_changed(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });

--- a/src/backend/src/plugins/shell/shell_service_impl.h
+++ b/src/backend/src/plugins/shell/shell_service_impl.h
@@ -118,11 +118,12 @@ public:
 
                 rpc_response.set_data(receive);
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _shell.subscribe_receive(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });

--- a/src/backend/src/plugins/telemetry/telemetry_service_impl.h
+++ b/src/backend/src/plugins/telemetry/telemetry_service_impl.h
@@ -1062,11 +1062,12 @@ public:
 
                 rpc_response.set_allocated_position(translateToRpcPosition(position).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_position(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1095,11 +1096,12 @@ public:
 
                 rpc_response.set_allocated_home(translateToRpcPosition(home).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_home(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1128,11 +1130,12 @@ public:
 
                 rpc_response.set_is_in_air(in_air);
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_in_air(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1161,11 +1164,12 @@ public:
 
                 rpc_response.set_landed_state(translateToRpcLandedState(landed_state));
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_landed_state(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1194,11 +1198,12 @@ public:
 
                 rpc_response.set_is_armed(armed);
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_armed(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1228,11 +1233,12 @@ public:
                 rpc_response.set_allocated_attitude_quaternion(
                     translateToRpcQuaternion(attitude_quaternion).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_attitude_quaternion(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1262,11 +1268,12 @@ public:
                 rpc_response.set_allocated_attitude_euler(
                     translateToRpcEulerAngle(attitude_euler).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_attitude_euler(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1296,11 +1303,12 @@ public:
                 rpc_response.set_allocated_attitude_angular_velocity_body(
                     translateToRpcAngularVelocityBody(attitude_angular_velocity_body).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_attitude_angular_velocity_body(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1330,11 +1338,12 @@ public:
                 rpc_response.set_allocated_attitude_quaternion(
                     translateToRpcQuaternion(camera_attitude_quaternion).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_camera_attitude_quaternion(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1364,11 +1373,12 @@ public:
                 rpc_response.set_allocated_attitude_euler(
                     translateToRpcEulerAngle(camera_attitude_euler).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_camera_attitude_euler(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1398,11 +1408,12 @@ public:
                 rpc_response.set_allocated_velocity_ned(
                     translateToRpcVelocityNed(velocity_ned).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_velocity_ned(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1431,11 +1442,12 @@ public:
 
                 rpc_response.set_allocated_gps_info(translateToRpcGpsInfo(gps_info).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_gps_info(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1464,11 +1476,12 @@ public:
 
                 rpc_response.set_allocated_battery(translateToRpcBattery(battery).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_battery(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1497,11 +1510,12 @@ public:
 
                 rpc_response.set_flight_mode(translateToRpcFlightMode(flight_mode));
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_flight_mode(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1530,11 +1544,12 @@ public:
 
                 rpc_response.set_allocated_health(translateToRpcHealth(health).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_health(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1563,11 +1578,12 @@ public:
 
                 rpc_response.set_allocated_rc_status(translateToRpcRcStatus(rc_status).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_rc_status(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1597,11 +1613,12 @@ public:
                 rpc_response.set_allocated_status_text(
                     translateToRpcStatusText(status_text).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_status_text(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1631,11 +1648,12 @@ public:
                 rpc_response.set_allocated_actuator_control_target(
                     translateToRpcActuatorControlTarget(actuator_control_target).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_actuator_control_target(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1665,11 +1683,12 @@ public:
                 rpc_response.set_allocated_actuator_output_status(
                     translateToRpcActuatorOutputStatus(actuator_output_status).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_actuator_output_status(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1698,11 +1717,12 @@ public:
 
                 rpc_response.set_allocated_odometry(translateToRpcOdometry(odometry).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_odometry(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1732,11 +1752,12 @@ public:
                 rpc_response.set_allocated_position_velocity_ned(
                     translateToRpcPositionVelocityNed(position_velocity_ned).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_position_velocity_ned(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1766,11 +1787,12 @@ public:
                 rpc_response.set_allocated_ground_truth(
                     translateToRpcGroundTruth(ground_truth).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_ground_truth(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1800,11 +1822,12 @@ public:
                 rpc_response.set_allocated_fixedwing_metrics(
                     translateToRpcFixedwingMetrics(fixedwing_metrics).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_fixedwing_metrics(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1833,11 +1856,12 @@ public:
 
                 rpc_response.set_allocated_imu(translateToRpcImu(imu).release());
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_imu(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1866,11 +1890,12 @@ public:
 
                 rpc_response.set_is_health_all_ok(health_all_ok);
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_health_all_ok(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });
@@ -1899,11 +1924,12 @@ public:
 
                 rpc_response.set_time_us(unix_epoch_time);
 
-                std::lock_guard<std::mutex> lock(subscribe_mutex);
+                std::unique_lock<std::mutex> lock(subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _telemetry.subscribe_unix_epoch_time(nullptr);
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);
+                    lock.unlock();
                     stream_closed_promise->set_value();
                 }
             });

--- a/src/backend/test/camera_service_impl_test.cpp
+++ b/src/backend/test/camera_service_impl_test.cpp
@@ -418,6 +418,19 @@ void CameraServiceImplTest::checkSendsModes(const std::vector<mavsdk::Camera::Mo
     mode_callback(ARBITRARY_CAMERA_MODE);
     mode_events_future.wait();
 
+    if (modes.size() != received_modes.size()) {
+        std::cout << "modes: " << std::endl;
+        for (size_t i = 0; i < modes.size(); i++) {
+            std::cout << i << ": " << modes[i] << std::endl;
+        }
+
+        std::cout << "received_modes: " << std::endl;
+
+        for (size_t i = 0; i < received_modes.size(); i++) {
+            std::cout << i << ": " << received_modes[i] << std::endl;
+        }
+    }
+
     ASSERT_EQ(modes.size(), received_modes.size());
     for (size_t i = 0; i < modes.size(); i++) {
         EXPECT_EQ(modes.at(i), received_modes.at(i));

--- a/templates/mavsdk_server/stream.j2
+++ b/templates/mavsdk_server/stream.j2
@@ -37,11 +37,12 @@ grpc::Status Subscribe{{ name.upper_camel_case }}(grpc::ServerContext* /* contex
         rpc_response.set_allocated_{{ plugin_name.lower_snake_case }}_result(rpc_{{ plugin_name.lower_snake_case }}_result);
     {% endif %}
 
-        std::lock_guard<std::mutex> lock(subscribe_mutex);
+        std::unique_lock<std::mutex> lock(subscribe_mutex);
         if (!*is_finished && !writer->Write(rpc_response)) {
             _{{ plugin_name.lower_snake_case }}.{% if not is_finite %}subscribe_{% endif %}{{ name.lower_snake_case }}{% if is_finite %}_async{% endif %}(nullptr);
             *is_finished = true;
             unregister_stream_stop_promise(stream_closed_promise);
+            lock.unlock();
             stream_closed_promise->set_value();
         }
     });


### PR DESCRIPTION
This should fix a race condition that can happen for streams.

It seems to me what happened was that:
1. The promise is set.
2. The wait at the end of the function returns and the function goes out of scope.
3. Therefore the lock is now destructed.
4. And finally now the lock_guard goes out of scope, again trying to unlock the lock.

I think this only happened intermittently and sometimes in valgrind.

Fixes #1091.