### PR TITLE
Add prefix to C API, because there is no namespacing

### DIFF
--- a/src/backend/src/backend_api.cpp
+++ b/src/backend/src/backend_api.cpp
@@ -2,7 +2,7 @@
 #include "backend.h"
 #include <string>
 
-MavsdkBackend* runBackend(const char* system_address, const int mavsdk_server_port)
+MavsdkBackend* mavsdk_server_run(const char* system_address, const int mavsdk_server_port)
 {
     auto backend = new MavsdkBackend();
 
@@ -17,17 +17,17 @@ MavsdkBackend* runBackend(const char* system_address, const int mavsdk_server_po
     return backend;
 }
 
-int getPort(MavsdkBackend* backend)
+int mavsdk_server_get_port(MavsdkBackend* backend)
 {
     return backend->getPort();
 }
 
-void attach(MavsdkBackend* backend)
+void mavsdk_server_attach(MavsdkBackend* backend)
 {
     backend->wait();
 }
 
-void stopBackend(MavsdkBackend* backend)
+void mavsdk_server_stop(MavsdkBackend* backend)
 {
     backend->stop();
     delete backend;

--- a/src/backend/src/backend_api.h
+++ b/src/backend/src/backend_api.h
@@ -11,13 +11,13 @@ extern "C" {
 #endif
 
 DLLExport struct MavsdkBackend*
-runBackend(const char* system_address, const int mavsdk_server_port);
+mavsdk_server_run(const char* system_address, const int mavsdk_server_port);
 
-DLLExport int getPort(struct MavsdkBackend* backend);
+DLLExport int mavsdk_server_get_port(struct MavsdkBackend* backend);
 
-DLLExport void attach(struct MavsdkBackend* backend);
+DLLExport void mavsdk_server_attach(struct MavsdkBackend* backend);
 
-DLLExport void stopBackend(struct MavsdkBackend* backend);
+DLLExport void mavsdk_server_stop(struct MavsdkBackend* backend);
 
 #ifdef __cplusplus
 }

--- a/src/backend/src/mavsdk_server.cpp
+++ b/src/backend/src/mavsdk_server.cpp
@@ -41,8 +41,8 @@ int main(int argc, char** argv)
         }
     }
 
-    auto backend = runBackend(connection_url.c_str(), mavsdk_server_port);
-    attach(backend);
+    auto backend = mavsdk_server_run(connection_url.c_str(), mavsdk_server_port);
+    mavsdk_server_attach(backend);
 }
 
 void usage()


### PR DESCRIPTION
Hoping that this interface will now be stable, because that's breaking iOS and Android :see_no_evil:.