### PR TITLE
Hardcode `CAM_MODE` to `uint32_t` to remove type warnings

### DIFF
--- a/src/plugins/camera/camera_definition.h
+++ b/src/plugins/camera/camera_definition.h
@@ -30,7 +30,7 @@ public:
         MAVLinkParameters::ParamValue value;
     };
 
-    bool set_setting(const std::string& name, const MAVLinkParameters::ParamValue& value);
+    bool set_setting(const std::string& name, const MAVLinkParameters::ParamValue value);
     bool get_setting(const std::string& name, MAVLinkParameters::ParamValue& value);
     bool get_all_settings(std::unordered_map<std::string, MAVLinkParameters::ParamValue>& settings);
     bool
@@ -82,6 +82,7 @@ private:
     };
 
     bool parse_xml();
+    std::vector<std::string> extract_exclusions();
 
     // Until we have std::optional we need to use std::pair to return something that might be
     // nothing.


### PR DESCRIPTION
New try after failing on https://github.com/mavlink/MAVSDK/pull/1243.

This PR now hardcodes `CAM_MODE` everywhere as `uint32_t` and forces it to come from the `CAMERA_SETTINGS` message, and to be set through the `MAV_CMD_SET_CAMERA_MODE` message.

What makes it complex is that this parameter can be defined in the camera definition file, with exclusions and all, but the camera definition file is optional, and consequently `CAM_MODE` has a mavlink command message just for itself. In the absence of a camera definition file, we hardcode that enum to a `uint32_t`. But if later a camera definition file arrives, it may redefine it completely.

To be really compliant with the MAVLink implementations, MAVSDK should account for all that, with the camera definition taking precedence in case `CAM_MODE` is defined both in `CAMERA_SETTINGS` and in the camera definition. Which IMO makes it weird, because it could make the `CAMERA_SETTINGS` message wrong. Anyway, I don't need that right now, so that could be contributed later (good luck :see_no_evil:).