### PR TITLE
Added QGC complex mission item importing

### DIFF
--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -1056,6 +1056,11 @@ Mission::Result MissionImpl::import_complex_mission_item(
         return Mission::Result::UnsupportedMissionCmd;
     }
 
+    // QGC supports more complex mission items than simple waypoints.
+    // Surveys and coridor scans (NOT structure scans) are stored in a so called "TransectStyleComplexItem" item inside the mission_items array.
+    // These ComplexItems also contain an array ("Items") which contains waypoints.
+    // It is used by GQC to keep survey parameters so one can edit it as a survey after importing.
+    // Structure scans are not supported as thes do not contain simple mission items.
     Json::Value complex_item = json_complex_mission_item["TransectStyleComplexItem"];
     for (auto& json_mission_item : complex_item["Items"]) {
         Mission::Result result =

--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -1024,6 +1024,45 @@ Mission::Result MissionImpl::build_mission_items(
     return result;
 }
 
+Mission::Result MissionImpl::import_simple_mission_item(
+        std::vector<Mission::MissionItem>& all_mission_items, const Json::Value& json_mission_item, MissionItem& new_mission_item)
+{
+    // Parameters of Mission item & MAV command of it.
+    MAV_CMD command = static_cast<MAV_CMD>(json_mission_item["command"].asInt());
+
+    // Extract parameters of each mission item
+    std::vector<double> params;
+    for (auto& p : json_mission_item["params"]) {
+        if (p.type() == Json::nullValue) {
+            // QGC sets params as `null` if they should be unchanged.
+            params.push_back(double(NAN));
+        } else {
+            params.push_back(p.asDouble());
+        }
+    }
+    return build_mission_items(command, params, new_mission_item, all_mission_items);            
+}
+
+Mission::Result MissionImpl::import_complex_mission_item(
+        std::vector<Mission::MissionItem>& all_mission_items, const Json::Value& json_mission_item, MissionItem& new_mission_item)
+{
+    if(json_mission_item["TransectStyleComplexItem"].isNull()){
+        LogWarn() << "Unknown complex item type (" << json_mission_item["complexItemType"] << ")";
+        return Mission::Result::UnsupportedMissionCmd;
+    }
+
+
+    Json::Value complex_item = json_mission_item["TransectStyleComplexItem"];
+    for (auto& json_mission_item : complex_item["Items"]) {
+        Mission::Result result =
+            import_simple_mission_item(all_mission_items, json_mission_item, new_mission_item);
+        if (result != Mission::Result::Success) {
+            return result;
+        }
+    }
+    return Mission::Result::Success;
+}
+
 Mission::Result MissionImpl::import_mission_items(
     std::vector<Mission::MissionItem>& all_mission_items, const Json::Value& qgc_plan_json)
 {
@@ -1032,22 +1071,17 @@ Mission::Result MissionImpl::import_mission_items(
 
     // Iterate mission items and build Mavsdk mission items.
     for (auto& json_mission_item : json_mission_items["items"]) {
-        // Parameters of Mission item & MAV command of it.
-        MAV_CMD command = static_cast<MAV_CMD>(json_mission_item["command"].asInt());
+        Mission::Result result;
 
-        // Extract parameters of each mission item
-        std::vector<double> params;
-        for (auto& p : json_mission_item["params"]) {
-            if (p.type() == Json::nullValue) {
-                // QGC sets params as `null` if they should be unchanged.
-                params.push_back(double(NAN));
-            } else {
-                params.push_back(p.asDouble());
-            }
+        // Check if mission item is complex (like a survey from qgc) or a simple item
+        Json::Value type = json_mission_item["type"];
+        
+        if (!type.isNull() && type.asString() == "ComplexItem") {
+            result = import_complex_mission_item(all_mission_items, json_mission_item, new_mission_item);
+        } else {
+            result = import_simple_mission_item(all_mission_items, json_mission_item, new_mission_item);
         }
 
-        Mission::Result result =
-            build_mission_items(command, params, new_mission_item, all_mission_items);
         if (result != Mission::Result::Success) {
             break;
         }

--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -1025,7 +1025,9 @@ Mission::Result MissionImpl::build_mission_items(
 }
 
 Mission::Result MissionImpl::import_simple_mission_item(
-        std::vector<Mission::MissionItem>& all_mission_items, const Json::Value& json_mission_item, MissionItem& new_mission_item)
+    std::vector<Mission::MissionItem>& all_mission_items,
+    const Json::Value& json_mission_item,
+    MissionItem& new_mission_item)
 {
     // Parameters of Mission item & MAV command of it.
     MAV_CMD command = static_cast<MAV_CMD>(json_mission_item["command"].asInt());
@@ -1040,17 +1042,19 @@ Mission::Result MissionImpl::import_simple_mission_item(
             params.push_back(p.asDouble());
         }
     }
-    return build_mission_items(command, params, new_mission_item, all_mission_items);            
+    return build_mission_items(command, params, new_mission_item, all_mission_items);
 }
 
 Mission::Result MissionImpl::import_complex_mission_item(
-        std::vector<Mission::MissionItem>& all_mission_items, const Json::Value& json_complex_mission_item, MissionItem& new_mission_item)
+    std::vector<Mission::MissionItem>& all_mission_items,
+    const Json::Value& json_complex_mission_item,
+    MissionItem& new_mission_item)
 {
-    if(json_complex_mission_item["TransectStyleComplexItem"].isNull()){
-        LogWarn() << "Unknown complex item type (" << json_complex_mission_item["complexItemType"] << ")";
+    if (json_complex_mission_item["TransectStyleComplexItem"].isNull()) {
+        LogWarn() << "Unknown complex item type (" << json_complex_mission_item["complexItemType"]
+                  << ")";
         return Mission::Result::UnsupportedMissionCmd;
     }
-
 
     Json::Value complex_item = json_complex_mission_item["TransectStyleComplexItem"];
     for (auto& json_mission_item : complex_item["Items"]) {
@@ -1075,11 +1079,13 @@ Mission::Result MissionImpl::import_mission_items(
 
         // Check if mission item is complex (like a survey from qgc) or a simple item
         Json::Value type = json_mission_item["type"];
-        
+
         if (!type.isNull() && type.asString() == "ComplexItem") {
-            result = import_complex_mission_item(all_mission_items, json_mission_item, new_mission_item);
+            result =
+                import_complex_mission_item(all_mission_items, json_mission_item, new_mission_item);
         } else {
-            result = import_simple_mission_item(all_mission_items, json_mission_item, new_mission_item);
+            result =
+                import_simple_mission_item(all_mission_items, json_mission_item, new_mission_item);
         }
 
         if (result != Mission::Result::Success) {

--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -1044,15 +1044,15 @@ Mission::Result MissionImpl::import_simple_mission_item(
 }
 
 Mission::Result MissionImpl::import_complex_mission_item(
-        std::vector<Mission::MissionItem>& all_mission_items, const Json::Value& json_mission_item, MissionItem& new_mission_item)
+        std::vector<Mission::MissionItem>& all_mission_items, const Json::Value& json_complex_mission_item, MissionItem& new_mission_item)
 {
-    if(json_mission_item["TransectStyleComplexItem"].isNull()){
-        LogWarn() << "Unknown complex item type (" << json_mission_item["complexItemType"] << ")";
+    if(json_complex_mission_item["TransectStyleComplexItem"].isNull()){
+        LogWarn() << "Unknown complex item type (" << json_complex_mission_item["complexItemType"] << ")";
         return Mission::Result::UnsupportedMissionCmd;
     }
 
 
-    Json::Value complex_item = json_mission_item["TransectStyleComplexItem"];
+    Json::Value complex_item = json_complex_mission_item["TransectStyleComplexItem"];
     for (auto& json_mission_item : complex_item["Items"]) {
         Mission::Result result =
             import_simple_mission_item(all_mission_items, json_mission_item, new_mission_item);

--- a/src/plugins/mission/mission_impl.h
+++ b/src/plugins/mission/mission_impl.h
@@ -98,10 +98,14 @@ private:
     static Mission::Result convert_result(MAVLinkMissionTransfer::Result result);
 
     static Mission::Result import_simple_mission_item(
-        std::vector<Mission::MissionItem>& all_mission_items, const Json::Value& json_mission_item, Mission::MissionItem& new_mission_item);
+        std::vector<Mission::MissionItem>& all_mission_items,
+        const Json::Value& json_mission_item,
+        Mission::MissionItem& new_mission_item);
 
     static Mission::Result import_complex_mission_item(
-        std::vector<Mission::MissionItem>& all_mission_items, const Json::Value& json_mission_item, Mission::MissionItem& new_mission_item);
+        std::vector<Mission::MissionItem>& all_mission_items,
+        const Json::Value& json_mission_item,
+        Mission::MissionItem& new_mission_item);
 
     static Mission::Result import_mission_items(
         std::vector<Mission::MissionItem>& all_mission_items, const Json::Value& qgc_plan_json);

--- a/src/plugins/mission/mission_impl.h
+++ b/src/plugins/mission/mission_impl.h
@@ -97,6 +97,12 @@ private:
 
     static Mission::Result convert_result(MAVLinkMissionTransfer::Result result);
 
+    static Mission::Result import_simple_mission_item(
+        std::vector<Mission::MissionItem>& all_mission_items, const Json::Value& json_mission_item, Mission::MissionItem& new_mission_item);
+
+    static Mission::Result import_complex_mission_item(
+        std::vector<Mission::MissionItem>& all_mission_items, const Json::Value& json_mission_item, Mission::MissionItem& new_mission_item);
+
     static Mission::Result import_mission_items(
         std::vector<Mission::MissionItem>& all_mission_items, const Json::Value& qgc_plan_json);
 

--- a/src/plugins/mission/mission_import_qgc_test.cpp
+++ b/src/plugins/mission/mission_import_qgc_test.cpp
@@ -13,6 +13,8 @@ using MissionItem = Mission::MissionItem;
 using CameraAction = Mission::MissionItem::CameraAction;
 
 static const std::string QGC_SAMPLE_PLAN = "src/plugins/mission/qgroundcontrol_sample.plan";
+static const std::string QGC_COMPLEX_SAMPLE_PLAN =
+    "src/plugins/mission/qgroundcontrol_sample_with_survey.plan";
 
 struct QGCMissionItem {
     MAV_CMD command;
@@ -26,6 +28,108 @@ Mission::Result compose_mission_items(
     std::vector<Mission::MissionItem>& mission_items);
 
 static void compare(const MissionItem& local, const MissionItem& imported);
+
+// capture array size
+template<size_t N>
+static void build_local_mission_items(
+    QGCMissionItem (&items_test)[N], std::vector<Mission::MissionItem>& mission_items_local)
+{
+    MissionItem new_mission_item{};
+    Mission::Result result = Mission::Result::Success;
+
+    for (auto& qgc_it : items_test) {
+        auto command = qgc_it.command;
+        auto params = qgc_it.params;
+        result = compose_mission_items(command, params, new_mission_item, mission_items_local);
+        EXPECT_EQ(result, Mission::Result::Success);
+    }
+    mission_items_local.push_back(new_mission_item);
+}
+
+static void test_mission_items(
+    std::string qgc_mission_plan_path, std::vector<Mission::MissionItem>& expected_mission_items)
+{
+    // Import Mission items from QGC plan
+    auto import_result = MissionImpl::import_qgroundcontrol_mission(qgc_mission_plan_path);
+    ASSERT_EQ(import_result.first, Mission::Result::Success);
+    EXPECT_NE(import_result.second.mission_items.size(), 0);
+
+    // Compare local & parsed mission items
+    ASSERT_EQ(expected_mission_items.size(), import_result.second.mission_items.size());
+    for (unsigned i = 0; i < import_result.second.mission_items.size(); ++i) {
+        compare(expected_mission_items.at(i), import_result.second.mission_items.at(i));
+    }
+}
+
+TEST(QGCComplextMissionImport, ValidateQGCComplexMissionItems)
+{
+    // These mission items are meant to match those in
+    // file:://plugins/mission/qgroundcontrol_sample_with_survey.plan
+    QGCMissionItem items_test[] = {
+        {MAV_CMD_NAV_TAKEOFF, {0., 0., 0., double(NAN), 47.39781011, 8.54553801, 15.}},
+        // Survey starts here
+        {MAV_CMD_NAV_WAYPOINT, {0., 0., 0., double(NAN), 47.39784192965106, 8.545413449078293, 50}},
+        {MAV_CMD_NAV_WAYPOINT, {0., 0., 0., double(NAN), 47.39790440182785, 8.545317879157443, 50}},
+        {MAV_CMD_DO_SET_CAM_TRIGG_DIST, {250., 0., 1., 0., 0., 0., 0.}},
+        {MAV_CMD_NAV_WAYPOINT,
+         {0., 0., 0., double(NAN), 47.397974177081146, 8.545211136580374, 50}},
+        {MAV_CMD_DO_SET_CAM_TRIGG_DIST, {0., 0., 0., 0., 0., 0., 0.}},
+        {MAV_CMD_NAV_WAYPOINT,
+         {0., 0., 0., double(NAN), 47.398036649089796, 8.545115566179781, 50}},
+        {MAV_CMD_NAV_WAYPOINT, {0., 0., 0., double(NAN), 47.39800123401638, 8.545074115797751, 50}},
+        {MAV_CMD_NAV_WAYPOINT, {0., 0., 0., double(NAN), 47.39793876204219, 8.545169686183264, 50}},
+        {MAV_CMD_DO_SET_CAM_TRIGG_DIST, {250., 0., 1., 0., 0., 0., 0.}},
+        {MAV_CMD_NAV_WAYPOINT,
+         {0., 0., 0., double(NAN), 47.397879855533304, 8.545259801757693, 50}},
+        {MAV_CMD_DO_SET_CAM_TRIGG_DIST, {0., 0., 0., 0., 0., 0., 0.}},
+        {MAV_CMD_NAV_WAYPOINT, {0., 0., 0., double(NAN), 47.3978173834048, 8.545355371702888, 50}},
+        {MAV_CMD_NAV_WAYPOINT,
+         {0., 0., 0., double(NAN), 47.397792837129174, 8.545297294381587, 50}},
+        {MAV_CMD_NAV_WAYPOINT,
+         {0., 0., 0., double(NAN), 47.397855309209426, 8.545201724412054, 50}},
+        {MAV_CMD_DO_SET_CAM_TRIGG_DIST, {250., 0., 1., 0., 0., 0., 0.}},
+        {MAV_CMD_NAV_WAYPOINT,
+         {0., 0., 0., double(NAN), 47.397894043423285, 8.545142468524519, 50}},
+        {MAV_CMD_DO_SET_CAM_TRIGG_DIST, {0., 0., 0., 0., 0., 0., 0.}},
+        {MAV_CMD_NAV_WAYPOINT,
+         {0., 0., 0., double(NAN), 47.397956515374865, 8.545046898187849, 50}},
+        {MAV_CMD_NAV_WAYPOINT,
+         {0., 0., 0., double(NAN), 47.397911199101806, 8.545020594879665, 50}},
+        {MAV_CMD_NAV_WAYPOINT, {0., 0., 0., double(NAN), 47.39784872717209, 8.545116165165322, 50}},
+        {MAV_CMD_DO_SET_CAM_TRIGG_DIST, {250., 0., 1., 0., 0., 0., 0.}},
+        {MAV_CMD_NAV_WAYPOINT, {0., 0., 0., double(NAN), 47.39783076285621, 8.545143647120529, 50}},
+        {MAV_CMD_DO_SET_CAM_TRIGG_DIST, {0., 0., 0., 0., 0., 0., 0.}},
+        {MAV_CMD_NAV_WAYPOINT, {0., 0., 0., double(NAN), 47.39776829082423, 8.545239217114402, 50}},
+        // Survey ends here
+        // Corridor Scan starts here
+        {MAV_CMD_NAV_WAYPOINT, {0., 0., 0., double(NAN), 47.3976842915956, 8.545111950891618, 50}},
+        {MAV_CMD_DO_SET_CAM_TRIGG_DIST, {25., 0., 1., 0., 0., 0., 0.}},
+        {MAV_CMD_NAV_WAYPOINT, {0., 0., 0., double(NAN), 47.39767426032188, 8.545243979383299, 50}},
+        {MAV_CMD_DO_SET_CAM_TRIGG_DIST, {25., 0., 1., 0., 0., 0., 0.}},
+        {MAV_CMD_NAV_WAYPOINT, {0., 0., 0., double(NAN), 47.39766439222148, 8.545373858243078, 50}},
+        {MAV_CMD_NAV_WAYPOINT, {0., 0., 0., double(NAN), 47.39766180157361, 8.545586905499258, 50}},
+        {MAV_CMD_NAV_WAYPOINT, {0., 0., 0., double(NAN), 47.39779107211276, 8.545911807235703, 50}},
+        {MAV_CMD_NAV_WAYPOINT,
+         {0., 0., 0., double(NAN), 47.398005467277635, 8.545879128614397, 50}},
+        {MAV_CMD_NAV_WAYPOINT, {0., 0., 0., double(NAN), 47.39809492445337, 8.54586549325971, 50}},
+        {MAV_CMD_NAV_WAYPOINT,
+         {0., 0., 0., double(NAN), 47.398099539336236, 8.545931571871845, 50}},
+        {MAV_CMD_NAV_WAYPOINT, {0., 0., 0., double(NAN), 47.39801008215267, 8.54594520711554, 50}},
+        {MAV_CMD_DO_SET_CAM_TRIGG_DIST, {25., 0., 1., 0., 0., 0., 0.}},
+        {MAV_CMD_NAV_WAYPOINT, {0., 0., 0., double(NAN), 47.39776694725207, 8.545982265990538, 50}},
+        {MAV_CMD_NAV_WAYPOINT, {0., 0., 0., double(NAN), 47.3976166151349, 8.545604428957498, 50}},
+        {MAV_CMD_NAV_WAYPOINT, {0., 0., 0., double(NAN), 47.39761947130397, 8.545369547331699, 50}},
+        {MAV_CMD_NAV_WAYPOINT, {0., 0., 0., double(NAN), 47.39762957485054, 8.545236569673113, 50}},
+        {MAV_CMD_NAV_WAYPOINT, {0., 0., 0., double(NAN), 47.39763960611574, 8.545104541291987, 50}},
+        {MAV_CMD_DO_SET_CAM_TRIGG_DIST, {0., 0., 0., 0., 0., 0., 0.}},
+        // Corridor Scan ends here
+        {MAV_CMD_NAV_RETURN_TO_LAUNCH, {0., 0., 0., 0., 0., 0., 0.}}};
+
+    // Build mission items for comparison
+    std::vector<Mission::MissionItem> mission_items_local;
+    build_local_mission_items<>(items_test, mission_items_local);
+    test_mission_items(QGC_COMPLEX_SAMPLE_PLAN, mission_items_local);
+}
 
 TEST(QGCMissionImport, ValidateQGCMissonItems)
 {
@@ -62,27 +166,9 @@ TEST(QGCMissionImport, ValidateQGCMissonItems)
 
     // Build mission items for comparison
     std::vector<Mission::MissionItem> mission_items_local;
-    MissionItem new_mission_item{};
-    Mission::Result result = Mission::Result::Success;
+    build_local_mission_items(items_test, mission_items_local);
 
-    for (auto& qgc_it : items_test) {
-        auto command = qgc_it.command;
-        auto params = qgc_it.params;
-        result = compose_mission_items(command, params, new_mission_item, mission_items_local);
-        EXPECT_EQ(result, Mission::Result::Success);
-    }
-    mission_items_local.push_back(new_mission_item);
-
-    // Import Mission items from QGC plan
-    auto import_result = MissionImpl::import_qgroundcontrol_mission(QGC_SAMPLE_PLAN);
-    ASSERT_EQ(import_result.first, Mission::Result::Success);
-    EXPECT_NE(import_result.second.mission_items.size(), 0);
-
-    // Compare local & parsed mission items
-    ASSERT_EQ(mission_items_local.size(), import_result.second.mission_items.size());
-    for (unsigned i = 0; i < import_result.second.mission_items.size(); ++i) {
-        compare(mission_items_local.at(i), import_result.second.mission_items.at(i));
-    }
+    test_mission_items(QGC_SAMPLE_PLAN, mission_items_local);
 }
 
 Mission::Result compose_mission_items(

--- a/src/plugins/mission/qgroundcontrol_sample_with_survey.plan
+++ b/src/plugins/mission/qgroundcontrol_sample_with_survey.plan
@@ -1,0 +1,956 @@
+{
+    "fileType": "Plan",
+    "geoFence": {
+        "circles": [
+        ],
+        "polygons": [
+        ],
+        "version": 2
+    },
+    "groundStation": "QGroundControl",
+    "mission": {
+        "cruiseSpeed": 15,
+        "firmwareType": 12,
+        "hoverSpeed": 5,
+        "items": [
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 15,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 22,
+                "doJumpId": 1,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    47.39781011,
+                    8.54553801,
+                    15
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "TransectStyleComplexItem": {
+                    "CameraCalc": {
+                        "AdjustedFootprintFrontal": 250,
+                        "AdjustedFootprintSide": 5,
+                        "CameraName": "Manual (no camera specs)",
+                        "DistanceToSurface": 50,
+                        "DistanceToSurfaceRelative": true,
+                        "version": 1
+                    },
+                    "CameraShots": 4,
+                    "CameraTriggerInTurnAround": false,
+                    "FollowTerrain": false,
+                    "HoverAndCapture": false,
+                    "Items": [
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 2,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.39784192965106,
+                                8.545413449078293,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 3,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.39790440182785,
+                                8.545317879157443,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 206,
+                            "doJumpId": 4,
+                            "frame": 2,
+                            "params": [
+                                250,
+                                0,
+                                1,
+                                0,
+                                0,
+                                0,
+                                0
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 5,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.397974177081146,
+                                8.545211136580374,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 206,
+                            "doJumpId": 6,
+                            "frame": 2,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 7,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.398036649089796,
+                                8.545115566179781,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 8,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.39800123401638,
+                                8.545074115797751,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 9,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.39793876204219,
+                                8.545169686183264,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 206,
+                            "doJumpId": 10,
+                            "frame": 2,
+                            "params": [
+                                250,
+                                0,
+                                1,
+                                0,
+                                0,
+                                0,
+                                0
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 11,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.397879855533304,
+                                8.545259801757693,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 206,
+                            "doJumpId": 12,
+                            "frame": 2,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 13,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.3978173834048,
+                                8.545355371702888,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 14,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.397792837129174,
+                                8.545297294381587,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 15,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.397855309209426,
+                                8.545201724412054,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 206,
+                            "doJumpId": 16,
+                            "frame": 2,
+                            "params": [
+                                250,
+                                0,
+                                1,
+                                0,
+                                0,
+                                0,
+                                0
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 17,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.397894043423285,
+                                8.545142468524519,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 206,
+                            "doJumpId": 18,
+                            "frame": 2,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 19,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.397956515374865,
+                                8.545046898187849,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 20,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.397911199101806,
+                                8.545020594879665,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 21,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.39784872717209,
+                                8.545116165165322,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 206,
+                            "doJumpId": 22,
+                            "frame": 2,
+                            "params": [
+                                250,
+                                0,
+                                1,
+                                0,
+                                0,
+                                0,
+                                0
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 23,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.39783076285621,
+                                8.545143647120529,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 206,
+                            "doJumpId": 24,
+                            "frame": 2,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 25,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.39776829082423,
+                                8.545239217114402,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        }
+                    ],
+                    "Refly90Degrees": false,
+                    "TurnAroundDistance": 10,
+                    "VisualTransectPoints": [
+                        [
+                            47.39784192965106,
+                            8.545413449078293
+                        ],
+                        [
+                            47.39790440182785,
+                            8.545317879157443
+                        ],
+                        [
+                            47.397974177081146,
+                            8.545211136580374
+                        ],
+                        [
+                            47.398036649089796,
+                            8.545115566179781
+                        ],
+                        [
+                            47.39800123401638,
+                            8.545074115797751
+                        ],
+                        [
+                            47.39793876204219,
+                            8.545169686183264
+                        ],
+                        [
+                            47.397879855533304,
+                            8.545259801757693
+                        ],
+                        [
+                            47.3978173834048,
+                            8.545355371702888
+                        ],
+                        [
+                            47.397792837129174,
+                            8.545297294381587
+                        ],
+                        [
+                            47.397855309209426,
+                            8.545201724412054
+                        ],
+                        [
+                            47.397894043423285,
+                            8.545142468524519
+                        ],
+                        [
+                            47.397956515374865,
+                            8.545046898187849
+                        ],
+                        [
+                            47.397911199101806,
+                            8.545020594879665
+                        ],
+                        [
+                            47.39784872717209,
+                            8.545116165165322
+                        ],
+                        [
+                            47.39783076285621,
+                            8.545143647120529
+                        ],
+                        [
+                            47.39776829082423,
+                            8.545239217114402
+                        ]
+                    ],
+                    "version": 1
+                },
+                "angle": 314,
+                "complexItemType": "survey",
+                "entryLocation": 0,
+                "flyAlternateTransects": false,
+                "polygon": [
+                    [
+                        47.397983603206725,
+                        8.54522216909925
+                    ],
+                    [
+                        47.397924595864666,
+                        8.545365659054301
+                    ],
+                    [
+                        47.39780953215994,
+                        8.545093414856652
+                    ],
+                    [
+                        47.397936624425284,
+                        8.545167184280425
+                    ]
+                ],
+                "splitConcavePolygons": false,
+                "type": "ComplexItem",
+                "version": 5
+            },
+            {
+                "CorridorWidth": 10,
+                "EntryPoint": 0,
+                "TransectStyleComplexItem": {
+                    "CameraCalc": {
+                        "AdjustedFootprintFrontal": 25,
+                        "AdjustedFootprintSide": 5,
+                        "CameraName": "Manual (no camera specs)",
+                        "DistanceToSurface": 50,
+                        "DistanceToSurfaceRelative": true,
+                        "version": 1
+                    },
+                    "CameraShots": 9,
+                    "CameraTriggerInTurnAround": true,
+                    "FollowTerrain": false,
+                    "HoverAndCapture": false,
+                    "Items": [
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 26,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.3976842915956,
+                                8.545111950891618,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 206,
+                            "doJumpId": 27,
+                            "frame": 2,
+                            "params": [
+                                25,
+                                0,
+                                1,
+                                0,
+                                0,
+                                0,
+                                0
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 28,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.39767426032188,
+                                8.545243979383299,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 206,
+                            "doJumpId": 29,
+                            "frame": 2,
+                            "params": [
+                                25,
+                                0,
+                                1,
+                                0,
+                                0,
+                                0,
+                                0
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 30,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.39766439222148,
+                                8.545373858243078,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 31,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.39766180157361,
+                                8.545586905499258,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 32,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.39779107211276,
+                                8.545911807235703,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 33,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.398005467277635,
+                                8.545879128614397,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 34,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.39809492445337,
+                                8.54586549325971,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 35,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.398099539336236,
+                                8.545931571871845,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 36,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.39801008215267,
+                                8.54594520711554,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 206,
+                            "doJumpId": 37,
+                            "frame": 2,
+                            "params": [
+                                25,
+                                0,
+                                1,
+                                0,
+                                0,
+                                0,
+                                0
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 38,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.39776694725207,
+                                8.545982265990538,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 39,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.3976166151349,
+                                8.545604428957498,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 40,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.39761947130397,
+                                8.545369547331699,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 41,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.39762957485054,
+                                8.545236569673113,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 16,
+                            "doJumpId": 42,
+                            "frame": 3,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                null,
+                                47.39763960611574,
+                                8.545104541291987,
+                                50
+                            ],
+                            "type": "SimpleItem"
+                        },
+                        {
+                            "autoContinue": true,
+                            "command": 206,
+                            "doJumpId": 43,
+                            "frame": 2,
+                            "params": [
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0
+                            ],
+                            "type": "SimpleItem"
+                        }
+                    ],
+                    "Refly90Degrees": false,
+                    "TurnAroundDistance": 10,
+                    "VisualTransectPoints": [
+                        [
+                            47.3976842915956,
+                            8.545111950891618
+                        ],
+                        [
+                            47.39767426032188,
+                            8.545243979383299
+                        ],
+                        [
+                            47.39766439222148,
+                            8.545373858243078
+                        ],
+                        [
+                            47.39766180157361,
+                            8.545586905499258
+                        ],
+                        [
+                            47.39779107211276,
+                            8.545911807235703
+                        ],
+                        [
+                            47.398005467277635,
+                            8.545879128614397
+                        ],
+                        [
+                            47.39809492445337,
+                            8.54586549325971
+                        ],
+                        [
+                            47.398099539336236,
+                            8.545931571871845
+                        ],
+                        [
+                            47.39801008215267,
+                            8.54594520711554
+                        ],
+                        [
+                            47.39776694725207,
+                            8.545982265990538
+                        ],
+                        [
+                            47.3976166151349,
+                            8.545604428957498
+                        ],
+                        [
+                            47.39761947130397,
+                            8.545369547331699
+                        ],
+                        [
+                            47.39762957485054,
+                            8.545236569673113
+                        ],
+                        [
+                            47.39763960611574,
+                            8.545104541291987
+                        ]
+                    ],
+                    "version": 1
+                },
+                "complexItemType": "CorridorScan",
+                "polyline": [
+                    [
+                        47.39765191758626,
+                        8.545240274526634
+                    ],
+                    [
+                        47.39764193176274,
+                        8.545371702786468
+                    ],
+                    [
+                        47.39763920835458,
+                        8.545595667232135
+                    ],
+                    [
+                        47.39777900968782,
+                        8.545947036621186
+                    ],
+                    [
+                        47.3980077747199,
+                        8.54591216786352
+                    ]
+                ],
+                "type": "ComplexItem",
+                "version": 2
+            },
+            {
+                "autoContinue": true,
+                "command": 20,
+                "doJumpId": 44,
+                "frame": 2,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                ],
+                "type": "SimpleItem"
+            }
+        ],
+        "plannedHomePosition": [
+            47.3977424,
+            8.545599,
+            489
+        ],
+        "vehicleType": 2,
+        "version": 2
+    },
+    "rallyPoints": {
+        "points": [
+        ],
+        "version": 2
+    },
+    "version": 1
+}


### PR DESCRIPTION
Currently the import_qgroundcontrol_mission function can only import simple items (waypoints).

QGC also supports surveys, corridor scans and structure scans.

This pull should fix the first two and allow importing surveys and corridor scans.

See https://github.com/mavlink/MAVSDK/issues/1116

It's not tested as I have problems connecting the server with my python-mavsdk scripts. (Timeout issues).
But it compiles at least.