### PR TITLE
Add support for getting the gps global origin

### DIFF
--- a/src/backend/src/generated/manual_control/manual_control.pb.cc
+++ b/src/backend/src/generated/manual_control/manual_control.pb.cc
@@ -234,28 +234,29 @@ const char descriptor_table_protodef_manual_5fcontrol_2fmanual_5fcontrol_2eproto
   "st\022\t\n\001x\030\001 \001(\002\022\t\n\001y\030\002 \001(\002\022\t\n\001z\030\003 \001(\002\022\t\n\001r"
   "\030\004 \001(\002\"n\n\035SetManualControlInputResponse\022"
   "M\n\025manual_control_result\030\001 \001(\0132..mavsdk."
-  "rpc.manual_control.ManualControlResult\"\265"
+  "rpc.manual_control.ManualControlResult\"\317"
   "\002\n\023ManualControlResult\022E\n\006result\030\001 \001(\01625"
   ".mavsdk.rpc.manual_control.ManualControl"
-  "Result.Result\022\022\n\nresult_str\030\002 \001(\t\"\302\001\n\006Re"
+  "Result.Result\022\022\n\nresult_str\030\002 \001(\t\"\334\001\n\006Re"
   "sult\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCCE"
   "SS\020\001\022\024\n\020RESULT_NO_SYSTEM\020\002\022\033\n\027RESULT_CON"
   "NECTION_ERROR\020\003\022\017\n\013RESULT_BUSY\020\004\022\031\n\025RESU"
   "LT_COMMAND_DENIED\020\005\022\022\n\016RESULT_TIMEOUT\020\006\022"
-  "\035\n\031RESULT_INPUT_OUT_OF_RANGE\020\0072\301\003\n\024Manua"
-  "lControlService\022\211\001\n\024StartPositionControl"
-  "\0226.mavsdk.rpc.manual_control.StartPositi"
-  "onControlRequest\0327.mavsdk.rpc.manual_con"
-  "trol.StartPositionControlResponse\"\000\022\211\001\n\024"
-  "StartAltitudeControl\0226.mavsdk.rpc.manual"
-  "_control.StartAltitudeControlRequest\0327.m"
-  "avsdk.rpc.manual_control.StartAltitudeCo"
-  "ntrolResponse\"\000\022\220\001\n\025SetManualControlInpu"
-  "t\0227.mavsdk.rpc.manual_control.SetManualC"
-  "ontrolInputRequest\0328.mavsdk.rpc.manual_c"
-  "ontrol.SetManualControlInputResponse\"\004\200\265"
-  "\030\001B.\n\030io.mavsdk.manual_controlB\022ManualCo"
-  "ntrolProtob\006proto3"
+  "\035\n\031RESULT_INPUT_OUT_OF_RANGE\020\007\022\030\n\024RESULT"
+  "_INPUT_NOT_SET\020\0102\301\003\n\024ManualControlServic"
+  "e\022\211\001\n\024StartPositionControl\0226.mavsdk.rpc."
+  "manual_control.StartPositionControlReque"
+  "st\0327.mavsdk.rpc.manual_control.StartPosi"
+  "tionControlResponse\"\000\022\211\001\n\024StartAltitudeC"
+  "ontrol\0226.mavsdk.rpc.manual_control.Start"
+  "AltitudeControlRequest\0327.mavsdk.rpc.manu"
+  "al_control.StartAltitudeControlResponse\""
+  "\000\022\220\001\n\025SetManualControlInput\0227.mavsdk.rpc"
+  ".manual_control.SetManualControlInputReq"
+  "uest\0328.mavsdk.rpc.manual_control.SetManu"
+  "alControlInputResponse\"\004\200\265\030\001B.\n\030io.mavsd"
+  "k.manual_controlB\022ManualControlProtob\006pr"
+  "oto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_manual_5fcontrol_2fmanual_5fcontrol_2eproto_deps[1] = {
   &::descriptor_table_mavsdk_5foptions_2eproto,
