### PR TITLE
No setpoint manual control

### DIFF
--- a/src/plugins/manual_control/manual_control_impl.cpp
+++ b/src/plugins/manual_control/manual_control_impl.cpp
@@ -27,9 +27,9 @@ void ManualControlImpl::enable() {}
 void ManualControlImpl::disable() {}
 
 void ManualControlImpl::start_position_control_async(const ManualControl::ResultCallback callback)
-{   
-    if (_input == Input::NotSet){
-        if(callback){
+{
+    if (_input == Input::NotSet) {
+        if (callback) {
             callback(ManualControl::Result::Unknown);
         }
         return;
@@ -44,10 +44,10 @@ void ManualControlImpl::start_position_control_async(const ManualControl::Result
 
 ManualControl::Result ManualControlImpl::start_position_control()
 {
-    if (_input == Input::NotSet){
+    if (_input == Input::NotSet) {
         return ManualControl::Result::Unknown;
     }
-    
+
     auto prom = std::promise<ManualControl::Result>();
     auto fut = prom.get_future();
 
@@ -58,8 +58,8 @@ ManualControl::Result ManualControlImpl::start_position_control()
 
 void ManualControlImpl::start_altitude_control_async(const ManualControl::ResultCallback callback)
 {
-    if (_input == Input::NotSet){
-        if(callback){
+    if (_input == Input::NotSet) {
+        if (callback) {
             callback(ManualControl::Result::Unknown);
         }
         return;
@@ -73,8 +73,7 @@ void ManualControlImpl::start_altitude_control_async(const ManualControl::Result
 
 ManualControl::Result ManualControlImpl::start_altitude_control()
 {
-
-    if (_input == Input::NotSet){
+    if (_input == Input::NotSet) {
         return ManualControl::Result::Unknown;
     }
     auto prom = std::promise<ManualControl::Result>();
@@ -92,7 +91,7 @@ ManualControlImpl::set_manual_control_input(float x, float y, float z, float r)
         return ManualControl::Result::InputOutOfRange;
     }
 
-    if (_input == Input::NotSet){
+    if (_input == Input::NotSet) {
         _input = Input::Set;
     }
 

--- a/src/plugins/manual_control/manual_control_impl.cpp
+++ b/src/plugins/manual_control/manual_control_impl.cpp
@@ -27,7 +27,14 @@ void ManualControlImpl::enable() {}
 void ManualControlImpl::disable() {}
 
 void ManualControlImpl::start_position_control_async(const ManualControl::ResultCallback callback)
-{
+{   
+    if (_input == Input::NotSet){
+        if(callback){
+            callback(ManualControl::Result::Unknown);
+        }
+        return;
+    }
+
     _parent->set_flight_mode_async(
         SystemImpl::FlightMode::Posctl,
         [this, callback](MavlinkCommandSender::Result result, float) {
@@ -37,6 +44,10 @@ void ManualControlImpl::start_position_control_async(const ManualControl::Result
 
 ManualControl::Result ManualControlImpl::start_position_control()
 {
+    if (_input == Input::NotSet){
+        return ManualControl::Result::Unknown;
+    }
+    
     auto prom = std::promise<ManualControl::Result>();
     auto fut = prom.get_future();
 
@@ -47,6 +58,12 @@ ManualControl::Result ManualControlImpl::start_position_control()
 
 void ManualControlImpl::start_altitude_control_async(const ManualControl::ResultCallback callback)
 {
+    if (_input == Input::NotSet){
+        if(callback){
+            callback(ManualControl::Result::Unknown);
+        }
+        return;
+    }
     _parent->set_flight_mode_async(
         SystemImpl::FlightMode::Altctl,
         [this, callback](MavlinkCommandSender::Result result, float) {
@@ -56,6 +73,10 @@ void ManualControlImpl::start_altitude_control_async(const ManualControl::Result
 
 ManualControl::Result ManualControlImpl::start_altitude_control()
 {
+
+    if (_input == Input::NotSet){
+        return ManualControl::Result::Unknown;
+    }
     auto prom = std::promise<ManualControl::Result>();
     auto fut = prom.get_future();
 
@@ -69,6 +90,10 @@ ManualControlImpl::set_manual_control_input(float x, float y, float z, float r)
 {
     if (x > 1.f || x < -1.f || y > 1.f || y < -1.f || z > 1.f || z < 0.f || r > 1.f || r < -1.f) {
         return ManualControl::Result::InputOutOfRange;
+    }
+
+    if (_input == Input::NotSet){
+        _input = Input::Set;
     }
 
     // No buttons supported yet.

--- a/src/plugins/manual_control/manual_control_impl.cpp
+++ b/src/plugins/manual_control/manual_control_impl.cpp
@@ -30,7 +30,9 @@ void ManualControlImpl::start_position_control_async(const ManualControl::Result
 {
     if (_input == Input::NotSet) {
         if (callback) {
-            callback(ManualControl::Result::Unknown);
+            auto temp_callback = callback;
+            _parent->call_user_callback(
+                [temp_callback]() { temp_callback(ManualControl::Result::Unknown); });
         }
         return;
     }
@@ -60,7 +62,9 @@ void ManualControlImpl::start_altitude_control_async(const ManualControl::Result
 {
     if (_input == Input::NotSet) {
         if (callback) {
-            callback(ManualControl::Result::Unknown);
+            auto temp_callback = callback;
+            _parent->call_user_callback(
+                [temp_callback]() { temp_callback(ManualControl::Result::Unknown); });
         }
         return;
     }

--- a/src/plugins/manual_control/manual_control_impl.h
+++ b/src/plugins/manual_control/manual_control_impl.h
@@ -28,7 +28,12 @@ public:
     ManualControl::Result set_manual_control_input(float x, float y, float z, float r);
 
 private:
-    ManualControl::Result
+
+    enum class Input {
+        NotSet, 
+        Set
+    } _input = Input::NotSet;
+    ManualControl::Result 
     manual_control_result_from_command_result(MavlinkCommandSender::Result result);
     void command_result_callback(
         MavlinkCommandSender::Result command_result, const ManualControl::ResultCallback& callback);

--- a/src/plugins/manual_control/manual_control_impl.h
+++ b/src/plugins/manual_control/manual_control_impl.h
@@ -28,12 +28,8 @@ public:
     ManualControl::Result set_manual_control_input(float x, float y, float z, float r);
 
 private:
-
-    enum class Input {
-        NotSet, 
-        Set
-    } _input = Input::NotSet;
-    ManualControl::Result 
+    enum class Input { NotSet, Set } _input = Input::NotSet;
+    ManualControl::Result
     manual_control_result_from_command_result(MavlinkCommandSender::Result result);
     void command_result_callback(
         MavlinkCommandSender::Result command_result, const ManualControl::ResultCallback& callback);


### PR DESCRIPTION
For #1173

Essentially just implements the same thing that offboard does with `Mode::NotActive` for this by adding` enum class Input { NotSet, Set } _input = Input::NotSet`. 
One thing that I am not sure about is that offboard has a `stop_sending_setpoints()` method to reset the `_mode` to `Mode::NotActive` after it has been set by some other method. I dont know if this is also needed for manual control. If it is need I will need some insights to implement it.

Tested this by calling the `start_position_control()` without setting any setpoints first with `set_manual_control_input()` with the following result 

```
[01:45:25|Info ] MAVSDK version: v0.34.0-6-g5c2031d9 (mavsdk_impl.cpp:20)
Waiting to discover system...
[01:45:25|Info ] New system on: 127.0.0.1:14580 (with sysid: 1) (udp_connection.cpp:190)
[01:45:25|Debug] New: System ID: 1 Comp ID: 1 (mavsdk_impl.cpp:417)
[01:45:25|Debug] Component Autopilot (1) added. (system_impl.cpp:314)
[01:45:25|Debug] Discovered 1 component(s) (UUID: 5283920058631409231) (system_impl.cpp:471)
Discovered system
Waiting for system to be ready
System is ready
Position control start failed: Unknown
```

I dont know if this is how @julianoes wanted it to be done so if its not the solution that is desired I can try to do what is required after discussing. 