### PR TITLE
third_party: use git apply, not patch

### DIFF
--- a/src/core/mavlink_statustext_handler_test.cpp
+++ b/src/core/mavlink_statustext_handler_test.cpp
@@ -1,5 +1,6 @@
 
 #include "mavlink_statustext_handler.h"
+#include <algorithm>
 #include <gtest/gtest.h>
 
 using namespace mavsdk;

--- a/third_party/curl/CMakeLists.txt
+++ b/third_party/curl/CMakeLists.txt
@@ -35,8 +35,10 @@ endforeach()
 
 ExternalProject_add(
     curl
-    URL https://github.com/curl/curl/archive/curl-7_73_0.zip
+    GIT_REPOSITORY https://github.com/curl/curl.git
+    GIT_TAG curl-7_73_0
+    GIT_SHALLOW ON
     PREFIX curl
-    PATCH_COMMAND patch CMakeLists.txt < ${PROJECT_SOURCE_DIR}/curl.patch
+    PATCH_COMMAND git apply ${PROJECT_SOURCE_DIR}/curl.patch
     CMAKE_ARGS "${CMAKE_ARGS}"
     )

--- a/third_party/curl/curl.patch
+++ b/third_party/curl/curl.patch
@@ -1,9 +1,11 @@
---- CMakeLists.txt	2020-10-22 13:52:47.849069912 -0800
-+++ CMakeLists.txt	2020-10-22 13:52:36.053060360 -0800
-@@ -371,6 +371,9 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ec1cfa782..bb95041d2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -386,6 +386,9 @@ if(CMAKE_USE_OPENSSL)
    set(SSL_ENABLED ON)
    set(USE_OPENSSL ON)
-
+ 
 +  list(APPEND OPENSSL_LIBRARIES rt)
 +  list(APPEND CURL_LIBS rt)
 +


### PR DESCRIPTION
Because we don't necessarily have patch on Win.