### PR TITLE
integration_tests: disable flip test for now

### DIFF
--- a/src/integration_tests/offboard_attitude.cpp
+++ b/src/integration_tests/offboard_attitude.cpp
@@ -16,7 +16,7 @@ static void flip_roll(std::shared_ptr<Offboard> offboard, std::shared_ptr<Teleme
 static void flip_pitch(std::shared_ptr<Offboard> offboard, std::shared_ptr<Telemetry> telemetry);
 static void turn_yaw(std::shared_ptr<Offboard> offboard);
 
-TEST_F(SitlTest, OffboardAttitudeRate)
+TEST(SitlTestDisabled, OffboardAttitudeRate)
 {
     Mavsdk mavsdk;
 


### PR DESCRIPTION
This test is implemented in a stupid way, so if it misses some telemetry updates during a (fast) flip, it will continue forever and make CI time out.

This change disables it because in CI only "SitlTest.*" are run.