### PR TITLE
gimbal: implement angular rate setpoints

### DIFF
--- a/src/integration_tests/gimbal.cpp
+++ b/src/integration_tests/gimbal.cpp
@@ -20,8 +20,6 @@ void send_gimbal_roi_location(
 void receive_gimbal_result(Gimbal::Result result);
 void receive_gimbal_attitude_euler_angles(Telemetry::EulerAngle euler_angle);
 
-// Note, this test does not work in SITL because the gimbal does not move
-// unless it is armed.
 TEST(SitlTestGimbal, GimbalMove)
 {
     Mavsdk mavsdk;
@@ -48,7 +46,26 @@ TEST(SitlTestGimbal, GimbalMove)
 
     EXPECT_EQ(gimbal->set_mode(Gimbal::GimbalMode::YawFollow), Gimbal::Result::Success);
 
-    gimbal_pattern(gimbal);
+    LogInfo() << "Pitch down for a  bit";
+    EXPECT_EQ(gimbal->set_pitch_rate_and_yaw_rate(-10.0f, 0.0f), Gimbal::Result::Success);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    LogInfo() << "Pitch up for a bit";
+    EXPECT_EQ(gimbal->set_pitch_rate_and_yaw_rate(10.0f, 0.0f), Gimbal::Result::Success);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    LogInfo() << "Yaw right for a bit";
+    EXPECT_EQ(gimbal->set_pitch_rate_and_yaw_rate(0.0f, 10.0f), Gimbal::Result::Success);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    LogInfo() << "Yaw left for a bit";
+    EXPECT_EQ(gimbal->set_pitch_rate_and_yaw_rate(0.0f, -10.0f), Gimbal::Result::Success);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    LogInfo() << "Reset back to 0,0";
+    EXPECT_EQ(gimbal->set_pitch_and_yaw(0.0f, 0.0f), Gimbal::Result::Success);
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
 }
 
 TEST(SitlTestGimbal, GimbalAngles)

--- a/src/mavsdk_server/src/generated/gimbal/gimbal.grpc.pb.cc
+++ b/src/mavsdk_server/src/generated/gimbal/gimbal.grpc.pb.cc
@@ -25,6 +25,7 @@ namespace gimbal {
 
 static const char* GimbalService_method_names[] = {
   "/mavsdk.rpc.gimbal.GimbalService/SetPitchAndYaw",
+  "/mavsdk.rpc.gimbal.GimbalService/SetPitchRateAndYawRate",
   "/mavsdk.rpc.gimbal.GimbalService/SetMode",
   "/mavsdk.rpc.gimbal.GimbalService/SetRoiLocation",
 };
@@ -37,8 +38,9 @@ std::unique_ptr< GimbalService::Stub> GimbalService::NewStub(const std::shared_p
 
 GimbalService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel)
   : channel_(channel), rpcmethod_SetPitchAndYaw_(GimbalService_method_names[0], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetMode_(GimbalService_method_names[1], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRoiLocation_(GimbalService_method_names[2], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetPitchRateAndYawRate_(GimbalService_method_names[1], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetMode_(GimbalService_method_names[2], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRoiLocation_(GimbalService_method_names[3], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status GimbalService::Stub::SetPitchAndYaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest& request, ::mavsdk::rpc::gimbal::SetPitchAndYawResponse* response) {
@@ -60,6 +62,29 @@ void GimbalService::Stub::experimental_async::SetPitchAndYaw(::grpc::ClientConte
 ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetPitchAndYawResponse>* GimbalService::Stub::AsyncSetPitchAndYawRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest& request, ::grpc::CompletionQueue* cq) {
   auto* result =
     this->PrepareAsyncSetPitchAndYawRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::Status GimbalService::Stub::SetPitchRateAndYawRate(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest& request, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_SetPitchRateAndYawRate_, context, request, response);
+}
+
+void GimbalService::Stub::experimental_async::SetPitchRateAndYawRate(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* request, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetPitchRateAndYawRate_, context, request, response, std::move(f));
+}
+
+void GimbalService::Stub::experimental_async::SetPitchRateAndYawRate(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* request, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetPitchRateAndYawRate_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>* GimbalService::Stub::PrepareAsyncSetPitchRateAndYawRateRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_SetPitchRateAndYawRate_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>* GimbalService::Stub::AsyncSetPitchRateAndYawRateRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncSetPitchRateAndYawRateRaw(context, request, cq);
   result->StartCall();
   return result;
 }
@@ -124,6 +149,16 @@ GimbalService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       GimbalService_method_names[1],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< GimbalService::Service, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](GimbalService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* req,
+             ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* resp) {
+               return service->SetPitchRateAndYawRate(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      GimbalService_method_names[2],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< GimbalService::Service, ::mavsdk::rpc::gimbal::SetModeRequest, ::mavsdk::rpc::gimbal::SetModeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](GimbalService::Service* service,
              ::grpc::ServerContext* ctx,
@@ -132,7 +167,7 @@ GimbalService::Service::Service() {
                return service->SetMode(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      GimbalService_method_names[2],
+      GimbalService_method_names[3],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< GimbalService::Service, ::mavsdk::rpc::gimbal::SetRoiLocationRequest, ::mavsdk::rpc::gimbal::SetRoiLocationResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](GimbalService::Service* service,
@@ -147,6 +182,13 @@ GimbalService::Service::~Service() {
 }
 
 ::grpc::Status GimbalService::Service::SetPitchAndYaw(::grpc::ServerContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest* request, ::mavsdk::rpc::gimbal::SetPitchAndYawResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status GimbalService::Service::SetPitchRateAndYawRate(::grpc::ServerContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* request, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/src/mavsdk_server/src/generated/gimbal/gimbal.grpc.pb.h
+++ b/src/mavsdk_server/src/generated/gimbal/gimbal.grpc.pb.h
@@ -54,6 +54,20 @@ class GimbalService final {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::SetPitchAndYawResponse>>(PrepareAsyncSetPitchAndYawRaw(context, request, cq));
     }
     //
+    //
+    // Set gimbal angular rates around pitch and yaw axes.
+    //
+    // This sets the desired angular rates around pitch and yaw axes of a gimbal.
+    // Will return when the command is accepted, however, it might
+    // take the gimbal longer to actually reach the angular rate.
+    virtual ::grpc::Status SetPitchRateAndYawRate(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest& request, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>> AsyncSetPitchRateAndYawRate(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>>(AsyncSetPitchRateAndYawRateRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>> PrepareAsyncSetPitchRateAndYawRate(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>>(PrepareAsyncSetPitchRateAndYawRateRaw(context, request, cq));
+    }
+    //
     // Set gimbal mode.
     //
     // This sets the desired yaw mode of a gimbal.
@@ -98,6 +112,19 @@ class GimbalService final {
       virtual void SetPitchAndYaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest* request, ::mavsdk::rpc::gimbal::SetPitchAndYawResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
       #endif
       //
+      //
+      // Set gimbal angular rates around pitch and yaw axes.
+      //
+      // This sets the desired angular rates around pitch and yaw axes of a gimbal.
+      // Will return when the command is accepted, however, it might
+      // take the gimbal longer to actually reach the angular rate.
+      virtual void SetPitchRateAndYawRate(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* request, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* response, std::function<void(::grpc::Status)>) = 0;
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      virtual void SetPitchRateAndYawRate(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* request, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      #else
+      virtual void SetPitchRateAndYawRate(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* request, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
+      #endif
+      //
       // Set gimbal mode.
       //
       // This sets the desired yaw mode of a gimbal.
@@ -134,6 +161,8 @@ class GimbalService final {
   private:
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::SetPitchAndYawResponse>* AsyncSetPitchAndYawRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::SetPitchAndYawResponse>* PrepareAsyncSetPitchAndYawRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>* AsyncSetPitchRateAndYawRateRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>* PrepareAsyncSetPitchRateAndYawRateRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::SetModeResponse>* AsyncSetModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetModeRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::SetModeResponse>* PrepareAsyncSetModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetModeRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::SetRoiLocationResponse>* AsyncSetRoiLocationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetRoiLocationRequest& request, ::grpc::CompletionQueue* cq) = 0;
@@ -148,6 +177,13 @@ class GimbalService final {
     }
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetPitchAndYawResponse>> PrepareAsyncSetPitchAndYaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetPitchAndYawResponse>>(PrepareAsyncSetPitchAndYawRaw(context, request, cq));
+    }
+    ::grpc::Status SetPitchRateAndYawRate(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest& request, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>> AsyncSetPitchRateAndYawRate(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>>(AsyncSetPitchRateAndYawRateRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>> PrepareAsyncSetPitchRateAndYawRate(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>>(PrepareAsyncSetPitchRateAndYawRateRaw(context, request, cq));
     }
     ::grpc::Status SetMode(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetModeRequest& request, ::mavsdk::rpc::gimbal::SetModeResponse* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetModeResponse>> AsyncSetMode(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetModeRequest& request, ::grpc::CompletionQueue* cq) {
@@ -171,6 +207,12 @@ class GimbalService final {
       void SetPitchAndYaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest* request, ::mavsdk::rpc::gimbal::SetPitchAndYawResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       #else
       void SetPitchAndYaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest* request, ::mavsdk::rpc::gimbal::SetPitchAndYawResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
+      #endif
+      void SetPitchRateAndYawRate(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* request, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* response, std::function<void(::grpc::Status)>) override;
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      void SetPitchRateAndYawRate(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* request, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      #else
+      void SetPitchRateAndYawRate(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* request, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
       #endif
       void SetMode(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetModeRequest* request, ::mavsdk::rpc::gimbal::SetModeResponse* response, std::function<void(::grpc::Status)>) override;
       #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -197,11 +239,14 @@ class GimbalService final {
     class experimental_async async_stub_{this};
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetPitchAndYawResponse>* AsyncSetPitchAndYawRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetPitchAndYawResponse>* PrepareAsyncSetPitchAndYawRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>* AsyncSetPitchRateAndYawRateRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>* PrepareAsyncSetPitchRateAndYawRateRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetModeResponse>* AsyncSetModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetModeRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetModeResponse>* PrepareAsyncSetModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetModeRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetRoiLocationResponse>* AsyncSetRoiLocationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetRoiLocationRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetRoiLocationResponse>* PrepareAsyncSetRoiLocationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetRoiLocationRequest& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_SetPitchAndYaw_;
+    const ::grpc::internal::RpcMethod rpcmethod_SetPitchRateAndYawRate_;
     const ::grpc::internal::RpcMethod rpcmethod_SetMode_;
     const ::grpc::internal::RpcMethod rpcmethod_SetRoiLocation_;
   };
@@ -219,6 +264,14 @@ class GimbalService final {
     // Will return when the command is accepted, however, it might
     // take the gimbal longer to actually be set to the new angles.
     virtual ::grpc::Status SetPitchAndYaw(::grpc::ServerContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest* request, ::mavsdk::rpc::gimbal::SetPitchAndYawResponse* response);
+    //
+    //
+    // Set gimbal angular rates around pitch and yaw axes.
+    //
+    // This sets the desired angular rates around pitch and yaw axes of a gimbal.
+    // Will return when the command is accepted, however, it might
+    // take the gimbal longer to actually reach the angular rate.
+    virtual ::grpc::Status SetPitchRateAndYawRate(::grpc::ServerContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* request, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* response);
     //
     // Set gimbal mode.
     //
@@ -257,12 +310,32 @@ class GimbalService final {
     }
   };
   template <class BaseClass>
+  class WithAsyncMethod_SetPitchRateAndYawRate : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SetPitchRateAndYawRate() {
+      ::grpc::Service::MarkMethodAsync(1);
+    }
+    ~WithAsyncMethod_SetPitchRateAndYawRate() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetPitchRateAndYawRate(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* /*request*/, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetPitchRateAndYawRate(::grpc::ServerContext* context, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithAsyncMethod_SetMode : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetMode() {
-      ::grpc::Service::MarkMethodAsync(1);
+      ::grpc::Service::MarkMethodAsync(2);
     }
     ~WithAsyncMethod_SetMode() override {
       BaseClassMustBeDerivedFromService(this);
@@ -273,7 +346,7 @@ class GimbalService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetMode(::grpc::ServerContext* context, ::mavsdk::rpc::gimbal::SetModeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::gimbal::SetModeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -282,7 +355,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRoiLocation() {
-      ::grpc::Service::MarkMethodAsync(2);
+      ::grpc::Service::MarkMethodAsync(3);
     }
     ~WithAsyncMethod_SetRoiLocation() override {
       BaseClassMustBeDerivedFromService(this);
@@ -293,10 +366,10 @@ class GimbalService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRoiLocation(::grpc::ServerContext* context, ::mavsdk::rpc::gimbal::SetRoiLocationRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::gimbal::SetRoiLocationResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_SetPitchAndYaw<WithAsyncMethod_SetMode<WithAsyncMethod_SetRoiLocation<Service > > > AsyncService;
+  typedef WithAsyncMethod_SetPitchAndYaw<WithAsyncMethod_SetPitchRateAndYawRate<WithAsyncMethod_SetMode<WithAsyncMethod_SetRoiLocation<Service > > > > AsyncService;
   template <class BaseClass>
   class ExperimentalWithCallbackMethod_SetPitchAndYaw : public BaseClass {
    private:
@@ -345,6 +418,53 @@ class GimbalService final {
       { return nullptr; }
   };
   template <class BaseClass>
+  class ExperimentalWithCallbackMethod_SetPitchRateAndYawRate : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    ExperimentalWithCallbackMethod_SetPitchRateAndYawRate() {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodCallback(1,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* request, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* response) { return this->SetPitchRateAndYawRate(context, request, response); }));}
+    void SetMessageAllocatorFor_SetPitchRateAndYawRate(
+        ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>* allocator) {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(1);
+    #else
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(1);
+    #endif
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~ExperimentalWithCallbackMethod_SetPitchRateAndYawRate() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetPitchRateAndYawRate(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* /*request*/, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerUnaryReactor* SetPitchRateAndYawRate(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* /*request*/, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* /*response*/)
+    #else
+    virtual ::grpc::experimental::ServerUnaryReactor* SetPitchRateAndYawRate(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* /*request*/, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* /*response*/)
+    #endif
+      { return nullptr; }
+  };
+  template <class BaseClass>
   class ExperimentalWithCallbackMethod_SetMode : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
@@ -355,7 +475,7 @@ class GimbalService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(1,
+        MarkMethodCallback(2,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::gimbal::SetModeRequest, ::mavsdk::rpc::gimbal::SetModeResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -367,9 +487,9 @@ class GimbalService final {
     void SetMessageAllocatorFor_SetMode(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::gimbal::SetModeRequest, ::mavsdk::rpc::gimbal::SetModeResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(1);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(2);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(1);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(2);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::gimbal::SetModeRequest, ::mavsdk::rpc::gimbal::SetModeResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -402,7 +522,7 @@ class GimbalService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(2,
+        MarkMethodCallback(3,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::gimbal::SetRoiLocationRequest, ::mavsdk::rpc::gimbal::SetRoiLocationResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -414,9 +534,9 @@ class GimbalService final {
     void SetMessageAllocatorFor_SetRoiLocation(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::gimbal::SetRoiLocationRequest, ::mavsdk::rpc::gimbal::SetRoiLocationResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(2);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(3);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(2);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(3);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::gimbal::SetRoiLocationRequest, ::mavsdk::rpc::gimbal::SetRoiLocationResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -439,10 +559,10 @@ class GimbalService final {
       { return nullptr; }
   };
   #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-  typedef ExperimentalWithCallbackMethod_SetPitchAndYaw<ExperimentalWithCallbackMethod_SetMode<ExperimentalWithCallbackMethod_SetRoiLocation<Service > > > CallbackService;
+  typedef ExperimentalWithCallbackMethod_SetPitchAndYaw<ExperimentalWithCallbackMethod_SetPitchRateAndYawRate<ExperimentalWithCallbackMethod_SetMode<ExperimentalWithCallbackMethod_SetRoiLocation<Service > > > > CallbackService;
   #endif
 
-  typedef ExperimentalWithCallbackMethod_SetPitchAndYaw<ExperimentalWithCallbackMethod_SetMode<ExperimentalWithCallbackMethod_SetRoiLocation<Service > > > ExperimentalCallbackService;
+  typedef ExperimentalWithCallbackMethod_SetPitchAndYaw<ExperimentalWithCallbackMethod_SetPitchRateAndYawRate<ExperimentalWithCallbackMethod_SetMode<ExperimentalWithCallbackMethod_SetRoiLocation<Service > > > > ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_SetPitchAndYaw : public BaseClass {
    private:
@@ -461,12 +581,29 @@ class GimbalService final {
     }
   };
   template <class BaseClass>
+  class WithGenericMethod_SetPitchRateAndYawRate : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SetPitchRateAndYawRate() {
+      ::grpc::Service::MarkMethodGeneric(1);
+    }
+    ~WithGenericMethod_SetPitchRateAndYawRate() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetPitchRateAndYawRate(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* /*request*/, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
   class WithGenericMethod_SetMode : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetMode() {
-      ::grpc::Service::MarkMethodGeneric(1);
+      ::grpc::Service::MarkMethodGeneric(2);
     }
     ~WithGenericMethod_SetMode() override {
       BaseClassMustBeDerivedFromService(this);
@@ -483,7 +620,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRoiLocation() {
-      ::grpc::Service::MarkMethodGeneric(2);
+      ::grpc::Service::MarkMethodGeneric(3);
     }
     ~WithGenericMethod_SetRoiLocation() override {
       BaseClassMustBeDerivedFromService(this);
@@ -515,12 +652,32 @@ class GimbalService final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_SetPitchRateAndYawRate : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SetPitchRateAndYawRate() {
+      ::grpc::Service::MarkMethodRaw(1);
+    }
+    ~WithRawMethod_SetPitchRateAndYawRate() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetPitchRateAndYawRate(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* /*request*/, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetPitchRateAndYawRate(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithRawMethod_SetMode : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetMode() {
-      ::grpc::Service::MarkMethodRaw(1);
+      ::grpc::Service::MarkMethodRaw(2);
     }
     ~WithRawMethod_SetMode() override {
       BaseClassMustBeDerivedFromService(this);
@@ -531,7 +688,7 @@ class GimbalService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetMode(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -540,7 +697,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRoiLocation() {
-      ::grpc::Service::MarkMethodRaw(2);
+      ::grpc::Service::MarkMethodRaw(3);
     }
     ~WithRawMethod_SetRoiLocation() override {
       BaseClassMustBeDerivedFromService(this);
@@ -551,7 +708,7 @@ class GimbalService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRoiLocation(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -593,6 +750,44 @@ class GimbalService final {
       { return nullptr; }
   };
   template <class BaseClass>
+  class ExperimentalWithRawCallbackMethod_SetPitchRateAndYawRate : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    ExperimentalWithRawCallbackMethod_SetPitchRateAndYawRate() {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodRawCallback(1,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetPitchRateAndYawRate(context, request, response); }));
+    }
+    ~ExperimentalWithRawCallbackMethod_SetPitchRateAndYawRate() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetPitchRateAndYawRate(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* /*request*/, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerUnaryReactor* SetPitchRateAndYawRate(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
+    #else
+    virtual ::grpc::experimental::ServerUnaryReactor* SetPitchRateAndYawRate(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
+    #endif
+      { return nullptr; }
+  };
+  template <class BaseClass>
   class ExperimentalWithRawCallbackMethod_SetMode : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
@@ -603,7 +798,7 @@ class GimbalService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(1,
+        MarkMethodRawCallback(2,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -641,7 +836,7 @@ class GimbalService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(2,
+        MarkMethodRawCallback(3,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -696,12 +891,39 @@ class GimbalService final {
     virtual ::grpc::Status StreamedSetPitchAndYaw(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::gimbal::SetPitchAndYawRequest,::mavsdk::rpc::gimbal::SetPitchAndYawResponse>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
+  class WithStreamedUnaryMethod_SetPitchRateAndYawRate : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_SetPitchRateAndYawRate() {
+      ::grpc::Service::MarkMethodStreamed(1,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>* streamer) {
+                       return this->StreamedSetPitchRateAndYawRate(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_SetPitchRateAndYawRate() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SetPitchRateAndYawRate(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* /*request*/, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedSetPitchRateAndYawRate(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest,::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_SetMode : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetMode() {
-      ::grpc::Service::MarkMethodStreamed(1,
+      ::grpc::Service::MarkMethodStreamed(2,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::gimbal::SetModeRequest, ::mavsdk::rpc::gimbal::SetModeResponse>(
             [this](::grpc::ServerContext* context,
@@ -728,7 +950,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRoiLocation() {
-      ::grpc::Service::MarkMethodStreamed(2,
+      ::grpc::Service::MarkMethodStreamed(3,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::gimbal::SetRoiLocationRequest, ::mavsdk::rpc::gimbal::SetRoiLocationResponse>(
             [this](::grpc::ServerContext* context,
@@ -749,9 +971,9 @@ class GimbalService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedSetRoiLocation(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::gimbal::SetRoiLocationRequest,::mavsdk::rpc::gimbal::SetRoiLocationResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_SetPitchAndYaw<WithStreamedUnaryMethod_SetMode<WithStreamedUnaryMethod_SetRoiLocation<Service > > > StreamedUnaryService;
+  typedef WithStreamedUnaryMethod_SetPitchAndYaw<WithStreamedUnaryMethod_SetPitchRateAndYawRate<WithStreamedUnaryMethod_SetMode<WithStreamedUnaryMethod_SetRoiLocation<Service > > > > StreamedUnaryService;
   typedef Service SplitStreamedService;
-  typedef WithStreamedUnaryMethod_SetPitchAndYaw<WithStreamedUnaryMethod_SetMode<WithStreamedUnaryMethod_SetRoiLocation<Service > > > StreamedService;
+  typedef WithStreamedUnaryMethod_SetPitchAndYaw<WithStreamedUnaryMethod_SetPitchRateAndYawRate<WithStreamedUnaryMethod_SetMode<WithStreamedUnaryMethod_SetRoiLocation<Service > > > > StreamedService;
 };
 
 }  // namespace gimbal

--- a/src/mavsdk_server/src/generated/gimbal/gimbal.pb.cc
+++ b/src/mavsdk_server/src/generated/gimbal/gimbal.pb.cc
@@ -26,6 +26,14 @@ class SetPitchAndYawResponseDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<SetPitchAndYawResponse> _instance;
 } _SetPitchAndYawResponse_default_instance_;
+class SetPitchRateAndYawRateRequestDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<SetPitchRateAndYawRateRequest> _instance;
+} _SetPitchRateAndYawRateRequest_default_instance_;
+class SetPitchRateAndYawRateResponseDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<SetPitchRateAndYawRateResponse> _instance;
+} _SetPitchRateAndYawRateResponse_default_instance_;
 class SetModeRequestDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<SetModeRequest> _instance;
@@ -121,6 +129,35 @@ static void InitDefaultsscc_info_SetPitchAndYawResponse_gimbal_2fgimbal_2eproto(
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_SetPitchAndYawResponse_gimbal_2fgimbal_2eproto}, {
       &scc_info_GimbalResult_gimbal_2fgimbal_2eproto.base,}};
 
+static void InitDefaultsscc_info_SetPitchRateAndYawRateRequest_gimbal_2fgimbal_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::mavsdk::rpc::gimbal::_SetPitchRateAndYawRateRequest_default_instance_;
+    new (ptr) ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_SetPitchRateAndYawRateRequest_gimbal_2fgimbal_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_SetPitchRateAndYawRateRequest_gimbal_2fgimbal_2eproto}, {}};
+
+static void InitDefaultsscc_info_SetPitchRateAndYawRateResponse_gimbal_2fgimbal_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::mavsdk::rpc::gimbal::_SetPitchRateAndYawRateResponse_default_instance_;
+    new (ptr) ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_SetPitchRateAndYawRateResponse_gimbal_2fgimbal_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_SetPitchRateAndYawRateResponse_gimbal_2fgimbal_2eproto}, {
+      &scc_info_GimbalResult_gimbal_2fgimbal_2eproto.base,}};
+
 static void InitDefaultsscc_info_SetRoiLocationRequest_gimbal_2fgimbal_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
@@ -150,7 +187,7 @@ static void InitDefaultsscc_info_SetRoiLocationResponse_gimbal_2fgimbal_2eproto(
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_SetRoiLocationResponse_gimbal_2fgimbal_2eproto}, {
       &scc_info_GimbalResult_gimbal_2fgimbal_2eproto.base,}};
 
-static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_gimbal_2fgimbal_2eproto[7];
+static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_gimbal_2fgimbal_2eproto[9];
 static const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* file_level_enum_descriptors_gimbal_2fgimbal_2eproto[2];
 static constexpr ::PROTOBUF_NAMESPACE_ID::ServiceDescriptor const** file_level_service_descriptors_gimbal_2fgimbal_2eproto = nullptr;
 
@@ -168,6 +205,19 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_gimbal_2fgimbal_2eproto::offse
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::gimbal::SetPitchAndYawResponse, gimbal_result_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest, pitch_rate_deg_s_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest, yaw_rate_deg_s_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse, gimbal_result_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::gimbal::SetModeRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -205,16 +255,20 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_gimbal_2fgimbal_2eproto::offse
 static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, sizeof(::mavsdk::rpc::gimbal::SetPitchAndYawRequest)},
   { 7, -1, sizeof(::mavsdk::rpc::gimbal::SetPitchAndYawResponse)},
-  { 13, -1, sizeof(::mavsdk::rpc::gimbal::SetModeRequest)},
-  { 19, -1, sizeof(::mavsdk::rpc::gimbal::SetModeResponse)},
-  { 25, -1, sizeof(::mavsdk::rpc::gimbal::SetRoiLocationRequest)},
-  { 33, -1, sizeof(::mavsdk::rpc::gimbal::SetRoiLocationResponse)},
-  { 39, -1, sizeof(::mavsdk::rpc::gimbal::GimbalResult)},
+  { 13, -1, sizeof(::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest)},
+  { 20, -1, sizeof(::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse)},
+  { 26, -1, sizeof(::mavsdk::rpc::gimbal::SetModeRequest)},
+  { 32, -1, sizeof(::mavsdk::rpc::gimbal::SetModeResponse)},
+  { 38, -1, sizeof(::mavsdk::rpc::gimbal::SetRoiLocationRequest)},
+  { 46, -1, sizeof(::mavsdk::rpc::gimbal::SetRoiLocationResponse)},
+  { 52, -1, sizeof(::mavsdk::rpc::gimbal::GimbalResult)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::gimbal::_SetPitchAndYawRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::gimbal::_SetPitchAndYawResponse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::gimbal::_SetPitchRateAndYawRateRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::gimbal::_SetPitchRateAndYawRateResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::gimbal::_SetModeRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::gimbal::_SetModeResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::gimbal::_SetRoiLocationRequest_default_instance_),
@@ -227,49 +281,58 @@ const char descriptor_table_protodef_gimbal_2fgimbal_2eproto[] PROTOBUF_SECTION_
   "\";\n\025SetPitchAndYawRequest\022\021\n\tpitch_deg\030\001"
   " \001(\002\022\017\n\007yaw_deg\030\002 \001(\002\"P\n\026SetPitchAndYawR"
   "esponse\0226\n\rgimbal_result\030\001 \001(\0132\037.mavsdk."
-  "rpc.gimbal.GimbalResult\"D\n\016SetModeReques"
-  "t\0222\n\013gimbal_mode\030\001 \001(\0162\035.mavsdk.rpc.gimb"
-  "al.GimbalMode\"I\n\017SetModeResponse\0226\n\rgimb"
-  "al_result\030\001 \001(\0132\037.mavsdk.rpc.gimbal.Gimb"
-  "alResult\"X\n\025SetRoiLocationRequest\022\024\n\014lat"
-  "itude_deg\030\001 \001(\001\022\025\n\rlongitude_deg\030\002 \001(\001\022\022"
-  "\n\naltitude_m\030\003 \001(\002\"P\n\026SetRoiLocationResp"
-  "onse\0226\n\rgimbal_result\030\001 \001(\0132\037.mavsdk.rpc"
-  ".gimbal.GimbalResult\"\312\001\n\014GimbalResult\0226\n"
-  "\006result\030\001 \001(\0162&.mavsdk.rpc.gimbal.Gimbal"
-  "Result.Result\022\022\n\nresult_str\030\002 \001(\t\"n\n\006Res"
-  "ult\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCCES"
-  "S\020\001\022\020\n\014RESULT_ERROR\020\002\022\022\n\016RESULT_TIMEOUT\020"
-  "\003\022\026\n\022RESULT_UNSUPPORTED\020\004*B\n\nGimbalMode\022"
-  "\032\n\026GIMBAL_MODE_YAW_FOLLOW\020\000\022\030\n\024GIMBAL_MO"
-  "DE_YAW_LOCK\020\0012\265\002\n\rGimbalService\022g\n\016SetPi"
-  "tchAndYaw\022(.mavsdk.rpc.gimbal.SetPitchAn"
-  "dYawRequest\032).mavsdk.rpc.gimbal.SetPitch"
-  "AndYawResponse\"\000\022R\n\007SetMode\022!.mavsdk.rpc"
-  ".gimbal.SetModeRequest\032\".mavsdk.rpc.gimb"
-  "al.SetModeResponse\"\000\022g\n\016SetRoiLocation\022("
-  ".mavsdk.rpc.gimbal.SetRoiLocationRequest"
-  "\032).mavsdk.rpc.gimbal.SetRoiLocationRespo"
-  "nse\"\000B\037\n\020io.mavsdk.gimbalB\013GimbalProtob\006"
-  "proto3"
+  "rpc.gimbal.GimbalResult\"Q\n\035SetPitchRateA"
+  "ndYawRateRequest\022\030\n\020pitch_rate_deg_s\030\001 \001"
+  "(\002\022\026\n\016yaw_rate_deg_s\030\002 \001(\002\"X\n\036SetPitchRa"
+  "teAndYawRateResponse\0226\n\rgimbal_result\030\001 "
+  "\001(\0132\037.mavsdk.rpc.gimbal.GimbalResult\"D\n\016"
+  "SetModeRequest\0222\n\013gimbal_mode\030\001 \001(\0162\035.ma"
+  "vsdk.rpc.gimbal.GimbalMode\"I\n\017SetModeRes"
+  "ponse\0226\n\rgimbal_result\030\001 \001(\0132\037.mavsdk.rp"
+  "c.gimbal.GimbalResult\"X\n\025SetRoiLocationR"
+  "equest\022\024\n\014latitude_deg\030\001 \001(\001\022\025\n\rlongitud"
+  "e_deg\030\002 \001(\001\022\022\n\naltitude_m\030\003 \001(\002\"P\n\026SetRo"
+  "iLocationResponse\0226\n\rgimbal_result\030\001 \001(\013"
+  "2\037.mavsdk.rpc.gimbal.GimbalResult\"\312\001\n\014Gi"
+  "mbalResult\0226\n\006result\030\001 \001(\0162&.mavsdk.rpc."
+  "gimbal.GimbalResult.Result\022\022\n\nresult_str"
+  "\030\002 \001(\t\"n\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016"
+  "RESULT_SUCCESS\020\001\022\020\n\014RESULT_ERROR\020\002\022\022\n\016RE"
+  "SULT_TIMEOUT\020\003\022\026\n\022RESULT_UNSUPPORTED\020\004*B"
+  "\n\nGimbalMode\022\032\n\026GIMBAL_MODE_YAW_FOLLOW\020\000"
+  "\022\030\n\024GIMBAL_MODE_YAW_LOCK\020\0012\266\003\n\rGimbalSer"
+  "vice\022g\n\016SetPitchAndYaw\022(.mavsdk.rpc.gimb"
+  "al.SetPitchAndYawRequest\032).mavsdk.rpc.gi"
+  "mbal.SetPitchAndYawResponse\"\000\022\177\n\026SetPitc"
+  "hRateAndYawRate\0220.mavsdk.rpc.gimbal.SetP"
+  "itchRateAndYawRateRequest\0321.mavsdk.rpc.g"
+  "imbal.SetPitchRateAndYawRateResponse\"\000\022R"
+  "\n\007SetMode\022!.mavsdk.rpc.gimbal.SetModeReq"
+  "uest\032\".mavsdk.rpc.gimbal.SetModeResponse"
+  "\"\000\022g\n\016SetRoiLocation\022(.mavsdk.rpc.gimbal"
+  ".SetRoiLocationRequest\032).mavsdk.rpc.gimb"
+  "al.SetRoiLocationResponse\"\000B\037\n\020io.mavsdk"
+  ".gimbalB\013GimbalProtob\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_gimbal_2fgimbal_2eproto_deps[1] = {
 };
-static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_gimbal_2fgimbal_2eproto_sccs[7] = {
+static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_gimbal_2fgimbal_2eproto_sccs[9] = {
   &scc_info_GimbalResult_gimbal_2fgimbal_2eproto.base,
   &scc_info_SetModeRequest_gimbal_2fgimbal_2eproto.base,
   &scc_info_SetModeResponse_gimbal_2fgimbal_2eproto.base,
   &scc_info_SetPitchAndYawRequest_gimbal_2fgimbal_2eproto.base,
   &scc_info_SetPitchAndYawResponse_gimbal_2fgimbal_2eproto.base,
+  &scc_info_SetPitchRateAndYawRateRequest_gimbal_2fgimbal_2eproto.base,
+  &scc_info_SetPitchRateAndYawRateResponse_gimbal_2fgimbal_2eproto.base,
   &scc_info_SetRoiLocationRequest_gimbal_2fgimbal_2eproto.base,
   &scc_info_SetRoiLocationResponse_gimbal_2fgimbal_2eproto.base,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_gimbal_2fgimbal_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_gimbal_2fgimbal_2eproto = {
-  false, false, descriptor_table_protodef_gimbal_2fgimbal_2eproto, "gimbal/gimbal.proto", 1126,
-  &descriptor_table_gimbal_2fgimbal_2eproto_once, descriptor_table_gimbal_2fgimbal_2eproto_sccs, descriptor_table_gimbal_2fgimbal_2eproto_deps, 7, 0,
+  false, false, descriptor_table_protodef_gimbal_2fgimbal_2eproto, "gimbal/gimbal.proto", 1428,
+  &descriptor_table_gimbal_2fgimbal_2eproto_once, descriptor_table_gimbal_2fgimbal_2eproto_sccs, descriptor_table_gimbal_2fgimbal_2eproto_deps, 9, 0,
   schemas, file_default_instances, TableStruct_gimbal_2fgimbal_2eproto::offsets,
-  file_level_metadata_gimbal_2fgimbal_2eproto, 7, file_level_enum_descriptors_gimbal_2fgimbal_2eproto, file_level_service_descriptors_gimbal_2fgimbal_2eproto,
+  file_level_metadata_gimbal_2fgimbal_2eproto, 9, file_level_enum_descriptors_gimbal_2fgimbal_2eproto, file_level_service_descriptors_gimbal_2fgimbal_2eproto,
 };
 
 // Force running AddDescriptors() at dynamic initialization time.
@@ -757,6 +820,448 @@ void SetPitchAndYawResponse::InternalSwap(SetPitchAndYawResponse* other) {
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata SetPitchAndYawResponse::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+void SetPitchRateAndYawRateRequest::InitAsDefaultInstance() {
+}
+class SetPitchRateAndYawRateRequest::_Internal {
+ public:
+};
+
+SetPitchRateAndYawRateRequest::SetPitchRateAndYawRateRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.gimbal.SetPitchRateAndYawRateRequest)
+}
+SetPitchRateAndYawRateRequest::SetPitchRateAndYawRateRequest(const SetPitchRateAndYawRateRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::memcpy(&pitch_rate_deg_s_, &from.pitch_rate_deg_s_,
+    static_cast<size_t>(reinterpret_cast<char*>(&yaw_rate_deg_s_) -
+    reinterpret_cast<char*>(&pitch_rate_deg_s_)) + sizeof(yaw_rate_deg_s_));
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.gimbal.SetPitchRateAndYawRateRequest)
+}
+
+void SetPitchRateAndYawRateRequest::SharedCtor() {
+  ::memset(&pitch_rate_deg_s_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&yaw_rate_deg_s_) -
+      reinterpret_cast<char*>(&pitch_rate_deg_s_)) + sizeof(yaw_rate_deg_s_));
+}
+
+SetPitchRateAndYawRateRequest::~SetPitchRateAndYawRateRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.gimbal.SetPitchRateAndYawRateRequest)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void SetPitchRateAndYawRateRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+}
+
+void SetPitchRateAndYawRateRequest::ArenaDtor(void* object) {
+  SetPitchRateAndYawRateRequest* _this = reinterpret_cast< SetPitchRateAndYawRateRequest* >(object);
+  (void)_this;
+}
+void SetPitchRateAndYawRateRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void SetPitchRateAndYawRateRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const SetPitchRateAndYawRateRequest& SetPitchRateAndYawRateRequest::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_SetPitchRateAndYawRateRequest_gimbal_2fgimbal_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void SetPitchRateAndYawRateRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.gimbal.SetPitchRateAndYawRateRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  ::memset(&pitch_rate_deg_s_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&yaw_rate_deg_s_) -
+      reinterpret_cast<char*>(&pitch_rate_deg_s_)) + sizeof(yaw_rate_deg_s_));
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* SetPitchRateAndYawRateRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  ::PROTOBUF_NAMESPACE_ID::Arena* arena = GetArena(); (void)arena;
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // float pitch_rate_deg_s = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 13)) {
+          pitch_rate_deg_s_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<float>(ptr);
+          ptr += sizeof(float);
+        } else goto handle_unusual;
+        continue;
+      // float yaw_rate_deg_s = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 21)) {
+          yaw_rate_deg_s_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<float>(ptr);
+          ptr += sizeof(float);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* SetPitchRateAndYawRateRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.gimbal.SetPitchRateAndYawRateRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // float pitch_rate_deg_s = 1;
+  if (!(this->pitch_rate_deg_s() <= 0 && this->pitch_rate_deg_s() >= 0)) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteFloatToArray(1, this->_internal_pitch_rate_deg_s(), target);
+  }
+
+  // float yaw_rate_deg_s = 2;
+  if (!(this->yaw_rate_deg_s() <= 0 && this->yaw_rate_deg_s() >= 0)) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteFloatToArray(2, this->_internal_yaw_rate_deg_s(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.gimbal.SetPitchRateAndYawRateRequest)
+  return target;
+}
+
+size_t SetPitchRateAndYawRateRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.gimbal.SetPitchRateAndYawRateRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // float pitch_rate_deg_s = 1;
+  if (!(this->pitch_rate_deg_s() <= 0 && this->pitch_rate_deg_s() >= 0)) {
+    total_size += 1 + 4;
+  }
+
+  // float yaw_rate_deg_s = 2;
+  if (!(this->yaw_rate_deg_s() <= 0 && this->yaw_rate_deg_s() >= 0)) {
+    total_size += 1 + 4;
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void SetPitchRateAndYawRateRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:mavsdk.rpc.gimbal.SetPitchRateAndYawRateRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const SetPitchRateAndYawRateRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<SetPitchRateAndYawRateRequest>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:mavsdk.rpc.gimbal.SetPitchRateAndYawRateRequest)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:mavsdk.rpc.gimbal.SetPitchRateAndYawRateRequest)
+    MergeFrom(*source);
+  }
+}
+
+void SetPitchRateAndYawRateRequest::MergeFrom(const SetPitchRateAndYawRateRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.gimbal.SetPitchRateAndYawRateRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!(from.pitch_rate_deg_s() <= 0 && from.pitch_rate_deg_s() >= 0)) {
+    _internal_set_pitch_rate_deg_s(from._internal_pitch_rate_deg_s());
+  }
+  if (!(from.yaw_rate_deg_s() <= 0 && from.yaw_rate_deg_s() >= 0)) {
+    _internal_set_yaw_rate_deg_s(from._internal_yaw_rate_deg_s());
+  }
+}
+
+void SetPitchRateAndYawRateRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:mavsdk.rpc.gimbal.SetPitchRateAndYawRateRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void SetPitchRateAndYawRateRequest::CopyFrom(const SetPitchRateAndYawRateRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.gimbal.SetPitchRateAndYawRateRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SetPitchRateAndYawRateRequest::IsInitialized() const {
+  return true;
+}
+
+void SetPitchRateAndYawRateRequest::InternalSwap(SetPitchRateAndYawRateRequest* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(SetPitchRateAndYawRateRequest, yaw_rate_deg_s_)
+      + sizeof(SetPitchRateAndYawRateRequest::yaw_rate_deg_s_)
+      - PROTOBUF_FIELD_OFFSET(SetPitchRateAndYawRateRequest, pitch_rate_deg_s_)>(
+          reinterpret_cast<char*>(&pitch_rate_deg_s_),
+          reinterpret_cast<char*>(&other->pitch_rate_deg_s_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata SetPitchRateAndYawRateRequest::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+void SetPitchRateAndYawRateResponse::InitAsDefaultInstance() {
+  ::mavsdk::rpc::gimbal::_SetPitchRateAndYawRateResponse_default_instance_._instance.get_mutable()->gimbal_result_ = const_cast< ::mavsdk::rpc::gimbal::GimbalResult*>(
+      ::mavsdk::rpc::gimbal::GimbalResult::internal_default_instance());
+}
+class SetPitchRateAndYawRateResponse::_Internal {
+ public:
+  static const ::mavsdk::rpc::gimbal::GimbalResult& gimbal_result(const SetPitchRateAndYawRateResponse* msg);
+};
+
+const ::mavsdk::rpc::gimbal::GimbalResult&
+SetPitchRateAndYawRateResponse::_Internal::gimbal_result(const SetPitchRateAndYawRateResponse* msg) {
+  return *msg->gimbal_result_;
+}
+SetPitchRateAndYawRateResponse::SetPitchRateAndYawRateResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse)
+}
+SetPitchRateAndYawRateResponse::SetPitchRateAndYawRateResponse(const SetPitchRateAndYawRateResponse& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_gimbal_result()) {
+    gimbal_result_ = new ::mavsdk::rpc::gimbal::GimbalResult(*from.gimbal_result_);
+  } else {
+    gimbal_result_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse)
+}
+
+void SetPitchRateAndYawRateResponse::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_SetPitchRateAndYawRateResponse_gimbal_2fgimbal_2eproto.base);
+  gimbal_result_ = nullptr;
+}
+
+SetPitchRateAndYawRateResponse::~SetPitchRateAndYawRateResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void SetPitchRateAndYawRateResponse::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  if (this != internal_default_instance()) delete gimbal_result_;
+}
+
+void SetPitchRateAndYawRateResponse::ArenaDtor(void* object) {
+  SetPitchRateAndYawRateResponse* _this = reinterpret_cast< SetPitchRateAndYawRateResponse* >(object);
+  (void)_this;
+}
+void SetPitchRateAndYawRateResponse::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void SetPitchRateAndYawRateResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const SetPitchRateAndYawRateResponse& SetPitchRateAndYawRateResponse::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_SetPitchRateAndYawRateResponse_gimbal_2fgimbal_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void SetPitchRateAndYawRateResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArena() == nullptr && gimbal_result_ != nullptr) {
+    delete gimbal_result_;
+  }
+  gimbal_result_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* SetPitchRateAndYawRateResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  ::PROTOBUF_NAMESPACE_ID::Arena* arena = GetArena(); (void)arena;
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // .mavsdk.rpc.gimbal.GimbalResult gimbal_result = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_gimbal_result(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* SetPitchRateAndYawRateResponse::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.gimbal.GimbalResult gimbal_result = 1;
+  if (this->has_gimbal_result()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::gimbal_result(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse)
+  return target;
+}
+
+size_t SetPitchRateAndYawRateResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.gimbal.GimbalResult gimbal_result = 1;
+  if (this->has_gimbal_result()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *gimbal_result_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void SetPitchRateAndYawRateResponse::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  const SetPitchRateAndYawRateResponse* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<SetPitchRateAndYawRateResponse>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse)
+    MergeFrom(*source);
+  }
+}
+
+void SetPitchRateAndYawRateResponse::MergeFrom(const SetPitchRateAndYawRateResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.has_gimbal_result()) {
+    _internal_mutable_gimbal_result()->::mavsdk::rpc::gimbal::GimbalResult::MergeFrom(from._internal_gimbal_result());
+  }
+}
+
+void SetPitchRateAndYawRateResponse::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void SetPitchRateAndYawRateResponse::CopyFrom(const SetPitchRateAndYawRateResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SetPitchRateAndYawRateResponse::IsInitialized() const {
+  return true;
+}
+
+void SetPitchRateAndYawRateResponse::InternalSwap(SetPitchRateAndYawRateResponse* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  swap(gimbal_result_, other->gimbal_result_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata SetPitchRateAndYawRateResponse::GetMetadata() const {
   return GetMetadataStatic();
 }
 
@@ -1884,6 +2389,12 @@ template<> PROTOBUF_NOINLINE ::mavsdk::rpc::gimbal::SetPitchAndYawRequest* Arena
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::gimbal::SetPitchAndYawResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::gimbal::SetPitchAndYawResponse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::gimbal::SetPitchAndYawResponse >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse >(arena);
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::gimbal::SetModeRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::gimbal::SetModeRequest >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::gimbal::SetModeRequest >(arena);

--- a/src/mavsdk_server/src/generated/gimbal/gimbal.pb.h
+++ b/src/mavsdk_server/src/generated/gimbal/gimbal.pb.h
@@ -48,7 +48,7 @@ struct TableStruct_gimbal_2fgimbal_2eproto {
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::AuxiliaryParseTableField aux[]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
-  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[7]
+  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[9]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::FieldMetadata field_metadata[];
   static const ::PROTOBUF_NAMESPACE_ID::internal::SerializationTable serialization_table[];
@@ -73,6 +73,12 @@ extern SetPitchAndYawRequestDefaultTypeInternal _SetPitchAndYawRequest_default_i
 class SetPitchAndYawResponse;
 class SetPitchAndYawResponseDefaultTypeInternal;
 extern SetPitchAndYawResponseDefaultTypeInternal _SetPitchAndYawResponse_default_instance_;
+class SetPitchRateAndYawRateRequest;
+class SetPitchRateAndYawRateRequestDefaultTypeInternal;
+extern SetPitchRateAndYawRateRequestDefaultTypeInternal _SetPitchRateAndYawRateRequest_default_instance_;
+class SetPitchRateAndYawRateResponse;
+class SetPitchRateAndYawRateResponseDefaultTypeInternal;
+extern SetPitchRateAndYawRateResponseDefaultTypeInternal _SetPitchRateAndYawRateResponse_default_instance_;
 class SetRoiLocationRequest;
 class SetRoiLocationRequestDefaultTypeInternal;
 extern SetRoiLocationRequestDefaultTypeInternal _SetRoiLocationRequest_default_instance_;
@@ -88,6 +94,8 @@ template<> ::mavsdk::rpc::gimbal::SetModeRequest* Arena::CreateMaybeMessage<::ma
 template<> ::mavsdk::rpc::gimbal::SetModeResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::gimbal::SetModeResponse>(Arena*);
 template<> ::mavsdk::rpc::gimbal::SetPitchAndYawRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::gimbal::SetPitchAndYawRequest>(Arena*);
 template<> ::mavsdk::rpc::gimbal::SetPitchAndYawResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::gimbal::SetPitchAndYawResponse>(Arena*);
+template<> ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest>(Arena*);
+template<> ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>(Arena*);
 template<> ::mavsdk::rpc::gimbal::SetRoiLocationRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::gimbal::SetRoiLocationRequest>(Arena*);
 template<> ::mavsdk::rpc::gimbal::SetRoiLocationResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::gimbal::SetRoiLocationResponse>(Arena*);
 PROTOBUF_NAMESPACE_CLOSE
@@ -444,6 +452,300 @@ class SetPitchAndYawResponse PROTOBUF_FINAL :
 };
 // -------------------------------------------------------------------
 
+class SetPitchRateAndYawRateRequest PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.gimbal.SetPitchRateAndYawRateRequest) */ {
+ public:
+  inline SetPitchRateAndYawRateRequest() : SetPitchRateAndYawRateRequest(nullptr) {}
+  virtual ~SetPitchRateAndYawRateRequest();
+
+  SetPitchRateAndYawRateRequest(const SetPitchRateAndYawRateRequest& from);
+  SetPitchRateAndYawRateRequest(SetPitchRateAndYawRateRequest&& from) noexcept
+    : SetPitchRateAndYawRateRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline SetPitchRateAndYawRateRequest& operator=(const SetPitchRateAndYawRateRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetPitchRateAndYawRateRequest& operator=(SetPitchRateAndYawRateRequest&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const SetPitchRateAndYawRateRequest& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const SetPitchRateAndYawRateRequest* internal_default_instance() {
+    return reinterpret_cast<const SetPitchRateAndYawRateRequest*>(
+               &_SetPitchRateAndYawRateRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    2;
+
+  friend void swap(SetPitchRateAndYawRateRequest& a, SetPitchRateAndYawRateRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(SetPitchRateAndYawRateRequest* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetPitchRateAndYawRateRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline SetPitchRateAndYawRateRequest* New() const final {
+    return CreateMaybeMessage<SetPitchRateAndYawRateRequest>(nullptr);
+  }
+
+  SetPitchRateAndYawRateRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<SetPitchRateAndYawRateRequest>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const SetPitchRateAndYawRateRequest& from);
+  void MergeFrom(const SetPitchRateAndYawRateRequest& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(SetPitchRateAndYawRateRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.gimbal.SetPitchRateAndYawRateRequest";
+  }
+  protected:
+  explicit SetPitchRateAndYawRateRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_gimbal_2fgimbal_2eproto);
+    return ::descriptor_table_gimbal_2fgimbal_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kPitchRateDegSFieldNumber = 1,
+    kYawRateDegSFieldNumber = 2,
+  };
+  // float pitch_rate_deg_s = 1;
+  void clear_pitch_rate_deg_s();
+  float pitch_rate_deg_s() const;
+  void set_pitch_rate_deg_s(float value);
+  private:
+  float _internal_pitch_rate_deg_s() const;
+  void _internal_set_pitch_rate_deg_s(float value);
+  public:
+
+  // float yaw_rate_deg_s = 2;
+  void clear_yaw_rate_deg_s();
+  float yaw_rate_deg_s() const;
+  void set_yaw_rate_deg_s(float value);
+  private:
+  float _internal_yaw_rate_deg_s() const;
+  void _internal_set_yaw_rate_deg_s(float value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.gimbal.SetPitchRateAndYawRateRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  float pitch_rate_deg_s_;
+  float yaw_rate_deg_s_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_gimbal_2fgimbal_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SetPitchRateAndYawRateResponse PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse) */ {
+ public:
+  inline SetPitchRateAndYawRateResponse() : SetPitchRateAndYawRateResponse(nullptr) {}
+  virtual ~SetPitchRateAndYawRateResponse();
+
+  SetPitchRateAndYawRateResponse(const SetPitchRateAndYawRateResponse& from);
+  SetPitchRateAndYawRateResponse(SetPitchRateAndYawRateResponse&& from) noexcept
+    : SetPitchRateAndYawRateResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline SetPitchRateAndYawRateResponse& operator=(const SetPitchRateAndYawRateResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetPitchRateAndYawRateResponse& operator=(SetPitchRateAndYawRateResponse&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const SetPitchRateAndYawRateResponse& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const SetPitchRateAndYawRateResponse* internal_default_instance() {
+    return reinterpret_cast<const SetPitchRateAndYawRateResponse*>(
+               &_SetPitchRateAndYawRateResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    3;
+
+  friend void swap(SetPitchRateAndYawRateResponse& a, SetPitchRateAndYawRateResponse& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(SetPitchRateAndYawRateResponse* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetPitchRateAndYawRateResponse* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline SetPitchRateAndYawRateResponse* New() const final {
+    return CreateMaybeMessage<SetPitchRateAndYawRateResponse>(nullptr);
+  }
+
+  SetPitchRateAndYawRateResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<SetPitchRateAndYawRateResponse>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const SetPitchRateAndYawRateResponse& from);
+  void MergeFrom(const SetPitchRateAndYawRateResponse& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(SetPitchRateAndYawRateResponse* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse";
+  }
+  protected:
+  explicit SetPitchRateAndYawRateResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_gimbal_2fgimbal_2eproto);
+    return ::descriptor_table_gimbal_2fgimbal_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kGimbalResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.gimbal.GimbalResult gimbal_result = 1;
+  bool has_gimbal_result() const;
+  private:
+  bool _internal_has_gimbal_result() const;
+  public:
+  void clear_gimbal_result();
+  const ::mavsdk::rpc::gimbal::GimbalResult& gimbal_result() const;
+  ::mavsdk::rpc::gimbal::GimbalResult* release_gimbal_result();
+  ::mavsdk::rpc::gimbal::GimbalResult* mutable_gimbal_result();
+  void set_allocated_gimbal_result(::mavsdk::rpc::gimbal::GimbalResult* gimbal_result);
+  private:
+  const ::mavsdk::rpc::gimbal::GimbalResult& _internal_gimbal_result() const;
+  ::mavsdk::rpc::gimbal::GimbalResult* _internal_mutable_gimbal_result();
+  public:
+  void unsafe_arena_set_allocated_gimbal_result(
+      ::mavsdk::rpc::gimbal::GimbalResult* gimbal_result);
+  ::mavsdk::rpc::gimbal::GimbalResult* unsafe_arena_release_gimbal_result();
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::mavsdk::rpc::gimbal::GimbalResult* gimbal_result_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_gimbal_2fgimbal_2eproto;
+};
+// -------------------------------------------------------------------
+
 class SetModeRequest PROTOBUF_FINAL :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.gimbal.SetModeRequest) */ {
  public:
@@ -486,7 +788,7 @@ class SetModeRequest PROTOBUF_FINAL :
                &_SetModeRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    2;
+    4;
 
   friend void swap(SetModeRequest& a, SetModeRequest& b) {
     a.Swap(&b);
@@ -623,7 +925,7 @@ class SetModeResponse PROTOBUF_FINAL :
                &_SetModeResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    3;
+    5;
 
   friend void swap(SetModeResponse& a, SetModeResponse& b) {
     a.Swap(&b);
@@ -769,7 +1071,7 @@ class SetRoiLocationRequest PROTOBUF_FINAL :
                &_SetRoiLocationRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    4;
+    6;
 
   friend void swap(SetRoiLocationRequest& a, SetRoiLocationRequest& b) {
     a.Swap(&b);
@@ -928,7 +1230,7 @@ class SetRoiLocationResponse PROTOBUF_FINAL :
                &_SetRoiLocationResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    5;
+    7;
 
   friend void swap(SetRoiLocationResponse& a, SetRoiLocationResponse& b) {
     a.Swap(&b);
@@ -1074,7 +1376,7 @@ class GimbalResult PROTOBUF_FINAL :
                &_GimbalResult_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    6;
+    8;
 
   friend void swap(GimbalResult& a, GimbalResult& b) {
     a.Swap(&b);
@@ -1357,6 +1659,137 @@ inline void SetPitchAndYawResponse::set_allocated_gimbal_result(::mavsdk::rpc::g
   }
   gimbal_result_ = gimbal_result;
   // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.gimbal.SetPitchAndYawResponse.gimbal_result)
+}
+
+// -------------------------------------------------------------------
+
+// SetPitchRateAndYawRateRequest
+
+// float pitch_rate_deg_s = 1;
+inline void SetPitchRateAndYawRateRequest::clear_pitch_rate_deg_s() {
+  pitch_rate_deg_s_ = 0;
+}
+inline float SetPitchRateAndYawRateRequest::_internal_pitch_rate_deg_s() const {
+  return pitch_rate_deg_s_;
+}
+inline float SetPitchRateAndYawRateRequest::pitch_rate_deg_s() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.gimbal.SetPitchRateAndYawRateRequest.pitch_rate_deg_s)
+  return _internal_pitch_rate_deg_s();
+}
+inline void SetPitchRateAndYawRateRequest::_internal_set_pitch_rate_deg_s(float value) {
+  
+  pitch_rate_deg_s_ = value;
+}
+inline void SetPitchRateAndYawRateRequest::set_pitch_rate_deg_s(float value) {
+  _internal_set_pitch_rate_deg_s(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.gimbal.SetPitchRateAndYawRateRequest.pitch_rate_deg_s)
+}
+
+// float yaw_rate_deg_s = 2;
+inline void SetPitchRateAndYawRateRequest::clear_yaw_rate_deg_s() {
+  yaw_rate_deg_s_ = 0;
+}
+inline float SetPitchRateAndYawRateRequest::_internal_yaw_rate_deg_s() const {
+  return yaw_rate_deg_s_;
+}
+inline float SetPitchRateAndYawRateRequest::yaw_rate_deg_s() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.gimbal.SetPitchRateAndYawRateRequest.yaw_rate_deg_s)
+  return _internal_yaw_rate_deg_s();
+}
+inline void SetPitchRateAndYawRateRequest::_internal_set_yaw_rate_deg_s(float value) {
+  
+  yaw_rate_deg_s_ = value;
+}
+inline void SetPitchRateAndYawRateRequest::set_yaw_rate_deg_s(float value) {
+  _internal_set_yaw_rate_deg_s(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.gimbal.SetPitchRateAndYawRateRequest.yaw_rate_deg_s)
+}
+
+// -------------------------------------------------------------------
+
+// SetPitchRateAndYawRateResponse
+
+// .mavsdk.rpc.gimbal.GimbalResult gimbal_result = 1;
+inline bool SetPitchRateAndYawRateResponse::_internal_has_gimbal_result() const {
+  return this != internal_default_instance() && gimbal_result_ != nullptr;
+}
+inline bool SetPitchRateAndYawRateResponse::has_gimbal_result() const {
+  return _internal_has_gimbal_result();
+}
+inline void SetPitchRateAndYawRateResponse::clear_gimbal_result() {
+  if (GetArena() == nullptr && gimbal_result_ != nullptr) {
+    delete gimbal_result_;
+  }
+  gimbal_result_ = nullptr;
+}
+inline const ::mavsdk::rpc::gimbal::GimbalResult& SetPitchRateAndYawRateResponse::_internal_gimbal_result() const {
+  const ::mavsdk::rpc::gimbal::GimbalResult* p = gimbal_result_;
+  return p != nullptr ? *p : *reinterpret_cast<const ::mavsdk::rpc::gimbal::GimbalResult*>(
+      &::mavsdk::rpc::gimbal::_GimbalResult_default_instance_);
+}
+inline const ::mavsdk::rpc::gimbal::GimbalResult& SetPitchRateAndYawRateResponse::gimbal_result() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse.gimbal_result)
+  return _internal_gimbal_result();
+}
+inline void SetPitchRateAndYawRateResponse::unsafe_arena_set_allocated_gimbal_result(
+    ::mavsdk::rpc::gimbal::GimbalResult* gimbal_result) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(gimbal_result_);
+  }
+  gimbal_result_ = gimbal_result;
+  if (gimbal_result) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse.gimbal_result)
+}
+inline ::mavsdk::rpc::gimbal::GimbalResult* SetPitchRateAndYawRateResponse::release_gimbal_result() {
+  
+  ::mavsdk::rpc::gimbal::GimbalResult* temp = gimbal_result_;
+  gimbal_result_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::mavsdk::rpc::gimbal::GimbalResult* SetPitchRateAndYawRateResponse::unsafe_arena_release_gimbal_result() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse.gimbal_result)
+  
+  ::mavsdk::rpc::gimbal::GimbalResult* temp = gimbal_result_;
+  gimbal_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::gimbal::GimbalResult* SetPitchRateAndYawRateResponse::_internal_mutable_gimbal_result() {
+  
+  if (gimbal_result_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::gimbal::GimbalResult>(GetArena());
+    gimbal_result_ = p;
+  }
+  return gimbal_result_;
+}
+inline ::mavsdk::rpc::gimbal::GimbalResult* SetPitchRateAndYawRateResponse::mutable_gimbal_result() {
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse.gimbal_result)
+  return _internal_mutable_gimbal_result();
+}
+inline void SetPitchRateAndYawRateResponse::set_allocated_gimbal_result(::mavsdk::rpc::gimbal::GimbalResult* gimbal_result) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete gimbal_result_;
+  }
+  if (gimbal_result) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(gimbal_result);
+    if (message_arena != submessage_arena) {
+      gimbal_result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, gimbal_result, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  gimbal_result_ = gimbal_result;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.gimbal.SetPitchRateAndYawRateResponse.gimbal_result)
 }
 
 // -------------------------------------------------------------------
@@ -1710,6 +2143,10 @@ inline void GimbalResult::set_allocated_result_str(std::string* result_str) {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/src/mavsdk_server/src/plugins/gimbal/gimbal_service_impl.h
+++ b/src/mavsdk_server/src/plugins/gimbal/gimbal_service_impl.h
@@ -123,6 +123,26 @@ public:
         return grpc::Status::OK;
     }
 
+    grpc::Status SetPitchRateAndYawRate(
+        grpc::ServerContext* /* context */,
+        const rpc::gimbal::SetPitchRateAndYawRateRequest* request,
+        rpc::gimbal::SetPitchRateAndYawRateResponse* response) override
+    {
+        if (request == nullptr) {
+            LogWarn() << "SetPitchRateAndYawRate sent with a null request! Ignoring...";
+            return grpc::Status::OK;
+        }
+
+        auto result = _gimbal.set_pitch_rate_and_yaw_rate(
+            request->pitch_rate_deg_s(), request->yaw_rate_deg_s());
+
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+
+        return grpc::Status::OK;
+    }
+
     grpc::Status SetMode(
         grpc::ServerContext* /* context */,
         const rpc::gimbal::SetModeRequest* request,

--- a/src/plugins/gimbal/gimbal.cpp
+++ b/src/plugins/gimbal/gimbal.cpp
@@ -25,6 +25,18 @@ Gimbal::Result Gimbal::set_pitch_and_yaw(float pitch_deg, float yaw_deg) const
     return _impl->set_pitch_and_yaw(pitch_deg, yaw_deg);
 }
 
+void Gimbal::set_pitch_rate_and_yaw_rate_async(
+    float pitch_rate_deg_s, float yaw_rate_deg_s, const ResultCallback callback)
+{
+    _impl->set_pitch_rate_and_yaw_rate_async(pitch_rate_deg_s, yaw_rate_deg_s, callback);
+}
+
+Gimbal::Result
+Gimbal::set_pitch_rate_and_yaw_rate(float pitch_rate_deg_s, float yaw_rate_deg_s) const
+{
+    return _impl->set_pitch_rate_and_yaw_rate(pitch_rate_deg_s, yaw_rate_deg_s);
+}
+
 void Gimbal::set_mode_async(GimbalMode gimbal_mode, const ResultCallback callback)
 {
     _impl->set_mode_async(gimbal_mode, callback);

--- a/src/plugins/gimbal/gimbal_impl.cpp
+++ b/src/plugins/gimbal/gimbal_impl.cpp
@@ -86,6 +86,22 @@ void GimbalImpl::set_pitch_and_yaw_async(
         [=]() { _gimbal_protocol->set_pitch_and_yaw_async(pitch_deg, yaw_deg, callback); });
 }
 
+Gimbal::Result GimbalImpl::set_pitch_rate_and_yaw_rate(float pitch_rate_deg_s, float yaw_rate_deg_s)
+{
+    wait_for_protocol();
+
+    return _gimbal_protocol->set_pitch_rate_and_yaw_rate(pitch_rate_deg_s, yaw_rate_deg_s);
+}
+
+void GimbalImpl::set_pitch_rate_and_yaw_rate_async(
+    float pitch_rate_deg_s, float yaw_rate_deg_s, Gimbal::ResultCallback callback)
+{
+    wait_for_protocol_async([=]() {
+        _gimbal_protocol->set_pitch_rate_and_yaw_rate_async(
+            pitch_rate_deg_s, yaw_rate_deg_s, callback);
+    });
+}
+
 Gimbal::Result GimbalImpl::set_mode(const Gimbal::GimbalMode gimbal_mode)
 {
     wait_for_protocol();

--- a/src/plugins/gimbal/gimbal_impl.cpp
+++ b/src/plugins/gimbal/gimbal_impl.cpp
@@ -69,7 +69,8 @@ void GimbalImpl::process_gimbal_manager_information(const mavlink_message_t& mes
                << " was discovered";
 
     _parent->unregister_timeout_handler(_protocol_cookie);
-    _gimbal_protocol.reset(new GimbalProtocolV2(*_parent, gimbal_manager_information));
+    _gimbal_protocol.reset(
+        new GimbalProtocolV2(*_parent, gimbal_manager_information, message.sysid, message.compid));
 }
 
 Gimbal::Result GimbalImpl::set_pitch_and_yaw(float pitch_deg, float yaw_deg)

--- a/src/plugins/gimbal/gimbal_impl.h
+++ b/src/plugins/gimbal/gimbal_impl.h
@@ -23,6 +23,11 @@ public:
 
     void set_pitch_and_yaw_async(float pitch_deg, float yaw_deg, Gimbal::ResultCallback callback);
 
+    Gimbal::Result set_pitch_rate_and_yaw_rate(float pitch_rate_deg_s, float yaw_rate_deg_s);
+
+    void set_pitch_rate_and_yaw_rate_async(
+        float pitch_rate_deg_s, float yaw_rate_deg_s, Gimbal::ResultCallback callback);
+
     Gimbal::Result set_mode(const Gimbal::GimbalMode gimbal_mode);
 
     void set_mode_async(const Gimbal::GimbalMode gimbal_mode, Gimbal::ResultCallback callback);

--- a/src/plugins/gimbal/gimbal_protocol_base.h
+++ b/src/plugins/gimbal/gimbal_protocol_base.h
@@ -16,6 +16,12 @@ public:
     virtual void
     set_pitch_and_yaw_async(float pitch_deg, float yaw_deg, Gimbal::ResultCallback callback) = 0;
 
+    virtual Gimbal::Result
+    set_pitch_rate_and_yaw_rate(float pitch_rate_deg_s, float yaw_rate_deg_s) = 0;
+
+    virtual void set_pitch_rate_and_yaw_rate_async(
+        float pitch_rate_deg_s, float yaw_rate_deg_s, Gimbal::ResultCallback callback) = 0;
+
     virtual Gimbal::Result set_mode(const Gimbal::GimbalMode gimbal_mode) = 0;
 
     virtual void

--- a/src/plugins/gimbal/gimbal_protocol_v1.cpp
+++ b/src/plugins/gimbal/gimbal_protocol_v1.cpp
@@ -43,6 +43,27 @@ void GimbalProtocolV1::set_pitch_and_yaw_async(
         });
 }
 
+Gimbal::Result
+GimbalProtocolV1::set_pitch_rate_and_yaw_rate(float pitch_rate_deg_s, float yaw_rate_deg_s)
+{
+    UNUSED(pitch_rate_deg_s);
+    UNUSED(yaw_rate_deg_s);
+    return Gimbal::Result::Unsupported;
+}
+
+void GimbalProtocolV1::set_pitch_rate_and_yaw_rate_async(
+    float pitch_rate_deg_s, float yaw_rate_deg_s, Gimbal::ResultCallback callback)
+{
+    UNUSED(pitch_rate_deg_s);
+    UNUSED(yaw_rate_deg_s);
+
+    if (callback) {
+        auto temp_callback = callback;
+        _system_impl.call_user_callback(
+            [temp_callback]() { temp_callback(Gimbal::Result::Unsupported); });
+    }
+}
+
 Gimbal::Result GimbalProtocolV1::set_mode(const Gimbal::GimbalMode gimbal_mode)
 {
     MavlinkCommandSender::CommandInt command{};

--- a/src/plugins/gimbal/gimbal_protocol_v1.h
+++ b/src/plugins/gimbal/gimbal_protocol_v1.h
@@ -15,6 +15,12 @@ public:
     void set_pitch_and_yaw_async(
         float pitch_deg, float yaw_deg, Gimbal::ResultCallback callback) override;
 
+    Gimbal::Result
+    set_pitch_rate_and_yaw_rate(float pitch_rate_deg_s, float yaw_rate_deg_s) override;
+
+    void set_pitch_rate_and_yaw_rate_async(
+        float pitch_rate_deg_s, float yaw_rate_deg_s, Gimbal::ResultCallback callback) override;
+
     Gimbal::Result set_mode(const Gimbal::GimbalMode gimbal_mode) override;
 
     void

--- a/src/plugins/gimbal/gimbal_protocol_v2.cpp
+++ b/src/plugins/gimbal/gimbal_protocol_v2.cpp
@@ -7,17 +7,15 @@
 namespace mavsdk {
 
 GimbalProtocolV2::GimbalProtocolV2(
-    SystemImpl& system_impl, const mavlink_gimbal_manager_information_t& information) :
-    GimbalProtocolBase(system_impl)
-{
-    set_gimbal_information(information);
-}
-
-void GimbalProtocolV2::set_gimbal_information(
-    const mavlink_gimbal_manager_information_t& information)
-{
-    _gimbal_device_id = information.gimbal_device_id;
-}
+    SystemImpl& system_impl,
+    const mavlink_gimbal_manager_information_t& information,
+    uint8_t gimbal_manager_sysid,
+    uint8_t gimbal_manager_compid) :
+    GimbalProtocolBase(system_impl),
+    _gimbal_device_id(information.gimbal_device_id),
+    _gimbal_manager_sysid(gimbal_manager_sysid),
+    _gimbal_manager_compid(gimbal_manager_compid)
+{}
 
 Gimbal::Result GimbalProtocolV2::set_pitch_and_yaw(float pitch_deg, float yaw_deg)
 {
@@ -37,8 +35,8 @@ Gimbal::Result GimbalProtocolV2::set_pitch_and_yaw(float pitch_deg, float yaw_de
         _system_impl.get_own_system_id(),
         _system_impl.get_own_component_id(),
         &message,
-        _system_impl.get_system_id(),
-        _system_impl.get_autopilot_id(), // FIXME: this is hard-coded to autopilot for now
+        _gimbal_manager_sysid,
+        _gimbal_manager_compid,
         flags,
         _gimbal_device_id,
         quaternion,
@@ -75,8 +73,8 @@ GimbalProtocolV2::set_pitch_rate_and_yaw_rate(float pitch_rate_deg_s, float yaw_
         _system_impl.get_own_system_id(),
         _system_impl.get_own_component_id(),
         &message,
-        _system_impl.get_system_id(),
-        _system_impl.get_autopilot_id(), // FIXME: this is hard-coded to autopilot for now
+        _gimbal_manager_sysid,
+        _gimbal_manager_compid,
         flags,
         _gimbal_device_id,
         quaternion,

--- a/src/plugins/gimbal/gimbal_protocol_v2.cpp
+++ b/src/plugins/gimbal/gimbal_protocol_v2.cpp
@@ -61,6 +61,44 @@ void GimbalProtocolV2::set_pitch_and_yaw_async(
     }
 }
 
+Gimbal::Result
+GimbalProtocolV2::set_pitch_rate_and_yaw_rate(float pitch_rate_deg_s, float yaw_rate_deg_s)
+{
+    const uint32_t flags =
+        GIMBAL_MANAGER_FLAGS_ROLL_LOCK | GIMBAL_MANAGER_FLAGS_PITCH_LOCK |
+        ((_gimbal_mode == Gimbal::GimbalMode::YawLock) ? GIMBAL_MANAGER_FLAGS_YAW_LOCK : 0);
+
+    const float quaternion[4] = {NAN, NAN, NAN, NAN};
+
+    mavlink_message_t message;
+    mavlink_msg_gimbal_manager_set_attitude_pack(
+        _system_impl.get_own_system_id(),
+        _system_impl.get_own_component_id(),
+        &message,
+        _system_impl.get_system_id(),
+        _system_impl.get_autopilot_id(), // FIXME: this is hard-coded to autopilot for now
+        flags,
+        _gimbal_device_id,
+        quaternion,
+        0.0f,
+        to_rad_from_deg(pitch_rate_deg_s),
+        to_rad_from_deg(yaw_rate_deg_s));
+
+    return _system_impl.send_message(message) ? Gimbal::Result::Success : Gimbal::Result::Error;
+}
+
+void GimbalProtocolV2::set_pitch_rate_and_yaw_rate_async(
+    float pitch_rate_deg_s, float yaw_rate_deg_s, Gimbal::ResultCallback callback)
+{
+    // Sending the message should be quick and we can just do that straighaway.
+    Gimbal::Result result = set_pitch_rate_and_yaw_rate(pitch_rate_deg_s, yaw_rate_deg_s);
+
+    if (callback) {
+        auto temp_callback = callback;
+        _system_impl.call_user_callback([temp_callback, result]() { temp_callback(result); });
+    }
+}
+
 Gimbal::Result GimbalProtocolV2::set_mode(const Gimbal::GimbalMode gimbal_mode)
 {
     _gimbal_mode = gimbal_mode;

--- a/src/plugins/gimbal/gimbal_protocol_v2.h
+++ b/src/plugins/gimbal/gimbal_protocol_v2.h
@@ -16,6 +16,12 @@ public:
     void set_pitch_and_yaw_async(
         float pitch_deg, float yaw_deg, Gimbal::ResultCallback callback) override;
 
+    Gimbal::Result
+    set_pitch_rate_and_yaw_rate(float pitch_rate_deg_s, float yaw_rate_deg_s) override;
+
+    void set_pitch_rate_and_yaw_rate_async(
+        float pitch_rate_deg_s, float yaw_rate_deg_s, Gimbal::ResultCallback callback) override;
+
     Gimbal::Result set_mode(const Gimbal::GimbalMode gimbal_mode) override;
 
     void

--- a/src/plugins/gimbal/gimbal_protocol_v2.h
+++ b/src/plugins/gimbal/gimbal_protocol_v2.h
@@ -8,7 +8,10 @@ namespace mavsdk {
 class GimbalProtocolV2 : public GimbalProtocolBase {
 public:
     GimbalProtocolV2(
-        SystemImpl& system_impl, const mavlink_gimbal_manager_information_t& information);
+        SystemImpl& system_impl,
+        const mavlink_gimbal_manager_information_t& information,
+        uint8_t gimbal_manager_sysid,
+        uint8_t gimbal_manager_compid);
     ~GimbalProtocolV2() = default;
 
     Gimbal::Result set_pitch_and_yaw(float pitch_deg, float yaw_deg) override;
@@ -37,9 +40,10 @@ public:
         Gimbal::ResultCallback callback) override;
 
 private:
-    void set_gimbal_information(const mavlink_gimbal_manager_information_t& information);
+    uint8_t _gimbal_manager_sysid;
+    uint8_t _gimbal_manager_compid;
+    uint8_t _gimbal_device_id;
 
-    uint8_t _gimbal_device_id{0};
     Gimbal::GimbalMode _gimbal_mode{Gimbal::GimbalMode::YawFollow};
 };
 

--- a/src/plugins/gimbal/include/plugins/gimbal/gimbal.h
+++ b/src/plugins/gimbal/include/plugins/gimbal/gimbal.h
@@ -119,6 +119,33 @@ public:
     Result set_pitch_and_yaw(float pitch_deg, float yaw_deg) const;
 
     /**
+     * @brief Set gimbal angular rates around pitch and yaw axes.
+     *
+     * This sets the desired angular rates around pitch and yaw axes of a gimbal.
+     * Will return when the command is accepted, however, it might
+     * take the gimbal longer to actually reach the angular rate.
+     *
+     * This function is non-blocking. See 'set_pitch_rate_and_yaw_rate' for the blocking
+     * counterpart.
+     */
+    void set_pitch_rate_and_yaw_rate_async(
+        float pitch_rate_deg_s, float yaw_rate_deg_s, const ResultCallback callback);
+
+    /**
+     * @brief Set gimbal angular rates around pitch and yaw axes.
+     *
+     * This sets the desired angular rates around pitch and yaw axes of a gimbal.
+     * Will return when the command is accepted, however, it might
+     * take the gimbal longer to actually reach the angular rate.
+     *
+     * This function is blocking. See 'set_pitch_rate_and_yaw_rate_async' for the non-blocking
+     * counterpart.
+     *
+     * @return Result of request.
+     */
+    Result set_pitch_rate_and_yaw_rate(float pitch_rate_deg_s, float yaw_rate_deg_s) const;
+
+    /**
      * @brief Set gimbal mode.
      *
      * This sets the desired yaw mode of a gimbal.


### PR DESCRIPTION
This adds the API for angular rates around the pitch and yaw axes. This API is unsupported if the gimbal v1 protocol is used though.