### PR TITLE
serial: add support for flow control

### DIFF
--- a/src/core/cli_arg.cpp
+++ b/src/core/cli_arg.cpp
@@ -46,6 +46,7 @@ bool CliArg::find_protocol(std::string& rest)
     const std::string udp = "udp";
     const std::string tcp = "tcp";
     const std::string serial = "serial";
+    const std::string serial_flowcontrol = "serial_flowcontrol";
     const std::string delimiter = "://";
 
     if (rest.find(udp + delimiter) == 0) {
@@ -58,7 +59,13 @@ bool CliArg::find_protocol(std::string& rest)
         return true;
     } else if (rest.find(serial + delimiter) == 0) {
         _protocol = Protocol::Serial;
+        _flow_control_enabled = false;
         rest.erase(0, serial.length() + delimiter.length());
+        return true;
+    } else if (rest.find(serial_flowcontrol + delimiter) == 0) {
+        _protocol = Protocol::Serial;
+        _flow_control_enabled = true;
+        rest.erase(0, serial_flowcontrol.length() + delimiter.length());
         return true;
     } else {
         LogWarn() << "Unknown protocol";

--- a/src/core/cli_arg.h
+++ b/src/core/cli_arg.h
@@ -16,6 +16,8 @@ public:
 
     int get_baudrate() const { return _baudrate; }
 
+    bool get_flow_control() const { return _flow_control_enabled; }
+
     std::string get_path() const { return _path; }
 
 private:
@@ -29,6 +31,7 @@ private:
     std::string _path{};
     int _port{0};
     int _baudrate{0};
+    bool _flow_control_enabled{false};
 };
 
 } // namespace mavsdk

--- a/src/core/cli_arg_test.cpp
+++ b/src/core/cli_arg_test.cpp
@@ -122,21 +122,31 @@ TEST(CliArg, SerialConnections)
     EXPECT_EQ(ca.get_protocol(), CliArg::Protocol::Serial);
     EXPECT_STREQ(ca.get_path().c_str(), "/dev/ttyS0");
     EXPECT_EQ(0, ca.get_baudrate());
+    EXPECT_EQ(false, ca.get_flow_control());
+
+    EXPECT_TRUE(ca.parse("serial_flowcontrol:///dev/ttyS0:4000000"));
+    EXPECT_EQ(ca.get_protocol(), CliArg::Protocol::Serial);
+    EXPECT_STREQ(ca.get_path().c_str(), "/dev/ttyS0");
+    EXPECT_EQ(4000000, ca.get_baudrate());
+    EXPECT_EQ(true, ca.get_flow_control());
 
     EXPECT_TRUE(ca.parse("serial://COM13:57600"));
     EXPECT_EQ(ca.get_protocol(), CliArg::Protocol::Serial);
     EXPECT_STREQ(ca.get_path().c_str(), "COM13");
     EXPECT_EQ(57600, ca.get_baudrate());
+    EXPECT_EQ(false, ca.get_flow_control());
 
     EXPECT_TRUE(ca.parse("serial:///dev/tty.usbmodem1:115200"));
     EXPECT_EQ(ca.get_protocol(), CliArg::Protocol::Serial);
     EXPECT_STREQ(ca.get_path().c_str(), "/dev/tty.usbmodem1");
     EXPECT_EQ(115200, ca.get_baudrate());
+    EXPECT_EQ(false, ca.get_flow_control());
 
     EXPECT_TRUE(ca.parse("serial://COM3"));
     EXPECT_EQ(ca.get_protocol(), CliArg::Protocol::Serial);
     EXPECT_STREQ(ca.get_path().c_str(), "COM3");
     EXPECT_EQ(0, ca.get_baudrate());
+    EXPECT_EQ(false, ca.get_flow_control());
 
     // All the wrong combinations.
     EXPECT_FALSE(ca.parse(""));

--- a/src/core/mavsdk.cpp
+++ b/src/core/mavsdk.cpp
@@ -39,9 +39,10 @@ ConnectionResult Mavsdk::add_tcp_connection(const std::string& remote_ip, const 
     return _impl->add_tcp_connection(remote_ip, remote_port);
 }
 
