### PR TITLE
Continue #1218: Added Mavlink command reception support

### DIFF
--- a/src/core/mavlink_commands.h
+++ b/src/core/mavlink_commands.h
@@ -133,34 +133,25 @@ public:
     explicit MavlinkCommandReceiver(SystemImpl& system_impl);
     ~MavlinkCommandReceiver();
 
-    struct Command {
+    struct CommandInt {
         uint8_t target_system_id{0};
         uint8_t target_component_id{0};
+        MAV_FRAME frame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
         uint16_t command{0};
-
-        // Int
-        MAV_FRAME frame{MAV_FRAME_GLOBAL_RELATIVE_ALT};
         bool current{0};
         bool autocontinue{false};
-
-        // Long
-        uint8_t confirmation{0};
-
-        // Mixed
+        // Most of the "Reserved" values in MAVLink spec are NAN.
         struct Params {
-            float param1{NAN};
-            float param2{NAN};
-            float param3{NAN};
-            float param4{NAN};
-            float param5{NAN};
-            float param6{NAN};
-            float param7{NAN};
-            int32_t x{0};
-            int32_t y{0};
-            float z{NAN};
+            float param1 = NAN;
+            float param2 = NAN;
+            float param3 = NAN;
+            float param4 = NAN;
+            int32_t x = 0;
+            int32_t y = 0;
+            float z = NAN;
         } params{};
 
-        Command(mavlink_command_int_t command_int)
+        CommandInt(const mavlink_command_int_t& command_int)
         {
             target_system_id = command_int.target_system;
             target_component_id = command_int.target_component;
@@ -176,8 +167,24 @@ public:
             params.y = command_int.y;
             params.z = command_int.z;
         }
+    };
 
-        Command(mavlink_command_long_t command_long)
+    struct CommandLong {
+        uint8_t target_system_id{0};
+        uint8_t target_component_id{0};
+        uint16_t command{0};
+        uint8_t confirmation{0};
+        struct Params {
+            float param1 = NAN;
+            float param2 = NAN;
+            float param3 = NAN;
+            float param4 = NAN;
+            float param5 = NAN;
+            float param6 = NAN;
+            float param7 = NAN;
+        } params{};
+
+        CommandLong(const mavlink_command_long_t& command_long)
         {
             target_system_id = command_long.target_system;
             target_component_id = command_long.target_component;
@@ -193,9 +200,13 @@ public:
         }
     };
 
-    typedef std::function<void(const Command&)> mavlink_command_handler_t;
+    typedef std::function<void(const CommandInt&)> mavlink_command_int_handler_t;
+    typedef std::function<void(const CommandLong&)> mavlink_command_long_handler_t;
+
     void register_mavlink_command_handler(
-        uint16_t cmd_id, mavlink_command_handler_t callback, const void* cookie);
+        uint16_t cmd_id, mavlink_command_int_handler_t callback, const void* cookie);
+    void register_mavlink_command_handler(
+        uint16_t cmd_id, mavlink_command_long_handler_t callback, const void* cookie);
 
     void unregister_mavlink_command_handler(uint16_t cmd_id, const void* cookie);
     void unregister_all_mavlink_command_handlers(const void* cookie);
@@ -205,14 +216,21 @@ public:
     void receive_command_int(const mavlink_message_t& message);
     void receive_command_long(const mavlink_message_t& message);
 
-    struct MAVLinkCommandHandlerTableEntry {
+    struct MAVLinkCommandIntHandlerTableEntry {
         uint16_t cmd_id;
-        mavlink_command_handler_t callback;
+        mavlink_command_int_handler_t callback;
+        const void* cookie; // This is the identification to unregister.
+    };
+
+    struct MAVLinkCommandLongHandlerTableEntry {
+        uint16_t cmd_id;
+        mavlink_command_long_handler_t callback;
         const void* cookie; // This is the identification to unregister.
     };
 
     std::mutex _mavlink_command_handler_table_mutex{};
-    std::vector<MAVLinkCommandHandlerTableEntry> _mavlink_command_handler_table{};
+    std::vector<MAVLinkCommandIntHandlerTableEntry> _mavlink_command_int_handler_table{};
+    std::vector<MAVLinkCommandLongHandlerTableEntry> _mavlink_command_long_handler_table{};
 };
 
 } // namespace mavsdk

