### PR TITLE
core: prevent confusions between path and port

### DIFF
--- a/src/core/cli_arg.cpp
+++ b/src/core/cli_arg.cpp
@@ -1,9 +1,10 @@
 #include "global_include.h"
 #include "cli_arg.h"
 #include "log.h"
-#include <vector>
 #include <cctype>
 #include <climits>
+#include <algorithm>
+#include <vector>
 
 namespace mavsdk {
 
@@ -91,8 +92,16 @@ bool CliArg::find_path(std::string& rest)
         _path = rest.substr(0, pos);
         rest.erase(0, pos + delimiter.length());
     } else {
-        _path = rest;
-        rest = "";
+        const auto path_is_only_numbers = std::all_of(
+            rest.cbegin(), rest.cend(), [](unsigned char c) { return std::isdigit(c); });
+
+        if (path_is_only_numbers) {
+            LogWarn() << "Path can't be numbers only.";
+            return false;
+        } else {
+            _path = rest;
+            rest = "";
+        }
     }
 
     if (_protocol == Protocol::Serial) {

--- a/src/core/cli_arg_test.cpp
+++ b/src/core/cli_arg_test.cpp
@@ -19,10 +19,13 @@ TEST(CliArg, UDPConnections)
     EXPECT_STREQ(ca.get_path().c_str(), "");
     EXPECT_EQ(0, ca.get_port());
 
-    ca.parse("udp://:7");
+    // Not a valid hostname
+    EXPECT_FALSE(ca.parse("udp://555"));
+
+    ca.parse("udp://:777");
     EXPECT_EQ(ca.get_protocol(), CliArg::Protocol::Udp);
     EXPECT_STREQ(ca.get_path().c_str(), "");
-    EXPECT_EQ(7, ca.get_port());
+    EXPECT_EQ(777, ca.get_port());
 
     ca.parse("udp://0.0.0.0");
     EXPECT_EQ(ca.get_protocol(), CliArg::Protocol::Udp);


### PR DESCRIPTION
This change makes sure that the parser complains if parses a number only which is likely meant as a port.

So ths makes sure that udp://14540 fails while udp://:14540 passes.

Fixes #1299.