### PR TITLE
Remove sysid from UDP remotes, which induced duplicated messages

### DIFF
--- a/src/core/udp_connection.h
+++ b/src/core/udp_connection.h
@@ -47,11 +47,8 @@ private:
 
         bool operator==(const UdpConnection::Remote& other)
         {
-            return ip == other.ip && port_number == other.port_number &&
-                   system_id == other.system_id;
+            return ip == other.ip && port_number == other.port_number;
         }
-
-        uint8_t system_id{0};
     };
     std::vector<Remote> _remotes{};
 


### PR DESCRIPTION
Until this PR, a UDP remote is identified by an `<ip, port, sysid>`. This means that if two systems exist on the same `UDPConnection` (which typically happens when you have an onboard component connecting to both the FCU and a ground station), two remotes will be created. As a consequence, broadcast messages (such as `HEARTBEAT` or `TIMESYNC`) will be sent twice on that `<ip, port>`, because of the different `sysid`s. This should not happen.

This PR removes the `sysid` from the remotes, so that they are now identified with `<ip, port>`. I believe that the only consequence of that (apart from not sending duplicated messages) is that directed messages will be sent to all remotes instead of being filtered by `target_system_id`. I believe this is fine, because that's anyway the case for all the broadcast messages.

Note: it seems to me that there was duplicated code there, too, that I removed. Not sure if that has consequences, but I don't think so.