### PR TITLE
Add android-x86 and android-x86_64 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -321,6 +321,10 @@ jobs:
             arch: armeabi-v7a
           - name: android-arm64
             arch: arm64-v8a
+          - name: android-x86
+            arch: x86
+          - name: android-x86_64
+            arch: x86_64
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
It got merged into dockcross, we can now start using it :tada:.