### PR TITLE
hitl can be 1, or 2 when using the SIH

### DIFF
--- a/src/plugins/telemetry/telemetry_impl.cpp
+++ b/src/plugins/telemetry/telemetry_impl.cpp
@@ -1147,7 +1147,7 @@ void TelemetryImpl::receive_param_hitl(MAVLinkParameters::Result result, int val
         return;
     }
 
-    _hitl_enabled = (value == 1);
+    _hitl_enabled = (value > 0);
 
     // assume sensor calibration ok in hitl
     if (_hitl_enabled) {


### PR DESCRIPTION
When using the MAVSDK examples with the SIH, the system never gets ready with `health_all_ok`, because the accelerometer, gyro and compass are seen as uncalibrated. 

I'm refering to [1100_rc_quad_x_sih.hil](https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d/airframes/1100_rc_quad_x_sih.hil#L17)