### PR TITLE
Immediately call new_system_callback if a system is already present

### DIFF
--- a/src/core/mavsdk_impl.cpp
+++ b/src/core/mavsdk_impl.cpp
@@ -456,6 +456,10 @@ void MavsdkImpl::subscribe_on_new_system(Mavsdk::NewSystemCallback callback)
 {
     std::lock_guard<std::mutex> lock(_new_system_callback_mutex);
     _new_system_callback = callback;
+
+    if (_new_system_callback != nullptr && systems().size() > 0) {
+        _new_system_callback();
+    }
 }
 
 void MavsdkImpl::register_on_discover(const Mavsdk::event_callback_t callback)


### PR DESCRIPTION
Otherwise code like this never triggers if the system is detected before the callback is set:

```python
    print("Waiting for drone to connect...")
    async for state in drone.core.connection_state():
        if state.is_connected:
            print(f"Drone discovered")
            break
```