### PR TITLE
Update docker: PX4 releases and bump Fedora version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -206,7 +206,7 @@ jobs:
     container: mavsdk/mavsdk-${{ matrix.container_name }}
     strategy:
       matrix:
-        container_name: [fedora-31, fedora-32]
+        container_name: [fedora-32, fedora-33]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/docker/Dockerfile-Fedora-33
+++ b/docker/Dockerfile-Fedora-33
@@ -1,10 +1,10 @@
 #
-# Development environment for the MAVSDK based on Fedora 31.
+# Development environment for the MAVSDK based on Fedora 33.
 #
 # Author: Julian Oes <julian@oes.ch>
 #
 
-FROM fedora:31
+FROM fedora:33
 
 MAINTAINER Julian Oes <julian@oes.ch>
 

--- a/docker/Dockerfile-Ubuntu-18.04-PX4-SITL-v1.10
+++ b/docker/Dockerfile-Ubuntu-18.04-PX4-SITL-v1.10
@@ -1,5 +1,5 @@
 #
-# PX4 v1.10.1 SITL testing environment for MAVSDK based on Ubuntu 18.04.
+# PX4 v1.10.2 SITL testing environment for MAVSDK based on Ubuntu 18.04.
 # Author: Julian Oes <julian@oes.ch>
 #
 FROM mavsdk/mavsdk-ubuntu-18.04
@@ -34,6 +34,6 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN git clone https://github.com/PX4/Firmware.git ${FIRMWARE_DIR}
-RUN git -C ${FIRMWARE_DIR} checkout v1.10.1
+RUN git -C ${FIRMWARE_DIR} checkout v1.10.2
 RUN git -C ${FIRMWARE_DIR} submodule update --init --recursive
 RUN cd ${FIRMWARE_DIR} && DONT_RUN=1 make px4_sitl gazebo && DONT_RUN=1 make px4_sitl gazebo

--- a/docker/Dockerfile-Ubuntu-20.04-PX4-SITL-v1.11
+++ b/docker/Dockerfile-Ubuntu-20.04-PX4-SITL-v1.11
@@ -1,5 +1,5 @@
 #
-# PX4 v1.11.0 SITL testing environment for MAVSDK based on Ubuntu 20.04.
+# PX4 v1.11.2 SITL testing environment for MAVSDK based on Ubuntu 20.04.
 # Author: Julian Oes <julian@oes.ch>
 #
 FROM mavsdk/mavsdk-ubuntu-20.04
@@ -19,7 +19,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 RUN git clone https://github.com/PX4/Firmware.git ${FIRMWARE_DIR}
-RUN git -C ${FIRMWARE_DIR} checkout release/1.11-loiter-switch-fix # should point to v1.11.x again once patch is merged and released.
+RUN git -C ${FIRMWARE_DIR} checkout v1.11.2
 RUN git -C ${FIRMWARE_DIR} submodule update --init --recursive
 RUN cd ${FIRMWARE_DIR} && Tools/setup/ubuntu.sh --no-nuttx
 RUN cd ${FIRMWARE_DIR} && DONT_RUN=1 make px4_sitl gazebo && DONT_RUN=1 make px4_sitl gazebo

--- a/docker/build_and_push_docker_images.sh
+++ b/docker/build_and_push_docker_images.sh
@@ -2,16 +2,16 @@
 
 set -e
 
-docker build -f Dockerfile-Fedora-31 -t mavsdk/mavsdk-fedora-31 .
 docker build -f Dockerfile-Fedora-32 -t mavsdk/mavsdk-fedora-32 .
+docker build -f Dockerfile-Fedora-33 -t mavsdk/mavsdk-fedora-33 .
 docker build -f Dockerfile-Ubuntu-18.04 -t mavsdk/mavsdk-ubuntu-18.04 .
 docker build -f Dockerfile-Ubuntu-20.04 -t mavsdk/mavsdk-ubuntu-20.04 .
 docker build -f Dockerfile-Ubuntu-18.04-PX4-SITL-v1.9 -t mavsdk/mavsdk-ubuntu-18.04-px4-sitl-v1.9 .
 docker build -f Dockerfile-Ubuntu-18.04-PX4-SITL-v1.10 -t mavsdk/mavsdk-ubuntu-18.04-px4-sitl-v1.10 .
 docker build -f Dockerfile-Ubuntu-20.04-PX4-SITL-v1.11 -t mavsdk/mavsdk-ubuntu-20.04-px4-sitl-v1.11 .
 
-docker push mavsdk/mavsdk-fedora-31:latest
 docker push mavsdk/mavsdk-fedora-32:latest
+docker push mavsdk/mavsdk-fedora-33:latest
 docker push mavsdk/mavsdk-ubuntu-18.04:latest
 docker push mavsdk/mavsdk-ubuntu-20.04:latest
 docker push mavsdk/mavsdk-ubuntu-18.04-px4-sitl-v1.9:latest


### PR DESCRIPTION
See commits. Docker images are already regenerated and pushed to dockerhub.