### PR TITLE
Do not throw SIGPIPE when TCP connection is closed

### DIFF
--- a/src/core/mavsdk_impl.cpp
+++ b/src/core/mavsdk_impl.cpp
@@ -452,6 +452,12 @@ void MavsdkImpl::notify_on_timeout(const uint64_t uuid)
     if (_on_timeout_callback) {
         _on_timeout_callback(uuid);
     }
+
+    std::lock_guard<std::mutex> lock(_new_system_callback_mutex);
+    if (_new_system_callback) {
+        auto temp_callback = _new_system_callback;
+        call_user_callback([temp_callback]() { temp_callback(); });
+    }
 }
 
 void MavsdkImpl::subscribe_on_new_system(Mavsdk::NewSystemCallback callback)

--- a/src/core/tcp_connection.cpp
+++ b/src/core/tcp_connection.cpp
@@ -130,6 +130,10 @@ ConnectionResult TcpConnection::stop()
 
 bool TcpConnection::send_message(const mavlink_message_t& message)
 {
+    if (!_is_ok) {
+        return false;
+    }
+
     if (_remote_ip.empty()) {
         LogErr() << "Remote IP unknown";
         return false;

--- a/src/core/tcp_connection.cpp
+++ b/src/core/tcp_connection.cpp
@@ -153,11 +153,17 @@ bool TcpConnection::send_message(const mavlink_message_t& message)
     // TODO: remove this assert again
     assert(buffer_len <= MAVLINK_MAX_PACKET_LEN);
 
+#if defined(WINDOWS)
+    auto flags = 0;
+#else
+    auto flags = MSG_NOSIGNAL;
+#endif
+
     const auto send_len = sendto(
         _socket_fd,
         reinterpret_cast<char*>(buffer),
         buffer_len,
-        0,
+        flags,
         reinterpret_cast<const sockaddr*>(&dest_addr),
         sizeof(dest_addr));
 


### PR DESCRIPTION
* Do not throw SIGPIPE when TCP connection ends (ignore and retry instead)
* Ignore send_message() while TCP connection is off
* mavsdk_server: send connection state when system gets disconnected
* mavsdk_server: send connection state on subscribe (instead of having to wait for an update)