### PR TITLE
core: move sending heartbeats to Mavsdk class

### DIFF
--- a/src/core/mavsdk.cpp
+++ b/src/core/mavsdk.cpp
@@ -98,34 +98,38 @@ void Mavsdk::register_on_timeout(const event_callback_t callback)
     _impl->register_on_timeout(callback);
 }
 
-Mavsdk::Configuration::Configuration(uint8_t system_id, uint8_t component_id) :
+Mavsdk::Configuration::Configuration(
+    uint8_t system_id, uint8_t component_id, bool always_send_heartbeats) :
     _system_id(system_id),
     _component_id(component_id),
+    _always_send_heartbeats(always_send_heartbeats),
     _usage_type(Mavsdk::Configuration::UsageType::Custom)
 {}
 
 Mavsdk::Configuration::Configuration(UsageType usage_type) :
     _system_id(MavsdkImpl::DEFAULT_SYSTEM_ID_GCS),
     _component_id(MavsdkImpl::DEFAULT_COMPONENT_ID_GCS),
+    _always_send_heartbeats(false),
     _usage_type(usage_type)
 {
     switch (usage_type) {
         case Mavsdk::Configuration::UsageType::GroundStation:
             _system_id = MavsdkImpl::DEFAULT_SYSTEM_ID_GCS;
             _component_id = MavsdkImpl::DEFAULT_COMPONENT_ID_GCS;
+            _always_send_heartbeats = false;
             break;
         case Mavsdk::Configuration::UsageType::CompanionComputer:
             // TODO implement autodetection of system ID - maybe from heartbeats?
             _system_id = MavsdkImpl::DEFAULT_SYSTEM_ID_CC;
             _component_id = MavsdkImpl::DEFAULT_COMPONENT_ID_CC;
+            _always_send_heartbeats = true;
             break;
         case Mavsdk::Configuration::UsageType::Autopilot:
             _system_id = MavsdkImpl::DEFAULT_SYSTEM_ID_AUTOPILOT;
             _component_id = MavsdkImpl::DEFAULT_COMPONENT_ID_AUTOPILOT;
+            _always_send_heartbeats = true;
             break;
         default:
-            _system_id = MavsdkImpl::DEFAULT_SYSTEM_ID_GCS;
-            _component_id = MavsdkImpl::DEFAULT_COMPONENT_ID_GCS;
             break;
     }
 }
@@ -148,6 +152,16 @@ uint8_t Mavsdk::Configuration::get_component_id() const
 void Mavsdk::Configuration::set_component_id(uint8_t component_id)
 {
     _component_id = component_id;
+}
+
+bool Mavsdk::Configuration::get_always_send_heartbeats() const
+{
+    return _always_send_heartbeats;
+}
+
+void Mavsdk::Configuration::set_always_send_heartbeats(bool always_send_heartbeats)
+{
+    _always_send_heartbeats = always_send_heartbeats;
 }
 
 Mavsdk::Configuration::UsageType Mavsdk::Configuration::get_usage_type() const

--- a/src/core/mavsdk.h
+++ b/src/core/mavsdk.h
@@ -163,8 +163,10 @@ public:
          * system and component ID.
          * @param system_id the system id to store in this configuration
          * @param component_id the component id to store in this configuration
+         * @param always_send_heartbeats send heartbeats by default even without a system connected
          */
-        explicit Configuration(uint8_t system_id, uint8_t component_id);
+        explicit Configuration(
+            uint8_t system_id, uint8_t component_id, bool always_send_heartbeats);
         /**
          * @brief Create new Configuration using a usage type.
          * In this mode, the system and component ID will be automatically chosen.
@@ -197,6 +199,17 @@ public:
          */
         void set_component_id(uint8_t component_id);
 
+        /**
+         * @brief Get whether to send heartbeats by default.
+         * @return whether to always send heartbeats
+         */
+        bool get_always_send_heartbeats() const;
+
+        /**
+         * @brief Set whether to send heartbeats by default.
+         */
+        void set_always_send_heartbeats(bool always_send_heartbeats);
+
         /** @brief Usage type of this configuration, used for automatic ID set */
         UsageType get_usage_type() const;
 
@@ -208,6 +221,7 @@ public:
     private:
         uint8_t _system_id;
         uint8_t _component_id;
+        bool _always_send_heartbeats;
         UsageType _usage_type;
     };
 

--- a/src/core/mavsdk_impl.h
+++ b/src/core/mavsdk_impl.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <atomic>
 
+#include "call_every_handler.h"
 #include "connection.h"
 #include "mavsdk.h"
 #include "mavlink_include.h"
@@ -71,7 +72,10 @@ public:
     void notify_on_discover(uint64_t uuid);
     void notify_on_timeout(uint64_t uuid);
 
+    void start_sending_heartbeat();
+
     TimeoutHandler timeout_handler;
+    CallEveryHandler call_every_handler;
 
     void call_user_callback_located(
         const std::string& filename, const int linenumber, const std::function<void()>& func);
@@ -85,6 +89,8 @@ private:
 
     void work_thread();
     void process_user_callbacks_thread();
+
+    void send_heartbeat();
 
     using system_entry_t = std::pair<uint8_t, std::shared_ptr<System>>;
 
@@ -126,6 +132,10 @@ private:
     std::thread* _process_user_callbacks_thread{nullptr};
     SafeQueue<UserCallback> _user_callback_queue{};
     bool _callback_debugging{false};
+
+    static constexpr double _HEARTBEAT_SEND_INTERVAL_S = 1.0;
+    std::atomic<bool> _sending_heartbeats{false};
+    void* _heartbeat_send_cookie = nullptr;
 
     std::atomic<bool> _should_exit = {false};
 };

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -9,7 +9,6 @@
 #include "mavlink_mission_transfer.h"
 #include "mavlink_statustext_handler.h"
 #include "timeout_handler.h"
-#include "call_every_handler.h"
 #include "safe_queue.h"
 #include "timesync.h"
 #include "system.h"
@@ -266,7 +265,6 @@ private:
     static ComponentType component_type(uint8_t component_id);
 
     void system_thread();
-    void send_heartbeat();
 
     // We use std::pair instead of a std::optional.
     std::pair<MavlinkCommandSender::Result, MavlinkCommandSender::CommandLong>
@@ -320,20 +318,15 @@ private:
     bool _connected{false};
     System::IsConnectedCallback _is_connected_callback{nullptr};
     void* _heartbeat_timeout_cookie = nullptr;
-    void* _heartbeat_send_cookie = nullptr;
 
     std::atomic<bool> _autopilot_version_pending{false};
     void* _autopilot_version_timed_out_cookie = nullptr;
-
-    static constexpr double _HEARTBEAT_SEND_INTERVAL_S = 1.0;
 
     MAVLinkParameters _params;
     MavlinkCommandSender _send_commands;
     MavlinkCommandReceiver _receive_commands;
 
     Timesync _timesync;
-
-    CallEveryHandler _call_every_handler;
 
     MAVLinkMissionTransfer _mission_transfer;
 


### PR DESCRIPTION
It actually did not make sense to send heartbeats in the System class because it's the Mavsdk MAVLink node that sends them as broadcast and not per vehicle.

The change was required in order to enable sending heartbeats without first discovering a system. That's needed if MAVSDK is used on a companion or as an autopilot instead of as a ground station.

A few specifics for the change:
- Move call_every_handler from SystemImpl to MavsdkImpl.
- Add config option to always send heartbeats, and not just when a vehicle has been discovered.
- Remove duplicate system_id/component_id vars in MavsdkImpl and use vars in configuration instead.