### PR TITLE
Add linux-armv6-musl build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -282,7 +282,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        arch_name: [linux-armv7l-musl, linux-arm64-musl]
+        arch_name: [linux-armv6-musl, linux-armv7l-musl, linux-arm64-musl]
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Useful for e.g. RPi Zero.