### PR TITLE
Test: using a custom dialect

### DIFF
--- a/examples/dialect/CMakeLists.txt
+++ b/examples/dialect/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.10.2)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+project(dialect)
+
+if(NOT MSVC)
+    add_definitions("-Wall -Wextra ")
+    add_definitions("-Wno-address-of-packed-member")
+else()
+    add_definitions("-WX -W2")
+endif()
+
+find_package(MAVSDK REQUIRED)
+
+add_executable(dialect_client
+    dialect_client.cpp
+)
+
+target_link_libraries(dialect_client
+    MAVSDK::mavsdk_mavlink_passthrough
+    MAVSDK::mavsdk
+)
+
+add_executable(dialect_server
+    dialect_server.cpp
+)
+
+target_link_libraries(dialect_server
+    MAVSDK::mavsdk_mavlink_passthrough
+    MAVSDK::mavsdk
+)

--- a/examples/dialect/dialect_client.cpp
+++ b/examples/dialect/dialect_client.cpp
@@ -1,0 +1,83 @@
+#include <mavsdk/mavsdk.h>
+#include <mavsdk/plugins/mavlink_passthrough/mavlink_passthrough.h>
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <future>
+#include <memory>
+
+using namespace mavsdk;
+
+static void usage(const std::string& bin_name);
+static std::string mood2str(const uint8_t mood_enum_value);
+
+int main(int argc, char** argv)
+{
+    Mavsdk mavsdk;
+    std::string connection_url;
+    ConnectionResult connection_result;
+
+    if (argc == 2) {
+        connection_url = argv[1];
+        connection_result = mavsdk.add_any_connection(connection_url);
+    } else {
+        usage(argv[0]);
+        return 1;
+    }
+
+    if (connection_result != ConnectionResult::Success) {
+        std::cout << "Connection failed: " << connection_result << std::endl;
+        return 1;
+    }
+
+    std::promise<void> prom;
+    std::future<void> fut = prom.get_future();
+    std::cout << "Waiting to discover system..." << std::endl;
+    mavsdk.subscribe_on_new_system([&mavsdk, &prom]() {
+        const auto system = mavsdk.systems().at(0);
+
+        if (system->is_connected()) {
+            prom.set_value();
+        }
+    });
+    fut.wait();
+
+    auto system = mavsdk.systems().at(0);
+    auto mavlink_passthrough = MavlinkPassthrough{system};
+
+    mavlink_passthrough.subscribe_message_async(MAVLINK_MSG_ID_CURRENT_MOOD, [](const mavlink_message_t& message) {
+        mavlink_current_mood_t current_mood;
+        mavlink_msg_current_mood_decode(&message, &current_mood);
+
+        std::cout << "Current mood is: " << mood2str(current_mood.mood) << std::endl;
+    });
+
+    std::promise<void> termination_prom;
+    auto termination_fut = termination_prom.get_future();
+    termination_fut.wait();
+
+    return 0;
+}
+
+void usage(const std::string& bin_name)
+{
+    std::cout << "Usage : " << bin_name << " <connection_url>" << std::endl
+              << "Connection URL format should be :" << std::endl
+              << " For TCP : tcp://[server_host][:server_port]" << std::endl
+              << " For UDP : udp://[bind_host][:bind_port]" << std::endl
+              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl
+              << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
+}
+
+std::string mood2str(const uint8_t mood_enum_value)
+{
+    switch (mood_enum_value) {
+        case 1:
+            return "Happy";
+        case 2:
+            return "Sad";
+        case 3:
+        default:
+            return "Not sure";
+    }
+}

