### PR TITLE
system: add getter for MAVLink system ID

### DIFF
--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -52,6 +52,11 @@ uint64_t System::get_uuid() const
     return _system_impl->get_uuid();
 }
 
+uint8_t System::get_system_id() const
+{
+    return _system_impl->get_system_id();
+}
+
 void System::register_component_discovered_callback(discover_callback_t callback) const
 {
     return _system_impl->register_component_discovered_callback(callback);

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -90,6 +90,15 @@ public:
     uint64_t get_uuid() const;
 
     /**
+     * @brief MAVLink System ID of connected system.
+     *
+     * @note: this is 0 if nothing is connected yet.
+     *
+     * @return the system ID.
+     */
+    uint8_t get_system_id() const;
+
+    /**
      * @brief Register a callback to be called when a component is discovered.
      *
      * @param callback a function of type void(ComponentType) which will be called with the


### PR DESCRIPTION
This helps to distinguish various systems.