### PR TITLE
iOS: build xcframework instead of fat binary

### DIFF
--- a/src/backend/tools/package_backend_framework.bash
+++ b/src/backend/tools/package_backend_framework.bash
@@ -3,28 +3,19 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-IOS_BACKEND_DIR=${SCRIPT_DIR}/../../../build/ios/src/backend/src
-IOS_SIM_BACKEND_DIR=${SCRIPT_DIR}/../../../build/ios_simulator/src/backend/src
-FAT_BIN_DIR=${SCRIPT_DIR}/../../../build/fat_bin
+BUILD_DIR=${SCRIPT_DIR}/../../../build
+IOS_BACKEND_DIR=${BUILD_DIR}/ios/src/backend/src
+IOS_SIM_BACKEND_DIR=${BUILD_DIR}/ios_simulator/src/backend/src
 
-mkdir -p ${FAT_BIN_DIR}
-
-if [ -d ${FAT_BIN_DIR}/mavsdk_server.framework ]; then
-    echo "${FAT_BIN_DIR}/mavsdk_server.framework already exists! Aborting..."
+if [ -d ${BUILD_DIR}/mavsdk_server.xcframework ]; then
+    echo "${BUILD_DIR}/mavsdk_server.xcframework already exists! Aborting..."
     exit 1
 fi
 
-if [ -f ${FAT_BIN_DIR}/mavsdk_server.zip ]; then
-    echo "${FAT_BIN_DIR}/mavsdk_server.zip already exists! Aborting..."
-    exit 1
-fi
+echo "Creating xcframework..."
+xcodebuild -create-xcframework -framework ${IOS_BACKEND_DIR}/mavsdk_server.framework -framework ${IOS_SIM_BACKEND_DIR}/mavsdk_server.framework -output ${BUILD_DIR}/mavsdk_server.xcframework
 
-echo "Creating fat bin..."
+cd ${BUILD_DIR}
+zip -9 -r mavsdk_server.zip mavsdk_server.xcframework
 
-cp -r ${IOS_BACKEND_DIR}/mavsdk_server.framework ${FAT_BIN_DIR}
-lipo ${IOS_BACKEND_DIR}/mavsdk_server.framework/mavsdk_server ${IOS_SIM_BACKEND_DIR}/mavsdk_server.framework/mavsdk_server -create -output ${FAT_BIN_DIR}/mavsdk_server.framework/mavsdk_server
-
-cd ${FAT_BIN_DIR}
-zip -9 -r mavsdk_server.zip mavsdk_server.framework
-
-echo "Success! You'll find the fat bin in ${FAT_BIN_DIR}!"
+echo "Success! You will find the xcframework in ${BUILD_DIR}!"


### PR DESCRIPTION
Fat binaries are now replaced by xcframeworks, which seem like a better way to do it (it actually looks like the way Android handles multiple architectures).

The main point here is that we are moving mavsdk-swift to using SwiftPM instead of Carthage, and we need an xcframework instead of a fat binary there.

The good thing is that it should not affect the release process, as the output is the same: `mavsdk_server_ios.zip`.