--- a/examples/dialect/dialect_server.cpp
+++ b/examples/dialect/dialect_server.cpp
@@ -1,0 +1,61 @@
+#include <mavsdk/mavsdk.h>
+#include <mavsdk/plugins/mavlink_passthrough/mavlink_passthrough.h>
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <future>
+#include <memory>
+
+using namespace mavsdk;
+
+static void send_current_mood(MavlinkPassthrough& mavlink_passthrough);
+static void usage(const std::string& bin_name);
+
+int main(int argc, char** argv)
+{
+    if (argc != 3) {
+        usage(argv[0]);
+        return 1;
+    }
+
+    Mavsdk mavsdk;
+    Mavsdk::Configuration configuration(Mavsdk::Configuration::UsageType::CompanionComputer);
+    mavsdk.set_configuration(configuration);
+    ConnectionResult connection_result = mavsdk.setup_udp_remote(argv[1], std::stoi(argv[2]));
+
+    if (connection_result != ConnectionResult::Success) {
+        std::cout << "Connection failed: " << connection_result << std::endl;
+        return 1;
+    }
+
+    auto system = mavsdk.systems().at(0);
+    auto mavlink_passthrough = MavlinkPassthrough{system};
+
+    std::cout << "Starting to broadcast mood to " << argv[1] << ":" << argv[2] << std::endl;
+
+    while (true) {
+        std::cout << "Sending mood" << std::endl;
+        send_current_mood(mavlink_passthrough);
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    return 0;
+}
+
+void send_current_mood(MavlinkPassthrough& mavlink_passthrough)
+{
+    mavlink_message_t message;
+    mavlink_msg_current_mood_pack(
+        mavlink_passthrough.get_our_sysid(),
+        mavlink_passthrough.get_our_compid(),
+        &message,
+        HAPPY
+        );
+
+    mavlink_passthrough.send_message(message);
+}
+
+void usage(const std::string& bin_name)
+{
+    std::cout << "Usage : " << bin_name << " <remote_ip> <remote_port>" << std::endl;
+}

--- a/src/core/mavlink_include.h
+++ b/src/core/mavlink_include.h
@@ -4,4 +4,4 @@
 #pragma GCC system_header
 #endif
 
-#include "mavlink/v2.0/common/mavlink.h"
+#include "mavlink/v2.0/custom/mavlink.h"


### PR DESCRIPTION
The purpose of this PR is to quickly test and document using a custom dialect in MAVSDK. __It is not meant to be merged as-is.__

### Dialect definition

In order to use a custom dialect, I went for [forking c_library_v2](https://github.com/JonasVautherin/c_library_v2) and [adding my dialect file there](https://github.com/JonasVautherin/c_library_v2/commit/4b28035416b6154faf290f97acdd620038558347), called "custom.xml". It looks like this (note that it includes "common.xml"):

```xml
<?xml version="1.0"?>
<mavlink>
  <include>common.xml</include>
  <!-- Note that custom messages should use the command id range from 150 to 250, to leave plenty of room for growth of common.xml If you prototype a message here, then you should consider if it is general enough to move into common.xml later -->
  <enums>
    <enum name="MOOD">
      <entry value="1" name="HAPPY"/>
      <entry value="2" name="SAD"/>
      <entry value="3" name="NOT_SURE"/>
    </enum>
  </enums>
  <messages>
    <message id="150" name="CURRENT_MOOD">
      <description>Message containing the mood of the source</description>
      <field type="uint8_t" name="mood" enum="MOOD">Mood</field>
    </message>
  </messages>
</mavlink>
```

### MAVLink headers in MAVSDK

In the MAVSDK repo, we now need to replace the MAVLink submodule by our fork, that contains the dialect:

```
cd /path/to/mavsdk
cd src/third_party/mavlink/include/mavlink/v2.0
git remote set-url origin git@github.com:jonasvautherin/c_library_v2 # Replace jonasvautherin with your github username
```

### MAVLink headers generation

Once the dialect file is written, the next step is to generate the MAVLink headers, which in this case resulted in [the changes linked here](https://github.com/JonasVautherin/c_library_v2/commit/47429f48541b55a13b08a89a9189e69cd4ebbff3). This was done by running `mavgen.py` from the root of MAVSDK, as follows:

```
mavgen.py --lang=C --wire-protocol=2.0 --output=$(pwd)/src/third_party/mavlink/include/mavlink/v2.0 $(pwd)/src/third_party/mavlink/include/mavlink/v2.0/message_definitions/custom.xml
```

Note that `mavgen.py` needs to be in your PATH. One way to do that is to install MAVLink in a venv:

```
TMP_DIR="$(mktemp -d)" # Create a temporary directory
cd ${TMP_DIR} # Change to this newly-created directory
python3 -m venv venv # Create a new venv in ${TMP_DIR}/venv
source ./venv/bin/activate # Activate the venv

# Install mavlink in that venv, effectively putting mavgen.py in the PATH
git clone https://github.com/mavlink/mavlink --recursive
cd mavlink/pymavlink
pip install -e .

# Move to the root of the MAVSDK repo and generate the MAVLink headers
cd /path/to/mavsdk
mavgen.py --lang=C --wire-protocol=2.0 --output=$(pwd)/src/third_party/mavlink/include/mavlink/v2.0 $(pwd)/src/third_party/mavlink/include/mavlink/v2.0/message_definitions/custom.xml
```

### Using in MAVSDK

Now that we have generated the MAVLink headers for our `custom` dialect, we need to include them (MAVSDK upstream includes only `common`. This is done in `src/core/mavlink_include.h`, with the following change:

```
- #include "mavlink/v2.0/common/mavlink.h"
+ #include "mavlink/v2.0/custom/mavlink.h"
```