### PR TITLE
Support statustext with multiple chunks, fix calibration

### DIFF
--- a/src/cmake/compiler_flags.cmake
+++ b/src/cmake/compiler_flags.cmake
@@ -30,6 +30,9 @@ else()
         if (WERROR)
             set(warnings "${warnings} -Werror")
         endif()
+
+        # Allow #pragma GCC diagnostic ignored "-Wstringop-truncation"
+        set(warnings "${warnings} -Wno-pragmas -Wno-unknown-warning-option")
     endif()
 
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(mavsdk
     mavlink_mission_transfer.cpp
     mavlink_parameters.cpp
     mavlink_receiver.cpp
+    mavlink_statustext_handler.cpp
     mavlink_message_handler.cpp
     plugin_impl_base.cpp
     serial_connection.cpp
@@ -109,6 +110,7 @@ list(APPEND UNIT_TEST_SOURCES
     ${PROJECT_SOURCE_DIR}/core/safe_queue_test.cpp
     ${PROJECT_SOURCE_DIR}/core/mavsdk_test.cpp
     ${PROJECT_SOURCE_DIR}/core/mavlink_mission_transfer_test.cpp
+    ${PROJECT_SOURCE_DIR}/core/mavlink_statustext_handler_test.cpp
     ${PROJECT_SOURCE_DIR}/core/geometry_test.cpp
 )
 set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} PARENT_SCOPE)

--- a/src/core/mavlink_statustext_handler.cpp
+++ b/src/core/mavlink_statustext_handler.cpp
@@ -1,0 +1,63 @@
+#include "mavlink_statustext_handler.h"
+#include "log.h"
+
+namespace mavsdk {
+
+std::pair<bool, std::string> MavlinkStatustextHandler::process_severity(const mavlink_statustext_t& statustext)
+{
+    switch (statustext.severity) {
+        case MAV_SEVERITY_EMERGENCY:
+            return {true, "emergency"};
+        case MAV_SEVERITY_ALERT:
+            return {true, "alert"};
+        case MAV_SEVERITY_CRITICAL:
+            return {true, "critical"};
+        case MAV_SEVERITY_ERROR:
+            return {true, "error"};
+        case MAV_SEVERITY_WARNING:
+            return {true, "warning"};
+        case MAV_SEVERITY_NOTICE:
+            return {true, "notice"};
+        case MAV_SEVERITY_INFO:
+            return {true, "info"};
+        case MAV_SEVERITY_DEBUG:
+            return {true, "debug"};
+        default:
+            return {false, ""};
+    }
+}
+
+std::pair<bool, std::string> MavlinkStatustextHandler::process_text(const mavlink_statustext_t& statustext)
+{
+    char text_with_null[sizeof(statustext.text) + 1] {};
+    strncpy(text_with_null, statustext.text, sizeof(text_with_null) - 1);
+
+    if (statustext.id > 0) {
+
+        if (statustext.id != _last_id) {
+            _temp_multi_str = "";
+            _last_chunk_seq = 0;
+            _last_id = statustext.id;
+        }
+
+        // We can recover from missing chunks in-between but not if the first or last one is lost.
+        if (_last_chunk_seq + 1 < statustext.chunk_seq) {
+            _temp_multi_str += "[ missing ... ]";
+        }
+
+        _last_chunk_seq = statustext.chunk_seq;
+
+        _temp_multi_str += text_with_null;
+
+        if (strlen(text_with_null) == sizeof(statustext.text)) {
+            // No zero termination yet, keep going.
+            return {false, ""};
+        } else {
+            return {true, _temp_multi_str};
+        }
+    }
+
+    return std::make_pair<bool, std::string>(true, text_with_null);
+}
+
+} // namespace mavsdk