-ConnectionResult Mavsdk::add_serial_connection(const std::string& dev_path, const int baudrate)
+ConnectionResult
+Mavsdk::add_serial_connection(const std::string& dev_path, const int baudrate, bool flow_control)
 {
-    return _impl->add_serial_connection(dev_path, baudrate);
+    return _impl->add_serial_connection(dev_path, baudrate, flow_control);
 }
 
 void Mavsdk::set_configuration(Configuration configuration)

--- a/src/core/mavsdk.h
+++ b/src/core/mavsdk.h
@@ -126,10 +126,13 @@ public:
      *
      * @param dev_path COM or UART dev node name/path (e.g. "/dev/ttyS0", or "COM3" on Windows).
      * @param baudrate Baudrate of the serial port (defaults to 57600).
+     * @param flow_control enable/disable flow control
      * @return The result of adding the connection.
      */
-    ConnectionResult
-    add_serial_connection(const std::string& dev_path, int baudrate = DEFAULT_SERIAL_BAUDRATE);
+    ConnectionResult add_serial_connection(
+        const std::string& dev_path,
+        int baudrate = DEFAULT_SERIAL_BAUDRATE,
+        bool flow_control = false);
 
     /**
      * @brief Stores the configured system id and component id of the MAVSDK instance

--- a/src/core/mavsdk_impl.cpp
+++ b/src/core/mavsdk_impl.cpp
@@ -162,7 +162,8 @@ ConnectionResult MavsdkImpl::add_any_connection(const std::string& connection_ur
             if (cli_arg.get_baudrate()) {
                 baudrate = cli_arg.get_baudrate();
             }
-            return add_serial_connection(cli_arg.get_path(), baudrate);
+            bool flow_control = cli_arg.get_flow_control();
+            return add_serial_connection(cli_arg.get_path(), baudrate, flow_control);
         }
 
         default:
@@ -217,10 +218,14 @@ ConnectionResult MavsdkImpl::add_tcp_connection(const std::string& remote_ip, in
     return ret;
 }
 
-ConnectionResult MavsdkImpl::add_serial_connection(const std::string& dev_path, int baudrate)
+ConnectionResult
+MavsdkImpl::add_serial_connection(const std::string& dev_path, int baudrate, bool flow_control)
 {
     auto new_conn = std::make_shared<SerialConnection>(
-        std::bind(&MavsdkImpl::receive_message, this, std::placeholders::_1), dev_path, baudrate);
+        std::bind(&MavsdkImpl::receive_message, this, std::placeholders::_1),
+        dev_path,
+        baudrate,
+        flow_control);
     if (!new_conn) {
         return ConnectionResult::ConnectionError;
     }

--- a/src/core/mavsdk_impl.h
+++ b/src/core/mavsdk_impl.h
@@ -41,7 +41,8 @@ public:
     add_link_connection(const std::string& protocol, const std::string& ip, int port);
     ConnectionResult add_udp_connection(const std::string& local_ip, int local_port_number);
     ConnectionResult add_tcp_connection(const std::string& remote_ip, int remote_port);
-    ConnectionResult add_serial_connection(const std::string& dev_path, int baudrate);
+    ConnectionResult
+    add_serial_connection(const std::string& dev_path, int baudrate, bool flow_control);
     ConnectionResult setup_udp_remote(const std::string& remote_ip, int remote_port);
 
     void set_configuration(Mavsdk::Configuration configuration);

--- a/src/core/serial_connection.h
+++ b/src/core/serial_connection.h
@@ -13,7 +13,10 @@ namespace mavsdk {
 class SerialConnection : public Connection {
 public:
     explicit SerialConnection(
-        Connection::receiver_callback_t receiver_callback, const std::string& path, int baudrate);
+        Connection::receiver_callback_t receiver_callback,
+        const std::string& path,
+        int baudrate,
+        bool flow_control);
     ConnectionResult start() override;
     ConnectionResult stop() override;
     ~SerialConnection();
@@ -33,8 +36,9 @@ private:
     static int define_from_baudrate(int baudrate);
 #endif
 
-    std::string _serial_node;
-    int _baudrate;
+    const std::string _serial_node;
+    const int _baudrate;
+    const bool _flow_control;
 
     std::mutex _mutex = {};
 #if !defined(WINDOWS)


### PR DESCRIPTION
Tested on Linux, not entirely sure about the Windows part.

Can be used as `serial_flowcontrol://<device>`