### PR TITLE
Add option to build macos framework

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -445,7 +445,7 @@ jobs:
         run: bash ./src/backend/tools/package_backend_framework.bash
       - uses: actions/upload-artifact@v2
         with:
-          name: mavsdk_server_ios.xcframework
+          name: mavsdk_server.xcframework
           path: ./build/mavsdk_server.xcframework
           retention-days: 2
       - name: Publish artefacts
@@ -453,8 +453,8 @@ jobs:
         uses: svenstaro/upload-release-action@v1-release
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: 'build/mavsdk_server.zip'
-          asset_name: 'mavsdk_server_ios.zip'
+          file: 'build/mavsdk_server.xcframework.zip'
+          asset_name: 'mavsdk_server.xcframework.zip'
           tag: ${{ github.ref }}
           overwrite: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -370,6 +370,23 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
 
+  macOS-framework:
+    name: macOS-framework
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: configure
+        run: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/release/install -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -DMACOS_FRAMEWORK=ON -DWERROR=OFF -j 2 -Bbuild/macos -H.
+      - name: build
+        run: cmake --build build/macos -j 2 --target install
+      - uses: actions/upload-artifact@v2
+        with:
+          name: mavsdk_server_macos.framework
+          path: ./build/macos/src/backend/src/mavsdk_server.framework
+          retention-days: 2
+
   iOS:
     name: iOS
     runs-on: macos-latest
@@ -406,7 +423,7 @@ jobs:
 
   iOS-XCFramework:
     name: iOS XCFramework
-    needs: [iOS, iOS-Simulator]
+    needs: [macOS-framework, iOS, iOS-Simulator]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
@@ -420,6 +437,10 @@ jobs:
         with:
           name: mavsdk_server_ios_simulator.framework
           path: ./build/ios_simulator/src/backend/src/mavsdk_server.framework
+      - uses: actions/download-artifact@v2
+        with:
+          name: mavsdk_server_macos.framework
+          path: ./build/macos/src/backend/src/mavsdk_server.framework
       - name: Package
         run: bash ./src/backend/tools/package_backend_framework.bash
       - uses: actions/upload-artifact@v2

--- a/src/backend/src/CMakeLists.txt
+++ b/src/backend/src/CMakeLists.txt
@@ -29,14 +29,14 @@ set(BACKEND_SOURCES
     grpc_server.cpp
 )
 
-if(IOS)
+if(IOS OR (APPLE AND MACOS_FRAMEWORK))
     set_property(SOURCE module.modulemap
         PROPERTY MACOSX_PACKAGE_LOCATION "Modules")
 
     list(APPEND BACKEND_SOURCES module.modulemap)
 endif()
 
-if(IOS OR ANDROID)
+if(IOS OR ANDROID OR (APPLE AND MACOS_FRAMEWORK))
     add_library(mavsdk_server SHARED ${BACKEND_SOURCES})
 else()
     add_library(mavsdk_server ${BACKEND_SOURCES})
@@ -116,7 +116,7 @@ if(NOT IOS AND NOT ANDROID)
 endif()
 
 # iOS builds mavsdk_server.framework
-if(IOS)
+if(IOS OR (APPLE AND MACOS_FRAMEWORK))
     set_target_properties(mavsdk_server PROPERTIES
         FRAMEWORK TRUE
         BUILD_WITH_INSTALL_RPATH TRUE

--- a/src/backend/tools/package_backend_framework.bash
+++ b/src/backend/tools/package_backend_framework.bash
@@ -14,12 +14,12 @@ if [ -d ${BUILD_DIR}/mavsdk_server.xcframework ]; then
 fi
 
 echo "Fixing Modules in macOS framework"
-ln -s Versions/Current/Modules ${MACOS_BACKEND_DIR}/mavsdk_server.framework
+ln -sf Versions/Current/Modules ${MACOS_BACKEND_DIR}/mavsdk_server.framework
 
 echo "Creating xcframework..."
 xcodebuild -create-xcframework -framework ${IOS_BACKEND_DIR}/mavsdk_server.framework -framework ${IOS_SIM_BACKEND_DIR}/mavsdk_server.framework -framework ${MACOS_BACKEND_DIR}/mavsdk_server.framework -output ${BUILD_DIR}/mavsdk_server.xcframework
 
 cd ${BUILD_DIR}
-zip -9 -r mavsdk_server.zip mavsdk_server.xcframework
+zip -9 -r mavsdk_server.xcframework.zip mavsdk_server.xcframework
 
 echo "Success! You will find the xcframework in ${BUILD_DIR}!"

--- a/src/backend/tools/package_backend_framework.bash
+++ b/src/backend/tools/package_backend_framework.bash
@@ -6,14 +6,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR=${SCRIPT_DIR}/../../../build
 IOS_BACKEND_DIR=${BUILD_DIR}/ios/src/backend/src
 IOS_SIM_BACKEND_DIR=${BUILD_DIR}/ios_simulator/src/backend/src
+MACOS_BACKEND_DIR=${BUILD_DIR}/macos/src/backend/src
 
 if [ -d ${BUILD_DIR}/mavsdk_server.xcframework ]; then
     echo "${BUILD_DIR}/mavsdk_server.xcframework already exists! Aborting..."
     exit 1
 fi
 
+echo "Fixing Modules in macOS framework"
+ln -s Versions/Current/Modules ${MACOS_BACKEND_DIR}/mavsdk_server.framework
+
 echo "Creating xcframework..."
-xcodebuild -create-xcframework -framework ${IOS_BACKEND_DIR}/mavsdk_server.framework -framework ${IOS_SIM_BACKEND_DIR}/mavsdk_server.framework -output ${BUILD_DIR}/mavsdk_server.xcframework
+xcodebuild -create-xcframework -framework ${IOS_BACKEND_DIR}/mavsdk_server.framework -framework ${IOS_SIM_BACKEND_DIR}/mavsdk_server.framework -framework ${MACOS_BACKEND_DIR}/mavsdk_server.framework -output ${BUILD_DIR}/mavsdk_server.xcframework
 
 cd ${BUILD_DIR}
 zip -9 -r mavsdk_server.zip mavsdk_server.xcframework


### PR DESCRIPTION
For Python, we need `mavsdk_server` as a macOS (almost-)static binary (the equivalent of manylinux).
For Swift, the idea would be to add macOS into the xcframework, such that it would "just work" with SwiftPM. That is what this PR is about.

It needs some testing with MAVSDK-Swift, and then the artifact would be rename from `mavsdk_server_ios.zip` to maybe `mavsdk_server.xcframework.zip`, or something like that.