### PR TITLE
docker containers: move install of locales and git to Dockerfile-Ubuntu-20.04

### DIFF
--- a/docker/Dockerfile-Ubuntu-20.04
+++ b/docker/Dockerfile-Ubuntu-20.04
@@ -29,6 +29,7 @@ RUN apt-get update \
         libtinyxml2-dev \
         libtool \
         libz-dev \
+        locales \
         ninja-build \
         python3 \
         python3-pip \

--- a/docker/Dockerfile-Ubuntu-20.04-PX4-SITL-v1.11
+++ b/docker/Dockerfile-Ubuntu-20.04-PX4-SITL-v1.11
@@ -7,12 +7,6 @@ MAINTAINER Julian Oes <julian@oes.ch>
 
 ENV FIRMWARE_DIR ${WORKDIR}../Firmware
 
-RUN apt-get update && \
-    apt-get install -y git locales \
-    && apt-get -y autoremove \
-    && apt-get clean autoclean \
-    && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
-
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en


### PR DESCRIPTION
* `git` was already in `Dockerfile-Ubuntu-20.04`
* moved `locales` as well as only `Dockerfile-Ubuntu-20.04-PX4-SITL-v1.11` depends on it and makes the file cleaner