### PR TITLE
log_files: fix chunks_received size in download_log_file

### DIFF
--- a/src/core/mavsdk.cpp
+++ b/src/core/mavsdk.cpp
@@ -149,5 +149,4 @@ void Mavsdk::Configuration::set_usage_type(Mavsdk::Configuration::UsageType usag
     _usage_type = usage_type;
 }
 
-
 } // namespace mavsdk

--- a/src/core/mavsdk.h
+++ b/src/core/mavsdk.h
@@ -162,7 +162,7 @@ public:
          */
         uint8_t get_system_id() const;
 
-        /** 
+        /**
          * @brief Set the system id of this configuration.
          */
         void set_system_id(uint8_t system_id);

--- a/src/plugins/log_files/log_files_impl.cpp
+++ b/src/plugins/log_files/log_files_impl.cpp
@@ -242,7 +242,9 @@ void LogFilesImpl::download_log_file_async(
         _data.part_start = 0;
         const auto part_size = determine_part_end() - _data.part_start;
         _data.bytes.resize(part_size);
-        _data.chunks_received.resize(part_size / MAVLINK_MSG_LOG_DATA_FIELD_DATA_LEN);
+        _data.chunks_received.resize(
+            part_size / MAVLINK_MSG_LOG_DATA_FIELD_DATA_LEN +
+            ((part_size % MAVLINK_MSG_LOG_DATA_FIELD_DATA_LEN) != 0));
 
         _parent->register_timeout_handler(
             std::bind(&LogFilesImpl::data_timeout, this), DATA_TIMEOUT_S, &_data.cookie);
@@ -376,7 +378,9 @@ void LogFilesImpl::check_part()
 
             const auto part_size = determine_part_end() - _data.part_start;
             _data.bytes.resize(part_size);
-            _data.chunks_received.resize(part_size / MAVLINK_MSG_LOG_DATA_FIELD_DATA_LEN);
+            _data.chunks_received.resize(
+                part_size / MAVLINK_MSG_LOG_DATA_FIELD_DATA_LEN +
+                ((part_size % MAVLINK_MSG_LOG_DATA_FIELD_DATA_LEN) != 0));
             std::fill(_data.chunks_received.begin(), _data.chunks_received.end(), false);
 
             request_log_data(_data.id, _data.part_start, _data.bytes.size());


### PR DESCRIPTION
I have always an error at the end of downloading a log file :
![Sans titre](https://user-images.githubusercontent.com/59083163/91441482-93179980-e870-11ea-821a-0b0cd748edff.png)

I use a mavsdk_server compiled on develop branch on Windows.

After digging a bit, I found that if log part size in not a multiple of MAVLINK_MSG_LOG_DATA_FIELD_DATA_LEN 
(it seems that there is no reason to be of a particular size),
chunks_received size must be "part_size / MAVLINK_MSG_LOG_DATA_FIELD_DATA_LEN +1"