### PR TITLE
ftp: add O_TRUNC flag if file is created

### DIFF
--- a/src/plugins/ftp/ftp_impl.cpp
+++ b/src/plugins/ftp/ftp_impl.cpp
@@ -819,7 +819,7 @@ void FtpImpl::process_mavlink_ftp_message(const mavlink_message_t& msg)
 
             case CMD_CREATE_FILE:
                 LogInfo() << "OPC:CMD_CREATE_FILE";
-                error_code = _work_open(payload, O_CREAT | O_WRONLY);
+                error_code = _work_open(payload, O_CREAT | O_TRUNC | O_WRONLY);
                 break;
 
             case CMD_OPEN_FILE_WO:


### PR DESCRIPTION
This way we match the implementation in PX4 and ArduPilot, and are consistent with
https://pubs.opengroup.org/onlinepubs/9699919799/functions/creat.html

Also see discussion in https://github.com/mavlink/mavlink-devguide/issues/301