### PR TITLE
Fix examples following mavlink update

### DIFF
--- a/examples/battery/battery.cpp
+++ b/examples/battery/battery.cpp
@@ -96,7 +96,8 @@ void send_battery_status(std::shared_ptr<MavlinkPassthrough> mavlink_passthrough
         -1, // energy consumed hJ
         80, // battery_remaining %
         3600, // time_remaining
-        MAV_BATTERY_CHARGE_STATE_OK);
+        MAV_BATTERY_CHARGE_STATE_OK,
+        0); // voltages_ext
 
     mavlink_passthrough->send_message(message);
 }


### PR DESCRIPTION
Fixes examples, which were broken by an extension in the recent MAVLink update.

Resolves #1178.