### PR TITLE
workflows: use checkout action v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,13 +129,27 @@ jobs:
       - name: test (mavsdk_server)
         run: ./build/release/src/backend/test/unit_tests_backend
 
-  px4-sitl:
+  px4-sitl-18.04:
     name: PX4 SITL ${{ matrix.px4_version }} (ubuntu-18.04)
     runs-on: ubuntu-18.04
     container: mavsdk/mavsdk-ubuntu-18.04-px4-sitl-${{ matrix.px4_version }}
     strategy:
       matrix:
-        px4_version: [v1.9, v1.10, v1.11]
+        px4_version: [v1.9, v1.10]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: test
+        run: PX4_VERSION=${{ matrix.px4_version }} tools/run-sitl-tests.sh /home/user/Firmware
+
+  px4-sitl-20.04:
+    name: PX4 SITL ${{ matrix.px4_version }} (ubuntu-20.04)
+    runs-on: ubuntu-18.04
+    container: mavsdk/mavsdk-ubuntu-20.04-px4-sitl-${{ matrix.px4_version }}
+    strategy:
+      matrix:
+        px4_version: [v1.11]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -149,7 +163,7 @@ jobs:
     container: mavsdk/mavsdk-${{ matrix.container_name }}
     strategy:
       matrix:
-        container_name: [ubuntu-16.04, ubuntu-18.04]
+        container_name: [ubuntu-18.04, ubuntu-20.04]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     name: coverage (ubuntu-18.04)
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: Install lcov
@@ -40,7 +40,7 @@ jobs:
     name: ubuntu-18.04 (non-backend, non-superbuild)
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: install
@@ -56,7 +56,7 @@ jobs:
     name: ubuntu-18.04 (backend, superbuild)
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: configure
@@ -78,7 +78,7 @@ jobs:
     name: ubuntu-18.04 (proto check)
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: install clang-format
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-18.04
     container: mavsdk/mavsdk-ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: check style
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-18.04
     container: alpine:3.11.6
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: install tools
@@ -137,7 +137,7 @@ jobs:
       matrix:
         px4_version: [v1.9, v1.10, v1.11]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: test
@@ -151,7 +151,7 @@ jobs:
       matrix:
         container_name: [ubuntu-16.04, ubuntu-18.04]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: configure
@@ -179,7 +179,7 @@ jobs:
       matrix:
         container_name: [fedora-30, fedora-31]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: configure
@@ -206,7 +206,7 @@ jobs:
       matrix:
         arch_name: [linux-armv6, linux-armv7, linux-arm64, manylinux2010-x64, manylinux2014-aarch64]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: setup dockcross
@@ -229,7 +229,7 @@ jobs:
     name: android-arm
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: setup dockcross
@@ -254,7 +254,7 @@ jobs:
     name: android-arm64
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: setup dockcross
@@ -293,7 +293,7 @@ jobs:
     name: macOS
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: configure
@@ -318,7 +318,7 @@ jobs:
     name: iOS
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: configure (ios)
@@ -346,7 +346,7 @@ jobs:
     name: Windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: configure

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -191,7 +191,7 @@ jobs:
     container: mavsdk/mavsdk-${{ matrix.container_name }}
     strategy:
       matrix:
-        container_name: [fedora-30, fedora-31]
+        container_name: [fedora-31, fedora-32]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,11 +115,11 @@ jobs:
     runs-on: ubuntu-18.04
     container: alpine:3.11.6
     steps:
+      - name: install tools
+        run: apk update && apk add build-base cmake git linux-headers
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: install tools
-        run: apk update && apk add build-base cmake git linux-headers
       - name: configure
         run: cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=install -Bbuild/release -H.
       - name: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,7 @@ jobs:
       - name: test (mavsdk_server)
         run: ./build/release/src/backend/test/unit_tests_backend
 
-  px4-sitl-18.04:
+  px4-sitl-older:
     name: PX4 SITL ${{ matrix.px4_version }} (ubuntu-18.04)
     runs-on: ubuntu-18.04
     container: mavsdk/mavsdk-ubuntu-18.04-px4-sitl-${{ matrix.px4_version }}
