### PR TITLE
Fix serial connection on windows

### DIFF
--- a/src/core/cli_arg.cpp
+++ b/src/core/cli_arg.cpp
@@ -111,6 +111,7 @@ bool CliArg::find_path(std::string& rest)
                     _path = "";
                     return false;
                 }
+            _path = "\\\\.\\" + _path;
             }
         } else {
             LogWarn() << "Invalid serial path";


### PR DESCRIPTION
on windows, for serial port > 9, "\\\\.\\" is needed before "COM"
These characters are also compatible with port <= 9

more details here: https://stackoverflow.com/questions/27909666/createfile-serial-communication-issue