### PR TITLE
Improve libmavsdk_server API

### DIFF
--- a/src/backend/src/backend.cpp
+++ b/src/backend/src/backend.cpp
@@ -16,7 +16,6 @@ public:
     void connect(const std::string& connection_url)
     {
         _connection_initiator.start(_dc, connection_url);
-        _connection_initiator.wait();
     }
 
     int startGRPCServer(const int port)

--- a/src/backend/src/backend_api.cpp
+++ b/src/backend/src/backend_api.cpp
@@ -2,11 +2,7 @@
 #include "backend.h"
 #include <string>
 
-MavsdkBackend* runBackend(
-    const char* system_address,
-    const int mavsdk_server_port,
-    void (*onServerStarted)(void*),
-    void* context)
+MavsdkBackend* runBackend(const char* system_address, const int mavsdk_server_port)
 {
     auto backend = new MavsdkBackend();
 
@@ -17,10 +13,6 @@ MavsdkBackend* runBackend(
     }
 
     backend->connect(std::string(system_address));
-
-    if (onServerStarted != nullptr) {
-        onServerStarted(context);
-    }
 
     return backend;
 }

--- a/src/backend/src/backend_api.h
+++ b/src/backend/src/backend_api.h
@@ -10,11 +10,8 @@ extern "C" {
 #define DLLExport __attribute__((visibility("default")))
 #endif
 
-DLLExport struct MavsdkBackend* runBackend(
-    const char* system_address,
-    const int mavsdk_server_port,
-    void (*onServerStarted)(void*),
-    void* context);
+DLLExport struct MavsdkBackend*
+runBackend(const char* system_address, const int mavsdk_server_port);
 
 DLLExport int getPort(struct MavsdkBackend* backend);
 

--- a/src/backend/src/mavsdk_server.cpp
+++ b/src/backend/src/mavsdk_server.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv)
         }
     }
 
-    auto backend = runBackend(connection_url.c_str(), mavsdk_server_port, nullptr, nullptr);
+    auto backend = runBackend(connection_url.c_str(), mavsdk_server_port);
     attach(backend);
 }
 


### PR DESCRIPTION
This improves `libmavsdk_server.so`'s API by not blocking until a drone is discovered, and by not relying on a callback and context to return the status. Now the lifecycle looks like this (thanks to previous PRs as well, but this is finishing the work):

1. `runBackend(string system_address = udp://:14540, mavsdkServerPort = 0)`: Starts `mavsdk_server` and return (don't block until a drone is discovered).
2. `getPort()`: get the port on which the gRPC server was started.
3. `attach()`: attach to the process, effectively blocking until `mavsdk_server` is stopped.
4. `stopBackend()`: cancel all subscriptions and stop `mavsdk_server`.

The behavior of `mavsdk_server`, the binary we embed e.g. in MAVSDK-Python, should not change at all.

Those changes are useful for Android and iOS, where the app has to be able to start and stop `mavsdk_server` gracefully according to its lifecycle.