### PR TITLE
Fix ios_simulator to xcode 12.0.1, because it seems to fail with 12.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -411,6 +411,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '12.0.1'
       - name: configure
         run: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$(pwd)/tools/ios.toolchain.cmake -DPLATFORM=SIMULATOR64 -DDEPLOYMENT_TARGET=11.0 -DBUILD_BACKEND=ON -DBUILD_SHARED_LIBS=OFF -DWERROR=OFF -j 2 -Bbuild/ios_simulator -H.
       - name: build


### PR DESCRIPTION
Let's see if that helps, but locally it builds with 12.2 :thinking:.