### PR TITLE
telemetry: handle lat = 0 lon = 0 correctly

### DIFF
--- a/src/plugins/telemetry/telemetry_impl.cpp
+++ b/src/plugins/telemetry/telemetry_impl.cpp
@@ -512,8 +512,14 @@ void TelemetryImpl::process_global_position_int(const mavlink_message_t& message
 
     {
         Telemetry::Position position;
-        position.latitude_deg = global_position_int.lat * 1e-7;
-        position.longitude_deg = global_position_int.lon * 1e-7;
+        // Special case to signal lat/lon is not set yet.
+        if (global_position_int.lat == 0 && global_position_int.lon == 0) {
+            position.latitude_deg = double(NAN);
+            position.longitude_deg = double(NAN);
+        } else {
+            position.latitude_deg = global_position_int.lat * 1e-7;
+            position.longitude_deg = global_position_int.lon * 1e-7;
+        }
         position.absolute_altitude_m = global_position_int.alt * 1e-3f;
         position.relative_altitude_m = global_position_int.relative_alt * 1e-3f;
         set_position(position);


### PR DESCRIPTION
For the case where the altitude is known but the global position is not, the message is sent with lat = 0 and lon = 0.

Still depends on the decision in https://github.com/PX4/Firmware/pull/15308.