@@ -271,7 +272,7 @@ static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_man
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_manual_5fcontrol_2fmanual_5fcontrol_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_manual_5fcontrol_2fmanual_5fcontrol_2eproto = {
-  false, false, descriptor_table_protodef_manual_5fcontrol_2fmanual_5fcontrol_2eproto, "manual_control/manual_control.proto", 1378,
+  false, false, descriptor_table_protodef_manual_5fcontrol_2fmanual_5fcontrol_2eproto, "manual_control/manual_control.proto", 1404,
   &descriptor_table_manual_5fcontrol_2fmanual_5fcontrol_2eproto_once, descriptor_table_manual_5fcontrol_2fmanual_5fcontrol_2eproto_sccs, descriptor_table_manual_5fcontrol_2fmanual_5fcontrol_2eproto_deps, 7, 1,
   schemas, file_default_instances, TableStruct_manual_5fcontrol_2fmanual_5fcontrol_2eproto::offsets,
   file_level_metadata_manual_5fcontrol_2fmanual_5fcontrol_2eproto, 7, file_level_enum_descriptors_manual_5fcontrol_2fmanual_5fcontrol_2eproto, file_level_service_descriptors_manual_5fcontrol_2fmanual_5fcontrol_2eproto,
@@ -296,6 +297,7 @@ bool ManualControlResult_Result_IsValid(int value) {
     case 5:
     case 6:
     case 7:
+    case 8:
       return true;
     default:
       return false;
@@ -311,6 +313,7 @@ constexpr ManualControlResult_Result ManualControlResult::RESULT_BUSY;
 constexpr ManualControlResult_Result ManualControlResult::RESULT_COMMAND_DENIED;
 constexpr ManualControlResult_Result ManualControlResult::RESULT_TIMEOUT;
 constexpr ManualControlResult_Result ManualControlResult::RESULT_INPUT_OUT_OF_RANGE;
+constexpr ManualControlResult_Result ManualControlResult::RESULT_INPUT_NOT_SET;
 constexpr ManualControlResult_Result ManualControlResult::Result_MIN;
 constexpr ManualControlResult_Result ManualControlResult::Result_MAX;
 constexpr int ManualControlResult::Result_ARRAYSIZE;

--- a/src/backend/src/generated/manual_control/manual_control.pb.h
+++ b/src/backend/src/generated/manual_control/manual_control.pb.h
@@ -105,12 +105,13 @@ enum ManualControlResult_Result : int {
   ManualControlResult_Result_RESULT_COMMAND_DENIED = 5,
   ManualControlResult_Result_RESULT_TIMEOUT = 6,
   ManualControlResult_Result_RESULT_INPUT_OUT_OF_RANGE = 7,
+  ManualControlResult_Result_RESULT_INPUT_NOT_SET = 8,
   ManualControlResult_Result_ManualControlResult_Result_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::min(),
   ManualControlResult_Result_ManualControlResult_Result_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::max()
 };
 bool ManualControlResult_Result_IsValid(int value);
 constexpr ManualControlResult_Result ManualControlResult_Result_Result_MIN = ManualControlResult_Result_RESULT_UNKNOWN;
-constexpr ManualControlResult_Result ManualControlResult_Result_Result_MAX = ManualControlResult_Result_RESULT_INPUT_OUT_OF_RANGE;
+constexpr ManualControlResult_Result ManualControlResult_Result_Result_MAX = ManualControlResult_Result_RESULT_INPUT_NOT_SET;
 constexpr int ManualControlResult_Result_Result_ARRAYSIZE = ManualControlResult_Result_Result_MAX + 1;
 
 const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* ManualControlResult_Result_descriptor();
@@ -1112,6 +1113,8 @@ class ManualControlResult PROTOBUF_FINAL :
     ManualControlResult_Result_RESULT_TIMEOUT;
   static constexpr Result RESULT_INPUT_OUT_OF_RANGE =
     ManualControlResult_Result_RESULT_INPUT_OUT_OF_RANGE;
+  static constexpr Result RESULT_INPUT_NOT_SET =
+    ManualControlResult_Result_RESULT_INPUT_NOT_SET;
   static inline bool Result_IsValid(int value) {
     return ManualControlResult_Result_IsValid(value);
   }

--- a/src/backend/src/generated/telemetry/telemetry.grpc.pb.cc
+++ b/src/backend/src/generated/telemetry/telemetry.grpc.pb.cc
@@ -70,6 +70,7 @@ static const char* TelemetryService_method_names[] = {
   "/mavsdk.rpc.telemetry.TelemetryService/SetRateImu",
   "/mavsdk.rpc.telemetry.TelemetryService/SetRateUnixEpochTime",
   "/mavsdk.rpc.telemetry.TelemetryService/SetRateDistanceSensor",
+  "/mavsdk.rpc.telemetry.TelemetryService/GetGpsGlobalOrigin",
 };
 
 std::unique_ptr< TelemetryService::Stub> TelemetryService::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
@@ -125,6 +126,7 @@ TelemetryService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& c
   , rpcmethod_SetRateImu_(TelemetryService_method_names[43], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_SetRateUnixEpochTime_(TelemetryService_method_names[44], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_SetRateDistanceSensor_(TelemetryService_method_names[45], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetGpsGlobalOrigin_(TelemetryService_method_names[46], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::ClientReader< ::mavsdk::rpc::telemetry::PositionResponse>* TelemetryService::Stub::SubscribePositionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribePositionRequest& request) {
@@ -996,6 +998,29 @@ void TelemetryService::Stub::experimental_async::SetRateDistanceSensor(::grpc::C
   return result;
 }
 
+::grpc::Status TelemetryService::Stub::GetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest& request, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_GetGpsGlobalOrigin_, context, request, response);
+}
+
+void TelemetryService::Stub::experimental_async::GetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* request, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_GetGpsGlobalOrigin_, context, request, response, std::move(f));
+}
+
+void TelemetryService::Stub::experimental_async::GetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* request, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_GetGpsGlobalOrigin_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>* TelemetryService::Stub::PrepareAsyncGetGpsGlobalOriginRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>::Create(channel_.get(), cq, rpcmethod_GetGpsGlobalOrigin_, context, request, false);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>* TelemetryService::Stub::AsyncGetGpsGlobalOriginRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncGetGpsGlobalOriginRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
 TelemetryService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       TelemetryService_method_names[0],
@@ -1457,6 +1482,16 @@ TelemetryService::Service::Service() {
              ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse* resp) {
                return service->SetRateDistanceSensor(ctx, req, resp);
              }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      TelemetryService_method_names[46],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>(
+          [](TelemetryService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* req,
+             ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* resp) {
+               return service->GetGpsGlobalOrigin(ctx, req, resp);
+             }, this)));
 }
 
 TelemetryService::Service::~Service() {
@@ -1778,6 +1813,13 @@ TelemetryService::Service::~Service() {
 }
 
 ::grpc::Status TelemetryService::Service::SetRateDistanceSensor(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest* request, ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status TelemetryService::Service::GetGpsGlobalOrigin(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* request, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/src/backend/src/generated/telemetry/telemetry.grpc.pb.h
+++ b/src/backend/src/generated/telemetry/telemetry.grpc.pb.h
@@ -463,6 +463,14 @@ class TelemetryService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse>> PrepareAsyncSetRateDistanceSensor(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse>>(PrepareAsyncSetRateDistanceSensorRaw(context, request, cq));
     }
+    // Get the GPS global origin.
+    virtual ::grpc::Status GetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest& request, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>> AsyncGetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>>(AsyncGetGpsGlobalOriginRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>> PrepareAsyncGetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>>(PrepareAsyncGetGpsGlobalOriginRaw(context, request, cq));
+    }
     class experimental_async_interface {
      public:
       virtual ~experimental_async_interface() {}
@@ -761,6 +769,13 @@ class TelemetryService final {
       #else
       virtual void SetRateDistanceSensor(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest* request, ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
       #endif
+      // Get the GPS global origin.
+      virtual void GetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* request, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* response, std::function<void(::grpc::Status)>) = 0;
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      virtual void GetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* request, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      #else
+      virtual void GetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* request, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
+      #endif
     };
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
     typedef class experimental_async_interface async_interface;
@@ -889,6 +904,8 @@ class TelemetryService final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry::SetRateUnixEpochTimeResponse>* PrepareAsyncSetRateUnixEpochTimeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRateUnixEpochTimeRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse>* AsyncSetRateDistanceSensorRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse>* PrepareAsyncSetRateDistanceSensorRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>* AsyncGetGpsGlobalOriginRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>* PrepareAsyncGetGpsGlobalOriginRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest& request, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
@@ -1269,6 +1286,13 @@ class TelemetryService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse>> PrepareAsyncSetRateDistanceSensor(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse>>(PrepareAsyncSetRateDistanceSensorRaw(context, request, cq));
     }
+    ::grpc::Status GetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest& request, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>> AsyncGetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>>(AsyncGetGpsGlobalOriginRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>> PrepareAsyncGetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>>(PrepareAsyncGetGpsGlobalOriginRaw(context, request, cq));
+    }
     class experimental_async final :
       public StubInterface::experimental_async_interface {
      public:
@@ -1521,6 +1545,12 @@ class TelemetryService final {
       #else
       void SetRateDistanceSensor(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest* request, ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
       #endif
+      void GetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* request, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* response, std::function<void(::grpc::Status)>) override;
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      void GetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* request, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      #else
+      void GetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* request, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
+      #endif
      private:
       friend class Stub;
       explicit experimental_async(Stub* stub): stub_(stub) { }
@@ -1651,6 +1681,8 @@ class TelemetryService final {
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry::SetRateUnixEpochTimeResponse>* PrepareAsyncSetRateUnixEpochTimeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRateUnixEpochTimeRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse>* AsyncSetRateDistanceSensorRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse>* PrepareAsyncSetRateDistanceSensorRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>* AsyncGetGpsGlobalOriginRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>* PrepareAsyncGetGpsGlobalOriginRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_SubscribePosition_;
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeHome_;
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeInAir_;
@@ -1697,6 +1729,7 @@ class TelemetryService final {
     const ::grpc::internal::RpcMethod rpcmethod_SetRateImu_;
     const ::grpc::internal::RpcMethod rpcmethod_SetRateUnixEpochTime_;
     const ::grpc::internal::RpcMethod rpcmethod_SetRateDistanceSensor_;
+    const ::grpc::internal::RpcMethod rpcmethod_GetGpsGlobalOrigin_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
 
@@ -1796,6 +1829,8 @@ class TelemetryService final {
     virtual ::grpc::Status SetRateUnixEpochTime(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry::SetRateUnixEpochTimeRequest* request, ::mavsdk::rpc::telemetry::SetRateUnixEpochTimeResponse* response);
     // Set rate to 'Distance Sensor' updates.
     virtual ::grpc::Status SetRateDistanceSensor(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest* request, ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse* response);
+    // Get the GPS global origin.
+    virtual ::grpc::Status GetGpsGlobalOrigin(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* request, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* response);
   };
   template <class BaseClass>
   class WithAsyncMethod_SubscribePosition : public BaseClass {
@@ -2717,7 +2752,27 @@ class TelemetryService final {
       ::grpc::Service::RequestAsyncUnary(45, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_SubscribePosition<WithAsyncMethod_SubscribeHome<WithAsyncMethod_SubscribeInAir<WithAsyncMethod_SubscribeLandedState<WithAsyncMethod_SubscribeArmed<WithAsyncMethod_SubscribeAttitudeQuaternion<WithAsyncMethod_SubscribeAttitudeEuler<WithAsyncMethod_SubscribeAttitudeAngularVelocityBody<WithAsyncMethod_SubscribeCameraAttitudeQuaternion<WithAsyncMethod_SubscribeCameraAttitudeEuler<WithAsyncMethod_SubscribeVelocityNed<WithAsyncMethod_SubscribeGpsInfo<WithAsyncMethod_SubscribeBattery<WithAsyncMethod_SubscribeFlightMode<WithAsyncMethod_SubscribeHealth<WithAsyncMethod_SubscribeRcStatus<WithAsyncMethod_SubscribeStatusText<WithAsyncMethod_SubscribeActuatorControlTarget<WithAsyncMethod_SubscribeActuatorOutputStatus<WithAsyncMethod_SubscribeOdometry<WithAsyncMethod_SubscribePositionVelocityNed<WithAsyncMethod_SubscribeGroundTruth<WithAsyncMethod_SubscribeFixedwingMetrics<WithAsyncMethod_SubscribeImu<WithAsyncMethod_SubscribeHealthAllOk<WithAsyncMethod_SubscribeUnixEpochTime<WithAsyncMethod_SubscribeDistanceSensor<WithAsyncMethod_SetRatePosition<WithAsyncMethod_SetRateHome<WithAsyncMethod_SetRateInAir<WithAsyncMethod_SetRateLandedState<WithAsyncMethod_SetRateAttitude<WithAsyncMethod_SetRateCameraAttitude<WithAsyncMethod_SetRateVelocityNed<WithAsyncMethod_SetRateGpsInfo<WithAsyncMethod_SetRateBattery<WithAsyncMethod_SetRateRcStatus<WithAsyncMethod_SetRateActuatorControlTarget<WithAsyncMethod_SetRateActuatorOutputStatus<WithAsyncMethod_SetRateOdometry<WithAsyncMethod_SetRatePositionVelocityNed<WithAsyncMethod_SetRateGroundTruth<WithAsyncMethod_SetRateFixedwingMetrics<WithAsyncMethod_SetRateImu<WithAsyncMethod_SetRateUnixEpochTime<WithAsyncMethod_SetRateDistanceSensor<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
+  template <class BaseClass>
+  class WithAsyncMethod_GetGpsGlobalOrigin : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_GetGpsGlobalOrigin() {
+      ::grpc::Service::MarkMethodAsync(46);
+    }
+    ~WithAsyncMethod_GetGpsGlobalOrigin() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GetGpsGlobalOrigin(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* /*request*/, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestGetGpsGlobalOrigin(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(46, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  typedef WithAsyncMethod_SubscribePosition<WithAsyncMethod_SubscribeHome<WithAsyncMethod_SubscribeInAir<WithAsyncMethod_SubscribeLandedState<WithAsyncMethod_SubscribeArmed<WithAsyncMethod_SubscribeAttitudeQuaternion<WithAsyncMethod_SubscribeAttitudeEuler<WithAsyncMethod_SubscribeAttitudeAngularVelocityBody<WithAsyncMethod_SubscribeCameraAttitudeQuaternion<WithAsyncMethod_SubscribeCameraAttitudeEuler<WithAsyncMethod_SubscribeVelocityNed<WithAsyncMethod_SubscribeGpsInfo<WithAsyncMethod_SubscribeBattery<WithAsyncMethod_SubscribeFlightMode<WithAsyncMethod_SubscribeHealth<WithAsyncMethod_SubscribeRcStatus<WithAsyncMethod_SubscribeStatusText<WithAsyncMethod_SubscribeActuatorControlTarget<WithAsyncMethod_SubscribeActuatorOutputStatus<WithAsyncMethod_SubscribeOdometry<WithAsyncMethod_SubscribePositionVelocityNed<WithAsyncMethod_SubscribeGroundTruth<WithAsyncMethod_SubscribeFixedwingMetrics<WithAsyncMethod_SubscribeImu<WithAsyncMethod_SubscribeHealthAllOk<WithAsyncMethod_SubscribeUnixEpochTime<WithAsyncMethod_SubscribeDistanceSensor<WithAsyncMethod_SetRatePosition<WithAsyncMethod_SetRateHome<WithAsyncMethod_SetRateInAir<WithAsyncMethod_SetRateLandedState<WithAsyncMethod_SetRateAttitude<WithAsyncMethod_SetRateCameraAttitude<WithAsyncMethod_SetRateVelocityNed<WithAsyncMethod_SetRateGpsInfo<WithAsyncMethod_SetRateBattery<WithAsyncMethod_SetRateRcStatus<WithAsyncMethod_SetRateActuatorControlTarget<WithAsyncMethod_SetRateActuatorOutputStatus<WithAsyncMethod_SetRateOdometry<WithAsyncMethod_SetRatePositionVelocityNed<WithAsyncMethod_SetRateGroundTruth<WithAsyncMethod_SetRateFixedwingMetrics<WithAsyncMethod_SetRateImu<WithAsyncMethod_SetRateUnixEpochTime<WithAsyncMethod_SetRateDistanceSensor<WithAsyncMethod_GetGpsGlobalOrigin<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class ExperimentalWithCallbackMethod_SubscribePosition : public BaseClass {
    private:
@@ -4637,11 +4692,58 @@ class TelemetryService final {
     #endif
       { return nullptr; }
   };
+  template <class BaseClass>
+  class ExperimentalWithCallbackMethod_GetGpsGlobalOrigin : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    ExperimentalWithCallbackMethod_GetGpsGlobalOrigin() {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodCallback(46,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* request, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* response) { return this->GetGpsGlobalOrigin(context, request, response); }));}
+    void SetMessageAllocatorFor_GetGpsGlobalOrigin(
+        ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>* allocator) {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(46);
+    #else
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(46);
+    #endif
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~ExperimentalWithCallbackMethod_GetGpsGlobalOrigin() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GetGpsGlobalOrigin(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* /*request*/, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerUnaryReactor* GetGpsGlobalOrigin(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* /*request*/, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* /*response*/)
+    #else
+    virtual ::grpc::experimental::ServerUnaryReactor* GetGpsGlobalOrigin(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* /*request*/, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* /*response*/)
+    #endif
+      { return nullptr; }
+  };
   #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-  typedef ExperimentalWithCallbackMethod_SubscribePosition<ExperimentalWithCallbackMethod_SubscribeHome<ExperimentalWithCallbackMethod_SubscribeInAir<ExperimentalWithCallbackMethod_SubscribeLandedState<ExperimentalWithCallbackMethod_SubscribeArmed<ExperimentalWithCallbackMethod_SubscribeAttitudeQuaternion<ExperimentalWithCallbackMethod_SubscribeAttitudeEuler<ExperimentalWithCallbackMethod_SubscribeAttitudeAngularVelocityBody<ExperimentalWithCallbackMethod_SubscribeCameraAttitudeQuaternion<ExperimentalWithCallbackMethod_SubscribeCameraAttitudeEuler<ExperimentalWithCallbackMethod_SubscribeVelocityNed<ExperimentalWithCallbackMethod_SubscribeGpsInfo<ExperimentalWithCallbackMethod_SubscribeBattery<ExperimentalWithCallbackMethod_SubscribeFlightMode<ExperimentalWithCallbackMethod_SubscribeHealth<ExperimentalWithCallbackMethod_SubscribeRcStatus<ExperimentalWithCallbackMethod_SubscribeStatusText<ExperimentalWithCallbackMethod_SubscribeActuatorControlTarget<ExperimentalWithCallbackMethod_SubscribeActuatorOutputStatus<ExperimentalWithCallbackMethod_SubscribeOdometry<ExperimentalWithCallbackMethod_SubscribePositionVelocityNed<ExperimentalWithCallbackMethod_SubscribeGroundTruth<ExperimentalWithCallbackMethod_SubscribeFixedwingMetrics<ExperimentalWithCallbackMethod_SubscribeImu<ExperimentalWithCallbackMethod_SubscribeHealthAllOk<ExperimentalWithCallbackMethod_SubscribeUnixEpochTime<ExperimentalWithCallbackMethod_SubscribeDistanceSensor<ExperimentalWithCallbackMethod_SetRatePosition<ExperimentalWithCallbackMethod_SetRateHome<ExperimentalWithCallbackMethod_SetRateInAir<ExperimentalWithCallbackMethod_SetRateLandedState<ExperimentalWithCallbackMethod_SetRateAttitude<ExperimentalWithCallbackMethod_SetRateCameraAttitude<ExperimentalWithCallbackMethod_SetRateVelocityNed<ExperimentalWithCallbackMethod_SetRateGpsInfo<ExperimentalWithCallbackMethod_SetRateBattery<ExperimentalWithCallbackMethod_SetRateRcStatus<ExperimentalWithCallbackMethod_SetRateActuatorControlTarget<ExperimentalWithCallbackMethod_SetRateActuatorOutputStatus<ExperimentalWithCallbackMethod_SetRateOdometry<ExperimentalWithCallbackMethod_SetRatePositionVelocityNed<ExperimentalWithCallbackMethod_SetRateGroundTruth<ExperimentalWithCallbackMethod_SetRateFixedwingMetrics<ExperimentalWithCallbackMethod_SetRateImu<ExperimentalWithCallbackMethod_SetRateUnixEpochTime<ExperimentalWithCallbackMethod_SetRateDistanceSensor<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
+  typedef ExperimentalWithCallbackMethod_SubscribePosition<ExperimentalWithCallbackMethod_SubscribeHome<ExperimentalWithCallbackMethod_SubscribeInAir<ExperimentalWithCallbackMethod_SubscribeLandedState<ExperimentalWithCallbackMethod_SubscribeArmed<ExperimentalWithCallbackMethod_SubscribeAttitudeQuaternion<ExperimentalWithCallbackMethod_SubscribeAttitudeEuler<ExperimentalWithCallbackMethod_SubscribeAttitudeAngularVelocityBody<ExperimentalWithCallbackMethod_SubscribeCameraAttitudeQuaternion<ExperimentalWithCallbackMethod_SubscribeCameraAttitudeEuler<ExperimentalWithCallbackMethod_SubscribeVelocityNed<ExperimentalWithCallbackMethod_SubscribeGpsInfo<ExperimentalWithCallbackMethod_SubscribeBattery<ExperimentalWithCallbackMethod_SubscribeFlightMode<ExperimentalWithCallbackMethod_SubscribeHealth<ExperimentalWithCallbackMethod_SubscribeRcStatus<ExperimentalWithCallbackMethod_SubscribeStatusText<ExperimentalWithCallbackMethod_SubscribeActuatorControlTarget<ExperimentalWithCallbackMethod_SubscribeActuatorOutputStatus<ExperimentalWithCallbackMethod_SubscribeOdometry<ExperimentalWithCallbackMethod_SubscribePositionVelocityNed<ExperimentalWithCallbackMethod_SubscribeGroundTruth<ExperimentalWithCallbackMethod_SubscribeFixedwingMetrics<ExperimentalWithCallbackMethod_SubscribeImu<ExperimentalWithCallbackMethod_SubscribeHealthAllOk<ExperimentalWithCallbackMethod_SubscribeUnixEpochTime<ExperimentalWithCallbackMethod_SubscribeDistanceSensor<ExperimentalWithCallbackMethod_SetRatePosition<ExperimentalWithCallbackMethod_SetRateHome<ExperimentalWithCallbackMethod_SetRateInAir<ExperimentalWithCallbackMethod_SetRateLandedState<ExperimentalWithCallbackMethod_SetRateAttitude<ExperimentalWithCallbackMethod_SetRateCameraAttitude<ExperimentalWithCallbackMethod_SetRateVelocityNed<ExperimentalWithCallbackMethod_SetRateGpsInfo<ExperimentalWithCallbackMethod_SetRateBattery<ExperimentalWithCallbackMethod_SetRateRcStatus<ExperimentalWithCallbackMethod_SetRateActuatorControlTarget<ExperimentalWithCallbackMethod_SetRateActuatorOutputStatus<ExperimentalWithCallbackMethod_SetRateOdometry<ExperimentalWithCallbackMethod_SetRatePositionVelocityNed<ExperimentalWithCallbackMethod_SetRateGroundTruth<ExperimentalWithCallbackMethod_SetRateFixedwingMetrics<ExperimentalWithCallbackMethod_SetRateImu<ExperimentalWithCallbackMethod_SetRateUnixEpochTime<ExperimentalWithCallbackMethod_SetRateDistanceSensor<ExperimentalWithCallbackMethod_GetGpsGlobalOrigin<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
   #endif
 
-  typedef ExperimentalWithCallbackMethod_SubscribePosition<ExperimentalWithCallbackMethod_SubscribeHome<ExperimentalWithCallbackMethod_SubscribeInAir<ExperimentalWithCallbackMethod_SubscribeLandedState<ExperimentalWithCallbackMethod_SubscribeArmed<ExperimentalWithCallbackMethod_SubscribeAttitudeQuaternion<ExperimentalWithCallbackMethod_SubscribeAttitudeEuler<ExperimentalWithCallbackMethod_SubscribeAttitudeAngularVelocityBody<ExperimentalWithCallbackMethod_SubscribeCameraAttitudeQuaternion<ExperimentalWithCallbackMethod_SubscribeCameraAttitudeEuler<ExperimentalWithCallbackMethod_SubscribeVelocityNed<ExperimentalWithCallbackMethod_SubscribeGpsInfo<ExperimentalWithCallbackMethod_SubscribeBattery<ExperimentalWithCallbackMethod_SubscribeFlightMode<ExperimentalWithCallbackMethod_SubscribeHealth<ExperimentalWithCallbackMethod_SubscribeRcStatus<ExperimentalWithCallbackMethod_SubscribeStatusText<ExperimentalWithCallbackMethod_SubscribeActuatorControlTarget<ExperimentalWithCallbackMethod_SubscribeActuatorOutputStatus<ExperimentalWithCallbackMethod_SubscribeOdometry<ExperimentalWithCallbackMethod_SubscribePositionVelocityNed<ExperimentalWithCallbackMethod_SubscribeGroundTruth<ExperimentalWithCallbackMethod_SubscribeFixedwingMetrics<ExperimentalWithCallbackMethod_SubscribeImu<ExperimentalWithCallbackMethod_SubscribeHealthAllOk<ExperimentalWithCallbackMethod_SubscribeUnixEpochTime<ExperimentalWithCallbackMethod_SubscribeDistanceSensor<ExperimentalWithCallbackMethod_SetRatePosition<ExperimentalWithCallbackMethod_SetRateHome<ExperimentalWithCallbackMethod_SetRateInAir<ExperimentalWithCallbackMethod_SetRateLandedState<ExperimentalWithCallbackMethod_SetRateAttitude<ExperimentalWithCallbackMethod_SetRateCameraAttitude<ExperimentalWithCallbackMethod_SetRateVelocityNed<ExperimentalWithCallbackMethod_SetRateGpsInfo<ExperimentalWithCallbackMethod_SetRateBattery<ExperimentalWithCallbackMethod_SetRateRcStatus<ExperimentalWithCallbackMethod_SetRateActuatorControlTarget<ExperimentalWithCallbackMethod_SetRateActuatorOutputStatus<ExperimentalWithCallbackMethod_SetRateOdometry<ExperimentalWithCallbackMethod_SetRatePositionVelocityNed<ExperimentalWithCallbackMethod_SetRateGroundTruth<ExperimentalWithCallbackMethod_SetRateFixedwingMetrics<ExperimentalWithCallbackMethod_SetRateImu<ExperimentalWithCallbackMethod_SetRateUnixEpochTime<ExperimentalWithCallbackMethod_SetRateDistanceSensor<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > ExperimentalCallbackService;
+  typedef ExperimentalWithCallbackMethod_SubscribePosition<ExperimentalWithCallbackMethod_SubscribeHome<ExperimentalWithCallbackMethod_SubscribeInAir<ExperimentalWithCallbackMethod_SubscribeLandedState<ExperimentalWithCallbackMethod_SubscribeArmed<ExperimentalWithCallbackMethod_SubscribeAttitudeQuaternion<ExperimentalWithCallbackMethod_SubscribeAttitudeEuler<ExperimentalWithCallbackMethod_SubscribeAttitudeAngularVelocityBody<ExperimentalWithCallbackMethod_SubscribeCameraAttitudeQuaternion<ExperimentalWithCallbackMethod_SubscribeCameraAttitudeEuler<ExperimentalWithCallbackMethod_SubscribeVelocityNed<ExperimentalWithCallbackMethod_SubscribeGpsInfo<ExperimentalWithCallbackMethod_SubscribeBattery<ExperimentalWithCallbackMethod_SubscribeFlightMode<ExperimentalWithCallbackMethod_SubscribeHealth<ExperimentalWithCallbackMethod_SubscribeRcStatus<ExperimentalWithCallbackMethod_SubscribeStatusText<ExperimentalWithCallbackMethod_SubscribeActuatorControlTarget<ExperimentalWithCallbackMethod_SubscribeActuatorOutputStatus<ExperimentalWithCallbackMethod_SubscribeOdometry<ExperimentalWithCallbackMethod_SubscribePositionVelocityNed<ExperimentalWithCallbackMethod_SubscribeGroundTruth<ExperimentalWithCallbackMethod_SubscribeFixedwingMetrics<ExperimentalWithCallbackMethod_SubscribeImu<ExperimentalWithCallbackMethod_SubscribeHealthAllOk<ExperimentalWithCallbackMethod_SubscribeUnixEpochTime<ExperimentalWithCallbackMethod_SubscribeDistanceSensor<ExperimentalWithCallbackMethod_SetRatePosition<ExperimentalWithCallbackMethod_SetRateHome<ExperimentalWithCallbackMethod_SetRateInAir<ExperimentalWithCallbackMethod_SetRateLandedState<ExperimentalWithCallbackMethod_SetRateAttitude<ExperimentalWithCallbackMethod_SetRateCameraAttitude<ExperimentalWithCallbackMethod_SetRateVelocityNed<ExperimentalWithCallbackMethod_SetRateGpsInfo<ExperimentalWithCallbackMethod_SetRateBattery<ExperimentalWithCallbackMethod_SetRateRcStatus<ExperimentalWithCallbackMethod_SetRateActuatorControlTarget<ExperimentalWithCallbackMethod_SetRateActuatorOutputStatus<ExperimentalWithCallbackMethod_SetRateOdometry<ExperimentalWithCallbackMethod_SetRatePositionVelocityNed<ExperimentalWithCallbackMethod_SetRateGroundTruth<ExperimentalWithCallbackMethod_SetRateFixedwingMetrics<ExperimentalWithCallbackMethod_SetRateImu<ExperimentalWithCallbackMethod_SetRateUnixEpochTime<ExperimentalWithCallbackMethod_SetRateDistanceSensor<ExperimentalWithCallbackMethod_GetGpsGlobalOrigin<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_SubscribePosition : public BaseClass {
    private:
@@ -5420,6 +5522,23 @@ class TelemetryService final {
     }
     // disable synchronous version of this method
     ::grpc::Status SetRateDistanceSensor(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest* /*request*/, ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_GetGpsGlobalOrigin : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_GetGpsGlobalOrigin() {
+      ::grpc::Service::MarkMethodGeneric(46);
+    }
+    ~WithGenericMethod_GetGpsGlobalOrigin() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GetGpsGlobalOrigin(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* /*request*/, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -6342,6 +6461,26 @@ class TelemetryService final {
     }
     void RequestSetRateDistanceSensor(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(45, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_GetGpsGlobalOrigin : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_GetGpsGlobalOrigin() {
+      ::grpc::Service::MarkMethodRaw(46);
+    }
+    ~WithRawMethod_GetGpsGlobalOrigin() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GetGpsGlobalOrigin(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* /*request*/, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestGetGpsGlobalOrigin(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(46, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -8093,6 +8232,44 @@ class TelemetryService final {
       { return nullptr; }
   };
   template <class BaseClass>
+  class ExperimentalWithRawCallbackMethod_GetGpsGlobalOrigin : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    ExperimentalWithRawCallbackMethod_GetGpsGlobalOrigin() {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodRawCallback(46,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->GetGpsGlobalOrigin(context, request, response); }));
+    }
+    ~ExperimentalWithRawCallbackMethod_GetGpsGlobalOrigin() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GetGpsGlobalOrigin(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* /*request*/, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerUnaryReactor* GetGpsGlobalOrigin(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
+    #else
+    virtual ::grpc::experimental::ServerUnaryReactor* GetGpsGlobalOrigin(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
+    #endif
+      { return nullptr; }
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_SetRatePosition : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
@@ -8605,7 +8782,34 @@ class TelemetryService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedSetRateDistanceSensor(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest,::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_SetRatePosition<WithStreamedUnaryMethod_SetRateHome<WithStreamedUnaryMethod_SetRateInAir<WithStreamedUnaryMethod_SetRateLandedState<WithStreamedUnaryMethod_SetRateAttitude<WithStreamedUnaryMethod_SetRateCameraAttitude<WithStreamedUnaryMethod_SetRateVelocityNed<WithStreamedUnaryMethod_SetRateGpsInfo<WithStreamedUnaryMethod_SetRateBattery<WithStreamedUnaryMethod_SetRateRcStatus<WithStreamedUnaryMethod_SetRateActuatorControlTarget<WithStreamedUnaryMethod_SetRateActuatorOutputStatus<WithStreamedUnaryMethod_SetRateOdometry<WithStreamedUnaryMethod_SetRatePositionVelocityNed<WithStreamedUnaryMethod_SetRateGroundTruth<WithStreamedUnaryMethod_SetRateFixedwingMetrics<WithStreamedUnaryMethod_SetRateImu<WithStreamedUnaryMethod_SetRateUnixEpochTime<WithStreamedUnaryMethod_SetRateDistanceSensor<Service > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_GetGpsGlobalOrigin : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_GetGpsGlobalOrigin() {
+      ::grpc::Service::MarkMethodStreamed(46,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>* streamer) {
+                       return this->StreamedGetGpsGlobalOrigin(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_GetGpsGlobalOrigin() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status GetGpsGlobalOrigin(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* /*request*/, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedGetGpsGlobalOrigin(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest,::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>* server_unary_streamer) = 0;
+  };
+  typedef WithStreamedUnaryMethod_SetRatePosition<WithStreamedUnaryMethod_SetRateHome<WithStreamedUnaryMethod_SetRateInAir<WithStreamedUnaryMethod_SetRateLandedState<WithStreamedUnaryMethod_SetRateAttitude<WithStreamedUnaryMethod_SetRateCameraAttitude<WithStreamedUnaryMethod_SetRateVelocityNed<WithStreamedUnaryMethod_SetRateGpsInfo<WithStreamedUnaryMethod_SetRateBattery<WithStreamedUnaryMethod_SetRateRcStatus<WithStreamedUnaryMethod_SetRateActuatorControlTarget<WithStreamedUnaryMethod_SetRateActuatorOutputStatus<WithStreamedUnaryMethod_SetRateOdometry<WithStreamedUnaryMethod_SetRatePositionVelocityNed<WithStreamedUnaryMethod_SetRateGroundTruth<WithStreamedUnaryMethod_SetRateFixedwingMetrics<WithStreamedUnaryMethod_SetRateImu<WithStreamedUnaryMethod_SetRateUnixEpochTime<WithStreamedUnaryMethod_SetRateDistanceSensor<WithStreamedUnaryMethod_GetGpsGlobalOrigin<Service > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
   template <class BaseClass>
   class WithSplitStreamingMethod_SubscribePosition : public BaseClass {
    private:
@@ -9336,7 +9540,7 @@ class TelemetryService final {
     virtual ::grpc::Status StreamedSubscribeDistanceSensor(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::telemetry::SubscribeDistanceSensorRequest,::mavsdk::rpc::telemetry::DistanceSensorResponse>* server_split_streamer) = 0;
   };
   typedef WithSplitStreamingMethod_SubscribePosition<WithSplitStreamingMethod_SubscribeHome<WithSplitStreamingMethod_SubscribeInAir<WithSplitStreamingMethod_SubscribeLandedState<WithSplitStreamingMethod_SubscribeArmed<WithSplitStreamingMethod_SubscribeAttitudeQuaternion<WithSplitStreamingMethod_SubscribeAttitudeEuler<WithSplitStreamingMethod_SubscribeAttitudeAngularVelocityBody<WithSplitStreamingMethod_SubscribeCameraAttitudeQuaternion<WithSplitStreamingMethod_SubscribeCameraAttitudeEuler<WithSplitStreamingMethod_SubscribeVelocityNed<WithSplitStreamingMethod_SubscribeGpsInfo<WithSplitStreamingMethod_SubscribeBattery<WithSplitStreamingMethod_SubscribeFlightMode<WithSplitStreamingMethod_SubscribeHealth<WithSplitStreamingMethod_SubscribeRcStatus<WithSplitStreamingMethod_SubscribeStatusText<WithSplitStreamingMethod_SubscribeActuatorControlTarget<WithSplitStreamingMethod_SubscribeActuatorOutputStatus<WithSplitStreamingMethod_SubscribeOdometry<WithSplitStreamingMethod_SubscribePositionVelocityNed<WithSplitStreamingMethod_SubscribeGroundTruth<WithSplitStreamingMethod_SubscribeFixedwingMetrics<WithSplitStreamingMethod_SubscribeImu<WithSplitStreamingMethod_SubscribeHealthAllOk<WithSplitStreamingMethod_SubscribeUnixEpochTime<WithSplitStreamingMethod_SubscribeDistanceSensor<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > SplitStreamedService;
-  typedef WithSplitStreamingMethod_SubscribePosition<WithSplitStreamingMethod_SubscribeHome<WithSplitStreamingMethod_SubscribeInAir<WithSplitStreamingMethod_SubscribeLandedState<WithSplitStreamingMethod_SubscribeArmed<WithSplitStreamingMethod_SubscribeAttitudeQuaternion<WithSplitStreamingMethod_SubscribeAttitudeEuler<WithSplitStreamingMethod_SubscribeAttitudeAngularVelocityBody<WithSplitStreamingMethod_SubscribeCameraAttitudeQuaternion<WithSplitStreamingMethod_SubscribeCameraAttitudeEuler<WithSplitStreamingMethod_SubscribeVelocityNed<WithSplitStreamingMethod_SubscribeGpsInfo<WithSplitStreamingMethod_SubscribeBattery<WithSplitStreamingMethod_SubscribeFlightMode<WithSplitStreamingMethod_SubscribeHealth<WithSplitStreamingMethod_SubscribeRcStatus<WithSplitStreamingMethod_SubscribeStatusText<WithSplitStreamingMethod_SubscribeActuatorControlTarget<WithSplitStreamingMethod_SubscribeActuatorOutputStatus<WithSplitStreamingMethod_SubscribeOdometry<WithSplitStreamingMethod_SubscribePositionVelocityNed<WithSplitStreamingMethod_SubscribeGroundTruth<WithSplitStreamingMethod_SubscribeFixedwingMetrics<WithSplitStreamingMethod_SubscribeImu<WithSplitStreamingMethod_SubscribeHealthAllOk<WithSplitStreamingMethod_SubscribeUnixEpochTime<WithSplitStreamingMethod_SubscribeDistanceSensor<WithStreamedUnaryMethod_SetRatePosition<WithStreamedUnaryMethod_SetRateHome<WithStreamedUnaryMethod_SetRateInAir<WithStreamedUnaryMethod_SetRateLandedState<WithStreamedUnaryMethod_SetRateAttitude<WithStreamedUnaryMethod_SetRateCameraAttitude<WithStreamedUnaryMethod_SetRateVelocityNed<WithStreamedUnaryMethod_SetRateGpsInfo<WithStreamedUnaryMethod_SetRateBattery<WithStreamedUnaryMethod_SetRateRcStatus<WithStreamedUnaryMethod_SetRateActuatorControlTarget<WithStreamedUnaryMethod_SetRateActuatorOutputStatus<WithStreamedUnaryMethod_SetRateOdometry<WithStreamedUnaryMethod_SetRatePositionVelocityNed<WithStreamedUnaryMethod_SetRateGroundTruth<WithStreamedUnaryMethod_SetRateFixedwingMetrics<WithStreamedUnaryMethod_SetRateImu<WithStreamedUnaryMethod_SetRateUnixEpochTime<WithStreamedUnaryMethod_SetRateDistanceSensor<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
+  typedef WithSplitStreamingMethod_SubscribePosition<WithSplitStreamingMethod_SubscribeHome<WithSplitStreamingMethod_SubscribeInAir<WithSplitStreamingMethod_SubscribeLandedState<WithSplitStreamingMethod_SubscribeArmed<WithSplitStreamingMethod_SubscribeAttitudeQuaternion<WithSplitStreamingMethod_SubscribeAttitudeEuler<WithSplitStreamingMethod_SubscribeAttitudeAngularVelocityBody<WithSplitStreamingMethod_SubscribeCameraAttitudeQuaternion<WithSplitStreamingMethod_SubscribeCameraAttitudeEuler<WithSplitStreamingMethod_SubscribeVelocityNed<WithSplitStreamingMethod_SubscribeGpsInfo<WithSplitStreamingMethod_SubscribeBattery<WithSplitStreamingMethod_SubscribeFlightMode<WithSplitStreamingMethod_SubscribeHealth<WithSplitStreamingMethod_SubscribeRcStatus<WithSplitStreamingMethod_SubscribeStatusText<WithSplitStreamingMethod_SubscribeActuatorControlTarget<WithSplitStreamingMethod_SubscribeActuatorOutputStatus<WithSplitStreamingMethod_SubscribeOdometry<WithSplitStreamingMethod_SubscribePositionVelocityNed<WithSplitStreamingMethod_SubscribeGroundTruth<WithSplitStreamingMethod_SubscribeFixedwingMetrics<WithSplitStreamingMethod_SubscribeImu<WithSplitStreamingMethod_SubscribeHealthAllOk<WithSplitStreamingMethod_SubscribeUnixEpochTime<WithSplitStreamingMethod_SubscribeDistanceSensor<WithStreamedUnaryMethod_SetRatePosition<WithStreamedUnaryMethod_SetRateHome<WithStreamedUnaryMethod_SetRateInAir<WithStreamedUnaryMethod_SetRateLandedState<WithStreamedUnaryMethod_SetRateAttitude<WithStreamedUnaryMethod_SetRateCameraAttitude<WithStreamedUnaryMethod_SetRateVelocityNed<WithStreamedUnaryMethod_SetRateGpsInfo<WithStreamedUnaryMethod_SetRateBattery<WithStreamedUnaryMethod_SetRateRcStatus<WithStreamedUnaryMethod_SetRateActuatorControlTarget<WithStreamedUnaryMethod_SetRateActuatorOutputStatus<WithStreamedUnaryMethod_SetRateOdometry<WithStreamedUnaryMethod_SetRatePositionVelocityNed<WithStreamedUnaryMethod_SetRateGroundTruth<WithStreamedUnaryMethod_SetRateFixedwingMetrics<WithStreamedUnaryMethod_SetRateImu<WithStreamedUnaryMethod_SetRateUnixEpochTime<WithStreamedUnaryMethod_SetRateDistanceSensor<WithStreamedUnaryMethod_GetGpsGlobalOrigin<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace telemetry

--- a/src/backend/src/generated/telemetry/telemetry.grpc.pb.h
+++ b/src/backend/src/generated/telemetry/telemetry.grpc.pb.h
@@ -463,7 +463,7 @@ class TelemetryService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse>> PrepareAsyncSetRateDistanceSensor(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse>>(PrepareAsyncSetRateDistanceSensorRaw(context, request, cq));
     }
-    // Get the GPS global origin.
+    // Get the GPS location of where the estimator has been initialized.
     virtual ::grpc::Status GetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest& request, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>> AsyncGetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>>(AsyncGetGpsGlobalOriginRaw(context, request, cq));
@@ -769,7 +769,7 @@ class TelemetryService final {
       #else
       virtual void SetRateDistanceSensor(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest* request, ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
       #endif
-      // Get the GPS global origin.
+      // Get the GPS location of where the estimator has been initialized.
       virtual void GetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* request, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* response, std::function<void(::grpc::Status)>) = 0;
       #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       virtual void GetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* request, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
@@ -1829,7 +1829,7 @@ class TelemetryService final {
     virtual ::grpc::Status SetRateUnixEpochTime(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry::SetRateUnixEpochTimeRequest* request, ::mavsdk::rpc::telemetry::SetRateUnixEpochTimeResponse* response);
     // Set rate to 'Distance Sensor' updates.
     virtual ::grpc::Status SetRateDistanceSensor(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest* request, ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse* response);
-    // Get the GPS global origin.
+    // Get the GPS location of where the estimator has been initialized.
     virtual ::grpc::Status GetGpsGlobalOrigin(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* request, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* response);
   };
   template <class BaseClass>

--- a/src/backend/src/generated/telemetry/telemetry.pb.cc
+++ b/src/backend/src/generated/telemetry/telemetry.pb.cc
@@ -24,6 +24,7 @@ extern PROTOBUF_INTERNAL_EXPORT_telemetry_2ftelemetry_2eproto ::PROTOBUF_NAMESPA
 extern PROTOBUF_INTERNAL_EXPORT_telemetry_2ftelemetry_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_DistanceSensor_telemetry_2ftelemetry_2eproto;
 extern PROTOBUF_INTERNAL_EXPORT_telemetry_2ftelemetry_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_EulerAngle_telemetry_2ftelemetry_2eproto;
 extern PROTOBUF_INTERNAL_EXPORT_telemetry_2ftelemetry_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_FixedwingMetrics_telemetry_2ftelemetry_2eproto;
+extern PROTOBUF_INTERNAL_EXPORT_telemetry_2ftelemetry_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_GpsGlobalOrigin_telemetry_2ftelemetry_2eproto;
 extern PROTOBUF_INTERNAL_EXPORT_telemetry_2ftelemetry_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_GpsInfo_telemetry_2ftelemetry_2eproto;
 extern PROTOBUF_INTERNAL_EXPORT_telemetry_2ftelemetry_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_GroundTruth_telemetry_2ftelemetry_2eproto;
 extern PROTOBUF_INTERNAL_EXPORT_telemetry_2ftelemetry_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_Health_telemetry_2ftelemetry_2eproto;
@@ -427,6 +428,14 @@ class SetRateDistanceSensorResponseDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<SetRateDistanceSensorResponse> _instance;
 } _SetRateDistanceSensorResponse_default_instance_;
+class GetGpsGlobalOriginRequestDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<GetGpsGlobalOriginRequest> _instance;
+} _GetGpsGlobalOriginRequest_default_instance_;
+class GetGpsGlobalOriginResponseDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<GetGpsGlobalOriginResponse> _instance;
+} _GetGpsGlobalOriginResponse_default_instance_;
 class PositionDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<Position> _instance;
@@ -527,6 +536,10 @@ class ImuDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<Imu> _instance;
 } _Imu_default_instance_;
+class GpsGlobalOriginDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<GpsGlobalOrigin> _instance;
+} _GpsGlobalOrigin_default_instance_;
 class TelemetryResultDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<TelemetryResult> _instance;
@@ -851,6 +864,50 @@ static void InitDefaultsscc_info_FlightModeResponse_telemetry_2ftelemetry_2eprot
 
 ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_FlightModeResponse_telemetry_2ftelemetry_2eproto =
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_FlightModeResponse_telemetry_2ftelemetry_2eproto}, {}};
+
+static void InitDefaultsscc_info_GetGpsGlobalOriginRequest_telemetry_2ftelemetry_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::mavsdk::rpc::telemetry::_GetGpsGlobalOriginRequest_default_instance_;
+    new (ptr) ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_GetGpsGlobalOriginRequest_telemetry_2ftelemetry_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_GetGpsGlobalOriginRequest_telemetry_2ftelemetry_2eproto}, {}};
+
+static void InitDefaultsscc_info_GetGpsGlobalOriginResponse_telemetry_2ftelemetry_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::mavsdk::rpc::telemetry::_GetGpsGlobalOriginResponse_default_instance_;
+    new (ptr) ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<2> scc_info_GetGpsGlobalOriginResponse_telemetry_2ftelemetry_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 2, 0, InitDefaultsscc_info_GetGpsGlobalOriginResponse_telemetry_2ftelemetry_2eproto}, {
+      &scc_info_TelemetryResult_telemetry_2ftelemetry_2eproto.base,
+      &scc_info_GpsGlobalOrigin_telemetry_2ftelemetry_2eproto.base,}};
+
+static void InitDefaultsscc_info_GpsGlobalOrigin_telemetry_2ftelemetry_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::mavsdk::rpc::telemetry::_GpsGlobalOrigin_default_instance_;
+    new (ptr) ::mavsdk::rpc::telemetry::GpsGlobalOrigin();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::mavsdk::rpc::telemetry::GpsGlobalOrigin::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_GpsGlobalOrigin_telemetry_2ftelemetry_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_GpsGlobalOrigin_telemetry_2ftelemetry_2eproto}, {}};
 
 static void InitDefaultsscc_info_GpsInfo_telemetry_2ftelemetry_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -2294,7 +2351,7 @@ static void InitDefaultsscc_info_VelocityNedResponse_telemetry_2ftelemetry_2epro
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_VelocityNedResponse_telemetry_2ftelemetry_2eproto}, {
       &scc_info_VelocityNed_telemetry_2ftelemetry_2eproto.base,}};
 
-static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_telemetry_2ftelemetry_2eproto[122];
+static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_telemetry_2ftelemetry_2eproto[125];
 static const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* file_level_enum_descriptors_telemetry_2ftelemetry_2eproto[6];
 static constexpr ::PROTOBUF_NAMESPACE_ID::ServiceDescriptor const** file_level_service_descriptors_telemetry_2ftelemetry_2eproto = nullptr;
 
@@ -2849,6 +2906,18 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_telemetry_2ftelemetry_2eproto:
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse, telemetry_result_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse, telemetry_result_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse, gps_global_origin_),
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::Position, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -3054,6 +3123,14 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_telemetry_2ftelemetry_2eproto:
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::Imu, magnetic_field_frd_),
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::Imu, temperature_degc_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::GpsGlobalOrigin, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::GpsGlobalOrigin, latitude_deg_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::GpsGlobalOrigin, longitude_deg_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::GpsGlobalOrigin, altitude_m_),
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::TelemetryResult, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -3158,32 +3235,35 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 531, -1, sizeof(::mavsdk::rpc::telemetry::SetRateUnixEpochTimeResponse)},
   { 537, -1, sizeof(::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest)},
   { 543, -1, sizeof(::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse)},
-  { 549, -1, sizeof(::mavsdk::rpc::telemetry::Position)},
-  { 558, -1, sizeof(::mavsdk::rpc::telemetry::Quaternion)},
-  { 567, -1, sizeof(::mavsdk::rpc::telemetry::EulerAngle)},
-  { 575, -1, sizeof(::mavsdk::rpc::telemetry::AngularVelocityBody)},
-  { 583, -1, sizeof(::mavsdk::rpc::telemetry::GpsInfo)},
-  { 590, -1, sizeof(::mavsdk::rpc::telemetry::Battery)},
-  { 597, -1, sizeof(::mavsdk::rpc::telemetry::Health)},
-  { 609, -1, sizeof(::mavsdk::rpc::telemetry::RcStatus)},
-  { 617, -1, sizeof(::mavsdk::rpc::telemetry::StatusText)},
-  { 624, -1, sizeof(::mavsdk::rpc::telemetry::ActuatorControlTarget)},
-  { 631, -1, sizeof(::mavsdk::rpc::telemetry::ActuatorOutputStatus)},
-  { 638, -1, sizeof(::mavsdk::rpc::telemetry::Covariance)},
-  { 644, -1, sizeof(::mavsdk::rpc::telemetry::VelocityBody)},
-  { 652, -1, sizeof(::mavsdk::rpc::telemetry::PositionBody)},
-  { 660, -1, sizeof(::mavsdk::rpc::telemetry::Odometry)},
-  { 674, -1, sizeof(::mavsdk::rpc::telemetry::DistanceSensor)},
-  { 682, -1, sizeof(::mavsdk::rpc::telemetry::PositionNed)},
-  { 690, -1, sizeof(::mavsdk::rpc::telemetry::VelocityNed)},
-  { 698, -1, sizeof(::mavsdk::rpc::telemetry::PositionVelocityNed)},
-  { 705, -1, sizeof(::mavsdk::rpc::telemetry::GroundTruth)},
-  { 713, -1, sizeof(::mavsdk::rpc::telemetry::FixedwingMetrics)},
-  { 721, -1, sizeof(::mavsdk::rpc::telemetry::AccelerationFrd)},
-  { 729, -1, sizeof(::mavsdk::rpc::telemetry::AngularVelocityFrd)},
-  { 737, -1, sizeof(::mavsdk::rpc::telemetry::MagneticFieldFrd)},
-  { 745, -1, sizeof(::mavsdk::rpc::telemetry::Imu)},
-  { 754, -1, sizeof(::mavsdk::rpc::telemetry::TelemetryResult)},
+  { 549, -1, sizeof(::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest)},
+  { 554, -1, sizeof(::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse)},
+  { 561, -1, sizeof(::mavsdk::rpc::telemetry::Position)},
+  { 570, -1, sizeof(::mavsdk::rpc::telemetry::Quaternion)},
+  { 579, -1, sizeof(::mavsdk::rpc::telemetry::EulerAngle)},
+  { 587, -1, sizeof(::mavsdk::rpc::telemetry::AngularVelocityBody)},
+  { 595, -1, sizeof(::mavsdk::rpc::telemetry::GpsInfo)},
+  { 602, -1, sizeof(::mavsdk::rpc::telemetry::Battery)},
+  { 609, -1, sizeof(::mavsdk::rpc::telemetry::Health)},
+  { 621, -1, sizeof(::mavsdk::rpc::telemetry::RcStatus)},
+  { 629, -1, sizeof(::mavsdk::rpc::telemetry::StatusText)},
+  { 636, -1, sizeof(::mavsdk::rpc::telemetry::ActuatorControlTarget)},
+  { 643, -1, sizeof(::mavsdk::rpc::telemetry::ActuatorOutputStatus)},
+  { 650, -1, sizeof(::mavsdk::rpc::telemetry::Covariance)},
+  { 656, -1, sizeof(::mavsdk::rpc::telemetry::VelocityBody)},
+  { 664, -1, sizeof(::mavsdk::rpc::telemetry::PositionBody)},
+  { 672, -1, sizeof(::mavsdk::rpc::telemetry::Odometry)},
+  { 686, -1, sizeof(::mavsdk::rpc::telemetry::DistanceSensor)},
+  { 694, -1, sizeof(::mavsdk::rpc::telemetry::PositionNed)},
+  { 702, -1, sizeof(::mavsdk::rpc::telemetry::VelocityNed)},
+  { 710, -1, sizeof(::mavsdk::rpc::telemetry::PositionVelocityNed)},
+  { 717, -1, sizeof(::mavsdk::rpc::telemetry::GroundTruth)},
+  { 725, -1, sizeof(::mavsdk::rpc::telemetry::FixedwingMetrics)},
+  { 733, -1, sizeof(::mavsdk::rpc::telemetry::AccelerationFrd)},
+  { 741, -1, sizeof(::mavsdk::rpc::telemetry::AngularVelocityFrd)},
+  { 749, -1, sizeof(::mavsdk::rpc::telemetry::MagneticFieldFrd)},
+  { 757, -1, sizeof(::mavsdk::rpc::telemetry::Imu)},
+  { 766, -1, sizeof(::mavsdk::rpc::telemetry::GpsGlobalOrigin)},
+  { 774, -1, sizeof(::mavsdk::rpc::telemetry::TelemetryResult)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -3283,6 +3363,8 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_SetRateUnixEpochTimeResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_SetRateDistanceSensorRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_SetRateDistanceSensorResponse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_GetGpsGlobalOriginRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_GetGpsGlobalOriginResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_Position_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_Quaternion_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_EulerAngle_default_instance_),
@@ -3308,6 +3390,7 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_AngularVelocityFrd_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_MagneticFieldFrd_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_Imu_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_GpsGlobalOrigin_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_TelemetryResult_default_instance_),
 };
 
@@ -3462,271 +3545,281 @@ const char descriptor_table_protodef_telemetry_2ftelemetry_2eproto[] PROTOBUF_SE
   "yResult\"/\n\034SetRateDistanceSensorRequest\022"
   "\017\n\007rate_hz\030\001 \001(\001\"`\n\035SetRateDistanceSenso"
   "rResponse\022\?\n\020telemetry_result\030\001 \001(\0132%.ma"
-  "vsdk.rpc.telemetry.TelemetryResult\"\225\001\n\010P"
-  "osition\022\035\n\014latitude_deg\030\001 \001(\001B\007\202\265\030\003NaN\022\036"
-  "\n\rlongitude_deg\030\002 \001(\001B\007\202\265\030\003NaN\022$\n\023absolu"
-  "te_altitude_m\030\003 \001(\002B\007\202\265\030\003NaN\022$\n\023relative"
-  "_altitude_m\030\004 \001(\002B\007\202\265\030\003NaN\"\\\n\nQuaternion"
-  "\022\022\n\001w\030\001 \001(\002B\007\202\265\030\003NaN\022\022\n\001x\030\002 \001(\002B\007\202\265\030\003NaN"
-  "\022\022\n\001y\030\003 \001(\002B\007\202\265\030\003NaN\022\022\n\001z\030\004 \001(\002B\007\202\265\030\003NaN"
-  "\"]\n\nEulerAngle\022\031\n\010roll_deg\030\001 \001(\002B\007\202\265\030\003Na"
-  "N\022\032\n\tpitch_deg\030\002 \001(\002B\007\202\265\030\003NaN\022\030\n\007yaw_deg"
-  "\030\003 \001(\002B\007\202\265\030\003NaN\"l\n\023AngularVelocityBody\022\033"
-  "\n\nroll_rad_s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013pitch_rad"
-  "_s\030\002 \001(\002B\007\202\265\030\003NaN\022\032\n\tyaw_rad_s\030\003 \001(\002B\007\202\265"
-  "\030\003NaN\"Y\n\007GpsInfo\022\035\n\016num_satellites\030\001 \001(\005"
-  "B\005\202\265\030\0010\022/\n\010fix_type\030\002 \001(\0162\035.mavsdk.rpc.t"
-  "elemetry.FixType\"I\n\007Battery\022\032\n\tvoltage_v"
-  "\030\001 \001(\002B\007\202\265\030\003NaN\022\"\n\021remaining_percent\030\002 \001"
-  "(\002B\007\202\265\030\003NaN\"\306\002\n\006Health\022.\n\033is_gyrometer_c"
-  "alibration_ok\030\001 \001(\010B\t\202\265\030\005false\0222\n\037is_acc"
-  "elerometer_calibration_ok\030\002 \001(\010B\t\202\265\030\005fal"
-  "se\0221\n\036is_magnetometer_calibration_ok\030\003 \001"
-  "(\010B\t\202\265\030\005false\022*\n\027is_level_calibration_ok"
-  "\030\004 \001(\010B\t\202\265\030\005false\022\'\n\024is_local_position_o"
-  "k\030\005 \001(\010B\t\202\265\030\005false\022(\n\025is_global_position"
-  "_ok\030\006 \001(\010B\t\202\265\030\005false\022&\n\023is_home_position"
-  "_ok\030\007 \001(\010B\t\202\265\030\005false\"z\n\010RcStatus\022%\n\022was_"
-  "available_once\030\001 \001(\010B\t\202\265\030\005false\022\037\n\014is_av"
-  "ailable\030\002 \001(\010B\t\202\265\030\005false\022&\n\027signal_stren"
-  "gth_percent\030\003 \001(\002B\005\202\265\030\0010\"N\n\nStatusText\0222"
-  "\n\004type\030\001 \001(\0162$.mavsdk.rpc.telemetry.Stat"
-  "usTextType\022\014\n\004text\030\002 \001(\t\"\?\n\025ActuatorCont"
-  "rolTarget\022\024\n\005group\030\001 \001(\005B\005\202\265\030\0010\022\020\n\010contr"
-  "ols\030\002 \003(\002\"\?\n\024ActuatorOutputStatus\022\025\n\006act"
-  "ive\030\001 \001(\rB\005\202\265\030\0010\022\020\n\010actuator\030\002 \003(\002\"\'\n\nCo"
-  "variance\022\031\n\021covariance_matrix\030\001 \003(\002\";\n\014V"
-  "elocityBody\022\r\n\005x_m_s\030\001 \001(\002\022\r\n\005y_m_s\030\002 \001("
-  "\002\022\r\n\005z_m_s\030\003 \001(\002\"5\n\014PositionBody\022\013\n\003x_m\030"
-  "\001 \001(\002\022\013\n\003y_m\030\002 \001(\002\022\013\n\003z_m\030\003 \001(\002\"\354\004\n\010Odom"
-  "etry\022\021\n\ttime_usec\030\001 \001(\004\0229\n\010frame_id\030\002 \001("
-  "\0162\'.mavsdk.rpc.telemetry.Odometry.MavFra"
-  "me\022\?\n\016child_frame_id\030\003 \001(\0162\'.mavsdk.rpc."
-  "telemetry.Odometry.MavFrame\0229\n\rposition_"
-  "body\030\004 \001(\0132\".mavsdk.rpc.telemetry.Positi"
-  "onBody\022+\n\001q\030\005 \001(\0132 .mavsdk.rpc.telemetry"
-  ".Quaternion\0229\n\rvelocity_body\030\006 \001(\0132\".mav"
-  "sdk.rpc.telemetry.VelocityBody\022H\n\025angula"
-  "r_velocity_body\030\007 \001(\0132).mavsdk.rpc.telem"
-  "etry.AngularVelocityBody\0229\n\017pose_covaria"
-  "nce\030\010 \001(\0132 .mavsdk.rpc.telemetry.Covaria"
-  "nce\022=\n\023velocity_covariance\030\t \001(\0132 .mavsd"
-  "k.rpc.telemetry.Covariance\"j\n\010MavFrame\022\023"
-  "\n\017MAV_FRAME_UNDEF\020\000\022\026\n\022MAV_FRAME_BODY_NE"
-  "D\020\010\022\030\n\024MAV_FRAME_VISION_NED\020\020\022\027\n\023MAV_FRA"
-  "ME_ESTIM_NED\020\022\"\177\n\016DistanceSensor\022#\n\022mini"
-  "mum_distance_m\030\001 \001(\002B\007\202\265\030\003NaN\022#\n\022maximum"
-  "_distance_m\030\002 \001(\002B\007\202\265\030\003NaN\022#\n\022current_di"
-  "stance_m\030\003 \001(\002B\007\202\265\030\003NaN\"Y\n\013PositionNed\022\030"
-  "\n\007north_m\030\001 \001(\002B\007\202\265\030\003NaN\022\027\n\006east_m\030\002 \001(\002"
-  "B\007\202\265\030\003NaN\022\027\n\006down_m\030\003 \001(\002B\007\202\265\030\003NaN\"D\n\013Ve"
-  "locityNed\022\021\n\tnorth_m_s\030\001 \001(\002\022\020\n\010east_m_s"
-  "\030\002 \001(\002\022\020\n\010down_m_s\030\003 \001(\002\"\177\n\023PositionVelo"
-  "cityNed\0223\n\010position\030\001 \001(\0132!.mavsdk.rpc.t"
-  "elemetry.PositionNed\0223\n\010velocity\030\002 \001(\0132!"
-  ".mavsdk.rpc.telemetry.VelocityNed\"r\n\013Gro"
-  "undTruth\022\035\n\014latitude_deg\030\001 \001(\001B\007\202\265\030\003NaN\022"
-  "\036\n\rlongitude_deg\030\002 \001(\001B\007\202\265\030\003NaN\022$\n\023absol"
-  "ute_altitude_m\030\003 \001(\002B\007\202\265\030\003NaN\"x\n\020Fixedwi"
-  "ngMetrics\022\035\n\014airspeed_m_s\030\001 \001(\002B\007\202\265\030\003NaN"
-  "\022$\n\023throttle_percentage\030\002 \001(\002B\007\202\265\030\003NaN\022\037"
-  "\n\016climb_rate_m_s\030\003 \001(\002B\007\202\265\030\003NaN\"i\n\017Accel"
-  "erationFrd\022\035\n\014forward_m_s2\030\001 \001(\002B\007\202\265\030\003Na"
-  "N\022\033\n\nright_m_s2\030\002 \001(\002B\007\202\265\030\003NaN\022\032\n\tdown_m"
-  "_s2\030\003 \001(\002B\007\202\265\030\003NaN\"o\n\022AngularVelocityFrd"
-  "\022\036\n\rforward_rad_s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013righ"
-  "t_rad_s\030\002 \001(\002B\007\202\265\030\003NaN\022\033\n\ndown_rad_s\030\003 \001"
-  "(\002B\007\202\265\030\003NaN\"m\n\020MagneticFieldFrd\022\036\n\rforwa"
-  "rd_gauss\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right_gauss\030\002"
-  " \001(\002B\007\202\265\030\003NaN\022\033\n\ndown_gauss\030\003 \001(\002B\007\202\265\030\003N"
-  "aN\"\365\001\n\003Imu\022\?\n\020acceleration_frd\030\001 \001(\0132%.m"
-  "avsdk.rpc.telemetry.AccelerationFrd\022F\n\024a"
-  "ngular_velocity_frd\030\002 \001(\0132(.mavsdk.rpc.t"
-  "elemetry.AngularVelocityFrd\022B\n\022magnetic_"
-  "field_frd\030\003 \001(\0132&.mavsdk.rpc.telemetry.M"
-  "agneticFieldFrd\022!\n\020temperature_degc\030\004 \001("
-  "\002B\007\202\265\030\003NaN\"\211\002\n\017TelemetryResult\022<\n\006result"
-  "\030\001 \001(\0162,.mavsdk.rpc.telemetry.TelemetryR"
-  "esult.Result\022\022\n\nresult_str\030\002 \001(\t\"\243\001\n\006Res"
-  "ult\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCCES"
-  "S\020\001\022\024\n\020RESULT_NO_SYSTEM\020\002\022\033\n\027RESULT_CONN"
-  "ECTION_ERROR\020\003\022\017\n\013RESULT_BUSY\020\004\022\031\n\025RESUL"
-  "T_COMMAND_DENIED\020\005\022\022\n\016RESULT_TIMEOUT\020\006*\244"
-  "\001\n\007FixType\022\023\n\017FIX_TYPE_NO_GPS\020\000\022\023\n\017FIX_T"
-  "YPE_NO_FIX\020\001\022\023\n\017FIX_TYPE_FIX_2D\020\002\022\023\n\017FIX"
-  "_TYPE_FIX_3D\020\003\022\025\n\021FIX_TYPE_FIX_DGPS\020\004\022\026\n"
-  "\022FIX_TYPE_RTK_FLOAT\020\005\022\026\n\022FIX_TYPE_RTK_FI"
-  "XED\020\006*\206\003\n\nFlightMode\022\027\n\023FLIGHT_MODE_UNKN"
-  "OWN\020\000\022\025\n\021FLIGHT_MODE_READY\020\001\022\027\n\023FLIGHT_M"
-  "ODE_TAKEOFF\020\002\022\024\n\020FLIGHT_MODE_HOLD\020\003\022\027\n\023F"
-  "LIGHT_MODE_MISSION\020\004\022 \n\034FLIGHT_MODE_RETU"
-  "RN_TO_LAUNCH\020\005\022\024\n\020FLIGHT_MODE_LAND\020\006\022\030\n\024"
-  "FLIGHT_MODE_OFFBOARD\020\007\022\031\n\025FLIGHT_MODE_FO"
-  "LLOW_ME\020\010\022\026\n\022FLIGHT_MODE_MANUAL\020\t\022\026\n\022FLI"
-  "GHT_MODE_ALTCTL\020\n\022\026\n\022FLIGHT_MODE_POSCTL\020"
-  "\013\022\024\n\020FLIGHT_MODE_ACRO\020\014\022\032\n\026FLIGHT_MODE_S"
-  "TABILIZED\020\r\022\031\n\025FLIGHT_MODE_RATTITUDE\020\016*\371"
-  "\001\n\016StatusTextType\022\032\n\026STATUS_TEXT_TYPE_DE"
-  "BUG\020\000\022\031\n\025STATUS_TEXT_TYPE_INFO\020\001\022\033\n\027STAT"
-  "US_TEXT_TYPE_NOTICE\020\002\022\034\n\030STATUS_TEXT_TYP"
-  "E_WARNING\020\003\022\032\n\026STATUS_TEXT_TYPE_ERROR\020\004\022"
-  "\035\n\031STATUS_TEXT_TYPE_CRITICAL\020\005\022\032\n\026STATUS"
-  "_TEXT_TYPE_ALERT\020\006\022\036\n\032STATUS_TEXT_TYPE_E"
-  "MERGENCY\020\007*\223\001\n\013LandedState\022\030\n\024LANDED_STA"
-  "TE_UNKNOWN\020\000\022\032\n\026LANDED_STATE_ON_GROUND\020\001"
-  "\022\027\n\023LANDED_STATE_IN_AIR\020\002\022\033\n\027LANDED_STAT"
-  "E_TAKING_OFF\020\003\022\030\n\024LANDED_STATE_LANDING\020\004"
-  "2\375,\n\020TelemetryService\022o\n\021SubscribePositi"
-  "on\022..mavsdk.rpc.telemetry.SubscribePosit"
-  "ionRequest\032&.mavsdk.rpc.telemetry.Positi"
-  "onResponse\"\0000\001\022c\n\rSubscribeHome\022*.mavsdk"
-  ".rpc.telemetry.SubscribeHomeRequest\032\".ma"
-  "vsdk.rpc.telemetry.HomeResponse\"\0000\001\022f\n\016S"
-  "ubscribeInAir\022+.mavsdk.rpc.telemetry.Sub"
-  "scribeInAirRequest\032#.mavsdk.rpc.telemetr"
-  "y.InAirResponse\"\0000\001\022x\n\024SubscribeLandedSt"
-  "ate\0221.mavsdk.rpc.telemetry.SubscribeLand"
-  "edStateRequest\032).mavsdk.rpc.telemetry.La"
-  "ndedStateResponse\"\0000\001\022f\n\016SubscribeArmed\022"
-  "+.mavsdk.rpc.telemetry.SubscribeArmedReq"
-  "uest\032#.mavsdk.rpc.telemetry.ArmedRespons"
-  "e\"\0000\001\022\215\001\n\033SubscribeAttitudeQuaternion\0228."
-  "mavsdk.rpc.telemetry.SubscribeAttitudeQu"
-  "aternionRequest\0320.mavsdk.rpc.telemetry.A"
-  "ttitudeQuaternionResponse\"\0000\001\022~\n\026Subscri"
-  "beAttitudeEuler\0223.mavsdk.rpc.telemetry.S"
-  "ubscribeAttitudeEulerRequest\032+.mavsdk.rp"
-  "c.telemetry.AttitudeEulerResponse\"\0000\001\022\250\001"
-  "\n$SubscribeAttitudeAngularVelocityBody\022A"
-  ".mavsdk.rpc.telemetry.SubscribeAttitudeA"
-  "ngularVelocityBodyRequest\0329.mavsdk.rpc.t"
-  "elemetry.AttitudeAngularVelocityBodyResp"
-  "onse\"\0000\001\022\237\001\n!SubscribeCameraAttitudeQuat"
-  "ernion\022>.mavsdk.rpc.telemetry.SubscribeC"
-  "ameraAttitudeQuaternionRequest\0326.mavsdk."
-  "rpc.telemetry.CameraAttitudeQuaternionRe"
-  "sponse\"\0000\001\022\220\001\n\034SubscribeCameraAttitudeEu"
-  "ler\0229.mavsdk.rpc.telemetry.SubscribeCame"
-  "raAttitudeEulerRequest\0321.mavsdk.rpc.tele"
-  "metry.CameraAttitudeEulerResponse\"\0000\001\022x\n"
-  "\024SubscribeVelocityNed\0221.mavsdk.rpc.telem"
-  "etry.SubscribeVelocityNedRequest\032).mavsd"
-  "k.rpc.telemetry.VelocityNedResponse\"\0000\001\022"
-  "l\n\020SubscribeGpsInfo\022-.mavsdk.rpc.telemet"
-  "ry.SubscribeGpsInfoRequest\032%.mavsdk.rpc."
-  "telemetry.GpsInfoResponse\"\0000\001\022l\n\020Subscri"
-  "beBattery\022-.mavsdk.rpc.telemetry.Subscri"
-  "beBatteryRequest\032%.mavsdk.rpc.telemetry."
-  "BatteryResponse\"\0000\001\022u\n\023SubscribeFlightMo"
-  "de\0220.mavsdk.rpc.telemetry.SubscribeFligh"
-  "tModeRequest\032(.mavsdk.rpc.telemetry.Flig"
-  "htModeResponse\"\0000\001\022i\n\017SubscribeHealth\022,."
-  "mavsdk.rpc.telemetry.SubscribeHealthRequ"
-  "est\032$.mavsdk.rpc.telemetry.HealthRespons"
-  "e\"\0000\001\022o\n\021SubscribeRcStatus\022..mavsdk.rpc."
-  "telemetry.SubscribeRcStatusRequest\032&.mav"
-  "sdk.rpc.telemetry.RcStatusResponse\"\0000\001\022u"
-  "\n\023SubscribeStatusText\0220.mavsdk.rpc.telem"
-  "etry.SubscribeStatusTextRequest\032(.mavsdk"
-  ".rpc.telemetry.StatusTextResponse\"\0000\001\022\226\001"
-  "\n\036SubscribeActuatorControlTarget\022;.mavsd"
-  "k.rpc.telemetry.SubscribeActuatorControl"
-  "TargetRequest\0323.mavsdk.rpc.telemetry.Act"
-  "uatorControlTargetResponse\"\0000\001\022\223\001\n\035Subsc"
-  "ribeActuatorOutputStatus\022:.mavsdk.rpc.te"
-  "lemetry.SubscribeActuatorOutputStatusReq"
-  "uest\0322.mavsdk.rpc.telemetry.ActuatorOutp"
-  "utStatusResponse\"\0000\001\022o\n\021SubscribeOdometr"
-  "y\022..mavsdk.rpc.telemetry.SubscribeOdomet"
-  "ryRequest\032&.mavsdk.rpc.telemetry.Odometr"
-  "yResponse\"\0000\001\022\220\001\n\034SubscribePositionVeloc"
-  "ityNed\0229.mavsdk.rpc.telemetry.SubscribeP"
-  "ositionVelocityNedRequest\0321.mavsdk.rpc.t"
-  "elemetry.PositionVelocityNedResponse\"\0000\001"
-  "\022x\n\024SubscribeGroundTruth\0221.mavsdk.rpc.te"
-  "lemetry.SubscribeGroundTruthRequest\032).ma"
-  "vsdk.rpc.telemetry.GroundTruthResponse\"\000"
-  "0\001\022\207\001\n\031SubscribeFixedwingMetrics\0226.mavsd"
-  "k.rpc.telemetry.SubscribeFixedwingMetric"
-  "sRequest\032..mavsdk.rpc.telemetry.Fixedwin"
-  "gMetricsResponse\"\0000\001\022`\n\014SubscribeImu\022).m"
-  "avsdk.rpc.telemetry.SubscribeImuRequest\032"
-  "!.mavsdk.rpc.telemetry.ImuResponse\"\0000\001\022x"
-  "\n\024SubscribeHealthAllOk\0221.mavsdk.rpc.tele"
-  "metry.SubscribeHealthAllOkRequest\032).mavs"
-  "dk.rpc.telemetry.HealthAllOkResponse\"\0000\001"
-  "\022~\n\026SubscribeUnixEpochTime\0223.mavsdk.rpc."
-  "telemetry.SubscribeUnixEpochTimeRequest\032"
-  "+.mavsdk.rpc.telemetry.UnixEpochTimeResp"
-  "onse\"\0000\001\022\201\001\n\027SubscribeDistanceSensor\0224.m"
-  "avsdk.rpc.telemetry.SubscribeDistanceSen"
-  "sorRequest\032,.mavsdk.rpc.telemetry.Distan"
-  "ceSensorResponse\"\0000\001\022p\n\017SetRatePosition\022"
-  ",.mavsdk.rpc.telemetry.SetRatePositionRe"
-  "quest\032-.mavsdk.rpc.telemetry.SetRatePosi"
-  "tionResponse\"\000\022d\n\013SetRateHome\022(.mavsdk.r"
-  "pc.telemetry.SetRateHomeRequest\032).mavsdk"
-  ".rpc.telemetry.SetRateHomeResponse\"\000\022g\n\014"
-  "SetRateInAir\022).mavsdk.rpc.telemetry.SetR"
-  "ateInAirRequest\032*.mavsdk.rpc.telemetry.S"
-  "etRateInAirResponse\"\000\022y\n\022SetRateLandedSt"
-  "ate\022/.mavsdk.rpc.telemetry.SetRateLanded"
-  "StateRequest\0320.mavsdk.rpc.telemetry.SetR"
-  "ateLandedStateResponse\"\000\022p\n\017SetRateAttit"
-  "ude\022,.mavsdk.rpc.telemetry.SetRateAttitu"
-  "deRequest\032-.mavsdk.rpc.telemetry.SetRate"
-  "AttitudeResponse\"\000\022\202\001\n\025SetRateCameraAtti"
-  "tude\0222.mavsdk.rpc.telemetry.SetRateCamer"
-  "aAttitudeRequest\0323.mavsdk.rpc.telemetry."
-  "SetRateCameraAttitudeResponse\"\000\022y\n\022SetRa"
-  "teVelocityNed\022/.mavsdk.rpc.telemetry.Set"
-  "RateVelocityNedRequest\0320.mavsdk.rpc.tele"
-  "metry.SetRateVelocityNedResponse\"\000\022m\n\016Se"
-  "tRateGpsInfo\022+.mavsdk.rpc.telemetry.SetR"
-  "ateGpsInfoRequest\032,.mavsdk.rpc.telemetry"
-  ".SetRateGpsInfoResponse\"\000\022m\n\016SetRateBatt"
-  "ery\022+.mavsdk.rpc.telemetry.SetRateBatter"
-  "yRequest\032,.mavsdk.rpc.telemetry.SetRateB"
-  "atteryResponse\"\000\022p\n\017SetRateRcStatus\022,.ma"
-  "vsdk.rpc.telemetry.SetRateRcStatusReques"
-  "t\032-.mavsdk.rpc.telemetry.SetRateRcStatus"
-  "Response\"\000\022\227\001\n\034SetRateActuatorControlTar"
-  "get\0229.mavsdk.rpc.telemetry.SetRateActuat"
-  "orControlTargetRequest\032:.mavsdk.rpc.tele"
-  "metry.SetRateActuatorControlTargetRespon"
-  "se\"\000\022\224\001\n\033SetRateActuatorOutputStatus\0228.m"
+  "vsdk.rpc.telemetry.TelemetryResult\"\033\n\031Ge"
+  "tGpsGlobalOriginRequest\"\237\001\n\032GetGpsGlobal"
+  "OriginResponse\022\?\n\020telemetry_result\030\001 \001(\013"
+  "2%.mavsdk.rpc.telemetry.TelemetryResult\022"
+  "@\n\021gps_global_origin\030\002 \001(\0132%.mavsdk.rpc."
+  "telemetry.GpsGlobalOrigin\"\225\001\n\010Position\022\035"
+  "\n\014latitude_deg\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlongitu"
+  "de_deg\030\002 \001(\001B\007\202\265\030\003NaN\022$\n\023absolute_altitu"
+  "de_m\030\003 \001(\002B\007\202\265\030\003NaN\022$\n\023relative_altitude"
+  "_m\030\004 \001(\002B\007\202\265\030\003NaN\"\\\n\nQuaternion\022\022\n\001w\030\001 \001"
+  "(\002B\007\202\265\030\003NaN\022\022\n\001x\030\002 \001(\002B\007\202\265\030\003NaN\022\022\n\001y\030\003 \001"
+  "(\002B\007\202\265\030\003NaN\022\022\n\001z\030\004 \001(\002B\007\202\265\030\003NaN\"]\n\nEuler"
+  "Angle\022\031\n\010roll_deg\030\001 \001(\002B\007\202\265\030\003NaN\022\032\n\tpitc"
+  "h_deg\030\002 \001(\002B\007\202\265\030\003NaN\022\030\n\007yaw_deg\030\003 \001(\002B\007\202"
+  "\265\030\003NaN\"l\n\023AngularVelocityBody\022\033\n\nroll_ra"
+  "d_s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013pitch_rad_s\030\002 \001(\002B"
+  "\007\202\265\030\003NaN\022\032\n\tyaw_rad_s\030\003 \001(\002B\007\202\265\030\003NaN\"Y\n\007"
+  "GpsInfo\022\035\n\016num_satellites\030\001 \001(\005B\005\202\265\030\0010\022/"
+  "\n\010fix_type\030\002 \001(\0162\035.mavsdk.rpc.telemetry."
+  "FixType\"I\n\007Battery\022\032\n\tvoltage_v\030\001 \001(\002B\007\202"
+  "\265\030\003NaN\022\"\n\021remaining_percent\030\002 \001(\002B\007\202\265\030\003N"
+  "aN\"\306\002\n\006Health\022.\n\033is_gyrometer_calibratio"
+  "n_ok\030\001 \001(\010B\t\202\265\030\005false\0222\n\037is_acceleromete"
+  "r_calibration_ok\030\002 \001(\010B\t\202\265\030\005false\0221\n\036is_"
+  "magnetometer_calibration_ok\030\003 \001(\010B\t\202\265\030\005f"
+  "alse\022*\n\027is_level_calibration_ok\030\004 \001(\010B\t\202"
+  "\265\030\005false\022\'\n\024is_local_position_ok\030\005 \001(\010B\t"
+  "\202\265\030\005false\022(\n\025is_global_position_ok\030\006 \001(\010"
+  "B\t\202\265\030\005false\022&\n\023is_home_position_ok\030\007 \001(\010"
+  "B\t\202\265\030\005false\"z\n\010RcStatus\022%\n\022was_available"
+  "_once\030\001 \001(\010B\t\202\265\030\005false\022\037\n\014is_available\030\002"
+  " \001(\010B\t\202\265\030\005false\022&\n\027signal_strength_perce"
+  "nt\030\003 \001(\002B\005\202\265\030\0010\"N\n\nStatusText\0222\n\004type\030\001 "
+  "\001(\0162$.mavsdk.rpc.telemetry.StatusTextTyp"
+  "e\022\014\n\004text\030\002 \001(\t\"\?\n\025ActuatorControlTarget"
+  "\022\024\n\005group\030\001 \001(\005B\005\202\265\030\0010\022\020\n\010controls\030\002 \003(\002"
+  "\"\?\n\024ActuatorOutputStatus\022\025\n\006active\030\001 \001(\r"
+  "B\005\202\265\030\0010\022\020\n\010actuator\030\002 \003(\002\"\'\n\nCovariance\022"
+  "\031\n\021covariance_matrix\030\001 \003(\002\";\n\014VelocityBo"
+  "dy\022\r\n\005x_m_s\030\001 \001(\002\022\r\n\005y_m_s\030\002 \001(\002\022\r\n\005z_m_"
+  "s\030\003 \001(\002\"5\n\014PositionBody\022\013\n\003x_m\030\001 \001(\002\022\013\n\003"
+  "y_m\030\002 \001(\002\022\013\n\003z_m\030\003 \001(\002\"\354\004\n\010Odometry\022\021\n\tt"
+  "ime_usec\030\001 \001(\004\0229\n\010frame_id\030\002 \001(\0162\'.mavsd"
+  "k.rpc.telemetry.Odometry.MavFrame\022\?\n\016chi"
+  "ld_frame_id\030\003 \001(\0162\'.mavsdk.rpc.telemetry"
+  ".Odometry.MavFrame\0229\n\rposition_body\030\004 \001("
+  "\0132\".mavsdk.rpc.telemetry.PositionBody\022+\n"
+  "\001q\030\005 \001(\0132 .mavsdk.rpc.telemetry.Quaterni"
+  "on\0229\n\rvelocity_body\030\006 \001(\0132\".mavsdk.rpc.t"
+  "elemetry.VelocityBody\022H\n\025angular_velocit"
+  "y_body\030\007 \001(\0132).mavsdk.rpc.telemetry.Angu"
+  "larVelocityBody\0229\n\017pose_covariance\030\010 \001(\013"
+  "2 .mavsdk.rpc.telemetry.Covariance\022=\n\023ve"
+  "locity_covariance\030\t \001(\0132 .mavsdk.rpc.tel"
+  "emetry.Covariance\"j\n\010MavFrame\022\023\n\017MAV_FRA"
+  "ME_UNDEF\020\000\022\026\n\022MAV_FRAME_BODY_NED\020\010\022\030\n\024MA"
+  "V_FRAME_VISION_NED\020\020\022\027\n\023MAV_FRAME_ESTIM_"
+  "NED\020\022\"\177\n\016DistanceSensor\022#\n\022minimum_dista"
+  "nce_m\030\001 \001(\002B\007\202\265\030\003NaN\022#\n\022maximum_distance"
+  "_m\030\002 \001(\002B\007\202\265\030\003NaN\022#\n\022current_distance_m\030"
+  "\003 \001(\002B\007\202\265\030\003NaN\"Y\n\013PositionNed\022\030\n\007north_m"
+  "\030\001 \001(\002B\007\202\265\030\003NaN\022\027\n\006east_m\030\002 \001(\002B\007\202\265\030\003NaN"
+  "\022\027\n\006down_m\030\003 \001(\002B\007\202\265\030\003NaN\"D\n\013VelocityNed"
+  "\022\021\n\tnorth_m_s\030\001 \001(\002\022\020\n\010east_m_s\030\002 \001(\002\022\020\n"
+  "\010down_m_s\030\003 \001(\002\"\177\n\023PositionVelocityNed\0223"
+  "\n\010position\030\001 \001(\0132!.mavsdk.rpc.telemetry."
+  "PositionNed\0223\n\010velocity\030\002 \001(\0132!.mavsdk.r"
+  "pc.telemetry.VelocityNed\"r\n\013GroundTruth\022"
+  "\035\n\014latitude_deg\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlongit"
+  "ude_deg\030\002 \001(\001B\007\202\265\030\003NaN\022$\n\023absolute_altit"
+  "ude_m\030\003 \001(\002B\007\202\265\030\003NaN\"x\n\020FixedwingMetrics"
+  "\022\035\n\014airspeed_m_s\030\001 \001(\002B\007\202\265\030\003NaN\022$\n\023throt"
+  "tle_percentage\030\002 \001(\002B\007\202\265\030\003NaN\022\037\n\016climb_r"
+  "ate_m_s\030\003 \001(\002B\007\202\265\030\003NaN\"i\n\017AccelerationFr"
+  "d\022\035\n\014forward_m_s2\030\001 \001(\002B\007\202\265\030\003NaN\022\033\n\nrigh"
+  "t_m_s2\030\002 \001(\002B\007\202\265\030\003NaN\022\032\n\tdown_m_s2\030\003 \001(\002"
+  "B\007\202\265\030\003NaN\"o\n\022AngularVelocityFrd\022\036\n\rforwa"
+  "rd_rad_s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right_rad_s\030\002"
+  " \001(\002B\007\202\265\030\003NaN\022\033\n\ndown_rad_s\030\003 \001(\002B\007\202\265\030\003N"
+  "aN\"m\n\020MagneticFieldFrd\022\036\n\rforward_gauss\030"
+  "\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right_gauss\030\002 \001(\002B\007\202\265\030"
+  "\003NaN\022\033\n\ndown_gauss\030\003 \001(\002B\007\202\265\030\003NaN\"\365\001\n\003Im"
+  "u\022\?\n\020acceleration_frd\030\001 \001(\0132%.mavsdk.rpc"
+  ".telemetry.AccelerationFrd\022F\n\024angular_ve"
+  "locity_frd\030\002 \001(\0132(.mavsdk.rpc.telemetry."
+  "AngularVelocityFrd\022B\n\022magnetic_field_frd"
+  "\030\003 \001(\0132&.mavsdk.rpc.telemetry.MagneticFi"
+  "eldFrd\022!\n\020temperature_degc\030\004 \001(\002B\007\202\265\030\003Na"
+  "N\"m\n\017GpsGlobalOrigin\022\035\n\014latitude_deg\030\001 \001"
+  "(\001B\007\202\265\030\003NaN\022\036\n\rlongitude_deg\030\002 \001(\001B\007\202\265\030\003"
+  "NaN\022\033\n\naltitude_m\030\003 \001(\002B\007\202\265\030\003NaN\"\211\002\n\017Tel"
+  "emetryResult\022<\n\006result\030\001 \001(\0162,.mavsdk.rp"
+  "c.telemetry.TelemetryResult.Result\022\022\n\nre"
+  "sult_str\030\002 \001(\t\"\243\001\n\006Result\022\022\n\016RESULT_UNKN"
+  "OWN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\024\n\020RESULT_NO_S"
+  "YSTEM\020\002\022\033\n\027RESULT_CONNECTION_ERROR\020\003\022\017\n\013"
+  "RESULT_BUSY\020\004\022\031\n\025RESULT_COMMAND_DENIED\020\005"
+  "\022\022\n\016RESULT_TIMEOUT\020\006*\244\001\n\007FixType\022\023\n\017FIX_"
+  "TYPE_NO_GPS\020\000\022\023\n\017FIX_TYPE_NO_FIX\020\001\022\023\n\017FI"
+  "X_TYPE_FIX_2D\020\002\022\023\n\017FIX_TYPE_FIX_3D\020\003\022\025\n\021"
+  "FIX_TYPE_FIX_DGPS\020\004\022\026\n\022FIX_TYPE_RTK_FLOA"
+  "T\020\005\022\026\n\022FIX_TYPE_RTK_FIXED\020\006*\206\003\n\nFlightMo"
+  "de\022\027\n\023FLIGHT_MODE_UNKNOWN\020\000\022\025\n\021FLIGHT_MO"
+  "DE_READY\020\001\022\027\n\023FLIGHT_MODE_TAKEOFF\020\002\022\024\n\020F"
+  "LIGHT_MODE_HOLD\020\003\022\027\n\023FLIGHT_MODE_MISSION"
+  "\020\004\022 \n\034FLIGHT_MODE_RETURN_TO_LAUNCH\020\005\022\024\n\020"
+  "FLIGHT_MODE_LAND\020\006\022\030\n\024FLIGHT_MODE_OFFBOA"
+  "RD\020\007\022\031\n\025FLIGHT_MODE_FOLLOW_ME\020\010\022\026\n\022FLIGH"
+  "T_MODE_MANUAL\020\t\022\026\n\022FLIGHT_MODE_ALTCTL\020\n\022"
+  "\026\n\022FLIGHT_MODE_POSCTL\020\013\022\024\n\020FLIGHT_MODE_A"
+  "CRO\020\014\022\032\n\026FLIGHT_MODE_STABILIZED\020\r\022\031\n\025FLI"
+  "GHT_MODE_RATTITUDE\020\016*\371\001\n\016StatusTextType\022"
+  "\032\n\026STATUS_TEXT_TYPE_DEBUG\020\000\022\031\n\025STATUS_TE"
+  "XT_TYPE_INFO\020\001\022\033\n\027STATUS_TEXT_TYPE_NOTIC"
+  "E\020\002\022\034\n\030STATUS_TEXT_TYPE_WARNING\020\003\022\032\n\026STA"
+  "TUS_TEXT_TYPE_ERROR\020\004\022\035\n\031STATUS_TEXT_TYP"
+  "E_CRITICAL\020\005\022\032\n\026STATUS_TEXT_TYPE_ALERT\020\006"
+  "\022\036\n\032STATUS_TEXT_TYPE_EMERGENCY\020\007*\223\001\n\013Lan"
+  "dedState\022\030\n\024LANDED_STATE_UNKNOWN\020\000\022\032\n\026LA"
+  "NDED_STATE_ON_GROUND\020\001\022\027\n\023LANDED_STATE_I"
+  "N_AIR\020\002\022\033\n\027LANDED_STATE_TAKING_OFF\020\003\022\030\n\024"
+  "LANDED_STATE_LANDING\020\0042\370-\n\020TelemetryServ"
+  "ice\022o\n\021SubscribePosition\022..mavsdk.rpc.te"
+  "lemetry.SubscribePositionRequest\032&.mavsd"
+  "k.rpc.telemetry.PositionResponse\"\0000\001\022c\n\r"
+  "SubscribeHome\022*.mavsdk.rpc.telemetry.Sub"
+  "scribeHomeRequest\032\".mavsdk.rpc.telemetry"
+  ".HomeResponse\"\0000\001\022f\n\016SubscribeInAir\022+.ma"
+  "vsdk.rpc.telemetry.SubscribeInAirRequest"
+  "\032#.mavsdk.rpc.telemetry.InAirResponse\"\0000"
+  "\001\022x\n\024SubscribeLandedState\0221.mavsdk.rpc.t"
+  "elemetry.SubscribeLandedStateRequest\032).m"
+  "avsdk.rpc.telemetry.LandedStateResponse\""
+  "\0000\001\022f\n\016SubscribeArmed\022+.mavsdk.rpc.telem"
+  "etry.SubscribeArmedRequest\032#.mavsdk.rpc."
+  "telemetry.ArmedResponse\"\0000\001\022\215\001\n\033Subscrib"
+  "eAttitudeQuaternion\0228.mavsdk.rpc.telemet"
+  "ry.SubscribeAttitudeQuaternionRequest\0320."
+  "mavsdk.rpc.telemetry.AttitudeQuaternionR"
+  "esponse\"\0000\001\022~\n\026SubscribeAttitudeEuler\0223."
+  "mavsdk.rpc.telemetry.SubscribeAttitudeEu"
+  "lerRequest\032+.mavsdk.rpc.telemetry.Attitu"
+  "deEulerResponse\"\0000\001\022\250\001\n$SubscribeAttitud"
+  "eAngularVelocityBody\022A.mavsdk.rpc.teleme"
+  "try.SubscribeAttitudeAngularVelocityBody"
+  "Request\0329.mavsdk.rpc.telemetry.AttitudeA"
+  "ngularVelocityBodyResponse\"\0000\001\022\237\001\n!Subsc"
+  "ribeCameraAttitudeQuaternion\022>.mavsdk.rp"
+  "c.telemetry.SubscribeCameraAttitudeQuate"
+  "rnionRequest\0326.mavsdk.rpc.telemetry.Came"
+  "raAttitudeQuaternionResponse\"\0000\001\022\220\001\n\034Sub"
+  "scribeCameraAttitudeEuler\0229.mavsdk.rpc.t"
+  "elemetry.SubscribeCameraAttitudeEulerReq"
+  "uest\0321.mavsdk.rpc.telemetry.CameraAttitu"
+  "deEulerResponse\"\0000\001\022x\n\024SubscribeVelocity"
+  "Ned\0221.mavsdk.rpc.telemetry.SubscribeVelo"
+  "cityNedRequest\032).mavsdk.rpc.telemetry.Ve"
+  "locityNedResponse\"\0000\001\022l\n\020SubscribeGpsInf"
+  "o\022-.mavsdk.rpc.telemetry.SubscribeGpsInf"
+  "oRequest\032%.mavsdk.rpc.telemetry.GpsInfoR"
+  "esponse\"\0000\001\022l\n\020SubscribeBattery\022-.mavsdk"
+  ".rpc.telemetry.SubscribeBatteryRequest\032%"
+  ".mavsdk.rpc.telemetry.BatteryResponse\"\0000"
+  "\001\022u\n\023SubscribeFlightMode\0220.mavsdk.rpc.te"
+  "lemetry.SubscribeFlightModeRequest\032(.mav"
+  "sdk.rpc.telemetry.FlightModeResponse\"\0000\001"
+  "\022i\n\017SubscribeHealth\022,.mavsdk.rpc.telemet"
+  "ry.SubscribeHealthRequest\032$.mavsdk.rpc.t"
+  "elemetry.HealthResponse\"\0000\001\022o\n\021Subscribe"
+  "RcStatus\022..mavsdk.rpc.telemetry.Subscrib"
+  "eRcStatusRequest\032&.mavsdk.rpc.telemetry."
+  "RcStatusResponse\"\0000\001\022u\n\023SubscribeStatusT"
+  "ext\0220.mavsdk.rpc.telemetry.SubscribeStat"
+  "usTextRequest\032(.mavsdk.rpc.telemetry.Sta"
+  "tusTextResponse\"\0000\001\022\226\001\n\036SubscribeActuato"
+  "rControlTarget\022;.mavsdk.rpc.telemetry.Su"
+  "bscribeActuatorControlTargetRequest\0323.ma"
+  "vsdk.rpc.telemetry.ActuatorControlTarget"
+  "Response\"\0000\001\022\223\001\n\035SubscribeActuatorOutput"
+  "Status\022:.mavsdk.rpc.telemetry.SubscribeA"
+  "ctuatorOutputStatusRequest\0322.mavsdk.rpc."
+  "telemetry.ActuatorOutputStatusResponse\"\000"
+  "0\001\022o\n\021SubscribeOdometry\022..mavsdk.rpc.tel"
+  "emetry.SubscribeOdometryRequest\032&.mavsdk"
+  ".rpc.telemetry.OdometryResponse\"\0000\001\022\220\001\n\034"
+  "SubscribePositionVelocityNed\0229.mavsdk.rp"
+  "c.telemetry.SubscribePositionVelocityNed"
+  "Request\0321.mavsdk.rpc.telemetry.PositionV"
+  "elocityNedResponse\"\0000\001\022x\n\024SubscribeGroun"
+  "dTruth\0221.mavsdk.rpc.telemetry.SubscribeG"
+  "roundTruthRequest\032).mavsdk.rpc.telemetry"
+  ".GroundTruthResponse\"\0000\001\022\207\001\n\031SubscribeFi"
+  "xedwingMetrics\0226.mavsdk.rpc.telemetry.Su"
+  "bscribeFixedwingMetricsRequest\032..mavsdk."
+  "rpc.telemetry.FixedwingMetricsResponse\"\000"
+  "0\001\022`\n\014SubscribeImu\022).mavsdk.rpc.telemetr"
+  "y.SubscribeImuRequest\032!.mavsdk.rpc.telem"
+  "etry.ImuResponse\"\0000\001\022x\n\024SubscribeHealthA"
+  "llOk\0221.mavsdk.rpc.telemetry.SubscribeHea"
+  "lthAllOkRequest\032).mavsdk.rpc.telemetry.H"
+  "ealthAllOkResponse\"\0000\001\022~\n\026SubscribeUnixE"
+  "pochTime\0223.mavsdk.rpc.telemetry.Subscrib"
+  "eUnixEpochTimeRequest\032+.mavsdk.rpc.telem"
+  "etry.UnixEpochTimeResponse\"\0000\001\022\201\001\n\027Subsc"
+  "ribeDistanceSensor\0224.mavsdk.rpc.telemetr"
+  "y.SubscribeDistanceSensorRequest\032,.mavsd"
+  "k.rpc.telemetry.DistanceSensorResponse\"\000"
+  "0\001\022p\n\017SetRatePosition\022,.mavsdk.rpc.telem"
+  "etry.SetRatePositionRequest\032-.mavsdk.rpc"
+  ".telemetry.SetRatePositionResponse\"\000\022d\n\013"
+  "SetRateHome\022(.mavsdk.rpc.telemetry.SetRa"
+  "teHomeRequest\032).mavsdk.rpc.telemetry.Set"
+  "RateHomeResponse\"\000\022g\n\014SetRateInAir\022).mav"
+  "sdk.rpc.telemetry.SetRateInAirRequest\032*."
+  "mavsdk.rpc.telemetry.SetRateInAirRespons"
+  "e\"\000\022y\n\022SetRateLandedState\022/.mavsdk.rpc.t"
+  "elemetry.SetRateLandedStateRequest\0320.mav"
+  "sdk.rpc.telemetry.SetRateLandedStateResp"
+  "onse\"\000\022p\n\017SetRateAttitude\022,.mavsdk.rpc.t"
+  "elemetry.SetRateAttitudeRequest\032-.mavsdk"
+  ".rpc.telemetry.SetRateAttitudeResponse\"\000"
+  "\022\202\001\n\025SetRateCameraAttitude\0222.mavsdk.rpc."
+  "telemetry.SetRateCameraAttitudeRequest\0323"
+  ".mavsdk.rpc.telemetry.SetRateCameraAttit"
+  "udeResponse\"\000\022y\n\022SetRateVelocityNed\022/.ma"
+  "vsdk.rpc.telemetry.SetRateVelocityNedReq"
+  "uest\0320.mavsdk.rpc.telemetry.SetRateVeloc"
+  "ityNedResponse\"\000\022m\n\016SetRateGpsInfo\022+.mav"
+  "sdk.rpc.telemetry.SetRateGpsInfoRequest\032"
+  ",.mavsdk.rpc.telemetry.SetRateGpsInfoRes"
+  "ponse\"\000\022m\n\016SetRateBattery\022+.mavsdk.rpc.t"
+  "elemetry.SetRateBatteryRequest\032,.mavsdk."
+  "rpc.telemetry.SetRateBatteryResponse\"\000\022p"
+  "\n\017SetRateRcStatus\022,.mavsdk.rpc.telemetry"
+  ".SetRateRcStatusRequest\032-.mavsdk.rpc.tel"
+  "emetry.SetRateRcStatusResponse\"\000\022\227\001\n\034Set"
+  "RateActuatorControlTarget\0229.mavsdk.rpc.t"
+  "elemetry.SetRateActuatorControlTargetReq"
+  "uest\032:.mavsdk.rpc.telemetry.SetRateActua"
+  "torControlTargetResponse\"\000\022\224\001\n\033SetRateAc"
+  "tuatorOutputStatus\0228.mavsdk.rpc.telemetr"
+  "y.SetRateActuatorOutputStatusRequest\0329.m"
   "avsdk.rpc.telemetry.SetRateActuatorOutpu"
-  "tStatusRequest\0329.mavsdk.rpc.telemetry.Se"
-  "tRateActuatorOutputStatusResponse\"\000\022p\n\017S"
-  "etRateOdometry\022,.mavsdk.rpc.telemetry.Se"
-  "tRateOdometryRequest\032-.mavsdk.rpc.teleme"
-  "try.SetRateOdometryResponse\"\000\022\221\001\n\032SetRat"
-  "ePositionVelocityNed\0227.mavsdk.rpc.teleme"
-  "try.SetRatePositionVelocityNedRequest\0328."
-  "mavsdk.rpc.telemetry.SetRatePositionVelo"
-  "cityNedResponse\"\000\022y\n\022SetRateGroundTruth\022"
-  "/.mavsdk.rpc.telemetry.SetRateGroundTrut"
-  "hRequest\0320.mavsdk.rpc.telemetry.SetRateG"
-  "roundTruthResponse\"\000\022\210\001\n\027SetRateFixedwin"
-  "gMetrics\0224.mavsdk.rpc.telemetry.SetRateF"
-  "ixedwingMetricsRequest\0325.mavsdk.rpc.tele"
-  "metry.SetRateFixedwingMetricsResponse\"\000\022"
-  "a\n\nSetRateImu\022\'.mavsdk.rpc.telemetry.Set"
-  "RateImuRequest\032(.mavsdk.rpc.telemetry.Se"
-  "tRateImuResponse\"\000\022\177\n\024SetRateUnixEpochTi"
-  "me\0221.mavsdk.rpc.telemetry.SetRateUnixEpo"
-  "chTimeRequest\0322.mavsdk.rpc.telemetry.Set"
-  "RateUnixEpochTimeResponse\"\000\022\202\001\n\025SetRateD"
-  "istanceSensor\0222.mavsdk.rpc.telemetry.Set"
-  "RateDistanceSensorRequest\0323.mavsdk.rpc.t"
-  "elemetry.SetRateDistanceSensorResponse\"\000"
-  "B%\n\023io.mavsdk.telemetryB\016TelemetryProtob"
-  "\006proto3"
+  "tStatusResponse\"\000\022p\n\017SetRateOdometry\022,.m"
+  "avsdk.rpc.telemetry.SetRateOdometryReque"
+  "st\032-.mavsdk.rpc.telemetry.SetRateOdometr"
+  "yResponse\"\000\022\221\001\n\032SetRatePositionVelocityN"
+  "ed\0227.mavsdk.rpc.telemetry.SetRatePositio"
+  "nVelocityNedRequest\0328.mavsdk.rpc.telemet"
+  "ry.SetRatePositionVelocityNedResponse\"\000\022"
+  "y\n\022SetRateGroundTruth\022/.mavsdk.rpc.telem"
+  "etry.SetRateGroundTruthRequest\0320.mavsdk."
+  "rpc.telemetry.SetRateGroundTruthResponse"
+  "\"\000\022\210\001\n\027SetRateFixedwingMetrics\0224.mavsdk."
+  "rpc.telemetry.SetRateFixedwingMetricsReq"
+  "uest\0325.mavsdk.rpc.telemetry.SetRateFixed"
+  "wingMetricsResponse\"\000\022a\n\nSetRateImu\022\'.ma"
+  "vsdk.rpc.telemetry.SetRateImuRequest\032(.m"
+  "avsdk.rpc.telemetry.SetRateImuResponse\"\000"
+  "\022\177\n\024SetRateUnixEpochTime\0221.mavsdk.rpc.te"
+  "lemetry.SetRateUnixEpochTimeRequest\0322.ma"
+  "vsdk.rpc.telemetry.SetRateUnixEpochTimeR"
+  "esponse\"\000\022\202\001\n\025SetRateDistanceSensor\0222.ma"
+  "vsdk.rpc.telemetry.SetRateDistanceSensor"
+  "Request\0323.mavsdk.rpc.telemetry.SetRateDi"
+  "stanceSensorResponse\"\000\022y\n\022GetGpsGlobalOr"
+  "igin\022/.mavsdk.rpc.telemetry.GetGpsGlobal"
+  "OriginRequest\0320.mavsdk.rpc.telemetry.Get"
+  "GpsGlobalOriginResponse\"\000B%\n\023io.mavsdk.t"
+  "elemetryB\016TelemetryProtob\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_telemetry_2ftelemetry_2eproto_deps[1] = {
   &::descriptor_table_mavsdk_5foptions_2eproto,
 };
-static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_telemetry_2ftelemetry_2eproto_sccs[122] = {
+static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_telemetry_2ftelemetry_2eproto_sccs[125] = {
   &scc_info_AccelerationFrd_telemetry_2ftelemetry_2eproto.base,
   &scc_info_ActuatorControlTarget_telemetry_2ftelemetry_2eproto.base,
   &scc_info_ActuatorControlTargetResponse_telemetry_2ftelemetry_2eproto.base,
@@ -3749,6 +3842,9 @@ static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_tel
   &scc_info_FixedwingMetrics_telemetry_2ftelemetry_2eproto.base,
   &scc_info_FixedwingMetricsResponse_telemetry_2ftelemetry_2eproto.base,
   &scc_info_FlightModeResponse_telemetry_2ftelemetry_2eproto.base,
+  &scc_info_GetGpsGlobalOriginRequest_telemetry_2ftelemetry_2eproto.base,
+  &scc_info_GetGpsGlobalOriginResponse_telemetry_2ftelemetry_2eproto.base,
+  &scc_info_GpsGlobalOrigin_telemetry_2ftelemetry_2eproto.base,
   &scc_info_GpsInfo_telemetry_2ftelemetry_2eproto.base,
   &scc_info_GpsInfoResponse_telemetry_2ftelemetry_2eproto.base,
   &scc_info_GroundTruth_telemetry_2ftelemetry_2eproto.base,
@@ -3852,10 +3948,10 @@ static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_tel
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_telemetry_2ftelemetry_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_telemetry_2ftelemetry_2eproto = {
-  false, false, descriptor_table_protodef_telemetry_2ftelemetry_2eproto, "telemetry/telemetry.proto", 16367,
-  &descriptor_table_telemetry_2ftelemetry_2eproto_once, descriptor_table_telemetry_2ftelemetry_2eproto_sccs, descriptor_table_telemetry_2ftelemetry_2eproto_deps, 122, 1,
+  false, false, descriptor_table_protodef_telemetry_2ftelemetry_2eproto, "telemetry/telemetry.proto", 16792,
+  &descriptor_table_telemetry_2ftelemetry_2eproto_once, descriptor_table_telemetry_2ftelemetry_2eproto_sccs, descriptor_table_telemetry_2ftelemetry_2eproto_deps, 125, 1,
   schemas, file_default_instances, TableStruct_telemetry_2ftelemetry_2eproto::offsets,
-  file_level_metadata_telemetry_2ftelemetry_2eproto, 122, file_level_enum_descriptors_telemetry_2ftelemetry_2eproto, file_level_service_descriptors_telemetry_2ftelemetry_2eproto,
+  file_level_metadata_telemetry_2ftelemetry_2eproto, 125, file_level_enum_descriptors_telemetry_2ftelemetry_2eproto, file_level_service_descriptors_telemetry_2ftelemetry_2eproto,
 };
 
 // Force running AddDescriptors() at dynamic initialization time.
@@ -22763,6 +22859,435 @@ void SetRateDistanceSensorResponse::InternalSwap(SetRateDistanceSensorResponse* 
 
 // ===================================================================
 
+void GetGpsGlobalOriginRequest::InitAsDefaultInstance() {
+}
+class GetGpsGlobalOriginRequest::_Internal {
+ public:
+};
+
+GetGpsGlobalOriginRequest::GetGpsGlobalOriginRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.telemetry.GetGpsGlobalOriginRequest)
+}
+GetGpsGlobalOriginRequest::GetGpsGlobalOriginRequest(const GetGpsGlobalOriginRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.telemetry.GetGpsGlobalOriginRequest)
+}
+
+void GetGpsGlobalOriginRequest::SharedCtor() {
+}
+
+GetGpsGlobalOriginRequest::~GetGpsGlobalOriginRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.telemetry.GetGpsGlobalOriginRequest)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void GetGpsGlobalOriginRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+}
+
+void GetGpsGlobalOriginRequest::ArenaDtor(void* object) {
+  GetGpsGlobalOriginRequest* _this = reinterpret_cast< GetGpsGlobalOriginRequest* >(object);
+  (void)_this;
+}
+void GetGpsGlobalOriginRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void GetGpsGlobalOriginRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const GetGpsGlobalOriginRequest& GetGpsGlobalOriginRequest::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_GetGpsGlobalOriginRequest_telemetry_2ftelemetry_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void GetGpsGlobalOriginRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.telemetry.GetGpsGlobalOriginRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* GetGpsGlobalOriginRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  ::PROTOBUF_NAMESPACE_ID::Arena* arena = GetArena(); (void)arena;
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* GetGpsGlobalOriginRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.telemetry.GetGpsGlobalOriginRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.telemetry.GetGpsGlobalOriginRequest)
+  return target;
+}
+
+size_t GetGpsGlobalOriginRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.telemetry.GetGpsGlobalOriginRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void GetGpsGlobalOriginRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:mavsdk.rpc.telemetry.GetGpsGlobalOriginRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const GetGpsGlobalOriginRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<GetGpsGlobalOriginRequest>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:mavsdk.rpc.telemetry.GetGpsGlobalOriginRequest)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:mavsdk.rpc.telemetry.GetGpsGlobalOriginRequest)
+    MergeFrom(*source);
+  }
+}
+
+void GetGpsGlobalOriginRequest::MergeFrom(const GetGpsGlobalOriginRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.telemetry.GetGpsGlobalOriginRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+}
+
+void GetGpsGlobalOriginRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:mavsdk.rpc.telemetry.GetGpsGlobalOriginRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void GetGpsGlobalOriginRequest::CopyFrom(const GetGpsGlobalOriginRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.telemetry.GetGpsGlobalOriginRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool GetGpsGlobalOriginRequest::IsInitialized() const {
+  return true;
+}
+
+void GetGpsGlobalOriginRequest::InternalSwap(GetGpsGlobalOriginRequest* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata GetGpsGlobalOriginRequest::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+void GetGpsGlobalOriginResponse::InitAsDefaultInstance() {
+  ::mavsdk::rpc::telemetry::_GetGpsGlobalOriginResponse_default_instance_._instance.get_mutable()->telemetry_result_ = const_cast< ::mavsdk::rpc::telemetry::TelemetryResult*>(
+      ::mavsdk::rpc::telemetry::TelemetryResult::internal_default_instance());
+  ::mavsdk::rpc::telemetry::_GetGpsGlobalOriginResponse_default_instance_._instance.get_mutable()->gps_global_origin_ = const_cast< ::mavsdk::rpc::telemetry::GpsGlobalOrigin*>(
+      ::mavsdk::rpc::telemetry::GpsGlobalOrigin::internal_default_instance());
+}
+class GetGpsGlobalOriginResponse::_Internal {
+ public:
+  static const ::mavsdk::rpc::telemetry::TelemetryResult& telemetry_result(const GetGpsGlobalOriginResponse* msg);
+  static const ::mavsdk::rpc::telemetry::GpsGlobalOrigin& gps_global_origin(const GetGpsGlobalOriginResponse* msg);
+};
+
+const ::mavsdk::rpc::telemetry::TelemetryResult&
+GetGpsGlobalOriginResponse::_Internal::telemetry_result(const GetGpsGlobalOriginResponse* msg) {
+  return *msg->telemetry_result_;
+}
+const ::mavsdk::rpc::telemetry::GpsGlobalOrigin&
+GetGpsGlobalOriginResponse::_Internal::gps_global_origin(const GetGpsGlobalOriginResponse* msg) {
+  return *msg->gps_global_origin_;
+}
+GetGpsGlobalOriginResponse::GetGpsGlobalOriginResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse)
+}
+GetGpsGlobalOriginResponse::GetGpsGlobalOriginResponse(const GetGpsGlobalOriginResponse& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_telemetry_result()) {
+    telemetry_result_ = new ::mavsdk::rpc::telemetry::TelemetryResult(*from.telemetry_result_);
+  } else {
+    telemetry_result_ = nullptr;
+  }
+  if (from._internal_has_gps_global_origin()) {
+    gps_global_origin_ = new ::mavsdk::rpc::telemetry::GpsGlobalOrigin(*from.gps_global_origin_);
+  } else {
+    gps_global_origin_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse)
+}
+
+void GetGpsGlobalOriginResponse::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_GetGpsGlobalOriginResponse_telemetry_2ftelemetry_2eproto.base);
+  ::memset(&telemetry_result_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&gps_global_origin_) -
+      reinterpret_cast<char*>(&telemetry_result_)) + sizeof(gps_global_origin_));
+}
+
+GetGpsGlobalOriginResponse::~GetGpsGlobalOriginResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void GetGpsGlobalOriginResponse::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  if (this != internal_default_instance()) delete telemetry_result_;
+  if (this != internal_default_instance()) delete gps_global_origin_;
+}
+
+void GetGpsGlobalOriginResponse::ArenaDtor(void* object) {
+  GetGpsGlobalOriginResponse* _this = reinterpret_cast< GetGpsGlobalOriginResponse* >(object);
+  (void)_this;
+}
+void GetGpsGlobalOriginResponse::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void GetGpsGlobalOriginResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const GetGpsGlobalOriginResponse& GetGpsGlobalOriginResponse::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_GetGpsGlobalOriginResponse_telemetry_2ftelemetry_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void GetGpsGlobalOriginResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArena() == nullptr && telemetry_result_ != nullptr) {
+    delete telemetry_result_;
+  }
+  telemetry_result_ = nullptr;
+  if (GetArena() == nullptr && gps_global_origin_ != nullptr) {
+    delete gps_global_origin_;
+  }
+  gps_global_origin_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* GetGpsGlobalOriginResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  ::PROTOBUF_NAMESPACE_ID::Arena* arena = GetArena(); (void)arena;
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // .mavsdk.rpc.telemetry.TelemetryResult telemetry_result = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_telemetry_result(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .mavsdk.rpc.telemetry.GpsGlobalOrigin gps_global_origin = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          ptr = ctx->ParseMessage(_internal_mutable_gps_global_origin(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* GetGpsGlobalOriginResponse::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.telemetry.TelemetryResult telemetry_result = 1;
+  if (this->has_telemetry_result()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::telemetry_result(this), target, stream);
+  }
+
+  // .mavsdk.rpc.telemetry.GpsGlobalOrigin gps_global_origin = 2;
+  if (this->has_gps_global_origin()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        2, _Internal::gps_global_origin(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse)
+  return target;
+}
+
+size_t GetGpsGlobalOriginResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.telemetry.TelemetryResult telemetry_result = 1;
+  if (this->has_telemetry_result()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *telemetry_result_);
+  }
+
+  // .mavsdk.rpc.telemetry.GpsGlobalOrigin gps_global_origin = 2;
+  if (this->has_gps_global_origin()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *gps_global_origin_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void GetGpsGlobalOriginResponse::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  const GetGpsGlobalOriginResponse* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<GetGpsGlobalOriginResponse>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse)
+    MergeFrom(*source);
+  }
+}
+
+void GetGpsGlobalOriginResponse::MergeFrom(const GetGpsGlobalOriginResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.has_telemetry_result()) {
+    _internal_mutable_telemetry_result()->::mavsdk::rpc::telemetry::TelemetryResult::MergeFrom(from._internal_telemetry_result());
+  }
+  if (from.has_gps_global_origin()) {
+    _internal_mutable_gps_global_origin()->::mavsdk::rpc::telemetry::GpsGlobalOrigin::MergeFrom(from._internal_gps_global_origin());
+  }
+}
+
+void GetGpsGlobalOriginResponse::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void GetGpsGlobalOriginResponse::CopyFrom(const GetGpsGlobalOriginResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool GetGpsGlobalOriginResponse::IsInitialized() const {
+  return true;
+}
+
+void GetGpsGlobalOriginResponse::InternalSwap(GetGpsGlobalOriginResponse* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(GetGpsGlobalOriginResponse, gps_global_origin_)
+      + sizeof(GetGpsGlobalOriginResponse::gps_global_origin_)
+      - PROTOBUF_FIELD_OFFSET(GetGpsGlobalOriginResponse, telemetry_result_)>(
+          reinterpret_cast<char*>(&telemetry_result_),
+          reinterpret_cast<char*>(&other->telemetry_result_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata GetGpsGlobalOriginResponse::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
 void Position::InitAsDefaultInstance() {
 }
 class Position::_Internal {
@@ -29324,6 +29849,254 @@ void Imu::InternalSwap(Imu* other) {
 
 // ===================================================================
 
+void GpsGlobalOrigin::InitAsDefaultInstance() {
+}
+class GpsGlobalOrigin::_Internal {
+ public:
+};
+
+GpsGlobalOrigin::GpsGlobalOrigin(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.telemetry.GpsGlobalOrigin)
+}
+GpsGlobalOrigin::GpsGlobalOrigin(const GpsGlobalOrigin& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::memcpy(&latitude_deg_, &from.latitude_deg_,
+    static_cast<size_t>(reinterpret_cast<char*>(&altitude_m_) -
+    reinterpret_cast<char*>(&latitude_deg_)) + sizeof(altitude_m_));
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.telemetry.GpsGlobalOrigin)
+}
+
+void GpsGlobalOrigin::SharedCtor() {
+  ::memset(&latitude_deg_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&altitude_m_) -
+      reinterpret_cast<char*>(&latitude_deg_)) + sizeof(altitude_m_));
+}
+
+GpsGlobalOrigin::~GpsGlobalOrigin() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.telemetry.GpsGlobalOrigin)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void GpsGlobalOrigin::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+}
+
+void GpsGlobalOrigin::ArenaDtor(void* object) {
+  GpsGlobalOrigin* _this = reinterpret_cast< GpsGlobalOrigin* >(object);
+  (void)_this;
+}
+void GpsGlobalOrigin::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void GpsGlobalOrigin::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const GpsGlobalOrigin& GpsGlobalOrigin::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_GpsGlobalOrigin_telemetry_2ftelemetry_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void GpsGlobalOrigin::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.telemetry.GpsGlobalOrigin)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  ::memset(&latitude_deg_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&altitude_m_) -
+      reinterpret_cast<char*>(&latitude_deg_)) + sizeof(altitude_m_));
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* GpsGlobalOrigin::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  ::PROTOBUF_NAMESPACE_ID::Arena* arena = GetArena(); (void)arena;
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // double latitude_deg = 1 [(.mavsdk.options.default_value) = "NaN"];
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 9)) {
+          latitude_deg_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<double>(ptr);
+          ptr += sizeof(double);
+        } else goto handle_unusual;
+        continue;
+      // double longitude_deg = 2 [(.mavsdk.options.default_value) = "NaN"];
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 17)) {
+          longitude_deg_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<double>(ptr);
+          ptr += sizeof(double);
+        } else goto handle_unusual;
+        continue;
+      // float altitude_m = 3 [(.mavsdk.options.default_value) = "NaN"];
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 29)) {
+          altitude_m_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<float>(ptr);
+          ptr += sizeof(float);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* GpsGlobalOrigin::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.telemetry.GpsGlobalOrigin)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // double latitude_deg = 1 [(.mavsdk.options.default_value) = "NaN"];
+  if (!(this->latitude_deg() <= 0 && this->latitude_deg() >= 0)) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteDoubleToArray(1, this->_internal_latitude_deg(), target);
+  }
+
+  // double longitude_deg = 2 [(.mavsdk.options.default_value) = "NaN"];
+  if (!(this->longitude_deg() <= 0 && this->longitude_deg() >= 0)) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteDoubleToArray(2, this->_internal_longitude_deg(), target);
+  }
+
+  // float altitude_m = 3 [(.mavsdk.options.default_value) = "NaN"];
+  if (!(this->altitude_m() <= 0 && this->altitude_m() >= 0)) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteFloatToArray(3, this->_internal_altitude_m(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.telemetry.GpsGlobalOrigin)
+  return target;
+}
+
+size_t GpsGlobalOrigin::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.telemetry.GpsGlobalOrigin)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // double latitude_deg = 1 [(.mavsdk.options.default_value) = "NaN"];
+  if (!(this->latitude_deg() <= 0 && this->latitude_deg() >= 0)) {
+    total_size += 1 + 8;
+  }
+
+  // double longitude_deg = 2 [(.mavsdk.options.default_value) = "NaN"];
+  if (!(this->longitude_deg() <= 0 && this->longitude_deg() >= 0)) {
+    total_size += 1 + 8;
+  }
+
+  // float altitude_m = 3 [(.mavsdk.options.default_value) = "NaN"];
+  if (!(this->altitude_m() <= 0 && this->altitude_m() >= 0)) {
+    total_size += 1 + 4;
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void GpsGlobalOrigin::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:mavsdk.rpc.telemetry.GpsGlobalOrigin)
+  GOOGLE_DCHECK_NE(&from, this);
+  const GpsGlobalOrigin* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<GpsGlobalOrigin>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:mavsdk.rpc.telemetry.GpsGlobalOrigin)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:mavsdk.rpc.telemetry.GpsGlobalOrigin)
+    MergeFrom(*source);
+  }
+}
+
+void GpsGlobalOrigin::MergeFrom(const GpsGlobalOrigin& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.telemetry.GpsGlobalOrigin)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!(from.latitude_deg() <= 0 && from.latitude_deg() >= 0)) {
+    _internal_set_latitude_deg(from._internal_latitude_deg());
+  }
+  if (!(from.longitude_deg() <= 0 && from.longitude_deg() >= 0)) {
+    _internal_set_longitude_deg(from._internal_longitude_deg());
+  }
+  if (!(from.altitude_m() <= 0 && from.altitude_m() >= 0)) {
+    _internal_set_altitude_m(from._internal_altitude_m());
+  }
+}
+
+void GpsGlobalOrigin::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:mavsdk.rpc.telemetry.GpsGlobalOrigin)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void GpsGlobalOrigin::CopyFrom(const GpsGlobalOrigin& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.telemetry.GpsGlobalOrigin)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool GpsGlobalOrigin::IsInitialized() const {
+  return true;
+}
+
+void GpsGlobalOrigin::InternalSwap(GpsGlobalOrigin* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(GpsGlobalOrigin, altitude_m_)
+      + sizeof(GpsGlobalOrigin::altitude_m_)
+      - PROTOBUF_FIELD_OFFSET(GpsGlobalOrigin, latitude_deg_)>(
+          reinterpret_cast<char*>(&latitude_deg_),
+          reinterpret_cast<char*>(&other->latitude_deg_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata GpsGlobalOrigin::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
 void TelemetryResult::InitAsDefaultInstance() {
 }
 class TelemetryResult::_Internal {
@@ -29852,6 +30625,12 @@ template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequ
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse >(arena);
 }
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse >(arena);
+}
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry::Position* Arena::CreateMaybeMessage< ::mavsdk::rpc::telemetry::Position >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::telemetry::Position >(arena);
 }
@@ -29926,6 +30705,9 @@ template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry::MagneticFieldFrd* Arena::
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry::Imu* Arena::CreateMaybeMessage< ::mavsdk::rpc::telemetry::Imu >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::telemetry::Imu >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry::GpsGlobalOrigin* Arena::CreateMaybeMessage< ::mavsdk::rpc::telemetry::GpsGlobalOrigin >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::telemetry::GpsGlobalOrigin >(arena);
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry::TelemetryResult* Arena::CreateMaybeMessage< ::mavsdk::rpc::telemetry::TelemetryResult >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::telemetry::TelemetryResult >(arena);

--- a/src/backend/src/generated/telemetry/telemetry.pb.h
+++ b/src/backend/src/generated/telemetry/telemetry.pb.h
@@ -49,7 +49,7 @@ struct TableStruct_telemetry_2ftelemetry_2eproto {
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::AuxiliaryParseTableField aux[]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
-  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[122]
+  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[125]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::FieldMetadata field_metadata[];
   static const ::PROTOBUF_NAMESPACE_ID::internal::SerializationTable serialization_table[];
@@ -125,6 +125,15 @@ extern FixedwingMetricsResponseDefaultTypeInternal _FixedwingMetricsResponse_def
 class FlightModeResponse;
 class FlightModeResponseDefaultTypeInternal;
 extern FlightModeResponseDefaultTypeInternal _FlightModeResponse_default_instance_;
+class GetGpsGlobalOriginRequest;
+class GetGpsGlobalOriginRequestDefaultTypeInternal;
+extern GetGpsGlobalOriginRequestDefaultTypeInternal _GetGpsGlobalOriginRequest_default_instance_;
+class GetGpsGlobalOriginResponse;
+class GetGpsGlobalOriginResponseDefaultTypeInternal;
+extern GetGpsGlobalOriginResponseDefaultTypeInternal _GetGpsGlobalOriginResponse_default_instance_;
+class GpsGlobalOrigin;
+class GpsGlobalOriginDefaultTypeInternal;
+extern GpsGlobalOriginDefaultTypeInternal _GpsGlobalOrigin_default_instance_;
 class GpsInfo;
 class GpsInfoDefaultTypeInternal;
 extern GpsInfoDefaultTypeInternal _GpsInfo_default_instance_;
@@ -451,6 +460,9 @@ template<> ::mavsdk::rpc::telemetry::EulerAngle* Arena::CreateMaybeMessage<::mav
 template<> ::mavsdk::rpc::telemetry::FixedwingMetrics* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::FixedwingMetrics>(Arena*);
 template<> ::mavsdk::rpc::telemetry::FixedwingMetricsResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::FixedwingMetricsResponse>(Arena*);
 template<> ::mavsdk::rpc::telemetry::FlightModeResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::FlightModeResponse>(Arena*);
+template<> ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest>(Arena*);
+template<> ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>(Arena*);
+template<> ::mavsdk::rpc::telemetry::GpsGlobalOrigin* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::GpsGlobalOrigin>(Arena*);
 template<> ::mavsdk::rpc::telemetry::GpsInfo* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::GpsInfo>(Arena*);
 template<> ::mavsdk::rpc::telemetry::GpsInfoResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::GpsInfoResponse>(Arena*);
 template<> ::mavsdk::rpc::telemetry::GroundTruth* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::GroundTruth>(Arena*);
@@ -13921,6 +13933,296 @@ class SetRateDistanceSensorResponse PROTOBUF_FINAL :
 };
 // -------------------------------------------------------------------
 
+class GetGpsGlobalOriginRequest PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.telemetry.GetGpsGlobalOriginRequest) */ {
+ public:
+  inline GetGpsGlobalOriginRequest() : GetGpsGlobalOriginRequest(nullptr) {}
+  virtual ~GetGpsGlobalOriginRequest();
+
+  GetGpsGlobalOriginRequest(const GetGpsGlobalOriginRequest& from);
+  GetGpsGlobalOriginRequest(GetGpsGlobalOriginRequest&& from) noexcept
+    : GetGpsGlobalOriginRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline GetGpsGlobalOriginRequest& operator=(const GetGpsGlobalOriginRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline GetGpsGlobalOriginRequest& operator=(GetGpsGlobalOriginRequest&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const GetGpsGlobalOriginRequest& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const GetGpsGlobalOriginRequest* internal_default_instance() {
+    return reinterpret_cast<const GetGpsGlobalOriginRequest*>(
+               &_GetGpsGlobalOriginRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    96;
+
+  friend void swap(GetGpsGlobalOriginRequest& a, GetGpsGlobalOriginRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(GetGpsGlobalOriginRequest* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(GetGpsGlobalOriginRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline GetGpsGlobalOriginRequest* New() const final {
+    return CreateMaybeMessage<GetGpsGlobalOriginRequest>(nullptr);
+  }
+
+  GetGpsGlobalOriginRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<GetGpsGlobalOriginRequest>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const GetGpsGlobalOriginRequest& from);
+  void MergeFrom(const GetGpsGlobalOriginRequest& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(GetGpsGlobalOriginRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.telemetry.GetGpsGlobalOriginRequest";
+  }
+  protected:
+  explicit GetGpsGlobalOriginRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_telemetry_2ftelemetry_2eproto);
+    return ::descriptor_table_telemetry_2ftelemetry_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.telemetry.GetGpsGlobalOriginRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_telemetry_2ftelemetry_2eproto;
+};
+// -------------------------------------------------------------------
+
+class GetGpsGlobalOriginResponse PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse) */ {
+ public:
+  inline GetGpsGlobalOriginResponse() : GetGpsGlobalOriginResponse(nullptr) {}
+  virtual ~GetGpsGlobalOriginResponse();
+
+  GetGpsGlobalOriginResponse(const GetGpsGlobalOriginResponse& from);
+  GetGpsGlobalOriginResponse(GetGpsGlobalOriginResponse&& from) noexcept
+    : GetGpsGlobalOriginResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline GetGpsGlobalOriginResponse& operator=(const GetGpsGlobalOriginResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline GetGpsGlobalOriginResponse& operator=(GetGpsGlobalOriginResponse&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const GetGpsGlobalOriginResponse& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const GetGpsGlobalOriginResponse* internal_default_instance() {
+    return reinterpret_cast<const GetGpsGlobalOriginResponse*>(
+               &_GetGpsGlobalOriginResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    97;
+
+  friend void swap(GetGpsGlobalOriginResponse& a, GetGpsGlobalOriginResponse& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(GetGpsGlobalOriginResponse* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(GetGpsGlobalOriginResponse* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline GetGpsGlobalOriginResponse* New() const final {
+    return CreateMaybeMessage<GetGpsGlobalOriginResponse>(nullptr);
+  }
+
+  GetGpsGlobalOriginResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<GetGpsGlobalOriginResponse>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const GetGpsGlobalOriginResponse& from);
+  void MergeFrom(const GetGpsGlobalOriginResponse& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(GetGpsGlobalOriginResponse* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse";
+  }
+  protected:
+  explicit GetGpsGlobalOriginResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_telemetry_2ftelemetry_2eproto);
+    return ::descriptor_table_telemetry_2ftelemetry_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kTelemetryResultFieldNumber = 1,
+    kGpsGlobalOriginFieldNumber = 2,
+  };
+  // .mavsdk.rpc.telemetry.TelemetryResult telemetry_result = 1;
+  bool has_telemetry_result() const;
+  private:
+  bool _internal_has_telemetry_result() const;
+  public:
+  void clear_telemetry_result();
+  const ::mavsdk::rpc::telemetry::TelemetryResult& telemetry_result() const;
+  ::mavsdk::rpc::telemetry::TelemetryResult* release_telemetry_result();
+  ::mavsdk::rpc::telemetry::TelemetryResult* mutable_telemetry_result();
+  void set_allocated_telemetry_result(::mavsdk::rpc::telemetry::TelemetryResult* telemetry_result);
+  private:
+  const ::mavsdk::rpc::telemetry::TelemetryResult& _internal_telemetry_result() const;
+  ::mavsdk::rpc::telemetry::TelemetryResult* _internal_mutable_telemetry_result();
+  public:
+  void unsafe_arena_set_allocated_telemetry_result(
+      ::mavsdk::rpc::telemetry::TelemetryResult* telemetry_result);
+  ::mavsdk::rpc::telemetry::TelemetryResult* unsafe_arena_release_telemetry_result();
+
+  // .mavsdk.rpc.telemetry.GpsGlobalOrigin gps_global_origin = 2;
+  bool has_gps_global_origin() const;
+  private:
+  bool _internal_has_gps_global_origin() const;
+  public:
+  void clear_gps_global_origin();
+  const ::mavsdk::rpc::telemetry::GpsGlobalOrigin& gps_global_origin() const;
+  ::mavsdk::rpc::telemetry::GpsGlobalOrigin* release_gps_global_origin();
+  ::mavsdk::rpc::telemetry::GpsGlobalOrigin* mutable_gps_global_origin();
+  void set_allocated_gps_global_origin(::mavsdk::rpc::telemetry::GpsGlobalOrigin* gps_global_origin);
+  private:
+  const ::mavsdk::rpc::telemetry::GpsGlobalOrigin& _internal_gps_global_origin() const;
+  ::mavsdk::rpc::telemetry::GpsGlobalOrigin* _internal_mutable_gps_global_origin();
+  public:
+  void unsafe_arena_set_allocated_gps_global_origin(
+      ::mavsdk::rpc::telemetry::GpsGlobalOrigin* gps_global_origin);
+  ::mavsdk::rpc::telemetry::GpsGlobalOrigin* unsafe_arena_release_gps_global_origin();
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::mavsdk::rpc::telemetry::TelemetryResult* telemetry_result_;
+  ::mavsdk::rpc::telemetry::GpsGlobalOrigin* gps_global_origin_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_telemetry_2ftelemetry_2eproto;
+};
+// -------------------------------------------------------------------
+
 class Position PROTOBUF_FINAL :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.telemetry.Position) */ {
  public:
@@ -13963,7 +14265,7 @@ class Position PROTOBUF_FINAL :
                &_Position_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    96;
+    98;
 
   friend void swap(Position& a, Position& b) {
     a.Swap(&b);
@@ -14133,7 +14435,7 @@ class Quaternion PROTOBUF_FINAL :
                &_Quaternion_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    97;
+    99;
 
   friend void swap(Quaternion& a, Quaternion& b) {
     a.Swap(&b);
@@ -14303,7 +14605,7 @@ class EulerAngle PROTOBUF_FINAL :
                &_EulerAngle_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    98;
+    100;
 
   friend void swap(EulerAngle& a, EulerAngle& b) {
     a.Swap(&b);
@@ -14462,7 +14764,7 @@ class AngularVelocityBody PROTOBUF_FINAL :
                &_AngularVelocityBody_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    99;
+    101;
 
   friend void swap(AngularVelocityBody& a, AngularVelocityBody& b) {
     a.Swap(&b);
@@ -14621,7 +14923,7 @@ class GpsInfo PROTOBUF_FINAL :
                &_GpsInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    100;
+    102;
 
   friend void swap(GpsInfo& a, GpsInfo& b) {
     a.Swap(&b);
@@ -14769,7 +15071,7 @@ class Battery PROTOBUF_FINAL :
                &_Battery_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    101;
+    103;
 
   friend void swap(Battery& a, Battery& b) {
     a.Swap(&b);
@@ -14917,7 +15219,7 @@ class Health PROTOBUF_FINAL :
                &_Health_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    102;
+    104;
 
   friend void swap(Health& a, Health& b) {
     a.Swap(&b);
@@ -15120,7 +15422,7 @@ class RcStatus PROTOBUF_FINAL :
                &_RcStatus_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    103;
+    105;
 
   friend void swap(RcStatus& a, RcStatus& b) {
     a.Swap(&b);
@@ -15279,7 +15581,7 @@ class StatusText PROTOBUF_FINAL :
                &_StatusText_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    104;
+    106;
 
   friend void swap(StatusText& a, StatusText& b) {
     a.Swap(&b);
@@ -15434,7 +15736,7 @@ class ActuatorControlTarget PROTOBUF_FINAL :
                &_ActuatorControlTarget_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    105;
+    107;
 
   friend void swap(ActuatorControlTarget& a, ActuatorControlTarget& b) {
     a.Swap(&b);
@@ -15596,7 +15898,7 @@ class ActuatorOutputStatus PROTOBUF_FINAL :
                &_ActuatorOutputStatus_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    106;
+    108;
 
   friend void swap(ActuatorOutputStatus& a, ActuatorOutputStatus& b) {
     a.Swap(&b);
@@ -15758,7 +16060,7 @@ class Covariance PROTOBUF_FINAL :
                &_Covariance_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    107;
+    109;
 
   friend void swap(Covariance& a, Covariance& b) {
     a.Swap(&b);
@@ -15909,7 +16211,7 @@ class VelocityBody PROTOBUF_FINAL :
                &_VelocityBody_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    108;
+    110;
 
   friend void swap(VelocityBody& a, VelocityBody& b) {
     a.Swap(&b);
@@ -16068,7 +16370,7 @@ class PositionBody PROTOBUF_FINAL :
                &_PositionBody_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    109;
+    111;
 
   friend void swap(PositionBody& a, PositionBody& b) {
     a.Swap(&b);
@@ -16227,7 +16529,7 @@ class Odometry PROTOBUF_FINAL :
                &_Odometry_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    110;
+    112;
 
   friend void swap(Odometry& a, Odometry& b) {
     a.Swap(&b);
@@ -16540,7 +16842,7 @@ class DistanceSensor PROTOBUF_FINAL :
                &_DistanceSensor_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    111;
+    113;
 
   friend void swap(DistanceSensor& a, DistanceSensor& b) {
     a.Swap(&b);
@@ -16699,7 +17001,7 @@ class PositionNed PROTOBUF_FINAL :
                &_PositionNed_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    112;
+    114;
 
   friend void swap(PositionNed& a, PositionNed& b) {
     a.Swap(&b);
@@ -16858,7 +17160,7 @@ class VelocityNed PROTOBUF_FINAL :
                &_VelocityNed_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    113;
+    115;
 
   friend void swap(VelocityNed& a, VelocityNed& b) {
     a.Swap(&b);
@@ -17017,7 +17319,7 @@ class PositionVelocityNed PROTOBUF_FINAL :
                &_PositionVelocityNed_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    114;
+    116;
 
   friend void swap(PositionVelocityNed& a, PositionVelocityNed& b) {
     a.Swap(&b);
@@ -17183,7 +17485,7 @@ class GroundTruth PROTOBUF_FINAL :
                &_GroundTruth_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    115;
+    117;
 
   friend void swap(GroundTruth& a, GroundTruth& b) {
     a.Swap(&b);
@@ -17342,7 +17644,7 @@ class FixedwingMetrics PROTOBUF_FINAL :
                &_FixedwingMetrics_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    116;
+    118;
 
   friend void swap(FixedwingMetrics& a, FixedwingMetrics& b) {
     a.Swap(&b);
@@ -17501,7 +17803,7 @@ class AccelerationFrd PROTOBUF_FINAL :
                &_AccelerationFrd_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    117;
+    119;
 
   friend void swap(AccelerationFrd& a, AccelerationFrd& b) {
     a.Swap(&b);
@@ -17660,7 +17962,7 @@ class AngularVelocityFrd PROTOBUF_FINAL :
                &_AngularVelocityFrd_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    118;
+    120;
 
   friend void swap(AngularVelocityFrd& a, AngularVelocityFrd& b) {
     a.Swap(&b);
@@ -17819,7 +18121,7 @@ class MagneticFieldFrd PROTOBUF_FINAL :
                &_MagneticFieldFrd_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    119;
+    121;
 
   friend void swap(MagneticFieldFrd& a, MagneticFieldFrd& b) {
     a.Swap(&b);
@@ -17978,7 +18280,7 @@ class Imu PROTOBUF_FINAL :
                &_Imu_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    120;
+    122;
 
   friend void swap(Imu& a, Imu& b) {
     a.Swap(&b);
@@ -18133,6 +18435,165 @@ class Imu PROTOBUF_FINAL :
 };
 // -------------------------------------------------------------------
 
+class GpsGlobalOrigin PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.telemetry.GpsGlobalOrigin) */ {
+ public:
+  inline GpsGlobalOrigin() : GpsGlobalOrigin(nullptr) {}
+  virtual ~GpsGlobalOrigin();
+
+  GpsGlobalOrigin(const GpsGlobalOrigin& from);
+  GpsGlobalOrigin(GpsGlobalOrigin&& from) noexcept
+    : GpsGlobalOrigin() {
+    *this = ::std::move(from);
+  }
+
+  inline GpsGlobalOrigin& operator=(const GpsGlobalOrigin& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline GpsGlobalOrigin& operator=(GpsGlobalOrigin&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const GpsGlobalOrigin& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const GpsGlobalOrigin* internal_default_instance() {
+    return reinterpret_cast<const GpsGlobalOrigin*>(
+               &_GpsGlobalOrigin_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    123;
+
+  friend void swap(GpsGlobalOrigin& a, GpsGlobalOrigin& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(GpsGlobalOrigin* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(GpsGlobalOrigin* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline GpsGlobalOrigin* New() const final {
+    return CreateMaybeMessage<GpsGlobalOrigin>(nullptr);
+  }
+
+  GpsGlobalOrigin* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<GpsGlobalOrigin>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const GpsGlobalOrigin& from);
+  void MergeFrom(const GpsGlobalOrigin& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(GpsGlobalOrigin* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.telemetry.GpsGlobalOrigin";
+  }
+  protected:
+  explicit GpsGlobalOrigin(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_telemetry_2ftelemetry_2eproto);
+    return ::descriptor_table_telemetry_2ftelemetry_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kLatitudeDegFieldNumber = 1,
+    kLongitudeDegFieldNumber = 2,
+    kAltitudeMFieldNumber = 3,
+  };
+  // double latitude_deg = 1 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_latitude_deg();
+  double latitude_deg() const;
+  void set_latitude_deg(double value);
+  private:
+  double _internal_latitude_deg() const;
+  void _internal_set_latitude_deg(double value);
+  public:
+
+  // double longitude_deg = 2 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_longitude_deg();
+  double longitude_deg() const;
+  void set_longitude_deg(double value);
+  private:
+  double _internal_longitude_deg() const;
+  void _internal_set_longitude_deg(double value);
+  public:
+
+  // float altitude_m = 3 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_altitude_m();
+  float altitude_m() const;
+  void set_altitude_m(float value);
+  private:
+  float _internal_altitude_m() const;
+  void _internal_set_altitude_m(float value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.telemetry.GpsGlobalOrigin)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  double latitude_deg_;
+  double longitude_deg_;
+  float altitude_m_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_telemetry_2ftelemetry_2eproto;
+};
+// -------------------------------------------------------------------
+
 class TelemetryResult PROTOBUF_FINAL :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.telemetry.TelemetryResult) */ {
  public:
@@ -18175,7 +18636,7 @@ class TelemetryResult PROTOBUF_FINAL :
                &_TelemetryResult_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    121;
+    124;
 
   friend void swap(TelemetryResult& a, TelemetryResult& b) {
     a.Swap(&b);
@@ -22745,6 +23206,180 @@ inline void SetRateDistanceSensorResponse::set_allocated_telemetry_result(::mavs
 
 // -------------------------------------------------------------------
 
+// GetGpsGlobalOriginRequest
+
+// -------------------------------------------------------------------
+
+// GetGpsGlobalOriginResponse
+
+// .mavsdk.rpc.telemetry.TelemetryResult telemetry_result = 1;
+inline bool GetGpsGlobalOriginResponse::_internal_has_telemetry_result() const {
+  return this != internal_default_instance() && telemetry_result_ != nullptr;
+}
+inline bool GetGpsGlobalOriginResponse::has_telemetry_result() const {
+  return _internal_has_telemetry_result();
+}
+inline void GetGpsGlobalOriginResponse::clear_telemetry_result() {
+  if (GetArena() == nullptr && telemetry_result_ != nullptr) {
+    delete telemetry_result_;
+  }
+  telemetry_result_ = nullptr;
+}
+inline const ::mavsdk::rpc::telemetry::TelemetryResult& GetGpsGlobalOriginResponse::_internal_telemetry_result() const {
+  const ::mavsdk::rpc::telemetry::TelemetryResult* p = telemetry_result_;
+  return p != nullptr ? *p : *reinterpret_cast<const ::mavsdk::rpc::telemetry::TelemetryResult*>(
+      &::mavsdk::rpc::telemetry::_TelemetryResult_default_instance_);
+}
+inline const ::mavsdk::rpc::telemetry::TelemetryResult& GetGpsGlobalOriginResponse::telemetry_result() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse.telemetry_result)
+  return _internal_telemetry_result();
+}
+inline void GetGpsGlobalOriginResponse::unsafe_arena_set_allocated_telemetry_result(
+    ::mavsdk::rpc::telemetry::TelemetryResult* telemetry_result) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(telemetry_result_);
+  }
+  telemetry_result_ = telemetry_result;
+  if (telemetry_result) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse.telemetry_result)
+}
+inline ::mavsdk::rpc::telemetry::TelemetryResult* GetGpsGlobalOriginResponse::release_telemetry_result() {
+  
+  ::mavsdk::rpc::telemetry::TelemetryResult* temp = telemetry_result_;
+  telemetry_result_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::mavsdk::rpc::telemetry::TelemetryResult* GetGpsGlobalOriginResponse::unsafe_arena_release_telemetry_result() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse.telemetry_result)
+  
+  ::mavsdk::rpc::telemetry::TelemetryResult* temp = telemetry_result_;
+  telemetry_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::telemetry::TelemetryResult* GetGpsGlobalOriginResponse::_internal_mutable_telemetry_result() {
+  
+  if (telemetry_result_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::telemetry::TelemetryResult>(GetArena());
+    telemetry_result_ = p;
+  }
+  return telemetry_result_;
+}
+inline ::mavsdk::rpc::telemetry::TelemetryResult* GetGpsGlobalOriginResponse::mutable_telemetry_result() {
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse.telemetry_result)
+  return _internal_mutable_telemetry_result();
+}
+inline void GetGpsGlobalOriginResponse::set_allocated_telemetry_result(::mavsdk::rpc::telemetry::TelemetryResult* telemetry_result) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete telemetry_result_;
+  }
+  if (telemetry_result) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(telemetry_result);
+    if (message_arena != submessage_arena) {
+      telemetry_result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, telemetry_result, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  telemetry_result_ = telemetry_result;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse.telemetry_result)
+}
+
+// .mavsdk.rpc.telemetry.GpsGlobalOrigin gps_global_origin = 2;
+inline bool GetGpsGlobalOriginResponse::_internal_has_gps_global_origin() const {
+  return this != internal_default_instance() && gps_global_origin_ != nullptr;
+}
+inline bool GetGpsGlobalOriginResponse::has_gps_global_origin() const {
+  return _internal_has_gps_global_origin();
+}
+inline void GetGpsGlobalOriginResponse::clear_gps_global_origin() {
+  if (GetArena() == nullptr && gps_global_origin_ != nullptr) {
+    delete gps_global_origin_;
+  }
+  gps_global_origin_ = nullptr;
+}
+inline const ::mavsdk::rpc::telemetry::GpsGlobalOrigin& GetGpsGlobalOriginResponse::_internal_gps_global_origin() const {
+  const ::mavsdk::rpc::telemetry::GpsGlobalOrigin* p = gps_global_origin_;
+  return p != nullptr ? *p : *reinterpret_cast<const ::mavsdk::rpc::telemetry::GpsGlobalOrigin*>(
+      &::mavsdk::rpc::telemetry::_GpsGlobalOrigin_default_instance_);
+}
+inline const ::mavsdk::rpc::telemetry::GpsGlobalOrigin& GetGpsGlobalOriginResponse::gps_global_origin() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse.gps_global_origin)
+  return _internal_gps_global_origin();
+}
+inline void GetGpsGlobalOriginResponse::unsafe_arena_set_allocated_gps_global_origin(
+    ::mavsdk::rpc::telemetry::GpsGlobalOrigin* gps_global_origin) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(gps_global_origin_);
+  }
+  gps_global_origin_ = gps_global_origin;
+  if (gps_global_origin) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse.gps_global_origin)
+}
+inline ::mavsdk::rpc::telemetry::GpsGlobalOrigin* GetGpsGlobalOriginResponse::release_gps_global_origin() {
+  
+  ::mavsdk::rpc::telemetry::GpsGlobalOrigin* temp = gps_global_origin_;
+  gps_global_origin_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::mavsdk::rpc::telemetry::GpsGlobalOrigin* GetGpsGlobalOriginResponse::unsafe_arena_release_gps_global_origin() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse.gps_global_origin)
+  
+  ::mavsdk::rpc::telemetry::GpsGlobalOrigin* temp = gps_global_origin_;
+  gps_global_origin_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::telemetry::GpsGlobalOrigin* GetGpsGlobalOriginResponse::_internal_mutable_gps_global_origin() {
+  
+  if (gps_global_origin_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::telemetry::GpsGlobalOrigin>(GetArena());
+    gps_global_origin_ = p;
+  }
+  return gps_global_origin_;
+}
+inline ::mavsdk::rpc::telemetry::GpsGlobalOrigin* GetGpsGlobalOriginResponse::mutable_gps_global_origin() {
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse.gps_global_origin)
+  return _internal_mutable_gps_global_origin();
+}
+inline void GetGpsGlobalOriginResponse::set_allocated_gps_global_origin(::mavsdk::rpc::telemetry::GpsGlobalOrigin* gps_global_origin) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete gps_global_origin_;
+  }
+  if (gps_global_origin) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(gps_global_origin);
+    if (message_arena != submessage_arena) {
+      gps_global_origin = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, gps_global_origin, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  gps_global_origin_ = gps_global_origin;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.telemetry.GetGpsGlobalOriginResponse.gps_global_origin)
+}
+
+// -------------------------------------------------------------------
+
 // Position
 
 // double latitude_deg = 1 [(.mavsdk.options.default_value) = "NaN"];
@@ -25261,6 +25896,70 @@ inline void Imu::set_temperature_degc(float value) {
 
 // -------------------------------------------------------------------
 
+// GpsGlobalOrigin
+
+// double latitude_deg = 1 [(.mavsdk.options.default_value) = "NaN"];
+inline void GpsGlobalOrigin::clear_latitude_deg() {
+  latitude_deg_ = 0;
+}
+inline double GpsGlobalOrigin::_internal_latitude_deg() const {
+  return latitude_deg_;
+}
+inline double GpsGlobalOrigin::latitude_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry.GpsGlobalOrigin.latitude_deg)
+  return _internal_latitude_deg();
+}
+inline void GpsGlobalOrigin::_internal_set_latitude_deg(double value) {
+  
+  latitude_deg_ = value;
+}
+inline void GpsGlobalOrigin::set_latitude_deg(double value) {
+  _internal_set_latitude_deg(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry.GpsGlobalOrigin.latitude_deg)
+}
+
+// double longitude_deg = 2 [(.mavsdk.options.default_value) = "NaN"];
+inline void GpsGlobalOrigin::clear_longitude_deg() {
+  longitude_deg_ = 0;
+}
+inline double GpsGlobalOrigin::_internal_longitude_deg() const {
+  return longitude_deg_;
+}
+inline double GpsGlobalOrigin::longitude_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry.GpsGlobalOrigin.longitude_deg)
+  return _internal_longitude_deg();
+}
+inline void GpsGlobalOrigin::_internal_set_longitude_deg(double value) {
+  
+  longitude_deg_ = value;
+}
+inline void GpsGlobalOrigin::set_longitude_deg(double value) {
+  _internal_set_longitude_deg(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry.GpsGlobalOrigin.longitude_deg)
+}
+
+// float altitude_m = 3 [(.mavsdk.options.default_value) = "NaN"];
+inline void GpsGlobalOrigin::clear_altitude_m() {
+  altitude_m_ = 0;
+}
+inline float GpsGlobalOrigin::_internal_altitude_m() const {
+  return altitude_m_;
+}
+inline float GpsGlobalOrigin::altitude_m() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry.GpsGlobalOrigin.altitude_m)
+  return _internal_altitude_m();
+}
+inline void GpsGlobalOrigin::_internal_set_altitude_m(float value) {
+  
+  altitude_m_ = value;
+}
+inline void GpsGlobalOrigin::set_altitude_m(float value) {
+  _internal_set_altitude_m(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry.GpsGlobalOrigin.altitude_m)
+}
+
+// -------------------------------------------------------------------
+
 // TelemetryResult
 
 // .mavsdk.rpc.telemetry.TelemetryResult.Result result = 1;
@@ -25348,6 +26047,12 @@ inline void TelemetryResult::set_allocated_result_str(std::string* result_str) {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/src/backend/src/plugins/manual_control/manual_control_service_impl.h
+++ b/src/backend/src/plugins/manual_control/manual_control_service_impl.h
@@ -60,6 +60,8 @@ public:
                 return rpc::manual_control::ManualControlResult_Result_RESULT_TIMEOUT;
             case mavsdk::ManualControl::Result::InputOutOfRange:
                 return rpc::manual_control::ManualControlResult_Result_RESULT_INPUT_OUT_OF_RANGE;
+            case mavsdk::ManualControl::Result::InputNotSet:
+                return rpc::manual_control::ManualControlResult_Result_RESULT_INPUT_NOT_SET;
         }
     }
 
@@ -86,6 +88,8 @@ public:
                 return mavsdk::ManualControl::Result::Timeout;
             case rpc::manual_control::ManualControlResult_Result_RESULT_INPUT_OUT_OF_RANGE:
                 return mavsdk::ManualControl::Result::InputOutOfRange;
+            case rpc::manual_control::ManualControlResult_Result_RESULT_INPUT_NOT_SET:
+                return mavsdk::ManualControl::Result::InputNotSet;
         }
     }
 

--- a/src/backend/src/plugins/telemetry/telemetry_service_impl.h
+++ b/src/backend/src/plugins/telemetry/telemetry_service_impl.h
@@ -1043,6 +1043,35 @@ public:
         return obj;
     }
 
+    static std::unique_ptr<rpc::telemetry::GpsGlobalOrigin>
+    translateToRpcGpsGlobalOrigin(const mavsdk::Telemetry::GpsGlobalOrigin& gps_global_origin)
+    {
+        std::unique_ptr<rpc::telemetry::GpsGlobalOrigin> rpc_obj(
+            new rpc::telemetry::GpsGlobalOrigin());
+
+        rpc_obj->set_latitude_deg(gps_global_origin.latitude_deg);
+
+        rpc_obj->set_longitude_deg(gps_global_origin.longitude_deg);
+
+        rpc_obj->set_altitude_m(gps_global_origin.altitude_m);
+
+        return rpc_obj;
+    }
+
+    static mavsdk::Telemetry::GpsGlobalOrigin
+    translateFromRpcGpsGlobalOrigin(const rpc::telemetry::GpsGlobalOrigin& gps_global_origin)
+    {
+        mavsdk::Telemetry::GpsGlobalOrigin obj;
+
+        obj.latitude_deg = gps_global_origin.latitude_deg();
+
+        obj.longitude_deg = gps_global_origin.longitude_deg();
+
+        obj.altitude_m = gps_global_origin.altitude_m();
+
+        return obj;
+    }
+
     static rpc::telemetry::TelemetryResult::Result
     translateToRpcResult(const mavsdk::Telemetry::Result& result)
     {
@@ -2405,6 +2434,23 @@ public:
 
         if (response != nullptr) {
             fillResponseWithResult(response, result);
+        }
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status GetGpsGlobalOrigin(
+        grpc::ServerContext* /* context */,
+        const rpc::telemetry::GetGpsGlobalOriginRequest* /* request */,
+        rpc::telemetry::GetGpsGlobalOriginResponse* response) override
+    {
+        auto result = _telemetry.get_gps_global_origin();
+
+        if (response != nullptr) {
+            fillResponseWithResult(response, result.first);
+
+            response->set_allocated_gps_global_origin(
+                translateToRpcGpsGlobalOrigin(result.second).release());
         }
 
         return grpc::Status::OK;

--- a/src/plugins/manual_control/include/plugins/manual_control/manual_control.h
+++ b/src/plugins/manual_control/include/plugins/manual_control/manual_control.h
@@ -69,6 +69,7 @@ public:
         CommandDenied, /**< @brief Command refused by vehicle. */
         Timeout, /**< @brief Request timed out. */
         InputOutOfRange, /**< @brief Input out of range. */
+        InputNotSet, /**< @brief No Input set. */
     };
 
     /**

--- a/src/plugins/manual_control/manual_control.cpp
+++ b/src/plugins/manual_control/manual_control.cpp
@@ -64,6 +64,8 @@ std::ostream& operator<<(std::ostream& str, ManualControl::Result const& result)
             return str << "Timeout";
         case ManualControl::Result::InputOutOfRange:
             return str << "Input Out Of Range";
+        case ManualControl::Result::InputNotSet:
+            return str << "Input Not Set";
         default:
             return str << "Unknown";
     }

--- a/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -818,6 +818,31 @@ public:
     friend std::ostream& operator<<(std::ostream& str, Telemetry::Imu const& imu);
 
     /**
+     * @brief Gps global origin type.
+     */
+    struct GpsGlobalOrigin {
+        double latitude_deg{double(NAN)}; /**< @brief Latitude of the origin */
+        double longitude_deg{double(NAN)}; /**< @brief Longitude of the origin */
+        float altitude_m{float(NAN)}; /**< @brief Altitude AMSL (above mean sea level) in metres */
+    };
+
+    /**
+     * @brief Equal operator to compare two `Telemetry::GpsGlobalOrigin` objects.
+     *
+     * @return `true` if items are equal.
+     */
+    friend bool
+    operator==(const Telemetry::GpsGlobalOrigin& lhs, const Telemetry::GpsGlobalOrigin& rhs);
+
+    /**
+     * @brief Stream operator to print information about a `Telemetry::GpsGlobalOrigin`.
+     *
+     * @return A reference to the stream.
+     */
+    friend std::ostream&
+    operator<<(std::ostream& str, Telemetry::GpsGlobalOrigin const& gps_global_origin);
+
+    /**
      * @brief Possible results returned for telemetry requests.
      */
     enum class Result {
@@ -1644,6 +1669,28 @@ public:
      * @return Result of request.
      */
     Result set_rate_distance_sensor(double rate_hz) const;
+
+    /**
+     * @brief Callback type for get_gps_global_origin_async.
+     */
+    using GetGpsGlobalOriginCallback = std::function<void(Result, GpsGlobalOrigin)>;
+
+    /**
+     * @brief Get the GPS global origin.
+     *
+     * This function is non-blocking. See 'get_gps_global_origin' for the blocking counterpart.
+     */
+    void get_gps_global_origin_async(const GetGpsGlobalOriginCallback callback);
+
+    /**
+     * @brief Get the GPS global origin.
+     *
+     * This function is blocking. See 'get_gps_global_origin_async' for the non-blocking
+     * counterpart.
+     *
+     * @return Result of request.
+     */
+    std::pair<Result, Telemetry::GpsGlobalOrigin> get_gps_global_origin() const;
 
     /**
      * @brief Copy constructor.

--- a/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -1676,14 +1676,14 @@ public:
     using GetGpsGlobalOriginCallback = std::function<void(Result, GpsGlobalOrigin)>;
 
     /**
-     * @brief Get the GPS global origin.
+     * @brief Get the GPS location of where the estimator has been initialized.
      *
      * This function is non-blocking. See 'get_gps_global_origin' for the blocking counterpart.
      */
     void get_gps_global_origin_async(const GetGpsGlobalOriginCallback callback);
 
     /**
-     * @brief Get the GPS global origin.
+     * @brief Get the GPS location of where the estimator has been initialized.
      *
      * This function is blocking. See 'get_gps_global_origin_async' for the non-blocking
      * counterpart.

--- a/src/plugins/telemetry/mocks/telemetry_mock.h
+++ b/src/plugins/telemetry/mocks/telemetry_mock.h
@@ -84,6 +84,10 @@ public:
     MOCK_CONST_METHOD2(set_rate_fixedwing_metrics_async, void(double, Telemetry::ResultCallback)){};
     MOCK_CONST_METHOD2(set_rate_imu_async, void(double, Telemetry::ResultCallback)){};
     MOCK_CONST_METHOD2(set_rate_unix_epoch_time_async, void(double, Telemetry::ResultCallback)){};
+
+    MOCK_METHOD0(
+        get_gps_global_origin, std::pair<Telemetry::Result, Telemetry::GpsGlobalOrigin>()){};
+    MOCK_METHOD1(get_gps_global_origin_async, void(Telemetry::GetGpsGlobalOriginCallback)){};
 };
 
 } // namespace testing

--- a/src/plugins/telemetry/telemetry.cpp
+++ b/src/plugins/telemetry/telemetry.cpp
@@ -34,6 +34,7 @@ using AccelerationFrd = Telemetry::AccelerationFrd;
 using AngularVelocityFrd = Telemetry::AngularVelocityFrd;
 using MagneticFieldFrd = Telemetry::MagneticFieldFrd;
 using Imu = Telemetry::Imu;
+using GpsGlobalOrigin = Telemetry::GpsGlobalOrigin;
 
 Telemetry::Telemetry(System& system) : PluginBase(), _impl{new TelemetryImpl(system)} {}
 
@@ -504,6 +505,16 @@ void Telemetry::set_rate_distance_sensor_async(double rate_hz, const ResultCallb
 Telemetry::Result Telemetry::set_rate_distance_sensor(double rate_hz) const
 {
     return _impl->set_rate_distance_sensor(rate_hz);
+}
+
+void Telemetry::get_gps_global_origin_async(const GetGpsGlobalOriginCallback callback)
+{
+    _impl->get_gps_global_origin_async(callback);
+}
+
+std::pair<Telemetry::Result, Telemetry::GpsGlobalOrigin> Telemetry::get_gps_global_origin() const
+{
+    return _impl->get_gps_global_origin();
 }
 
 bool operator==(const Telemetry::Position& lhs, const Telemetry::Position& rhs)
@@ -1029,6 +1040,27 @@ std::ostream& operator<<(std::ostream& str, Telemetry::Imu const& imu)
     str << "    angular_velocity_frd: " << imu.angular_velocity_frd << '\n';
     str << "    magnetic_field_frd: " << imu.magnetic_field_frd << '\n';
     str << "    temperature_degc: " << imu.temperature_degc << '\n';
+    str << '}';
+    return str;
+}
+
+bool operator==(const Telemetry::GpsGlobalOrigin& lhs, const Telemetry::GpsGlobalOrigin& rhs)
+{
+    return ((std::isnan(rhs.latitude_deg) && std::isnan(lhs.latitude_deg)) ||
+            rhs.latitude_deg == lhs.latitude_deg) &&
+           ((std::isnan(rhs.longitude_deg) && std::isnan(lhs.longitude_deg)) ||
+            rhs.longitude_deg == lhs.longitude_deg) &&
+           ((std::isnan(rhs.altitude_m) && std::isnan(lhs.altitude_m)) ||
+            rhs.altitude_m == lhs.altitude_m);
+}
+
+std::ostream& operator<<(std::ostream& str, Telemetry::GpsGlobalOrigin const& gps_global_origin)
+{
+    str << std::setprecision(15);
+    str << "gps_global_origin:" << '\n' << "{\n";
+    str << "    latitude_deg: " << gps_global_origin.latitude_deg << '\n';
+    str << "    longitude_deg: " << gps_global_origin.longitude_deg << '\n';
+    str << "    altitude_m: " << gps_global_origin.altitude_m << '\n';
     str << '}';
     return str;
 }

--- a/src/plugins/telemetry/telemetry_impl.cpp
+++ b/src/plugins/telemetry/telemetry_impl.cpp
@@ -1823,6 +1823,24 @@ void TelemetryImpl::distance_sensor_async(Telemetry::DistanceSensorCallback& cal
     _distance_sensor_subscription = callback;
 }
 
+
+void TelemetryImpl::get_gps_global_origin_async(const Telemetry::GetGpsGlobalOriginCallback callback)
+{
+}
+
+std::pair<Telemetry::Result, Telemetry::GpsGlobalOrigin> TelemetryImpl::get_gps_global_origin()
+{
+    auto prom = std::promise<std::pair<Telemetry::Result, Telemetry::GpsGlobalOrigin>>();
+    auto fut = prom.get_future();
+
+    get_gps_global_origin_async(
+        [&prom](Telemetry::Result result, Telemetry::GpsGlobalOrigin gps_global_origin) {
+            prom.set_value(std::make_pair(result, gps_global_origin));
+        });
+
+    return fut.get();
+}
+
 void TelemetryImpl::process_parameter_update(const std::string& name)
 {
     if (name.compare("CAL_GYRO0_ID") == 0) {

--- a/src/plugins/telemetry/telemetry_impl.h
+++ b/src/plugins/telemetry/telemetry_impl.h
@@ -68,6 +68,9 @@ public:
     void set_rate_distance_sensor_async(double rate_hz, Telemetry::ResultCallback callback);
     void set_rate_unix_epoch_time_async(double rate_hz, Telemetry::ResultCallback callback);
 
+    void get_gps_global_origin_async(const Telemetry::GetGpsGlobalOriginCallback callback);
+    std::pair<Telemetry::Result, Telemetry::GpsGlobalOrigin> get_gps_global_origin();
+
     Telemetry::PositionVelocityNed position_velocity_ned() const;
     Telemetry::Position position() const;
     Telemetry::Position home() const;


### PR DESCRIPTION
This adds support for GPS_GLOBAL_ORIGIN through MAV_CMD_REQUEST_MESSAGE.

Note: depends on https://github.com/mavlink/MAVSDK-Proto/pull/187