### PR TITLE
Ignore CAM_MODE when processing 'normal' parameters

### DIFF
--- a/src/core/mavlink_parameters.cpp
+++ b/src/core/mavlink_parameters.cpp
@@ -35,12 +35,6 @@ void MAVLinkParameters::set_param_async(
     const void* cookie,
     bool extended)
 {
-    // if (value.is_float()) {
-    //     LogDebug() << "setting param " << name << " to " << value.get_float();
-    // } else {
-    //     LogDebug() << "setting param " << name << " to " << value.get_int();
-    // }
-
     if (name.size() > PARAM_ID_LEN) {
         LogErr() << "Error: param name too long";
         if (callback) {
@@ -454,22 +448,6 @@ void MAVLinkParameters::process_param_ext_value(const mavlink_message_t& message
             if (value.is_same_type(work->param_value)) {
                 if (work->get_param_callback) {
                     work->get_param_callback(MAVLinkParameters::Result::Success, value);
-                }
-            } else if (value.is_uint8() && work->param_value.is_uint16()) {
-                // FIXME: workaround for mismatching type uint8_t which should be uint16_t.
-                ParamValue correct_type_value;
-                correct_type_value.set_uint16(static_cast<uint16_t>(value.get_uint8()));
-                if (work->get_param_callback) {
-                    work->get_param_callback(
-                        MAVLinkParameters::Result::Success, correct_type_value);
-                }
-            } else if (value.is_uint8() && work->param_value.is_uint32()) {
-                // FIXME: workaround for mismatching type uint8_t which should be uint32_t.
-                ParamValue correct_type_value;
-                correct_type_value.set_uint32(static_cast<uint32_t>(value.get_uint8()));
-                if (work->get_param_callback) {
-                    work->get_param_callback(
-                        MAVLinkParameters::Result::Success, correct_type_value);
                 }
             } else {
                 LogErr() << "Param types don't match";

--- a/src/plugins/camera/camera_definition.cpp
+++ b/src/plugins/camera/camera_definition.cpp
@@ -485,6 +485,12 @@ bool CameraDefinition::get_possible_settings(
     std::vector<std::string> exclusions{};
 
     for (const auto& parameter : _parameter_map) {
+        if (parameter.first == "CAM_MODE") {
+            // CAM_MODE is a "special" parameter that gets set through a specific MAVLink message
+            // (MAV_CMD_SET_CAMERA_MODE)
+            continue;
+        }
+
         for (const auto& option : parameter.second->options) {
             if (_current_settings[parameter.first].needs_updating) {
                 continue;
@@ -533,12 +539,12 @@ bool CameraDefinition::set_setting(
     if (_parameter_map[name]->is_range) {
         // Check against the minimum
         if (value < _parameter_map[name]->options[0]->value) {
-            LogErr() << "Chosen value smaller than minimum";
+            LogErr() << name << " (range): chosen value smaller than minimum";
             return false;
         }
 
         if (value > _parameter_map[name]->options[1]->value) {
-            LogErr() << "Chosen value bigger than maximum";
+            LogErr() << name << " (range): chosen value bigger than maximum";
             return false;
         }
 
@@ -647,6 +653,12 @@ bool CameraDefinition::get_possible_options(
     std::vector<std::string> exclusions{};
 
     for (const auto& parameter : _parameter_map) {
+        if (parameter.first == "CAM_MODE") {
+            // CAM_MODE is a "special" parameter that gets set through a specific MAVLink message
+            // (MAV_CMD_SET_CAMERA_MODE)
+            continue;
+        }
+
         for (const auto& option : parameter.second->options) {
             if (_current_settings[parameter.first].needs_updating) {
                 // LogWarn() << parameter.first << " needs updating";


### PR DESCRIPTION
When we get `CAM_MODE`, we hardcode it as an `uint32_t`, without honoring the type set in the camera definition file. This is fine, because we do not treat `CAM_MODE` like a normal camera parameter: we get (save) and set it independently.

However, this mismatch between the type in the camera definition and the hardcoded one causes _a lot_ of warnings to appear when processing normal parameters. This PR fixes that by not processing `CAM_MODE` together with the normal parameters.

At the same time, I removed a few workarounds that tried to fix issues on the camera side (i.e. the camera definition says a param is one type, and the actual param sent over mavlink is another type), because that really confused me a lot while debugging. If a camera messes up with the types, I find it okay for MAVSDK to ignore that parameter and report it, such that the camera side can be fixed.

Tested against the E90 and the AuterionSim.