### PR TITLE
Handle Result as parameter

### DIFF
--- a/templates/plugin_h/call.j2
+++ b/templates/plugin_h/call.j2
@@ -4,7 +4,7 @@
  *
  * This function is non-blocking.{% if is_sync %} See '{{ name.lower_snake_case }}' for the blocking counterpart.{% endif %}
  */
-void {{ name.lower_snake_case }}_async({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}, {% endfor %}const ResultCallback callback);
+void {{ name.lower_snake_case }}_async({% for param in params %}{% if param.type_info.name.endswith("Result") %}Result{% else %}{{ param.type_info.name }}{% endif %} {{ param.name.lower_snake_case }}, {% endfor %}const ResultCallback callback);
 {% endif %}
 
 {% if is_sync %}
@@ -15,5 +15,5 @@ void {{ name.lower_snake_case }}_async({% for param in params %}{{ param.type_in
  *
  * @return Result of request.
  */
-{% if has_result %}Result{% else %}void{% endif %} {{ name.lower_snake_case }}({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}{{ ", " if not loop.last }}{% endfor %}) const;
+{% if has_result %}Result{% else %}void{% endif %} {{ name.lower_snake_case }}({% for param in params %}{% if param.type_info.name.endswith("Result") %}Result{% else %}{{ param.type_info.name }}{% endif %} {{ param.name.lower_snake_case }}{{ ", " if not loop.last }}{% endfor %}) const;
 {% endif %}

--- a/templates/plugin_h/request.j2
+++ b/templates/plugin_h/request.j2
@@ -9,7 +9,7 @@ using {{ name.upper_camel_case }}Callback = std::function<void({% if has_result 
  *
  * This function is non-blocking.{% if is_sync %} See '{{ name.lower_snake_case }}' for the blocking counterpart.{% endif %}
  */
-void {{ name.lower_snake_case }}_async({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}, {% endfor %}const {{ name.upper_camel_case }}Callback callback);
+void {{ name.lower_snake_case }}_async({% for param in params %}{% if param.type_info.name.endswith("Result") %}Result{% else %}{{ param.type_info.name }}{% endif %} {{ param.name.lower_snake_case }}, {% endfor %}const {{ name.upper_camel_case }}Callback callback);
 {% endif %}
 
 {% if is_sync %}
@@ -20,5 +20,5 @@ void {{ name.lower_snake_case }}_async({% for param in params %}{{ param.type_in
  *
  * @return Result of request.
  */
-{% if has_result %}std::pair<Result{% endif %}{% if has_result %}, {% endif %}{% if return_type.is_repeated %}std::vector<{% if not return_type.is_primitive%}{{ plugin_name.upper_camel_case }}::{% endif %}{{ return_type.inner_name }}>{% else %}{% if not return_type.is_primitive%}{{ plugin_name.upper_camel_case }}::{% endif %}{{ return_type.name }}{% endif %}{% if has_result %}>{% endif %} {{ name.lower_snake_case }}({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}{{ ", " if not loop.last }}{% endfor %}) const;
+{% if has_result %}std::pair<Result, {% endif %}{% if return_type.is_repeated %}std::vector<{% if not return_type.is_primitive%}{{ plugin_name.upper_camel_case }}::{% endif %}{{ return_type.inner_name }}>{% else %}{% if not return_type.is_primitive%}{{ plugin_name.upper_camel_case }}::{% endif %}{{ return_type.name }}{% endif %}{% if has_result %}>{% endif %} {{ name.lower_snake_case }}({% for param in params %}{% if param.type_info.name.endswith("Result") %}Result{% else %}{{ param.type_info.name }}{% endif %} {{ param.name.lower_snake_case }}{{ ", " if not loop.last }}{% endfor %}) const;
 {% endif %}


### PR DESCRIPTION
A `Result` needs to be treated differently than other types in the templates. This is fixing the templates when `Result` is used as a parameter to a function.

@TSC21: FYI