### PR TITLE
cmake: include atomic library for armv6 and armv7

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -70,7 +70,8 @@ if(ANDROID)
     )
 endif()
 
-if(BUILD_STATIC_MAVSDK_SERVER AND ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU"))
+if( (BUILD_STATIC_MAVSDK_SERVER AND ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")) 
+    OR (${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "(armv6|armv7)") )
     target_link_libraries(mavsdk PRIVATE atomic)
 endif()
 


### PR DESCRIPTION
Compilation failed on raspberry pi (#1296). Adding the atomic library in case we are on armv6 or amrv7 fixes the issue