### PR TITLE
core: immediately call new entry

### DIFF
--- a/src/core/call_every_handler.h
+++ b/src/core/call_every_handler.h
@@ -19,8 +19,8 @@ public:
     CallEveryHandler& operator=(CallEveryHandler const&) = delete; // Copy assign
     CallEveryHandler& operator=(CallEveryHandler&&) = delete; // Move assign
 
-    void add(std::function<void()> callback, float interval_s, void** cookie);
-    void change(float interval_s, const void* cookie);
+    void add(std::function<void()> callback, double interval_s, void** cookie);
+    void change(double interval_s, const void* cookie);
     void reset(const void* cookie);
     void remove(const void* cookie);
 
@@ -30,7 +30,7 @@ private:
     struct Entry {
         std::function<void()> callback{nullptr};
         dl_time_t last_time{};
-        float interval_s{0.0f};
+        double interval_s{0.0f};
     };
 
     std::unordered_map<void*, std::shared_ptr<Entry>> _entries{};

--- a/src/core/call_every_handler_test.cpp
+++ b/src/core/call_every_handler_test.cpp
@@ -24,7 +24,7 @@ TEST(CallEveryHandler, Single)
         time.sleep_for(std::chrono::milliseconds(10));
         ceh.run_once();
     }
-    EXPECT_EQ(num_called, 1);
+    EXPECT_EQ(num_called, 2);
 
     UNUSED(cookie);
 }
@@ -40,8 +40,8 @@ TEST(CallEveryHandler, Multiple)
     ceh.add([&num_called]() { ++num_called; }, 0.1f, &cookie);
 
     for (int i = 0; i < 10; ++i) {
-        time.sleep_for(std::chrono::milliseconds(100));
         ceh.run_once();
+        time.sleep_for(std::chrono::milliseconds(100));
     }
     EXPECT_EQ(num_called, 10);
 
@@ -76,8 +76,8 @@ TEST(CallEveryHandler, InParallel)
     ceh.add([&num_called2]() { ++num_called2; }, 0.2f, &cookie2);
 
     for (int i = 0; i < 10; ++i) {
-        time.sleep_for(std::chrono::milliseconds(100));
         ceh.run_once();
+        time.sleep_for(std::chrono::milliseconds(100));
     }
 
     EXPECT_EQ(num_called1, 10);
@@ -90,8 +90,8 @@ TEST(CallEveryHandler, InParallel)
     ceh.change(0.1f, cookie2);
 
     for (int i = 0; i < 10; ++i) {
-        time.sleep_for(std::chrono::milliseconds(100));
         ceh.run_once();
+        time.sleep_for(std::chrono::milliseconds(100));
     }
 
     EXPECT_EQ(num_called1, 2);
@@ -109,23 +109,37 @@ TEST(CallEveryHandler, Reset)
     ceh.add([&num_called]() { ++num_called; }, 0.1f, &cookie);
 
     for (int i = 0; i < 8; ++i) {
-        time.sleep_for(std::chrono::milliseconds(10));
         ceh.run_once();
-        if (i == 8) {
-        }
+        time.sleep_for(std::chrono::milliseconds(10));
     }
-    EXPECT_EQ(num_called, 0);
+    EXPECT_EQ(num_called, 1);
 
     ceh.reset(cookie);
 
     for (int i = 0; i < 8; ++i) {
-        time.sleep_for(std::chrono::milliseconds(10));
         ceh.run_once();
+        time.sleep_for(std::chrono::milliseconds(10));
     }
-    EXPECT_EQ(num_called, 0);
+    EXPECT_EQ(num_called, 1);
 
     for (int i = 0; i < 3; ++i) {
+        ceh.run_once();
         time.sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_EQ(num_called, 2);
+}
+
+TEST(CallEveryHandler, CallImmediately)
+{
+    Time time{};
+    CallEveryHandler ceh(time);
+
+    int num_called = 0;
+
+    void* cookie = nullptr;
+    ceh.add([&num_called]() { ++num_called; }, 0.1f, &cookie);
+
+    for (int i = 0; i < 1; ++i) {
         ceh.run_once();
     }
     EXPECT_EQ(num_called, 1);


### PR DESCRIPTION
Instead of waiting for one interval we now call a new call every callback immediately in the first round. This is achieved by setting the initial time to now and subtract the interval.

This should fix the problem where the takeoff and hover test fails due to the vehicle going into failsafe. This happened because the vehicle had not received any heartbeats yet at the time of the takeoff.