### PR TITLE
manual_control: use proper result if input not set

### DIFF
--- a/src/plugins/manual_control/manual_control_impl.cpp
+++ b/src/plugins/manual_control/manual_control_impl.cpp
@@ -32,7 +32,7 @@ void ManualControlImpl::start_position_control_async(const ManualControl::Result
         if (callback) {
             auto temp_callback = callback;
             _parent->call_user_callback(
-                [temp_callback]() { temp_callback(ManualControl::Result::Unknown); });
+                [temp_callback]() { temp_callback(ManualControl::Result::InputNotSet); });
         }
         return;
     }
@@ -47,7 +47,7 @@ void ManualControlImpl::start_position_control_async(const ManualControl::Result
 ManualControl::Result ManualControlImpl::start_position_control()
 {
     if (_input == Input::NotSet) {
-        return ManualControl::Result::Unknown;
+        return ManualControl::Result::InputNotSet;
     }
 
     auto prom = std::promise<ManualControl::Result>();
@@ -64,7 +64,7 @@ void ManualControlImpl::start_altitude_control_async(const ManualControl::Result
         if (callback) {
             auto temp_callback = callback;
             _parent->call_user_callback(
-                [temp_callback]() { temp_callback(ManualControl::Result::Unknown); });
+                [temp_callback]() { temp_callback(ManualControl::Result::InputNotSet); });
         }
         return;
     }
@@ -78,7 +78,7 @@ void ManualControlImpl::start_altitude_control_async(const ManualControl::Result
 ManualControl::Result ManualControlImpl::start_altitude_control()
 {
     if (_input == Input::NotSet) {
-        return ManualControl::Result::Unknown;
+        return ManualControl::Result::InputNotSet;
     }
     auto prom = std::promise<ManualControl::Result>();
     auto fut = prom.get_future();

--- a/src/plugins/manual_control/manual_control_impl.h
+++ b/src/plugins/manual_control/manual_control_impl.h
@@ -28,11 +28,12 @@ public:
     ManualControl::Result set_manual_control_input(float x, float y, float z, float r);
 
 private:
-    enum class Input { NotSet, Set } _input = Input::NotSet;
     ManualControl::Result
     manual_control_result_from_command_result(MavlinkCommandSender::Result result);
     void command_result_callback(
         MavlinkCommandSender::Result command_result, const ManualControl::ResultCallback& callback);
+
+    enum class Input { NotSet, Set } _input{Input::NotSet};
 };
 
 } // namespace mavsdk


### PR DESCRIPTION
A result/error of unknown is not a good user feedback. Instead we need
to communicate the actual reason.

Closes #1173.