### PR TITLE
docker: use PX4 master for now

### DIFF
--- a/docker/Dockerfile-Ubuntu-20.04-PX4-SITL-v1.11
+++ b/docker/Dockerfile-Ubuntu-20.04-PX4-SITL-v1.11
@@ -19,7 +19,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 RUN git clone https://github.com/PX4/Firmware.git ${FIRMWARE_DIR}
-RUN git -C ${FIRMWARE_DIR} checkout v1.11.0-rc1
+RUN git -C ${FIRMWARE_DIR} checkout master # later: v1.11.0
 RUN git -C ${FIRMWARE_DIR} submodule update --init --recursive
 RUN cd ${FIRMWARE_DIR} && Tools/setup/ubuntu.sh --no-nuttx
 RUN cd ${FIRMWARE_DIR} && DONT_RUN=1 make px4_sitl gazebo && DONT_RUN=1 make px4_sitl gazebo


### PR DESCRIPTION
This is a workaround to prevent CI from being stuck for hours. Instead this should fail immediately if gzserver is not running.

To include https://github.com/PX4/Firmware/pull/15399.