@@ -143,7 +143,7 @@ jobs:
       - name: test
         run: PX4_VERSION=${{ matrix.px4_version }} tools/run-sitl-tests.sh /home/user/Firmware
 
-  px4-sitl-20.04:
+  px4-sitl-newer:
     name: PX4 SITL ${{ matrix.px4_version }} (ubuntu-20.04)
     runs-on: ubuntu-18.04
     container: mavsdk/mavsdk-ubuntu-20.04-px4-sitl-${{ matrix.px4_version }}

--- a/docker/Dockerfile-Fedora-32
+++ b/docker/Dockerfile-Fedora-32
@@ -1,10 +1,10 @@
 #
-# Development environment for the MAVSDK based on Fedora 30.
+# Development environment for the MAVSDK based on Fedora 32.
 #
 # Author: Julian Oes <julian@oes.ch>
 #
 
-FROM fedora:30
+FROM fedora:32
 
 MAINTAINER Julian Oes <julian@oes.ch>
 

--- a/docker/Dockerfile-Ubuntu-18.04
+++ b/docker/Dockerfile-Ubuntu-18.04
@@ -22,7 +22,6 @@ RUN apt-get update \
         cmake \
         colordiff \
         doxygen \
-        git \
         golang-go \
         libcurl4-openssl-dev \
         libltdl-dev \
@@ -38,6 +37,12 @@ RUN apt-get update \
         wget \
     && apt-get -y autoremove \
     && apt-get clean autoclean \
+    && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+# We need git with version at least 2.18 for GitHub checkout v2
+RUN add-apt-repository ppa:git-core/ppa -y \
+    && apt-get update \
+    && apt-get install git -y \
     && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN gem install --no-document fpm;

--- a/docker/Dockerfile-Ubuntu-20.04
+++ b/docker/Dockerfile-Ubuntu-20.04
@@ -1,10 +1,10 @@
 #
-# Development environment for MAVSDK based on Ubuntu 16.04.
+# Development environment for MAVSDK based on Ubuntu 20.04.
 #
 # Author: Julian Oes <julian@oes.ch>
 #
 
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 MAINTAINER Julian Oes <julian@oes.ch>
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -18,6 +18,7 @@ RUN apt-get update \
         build-essential \
         ca-certificates \
         ccache \
+        clang-format-9 \
         cmake \
         colordiff \
         doxygen \
@@ -37,12 +38,6 @@ RUN apt-get update \
         wget \
     && apt-get -y autoremove \
     && apt-get clean autoclean \
-    && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
-
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
-    && apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main" \
-    && apt-get update \
-    && apt-get install -y clang-format-9 \
     && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN gem install --no-document fpm;

--- a/docker/Dockerfile-Ubuntu-20.04
+++ b/docker/Dockerfile-Ubuntu-20.04
@@ -30,8 +30,8 @@ RUN apt-get update \
         libtool \
         libz-dev \
         ninja-build \
-        python \
-        python-pip \
+        python3 \
+        python3-pip \
         ruby-dev \
         software-properties-common \
         sudo \

--- a/docker/Dockerfile-Ubuntu-20.04-PX4-SITL-v1.11
+++ b/docker/Dockerfile-Ubuntu-20.04-PX4-SITL-v1.11
@@ -1,8 +1,8 @@
 #
-# PX4 v1.11.0-rc1 SITL testing environment for MAVSDK based on Ubuntu 18.04.
+# PX4 v1.11.0-rc1 SITL testing environment for MAVSDK based on Ubuntu 20.04.
 # Author: Julian Oes <julian@oes.ch>
 #
-FROM mavsdk/mavsdk-ubuntu-18.04
+FROM mavsdk/mavsdk-ubuntu-20.04
 MAINTAINER Julian Oes <julian@oes.ch>
 
 ENV FIRMWARE_DIR ${WORKDIR}../Firmware

--- a/docker/build_and_push_docker_images.sh
+++ b/docker/build_and_push_docker_images.sh
@@ -4,16 +4,16 @@ set -e
 
 docker build -f Dockerfile-Fedora-30 -t mavsdk/mavsdk-fedora-30 .
 docker build -f Dockerfile-Fedora-31 -t mavsdk/mavsdk-fedora-31 .
