### PR TITLE
plugins: mission_impl: update MAVLinkCommands to MavlinkCommandSender to fix build

### DIFF
--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -50,7 +50,7 @@ void MissionImpl::enable()
     _parent->register_timeout_handler(
         [this]() { receive_protocol_timeout(); }, 1.0, &_gimbal_protocol_cookie);
 
-    MAVLinkCommands::CommandLong command{};
+    MavlinkCommandSender::CommandLong command{};
     command.command = MAV_CMD_REQUEST_MESSAGE;
     command.params.param1 = static_cast<float>(MAVLINK_MSG_ID_GIMBAL_MANAGER_INFORMATION);
     command.target_component_id = 0; // any component


### PR DESCRIPTION
Fix the API problem introduced by https://github.com/mavlink/MAVSDK/pull/1233 in https://github.com/mavlink/MAVSDK/pull/1233/files#diff-b667ca284e1b075f788d382e50bd878119c4cbd2b239d91c3e6d4189211bc1a8R53.