### PR TITLE
Update Configuration for indep. control of sysid, compid, usage_type.

### DIFF
--- a/src/core/mavsdk.cpp
+++ b/src/core/mavsdk.cpp
@@ -124,14 +124,30 @@ uint8_t Mavsdk::Configuration::get_system_id() const
     return _system_id;
 }
 
+void Mavsdk::Configuration::set_system_id(uint8_t system_id)
+{
+    _system_id = system_id;
+}
+
 uint8_t Mavsdk::Configuration::get_component_id() const
 {
     return _component_id;
+}
+
+void Mavsdk::Configuration::set_component_id(uint8_t component_id)
+{
+    _component_id = component_id;
 }
 
 Mavsdk::Configuration::UsageType Mavsdk::Configuration::get_usage_type() const
 {
     return _usage_type;
 }
+
+void Mavsdk::Configuration::set_usage_type(Mavsdk::Configuration::UsageType usage_type)
+{
+    _usage_type = usage_type;
+}
+
 
 } // namespace mavsdk

--- a/src/core/mavsdk.h
+++ b/src/core/mavsdk.h
@@ -162,11 +162,21 @@ public:
          */
         uint8_t get_system_id() const;
 
+        /** 
+         * @brief Set the system id of this configuration.
+         */
+        void set_system_id(uint8_t system_id);
+
         /**
          * @brief Get the component id of this configuration
          * @return `uint8_t` the component id stored in this configuration,from 1-255
          */
         uint8_t get_component_id() const;
+
+        /**
+         * @brief Set the component id of this configuration.
+         */
+        void set_component_id(uint8_t component_id);
 
         /**
          * @brief UsageTypes of configurations, used for automatic ID setting
@@ -181,6 +191,11 @@ public:
 
         /** @brief Usage type of this configuration, used for automatic ID set */
         UsageType get_usage_type() const;
+
+        /**
+         * @brief Set the usage type of this configuration.
+         */
+        void set_usage_type(UsageType usage_type);
 
     private:
         uint8_t _system_id;

--- a/src/core/mavsdk_impl.cpp
+++ b/src/core/mavsdk_impl.cpp
@@ -273,6 +273,7 @@ void MavsdkImpl::set_configuration(Mavsdk::Configuration configuration)
 {
     own_address.system_id = configuration.get_system_id();
     own_address.component_id = configuration.get_component_id();
+    _configuration.set_usage_type(configuration.get_usage_type());
 }
 
 std::vector<uint64_t> MavsdkImpl::get_system_uuids() const


### PR DESCRIPTION
This regards issue #1158.

I think there are maybe two things here, closely related.

One is that the user ultimately doesnt have full control over the Mavsdk::Configuration object. This object basically exists to contain three parameters: system_id, component_id, and usage_type .. and, as far as I can tell, to help suggest good settings for them. Eg if the user provides a usage_type it'll set system_id and component_id automatically based on best guesses, and vice versa. The problem is that the user can't independently set them to arbitrary values, and I think this should be an option, for users with custom situations/requirements (as I seem to have).

The second issue is that even if a user is able to construct the right Configuration object, as it is you can only use it to set a MavsdkImpl object's internal system_id and component_id (stored in its "own_address MAVLinkAddress member, which is just a struct with those two vars), and not its usage_type. This happens by calling MavsdkImpl::set_configuration (defined in mavsdk_impl.cpp). In fact, MavsdkImpl doesnt have a usage_type member. I could only find one place where a system's usage type is looked up directly, and that is in MavsdkImpl::get_mav_type() (which is in turn used when creating heartbeat messages) and there it uses the usage_type from its member variable '_configuration'.

I kinda want to replace the current approach which uses the Configuration class, with a more flexible functionality that would manipulate MavsdkImpl member settings directly, via its constructor and some setters. But that would break the current API with the Configuration mechanism, and I might not fully understand the original intent..

This pull request only adds to the existing API, so existing code will still work, and tries to keep the changes minimal.

First, add setters to the Configuration class, making its system_id, component_id, and usage_type settings independently configurable.

Then, update MavsdkImpl::set_configuration so that in addition to updating the system_id and component_id, it'll update the "_configuration" member var as well. I looked thru the code in core/, and seems like that won't break anything. It didn't for my use case anyway (which at the moment is using MAVSDK to communicate with a gimbal from a linux laptop over a serial connection).

In reference to my use case that I described in issue #1158, I can now do the following to configure mavsdk how I need:

   mavsdk::Mavsdk dc;
   mavsdk::Mavsdk::Configuration mavsdkcfg(mavsdk::Mavsdk::Configuration::UsageType::CompanionComputer);
   mavsdkcfg.set_system_id(58);
   dc.set_configuration(mavsdkcfg);

And then the heartbeat messages have the right system_id and usage_type, or at least it's enough so that my gimbal will work.

Note, I haven't run any other tests..

@julianoes 
#1158 