### PR TITLE
core: attempt to fix connection race

### DIFF
--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -318,7 +318,7 @@ private:
     static constexpr double _HEARTBEAT_TIMEOUT_S = 3.0;
 
     std::mutex _connection_mutex{};
-    bool _connected{false};
+    std::atomic<bool> _connected{false};
     System::IsConnectedCallback _is_connected_callback{nullptr};
     void* _heartbeat_timeout_cookie = nullptr;
 


### PR DESCRIPTION
This is an attempt to prevent the race between the _connected flag and calling the on_change subscription.