### PR TITLE
Fix Windows build when MAVSDK with SUPERBUILD is external project

### DIFF
--- a/third_party/cmake/build_target.cmake
+++ b/third_party/cmake/build_target.cmake
@@ -16,7 +16,6 @@ function(build_target TARGET_NAME)
             "-G${CMAKE_GENERATOR}"
             "${PLATFORM_ARGUMENT}"
             "-DCMAKE_TOOLCHAIN_FILE:PATH=${CMAKE_TOOLCHAIN_FILE}"
-            "${CL_ARGS}"
             "-DCL_ARGS=${CL_ARGS}"
             "-DCMAKE_INSTALL_PREFIX:PATH=${TARGET_INSTALL_DIR}"
             "-DCMAKE_PREFIX_PATH:PATH=${CMAKE_PREFIX_PATH}"


### PR DESCRIPTION
Does that make any sense? It seems to work.