--- a/src/core/mavlink_commands.h
+++ b/src/core/mavlink_commands.h
@@ -12,94 +12,9 @@ namespace mavsdk {
 
 class SystemImpl;
 
-class MavlinkCommandReceiver {
-public:
-    explicit MavlinkCommandReceiver(SystemImpl& parent);
-    ~MavlinkCommandReceiver();
-
-    struct Command {
-        uint8_t target_system_id{0};
-        uint8_t target_component_id{0};
-        uint16_t command{0};
-
-        // Int
-        MAV_FRAME frame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
-        bool current = 0;
-        bool autocontinue = false;
-
-        // Long
-        uint8_t confirmation = 0;
-
-        // Mixed
-        struct Params {
-            float param1 = NAN;
-            float param2 = NAN;
-            float param3 = NAN;
-            float param4 = NAN;
-            float param5 = NAN;
-            float param6 = NAN;
-            float param7 = NAN;
-            int32_t x = 0;
-            int32_t y = 0;
-            float z = NAN;
-        } params{};
-
-        Command(mavlink_command_int_t command_int) {
-            target_system_id = command_int.target_system;
-            target_component_id = command_int.target_component;
-            command = command_int.command;
-            frame = static_cast<MAV_FRAME>(command_int.frame);
-            current = command_int.current;
-            autocontinue = command_int.autocontinue;
-            params.param1 = command_int.param1;
-            params.param2 = command_int.param2;
-            params.param3 = command_int.param3;
-            params.param4 = command_int.param4;
-            params.x = command_int.x;
-            params.y = command_int.y;
-            params.z = command_int.z;
-        }
-
-        Command(mavlink_command_long_t command_long) {
-            target_system_id = command_long.target_system;
-            target_component_id = command_long.target_component;
-            command = command_long.command;
-            confirmation = command_long.confirmation;
-            params.param1 = command_long.param1;
-            params.param2 = command_long.param2;
-            params.param3 = command_long.param3;
-            params.param4 = command_long.param4;
-            params.param5 = command_long.param5;
-            params.param6 = command_long.param6;
-            params.param7 = command_long.param7;
-        }
-    };
-
-    typedef std::function<void(const Command&)> mavlink_command_handler_t;
-    void register_mavlink_command_handler(
-        uint16_t cmd_id, mavlink_command_handler_t callback, const void* cookie);
-
-    void unregister_mavlink_command_handler(uint16_t cmd_id, const void* cookie);
-    void unregister_all_mavlink_command_handlers(const void* cookie);
-
-    SystemImpl& _parent;
-
-    void receive_command_int(mavlink_message_t message);
-    void receive_command_long(mavlink_message_t message);
-
-    struct MAVLinkCommandHandlerTableEntry {
-        uint16_t cmd_id;
-        mavlink_command_handler_t callback;
-        const void* cookie; // This is the identification to unregister.
-    };
-
-    std::mutex _mavlink_command_handler_table_mutex{};
-    std::vector<MAVLinkCommandHandlerTableEntry> _mavlink_command_handler_table{};
-};
-
 class MavlinkCommandSender {
 public:
-    explicit MavlinkCommandSender(SystemImpl& parent);
+    explicit MavlinkCommandSender(SystemImpl& system_impl);
     ~MavlinkCommandSender();
 
     enum class Result {
@@ -211,6 +126,93 @@ private:
     LockedQueue<Work> _work_queue{};
 
     void* _timeout_cookie = nullptr;
+};
+
+class MavlinkCommandReceiver {
+public:
+    explicit MavlinkCommandReceiver(SystemImpl& system_impl);
+    ~MavlinkCommandReceiver();
+
+    struct Command {
+        uint8_t target_system_id{0};
+        uint8_t target_component_id{0};
+        uint16_t command{0};
+
+        // Int
+        MAV_FRAME frame{MAV_FRAME_GLOBAL_RELATIVE_ALT};
+        bool current{0};
+        bool autocontinue{false};
+
+        // Long
+        uint8_t confirmation{0};
+
+        // Mixed
+        struct Params {
+            float param1{NAN};
+            float param2{NAN};
+            float param3{NAN};
+            float param4{NAN};
+            float param5{NAN};
+            float param6{NAN};
+            float param7{NAN};
+            int32_t x{0};
+            int32_t y{0};
+            float z{NAN};
+        } params{};
+
+        Command(mavlink_command_int_t command_int)
+        {
+            target_system_id = command_int.target_system;
+            target_component_id = command_int.target_component;
+            command = command_int.command;
+            frame = static_cast<MAV_FRAME>(command_int.frame);
+            current = command_int.current;
+            autocontinue = command_int.autocontinue;
+            params.param1 = command_int.param1;
+            params.param2 = command_int.param2;
+            params.param3 = command_int.param3;
+            params.param4 = command_int.param4;
+            params.x = command_int.x;
+            params.y = command_int.y;
+            params.z = command_int.z;
+        }
+
+        Command(mavlink_command_long_t command_long)
+        {
+            target_system_id = command_long.target_system;
+            target_component_id = command_long.target_component;
+            command = command_long.command;
+            confirmation = command_long.confirmation;
+            params.param1 = command_long.param1;
+            params.param2 = command_long.param2;
+            params.param3 = command_long.param3;
+            params.param4 = command_long.param4;
+            params.param5 = command_long.param5;
+            params.param6 = command_long.param6;
+            params.param7 = command_long.param7;
+        }
+    };
+
+    typedef std::function<void(const Command&)> mavlink_command_handler_t;
+    void register_mavlink_command_handler(
+        uint16_t cmd_id, mavlink_command_handler_t callback, const void* cookie);
+
+    void unregister_mavlink_command_handler(uint16_t cmd_id, const void* cookie);
+    void unregister_all_mavlink_command_handlers(const void* cookie);
+
+    SystemImpl& _parent;
+
+    void receive_command_int(const mavlink_message_t& message);
+    void receive_command_long(const mavlink_message_t& message);
+
+    struct MAVLinkCommandHandlerTableEntry {
+        uint16_t cmd_id;
+        mavlink_command_handler_t callback;
+        const void* cookie; // This is the identification to unregister.
+    };
+
+    std::mutex _mavlink_command_handler_table_mutex{};
+    std::vector<MAVLinkCommandHandlerTableEntry> _mavlink_command_handler_table{};
 };
 
 } // namespace mavsdk

--- a/src/core/mavlink_commands.h
+++ b/src/core/mavlink_commands.h
@@ -12,10 +12,95 @@ namespace mavsdk {
 
 class SystemImpl;
 
-class MAVLinkCommands {
+class MavlinkCommandReceiver {
 public:
-    explicit MAVLinkCommands(SystemImpl& parent);
-    ~MAVLinkCommands();
+    explicit MavlinkCommandReceiver(SystemImpl& parent);
+    ~MavlinkCommandReceiver();
+
+    struct Command {
+        uint8_t target_system_id{0};
+        uint8_t target_component_id{0};
+        uint16_t command{0};
+
+        // Int
+        MAV_FRAME frame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
+        bool current = 0;
+        bool autocontinue = false;
+
+        // Long
+        uint8_t confirmation = 0;
+
+        // Mixed
+        struct Params {
+            float param1 = NAN;
+            float param2 = NAN;
+            float param3 = NAN;
+            float param4 = NAN;
+            float param5 = NAN;
+            float param6 = NAN;
+            float param7 = NAN;
+            int32_t x = 0;
+            int32_t y = 0;
+            float z = NAN;
+        } params{};
+
+        Command(mavlink_command_int_t command_int) {
+            target_system_id = command_int.target_system;
+            target_component_id = command_int.target_component;
+            command = command_int.command;
+            frame = static_cast<MAV_FRAME>(command_int.frame);
+            current = command_int.current;
+            autocontinue = command_int.autocontinue;
+            params.param1 = command_int.param1;
+            params.param2 = command_int.param2;
+            params.param3 = command_int.param3;
+            params.param4 = command_int.param4;
+            params.x = command_int.x;
+            params.y = command_int.y;
+            params.z = command_int.z;
+        }
+
+        Command(mavlink_command_long_t command_long) {
+            target_system_id = command_long.target_system;
+            target_component_id = command_long.target_component;
+            command = command_long.command;
+            confirmation = command_long.confirmation;
+            params.param1 = command_long.param1;
+            params.param2 = command_long.param2;
+            params.param3 = command_long.param3;
+            params.param4 = command_long.param4;
+            params.param5 = command_long.param5;
+            params.param6 = command_long.param6;
+            params.param7 = command_long.param7;
+        }
+    };
+
+    typedef std::function<void(const Command&)> mavlink_command_handler_t;
+    void register_mavlink_command_handler(
+        uint16_t cmd_id, mavlink_command_handler_t callback, const void* cookie);
+
+    void unregister_mavlink_command_handler(uint16_t cmd_id, const void* cookie);
+    void unregister_all_mavlink_command_handlers(const void* cookie);
+
+    SystemImpl& _parent;
+
+    void receive_command_int(mavlink_message_t message);
+    void receive_command_long(mavlink_message_t message);
+
+    struct MAVLinkCommandHandlerTableEntry {
+        uint16_t cmd_id;
+        mavlink_command_handler_t callback;
+        const void* cookie; // This is the identification to unregister.
+    };
+
+    std::mutex _mavlink_command_handler_table_mutex{};
+    std::vector<MAVLinkCommandHandlerTableEntry> _mavlink_command_handler_table{};
+};
+
+class MavlinkCommandSender {
+public:
+    explicit MavlinkCommandSender(SystemImpl& parent);
+    ~MavlinkCommandSender();
 
     enum class Result {
         Success = 0,
@@ -103,73 +188,8 @@ public:
     static const int DEFAULT_COMPONENT_ID_AUTOPILOT = MAV_COMP_ID_AUTOPILOT1;
 
     // Non-copyable
-    MAVLinkCommands(const MAVLinkCommands&) = delete;
-    const MAVLinkCommands& operator=(const MAVLinkCommands&) = delete;
-    
-        struct Command {
-        uint8_t target_system_id{0};
-        uint8_t target_component_id{0};
-        uint16_t command{0};
-
-        // Int
-        MAV_FRAME frame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
-        bool current = 0;
-        bool autocontinue = false;
-
-        // Long
-        uint8_t confirmation = 0;
-
-        // Mixed
-        struct Params {
-            float param1 = NAN;
-            float param2 = NAN;
-            float param3 = NAN;
-            float param4 = NAN;
-            float param5 = NAN;
-            float param6 = NAN;
-            float param7 = NAN;
-            int32_t x = 0;
-            int32_t y = 0;
-            float z = NAN;
-        } params{};
-
-        Command(mavlink_command_int_t command_int) {
-            target_system_id = command_int.target_system;
-            target_component_id = command_int.target_component;
-            command = command_int.command;
-            frame = static_cast<MAV_FRAME>(command_int.frame);
-            current = command_int.current;
-            autocontinue = command_int.autocontinue;
-            params.param1 = command_int.param1;
-            params.param2 = command_int.param2;
-            params.param3 = command_int.param3;
-            params.param4 = command_int.param4;
-            params.x = command_int.x;
-            params.y = command_int.y;
-            params.z = command_int.z;
-        }
-
-        Command(mavlink_command_long_t command_long) {
-            target_system_id = command_long.target_system;
-            target_component_id = command_long.target_component;
-            command = command_long.command;
-            confirmation = command_long.confirmation;
-            params.param1 = command_long.param1;
-            params.param2 = command_long.param2;
-            params.param3 = command_long.param3;
-            params.param4 = command_long.param4;
-            params.param5 = command_long.param5;
-            params.param6 = command_long.param6;
-            params.param7 = command_long.param7;
-        }
-    };
-
-    typedef std::function<void(const Command&)> mavlink_command_handler_t;
-    void register_mavlink_command_handler(
-        uint16_t cmd_id, mavlink_command_handler_t callback, const void* cookie);
-
-    void unregister_mavlink_command_handler(uint16_t cmd_id, const void* cookie);
-    void unregister_all_mavlink_command_handlers(const void* cookie);
+    MavlinkCommandSender(const MavlinkCommandSender&) = delete;
+    const MavlinkCommandSender& operator=(const MavlinkCommandSender&) = delete;
 
 private:
     struct Work {
@@ -191,18 +211,6 @@ private:
     LockedQueue<Work> _work_queue{};
 
     void* _timeout_cookie = nullptr;
-    
-    void receive_command_int(mavlink_message_t message);
-    void receive_command_long(mavlink_message_t message);
-
-    struct MAVLinkCommandHandlerTableEntry {
-        uint16_t cmd_id;
-        mavlink_command_handler_t callback;
-        const void* cookie; // This is the identification to unregister.
-    };
-
-    std::mutex _mavlink_command_handler_table_mutex{};
-    std::vector<MAVLinkCommandHandlerTableEntry> _mavlink_command_handler_table{};
 };
 
 } // namespace mavsdk

--- a/src/core/mavlink_commands.h
+++ b/src/core/mavlink_commands.h
@@ -105,6 +105,71 @@ public:
     // Non-copyable
     MAVLinkCommands(const MAVLinkCommands&) = delete;
     const MAVLinkCommands& operator=(const MAVLinkCommands&) = delete;
+    
+        struct Command {
+        uint8_t target_system_id{0};
+        uint8_t target_component_id{0};
+        uint16_t command{0};
+
+        // Int
+        MAV_FRAME frame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
+        bool current = 0;
+        bool autocontinue = false;
+
+        // Long
+        uint8_t confirmation = 0;
+
+        // Mixed
+        struct Params {
+            float param1 = NAN;
+            float param2 = NAN;
+            float param3 = NAN;
+            float param4 = NAN;
+            float param5 = NAN;
+            float param6 = NAN;
+            float param7 = NAN;
+            int32_t x = 0;
+            int32_t y = 0;
+            float z = NAN;
+        } params{};
+
+        Command(mavlink_command_int_t command_int) {
+            target_system_id = command_int.target_system;
+            target_component_id = command_int.target_component;
+            command = command_int.command;
+            frame = static_cast<MAV_FRAME>(command_int.frame);
+            current = command_int.current;
+            autocontinue = command_int.autocontinue;
+            params.param1 = command_int.param1;
+            params.param2 = command_int.param2;
+            params.param3 = command_int.param3;
+            params.param4 = command_int.param4;
+            params.x = command_int.x;
+            params.y = command_int.y;
+            params.z = command_int.z;
+        }
+
+        Command(mavlink_command_long_t command_long) {
+            target_system_id = command_long.target_system;
+            target_component_id = command_long.target_component;
+            command = command_long.command;
+            confirmation = command_long.confirmation;
+            params.param1 = command_long.param1;
+            params.param2 = command_long.param2;
+            params.param3 = command_long.param3;
+            params.param4 = command_long.param4;
+            params.param5 = command_long.param5;
+            params.param6 = command_long.param6;
+            params.param7 = command_long.param7;
+        }
+    };
+
+    typedef std::function<void(const Command&)> mavlink_command_handler_t;
+    void register_mavlink_command_handler(
+        uint16_t cmd_id, mavlink_command_handler_t callback, const void* cookie);
+
+    void unregister_mavlink_command_handler(uint16_t cmd_id, const void* cookie);
+    void unregister_all_mavlink_command_handlers(const void* cookie);
 
 private:
     struct Work {
@@ -126,6 +191,18 @@ private:
     LockedQueue<Work> _work_queue{};
 
     void* _timeout_cookie = nullptr;
+    
+    void receive_command_int(mavlink_message_t message);
+    void receive_command_long(mavlink_message_t message);
+
+    struct MAVLinkCommandHandlerTableEntry {
+        uint16_t cmd_id;
+        mavlink_command_handler_t callback;
+        const void* cookie; // This is the identification to unregister.
+    };
+
+    std::mutex _mavlink_command_handler_table_mutex{};
+    std::vector<MAVLinkCommandHandlerTableEntry> _mavlink_command_handler_table{};
 };
 
 } // namespace mavsdk

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -972,7 +972,8 @@ SystemImpl::FlightMode SystemImpl::to_flight_mode_from_custom_mode(uint32_t cust
     }
 }
 
-MavlinkCommandSender::Result SystemImpl::set_flight_mode(FlightMode system_mode, uint8_t component_id)
+MavlinkCommandSender::Result
+SystemImpl::set_flight_mode(FlightMode system_mode, uint8_t component_id)
 {
     std::pair<MavlinkCommandSender::Result, MavlinkCommandSender::CommandLong> result =
         make_command_flight_mode(system_mode, component_id);
@@ -1107,14 +1108,16 @@ void SystemImpl::send_command_async(
 MavlinkCommandSender::Result
 SystemImpl::set_msg_rate(uint16_t message_id, double rate_hz, uint8_t component_id)
 {
-    MavlinkCommandSender::CommandLong command = make_command_msg_rate(message_id, rate_hz, component_id);
+    MavlinkCommandSender::CommandLong command =
+        make_command_msg_rate(message_id, rate_hz, component_id);
     return send_command(command);
 }
 
 void SystemImpl::set_msg_rate_async(
     uint16_t message_id, double rate_hz, CommandResultCallback callback, uint8_t component_id)
 {
-    MavlinkCommandSender::CommandLong command = make_command_msg_rate(message_id, rate_hz, component_id);
+    MavlinkCommandSender::CommandLong command =
+        make_command_msg_rate(message_id, rate_hz, component_id);
     send_command_async(command, callback);
 }
 
@@ -1230,9 +1233,8 @@ void SystemImpl::intercept_outgoing_messages(std::function<bool(mavlink_message_
     _outgoing_messages_intercept_callback = callback;
 }
 
-void SystemImpl::register_mavlink_command_handler(uint16_t cmd_id,
-                                      MavlinkCommandReceiver::mavlink_command_handler_t callback,
-                                      const void* cookie)
+void SystemImpl::register_mavlink_command_handler(
+    uint16_t cmd_id, MavlinkCommandReceiver::mavlink_command_handler_t callback, const void* cookie)
 {
     _receive_commands.register_mavlink_command_handler(cmd_id, callback, cookie);
 }

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -1234,7 +1234,17 @@ void SystemImpl::intercept_outgoing_messages(std::function<bool(mavlink_message_
 }
 
 void SystemImpl::register_mavlink_command_handler(
-    uint16_t cmd_id, MavlinkCommandReceiver::mavlink_command_handler_t callback, const void* cookie)
+    uint16_t cmd_id,
+    MavlinkCommandReceiver::mavlink_command_int_handler_t callback,
+    const void* cookie)
+{
+    _receive_commands.register_mavlink_command_handler(cmd_id, callback, cookie);
+}
+
+void SystemImpl::register_mavlink_command_handler(
+    uint16_t cmd_id,
+    MavlinkCommandReceiver::mavlink_command_long_handler_t callback,
+    const void* cookie)
 {
     _receive_commands.register_mavlink_command_handler(cmd_id, callback, cookie);
 }

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -21,7 +21,8 @@ SystemImpl::SystemImpl(MavsdkImpl& parent, uint8_t system_id, uint8_t comp_id, b
     Sender(parent.own_address, _target_address),
     _parent(parent),
     _params(*this),
-    _commands(*this),
+    _send_commands(*this),
+    _receive_commands(*this),
     _timesync(*this),
     _call_every_handler(_time),
     _mission_transfer(*this, _message_handler, _parent.timeout_handler)
@@ -159,7 +160,7 @@ void SystemImpl::process_heartbeat(const mavlink_message_t& message)
     mavlink_heartbeat_t heartbeat;
     mavlink_msg_heartbeat_decode(&message, &heartbeat);
 
-    if (message.compid == MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT) {
+    if (message.compid == MavlinkCommandSender::DEFAULT_COMPONENT_ID_AUTOPILOT) {
         _armed = ((heartbeat.base_mode & MAV_MODE_FLAG_SAFETY_ARMED) ? true : false);
         _hitl_enabled = ((heartbeat.base_mode & MAV_MODE_FLAG_HIL_ENABLED) ? true : false);
 
@@ -186,7 +187,7 @@ void SystemImpl::process_heartbeat(const mavlink_message_t& message)
 void SystemImpl::process_autopilot_version(const mavlink_message_t& message)
 {
     // Ignore if they don't come from the autopilot component
-    if (message.compid != MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT) {
+    if (message.compid != MavlinkCommandSender::DEFAULT_COMPONENT_ID_AUTOPILOT) {
         return;
     }
 
@@ -241,7 +242,7 @@ void SystemImpl::system_thread()
     while (!_should_exit) {
         _call_every_handler.run_once();
         _params.do_work();
-        _commands.do_work();
+        _send_commands.do_work();
         _timesync.do_work();
         _mission_transfer.do_work();
 
@@ -457,7 +458,7 @@ void SystemImpl::request_autopilot_version()
 void SystemImpl::send_autopilot_version_request()
 {
     // We don't care about an answer, we mostly care about receiving AUTOPILOT_VERSION.
-    MAVLinkCommands::CommandLong command{};
+    MavlinkCommandSender::CommandLong command{};
 
     command.command = MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES;
     command.params.param1 = 1.0f;
@@ -469,7 +470,7 @@ void SystemImpl::send_autopilot_version_request()
 void SystemImpl::send_flight_information_request()
 {
     // We don't care about an answer, we mostly care about receiving FLIGHT_INFORMATION.
-    MAVLinkCommands::CommandLong command{};
+    MavlinkCommandSender::CommandLong command{};
 
     command.command = MAV_CMD_REQUEST_FLIGHT_INFORMATION;
     command.params.param1 = 1.0f;
@@ -852,7 +853,7 @@ void SystemImpl::subscribe_param_float(
         cookie);
 }
 
-std::pair<MAVLinkCommands::Result, MAVLinkCommands::CommandLong>
+std::pair<MavlinkCommandSender::Result, MavlinkCommandSender::CommandLong>
 SystemImpl::make_command_flight_mode(FlightMode flight_mode, uint8_t component_id)
 {
     const uint8_t flag_safety_armed = is_armed() ? MAV_MODE_FLAG_SAFETY_ARMED : 0;
@@ -907,11 +908,11 @@ SystemImpl::make_command_flight_mode(FlightMode flight_mode, uint8_t component_i
             break;
         default:
             LogErr() << "Unknown Flight mode.";
-            MAVLinkCommands::CommandLong empty_command{};
-            return std::make_pair<>(MAVLinkCommands::Result::UnknownError, empty_command);
+            MavlinkCommandSender::CommandLong empty_command{};
+            return std::make_pair<>(MavlinkCommandSender::Result::UnknownError, empty_command);
     }
 
-    MAVLinkCommands::CommandLong command{};
+    MavlinkCommandSender::CommandLong command{};
 
     command.command = MAV_CMD_DO_SET_MODE;
     command.params.param1 = float(mode);
@@ -919,7 +920,7 @@ SystemImpl::make_command_flight_mode(FlightMode flight_mode, uint8_t component_i
     command.params.param3 = float(custom_sub_mode);
     command.target_component_id = component_id;
 
-    return std::make_pair<>(MAVLinkCommands::Result::Success, command);
+    return std::make_pair<>(MavlinkCommandSender::Result::Success, command);
 }
 
 SystemImpl::FlightMode SystemImpl::get_flight_mode() const
@@ -971,12 +972,12 @@ SystemImpl::FlightMode SystemImpl::to_flight_mode_from_custom_mode(uint32_t cust
     }
 }
 
-MAVLinkCommands::Result SystemImpl::set_flight_mode(FlightMode system_mode, uint8_t component_id)
+MavlinkCommandSender::Result SystemImpl::set_flight_mode(FlightMode system_mode, uint8_t component_id)
 {
-    std::pair<MAVLinkCommands::Result, MAVLinkCommands::CommandLong> result =
+    std::pair<MavlinkCommandSender::Result, MavlinkCommandSender::CommandLong> result =
         make_command_flight_mode(system_mode, component_id);
 
-    if (result.first != MAVLinkCommands::Result::Success) {
+    if (result.first != MavlinkCommandSender::Result::Success) {
         return result.first;
     }
 
@@ -986,10 +987,10 @@ MAVLinkCommands::Result SystemImpl::set_flight_mode(FlightMode system_mode, uint
 void SystemImpl::set_flight_mode_async(
     FlightMode system_mode, CommandResultCallback callback, uint8_t component_id)
 {
-    std::pair<MAVLinkCommands::Result, MAVLinkCommands::CommandLong> result =
+    std::pair<MavlinkCommandSender::Result, MavlinkCommandSender::CommandLong> result =
         make_command_flight_mode(system_mode, component_id);
 
-    if (result.first != MAVLinkCommands::Result::Success) {
+    if (result.first != MavlinkCommandSender::Result::Success) {
         if (callback) {
             callback(result.first, NAN);
         }
@@ -1030,7 +1031,7 @@ void SystemImpl::receive_int_param(
 uint8_t SystemImpl::get_autopilot_id() const
 {
     for (auto compid : _components)
-        if (compid == MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT) {
+        if (compid == MavlinkCommandSender::DEFAULT_COMPONENT_ID_AUTOPILOT) {
             return compid;
         }
     // FIXME: Not sure what should be returned if autopilot is not found
@@ -1057,70 +1058,70 @@ uint8_t SystemImpl::get_gimbal_id() const
     return uint8_t(0);
 }
 
-MAVLinkCommands::Result SystemImpl::send_command(MAVLinkCommands::CommandLong& command)
+MavlinkCommandSender::Result SystemImpl::send_command(MavlinkCommandSender::CommandLong& command)
 {
     if (_target_address.system_id == 0 && _components.size() == 0) {
-        return MAVLinkCommands::Result::NoSystem;
+        return MavlinkCommandSender::Result::NoSystem;
     }
     command.target_system_id = get_system_id();
-    return _commands.send_command(command);
+    return _send_commands.send_command(command);
 }
 
-MAVLinkCommands::Result SystemImpl::send_command(MAVLinkCommands::CommandInt& command)
+MavlinkCommandSender::Result SystemImpl::send_command(MavlinkCommandSender::CommandInt& command)
 {
     if (_target_address.system_id == 0 && _components.size() == 0) {
-        return MAVLinkCommands::Result::NoSystem;
+        return MavlinkCommandSender::Result::NoSystem;
     }
     command.target_system_id = get_system_id();
-    return _commands.send_command(command);
+    return _send_commands.send_command(command);
 }
 
 void SystemImpl::send_command_async(
-    MAVLinkCommands::CommandLong command, const CommandResultCallback callback)
+    MavlinkCommandSender::CommandLong command, const CommandResultCallback callback)
 {
     if (_target_address.system_id == 0 && _components.size() == 0) {
         if (callback) {
-            callback(MAVLinkCommands::Result::NoSystem, NAN);
+            callback(MavlinkCommandSender::Result::NoSystem, NAN);
         }
         return;
     }
     command.target_system_id = get_system_id();
 
-    _commands.queue_command_async(command, callback);
+    _send_commands.queue_command_async(command, callback);
 }
 
 void SystemImpl::send_command_async(
-    MAVLinkCommands::CommandInt command, const CommandResultCallback callback)
+    MavlinkCommandSender::CommandInt command, const CommandResultCallback callback)
 {
     if (_target_address.system_id == 0 && _components.size() == 0) {
         if (callback) {
-            callback(MAVLinkCommands::Result::NoSystem, NAN);
+            callback(MavlinkCommandSender::Result::NoSystem, NAN);
         }
         return;
     }
     command.target_system_id = get_system_id();
 
-    _commands.queue_command_async(command, callback);
+    _send_commands.queue_command_async(command, callback);
 }
 
-MAVLinkCommands::Result
+MavlinkCommandSender::Result
 SystemImpl::set_msg_rate(uint16_t message_id, double rate_hz, uint8_t component_id)
 {
-    MAVLinkCommands::CommandLong command = make_command_msg_rate(message_id, rate_hz, component_id);
+    MavlinkCommandSender::CommandLong command = make_command_msg_rate(message_id, rate_hz, component_id);
     return send_command(command);
 }
 
 void SystemImpl::set_msg_rate_async(
     uint16_t message_id, double rate_hz, CommandResultCallback callback, uint8_t component_id)
 {
-    MAVLinkCommands::CommandLong command = make_command_msg_rate(message_id, rate_hz, component_id);
+    MavlinkCommandSender::CommandLong command = make_command_msg_rate(message_id, rate_hz, component_id);
     send_command_async(command, callback);
 }
 
-MAVLinkCommands::CommandLong
+MavlinkCommandSender::CommandLong
 SystemImpl::make_command_msg_rate(uint16_t message_id, double rate_hz, uint8_t component_id)
 {
-    MAVLinkCommands::CommandLong command{};
+    MavlinkCommandSender::CommandLong command{};
 
     // 0 to request default rate, -1 to stop stream
 
@@ -1230,20 +1231,20 @@ void SystemImpl::intercept_outgoing_messages(std::function<bool(mavlink_message_
 }
 
 void SystemImpl::register_mavlink_command_handler(uint16_t cmd_id,
-                                      MAVLinkCommands::mavlink_command_handler_t callback,
+                                      MavlinkCommandReceiver::mavlink_command_handler_t callback,
                                       const void* cookie)
 {
-    _commands.register_mavlink_command_handler(cmd_id, callback, cookie);
+    _receive_commands.register_mavlink_command_handler(cmd_id, callback, cookie);
 }
 
 void SystemImpl::unregister_mavlink_command_handler(uint16_t cmd_id, const void* cookie)
 {
-    _commands.unregister_mavlink_command_handler(cmd_id, cookie);
+    _receive_commands.unregister_mavlink_command_handler(cmd_id, cookie);
 }
 
 void SystemImpl::unregister_all_mavlink_command_handlers(const void* cookie)
 {
-    _commands.unregister_all_mavlink_command_handlers(cookie);
+    _receive_commands.unregister_all_mavlink_command_handlers(cookie);
 }
 
 } // namespace mavsdk

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -1229,4 +1229,21 @@ void SystemImpl::intercept_outgoing_messages(std::function<bool(mavlink_message_
     _outgoing_messages_intercept_callback = callback;
 }
 
+void SystemImpl::register_mavlink_command_handler(uint16_t cmd_id,
+                                      MAVLinkCommands::mavlink_command_handler_t callback,
+                                      const void* cookie)
+{
+    _commands.register_mavlink_command_handler(cmd_id, callback, cookie);
+}
+
+void SystemImpl::unregister_mavlink_command_handler(uint16_t cmd_id, const void* cookie)
+{
+    _commands.unregister_mavlink_command_handler(cmd_id, cookie);
+}
+
+void SystemImpl::unregister_all_mavlink_command_handlers(const void* cookie)
+{
+    _commands.unregister_all_mavlink_command_handlers(cookie);
+}
+
 } // namespace mavsdk

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -87,10 +87,10 @@ public:
     MavlinkCommandSender::Result send_command(MavlinkCommandSender::CommandLong& command);
     MavlinkCommandSender::Result send_command(MavlinkCommandSender::CommandInt& command);
 
-    void
-    send_command_async(MavlinkCommandSender::CommandLong command, const CommandResultCallback callback);
-    void
-    send_command_async(MavlinkCommandSender::CommandInt command, const CommandResultCallback callback);
+    void send_command_async(
+        MavlinkCommandSender::CommandLong command, const CommandResultCallback callback);
+    void send_command_async(
+        MavlinkCommandSender::CommandInt command, const CommandResultCallback callback);
 
     MavlinkCommandSender::Result set_msg_rate(
         uint16_t message_id, double rate_hz, uint8_t component_id = MAV_COMP_ID_AUTOPILOT1);
@@ -236,9 +236,10 @@ public:
     SystemImpl(const SystemImpl&) = delete;
     const SystemImpl& operator=(const SystemImpl&) = delete;
 
-    void register_mavlink_command_handler(uint16_t cmd_id,
-                                      MavlinkCommandReceiver::mavlink_command_handler_t callback,
-                                      const void* cookie);
+    void register_mavlink_command_handler(
+        uint16_t cmd_id,
+        MavlinkCommandReceiver::mavlink_command_handler_t callback,
+        const void* cookie);
     void unregister_mavlink_command_handler(uint16_t cmd_id, const void* cookie);
     void unregister_all_mavlink_command_handlers(const void* cookie);
 

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -238,7 +238,11 @@ public:
 
     void register_mavlink_command_handler(
         uint16_t cmd_id,
-        MavlinkCommandReceiver::mavlink_command_handler_t callback,
+        MavlinkCommandReceiver::mavlink_command_int_handler_t callback,
+        const void* cookie);
+    void register_mavlink_command_handler(
+        uint16_t cmd_id,
+        MavlinkCommandReceiver::mavlink_command_long_handler_t callback,
         const void* cookie);
     void unregister_mavlink_command_handler(uint16_t cmd_id, const void* cookie);
     void unregister_all_mavlink_command_handlers(const void* cookie);

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -235,6 +235,12 @@ public:
     // Non-copyable
     SystemImpl(const SystemImpl&) = delete;
     const SystemImpl& operator=(const SystemImpl&) = delete;
+    
+    void register_mavlink_command_handler(uint16_t cmd_id,
+                                      MAVLinkCommands::mavlink_command_handler_t callback,
+                                      const void* cookie);
+    void unregister_mavlink_command_handler(uint16_t cmd_id, const void* cookie);
+    void unregister_all_mavlink_command_handlers(const void* cookie);
 
 private:
     static bool is_autopilot(uint8_t comp_id);

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -82,17 +82,17 @@ public:
 
     static FlightMode to_flight_mode_from_custom_mode(uint32_t custom_mode);
 
-    using CommandResultCallback = MAVLinkCommands::CommandResultCallback;
+    using CommandResultCallback = MavlinkCommandSender::CommandResultCallback;
 
-    MAVLinkCommands::Result send_command(MAVLinkCommands::CommandLong& command);
-    MAVLinkCommands::Result send_command(MAVLinkCommands::CommandInt& command);
+    MavlinkCommandSender::Result send_command(MavlinkCommandSender::CommandLong& command);
+    MavlinkCommandSender::Result send_command(MavlinkCommandSender::CommandInt& command);
 
     void
-    send_command_async(MAVLinkCommands::CommandLong command, const CommandResultCallback callback);
+    send_command_async(MavlinkCommandSender::CommandLong command, const CommandResultCallback callback);
     void
-    send_command_async(MAVLinkCommands::CommandInt command, const CommandResultCallback callback);
+    send_command_async(MavlinkCommandSender::CommandInt command, const CommandResultCallback callback);
 
-    MAVLinkCommands::Result set_msg_rate(
+    MavlinkCommandSender::Result set_msg_rate(
         uint16_t message_id, double rate_hz, uint8_t component_id = MAV_COMP_ID_AUTOPILOT1);
 
     void set_msg_rate_async(
@@ -154,7 +154,7 @@ public:
 
     FlightMode get_flight_mode() const;
 
-    MAVLinkCommands::Result
+    MavlinkCommandSender::Result
     set_flight_mode(FlightMode mode, uint8_t component_id = MAV_COMP_ID_AUTOPILOT1);
 
     void set_flight_mode_async(
@@ -235,9 +235,9 @@ public:
     // Non-copyable
     SystemImpl(const SystemImpl&) = delete;
     const SystemImpl& operator=(const SystemImpl&) = delete;
-    
+
     void register_mavlink_command_handler(uint16_t cmd_id,
-                                      MAVLinkCommands::mavlink_command_handler_t callback,
+                                      MavlinkCommandReceiver::mavlink_command_handler_t callback,
                                       const void* cookie);
     void unregister_mavlink_command_handler(uint16_t cmd_id, const void* cookie);
     void unregister_all_mavlink_command_handlers(const void* cookie);
@@ -264,10 +264,10 @@ private:
     void send_heartbeat();
 
     // We use std::pair instead of a std::optional.
-    std::pair<MAVLinkCommands::Result, MAVLinkCommands::CommandLong>
+    std::pair<MavlinkCommandSender::Result, MavlinkCommandSender::CommandLong>
     make_command_flight_mode(FlightMode mode, uint8_t component_id);
 
-    MAVLinkCommands::CommandLong
+    MavlinkCommandSender::CommandLong
     make_command_msg_rate(uint16_t message_id, double rate_hz, uint8_t component_id);
 
     static void receive_float_param(
@@ -323,7 +323,8 @@ private:
     static constexpr double _HEARTBEAT_SEND_INTERVAL_S = 1.0;
 
     MAVLinkParameters _params;
-    MAVLinkCommands _commands;
+    MavlinkCommandSender _send_commands;
+    MavlinkCommandReceiver _receive_commands;
 
     Timesync _timesync;
 

--- a/src/plugins/action/action_impl.cpp
+++ b/src/plugins/action/action_impl.cpp
@@ -48,7 +48,7 @@ void ActionImpl::enable()
         MAVLINK_MSG_ID_EXTENDED_SYS_STATE,
         1.0,
         nullptr,
-        MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
+        MavlinkCommandSender::DEFAULT_COMPONENT_ID_AUTOPILOT);
 }
 
 void ActionImpl::disable() {}
@@ -183,14 +183,14 @@ Action::Result ActionImpl::transition_to_multicopter() const
 void ActionImpl::arm_async(const Action::ResultCallback& callback) const
 {
     auto send_arm_command = [this, callback]() {
-        MAVLinkCommands::CommandLong command{};
+        MavlinkCommandSender::CommandLong command{};
 
         command.command = MAV_CMD_COMPONENT_ARM_DISARM;
         command.params.param1 = 1.0f; // arm
         command.target_component_id = _parent->get_autopilot_id();
 
         _parent->send_command_async(
-            command, [this, callback](MAVLinkCommands::Result result, float) {
+            command, [this, callback](MavlinkCommandSender::Result result, float) {
                 command_result_callback(result, callback);
             });
     };
@@ -199,7 +199,7 @@ void ActionImpl::arm_async(const Action::ResultCallback& callback) const
         _parent->get_flight_mode() == SystemImpl::FlightMode::ReturnToLaunch) {
         _parent->set_flight_mode_async(
             SystemImpl::FlightMode::Hold,
-            [callback, send_arm_command](MAVLinkCommands::Result result, float) {
+            [callback, send_arm_command](MavlinkCommandSender::Result result, float) {
                 Action::Result action_result = action_result_from_command_result(result);
                 if (action_result != Action::Result::Success) {
                     if (callback) {
@@ -224,47 +224,47 @@ void ActionImpl::disarm_async(const Action::ResultCallback& callback) const
         return;
     }
 
-    MAVLinkCommands::CommandLong command{};
+    MavlinkCommandSender::CommandLong command{};
 
     command.command = MAV_CMD_COMPONENT_ARM_DISARM;
     command.params.param1 = 0.0f; // disarm
     command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(command, [this, callback](MAVLinkCommands::Result result, float) {
+    _parent->send_command_async(command, [this, callback](MavlinkCommandSender::Result result, float) {
         command_result_callback(result, callback);
     });
 }
 
 void ActionImpl::terminate_async(const Action::ResultCallback& callback) const
 {
-    MAVLinkCommands::CommandLong command{};
+    MavlinkCommandSender::CommandLong command{};
 
     command.command = MAV_CMD_DO_FLIGHTTERMINATION;
     command.params.param1 = 1;
     command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(command, [this, callback](MAVLinkCommands::Result result, float) {
+    _parent->send_command_async(command, [this, callback](MavlinkCommandSender::Result result, float) {
         command_result_callback(result, callback);
     });
 }
 
 void ActionImpl::kill_async(const Action::ResultCallback& callback) const
 {
-    MAVLinkCommands::CommandLong command{};
+    MavlinkCommandSender::CommandLong command{};
 
     command.command = MAV_CMD_COMPONENT_ARM_DISARM;
     command.params.param1 = 0.0f; // kill
     command.params.param2 = 21196.f; // magic number to enforce in-air
     command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(command, [this, callback](MAVLinkCommands::Result result, float) {
+    _parent->send_command_async(command, [this, callback](MavlinkCommandSender::Result result, float) {
         command_result_callback(result, callback);
     });
 }
 
 void ActionImpl::reboot_async(const Action::ResultCallback& callback) const
 {
-    MAVLinkCommands::CommandLong command{};
+    MavlinkCommandSender::CommandLong command{};
 
     command.command = MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN;
     command.params.param1 = 1.0f; // reboot autopilot
@@ -273,14 +273,14 @@ void ActionImpl::reboot_async(const Action::ResultCallback& callback) const
     command.params.param4 = 1.0f; // reboot gimbal
     command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(command, [this, callback](MAVLinkCommands::Result result, float) {
+    _parent->send_command_async(command, [this, callback](MavlinkCommandSender::Result result, float) {
         command_result_callback(result, callback);
     });
 }
 
 void ActionImpl::shutdown_async(const Action::ResultCallback& callback) const
 {
-    MAVLinkCommands::CommandLong command{};
+    MavlinkCommandSender::CommandLong command{};
 
     command.command = MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN;
     command.params.param1 = 2.0f; // shutdown autopilot
@@ -289,32 +289,32 @@ void ActionImpl::shutdown_async(const Action::ResultCallback& callback) const
     command.params.param4 = 2.0f; // shutdown gimbal
     command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(command, [this, callback](MAVLinkCommands::Result result, float) {
+    _parent->send_command_async(command, [this, callback](MavlinkCommandSender::Result result, float) {
         command_result_callback(result, callback);
     });
 }
 
 void ActionImpl::takeoff_async(const Action::ResultCallback& callback) const
 {
-    MAVLinkCommands::CommandLong command{};
+    MavlinkCommandSender::CommandLong command{};
 
     command.command = MAV_CMD_NAV_TAKEOFF;
     command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(command, [this, callback](MAVLinkCommands::Result result, float) {
+    _parent->send_command_async(command, [this, callback](MavlinkCommandSender::Result result, float) {
         command_result_callback(result, callback);
     });
 }
 
 void ActionImpl::land_async(const Action::ResultCallback& callback) const
 {
-    MAVLinkCommands::CommandLong command{};
+    MavlinkCommandSender::CommandLong command{};
 
     command.command = MAV_CMD_NAV_LAND;
     command.params.param4 = NAN; // Don't change yaw.
     command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(command, [this, callback](MAVLinkCommands::Result result, float) {
+    _parent->send_command_async(command, [this, callback](MavlinkCommandSender::Result result, float) {
         command_result_callback(result, callback);
     });
 }
@@ -323,7 +323,7 @@ void ActionImpl::return_to_launch_async(const Action::ResultCallback& callback) 
 {
     _parent->set_flight_mode_async(
         SystemImpl::FlightMode::ReturnToLaunch,
-        [this, callback](MAVLinkCommands::Result result, float) {
+        [this, callback](MavlinkCommandSender::Result result, float) {
             command_result_callback(result, callback);
         });
 }
@@ -335,7 +335,7 @@ void ActionImpl::goto_location_async(
     const float yaw_deg,
     const Action::ResultCallback& callback)
 {
-    MAVLinkCommands::CommandInt command{};
+    MavlinkCommandSender::CommandInt command{};
 
     command.command = MAV_CMD_DO_REPOSITION;
     command.target_component_id = _parent->get_autopilot_id();
@@ -344,7 +344,7 @@ void ActionImpl::goto_location_async(
     command.params.y = int32_t(std::round(longitude_deg * 1e7));
     command.params.z = altitude_amsl_m;
 
-    _parent->send_command_async(command, [this, callback](MAVLinkCommands::Result result, float) {
+    _parent->send_command_async(command, [this, callback](MavlinkCommandSender::Result result, float) {
         command_result_callback(result, callback);
     });
 }
@@ -365,13 +365,13 @@ void ActionImpl::transition_to_fixedwing_async(const Action::ResultCallback& cal
         return;
     }
 
-    MAVLinkCommands::CommandLong command{};
+    MavlinkCommandSender::CommandLong command{};
 
     command.command = MAV_CMD_DO_VTOL_TRANSITION;
     command.params.param1 = float(MAV_VTOL_STATE_FW);
     command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(command, [this, callback](MAVLinkCommands::Result result, float) {
+    _parent->send_command_async(command, [this, callback](MavlinkCommandSender::Result result, float) {
         command_result_callback(result, callback);
     });
 }
@@ -391,13 +391,13 @@ void ActionImpl::transition_to_multicopter_async(const Action::ResultCallback& c
         }
         return;
     }
-    MAVLinkCommands::CommandLong command{};
+    MavlinkCommandSender::CommandLong command{};
 
     command.command = MAV_CMD_DO_VTOL_TRANSITION;
     command.params.param1 = float(MAV_VTOL_STATE_MC);
     command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(command, [this, callback](MAVLinkCommands::Result result, float) {
+    _parent->send_command_async(command, [this, callback](MavlinkCommandSender::Result result, float) {
         command_result_callback(result, callback);
     });
 }
@@ -537,20 +537,20 @@ std::pair<Action::Result, float> ActionImpl::get_return_to_launch_altitude() con
         result.second);
 }
 
-Action::Result ActionImpl::action_result_from_command_result(MAVLinkCommands::Result result)
+Action::Result ActionImpl::action_result_from_command_result(MavlinkCommandSender::Result result)
 {
     switch (result) {
-        case MAVLinkCommands::Result::Success:
+        case MavlinkCommandSender::Result::Success:
             return Action::Result::Success;
-        case MAVLinkCommands::Result::NoSystem:
+        case MavlinkCommandSender::Result::NoSystem:
             return Action::Result::NoSystem;
-        case MAVLinkCommands::Result::ConnectionError:
+        case MavlinkCommandSender::Result::ConnectionError:
             return Action::Result::ConnectionError;
-        case MAVLinkCommands::Result::Busy:
+        case MavlinkCommandSender::Result::Busy:
             return Action::Result::Busy;
-        case MAVLinkCommands::Result::CommandDenied:
+        case MavlinkCommandSender::Result::CommandDenied:
             return Action::Result::CommandDenied;
-        case MAVLinkCommands::Result::Timeout:
+        case MavlinkCommandSender::Result::Timeout:
             return Action::Result::Timeout;
         default:
             return Action::Result::Unknown;
@@ -558,7 +558,7 @@ Action::Result ActionImpl::action_result_from_command_result(MAVLinkCommands::Re
 }
 
 void ActionImpl::command_result_callback(
-    MAVLinkCommands::Result command_result, const Action::ResultCallback& callback) const
+    MavlinkCommandSender::Result command_result, const Action::ResultCallback& callback) const
 {
     Action::Result action_result = action_result_from_command_result(command_result);
 

--- a/src/plugins/action/action_impl.cpp
+++ b/src/plugins/action/action_impl.cpp
@@ -230,9 +230,10 @@ void ActionImpl::disarm_async(const Action::ResultCallback& callback) const
     command.params.param1 = 0.0f; // disarm
     command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(command, [this, callback](MavlinkCommandSender::Result result, float) {
-        command_result_callback(result, callback);
-    });
+    _parent->send_command_async(
+        command, [this, callback](MavlinkCommandSender::Result result, float) {
+            command_result_callback(result, callback);
+        });
 }
 
 void ActionImpl::terminate_async(const Action::ResultCallback& callback) const
@@ -243,9 +244,10 @@ void ActionImpl::terminate_async(const Action::ResultCallback& callback) const
     command.params.param1 = 1;
     command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(command, [this, callback](MavlinkCommandSender::Result result, float) {
-        command_result_callback(result, callback);
-    });
+    _parent->send_command_async(
+        command, [this, callback](MavlinkCommandSender::Result result, float) {
+            command_result_callback(result, callback);
+        });
 }
 
 void ActionImpl::kill_async(const Action::ResultCallback& callback) const
@@ -257,9 +259,10 @@ void ActionImpl::kill_async(const Action::ResultCallback& callback) const
     command.params.param2 = 21196.f; // magic number to enforce in-air
     command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(command, [this, callback](MavlinkCommandSender::Result result, float) {
-        command_result_callback(result, callback);
-    });
+    _parent->send_command_async(
+        command, [this, callback](MavlinkCommandSender::Result result, float) {
+            command_result_callback(result, callback);
+        });
 }
 
 void ActionImpl::reboot_async(const Action::ResultCallback& callback) const
@@ -273,9 +276,10 @@ void ActionImpl::reboot_async(const Action::ResultCallback& callback) const
     command.params.param4 = 1.0f; // reboot gimbal
     command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(command, [this, callback](MavlinkCommandSender::Result result, float) {
-        command_result_callback(result, callback);
-    });
+    _parent->send_command_async(
+        command, [this, callback](MavlinkCommandSender::Result result, float) {
+            command_result_callback(result, callback);
+        });
 }
 
 void ActionImpl::shutdown_async(const Action::ResultCallback& callback) const
@@ -289,9 +293,10 @@ void ActionImpl::shutdown_async(const Action::ResultCallback& callback) const
     command.params.param4 = 2.0f; // shutdown gimbal
     command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(command, [this, callback](MavlinkCommandSender::Result result, float) {
-        command_result_callback(result, callback);
-    });
+    _parent->send_command_async(
+        command, [this, callback](MavlinkCommandSender::Result result, float) {
+            command_result_callback(result, callback);
+        });
 }
 
 void ActionImpl::takeoff_async(const Action::ResultCallback& callback) const
@@ -301,9 +306,10 @@ void ActionImpl::takeoff_async(const Action::ResultCallback& callback) const
     command.command = MAV_CMD_NAV_TAKEOFF;
     command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(command, [this, callback](MavlinkCommandSender::Result result, float) {
-        command_result_callback(result, callback);
-    });
+    _parent->send_command_async(
+        command, [this, callback](MavlinkCommandSender::Result result, float) {
+            command_result_callback(result, callback);
+        });
 }
 
 void ActionImpl::land_async(const Action::ResultCallback& callback) const
@@ -314,9 +320,10 @@ void ActionImpl::land_async(const Action::ResultCallback& callback) const
     command.params.param4 = NAN; // Don't change yaw.
     command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(command, [this, callback](MavlinkCommandSender::Result result, float) {
-        command_result_callback(result, callback);
-    });
+    _parent->send_command_async(
+        command, [this, callback](MavlinkCommandSender::Result result, float) {
+            command_result_callback(result, callback);
+        });
 }
 
 void ActionImpl::return_to_launch_async(const Action::ResultCallback& callback) const
@@ -344,9 +351,10 @@ void ActionImpl::goto_location_async(
     command.params.y = int32_t(std::round(longitude_deg * 1e7));
     command.params.z = altitude_amsl_m;
 
-    _parent->send_command_async(command, [this, callback](MavlinkCommandSender::Result result, float) {
-        command_result_callback(result, callback);
-    });
+    _parent->send_command_async(
+        command, [this, callback](MavlinkCommandSender::Result result, float) {
+            command_result_callback(result, callback);
+        });
 }
 
 void ActionImpl::transition_to_fixedwing_async(const Action::ResultCallback& callback) const
@@ -371,9 +379,10 @@ void ActionImpl::transition_to_fixedwing_async(const Action::ResultCallback& cal
     command.params.param1 = float(MAV_VTOL_STATE_FW);
     command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(command, [this, callback](MavlinkCommandSender::Result result, float) {
-        command_result_callback(result, callback);
-    });
+    _parent->send_command_async(
+        command, [this, callback](MavlinkCommandSender::Result result, float) {
+            command_result_callback(result, callback);
+        });
 }
 
 void ActionImpl::transition_to_multicopter_async(const Action::ResultCallback& callback) const
@@ -397,9 +406,10 @@ void ActionImpl::transition_to_multicopter_async(const Action::ResultCallback& c
     command.params.param1 = float(MAV_VTOL_STATE_MC);
     command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(command, [this, callback](MavlinkCommandSender::Result result, float) {
-        command_result_callback(result, callback);
-    });
+    _parent->send_command_async(
+        command, [this, callback](MavlinkCommandSender::Result result, float) {
+            command_result_callback(result, callback);
+        });
 }
 
 Action::Result ActionImpl::taking_off_allowed() const

--- a/src/plugins/action/action_impl.h
+++ b/src/plugins/action/action_impl.h
@@ -83,10 +83,10 @@ private:
 
     void process_extended_sys_state(const mavlink_message_t& message);
 
-    static Action::Result action_result_from_command_result(MAVLinkCommands::Result result);
+    static Action::Result action_result_from_command_result(MavlinkCommandSender::Result result);
 
     void command_result_callback(
-        MAVLinkCommands::Result command_result, const Action::ResultCallback& callback) const;
+        MavlinkCommandSender::Result command_result, const Action::ResultCallback& callback) const;
 
     std::atomic<bool> _in_air_state_known{false};
     std::atomic<bool> _in_air{false};

--- a/src/plugins/calibration/calibration_impl.h
+++ b/src/plugins/calibration/calibration_impl.h
@@ -39,10 +39,10 @@ private:
         const Calibration::ProgressData progress_data);
     void process_statustext(const mavlink_message_t& message);
 
-    void command_result_callback(MAVLinkCommands::Result command_result, float progress);
+    void command_result_callback(MavlinkCommandSender::Result command_result, float progress);
 
     static Calibration::Result
-    calibration_result_from_command_result(MAVLinkCommands::Result result);
+    calibration_result_from_command_result(MavlinkCommandSender::Result result);
 
     void report_started();
     void report_done();

--- a/src/plugins/camera/camera_impl.cpp
+++ b/src/plugins/camera/camera_impl.cpp
@@ -183,9 +183,9 @@ Camera::Result CameraImpl::select_camera(const size_t id)
     return Camera::Result::Success;
 }
 
-MAVLinkCommands::CommandLong CameraImpl::make_command_request_flight_information()
+MavlinkCommandSender::CommandLong CameraImpl::make_command_request_flight_information()
 {
-    MAVLinkCommands::CommandLong command_flight_information{};
+    MavlinkCommandSender::CommandLong command_flight_information{};
 
     command_flight_information.command = MAV_CMD_REQUEST_FLIGHT_INFORMATION;
     command_flight_information.params.param1 = 1.0f; // Request it
@@ -194,9 +194,9 @@ MAVLinkCommands::CommandLong CameraImpl::make_command_request_flight_information
     return command_flight_information;
 }
 
-MAVLinkCommands::CommandLong CameraImpl::make_command_request_camera_info()
+MavlinkCommandSender::CommandLong CameraImpl::make_command_request_camera_info()
 {
-    MAVLinkCommands::CommandLong command_camera_info{};
+    MavlinkCommandSender::CommandLong command_camera_info{};
 
     command_camera_info.command = MAV_CMD_REQUEST_CAMERA_INFORMATION;
     command_camera_info.params.param1 = 1.0f; // Request it
@@ -205,10 +205,10 @@ MAVLinkCommands::CommandLong CameraImpl::make_command_request_camera_info()
     return command_camera_info;
 }
 
-MAVLinkCommands::CommandLong
+MavlinkCommandSender::CommandLong
 CameraImpl::make_command_take_photo(float interval_s, float no_of_photos)
 {
-    MAVLinkCommands::CommandLong cmd_take_photo{};
+    MavlinkCommandSender::CommandLong cmd_take_photo{};
 
     cmd_take_photo.command = MAV_CMD_IMAGE_START_CAPTURE;
     cmd_take_photo.params.param1 = 0.0f; // Reserved, set to 0
@@ -220,9 +220,9 @@ CameraImpl::make_command_take_photo(float interval_s, float no_of_photos)
     return cmd_take_photo;
 }
 
-MAVLinkCommands::CommandLong CameraImpl::make_command_stop_photo()
+MavlinkCommandSender::CommandLong CameraImpl::make_command_stop_photo()
 {
-    MAVLinkCommands::CommandLong cmd_stop_photo{};
+    MavlinkCommandSender::CommandLong cmd_stop_photo{};
 
     cmd_stop_photo.command = MAV_CMD_IMAGE_STOP_CAPTURE;
     cmd_stop_photo.target_component_id = _camera_id + MAV_COMP_ID_CAMERA;
@@ -230,9 +230,9 @@ MAVLinkCommands::CommandLong CameraImpl::make_command_stop_photo()
     return cmd_stop_photo;
 }
 
-MAVLinkCommands::CommandLong CameraImpl::make_command_start_video(float capture_status_rate_hz)
+MavlinkCommandSender::CommandLong CameraImpl::make_command_start_video(float capture_status_rate_hz)
 {
-    MAVLinkCommands::CommandLong cmd_start_video{};
+    MavlinkCommandSender::CommandLong cmd_start_video{};
 
     cmd_start_video.command = MAV_CMD_VIDEO_START_CAPTURE;
     cmd_start_video.params.param1 = 0.f; // Reserved, set to 0
@@ -242,9 +242,9 @@ MAVLinkCommands::CommandLong CameraImpl::make_command_start_video(float capture_
     return cmd_start_video;
 }
 
-MAVLinkCommands::CommandLong CameraImpl::make_command_stop_video()
+MavlinkCommandSender::CommandLong CameraImpl::make_command_stop_video()
 {
-    MAVLinkCommands::CommandLong cmd_stop_video{};
+    MavlinkCommandSender::CommandLong cmd_stop_video{};
 
     cmd_stop_video.command = MAV_CMD_VIDEO_STOP_CAPTURE;
     cmd_stop_video.params.param1 = 0.f; // Reserved, set to 0
@@ -253,9 +253,9 @@ MAVLinkCommands::CommandLong CameraImpl::make_command_stop_video()
     return cmd_stop_video;
 }
 
-MAVLinkCommands::CommandLong CameraImpl::make_command_set_camera_mode(float mavlink_mode)
+MavlinkCommandSender::CommandLong CameraImpl::make_command_set_camera_mode(float mavlink_mode)
 {
-    MAVLinkCommands::CommandLong cmd_set_camera_mode{};
+    MavlinkCommandSender::CommandLong cmd_set_camera_mode{};
 
     cmd_set_camera_mode.command = MAV_CMD_SET_CAMERA_MODE;
     cmd_set_camera_mode.params.param1 = 0.0f; // Reserved, set to 0
@@ -265,9 +265,9 @@ MAVLinkCommands::CommandLong CameraImpl::make_command_set_camera_mode(float mavl
     return cmd_set_camera_mode;
 }
 
-MAVLinkCommands::CommandLong CameraImpl::make_command_request_camera_settings()
+MavlinkCommandSender::CommandLong CameraImpl::make_command_request_camera_settings()
 {
-    MAVLinkCommands::CommandLong cmd_req_camera_settings{};
+    MavlinkCommandSender::CommandLong cmd_req_camera_settings{};
 
     cmd_req_camera_settings.command = MAV_CMD_REQUEST_CAMERA_SETTINGS;
     cmd_req_camera_settings.params.param1 = 1.f; // Request it
@@ -276,9 +276,9 @@ MAVLinkCommands::CommandLong CameraImpl::make_command_request_camera_settings()
     return cmd_req_camera_settings;
 }
 
-MAVLinkCommands::CommandLong CameraImpl::make_command_request_camera_capture_status()
+MavlinkCommandSender::CommandLong CameraImpl::make_command_request_camera_capture_status()
 {
-    MAVLinkCommands::CommandLong cmd_req_camera_cap_stat{};
+    MavlinkCommandSender::CommandLong cmd_req_camera_cap_stat{};
 
     cmd_req_camera_cap_stat.command = MAV_CMD_REQUEST_CAMERA_CAPTURE_STATUS;
     cmd_req_camera_cap_stat.params.param1 = 1.0f; // Request it
@@ -287,9 +287,9 @@ MAVLinkCommands::CommandLong CameraImpl::make_command_request_camera_capture_sta
     return cmd_req_camera_cap_stat;
 }
 
-MAVLinkCommands::CommandLong CameraImpl::make_command_request_storage_info()
+MavlinkCommandSender::CommandLong CameraImpl::make_command_request_storage_info()
 {
-    MAVLinkCommands::CommandLong cmd_req_storage_info{};
+    MavlinkCommandSender::CommandLong cmd_req_storage_info{};
 
     cmd_req_storage_info.command = MAV_CMD_REQUEST_STORAGE_INFORMATION;
     cmd_req_storage_info.params.param1 = 0.f; // Reserved, set to 0
@@ -299,9 +299,9 @@ MAVLinkCommands::CommandLong CameraImpl::make_command_request_storage_info()
     return cmd_req_storage_info;
 }
 
-MAVLinkCommands::CommandLong CameraImpl::make_command_start_video_streaming()
+MavlinkCommandSender::CommandLong CameraImpl::make_command_start_video_streaming()
 {
-    MAVLinkCommands::CommandLong cmd_start_video_streaming{};
+    MavlinkCommandSender::CommandLong cmd_start_video_streaming{};
 
     cmd_start_video_streaming.command = MAV_CMD_VIDEO_START_STREAMING;
     cmd_start_video_streaming.target_component_id = _camera_id + MAV_COMP_ID_CAMERA;
@@ -309,9 +309,9 @@ MAVLinkCommands::CommandLong CameraImpl::make_command_start_video_streaming()
     return cmd_start_video_streaming;
 }
 
-MAVLinkCommands::CommandLong CameraImpl::make_command_stop_video_streaming()
+MavlinkCommandSender::CommandLong CameraImpl::make_command_stop_video_streaming()
 {
-    MAVLinkCommands::CommandLong cmd_stop_video_streaming{};
+    MavlinkCommandSender::CommandLong cmd_stop_video_streaming{};
 
     cmd_stop_video_streaming.command = MAV_CMD_VIDEO_STOP_STREAMING;
     cmd_stop_video_streaming.target_component_id = _camera_id + MAV_COMP_ID_CAMERA;
@@ -319,9 +319,9 @@ MAVLinkCommands::CommandLong CameraImpl::make_command_stop_video_streaming()
     return cmd_stop_video_streaming;
 }
 
-MAVLinkCommands::CommandLong CameraImpl::make_command_request_video_stream_info()
+MavlinkCommandSender::CommandLong CameraImpl::make_command_request_video_stream_info()
 {
-    MAVLinkCommands::CommandLong cmd_req_video_stream_info{};
+    MavlinkCommandSender::CommandLong cmd_req_video_stream_info{};
 
     cmd_req_video_stream_info.command = MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION;
     cmd_req_video_stream_info.params.param2 = 1.0f;
@@ -533,20 +533,20 @@ void CameraImpl::video_stream_info_async(const Camera::VideoStreamInfoCallback c
 }
 
 Camera::Result
-CameraImpl::camera_result_from_command_result(const MAVLinkCommands::Result command_result)
+CameraImpl::camera_result_from_command_result(const MavlinkCommandSender::Result command_result)
 {
     switch (command_result) {
-        case MAVLinkCommands::Result::Success:
+        case MavlinkCommandSender::Result::Success:
             return Camera::Result::Success;
-        case MAVLinkCommands::Result::NoSystem:
+        case MavlinkCommandSender::Result::NoSystem:
         // FALLTHROUGH
-        case MAVLinkCommands::Result::ConnectionError:
+        case MavlinkCommandSender::Result::ConnectionError:
         // FALLTHROUGH
-        case MAVLinkCommands::Result::Busy:
+        case MavlinkCommandSender::Result::Busy:
             return Camera::Result::Error;
-        case MAVLinkCommands::Result::CommandDenied:
+        case MavlinkCommandSender::Result::CommandDenied:
             return Camera::Result::Denied;
-        case MAVLinkCommands::Result::Timeout:
+        case MavlinkCommandSender::Result::Timeout:
             return Camera::Result::Timeout;
         default:
             return Camera::Result::Unknown;
@@ -607,7 +607,7 @@ void CameraImpl::set_mode_async(const Camera::Mode mode, const Camera::ResultCal
 
     _parent->send_command_async(
         cmd_set_camera_mode,
-        [this, callback, mode](MAVLinkCommands::Result result, float progress) {
+        [this, callback, mode](MavlinkCommandSender::Result result, float progress) {
             UNUSED(progress);
             receive_set_mode_command_result(result, callback, mode);
         });
@@ -937,7 +937,7 @@ void CameraImpl::check_status()
 }
 
 void CameraImpl::receive_command_result(
-    MAVLinkCommands::Result command_result, const Camera::ResultCallback& callback)
+    MavlinkCommandSender::Result command_result, const Camera::ResultCallback& callback)
 {
     Camera::Result camera_result = camera_result_from_command_result(command_result);
 
@@ -947,7 +947,7 @@ void CameraImpl::receive_command_result(
 }
 
 void CameraImpl::receive_set_mode_command_result(
-    const MAVLinkCommands::Result command_result,
+    const MavlinkCommandSender::Result command_result,
     const Camera::ResultCallback callback,
     const Camera::Mode mode)
 {
@@ -959,7 +959,7 @@ void CameraImpl::receive_set_mode_command_result(
             [temp_callback, camera_result]() { temp_callback(camera_result); });
     }
 
-    if (command_result == MAVLinkCommands::Result::Success && _camera_definition) {
+    if (command_result == MavlinkCommandSender::Result::Success && _camera_definition) {
         // This "parameter" needs to be manually set.
         {
             std::lock_guard<std::mutex> lock(_mode.mutex);
@@ -1516,7 +1516,7 @@ Camera::Result CameraImpl::format_storage()
 
 void CameraImpl::format_storage_async(Camera::ResultCallback callback)
 {
-    MAVLinkCommands::CommandLong cmd_format{};
+    MavlinkCommandSender::CommandLong cmd_format{};
 
     cmd_format.command = MAV_CMD_STORAGE_FORMAT;
     cmd_format.params.param1 = 1.0f; // storage ID

--- a/src/plugins/camera/camera_impl.h
+++ b/src/plugins/camera/camera_impl.h
@@ -100,15 +100,15 @@ private:
     void manual_disable();
 
     void receive_set_mode_command_result(
-        const MAVLinkCommands::Result command_result,
+        const MavlinkCommandSender::Result command_result,
         const Camera::ResultCallback callback,
         const Camera::Mode mode);
 
     static Camera::Result
-    camera_result_from_command_result(const MAVLinkCommands::Result command_result);
+    camera_result_from_command_result(const MavlinkCommandSender::Result command_result);
 
     void receive_command_result(
-        MAVLinkCommands::Result command_result, const Camera::ResultCallback& callback);
+        MavlinkCommandSender::Result command_result, const Camera::ResultCallback& callback);
 
     static bool interval_valid(float interval_s);
 
@@ -148,23 +148,23 @@ private:
     void request_status();
     void request_flight_information();
 
-    MAVLinkCommands::CommandLong make_command_take_photo(float interval_s, float no_of_photos);
-    MAVLinkCommands::CommandLong make_command_stop_photo();
+    MavlinkCommandSender::CommandLong make_command_take_photo(float interval_s, float no_of_photos);
+    MavlinkCommandSender::CommandLong make_command_stop_photo();
 
-    MAVLinkCommands::CommandLong make_command_request_flight_information();
-    MAVLinkCommands::CommandLong make_command_request_camera_info();
-    MAVLinkCommands::CommandLong make_command_set_camera_mode(float mavlink_mode);
-    MAVLinkCommands::CommandLong make_command_request_camera_settings();
-    MAVLinkCommands::CommandLong make_command_request_camera_capture_status();
-    MAVLinkCommands::CommandLong make_command_request_storage_info();
+    MavlinkCommandSender::CommandLong make_command_request_flight_information();
+    MavlinkCommandSender::CommandLong make_command_request_camera_info();
+    MavlinkCommandSender::CommandLong make_command_set_camera_mode(float mavlink_mode);
+    MavlinkCommandSender::CommandLong make_command_request_camera_settings();
+    MavlinkCommandSender::CommandLong make_command_request_camera_capture_status();
+    MavlinkCommandSender::CommandLong make_command_request_storage_info();
 
-    MAVLinkCommands::CommandLong make_command_start_video(float capture_status_rate_hz);
-    MAVLinkCommands::CommandLong make_command_stop_video();
+    MavlinkCommandSender::CommandLong make_command_start_video(float capture_status_rate_hz);
+    MavlinkCommandSender::CommandLong make_command_stop_video();
 
-    MAVLinkCommands::CommandLong make_command_start_video_streaming();
-    MAVLinkCommands::CommandLong make_command_stop_video_streaming();
+    MavlinkCommandSender::CommandLong make_command_start_video_streaming();
+    MavlinkCommandSender::CommandLong make_command_stop_video_streaming();
 
-    MAVLinkCommands::CommandLong make_command_request_video_stream_info();
+    MavlinkCommandSender::CommandLong make_command_request_video_stream_info();
 
     std::unique_ptr<CameraDefinition> _camera_definition{};
 

--- a/src/plugins/failure/failure_impl.cpp
+++ b/src/plugins/failure/failure_impl.cpp
@@ -73,7 +73,7 @@ Failure::Result FailureImpl::inject(
         return Failure::Result::Disabled;
     }
 
-    MAVLinkCommands::CommandLong command{};
+    MavlinkCommandSender::CommandLong command{};
 
     command.command = MAV_CMD_INJECT_FAILURE;
     command.params.param1 = static_cast<float>(failure_unit);
@@ -85,20 +85,20 @@ Failure::Result FailureImpl::inject(
 }
 
 Failure::Result
-FailureImpl::failure_result_from_command_result(MAVLinkCommands::Result command_result)
+FailureImpl::failure_result_from_command_result(MavlinkCommandSender::Result command_result)
 {
     switch (command_result) {
-        case MAVLinkCommands::Result::Success:
+        case MavlinkCommandSender::Result::Success:
             return Failure::Result::Success;
-        case MAVLinkCommands::Result::NoSystem:
+        case MavlinkCommandSender::Result::NoSystem:
             return Failure::Result::NoSystem;
-        case MAVLinkCommands::Result::ConnectionError:
+        case MavlinkCommandSender::Result::ConnectionError:
             return Failure::Result::ConnectionError;
-        case MAVLinkCommands::Result::CommandDenied:
+        case MavlinkCommandSender::Result::CommandDenied:
             return Failure::Result::Denied;
-        case MAVLinkCommands::Result::Unsupported:
+        case MavlinkCommandSender::Result::Unsupported:
             return Failure::Result::Unsupported;
-        case MAVLinkCommands::Result::Timeout:
+        case MavlinkCommandSender::Result::Timeout:
             return Failure::Result::Timeout;
         default:
             return Failure::Result::Unknown;

--- a/src/plugins/failure/failure_impl.h
+++ b/src/plugins/failure/failure_impl.h
@@ -21,7 +21,7 @@ public:
     inject(Failure::FailureUnit failure_unit, Failure::FailureType failure_type, int32_t instance);
 
 private:
-    Failure::Result failure_result_from_command_result(MAVLinkCommands::Result command_result);
+    Failure::Result failure_result_from_command_result(MavlinkCommandSender::Result command_result);
 
     enum class EnabledState {
         Init,

--- a/src/plugins/follow_me/follow_me_impl.cpp
+++ b/src/plugins/follow_me/follow_me_impl.cpp
@@ -231,20 +231,20 @@ bool FollowMeImpl::is_config_ok(const FollowMe::Config& config) const
     return config_ok;
 }
 
-FollowMe::Result FollowMeImpl::to_follow_me_result(MAVLinkCommands::Result result) const
+FollowMe::Result FollowMeImpl::to_follow_me_result(MavlinkCommandSender::Result result) const
 {
     switch (result) {
-        case MAVLinkCommands::Result::Success:
+        case MavlinkCommandSender::Result::Success:
             return FollowMe::Result::Success;
-        case MAVLinkCommands::Result::NoSystem:
+        case MavlinkCommandSender::Result::NoSystem:
             return FollowMe::Result::NoSystem;
-        case MAVLinkCommands::Result::ConnectionError:
+        case MavlinkCommandSender::Result::ConnectionError:
             return FollowMe::Result::ConnectionError;
-        case MAVLinkCommands::Result::Busy:
+        case MavlinkCommandSender::Result::Busy:
             return FollowMe::Result::Busy;
-        case MAVLinkCommands::Result::CommandDenied:
+        case MavlinkCommandSender::Result::CommandDenied:
             return FollowMe::Result::CommandDenied;
-        case MAVLinkCommands::Result::Timeout:
+        case MavlinkCommandSender::Result::Timeout:
             return FollowMe::Result::Timeout;
         default:
             return FollowMe::Result::Unknown;

--- a/src/plugins/follow_me/follow_me_impl.h
+++ b/src/plugins/follow_me/follow_me_impl.h
@@ -43,7 +43,7 @@ private:
     enum class ConfigParameter;
     // Config methods
     bool is_config_ok(const FollowMe::Config& config) const;
-    FollowMe::Result to_follow_me_result(MAVLinkCommands::Result result) const;
+    FollowMe::Result to_follow_me_result(MavlinkCommandSender::Result result) const;
 
     bool is_target_location_set() const;
     void send_target_location();

--- a/src/plugins/gimbal/gimbal_impl.cpp
+++ b/src/plugins/gimbal/gimbal_impl.cpp
@@ -39,7 +39,7 @@ void GimbalImpl::enable()
     _parent->register_timeout_handler(
         [this]() { receive_protocol_timeout(); }, 1.0, &_protocol_cookie);
 
-    MAVLinkCommands::CommandLong command{};
+    MavlinkCommandSender::CommandLong command{};
     command.command = MAV_CMD_REQUEST_MESSAGE;
     command.params.param1 = static_cast<float>(MAVLINK_MSG_ID_GIMBAL_MANAGER_INFORMATION);
     command.target_component_id = 0; // any component
@@ -127,7 +127,7 @@ void GimbalImpl::wait_for_protocol_async(std::function<void()> callback)
 }
 
 void GimbalImpl::receive_command_result(
-    MAVLinkCommands::Result command_result, const Gimbal::ResultCallback& callback)
+    MavlinkCommandSender::Result command_result, const Gimbal::ResultCallback& callback)
 {
     Gimbal::Result gimbal_result = gimbal_result_from_command_result(command_result);
 
@@ -136,17 +136,17 @@ void GimbalImpl::receive_command_result(
     }
 }
 
-Gimbal::Result GimbalImpl::gimbal_result_from_command_result(MAVLinkCommands::Result command_result)
+Gimbal::Result GimbalImpl::gimbal_result_from_command_result(MavlinkCommandSender::Result command_result)
 {
     switch (command_result) {
-        case MAVLinkCommands::Result::Success:
+        case MavlinkCommandSender::Result::Success:
             return Gimbal::Result::Success;
-        case MAVLinkCommands::Result::Timeout:
+        case MavlinkCommandSender::Result::Timeout:
             return Gimbal::Result::Timeout;
-        case MAVLinkCommands::Result::NoSystem:
-        case MAVLinkCommands::Result::ConnectionError:
-        case MAVLinkCommands::Result::Busy:
-        case MAVLinkCommands::Result::CommandDenied:
+        case MavlinkCommandSender::Result::NoSystem:
+        case MavlinkCommandSender::Result::ConnectionError:
+        case MavlinkCommandSender::Result::Busy:
+        case MavlinkCommandSender::Result::CommandDenied:
         default:
             return Gimbal::Result::Error;
     }

--- a/src/plugins/gimbal/gimbal_impl.cpp
+++ b/src/plugins/gimbal/gimbal_impl.cpp
@@ -136,7 +136,8 @@ void GimbalImpl::receive_command_result(
     }
 }
 
-Gimbal::Result GimbalImpl::gimbal_result_from_command_result(MavlinkCommandSender::Result command_result)
+Gimbal::Result
+GimbalImpl::gimbal_result_from_command_result(MavlinkCommandSender::Result command_result)
 {
     switch (command_result) {
         case MavlinkCommandSender::Result::Success:

--- a/src/plugins/gimbal/gimbal_impl.h
+++ b/src/plugins/gimbal/gimbal_impl.h
@@ -35,7 +35,8 @@ public:
         float altitude_m,
         Gimbal::ResultCallback callback);
 
-    static Gimbal::Result gimbal_result_from_command_result(MavlinkCommandSender::Result command_result);
+    static Gimbal::Result
+    gimbal_result_from_command_result(MavlinkCommandSender::Result command_result);
 
     static void receive_command_result(
         MavlinkCommandSender::Result command_result, const Gimbal::ResultCallback& callback);

--- a/src/plugins/gimbal/gimbal_impl.h
+++ b/src/plugins/gimbal/gimbal_impl.h
@@ -35,10 +35,10 @@ public:
         float altitude_m,
         Gimbal::ResultCallback callback);
 
-    static Gimbal::Result gimbal_result_from_command_result(MAVLinkCommands::Result command_result);
+    static Gimbal::Result gimbal_result_from_command_result(MavlinkCommandSender::Result command_result);
 
     static void receive_command_result(
-        MAVLinkCommands::Result command_result, const Gimbal::ResultCallback& callback);
+        MavlinkCommandSender::Result command_result, const Gimbal::ResultCallback& callback);
 
     // Non-copyable
     GimbalImpl(const GimbalImpl&) = delete;

--- a/src/plugins/gimbal/gimbal_protocol_v1.cpp
+++ b/src/plugins/gimbal/gimbal_protocol_v1.cpp
@@ -11,7 +11,7 @@ GimbalProtocolV1::GimbalProtocolV1(SystemImpl& system_impl) : GimbalProtocolBase
 Gimbal::Result GimbalProtocolV1::set_pitch_and_yaw(float pitch_deg, float yaw_deg)
 {
     const float roll_deg = 0.0f;
-    MAVLinkCommands::CommandLong command{};
+    MavlinkCommandSender::CommandLong command{};
 
     command.command = MAV_CMD_DO_MOUNT_CONTROL;
     command.params.param1 = pitch_deg;
@@ -27,7 +27,7 @@ void GimbalProtocolV1::set_pitch_and_yaw_async(
     float pitch_deg, float yaw_deg, Gimbal::ResultCallback callback)
 {
     const float roll_deg = 0.0f;
-    MAVLinkCommands::CommandLong command{};
+    MavlinkCommandSender::CommandLong command{};
 
     command.command = MAV_CMD_DO_MOUNT_CONTROL;
     command.params.param1 = pitch_deg;
@@ -37,7 +37,7 @@ void GimbalProtocolV1::set_pitch_and_yaw_async(
     command.target_component_id = _system_impl.get_autopilot_id();
 
     _system_impl.send_command_async(
-        command, [callback](MAVLinkCommands::Result command_result, float progress) {
+        command, [callback](MavlinkCommandSender::Result command_result, float progress) {
             UNUSED(progress);
             GimbalImpl::receive_command_result(command_result, callback);
         });
@@ -45,7 +45,7 @@ void GimbalProtocolV1::set_pitch_and_yaw_async(
 
 Gimbal::Result GimbalProtocolV1::set_mode(const Gimbal::GimbalMode gimbal_mode)
 {
-    MAVLinkCommands::CommandInt command{};
+    MavlinkCommandSender::CommandInt command{};
 
     // Correct here would actually be to:
     // - set yaw stabilize / param4 to 0 as usual
@@ -68,7 +68,7 @@ Gimbal::Result GimbalProtocolV1::set_mode(const Gimbal::GimbalMode gimbal_mode)
 void GimbalProtocolV1::set_mode_async(
     const Gimbal::GimbalMode gimbal_mode, Gimbal::ResultCallback callback)
 {
-    MAVLinkCommands::CommandInt command{};
+    MavlinkCommandSender::CommandInt command{};
 
     // Correct here would actually be to:
     // - set yaw stabilize / param4 to 0 as usual
@@ -85,7 +85,7 @@ void GimbalProtocolV1::set_mode_async(
     command.target_component_id = _system_impl.get_autopilot_id();
 
     _system_impl.send_command_async(
-        command, [callback](MAVLinkCommands::Result command_result, float progress) {
+        command, [callback](MavlinkCommandSender::Result command_result, float progress) {
             UNUSED(progress);
             GimbalImpl::receive_command_result(command_result, callback);
         });
@@ -106,7 +106,7 @@ float GimbalProtocolV1::to_float_gimbal_mode(const Gimbal::GimbalMode gimbal_mod
 Gimbal::Result
 GimbalProtocolV1::set_roi_location(double latitude_deg, double longitude_deg, float altitude_m)
 {
-    MAVLinkCommands::CommandInt command{};
+    MavlinkCommandSender::CommandInt command{};
 
     command.command = MAV_CMD_DO_SET_ROI_LOCATION;
     command.params.x = int32_t(std::round(latitude_deg * 1e7));
@@ -120,7 +120,7 @@ GimbalProtocolV1::set_roi_location(double latitude_deg, double longitude_deg, fl
 void GimbalProtocolV1::set_roi_location_async(
     double latitude_deg, double longitude_deg, float altitude_m, Gimbal::ResultCallback callback)
 {
-    MAVLinkCommands::CommandInt command{};
+    MavlinkCommandSender::CommandInt command{};
 
     command.command = MAV_CMD_DO_SET_ROI_LOCATION;
     command.params.x = int32_t(std::round(latitude_deg * 1e7));
@@ -129,7 +129,7 @@ void GimbalProtocolV1::set_roi_location_async(
     command.target_component_id = _system_impl.get_autopilot_id();
 
     _system_impl.send_command_async(
-        command, [callback](MAVLinkCommands::Result command_result, float progress) {
+        command, [callback](MavlinkCommandSender::Result command_result, float progress) {
             UNUSED(progress);
             GimbalImpl::receive_command_result(command_result, callback);
         });

--- a/src/plugins/manual_control/manual_control_impl.cpp
+++ b/src/plugins/manual_control/manual_control_impl.cpp
@@ -29,7 +29,8 @@ void ManualControlImpl::disable() {}
 void ManualControlImpl::start_position_control_async(const ManualControl::ResultCallback callback)
 {
     _parent->set_flight_mode_async(
-        SystemImpl::FlightMode::Posctl, [this, callback](MavlinkCommandSender::Result result, float) {
+        SystemImpl::FlightMode::Posctl,
+        [this, callback](MavlinkCommandSender::Result result, float) {
             command_result_callback(result, callback);
         });
 }
@@ -47,7 +48,8 @@ ManualControl::Result ManualControlImpl::start_position_control()
 void ManualControlImpl::start_altitude_control_async(const ManualControl::ResultCallback callback)
 {
     _parent->set_flight_mode_async(
-        SystemImpl::FlightMode::Altctl, [this, callback](MavlinkCommandSender::Result result, float) {
+        SystemImpl::FlightMode::Altctl,
+        [this, callback](MavlinkCommandSender::Result result, float) {
             command_result_callback(result, callback);
         });
 }

--- a/src/plugins/manual_control/manual_control_impl.cpp
+++ b/src/plugins/manual_control/manual_control_impl.cpp
@@ -29,7 +29,7 @@ void ManualControlImpl::disable() {}
 void ManualControlImpl::start_position_control_async(const ManualControl::ResultCallback callback)
 {
     _parent->set_flight_mode_async(
-        SystemImpl::FlightMode::Posctl, [this, callback](MAVLinkCommands::Result result, float) {
+        SystemImpl::FlightMode::Posctl, [this, callback](MavlinkCommandSender::Result result, float) {
             command_result_callback(result, callback);
         });
 }
@@ -47,7 +47,7 @@ ManualControl::Result ManualControlImpl::start_position_control()
 void ManualControlImpl::start_altitude_control_async(const ManualControl::ResultCallback callback)
 {
     _parent->set_flight_mode_async(
-        SystemImpl::FlightMode::Altctl, [this, callback](MAVLinkCommands::Result result, float) {
+        SystemImpl::FlightMode::Altctl, [this, callback](MavlinkCommandSender::Result result, float) {
             command_result_callback(result, callback);
         });
 }
@@ -88,20 +88,20 @@ ManualControlImpl::set_manual_control_input(float x, float y, float z, float r)
 }
 
 ManualControl::Result
-ManualControlImpl::manual_control_result_from_command_result(MAVLinkCommands::Result result)
+ManualControlImpl::manual_control_result_from_command_result(MavlinkCommandSender::Result result)
 {
     switch (result) {
-        case MAVLinkCommands::Result::Success:
+        case MavlinkCommandSender::Result::Success:
             return ManualControl::Result::Success;
-        case MAVLinkCommands::Result::NoSystem:
+        case MavlinkCommandSender::Result::NoSystem:
             return ManualControl::Result::NoSystem;
-        case MAVLinkCommands::Result::ConnectionError:
+        case MavlinkCommandSender::Result::ConnectionError:
             return ManualControl::Result::ConnectionError;
-        case MAVLinkCommands::Result::Busy:
+        case MavlinkCommandSender::Result::Busy:
             return ManualControl::Result::Busy;
-        case MAVLinkCommands::Result::CommandDenied:
+        case MavlinkCommandSender::Result::CommandDenied:
             return ManualControl::Result::CommandDenied;
-        case MAVLinkCommands::Result::Timeout:
+        case MavlinkCommandSender::Result::Timeout:
             return ManualControl::Result::Timeout;
         default:
             return ManualControl::Result::Unknown;
@@ -109,7 +109,7 @@ ManualControlImpl::manual_control_result_from_command_result(MAVLinkCommands::Re
 }
 
 void ManualControlImpl::command_result_callback(
-    MAVLinkCommands::Result command_result, const ManualControl::ResultCallback& callback)
+    MavlinkCommandSender::Result command_result, const ManualControl::ResultCallback& callback)
 {
     ManualControl::Result action_result = manual_control_result_from_command_result(command_result);
 

--- a/src/plugins/manual_control/manual_control_impl.h
+++ b/src/plugins/manual_control/manual_control_impl.h
@@ -28,9 +28,9 @@ public:
     ManualControl::Result set_manual_control_input(float x, float y, float z, float r);
 
 private:
-    ManualControl::Result manual_control_result_from_command_result(MAVLinkCommands::Result result);
+    ManualControl::Result manual_control_result_from_command_result(MavlinkCommandSender::Result result);
     void command_result_callback(
-        MAVLinkCommands::Result command_result, const ManualControl::ResultCallback& callback);
+        MavlinkCommandSender::Result command_result, const ManualControl::ResultCallback& callback);
 };
 
 } // namespace mavsdk

--- a/src/plugins/manual_control/manual_control_impl.h
+++ b/src/plugins/manual_control/manual_control_impl.h
@@ -28,7 +28,8 @@ public:
     ManualControl::Result set_manual_control_input(float x, float y, float z, float r);
 
 private:
-    ManualControl::Result manual_control_result_from_command_result(MavlinkCommandSender::Result result);
+    ManualControl::Result
+    manual_control_result_from_command_result(MavlinkCommandSender::Result result);
     void command_result_callback(
         MavlinkCommandSender::Result command_result, const ManualControl::ResultCallback& callback);
 };

--- a/src/plugins/mavlink_passthrough/mavlink_passthrough_impl.cpp
+++ b/src/plugins/mavlink_passthrough/mavlink_passthrough_impl.cpp
@@ -103,7 +103,7 @@ MavlinkPassthroughImpl::to_mavlink_passthrough_result_from_mavlink_commands_resu
         default:
             // FALLTHROUGH
         case MavlinkCommandSender::Result::InProgress: // FIXME: currently not expected
-                                                  // FALLTHROUGH
+                                                       // FALLTHROUGH
         case MavlinkCommandSender::Result::UnknownError:
             return MavlinkPassthrough::Result::Unknown;
     }

--- a/src/plugins/mavlink_passthrough/mavlink_passthrough_impl.cpp
+++ b/src/plugins/mavlink_passthrough/mavlink_passthrough_impl.cpp
@@ -45,7 +45,7 @@ MavlinkPassthrough::Result MavlinkPassthroughImpl::send_message(mavlink_message_
 MavlinkPassthrough::Result
 MavlinkPassthroughImpl::send_command_long(const MavlinkPassthrough::CommandLong& command)
 {
-    MAVLinkCommands::CommandLong command_internal{};
+    MavlinkCommandSender::CommandLong command_internal{};
     command_internal.target_system_id = command.target_sysid;
     command_internal.target_component_id = command.target_compid;
     command_internal.command = command.command;
@@ -64,7 +64,7 @@ MavlinkPassthroughImpl::send_command_long(const MavlinkPassthrough::CommandLong&
 MavlinkPassthrough::Result
 MavlinkPassthroughImpl::send_command_int(const MavlinkPassthrough::CommandInt& command)
 {
-    MAVLinkCommands::CommandInt command_internal{};
+    MavlinkCommandSender::CommandInt command_internal{};
     command_internal.target_system_id = command.target_sysid;
     command_internal.target_component_id = command.target_compid;
     command_internal.frame = command.frame;
@@ -83,28 +83,28 @@ MavlinkPassthroughImpl::send_command_int(const MavlinkPassthrough::CommandInt& c
 
 MavlinkPassthrough::Result
 MavlinkPassthroughImpl::to_mavlink_passthrough_result_from_mavlink_commands_result(
-    MAVLinkCommands::Result result)
+    MavlinkCommandSender::Result result)
 {
     switch (result) {
-        case MAVLinkCommands::Result::Success:
+        case MavlinkCommandSender::Result::Success:
             return MavlinkPassthrough::Result::Success;
-        case MAVLinkCommands::Result::NoSystem:
+        case MavlinkCommandSender::Result::NoSystem:
             return MavlinkPassthrough::Result::CommandNoSystem;
-        case MAVLinkCommands::Result::ConnectionError:
+        case MavlinkCommandSender::Result::ConnectionError:
             return MavlinkPassthrough::Result::ConnectionError;
-        case MAVLinkCommands::Result::Busy:
+        case MavlinkCommandSender::Result::Busy:
             return MavlinkPassthrough::Result::CommandBusy;
-        case MAVLinkCommands::Result::CommandDenied:
+        case MavlinkCommandSender::Result::CommandDenied:
             return MavlinkPassthrough::Result::CommandDenied;
-        case MAVLinkCommands::Result::Unsupported:
+        case MavlinkCommandSender::Result::Unsupported:
             return MavlinkPassthrough::Result::CommandUnsupported;
-        case MAVLinkCommands::Result::Timeout:
+        case MavlinkCommandSender::Result::Timeout:
             return MavlinkPassthrough::Result::CommandTimeout;
         default:
             // FALLTHROUGH
-        case MAVLinkCommands::Result::InProgress: // FIXME: currently not expected
+        case MavlinkCommandSender::Result::InProgress: // FIXME: currently not expected
                                                   // FALLTHROUGH
-        case MAVLinkCommands::Result::UnknownError:
+        case MavlinkCommandSender::Result::UnknownError:
             return MavlinkPassthrough::Result::Unknown;
     }
 }

--- a/src/plugins/mavlink_passthrough/mavlink_passthrough_impl.h
+++ b/src/plugins/mavlink_passthrough/mavlink_passthrough_impl.h
@@ -37,7 +37,7 @@ public:
 
 private:
     static MavlinkPassthrough::Result
-    to_mavlink_passthrough_result_from_mavlink_commands_result(MAVLinkCommands::Result result);
+    to_mavlink_passthrough_result_from_mavlink_commands_result(MavlinkCommandSender::Result result);
 };
 
 } // namespace mavsdk

--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -621,7 +621,8 @@ Mission::Result MissionImpl::start_mission()
 void MissionImpl::start_mission_async(const Mission::ResultCallback& callback)
 {
     _parent->set_flight_mode_async(
-        SystemImpl::FlightMode::Mission, [this, callback](MavlinkCommandSender::Result result, float) {
+        SystemImpl::FlightMode::Mission,
+        [this, callback](MavlinkCommandSender::Result result, float) {
             report_flight_mode_change(callback, result);
         });
 }

--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -621,7 +621,7 @@ Mission::Result MissionImpl::start_mission()
 void MissionImpl::start_mission_async(const Mission::ResultCallback& callback)
 {
     _parent->set_flight_mode_async(
-        SystemImpl::FlightMode::Mission, [this, callback](MAVLinkCommands::Result result, float) {
+        SystemImpl::FlightMode::Mission, [this, callback](MavlinkCommandSender::Result result, float) {
             report_flight_mode_change(callback, result);
         });
 }
@@ -638,13 +638,13 @@ Mission::Result MissionImpl::pause_mission()
 void MissionImpl::pause_mission_async(const Mission::ResultCallback& callback)
 {
     _parent->set_flight_mode_async(
-        SystemImpl::FlightMode::Hold, [this, callback](MAVLinkCommands::Result result, float) {
+        SystemImpl::FlightMode::Hold, [this, callback](MavlinkCommandSender::Result result, float) {
             report_flight_mode_change(callback, result);
         });
 }
 
 void MissionImpl::report_flight_mode_change(
-    Mission::ResultCallback callback, MAVLinkCommands::Result result)
+    Mission::ResultCallback callback, MavlinkCommandSender::Result result)
 {
     if (!callback) {
         return;
@@ -654,24 +654,24 @@ void MissionImpl::report_flight_mode_change(
         [callback, result]() { callback(command_result_to_mission_result(result)); });
 }
 
-Mission::Result MissionImpl::command_result_to_mission_result(MAVLinkCommands::Result result)
+Mission::Result MissionImpl::command_result_to_mission_result(MavlinkCommandSender::Result result)
 {
     switch (result) {
-        case MAVLinkCommands::Result::Success:
+        case MavlinkCommandSender::Result::Success:
             return Mission::Result::Success;
-        case MAVLinkCommands::Result::NoSystem:
+        case MavlinkCommandSender::Result::NoSystem:
             return Mission::Result::Error; // FIXME
-        case MAVLinkCommands::Result::ConnectionError:
+        case MavlinkCommandSender::Result::ConnectionError:
             return Mission::Result::Error; // FIXME
-        case MAVLinkCommands::Result::Busy:
+        case MavlinkCommandSender::Result::Busy:
             return Mission::Result::Busy;
-        case MAVLinkCommands::Result::CommandDenied:
+        case MavlinkCommandSender::Result::CommandDenied:
             return Mission::Result::Error; // FIXME
-        case MAVLinkCommands::Result::Timeout:
+        case MavlinkCommandSender::Result::Timeout:
             return Mission::Result::Timeout;
-        case MAVLinkCommands::Result::InProgress:
+        case MavlinkCommandSender::Result::InProgress:
             return Mission::Result::Busy; // FIXME
-        case MAVLinkCommands::Result::UnknownError:
+        case MavlinkCommandSender::Result::UnknownError:
             return Mission::Result::Unknown;
         default:
             return Mission::Result::Unknown;

--- a/src/plugins/mission/mission_impl.h
+++ b/src/plugins/mission/mission_impl.h
@@ -88,8 +88,8 @@ private:
     void reset_mission_progress();
 
     void
-    report_flight_mode_change(Mission::ResultCallback callback, MAVLinkCommands::Result result);
-    static Mission::Result command_result_to_mission_result(MAVLinkCommands::Result result);
+    report_flight_mode_change(Mission::ResultCallback callback, MavlinkCommandSender::Result result);
+    static Mission::Result command_result_to_mission_result(MavlinkCommandSender::Result result);
 
     // FIXME: make static
     std::pair<Mission::Result, Mission::MissionPlan> convert_to_result_and_mission_items(

--- a/src/plugins/mission/mission_impl.h
+++ b/src/plugins/mission/mission_impl.h
@@ -87,8 +87,8 @@ private:
     void report_progress();
     void reset_mission_progress();
 
-    void
-    report_flight_mode_change(Mission::ResultCallback callback, MavlinkCommandSender::Result result);
+    void report_flight_mode_change(
+        Mission::ResultCallback callback, MavlinkCommandSender::Result result);
     static Mission::Result command_result_to_mission_result(MavlinkCommandSender::Result result);
 
     // FIXME: make static

--- a/src/plugins/mission_raw/mission_raw_impl.cpp
+++ b/src/plugins/mission_raw/mission_raw_impl.cpp
@@ -301,7 +301,8 @@ MissionRaw::Result MissionRawImpl::start_mission()
 void MissionRawImpl::start_mission_async(const MissionRaw::ResultCallback& callback)
 {
     _parent->set_flight_mode_async(
-        SystemImpl::FlightMode::Mission, [this, callback](MavlinkCommandSender::Result result, float) {
+        SystemImpl::FlightMode::Mission,
+        [this, callback](MavlinkCommandSender::Result result, float) {
             report_flight_mode_change(callback, result);
         });
 }
@@ -334,7 +335,8 @@ void MissionRawImpl::report_flight_mode_change(
         [callback, result]() { callback(command_result_to_mission_result(result)); });
 }
 
-MissionRaw::Result MissionRawImpl::command_result_to_mission_result(MavlinkCommandSender::Result result)
+MissionRaw::Result
+MissionRawImpl::command_result_to_mission_result(MavlinkCommandSender::Result result)
 {
     switch (result) {
         case MavlinkCommandSender::Result::Success:

--- a/src/plugins/mission_raw/mission_raw_impl.cpp
+++ b/src/plugins/mission_raw/mission_raw_impl.cpp
@@ -301,7 +301,7 @@ MissionRaw::Result MissionRawImpl::start_mission()
 void MissionRawImpl::start_mission_async(const MissionRaw::ResultCallback& callback)
 {
     _parent->set_flight_mode_async(
-        SystemImpl::FlightMode::Mission, [this, callback](MAVLinkCommands::Result result, float) {
+        SystemImpl::FlightMode::Mission, [this, callback](MavlinkCommandSender::Result result, float) {
             report_flight_mode_change(callback, result);
         });
 }
@@ -318,13 +318,13 @@ MissionRaw::Result MissionRawImpl::pause_mission()
 void MissionRawImpl::pause_mission_async(const MissionRaw::ResultCallback& callback)
 {
     _parent->set_flight_mode_async(
-        SystemImpl::FlightMode::Hold, [this, callback](MAVLinkCommands::Result result, float) {
+        SystemImpl::FlightMode::Hold, [this, callback](MavlinkCommandSender::Result result, float) {
             report_flight_mode_change(callback, result);
         });
 }
 
 void MissionRawImpl::report_flight_mode_change(
-    MissionRaw::ResultCallback callback, MAVLinkCommands::Result result)
+    MissionRaw::ResultCallback callback, MavlinkCommandSender::Result result)
 {
     if (!callback) {
         return;
@@ -334,24 +334,24 @@ void MissionRawImpl::report_flight_mode_change(
         [callback, result]() { callback(command_result_to_mission_result(result)); });
 }
 
-MissionRaw::Result MissionRawImpl::command_result_to_mission_result(MAVLinkCommands::Result result)
+MissionRaw::Result MissionRawImpl::command_result_to_mission_result(MavlinkCommandSender::Result result)
 {
     switch (result) {
-        case MAVLinkCommands::Result::Success:
+        case MavlinkCommandSender::Result::Success:
             return MissionRaw::Result::Success;
-        case MAVLinkCommands::Result::NoSystem:
+        case MavlinkCommandSender::Result::NoSystem:
             return MissionRaw::Result::Error; // FIXME
-        case MAVLinkCommands::Result::ConnectionError:
+        case MavlinkCommandSender::Result::ConnectionError:
             return MissionRaw::Result::Error; // FIXME
-        case MAVLinkCommands::Result::Busy:
+        case MavlinkCommandSender::Result::Busy:
             return MissionRaw::Result::Busy;
-        case MAVLinkCommands::Result::CommandDenied:
+        case MavlinkCommandSender::Result::CommandDenied:
             return MissionRaw::Result::Error; // FIXME
-        case MAVLinkCommands::Result::Timeout:
+        case MavlinkCommandSender::Result::Timeout:
             return MissionRaw::Result::Timeout;
-        case MAVLinkCommands::Result::InProgress:
+        case MavlinkCommandSender::Result::InProgress:
             return MissionRaw::Result::Busy; // FIXME
-        case MAVLinkCommands::Result::UnknownError:
+        case MavlinkCommandSender::Result::UnknownError:
             return MissionRaw::Result::Unknown;
         default:
             return MissionRaw::Result::Unknown;

--- a/src/plugins/mission_raw/mission_raw_impl.h
+++ b/src/plugins/mission_raw/mission_raw_impl.h
@@ -61,8 +61,8 @@ private:
 
     void report_progress_current();
 
-    void
-    report_flight_mode_change(MissionRaw::ResultCallback callback, MavlinkCommandSender::Result result);
+    void report_flight_mode_change(
+        MissionRaw::ResultCallback callback, MavlinkCommandSender::Result result);
     static MissionRaw::Result command_result_to_mission_result(MavlinkCommandSender::Result result);
 
     std::vector<MAVLinkMissionTransfer::ItemInt>

--- a/src/plugins/mission_raw/mission_raw_impl.h
+++ b/src/plugins/mission_raw/mission_raw_impl.h
@@ -62,8 +62,8 @@ private:
     void report_progress_current();
 
     void
-    report_flight_mode_change(MissionRaw::ResultCallback callback, MAVLinkCommands::Result result);
-    static MissionRaw::Result command_result_to_mission_result(MAVLinkCommands::Result result);
+    report_flight_mode_change(MissionRaw::ResultCallback callback, MavlinkCommandSender::Result result);
+    static MissionRaw::Result command_result_to_mission_result(MavlinkCommandSender::Result result);
 
     std::vector<MAVLinkMissionTransfer::ItemInt>
     convert_to_int_items(const std::vector<MissionRaw::MissionItem>& mission_raw);

--- a/src/plugins/offboard/offboard_impl.cpp
+++ b/src/plugins/offboard/offboard_impl.cpp
@@ -107,7 +107,7 @@ bool OffboardImpl::is_active()
 }
 
 void OffboardImpl::receive_command_result(
-    MAVLinkCommands::Result result, const Offboard::ResultCallback& callback)
+    MavlinkCommandSender::Result result, const Offboard::ResultCallback& callback)
 {
     Offboard::Result offboard_result = offboard_result_from_command_result(result);
     if (callback) {
@@ -608,20 +608,20 @@ void OffboardImpl::stop_sending_setpoints()
     _mode = Mode::NotActive;
 }
 
-Offboard::Result OffboardImpl::offboard_result_from_command_result(MAVLinkCommands::Result result)
+Offboard::Result OffboardImpl::offboard_result_from_command_result(MavlinkCommandSender::Result result)
 {
     switch (result) {
-        case MAVLinkCommands::Result::Success:
+        case MavlinkCommandSender::Result::Success:
             return Offboard::Result::Success;
-        case MAVLinkCommands::Result::NoSystem:
+        case MavlinkCommandSender::Result::NoSystem:
             return Offboard::Result::NoSystem;
-        case MAVLinkCommands::Result::ConnectionError:
+        case MavlinkCommandSender::Result::ConnectionError:
             return Offboard::Result::ConnectionError;
-        case MAVLinkCommands::Result::Busy:
+        case MavlinkCommandSender::Result::Busy:
             return Offboard::Result::Busy;
-        case MAVLinkCommands::Result::CommandDenied:
+        case MavlinkCommandSender::Result::CommandDenied:
             return Offboard::Result::CommandDenied;
-        case MAVLinkCommands::Result::Timeout:
+        case MavlinkCommandSender::Result::Timeout:
             return Offboard::Result::Timeout;
         default:
             return Offboard::Result::Unknown;

--- a/src/plugins/offboard/offboard_impl.cpp
+++ b/src/plugins/offboard/offboard_impl.cpp
@@ -608,7 +608,8 @@ void OffboardImpl::stop_sending_setpoints()
     _mode = Mode::NotActive;
 }
 
-Offboard::Result OffboardImpl::offboard_result_from_command_result(MavlinkCommandSender::Result result)
+Offboard::Result
+OffboardImpl::offboard_result_from_command_result(MavlinkCommandSender::Result result)
 {
     switch (result) {
         case MavlinkCommandSender::Result::Success:

--- a/src/plugins/offboard/offboard_impl.h
+++ b/src/plugins/offboard/offboard_impl.h
@@ -50,9 +50,9 @@ private:
 
     void process_heartbeat(const mavlink_message_t& message);
     void receive_command_result(
-        MAVLinkCommands::Result result, const Offboard::ResultCallback& callback);
+        MavlinkCommandSender::Result result, const Offboard::ResultCallback& callback);
 
-    static Offboard::Result offboard_result_from_command_result(MAVLinkCommands::Result result);
+    static Offboard::Result offboard_result_from_command_result(MavlinkCommandSender::Result result);
 
     void stop_sending_setpoints();
 

--- a/src/plugins/offboard/offboard_impl.h
+++ b/src/plugins/offboard/offboard_impl.h
@@ -52,7 +52,8 @@ private:
     void receive_command_result(
         MavlinkCommandSender::Result result, const Offboard::ResultCallback& callback);
 
-    static Offboard::Result offboard_result_from_command_result(MavlinkCommandSender::Result result);
+    static Offboard::Result
+    offboard_result_from_command_result(MavlinkCommandSender::Result result);
 
     void stop_sending_setpoints();
 

--- a/src/plugins/telemetry/telemetry_impl.cpp
+++ b/src/plugins/telemetry/telemetry_impl.cpp
@@ -483,20 +483,20 @@ void TelemetryImpl::set_rate_distance_sensor_async(
 }
 
 Telemetry::Result
-TelemetryImpl::telemetry_result_from_command_result(MAVLinkCommands::Result command_result)
+TelemetryImpl::telemetry_result_from_command_result(MavlinkCommandSender::Result command_result)
 {
     switch (command_result) {
-        case MAVLinkCommands::Result::Success:
+        case MavlinkCommandSender::Result::Success:
             return Telemetry::Result::Success;
-        case MAVLinkCommands::Result::NoSystem:
+        case MavlinkCommandSender::Result::NoSystem:
             return Telemetry::Result::NoSystem;
-        case MAVLinkCommands::Result::ConnectionError:
+        case MavlinkCommandSender::Result::ConnectionError:
             return Telemetry::Result::ConnectionError;
-        case MAVLinkCommands::Result::Busy:
+        case MavlinkCommandSender::Result::Busy:
             return Telemetry::Result::Busy;
-        case MAVLinkCommands::Result::CommandDenied:
+        case MavlinkCommandSender::Result::CommandDenied:
             return Telemetry::Result::CommandDenied;
-        case MAVLinkCommands::Result::Timeout:
+        case MavlinkCommandSender::Result::Timeout:
             return Telemetry::Result::Timeout;
         default:
             return Telemetry::Result::Unknown;
@@ -504,7 +504,7 @@ TelemetryImpl::telemetry_result_from_command_result(MAVLinkCommands::Result comm
 }
 
 void TelemetryImpl::command_result_callback(
-    MAVLinkCommands::Result command_result, const Telemetry::ResultCallback& callback)
+    MavlinkCommandSender::Result command_result, const Telemetry::ResultCallback& callback)
 {
     Telemetry::Result action_result = telemetry_result_from_command_result(command_result);
 

--- a/src/plugins/telemetry/telemetry_impl.h
+++ b/src/plugins/telemetry/telemetry_impl.h
@@ -194,10 +194,10 @@ private:
     void receive_unix_epoch_timeout();
 
     static Telemetry::Result
-    telemetry_result_from_command_result(MAVLinkCommands::Result command_result);
+    telemetry_result_from_command_result(MavlinkCommandSender::Result command_result);
 
     static void command_result_callback(
-        MAVLinkCommands::Result command_result, const Telemetry::ResultCallback& callback);
+        MavlinkCommandSender::Result command_result, const Telemetry::ResultCallback& callback);
 
     static Telemetry::LandedState to_landed_state(mavlink_extended_sys_state_t extended_sys_state);
 

--- a/src/plugins/tune/tune_impl.h
+++ b/src/plugins/tune/tune_impl.h
@@ -32,7 +32,7 @@ private:
     void report_tune_result(const Tune::ResultCallback& callback, Tune::Result result);
 
     void receive_command_result(
-        MAVLinkCommands::Result command_result, const Tune::ResultCallback& callback);
+        MavlinkCommandSender::Result command_result, const Tune::ResultCallback& callback);
 
     Tune::ResultCallback _result_callback = nullptr;
 

--- a/tools/rename-enums-to-camelcase.sh
+++ b/tools/rename-enums-to-camelcase.sh
@@ -236,14 +236,14 @@ sed -i 's/MAVLinkParameters::Result::CONNECTION_ERROR/MAVLinkParameters::Result:
 sed -i 's/MAVLinkParameters::Result::WRONG_TYPE/MAVLinkParameters::Result::WrongType/g' $files
 sed -i 's/MAVLinkParameters::Result::PARAM_NAME_TOO_LONG/MAVLinkParameters::Result::ParamNameTooLong/g' $files
 
-sed -i 's/MAVLinkCommands::Result::SUCCESS/MAVLinkCommands::Result::Success/g' $files
-sed -i 's/MAVLinkCommands::Result::NO_SYSTEM/MAVLinkCommands::Result::NoSystem/g' $files
-sed -i 's/MAVLinkCommands::Result::CONNECTION_ERROR/MAVLinkCommands::Result::ConnectionError/g' $files
-sed -i 's/MAVLinkCommands::Result::BUSY/MAVLinkCommands::Result::Busy/g' $files
-sed -i 's/MAVLinkCommands::Result::COMMAND_DENIED/MAVLinkCommands::Result::CommandDenied/g' $files
-sed -i 's/MAVLinkCommands::Result::TIMEOUT/MAVLinkCommands::Result::Timeout/g' $files
-sed -i 's/MAVLinkCommands::Result::IN_PROGRESS/MAVLinkCommands::Result::InProgress/g' $files
-sed -i 's/MAVLinkCommands::Result::UNKNOWN_ERROR/MAVLinkCommands::Result::UnknownError/g' $files
+sed -i 's/MavlinkCommandSender::Result::SUCCESS/MavlinkCommandSender::Result::Success/g' $files
+sed -i 's/MavlinkCommandSender::Result::NO_SYSTEM/MavlinkCommandSender::Result::NoSystem/g' $files
+sed -i 's/MavlinkCommandSender::Result::CONNECTION_ERROR/MavlinkCommandSender::Result::ConnectionError/g' $files
+sed -i 's/MavlinkCommandSender::Result::BUSY/MavlinkCommandSender::Result::Busy/g' $files
+sed -i 's/MavlinkCommandSender::Result::COMMAND_DENIED/MavlinkCommandSender::Result::CommandDenied/g' $files
+sed -i 's/MavlinkCommandSender::Result::TIMEOUT/MavlinkCommandSender::Result::Timeout/g' $files
+sed -i 's/MavlinkCommandSender::Result::IN_PROGRESS/MavlinkCommandSender::Result::InProgress/g' $files
+sed -i 's/MavlinkCommandSender::Result::UNKNOWN_ERROR/MavlinkCommandSender::Result::UnknownError/g' $files
 
 sed -i 's/Color::RED/Color::Red/g' $files
 sed -i 's/Color::GREEN/Color::Green/g' $files

--- a/tools/rename-enums-to-camelcase.sh
+++ b/tools/rename-enums-to-camelcase.sh
@@ -236,14 +236,14 @@ sed -i 's/MAVLinkParameters::Result::CONNECTION_ERROR/MAVLinkParameters::Result:
 sed -i 's/MAVLinkParameters::Result::WRONG_TYPE/MAVLinkParameters::Result::WrongType/g' $files
 sed -i 's/MAVLinkParameters::Result::PARAM_NAME_TOO_LONG/MAVLinkParameters::Result::ParamNameTooLong/g' $files
 
-sed -i 's/MavlinkCommandSender::Result::SUCCESS/MavlinkCommandSender::Result::Success/g' $files
-sed -i 's/MavlinkCommandSender::Result::NO_SYSTEM/MavlinkCommandSender::Result::NoSystem/g' $files
-sed -i 's/MavlinkCommandSender::Result::CONNECTION_ERROR/MavlinkCommandSender::Result::ConnectionError/g' $files
-sed -i 's/MavlinkCommandSender::Result::BUSY/MavlinkCommandSender::Result::Busy/g' $files
-sed -i 's/MavlinkCommandSender::Result::COMMAND_DENIED/MavlinkCommandSender::Result::CommandDenied/g' $files
-sed -i 's/MavlinkCommandSender::Result::TIMEOUT/MavlinkCommandSender::Result::Timeout/g' $files
-sed -i 's/MavlinkCommandSender::Result::IN_PROGRESS/MavlinkCommandSender::Result::InProgress/g' $files
-sed -i 's/MavlinkCommandSender::Result::UNKNOWN_ERROR/MavlinkCommandSender::Result::UnknownError/g' $files
+sed -i 's/MAVLinkCommands::Result::SUCCESS/MAVLinkCommands::Result::Success/g' $files
+sed -i 's/MAVLinkCommands::Result::NO_SYSTEM/MAVLinkCommands::Result::NoSystem/g' $files
+sed -i 's/MAVLinkCommands::Result::CONNECTION_ERROR/MAVLinkCommands::Result::ConnectionError/g' $files
+sed -i 's/MAVLinkCommands::Result::BUSY/MAVLinkCommands::Result::Busy/g' $files
+sed -i 's/MAVLinkCommands::Result::COMMAND_DENIED/MAVLinkCommands::Result::CommandDenied/g' $files
+sed -i 's/MAVLinkCommands::Result::TIMEOUT/MAVLinkCommands::Result::Timeout/g' $files
+sed -i 's/MAVLinkCommands::Result::IN_PROGRESS/MAVLinkCommands::Result::InProgress/g' $files
+sed -i 's/MAVLinkCommands::Result::UNKNOWN_ERROR/MAVLinkCommands::Result::UnknownError/g' $files
 
 sed -i 's/Color::RED/Color::Red/g' $files
 sed -i 's/Color::GREEN/Color::Green/g' $files


### PR DESCRIPTION
This continues the work of @yhabib29 and splits the Mavlink command send and receive functions between two different classes.