### PR TITLE
Disable timesync by default

### DIFF
--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -57,4 +57,9 @@ void System::register_component_discovered_callback(discover_callback_t callback
     return _system_impl->register_component_discovered_callback(callback);
 }
 
+void System::enable_timesync()
+{
+    _system_impl->enable_timesync();
+}
+
 } // namespace mavsdk

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -98,6 +98,11 @@ public:
     void register_component_discovered_callback(discover_callback_t callback) const;
 
     /**
+     * @brief Enable time synchronization using the TIMESYNC messages.
+     */
+    void enable_timesync();
+
+    /**
      * @brief Copy constructor (object is not copyable).
      */
     System(const System&) = delete;

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -108,6 +108,11 @@ void SystemImpl::unregister_timeout_handler(const void* cookie)
     _parent.timeout_handler.remove(cookie);
 }
 
+void SystemImpl::enable_timesync()
+{
+    _timesync.enable();
+}
+
 void SystemImpl::process_mavlink_message(mavlink_message_t& message)
 {
     // This is a low level interface where incoming messages can be tampered

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -53,6 +53,8 @@ public:
         MavsdkImpl& parent, uint8_t system_id, uint8_t component_id, bool connected);
     ~SystemImpl();
 
+    void enable_timesync();
+
     void process_mavlink_message(mavlink_message_t& message);
 
     typedef std::function<void(const mavlink_message_t&)> mavlink_message_handler_t;
@@ -231,7 +233,6 @@ public:
     const SystemImpl& operator=(const SystemImpl&) = delete;
 
 private:
-    // Helper methods added to increase readablity
     static bool is_autopilot(uint8_t comp_id);
     static bool is_camera(uint8_t comp_id);
 

--- a/src/core/timesync.h
+++ b/src/core/timesync.h
@@ -12,6 +12,7 @@ public:
     Timesync(SystemImpl& parent);
     ~Timesync();
 
+    void enable();
     void do_work();
 
     Timesync(const Timesync&) = delete;
@@ -30,6 +31,7 @@ private:
     static constexpr uint64_t _MAX_CONS_HIGH_RTT = 5;
     static constexpr uint64_t _MAX_RTT_SAMPLE_MS = 10;
     uint64_t _high_rtt_count{};
-    bool _autopilot_timesync_acquired = false;
+    bool _autopilot_timesync_acquired{false};
+    bool _is_enabled{false};
 };
 } // namespace mavsdk


### PR DESCRIPTION
It's not completely clear to me when timesync should be enabled: it seems like it is a broadcast, so I'm not sure if all the components should send it or only the autopilot.

I disabled it by default, so those who use it (e.g. @irsdkv) should enable it with `system.enable_timesync()`.