-docker build -f Dockerfile-Ubuntu-16.04 -t mavsdk/mavsdk-ubuntu-16.04 .
 docker build -f Dockerfile-Ubuntu-18.04 -t mavsdk/mavsdk-ubuntu-18.04 .
+docker build -f Dockerfile-Ubuntu-20.04 -t mavsdk/mavsdk-ubuntu-20.04 .
 docker build -f Dockerfile-Ubuntu-18.04-PX4-SITL-v1.9 -t mavsdk/mavsdk-ubuntu-18.04-px4-sitl-v1.9 .
 docker build -f Dockerfile-Ubuntu-18.04-PX4-SITL-v1.10 -t mavsdk/mavsdk-ubuntu-18.04-px4-sitl-v1.10 .
-docker build -f Dockerfile-Ubuntu-18.04-PX4-SITL-v1.11 -t mavsdk/mavsdk-ubuntu-18.04-px4-sitl-v1.11 .
+docker build -f Dockerfile-Ubuntu-20.04-PX4-SITL-v1.11 -t mavsdk/mavsdk-ubuntu-20.04-px4-sitl-v1.11 .
 
 docker push mavsdk/mavsdk-fedora-30:latest
 docker push mavsdk/mavsdk-fedora-31:latest
-docker push mavsdk/mavsdk-ubuntu-16.04:latest
 docker push mavsdk/mavsdk-ubuntu-18.04:latest
+docker push mavsdk/mavsdk-ubuntu-20.04:latest
 docker push mavsdk/mavsdk-ubuntu-18.04-px4-sitl-v1.9:latest
 docker push mavsdk/mavsdk-ubuntu-18.04-px4-sitl-v1.10:latest
-docker push mavsdk/mavsdk-ubuntu-18.04-px4-sitl-v1.11:latest
+docker push mavsdk/mavsdk-ubuntu-20.04-px4-sitl-v1.11:latest

--- a/docker/build_and_push_docker_images.sh
+++ b/docker/build_and_push_docker_images.sh
@@ -2,16 +2,16 @@
 
 set -e
 
-docker build -f Dockerfile-Fedora-30 -t mavsdk/mavsdk-fedora-30 .
 docker build -f Dockerfile-Fedora-31 -t mavsdk/mavsdk-fedora-31 .
+docker build -f Dockerfile-Fedora-32 -t mavsdk/mavsdk-fedora-32 .
 docker build -f Dockerfile-Ubuntu-18.04 -t mavsdk/mavsdk-ubuntu-18.04 .
 docker build -f Dockerfile-Ubuntu-20.04 -t mavsdk/mavsdk-ubuntu-20.04 .
 docker build -f Dockerfile-Ubuntu-18.04-PX4-SITL-v1.9 -t mavsdk/mavsdk-ubuntu-18.04-px4-sitl-v1.9 .
 docker build -f Dockerfile-Ubuntu-18.04-PX4-SITL-v1.10 -t mavsdk/mavsdk-ubuntu-18.04-px4-sitl-v1.10 .
 docker build -f Dockerfile-Ubuntu-20.04-PX4-SITL-v1.11 -t mavsdk/mavsdk-ubuntu-20.04-px4-sitl-v1.11 .
 
-docker push mavsdk/mavsdk-fedora-30:latest
 docker push mavsdk/mavsdk-fedora-31:latest
+docker push mavsdk/mavsdk-fedora-32:latest
 docker push mavsdk/mavsdk-ubuntu-18.04:latest
 docker push mavsdk/mavsdk-ubuntu-20.04:latest
 docker push mavsdk/mavsdk-ubuntu-18.04-px4-sitl-v1.9:latest


### PR DESCRIPTION
This should fix the coveralls error that we have been seeing:

```
Run coverallsapp/github-action@master
  with:
    github-token: ***
    path-to-lcov: ./lcov.info
    coveralls-endpoint: https://coveralls.io
Using lcov file: ./lcov.info
[error] "2020-07-16T13:40:56.682Z"  'error from getOptions'
fatal: Not a valid object name 3ce4b7b924ef507acc7570dce933938da28d9be9
```

See: https://github.com/coverallsapp/github-action/issues/55