### PR TITLE
fix examples to work with 0.34.0

### DIFF
--- a/examples/fly_multiple_drones/fly_multiple_drones.cpp
+++ b/examples/fly_multiple_drones/fly_multiple_drones.cpp
@@ -121,7 +121,7 @@ int main(int argc, char* argv[])
     mavsdk.subscribe_on_new_system([&mavsdk, &num_systems_discovered]() {
         const auto systems = mavsdk.systems();
 
-        if (systems.size() < num_systems_discovered) {
+        if (systems.size() > num_systems_discovered) {
             std::cout << "Discovered system" << std::endl;
             num_systems_discovered = systems.size();
         }
@@ -146,6 +146,7 @@ int main(int argc, char* argv[])
         threads.push_back(
             std::move(t)); // Instead of copying, move t into the vector (less expensive)
         planFile_provided += 1;
+        sleep_for(seconds(1));
     }
 
     for (auto& t : threads) {

--- a/examples/follow_me/follow_me.cpp
+++ b/examples/follow_me/follow_me.cpp
@@ -95,9 +95,8 @@ int main(int argc, char** argv)
 
     telemetry->subscribe_position([](Telemetry::Position position) {
         std::cout << TELEMETRY_CONSOLE_TEXT // set to blue
-                  << "Vehicle is at: " << position.latitude_deg << ", "
-                  << position.longitude_deg << " degrees"
-                  << NORMAL_CONSOLE_TEXT // set to default color again
+                  << "Vehicle is at: " << position.latitude_deg << ", " << position.longitude_deg
+                  << " degrees" << NORMAL_CONSOLE_TEXT // set to default color again
                   << std::endl;
     });
 
@@ -135,7 +134,7 @@ int main(int argc, char** argv)
         FollowMe::TargetLocation target_location{};
         target_location.latitude_deg = lat;
         target_location.longitude_deg = lon;
-        follow_me->set_target_location(target_location); 
+        follow_me->set_target_location(target_location);
     });
 
     while (location_provider.is_running()) {

--- a/examples/multiple_drones/multiple_drones.cpp
+++ b/examples/multiple_drones/multiple_drones.cpp
@@ -52,7 +52,7 @@ int main(int argc, char* argv[])
     mavsdk.subscribe_on_new_system([&mavsdk, &num_systems_discovered]() {
         const auto systems = mavsdk.systems();
 
-        if (systems.size() < num_systems_discovered) {
+        if (systems.size() > num_systems_discovered) {
             std::cout << "Discovered system" << std::endl;
             num_systems_discovered = systems.size();
         }
@@ -73,6 +73,7 @@ int main(int argc, char* argv[])
     for (auto system : mavsdk.systems()) {
         std::thread t(&takeoff_and_land, std::ref(system));
         threads.push_back(std::move(t));
+        sleep_for(seconds(1));
     }
 
     for (auto& t : threads) {

--- a/examples/takeoff_land/takeoff_and_land.cpp
+++ b/examples/takeoff_land/takeoff_and_land.cpp
@@ -75,9 +75,9 @@ int main(int argc, char** argv)
                   << std::endl;
         return 1;
     }
-    
+
     const auto system = mavsdk.systems().at(0);
-    
+
     // Register a callback so we get told when components (camera, gimbal) etc
     // are found.
     system->register_component_discovered_callback(component_discovered);

--- a/examples/takeoff_land/takeoff_and_land.cpp
+++ b/examples/takeoff_land/takeoff_and_land.cpp
@@ -56,8 +56,6 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto system = mavsdk.systems().at(0);
-
     std::cout << "Waiting to discover system..." << std::endl;
     mavsdk.subscribe_on_new_system([&mavsdk, &discovered_system]() {
         const auto system = mavsdk.systems().at(0);
@@ -77,7 +75,9 @@ int main(int argc, char** argv)
                   << std::endl;
         return 1;
     }
-
+    
+    const auto system = mavsdk.systems().at(0);
+    
     // Register a callback so we get told when components (camera, gimbal) etc
     // are found.
     system->register_component_discovered_callback(component_discovered);


### PR DESCRIPTION
In _examples/fly_multiple_drones/fly_multiple_drones.cpp_ and _examples/multiple_drones/multiple_drones.cpp_
`if (systems.size() < num_systems_discovered)` should be if `(systems.size() > num_systems_discovered)` otherwise 
``if (num_systems_discovered != total_ports_used)`` is always evaluated true and code aborts. 

```
    for (auto system : mavsdk.systems()) {
        std::thread t(&takeoff_and_land, std::ref(system));
        threads.push_back(std::move(t));
        sleep_for(seconds(1));
    }
```
If there is no time interval between thread creation it seems that the first vehicle rejects the initial command sent to it and the thread aborts resulting in only one vehicle executing the example.

In _examples/takeoff_land/takeoff_and_land.cpp_ access vehicle after discovering it.

In _examples/follow_me/follow_me.cpp_ target location is incorrectly reported as vehicle location. Fixed that and added a reporting vehicle location using telemetry