--- a/src/core/mavlink_statustext_handler.cpp
+++ b/src/core/mavlink_statustext_handler.cpp
@@ -3,7 +3,8 @@
 
 namespace mavsdk {
 
-std::pair<bool, std::string> MavlinkStatustextHandler::process_severity(const mavlink_statustext_t& statustext)
+std::pair<bool, std::string>
+MavlinkStatustextHandler::process_severity(const mavlink_statustext_t& statustext)
 {
     switch (statustext.severity) {
         case MAV_SEVERITY_EMERGENCY:
@@ -27,13 +28,13 @@ std::pair<bool, std::string> MavlinkStatustextHandler::process_severity(const ma
     }
 }
 
-std::pair<bool, std::string> MavlinkStatustextHandler::process_text(const mavlink_statustext_t& statustext)
+std::pair<bool, std::string>
+MavlinkStatustextHandler::process_text(const mavlink_statustext_t& statustext)
 {
-    char text_with_null[sizeof(statustext.text) + 1] {};
+    char text_with_null[sizeof(statustext.text) + 1]{};
     strncpy(text_with_null, statustext.text, sizeof(text_with_null) - 1);
 
     if (statustext.id > 0) {
-
         if (statustext.id != _last_id) {
             _temp_multi_str = "";
             _last_chunk_seq = 0;

--- a/src/core/mavlink_statustext_handler.h
+++ b/src/core/mavlink_statustext_handler.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "mavlink_include.h"
+#include <string>
+#include <utility>
+
+namespace mavsdk {
+
+class MavlinkStatustextHandler {
+public:
+    MavlinkStatustextHandler() = default;
+    ~MavlinkStatustextHandler() = default;
+
+    std::pair<bool, std::string> process_severity(const mavlink_statustext_t& statustext);
+    std::pair<bool, std::string> process_text(const mavlink_statustext_t& statustext);
+
+private:
+    std::string _temp_multi_str{};
+    uint16_t _last_id{0};
+    uint8_t _last_chunk_seq{0};
+};
+
+} // namespace mavsdk

--- a/src/core/mavlink_statustext_handler_test.cpp
+++ b/src/core/mavlink_statustext_handler_test.cpp
@@ -4,6 +4,12 @@
 
 using namespace mavsdk;
 
+// We need to use strncpy without zero termination, so with possible
+// stringop-truncation here, on purpose because the MAVLink message structure
+// of statustext.text does not include the zero termination.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+
 TEST(MavlinkStatustextHandler, Severities)
 {
     const std::vector<std::pair<uint8_t, std::string>> severities{
@@ -259,3 +265,5 @@ TEST(MavlinkStatustextHandler, MultiStatustextConsecutive)
         }
     }
 }
+
+#pragma GCC diagnostic pop

--- a/src/core/mavlink_statustext_handler_test.cpp
+++ b/src/core/mavlink_statustext_handler_test.cpp
@@ -1,0 +1,274 @@
+
+#include "mavlink_statustext_handler.h"
+#include <gtest/gtest.h>
+
+using namespace mavsdk;
+
+TEST(MavlinkStatustextHandler, Severities)
+{
+    const std::vector<std::pair<uint8_t, std::string>> severities {
+        {MAV_SEVERITY_DEBUG, "debug"},
+        {MAV_SEVERITY_INFO, "info"},
+        {MAV_SEVERITY_NOTICE, "notice"},
+        {MAV_SEVERITY_WARNING, "warning"},
+        {MAV_SEVERITY_ERROR, "error"},
+        {MAV_SEVERITY_CRITICAL, "critical"},
+        {MAV_SEVERITY_ALERT, "alert"},
+        {MAV_SEVERITY_EMERGENCY, "emergency"}
+    };
+
+    for (const auto& severity : severities) {
+        mavlink_statustext_t statustext{};
+        statustext.severity = severity.first;
+
+        MavlinkStatustextHandler handler;
+        auto result = handler.process_severity(statustext);
+        EXPECT_TRUE(result.first);
+        EXPECT_EQ(severity.second, result.second);
+    }
+}
+
+TEST(MavlinkStatustextHandler, WrongSeverity)
+{
+    mavlink_statustext_t statustext{};
+    statustext.severity = 255;
+
+    MavlinkStatustextHandler handler;
+    auto result = handler.process_severity(statustext);
+    EXPECT_FALSE(result.first);
+}
+
+TEST(MavlinkStatustextHandler, SingleStatustextWithNull)
+{
+    mavlink_statustext_t statustext{};
+    auto str = std::string {"Hello Reader"};
+    strncpy(statustext.text, str.c_str(), sizeof(statustext.text) - 1);
+
+    MavlinkStatustextHandler handler;
+    auto result = handler.process_text(statustext);
+    EXPECT_TRUE(result.first);
+    EXPECT_EQ(str, result.second);
+}
+
+TEST(MavlinkStatustextHandler, SingleStatustextWithoutNull)
+{
+    mavlink_statustext_t statustext{};
+    auto str = std::string {"asdfghjkl;asdfghjkl;asdfghjkl;asdfghjkl;asdfghjkl;"};
+    strncpy(statustext.text, str.c_str(), sizeof(statustext.text));
+
+    MavlinkStatustextHandler handler;
+    auto result = handler.process_text(statustext);
+    EXPECT_TRUE(result.first);
+    EXPECT_EQ(str, result.second);
+}
+
+TEST(MavlinkStatustextHandler, MultiStatustext)
+{
+    const std::string str =
+        "Lorem ipsum dolor sit amet, consectetur adipiscing"
+        " elit, sed do eiusmod tempor incididunt ut labore "
+        "et dolore magna aliqua. Venenatis cras sed felis e"
+        "get velit aliquet. Ac feugiat sed lectus vestibulu"
+        "m. Condimentum lacinia quis vel eros donec ac odio"
+        ". Eleifend mi in nulla posuere sollicitudin aliqua"
+        "m ultrices. Fusce ut placerat orci nulla pellentes"
+        "que dignissim.";
+
+    constexpr std::size_t chunk_len = sizeof(mavlink_statustext_t::text);
+
+    MavlinkStatustextHandler handler;
+
+    uint8_t chunk_seq = 0;
+    for (std::size_t start = 0; start < str.size(); start += chunk_len) {
+
+        bool is_last = (start + chunk_len >= str.size());
+
+        const std::size_t len = std::min(chunk_len, str.size() - start);
+        const auto chunk = str.substr(start, len);
+
+        mavlink_statustext_t statustext{};
+        strncpy(statustext.text, chunk.c_str(), sizeof(statustext.text));
+        statustext.id = 42;
+        statustext.chunk_seq = chunk_seq;
+
+        const auto result = handler.process_text(statustext);
+
+        if (is_last) {
+            EXPECT_TRUE(result.first);
+            EXPECT_EQ(result.second, str);
+        } else {
+            EXPECT_FALSE(result.first);
+        }
+        ++chunk_seq;
+    }
+}
+
+TEST(MavlinkStatustextHandler, MultiStatustextDivisibleByChunkLen)
+{
+    const std::string str =
+        "This string is unfortunately exactly the length of"
+        "two chunks which means it needs another message ju"
+        "st to send the strange zero termination character!";
+
+    constexpr std::size_t chunk_len = sizeof(mavlink_statustext_t::text);
+
+    MavlinkStatustextHandler handler;
+
+    uint8_t chunk_seq = 0;
+    for (std::size_t start = 0; start <= str.size(); start += chunk_len) {
+
+        bool is_last = (start + chunk_len > str.size());
+
+        const std::size_t len = std::min(chunk_len, str.size() - start);
+        const auto chunk = str.substr(start, len);
+
+        mavlink_statustext_t statustext{};
+        if (len > 0) {
+            strncpy(statustext.text, chunk.c_str(), sizeof(statustext.text));
+        } else {
+            // Last message with null only.
+            statustext.text[0] = '\0';
+        }
+        statustext.id = 42;
+        statustext.chunk_seq = chunk_seq;
+
+        const auto result = handler.process_text(statustext);
+
+        if (is_last) {
+            EXPECT_TRUE(result.first);
+            EXPECT_EQ(result.second, str);
+        } else {
+            EXPECT_FALSE(result.first);
+        }
+        ++chunk_seq;
+    }
+}
+
+TEST(MavlinkStatustextHandler, MultiStatustextMissingPart)
+{
+    const std::string str =
+        "Lorem ipsum dolor sit amet, consectetur adipiscing"
+        " elit, sed do eiusmod tempor incididunt ut labore "
+        "et dolore magna aliqua. Venenatis cras sed felis e"
+        "get velit aliquet. Ac feugiat sed lectus vestibulu"
+        "m. Condimentum lacinia quis vel eros donec ac odio"
+        ". Eleifend mi in nulla posuere sollicitudin aliqua"
+        "m ultrices. Fusce ut placerat orci nulla pellentes"
+        "que dignissim.";
+
+    const std::string str_missing =
+        "Lorem ipsum dolor sit amet, consectetur adipiscing"
+        " elit, sed do eiusmod tempor incididunt ut labore "
+        "et dolore magna aliqua. Venenatis cras sed felis e"
+        "[ missing ... ]"
+        "m. Condimentum lacinia quis vel eros donec ac odio"
+        ". Eleifend mi in nulla posuere sollicitudin aliqua"
+        "m ultrices. Fusce ut placerat orci nulla pellentes"
+        "que dignissim.";
+
+    constexpr std::size_t chunk_len = sizeof(mavlink_statustext_t::text);
+
+    MavlinkStatustextHandler handler;
+
+    uint8_t chunk_seq = 0;
+    for (std::size_t start = 0; start < str.size(); start += chunk_len) {
+
+        bool is_last = (start + chunk_len >= str.size());
+
+        const std::size_t len = std::min(chunk_len, str.size() - start);
+        const auto chunk = str.substr(start, len);
+
+        mavlink_statustext_t statustext{};
+        strncpy(statustext.text, chunk.c_str(), sizeof(statustext.text));
+        statustext.id = 42;
+        statustext.chunk_seq = chunk_seq;
+
+        if (chunk_seq != 3) {
+            const auto result = handler.process_text(statustext);
+
+            if (is_last) {
+                EXPECT_TRUE(result.first);
+                EXPECT_EQ(result.second, str_missing);
+            } else {
+                EXPECT_FALSE(result.first);
+            }
+        }
+        ++chunk_seq;
+    }
+}
+
+TEST(MavlinkStatustextHandler, MultiStatustextConsecutive)
+{
+    MavlinkStatustextHandler handler;
+
+    {
+        const std::string str =
+            "Lorem ipsum dolor sit amet, consectetur adipiscing"
+            " elit, sed do eiusmod tempor incididunt ut labore "
+            "et dolore magna aliqua. Venenatis cras sed felis e"
+            "get velit aliquet. Ac feugiat sed lectus vestibulu"
+            "m. Condimentum lacinia quis vel eros donec ac odio"
+            ". Eleifend mi in nulla posuere sollicitudin aliqua"
+            "m ultrices. Fusce ut placerat orci nulla pellentes"
+            "que dignissim.";
+
+        constexpr std::size_t chunk_len = sizeof(mavlink_statustext_t::text);
+
+        uint8_t chunk_seq = 0;
+        for (std::size_t start = 0; start < str.size(); start += chunk_len) {
+
+            bool is_last = (start + chunk_len >= str.size());
+
+            const std::size_t len = std::min(chunk_len, str.size() - start);
+            const auto chunk = str.substr(start, len);
+
+            mavlink_statustext_t statustext{};
+            strncpy(statustext.text, chunk.c_str(), sizeof(statustext.text));
+            statustext.id = 42;
+            statustext.chunk_seq = chunk_seq;
+
+            const auto result = handler.process_text(statustext);
+
+            if (is_last) {
+                EXPECT_TRUE(result.first);
+                EXPECT_EQ(result.second, str);
+            } else {
+                EXPECT_FALSE(result.first);
+            }
+            ++chunk_seq;
+        }
+    }
+
+    {
+        const std::string str =
+            "Blablablablablablablablablablablablablablablablabl"
+            "FooFooFooFoo.";
+
+        constexpr std::size_t chunk_len = sizeof(mavlink_statustext_t::text);
+
+        uint8_t chunk_seq = 0;
+        for (std::size_t start = 0; start < str.size(); start += chunk_len) {
+
+            bool is_last = (start + chunk_len >= str.size());
+
+            const std::size_t len = std::min(chunk_len, str.size() - start);
+            const auto chunk = str.substr(start, len);
+
+            mavlink_statustext_t statustext{};
+            strncpy(statustext.text, chunk.c_str(), sizeof(statustext.text));
+            statustext.id = 43;
+            statustext.chunk_seq = chunk_seq;
+
+            const auto result = handler.process_text(statustext);
+
+            if (is_last) {
+                EXPECT_TRUE(result.first);
+                EXPECT_EQ(result.second, str);
+            } else {
+                EXPECT_FALSE(result.first);
+            }
+            ++chunk_seq;
+        }
+    }
+}
+

--- a/src/core/mavlink_statustext_handler_test.cpp
+++ b/src/core/mavlink_statustext_handler_test.cpp
@@ -6,7 +6,7 @@ using namespace mavsdk;
 
 TEST(MavlinkStatustextHandler, Severities)
 {
-    const std::vector<std::pair<uint8_t, std::string>> severities {
+    const std::vector<std::pair<uint8_t, std::string>> severities{
         {MAV_SEVERITY_DEBUG, "debug"},
         {MAV_SEVERITY_INFO, "info"},
         {MAV_SEVERITY_NOTICE, "notice"},
@@ -14,8 +14,7 @@ TEST(MavlinkStatustextHandler, Severities)
         {MAV_SEVERITY_ERROR, "error"},
         {MAV_SEVERITY_CRITICAL, "critical"},
         {MAV_SEVERITY_ALERT, "alert"},
-        {MAV_SEVERITY_EMERGENCY, "emergency"}
-    };
+        {MAV_SEVERITY_EMERGENCY, "emergency"}};
 
     for (const auto& severity : severities) {
         mavlink_statustext_t statustext{};
@@ -41,7 +40,7 @@ TEST(MavlinkStatustextHandler, WrongSeverity)
 TEST(MavlinkStatustextHandler, SingleStatustextWithNull)
 {
     mavlink_statustext_t statustext{};
-    auto str = std::string {"Hello Reader"};
+    auto str = std::string{"Hello Reader"};
     strncpy(statustext.text, str.c_str(), sizeof(statustext.text) - 1);
 
     MavlinkStatustextHandler handler;
@@ -53,7 +52,7 @@ TEST(MavlinkStatustextHandler, SingleStatustextWithNull)
 TEST(MavlinkStatustextHandler, SingleStatustextWithoutNull)
 {
     mavlink_statustext_t statustext{};
-    auto str = std::string {"asdfghjkl;asdfghjkl;asdfghjkl;asdfghjkl;asdfghjkl;"};
+    auto str = std::string{"asdfghjkl;asdfghjkl;asdfghjkl;asdfghjkl;asdfghjkl;"};
     strncpy(statustext.text, str.c_str(), sizeof(statustext.text));
 
     MavlinkStatustextHandler handler;
@@ -64,15 +63,14 @@ TEST(MavlinkStatustextHandler, SingleStatustextWithoutNull)
 
 TEST(MavlinkStatustextHandler, MultiStatustext)
 {
-    const std::string str =
-        "Lorem ipsum dolor sit amet, consectetur adipiscing"
-        " elit, sed do eiusmod tempor incididunt ut labore "
-        "et dolore magna aliqua. Venenatis cras sed felis e"
-        "get velit aliquet. Ac feugiat sed lectus vestibulu"
-        "m. Condimentum lacinia quis vel eros donec ac odio"
-        ". Eleifend mi in nulla posuere sollicitudin aliqua"
-        "m ultrices. Fusce ut placerat orci nulla pellentes"
-        "que dignissim.";
+    const std::string str = "Lorem ipsum dolor sit amet, consectetur adipiscing"
+                            " elit, sed do eiusmod tempor incididunt ut labore "
+                            "et dolore magna aliqua. Venenatis cras sed felis e"
+                            "get velit aliquet. Ac feugiat sed lectus vestibulu"
+                            "m. Condimentum lacinia quis vel eros donec ac odio"
+                            ". Eleifend mi in nulla posuere sollicitudin aliqua"
+                            "m ultrices. Fusce ut placerat orci nulla pellentes"
+                            "que dignissim.";
 
     constexpr std::size_t chunk_len = sizeof(mavlink_statustext_t::text);
 
@@ -80,7 +78,6 @@ TEST(MavlinkStatustextHandler, MultiStatustext)
 
     uint8_t chunk_seq = 0;
     for (std::size_t start = 0; start < str.size(); start += chunk_len) {
-
         bool is_last = (start + chunk_len >= str.size());
 
         const std::size_t len = std::min(chunk_len, str.size() - start);
@@ -105,10 +102,9 @@ TEST(MavlinkStatustextHandler, MultiStatustext)
 
 TEST(MavlinkStatustextHandler, MultiStatustextDivisibleByChunkLen)
 {
-    const std::string str =
-        "This string is unfortunately exactly the length of"
-        "two chunks which means it needs another message ju"
-        "st to send the strange zero termination character!";
+    const std::string str = "This string is unfortunately exactly the length of"
+                            "two chunks which means it needs another message ju"
+                            "st to send the strange zero termination character!";
 
     constexpr std::size_t chunk_len = sizeof(mavlink_statustext_t::text);
 
@@ -116,7 +112,6 @@ TEST(MavlinkStatustextHandler, MultiStatustextDivisibleByChunkLen)
 
     uint8_t chunk_seq = 0;
     for (std::size_t start = 0; start <= str.size(); start += chunk_len) {
-
         bool is_last = (start + chunk_len > str.size());
 
         const std::size_t len = std::min(chunk_len, str.size() - start);
@@ -146,25 +141,23 @@ TEST(MavlinkStatustextHandler, MultiStatustextDivisibleByChunkLen)
 
 TEST(MavlinkStatustextHandler, MultiStatustextMissingPart)
 {
-    const std::string str =
-        "Lorem ipsum dolor sit amet, consectetur adipiscing"
-        " elit, sed do eiusmod tempor incididunt ut labore "
-        "et dolore magna aliqua. Venenatis cras sed felis e"
-        "get velit aliquet. Ac feugiat sed lectus vestibulu"
-        "m. Condimentum lacinia quis vel eros donec ac odio"
-        ". Eleifend mi in nulla posuere sollicitudin aliqua"
-        "m ultrices. Fusce ut placerat orci nulla pellentes"
-        "que dignissim.";
+    const std::string str = "Lorem ipsum dolor sit amet, consectetur adipiscing"
+                            " elit, sed do eiusmod tempor incididunt ut labore "
+                            "et dolore magna aliqua. Venenatis cras sed felis e"
+                            "get velit aliquet. Ac feugiat sed lectus vestibulu"
+                            "m. Condimentum lacinia quis vel eros donec ac odio"
+                            ". Eleifend mi in nulla posuere sollicitudin aliqua"
+                            "m ultrices. Fusce ut placerat orci nulla pellentes"
+                            "que dignissim.";
 
-    const std::string str_missing =
-        "Lorem ipsum dolor sit amet, consectetur adipiscing"
-        " elit, sed do eiusmod tempor incididunt ut labore "
-        "et dolore magna aliqua. Venenatis cras sed felis e"
-        "[ missing ... ]"
-        "m. Condimentum lacinia quis vel eros donec ac odio"
-        ". Eleifend mi in nulla posuere sollicitudin aliqua"
-        "m ultrices. Fusce ut placerat orci nulla pellentes"
-        "que dignissim.";
+    const std::string str_missing = "Lorem ipsum dolor sit amet, consectetur adipiscing"
+                                    " elit, sed do eiusmod tempor incididunt ut labore "
+                                    "et dolore magna aliqua. Venenatis cras sed felis e"
+                                    "[ missing ... ]"
+                                    "m. Condimentum lacinia quis vel eros donec ac odio"
+                                    ". Eleifend mi in nulla posuere sollicitudin aliqua"
+                                    "m ultrices. Fusce ut placerat orci nulla pellentes"
+                                    "que dignissim.";
 
     constexpr std::size_t chunk_len = sizeof(mavlink_statustext_t::text);
 
@@ -172,7 +165,6 @@ TEST(MavlinkStatustextHandler, MultiStatustextMissingPart)
 
     uint8_t chunk_seq = 0;
     for (std::size_t start = 0; start < str.size(); start += chunk_len) {
-
         bool is_last = (start + chunk_len >= str.size());
 
         const std::size_t len = std::min(chunk_len, str.size() - start);
@@ -202,21 +194,19 @@ TEST(MavlinkStatustextHandler, MultiStatustextConsecutive)
     MavlinkStatustextHandler handler;
 
     {
-        const std::string str =
-            "Lorem ipsum dolor sit amet, consectetur adipiscing"
-            " elit, sed do eiusmod tempor incididunt ut labore "
-            "et dolore magna aliqua. Venenatis cras sed felis e"
-            "get velit aliquet. Ac feugiat sed lectus vestibulu"
-            "m. Condimentum lacinia quis vel eros donec ac odio"
-            ". Eleifend mi in nulla posuere sollicitudin aliqua"
-            "m ultrices. Fusce ut placerat orci nulla pellentes"
-            "que dignissim.";
+        const std::string str = "Lorem ipsum dolor sit amet, consectetur adipiscing"
+                                " elit, sed do eiusmod tempor incididunt ut labore "
+                                "et dolore magna aliqua. Venenatis cras sed felis e"
+                                "get velit aliquet. Ac feugiat sed lectus vestibulu"
+                                "m. Condimentum lacinia quis vel eros donec ac odio"
+                                ". Eleifend mi in nulla posuere sollicitudin aliqua"
+                                "m ultrices. Fusce ut placerat orci nulla pellentes"
+                                "que dignissim.";
 
         constexpr std::size_t chunk_len = sizeof(mavlink_statustext_t::text);
 
         uint8_t chunk_seq = 0;
         for (std::size_t start = 0; start < str.size(); start += chunk_len) {
-
             bool is_last = (start + chunk_len >= str.size());
 
             const std::size_t len = std::min(chunk_len, str.size() - start);
@@ -240,15 +230,13 @@ TEST(MavlinkStatustextHandler, MultiStatustextConsecutive)
     }
 
     {
-        const std::string str =
-            "Blablablablablablablablablablablablablablablablabl"
-            "FooFooFooFoo.";
+        const std::string str = "Blablablablablablablablablablablablablablablablabl"
+                                "FooFooFooFoo.";
 
         constexpr std::size_t chunk_len = sizeof(mavlink_statustext_t::text);
 
         uint8_t chunk_seq = 0;
         for (std::size_t start = 0; start < str.size(); start += chunk_len) {
-
             bool is_last = (start + chunk_len >= str.size());
 
             const std::size_t len = std::min(chunk_len, str.size() - start);
@@ -271,4 +259,3 @@ TEST(MavlinkStatustextHandler, MultiStatustextConsecutive)
         }
     }
 }
-

--- a/src/core/mavlink_statustext_handler_test.cpp
+++ b/src/core/mavlink_statustext_handler_test.cpp
@@ -7,8 +7,10 @@ using namespace mavsdk;
 // We need to use strncpy without zero termination, so with possible
 // stringop-truncation here, on purpose because the MAVLink message structure
 // of statustext.text does not include the zero termination.
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif // defined(__GNUC__)
 
 TEST(MavlinkStatustextHandler, Severities)
 {
@@ -266,4 +268,6 @@ TEST(MavlinkStatustextHandler, MultiStatustextConsecutive)
     }
 }
 
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
+#endif // defined(__GNUC__)

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -216,48 +216,13 @@ void SystemImpl::process_statustext(const mavlink_message_t& message)
     mavlink_statustext_t statustext;
     mavlink_msg_statustext_decode(&message, &statustext);
 
-    std::string debug_str = "MAVLink: ";
+    const auto result_severity = _statustext_handler.process_severity(statustext);
+    const auto result_text = _statustext_handler.process_text(statustext);
 
-    switch (statustext.severity) {
-        case MAV_SEVERITY_EMERGENCY:
-            debug_str += "emergency";
-            break;
-        case MAV_SEVERITY_ALERT:
-            debug_str += "alert";
-            break;
-        case MAV_SEVERITY_CRITICAL:
-            debug_str += "critical";
-            break;
-        case MAV_SEVERITY_ERROR:
-            debug_str += "error";
-            break;
-        case MAV_SEVERITY_WARNING:
-            debug_str += "warning";
-            break;
-        case MAV_SEVERITY_NOTICE:
-            debug_str += "notice";
-            break;
-        case MAV_SEVERITY_INFO:
-            debug_str += "info";
-            break;
-        case MAV_SEVERITY_DEBUG:
-            debug_str += "debug";
-            break;
-        default:
-            break;
+    if (result_severity.first && result_text.first) {
+        LogDebug() << "MAVLink: " + result_severity.second + ": " + result_text.second;
+
     }
-
-    // statustext.text is not null terminated, therefore we copy it first to
-    // an array big enough that is zeroed.
-    char text_with_null[sizeof(statustext.text) + 1]{};
-    strncpy(text_with_null, statustext.text, sizeof(text_with_null) - 1);
-
-    // Only use the debug string for the first chunk of the sequence
-    // or if there is just one message in the sequence
-    if (statustext.id && statustext.chunk_seq)
-        LogDebug() << text_with_null;
-    else
-        LogDebug() << debug_str << ": " << text_with_null;
 }
 
 void SystemImpl::heartbeats_timed_out()

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -221,7 +221,6 @@ void SystemImpl::process_statustext(const mavlink_message_t& message)
 
     if (result_severity.first && result_text.first) {
         LogDebug() << "MAVLink: " + result_severity.second + ": " + result_text.second;
-
     }
 }
 

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -7,6 +7,7 @@
 #include "mavlink_commands.h"
 #include "mavlink_message_handler.h"
 #include "mavlink_mission_transfer.h"
+#include "mavlink_statustext_handler.h"
 #include "timeout_handler.h"
 #include "call_every_handler.h"
 #include "safe_queue.h"
@@ -280,6 +281,8 @@ private:
 
     // Needs to be before anything else because they can depend on it.
     MAVLinkMessageHandler _message_handler{};
+
+    MavlinkStatustextHandler _statustext_handler{};
 
     uint64_t _uuid{0};
 

--- a/src/plugins/calibration/calibration_impl.cpp
+++ b/src/plugins/calibration/calibration_impl.cpp
@@ -305,7 +305,10 @@ void CalibrationImpl::process_statustext(const mavlink_message_t& message)
     mavlink_msg_statustext_decode(&message, &statustext);
 
     _parser.reset();
-    _parser.parse(statustext.text);
+
+    char text_with_null[sizeof(statustext.text) + 1]{};
+    strncpy(text_with_null, statustext.text, sizeof(text_with_null) - 1);
+    _parser.parse(text_with_null);
 
     switch (_parser.get_status()) {
         case CalibrationStatustextParser::Status::None:


### PR DESCRIPTION
This adds proper support for multi chunk statustext messages, and finally fixes the calibration as raised in https://github.com/mavlink/MAVSDK-Python/issues/257.