### PR TITLE
integration_tests: fix takeoff and hover test with PX4 v1.11.0

### DIFF
--- a/docker/Dockerfile-Ubuntu-20.04-PX4-SITL-v1.11
+++ b/docker/Dockerfile-Ubuntu-20.04-PX4-SITL-v1.11
@@ -19,7 +19,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 RUN git clone https://github.com/PX4/Firmware.git ${FIRMWARE_DIR}
-RUN git -C ${FIRMWARE_DIR} checkout v1.11.0
+RUN git -C ${FIRMWARE_DIR} checkout release/1.11-loiter-switch-fix # should point to v1.11.x again once patch is merged and released.
 RUN git -C ${FIRMWARE_DIR} submodule update --init --recursive
 RUN cd ${FIRMWARE_DIR} && Tools/setup/ubuntu.sh --no-nuttx
 RUN cd ${FIRMWARE_DIR} && DONT_RUN=1 make px4_sitl gazebo && DONT_RUN=1 make px4_sitl gazebo


### PR DESCRIPTION
This hopefully fixes the integration tests.

Uses https://github.com/PX4/Firmware/pull/15808.