### PR TITLE
curl: patch file for libressl librt linking

### DIFF
--- a/third_party/curl/CMakeLists.txt
+++ b/third_party/curl/CMakeLists.txt
@@ -37,5 +37,6 @@ ExternalProject_add(
     curl
     URL https://github.com/curl/curl/archive/curl-7_70_0.zip
     PREFIX curl
+    PATCH_COMMAND patch CMakeLists.txt < ${PROJECT_SOURCE_DIR}/curl.patch
     CMAKE_ARGS "${CMAKE_ARGS}"
     )

--- a/third_party/curl/curl.patch
+++ b/third_party/curl/curl.patch
@@ -1,0 +1,12 @@
+--- CMakeLists.txt	2020-10-22 13:52:47.849069912 -0800
++++ CMakeLists.txt	2020-10-22 13:52:36.053060360 -0800
+@@ -371,6 +371,9 @@
+   set(SSL_ENABLED ON)
+   set(USE_OPENSSL ON)
+
++  list(APPEND OPENSSL_LIBRARIES rt)
++  list(APPEND CURL_LIBS rt)
++
+   # Depend on OpenSSL via imported targets if supported by the running
+   # version of CMake.  This allows our dependents to get our dependencies
+   # transitively.


### PR DESCRIPTION
If trying to use CMAKE_USE_OPENSSL in curl, the build fails with this error
```
[100%] Linking C executable curl
/work/install/lib/libcrypto.a(getentropy_linux.c.o): In function `getentropy_fallback':
/work/build/linux-armv6/third_party/libressl/libressl/src/libressl/crypto/compat/getentropy_linux.c:357: undefined reference to `clock_gettime'
/work/build/linux-armv6/third_party/libressl/libressl/src/libressl/crypto/compat/getentropy_linux.c:427: undefined reference to `clock_gettime'
collect2: error: ld returned 1 exit status
```
Added patch file for curl when using **CMAKE_USE_OPENSSL**, this forces linking against rt when building curl.

This now allows HTTPS URLs with curl -- tested on a raspberry pi successfully.