### PR TITLE
MavlinkPassthrough: add API to send commands

### DIFF
--- a/src/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.h
+++ b/src/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.h
@@ -46,7 +46,12 @@ public:
     enum class Result {
         Unknown, /**< @brief Unknown error. */
         Success, /**< @brief Success. */
-        ConnectionError /**< @brief Connection error. */
+        ConnectionError, /**< @brief Connection error. */
+        CommandNoSystem, /**< @brief System not available. */
+        CommandBusy, /**< @brief System is busy. */
+        CommandDenied, /**< @brief Command has been denied. */
+        CommandUnsupported, /**< @brief Command is not supported. */
+        CommandTimeout, /**< @brief A timeout happened. */
     };
 
     /**
@@ -62,6 +67,57 @@ public:
      * @return result of the request.
      */
     Result send_message(mavlink_message_t& message);
+
+    /**
+     * @brief Type for MAVLink command_long.
+     */
+    struct CommandLong {
+        uint8_t target_sysid; /**< @brief System ID to send command to */
+        uint8_t target_compid; /**< @brief Component ID to send command to */
+        uint16_t command; /**< @brief command to send. */
+        float param1; /**< @brief param1. */
+        float param2; /**< @brief param2. */
+        float param3; /**< @brief param3. */
+        float param4; /**< @brief param4. */
+        float param5; /**< @brief param5. */
+        float param6; /**< @brief param6. */
+        float param7; /**< @brief param7. */
+    };
+
+    /**
+     * @brief Type for MAVLink command_int.
+     */
+    struct CommandInt {
+        uint8_t target_sysid; /**< @brief System ID to send command to */
+        uint8_t target_compid; /**< @brief Component ID to send command to */
+        uint16_t command; /**< @brief command to send. */
+        MAV_FRAME frame; /**< Frame of command. */
+        float param1; /**< @brief param1. */
+        float param2; /**< @brief param2. */
+        float param3; /**< @brief param3. */
+        float param4; /**< @brief param4. */
+        int32_t x; /**< @brief x. */
+        int32_t y; /**< @brief y. */
+        float z; /**< @brief z. */
+    };
+
+    /**
+     * @brief Send a MAVLink command_long.
+     *
+     * @param command Command to send.
+     *
+     * @return result of the request.
+     */
+    Result send_command_long(const CommandLong& command);
+
+    /**
+     * @brief Send a MAVLink command_long.
+     *
+     * @param command Command to send.
+     *
+     * @return result of the request.
+     */
+    Result send_command_int(const CommandInt& command);
 
     /**
      * @brief Subscribe to messages using message ID.

--- a/src/plugins/mavlink_passthrough/mavlink_passthrough.cpp
+++ b/src/plugins/mavlink_passthrough/mavlink_passthrough.cpp
@@ -15,6 +15,16 @@ MavlinkPassthrough::Result MavlinkPassthrough::send_message(mavlink_message_t& m
     return _impl->send_message(message);
 }
 
+MavlinkPassthrough::Result MavlinkPassthrough::send_command_int(const CommandInt& command)
+{
+    return _impl->send_command_int(command);
+}
+
+MavlinkPassthrough::Result MavlinkPassthrough::send_command_long(const CommandLong& command)
+{
+    return _impl->send_command_long(command);
+}
+
 void MavlinkPassthrough::subscribe_message_async(
     uint16_t message_id, std::function<void(const mavlink_message_t&)> callback)
 {

--- a/src/plugins/mavlink_passthrough/mavlink_passthrough_impl.cpp
+++ b/src/plugins/mavlink_passthrough/mavlink_passthrough_impl.cpp
@@ -36,6 +36,73 @@ MavlinkPassthrough::Result MavlinkPassthroughImpl::send_message(mavlink_message_
     return MavlinkPassthrough::Result::Success;
 }
 
+MavlinkPassthrough::Result
+MavlinkPassthroughImpl::send_command_long(const MavlinkPassthrough::CommandLong& command)
+{
+    MAVLinkCommands::CommandLong command_internal{};
+    command_internal.target_system_id = command.target_sysid;
+    command_internal.target_component_id = command.target_compid;
+    command_internal.command = command.command;
+    command_internal.params.param1 = command.param1;
+    command_internal.params.param2 = command.param2;
+    command_internal.params.param3 = command.param3;
+    command_internal.params.param4 = command.param4;
+    command_internal.params.param5 = command.param5;
+    command_internal.params.param6 = command.param6;
+    command_internal.params.param7 = command.param7;
+
+    return to_mavlink_passthrough_result_from_mavlink_commands_result(
+        _parent->send_command(command_internal));
+}
+
+MavlinkPassthrough::Result
+MavlinkPassthroughImpl::send_command_int(const MavlinkPassthrough::CommandInt& command)
+{
+    MAVLinkCommands::CommandInt command_internal{};
+    command_internal.target_system_id = command.target_sysid;
+    command_internal.target_component_id = command.target_compid;
+    command_internal.frame = command.frame;
+    command_internal.command = command.command;
+    command_internal.params.param1 = command.param1;
+    command_internal.params.param2 = command.param2;
+    command_internal.params.param3 = command.param3;
+    command_internal.params.param4 = command.param4;
+    command_internal.params.x = command.x;
+    command_internal.params.y = command.y;
+    command_internal.params.z = command.z;
+
+    return to_mavlink_passthrough_result_from_mavlink_commands_result(
+        _parent->send_command(command_internal));
+}
+
+MavlinkPassthrough::Result
+MavlinkPassthroughImpl::to_mavlink_passthrough_result_from_mavlink_commands_result(
+    MAVLinkCommands::Result result)
+{
+    switch (result) {
+        case MAVLinkCommands::Result::Success:
+            return MavlinkPassthrough::Result::Success;
+        case MAVLinkCommands::Result::NoSystem:
+            return MavlinkPassthrough::Result::CommandNoSystem;
+        case MAVLinkCommands::Result::ConnectionError:
+            return MavlinkPassthrough::Result::ConnectionError;
+        case MAVLinkCommands::Result::Busy:
+            return MavlinkPassthrough::Result::CommandBusy;
+        case MAVLinkCommands::Result::CommandDenied:
+            return MavlinkPassthrough::Result::CommandDenied;
+        case MAVLinkCommands::Result::Unsupported:
+            return MavlinkPassthrough::Result::CommandUnsupported;
+        case MAVLinkCommands::Result::Timeout:
+            return MavlinkPassthrough::Result::CommandTimeout;
+        default:
+            // FALLTHROUGH
+        case MAVLinkCommands::Result::InProgress: // FIXME: currently not expected
+                                                  // FALLTHROUGH
+        case MAVLinkCommands::Result::UnknownError:
+            return MavlinkPassthrough::Result::Unknown;
+    }
+}
+
 void MavlinkPassthroughImpl::subscribe_message_async(
     uint16_t message_id, std::function<void(const mavlink_message_t&)> callback)
 {

--- a/src/plugins/mavlink_passthrough/mavlink_passthrough_impl.h
+++ b/src/plugins/mavlink_passthrough/mavlink_passthrough_impl.h
@@ -20,6 +20,8 @@ public:
     void disable() override;
 
     MavlinkPassthrough::Result send_message(mavlink_message_t& message);
+    MavlinkPassthrough::Result send_command_long(const MavlinkPassthrough::CommandLong& command);
+    MavlinkPassthrough::Result send_command_int(const MavlinkPassthrough::CommandInt& command);
 
     void subscribe_message_async(
         uint16_t message_id, std::function<void(const mavlink_message_t&)> callback);
@@ -33,6 +35,8 @@ public:
     void intercept_outgoing_messages_async(std::function<bool(mavlink_message_t&)> callback);
 
 private:
+    static MavlinkPassthrough::Result
+    to_mavlink_passthrough_result_from_mavlink_commands_result(MAVLinkCommands::Result result);
 };
 
 } // namespace mavsdk

--- a/src/plugins/telemetry/telemetry_impl.cpp
+++ b/src/plugins/telemetry/telemetry_impl.cpp
@@ -136,52 +136,57 @@ void TelemetryImpl::enable()
     // FIXME: The calibration check should eventually be better than this.
     //        For now, we just do the same as QGC does.
 
-    _parent->get_param_int_async(
-        std::string("CAL_GYRO0_ID"),
-        std::bind(
-            &TelemetryImpl::receive_param_cal_gyro,
-            this,
-            std::placeholders::_1,
-            std::placeholders::_2),
-        this);
+    if (_parent->has_autopilot()) {
+        _parent->get_param_int_async(
+            std::string("CAL_GYRO0_ID"),
+            std::bind(
+                &TelemetryImpl::receive_param_cal_gyro,
+                this,
+                std::placeholders::_1,
+                std::placeholders::_2),
+            this);
 
-    _parent->get_param_int_async(
-        std::string("CAL_ACC0_ID"),
-        std::bind(
-            &TelemetryImpl::receive_param_cal_accel,
-            this,
-            std::placeholders::_1,
-            std::placeholders::_2),
-        this);
+        _parent->get_param_int_async(
+            std::string("CAL_ACC0_ID"),
+            std::bind(
+                &TelemetryImpl::receive_param_cal_accel,
+                this,
+                std::placeholders::_1,
+                std::placeholders::_2),
+            this);
 
-    _parent->get_param_int_async(
-        std::string("CAL_MAG0_ID"),
-        std::bind(
-            &TelemetryImpl::receive_param_cal_mag,
-            this,
-            std::placeholders::_1,
-            std::placeholders::_2),
-        this);
+        _parent->get_param_int_async(
+            std::string("CAL_MAG0_ID"),
+            std::bind(
+                &TelemetryImpl::receive_param_cal_mag,
+                this,
+                std::placeholders::_1,
+                std::placeholders::_2),
+            this);
 
 #ifdef LEVEL_CALIBRATION
-    _parent->param_float_async(
-        std::string("SENS_BOARD_X_OFF"),
-        std::bind(
-            &TelemetryImpl::receive_param_cal_level,
-            this,
-            std::placeholders::_1,
-            std::placeholders::_2),
-        this);
+        _parent->param_float_async(
+            std::string("SENS_BOARD_X_OFF"),
+            std::bind(
+                &TelemetryImpl::receive_param_cal_level,
+                this,
+                std::placeholders::_1,
+                std::placeholders::_2),
+            this);
 #else
-    // If not available, just hardcode it to true.
-    set_health_level_calibration(true);
+        // If not available, just hardcode it to true.
+        set_health_level_calibration(true);
 #endif
 
-    _parent->get_param_int_async(
-        std::string("SYS_HITL"),
-        std::bind(
-            &TelemetryImpl::receive_param_hitl, this, std::placeholders::_1, std::placeholders::_2),
-        this);
+        _parent->get_param_int_async(
+            std::string("SYS_HITL"),
+            std::bind(
+                &TelemetryImpl::receive_param_hitl,
+                this,
+                std::placeholders::_1,
+                std::placeholders::_2),
+            this);
+    }
 }
 
 void TelemetryImpl::disable() {}


### PR DESCRIPTION
This makes it possible to re-use the command retransmission in the passthrough plugin.

In the future we could also consider adding a plugin to send commands.