### PR TITLE
Add support for list_photos()

### DIFF
--- a/src/mavsdk_server/src/generated/camera/camera.grpc.pb.cc
+++ b/src/mavsdk_server/src/generated/camera/camera.grpc.pb.cc
@@ -32,6 +32,7 @@ static const char* CameraService_method_names[] = {
   "/mavsdk.rpc.camera.CameraService/StartVideoStreaming",
   "/mavsdk.rpc.camera.CameraService/StopVideoStreaming",
   "/mavsdk.rpc.camera.CameraService/SetMode",
+  "/mavsdk.rpc.camera.CameraService/ListPhotos",
   "/mavsdk.rpc.camera.CameraService/SubscribeMode",
   "/mavsdk.rpc.camera.CameraService/SubscribeInformation",
   "/mavsdk.rpc.camera.CameraService/SubscribeVideoStreamInfo",
@@ -59,16 +60,17 @@ CameraService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& chan
   , rpcmethod_StartVideoStreaming_(CameraService_method_names[5], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_StopVideoStreaming_(CameraService_method_names[6], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_SetMode_(CameraService_method_names[7], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SubscribeMode_(CameraService_method_names[8], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
-  , rpcmethod_SubscribeInformation_(CameraService_method_names[9], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
-  , rpcmethod_SubscribeVideoStreamInfo_(CameraService_method_names[10], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
-  , rpcmethod_SubscribeCaptureInfo_(CameraService_method_names[11], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
-  , rpcmethod_SubscribeStatus_(CameraService_method_names[12], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
-  , rpcmethod_SubscribeCurrentSettings_(CameraService_method_names[13], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
-  , rpcmethod_SubscribePossibleSettingOptions_(CameraService_method_names[14], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
-  , rpcmethod_SetSetting_(CameraService_method_names[15], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_GetSetting_(CameraService_method_names[16], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_FormatStorage_(CameraService_method_names[17], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ListPhotos_(CameraService_method_names[8], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubscribeMode_(CameraService_method_names[9], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_SubscribeInformation_(CameraService_method_names[10], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_SubscribeVideoStreamInfo_(CameraService_method_names[11], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_SubscribeCaptureInfo_(CameraService_method_names[12], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_SubscribeStatus_(CameraService_method_names[13], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_SubscribeCurrentSettings_(CameraService_method_names[14], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_SubscribePossibleSettingOptions_(CameraService_method_names[15], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_SetSetting_(CameraService_method_names[16], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetSetting_(CameraService_method_names[17], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_FormatStorage_(CameraService_method_names[18], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status CameraService::Stub::TakePhoto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::TakePhotoRequest& request, ::mavsdk::rpc::camera::TakePhotoResponse* response) {
@@ -251,6 +253,29 @@ void CameraService::Stub::experimental_async::SetMode(::grpc::ClientContext* con
 ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::SetModeResponse>* CameraService::Stub::AsyncSetModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::SetModeRequest& request, ::grpc::CompletionQueue* cq) {
   auto* result =
     this->PrepareAsyncSetModeRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::Status CameraService::Stub::ListPhotos(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest& request, ::mavsdk::rpc::camera::ListPhotosResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera::ListPhotosRequest, ::mavsdk::rpc::camera::ListPhotosResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_ListPhotos_, context, request, response);
+}
+
+void CameraService::Stub::experimental_async::ListPhotos(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest* request, ::mavsdk::rpc::camera::ListPhotosResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera::ListPhotosRequest, ::mavsdk::rpc::camera::ListPhotosResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_ListPhotos_, context, request, response, std::move(f));
+}
+
+void CameraService::Stub::experimental_async::ListPhotos(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest* request, ::mavsdk::rpc::camera::ListPhotosResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_ListPhotos_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::ListPhotosResponse>* CameraService::Stub::PrepareAsyncListPhotosRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera::ListPhotosResponse, ::mavsdk::rpc::camera::ListPhotosRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_ListPhotos_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::ListPhotosResponse>* CameraService::Stub::AsyncListPhotosRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncListPhotosRaw(context, request, cq);
   result->StartCall();
   return result;
 }
@@ -519,6 +544,16 @@ CameraService::Service::Service() {
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       CameraService_method_names[8],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraService::Service, ::mavsdk::rpc::camera::ListPhotosRequest, ::mavsdk::rpc::camera::ListPhotosResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera::ListPhotosRequest* req,
+             ::mavsdk::rpc::camera::ListPhotosResponse* resp) {
+               return service->ListPhotos(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraService_method_names[9],
       ::grpc::internal::RpcMethod::SERVER_STREAMING,
       new ::grpc::internal::ServerStreamingHandler< CameraService::Service, ::mavsdk::rpc::camera::SubscribeModeRequest, ::mavsdk::rpc::camera::ModeResponse>(
           [](CameraService::Service* service,
@@ -528,7 +563,7 @@ CameraService::Service::Service() {
                return service->SubscribeMode(ctx, req, writer);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraService_method_names[9],
+      CameraService_method_names[10],
       ::grpc::internal::RpcMethod::SERVER_STREAMING,
       new ::grpc::internal::ServerStreamingHandler< CameraService::Service, ::mavsdk::rpc::camera::SubscribeInformationRequest, ::mavsdk::rpc::camera::InformationResponse>(
           [](CameraService::Service* service,
@@ -538,7 +573,7 @@ CameraService::Service::Service() {
                return service->SubscribeInformation(ctx, req, writer);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraService_method_names[10],
+      CameraService_method_names[11],
       ::grpc::internal::RpcMethod::SERVER_STREAMING,
       new ::grpc::internal::ServerStreamingHandler< CameraService::Service, ::mavsdk::rpc::camera::SubscribeVideoStreamInfoRequest, ::mavsdk::rpc::camera::VideoStreamInfoResponse>(
           [](CameraService::Service* service,
@@ -548,7 +583,7 @@ CameraService::Service::Service() {
                return service->SubscribeVideoStreamInfo(ctx, req, writer);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraService_method_names[11],
+      CameraService_method_names[12],
       ::grpc::internal::RpcMethod::SERVER_STREAMING,
       new ::grpc::internal::ServerStreamingHandler< CameraService::Service, ::mavsdk::rpc::camera::SubscribeCaptureInfoRequest, ::mavsdk::rpc::camera::CaptureInfoResponse>(
           [](CameraService::Service* service,
@@ -558,7 +593,7 @@ CameraService::Service::Service() {
                return service->SubscribeCaptureInfo(ctx, req, writer);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraService_method_names[12],
+      CameraService_method_names[13],
       ::grpc::internal::RpcMethod::SERVER_STREAMING,
       new ::grpc::internal::ServerStreamingHandler< CameraService::Service, ::mavsdk::rpc::camera::SubscribeStatusRequest, ::mavsdk::rpc::camera::StatusResponse>(
           [](CameraService::Service* service,
@@ -568,7 +603,7 @@ CameraService::Service::Service() {
                return service->SubscribeStatus(ctx, req, writer);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraService_method_names[13],
+      CameraService_method_names[14],
       ::grpc::internal::RpcMethod::SERVER_STREAMING,
       new ::grpc::internal::ServerStreamingHandler< CameraService::Service, ::mavsdk::rpc::camera::SubscribeCurrentSettingsRequest, ::mavsdk::rpc::camera::CurrentSettingsResponse>(
           [](CameraService::Service* service,
@@ -578,7 +613,7 @@ CameraService::Service::Service() {
                return service->SubscribeCurrentSettings(ctx, req, writer);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraService_method_names[14],
+      CameraService_method_names[15],
       ::grpc::internal::RpcMethod::SERVER_STREAMING,
       new ::grpc::internal::ServerStreamingHandler< CameraService::Service, ::mavsdk::rpc::camera::SubscribePossibleSettingOptionsRequest, ::mavsdk::rpc::camera::PossibleSettingOptionsResponse>(
           [](CameraService::Service* service,
@@ -588,7 +623,7 @@ CameraService::Service::Service() {
                return service->SubscribePossibleSettingOptions(ctx, req, writer);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraService_method_names[15],
+      CameraService_method_names[16],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraService::Service, ::mavsdk::rpc::camera::SetSettingRequest, ::mavsdk::rpc::camera::SetSettingResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraService::Service* service,
@@ -598,7 +633,7 @@ CameraService::Service::Service() {
                return service->SetSetting(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraService_method_names[16],
+      CameraService_method_names[17],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraService::Service, ::mavsdk::rpc::camera::GetSettingRequest, ::mavsdk::rpc::camera::GetSettingResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraService::Service* service,
@@ -608,7 +643,7 @@ CameraService::Service::Service() {
                return service->GetSetting(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraService_method_names[17],
+      CameraService_method_names[18],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraService::Service, ::mavsdk::rpc::camera::FormatStorageRequest, ::mavsdk::rpc::camera::FormatStorageResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraService::Service* service,
@@ -672,6 +707,13 @@ CameraService::Service::~Service() {
 }
 
 ::grpc::Status CameraService::Service::SetMode(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::SetModeRequest* request, ::mavsdk::rpc::camera::SetModeResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraService::Service::ListPhotos(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest* request, ::mavsdk::rpc::camera::ListPhotosResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/src/mavsdk_server/src/generated/camera/camera.grpc.pb.h
+++ b/src/mavsdk_server/src/generated/camera/camera.grpc.pb.h
@@ -119,6 +119,15 @@ class CameraService final {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::SetModeResponse>>(PrepareAsyncSetModeRaw(context, request, cq));
     }
     //
+    // List photos available on the camera.
+    virtual ::grpc::Status ListPhotos(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest& request, ::mavsdk::rpc::camera::ListPhotosResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::ListPhotosResponse>> AsyncListPhotos(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::ListPhotosResponse>>(AsyncListPhotosRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::ListPhotosResponse>> PrepareAsyncListPhotos(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::ListPhotosResponse>>(PrepareAsyncListPhotosRaw(context, request, cq));
+    }
+    //
     // Subscribe to camera mode updates.
     std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera::ModeResponse>> SubscribeMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::SubscribeModeRequest& request) {
       return std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera::ModeResponse>>(SubscribeModeRaw(context, request));
@@ -296,6 +305,14 @@ class CameraService final {
       virtual void SetMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::SetModeRequest* request, ::mavsdk::rpc::camera::SetModeResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
       #endif
       //
+      // List photos available on the camera.
+      virtual void ListPhotos(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest* request, ::mavsdk::rpc::camera::ListPhotosResponse* response, std::function<void(::grpc::Status)>) = 0;
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      virtual void ListPhotos(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest* request, ::mavsdk::rpc::camera::ListPhotosResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      #else
+      virtual void ListPhotos(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest* request, ::mavsdk::rpc::camera::ListPhotosResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
+      #endif
+      //
       // Subscribe to camera mode updates.
       #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       virtual void SubscribeMode(::grpc::ClientContext* context, ::mavsdk::rpc::camera::SubscribeModeRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera::ModeResponse>* reactor) = 0;
@@ -399,6 +416,8 @@ class CameraService final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::StopVideoStreamingResponse>* PrepareAsyncStopVideoStreamingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::StopVideoStreamingRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::SetModeResponse>* AsyncSetModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::SetModeRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::SetModeResponse>* PrepareAsyncSetModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::SetModeRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::ListPhotosResponse>* AsyncListPhotosRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::ListPhotosResponse>* PrepareAsyncListPhotosRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera::ModeResponse>* SubscribeModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::SubscribeModeRequest& request) = 0;
     virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera::ModeResponse>* AsyncSubscribeModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::SubscribeModeRequest& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
     virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera::ModeResponse>* PrepareAsyncSubscribeModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::SubscribeModeRequest& request, ::grpc::CompletionQueue* cq) = 0;
@@ -485,6 +504,13 @@ class CameraService final {
     }
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::SetModeResponse>> PrepareAsyncSetMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::SetModeRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::SetModeResponse>>(PrepareAsyncSetModeRaw(context, request, cq));
+    }
+    ::grpc::Status ListPhotos(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest& request, ::mavsdk::rpc::camera::ListPhotosResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::ListPhotosResponse>> AsyncListPhotos(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::ListPhotosResponse>>(AsyncListPhotosRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::ListPhotosResponse>> PrepareAsyncListPhotos(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::ListPhotosResponse>>(PrepareAsyncListPhotosRaw(context, request, cq));
     }
     std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera::ModeResponse>> SubscribeMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::SubscribeModeRequest& request) {
       return std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera::ModeResponse>>(SubscribeModeRaw(context, request));
@@ -621,6 +647,12 @@ class CameraService final {
       #else
       void SetMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::SetModeRequest* request, ::mavsdk::rpc::camera::SetModeResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
       #endif
+      void ListPhotos(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest* request, ::mavsdk::rpc::camera::ListPhotosResponse* response, std::function<void(::grpc::Status)>) override;
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      void ListPhotos(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest* request, ::mavsdk::rpc::camera::ListPhotosResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      #else
+      void ListPhotos(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest* request, ::mavsdk::rpc::camera::ListPhotosResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
+      #endif
       #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       void SubscribeMode(::grpc::ClientContext* context, ::mavsdk::rpc::camera::SubscribeModeRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera::ModeResponse>* reactor) override;
       #else
@@ -701,6 +733,8 @@ class CameraService final {
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::StopVideoStreamingResponse>* PrepareAsyncStopVideoStreamingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::StopVideoStreamingRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::SetModeResponse>* AsyncSetModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::SetModeRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::SetModeResponse>* PrepareAsyncSetModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::SetModeRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::ListPhotosResponse>* AsyncListPhotosRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::ListPhotosResponse>* PrepareAsyncListPhotosRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientReader< ::mavsdk::rpc::camera::ModeResponse>* SubscribeModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::SubscribeModeRequest& request) override;
     ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera::ModeResponse>* AsyncSubscribeModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::SubscribeModeRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
     ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera::ModeResponse>* PrepareAsyncSubscribeModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::SubscribeModeRequest& request, ::grpc::CompletionQueue* cq) override;
@@ -736,6 +770,7 @@ class CameraService final {
     const ::grpc::internal::RpcMethod rpcmethod_StartVideoStreaming_;
     const ::grpc::internal::RpcMethod rpcmethod_StopVideoStreaming_;
     const ::grpc::internal::RpcMethod rpcmethod_SetMode_;
+    const ::grpc::internal::RpcMethod rpcmethod_ListPhotos_;
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeMode_;
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeInformation_;
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeVideoStreamInfo_;
@@ -777,6 +812,9 @@ class CameraService final {
     //
     // Set camera mode.
     virtual ::grpc::Status SetMode(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::SetModeRequest* request, ::mavsdk::rpc::camera::SetModeResponse* response);
+    //
+    // List photos available on the camera.
+    virtual ::grpc::Status ListPhotos(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::ListPhotosRequest* request, ::mavsdk::rpc::camera::ListPhotosResponse* response);
     //
     // Subscribe to camera mode updates.
     virtual ::grpc::Status SubscribeMode(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::SubscribeModeRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera::ModeResponse>* writer);
@@ -975,12 +1013,32 @@ class CameraService final {
     }
   };
   template <class BaseClass>
+  class WithAsyncMethod_ListPhotos : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_ListPhotos() {
+      ::grpc::Service::MarkMethodAsync(8);
+    }
+    ~WithAsyncMethod_ListPhotos() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status ListPhotos(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::ListPhotosRequest* /*request*/, ::mavsdk::rpc::camera::ListPhotosResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestListPhotos(::grpc::ServerContext* context, ::mavsdk::rpc::camera::ListPhotosRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera::ListPhotosResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithAsyncMethod_SubscribeMode : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SubscribeMode() {
-      ::grpc::Service::MarkMethodAsync(8);
+      ::grpc::Service::MarkMethodAsync(9);
     }
     ~WithAsyncMethod_SubscribeMode() override {
       BaseClassMustBeDerivedFromService(this);
@@ -991,7 +1049,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeMode(::grpc::ServerContext* context, ::mavsdk::rpc::camera::SubscribeModeRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera::ModeResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(8, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(9, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1000,7 +1058,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SubscribeInformation() {
-      ::grpc::Service::MarkMethodAsync(9);
+      ::grpc::Service::MarkMethodAsync(10);
     }
     ~WithAsyncMethod_SubscribeInformation() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1011,7 +1069,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeInformation(::grpc::ServerContext* context, ::mavsdk::rpc::camera::SubscribeInformationRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera::InformationResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(9, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(10, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1020,7 +1078,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SubscribeVideoStreamInfo() {
-      ::grpc::Service::MarkMethodAsync(10);
+      ::grpc::Service::MarkMethodAsync(11);
     }
     ~WithAsyncMethod_SubscribeVideoStreamInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1031,7 +1089,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeVideoStreamInfo(::grpc::ServerContext* context, ::mavsdk::rpc::camera::SubscribeVideoStreamInfoRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera::VideoStreamInfoResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(10, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(11, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1040,7 +1098,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SubscribeCaptureInfo() {
-      ::grpc::Service::MarkMethodAsync(11);
+      ::grpc::Service::MarkMethodAsync(12);
     }
     ~WithAsyncMethod_SubscribeCaptureInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1051,7 +1109,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeCaptureInfo(::grpc::ServerContext* context, ::mavsdk::rpc::camera::SubscribeCaptureInfoRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera::CaptureInfoResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(11, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(12, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1060,7 +1118,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SubscribeStatus() {
-      ::grpc::Service::MarkMethodAsync(12);
+      ::grpc::Service::MarkMethodAsync(13);
     }
     ~WithAsyncMethod_SubscribeStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1071,7 +1129,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeStatus(::grpc::ServerContext* context, ::mavsdk::rpc::camera::SubscribeStatusRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera::StatusResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(12, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(13, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1080,7 +1138,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SubscribeCurrentSettings() {
-      ::grpc::Service::MarkMethodAsync(13);
+      ::grpc::Service::MarkMethodAsync(14);
     }
     ~WithAsyncMethod_SubscribeCurrentSettings() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1091,7 +1149,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeCurrentSettings(::grpc::ServerContext* context, ::mavsdk::rpc::camera::SubscribeCurrentSettingsRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera::CurrentSettingsResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(13, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(14, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1100,7 +1158,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SubscribePossibleSettingOptions() {
-      ::grpc::Service::MarkMethodAsync(14);
+      ::grpc::Service::MarkMethodAsync(15);
     }
     ~WithAsyncMethod_SubscribePossibleSettingOptions() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1111,7 +1169,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribePossibleSettingOptions(::grpc::ServerContext* context, ::mavsdk::rpc::camera::SubscribePossibleSettingOptionsRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera::PossibleSettingOptionsResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(14, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(15, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1120,7 +1178,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetSetting() {
-      ::grpc::Service::MarkMethodAsync(15);
+      ::grpc::Service::MarkMethodAsync(16);
     }
     ~WithAsyncMethod_SetSetting() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1131,7 +1189,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetSetting(::grpc::ServerContext* context, ::mavsdk::rpc::camera::SetSettingRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera::SetSettingResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1140,7 +1198,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_GetSetting() {
-      ::grpc::Service::MarkMethodAsync(16);
+      ::grpc::Service::MarkMethodAsync(17);
     }
     ~WithAsyncMethod_GetSetting() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1151,7 +1209,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetSetting(::grpc::ServerContext* context, ::mavsdk::rpc::camera::GetSettingRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera::GetSettingResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(17, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1160,7 +1218,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_FormatStorage() {
-      ::grpc::Service::MarkMethodAsync(17);
+      ::grpc::Service::MarkMethodAsync(18);
     }
     ~WithAsyncMethod_FormatStorage() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1171,10 +1229,10 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestFormatStorage(::grpc::ServerContext* context, ::mavsdk::rpc::camera::FormatStorageRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera::FormatStorageResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(17, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(18, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_TakePhoto<WithAsyncMethod_StartPhotoInterval<WithAsyncMethod_StopPhotoInterval<WithAsyncMethod_StartVideo<WithAsyncMethod_StopVideo<WithAsyncMethod_StartVideoStreaming<WithAsyncMethod_StopVideoStreaming<WithAsyncMethod_SetMode<WithAsyncMethod_SubscribeMode<WithAsyncMethod_SubscribeInformation<WithAsyncMethod_SubscribeVideoStreamInfo<WithAsyncMethod_SubscribeCaptureInfo<WithAsyncMethod_SubscribeStatus<WithAsyncMethod_SubscribeCurrentSettings<WithAsyncMethod_SubscribePossibleSettingOptions<WithAsyncMethod_SetSetting<WithAsyncMethod_GetSetting<WithAsyncMethod_FormatStorage<Service > > > > > > > > > > > > > > > > > > AsyncService;
+  typedef WithAsyncMethod_TakePhoto<WithAsyncMethod_StartPhotoInterval<WithAsyncMethod_StopPhotoInterval<WithAsyncMethod_StartVideo<WithAsyncMethod_StopVideo<WithAsyncMethod_StartVideoStreaming<WithAsyncMethod_StopVideoStreaming<WithAsyncMethod_SetMode<WithAsyncMethod_ListPhotos<WithAsyncMethod_SubscribeMode<WithAsyncMethod_SubscribeInformation<WithAsyncMethod_SubscribeVideoStreamInfo<WithAsyncMethod_SubscribeCaptureInfo<WithAsyncMethod_SubscribeStatus<WithAsyncMethod_SubscribeCurrentSettings<WithAsyncMethod_SubscribePossibleSettingOptions<WithAsyncMethod_SetSetting<WithAsyncMethod_GetSetting<WithAsyncMethod_FormatStorage<Service > > > > > > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class ExperimentalWithCallbackMethod_TakePhoto : public BaseClass {
    private:
@@ -1552,6 +1610,53 @@ class CameraService final {
       { return nullptr; }
   };
   template <class BaseClass>
+  class ExperimentalWithCallbackMethod_ListPhotos : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    ExperimentalWithCallbackMethod_ListPhotos() {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodCallback(8,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::ListPhotosRequest, ::mavsdk::rpc::camera::ListPhotosResponse>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const ::mavsdk::rpc::camera::ListPhotosRequest* request, ::mavsdk::rpc::camera::ListPhotosResponse* response) { return this->ListPhotos(context, request, response); }));}
+    void SetMessageAllocatorFor_ListPhotos(
+        ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::camera::ListPhotosRequest, ::mavsdk::rpc::camera::ListPhotosResponse>* allocator) {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(8);
+    #else
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(8);
+    #endif
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::ListPhotosRequest, ::mavsdk::rpc::camera::ListPhotosResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~ExperimentalWithCallbackMethod_ListPhotos() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status ListPhotos(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::ListPhotosRequest* /*request*/, ::mavsdk::rpc::camera::ListPhotosResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerUnaryReactor* ListPhotos(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera::ListPhotosRequest* /*request*/, ::mavsdk::rpc::camera::ListPhotosResponse* /*response*/)
+    #else
+    virtual ::grpc::experimental::ServerUnaryReactor* ListPhotos(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera::ListPhotosRequest* /*request*/, ::mavsdk::rpc::camera::ListPhotosResponse* /*response*/)
+    #endif
+      { return nullptr; }
+  };
+  template <class BaseClass>
   class ExperimentalWithCallbackMethod_SubscribeMode : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
@@ -1562,7 +1667,7 @@ class CameraService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(8,
+        MarkMethodCallback(9,
           new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera::SubscribeModeRequest, ::mavsdk::rpc::camera::ModeResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -1600,7 +1705,7 @@ class CameraService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(9,
+        MarkMethodCallback(10,
           new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera::SubscribeInformationRequest, ::mavsdk::rpc::camera::InformationResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -1638,7 +1743,7 @@ class CameraService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(10,
+        MarkMethodCallback(11,
           new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera::SubscribeVideoStreamInfoRequest, ::mavsdk::rpc::camera::VideoStreamInfoResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -1676,7 +1781,7 @@ class CameraService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(11,
+        MarkMethodCallback(12,
           new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera::SubscribeCaptureInfoRequest, ::mavsdk::rpc::camera::CaptureInfoResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -1714,7 +1819,7 @@ class CameraService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(12,
+        MarkMethodCallback(13,
           new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera::SubscribeStatusRequest, ::mavsdk::rpc::camera::StatusResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -1752,7 +1857,7 @@ class CameraService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(13,
+        MarkMethodCallback(14,
           new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera::SubscribeCurrentSettingsRequest, ::mavsdk::rpc::camera::CurrentSettingsResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -1790,7 +1895,7 @@ class CameraService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(14,
+        MarkMethodCallback(15,
           new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera::SubscribePossibleSettingOptionsRequest, ::mavsdk::rpc::camera::PossibleSettingOptionsResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -1828,7 +1933,7 @@ class CameraService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(15,
+        MarkMethodCallback(16,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::SetSettingRequest, ::mavsdk::rpc::camera::SetSettingResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -1840,9 +1945,9 @@ class CameraService final {
     void SetMessageAllocatorFor_SetSetting(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::camera::SetSettingRequest, ::mavsdk::rpc::camera::SetSettingResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(15);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(16);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(15);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(16);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::SetSettingRequest, ::mavsdk::rpc::camera::SetSettingResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -1875,7 +1980,7 @@ class CameraService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(16,
+        MarkMethodCallback(17,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::GetSettingRequest, ::mavsdk::rpc::camera::GetSettingResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -1887,9 +1992,9 @@ class CameraService final {
     void SetMessageAllocatorFor_GetSetting(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::camera::GetSettingRequest, ::mavsdk::rpc::camera::GetSettingResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(16);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(17);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(16);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(17);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::GetSettingRequest, ::mavsdk::rpc::camera::GetSettingResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -1922,7 +2027,7 @@ class CameraService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(17,
+        MarkMethodCallback(18,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FormatStorageRequest, ::mavsdk::rpc::camera::FormatStorageResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -1934,9 +2039,9 @@ class CameraService final {
     void SetMessageAllocatorFor_FormatStorage(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::camera::FormatStorageRequest, ::mavsdk::rpc::camera::FormatStorageResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(17);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(18);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(17);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(18);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FormatStorageRequest, ::mavsdk::rpc::camera::FormatStorageResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -1959,10 +2064,10 @@ class CameraService final {
       { return nullptr; }
   };
   #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-  typedef ExperimentalWithCallbackMethod_TakePhoto<ExperimentalWithCallbackMethod_StartPhotoInterval<ExperimentalWithCallbackMethod_StopPhotoInterval<ExperimentalWithCallbackMethod_StartVideo<ExperimentalWithCallbackMethod_StopVideo<ExperimentalWithCallbackMethod_StartVideoStreaming<ExperimentalWithCallbackMethod_StopVideoStreaming<ExperimentalWithCallbackMethod_SetMode<ExperimentalWithCallbackMethod_SubscribeMode<ExperimentalWithCallbackMethod_SubscribeInformation<ExperimentalWithCallbackMethod_SubscribeVideoStreamInfo<ExperimentalWithCallbackMethod_SubscribeCaptureInfo<ExperimentalWithCallbackMethod_SubscribeStatus<ExperimentalWithCallbackMethod_SubscribeCurrentSettings<ExperimentalWithCallbackMethod_SubscribePossibleSettingOptions<ExperimentalWithCallbackMethod_SetSetting<ExperimentalWithCallbackMethod_GetSetting<ExperimentalWithCallbackMethod_FormatStorage<Service > > > > > > > > > > > > > > > > > > CallbackService;
+  typedef ExperimentalWithCallbackMethod_TakePhoto<ExperimentalWithCallbackMethod_StartPhotoInterval<ExperimentalWithCallbackMethod_StopPhotoInterval<ExperimentalWithCallbackMethod_StartVideo<ExperimentalWithCallbackMethod_StopVideo<ExperimentalWithCallbackMethod_StartVideoStreaming<ExperimentalWithCallbackMethod_StopVideoStreaming<ExperimentalWithCallbackMethod_SetMode<ExperimentalWithCallbackMethod_ListPhotos<ExperimentalWithCallbackMethod_SubscribeMode<ExperimentalWithCallbackMethod_SubscribeInformation<ExperimentalWithCallbackMethod_SubscribeVideoStreamInfo<ExperimentalWithCallbackMethod_SubscribeCaptureInfo<ExperimentalWithCallbackMethod_SubscribeStatus<ExperimentalWithCallbackMethod_SubscribeCurrentSettings<ExperimentalWithCallbackMethod_SubscribePossibleSettingOptions<ExperimentalWithCallbackMethod_SetSetting<ExperimentalWithCallbackMethod_GetSetting<ExperimentalWithCallbackMethod_FormatStorage<Service > > > > > > > > > > > > > > > > > > > CallbackService;
   #endif
 
-  typedef ExperimentalWithCallbackMethod_TakePhoto<ExperimentalWithCallbackMethod_StartPhotoInterval<ExperimentalWithCallbackMethod_StopPhotoInterval<ExperimentalWithCallbackMethod_StartVideo<ExperimentalWithCallbackMethod_StopVideo<ExperimentalWithCallbackMethod_StartVideoStreaming<ExperimentalWithCallbackMethod_StopVideoStreaming<ExperimentalWithCallbackMethod_SetMode<ExperimentalWithCallbackMethod_SubscribeMode<ExperimentalWithCallbackMethod_SubscribeInformation<ExperimentalWithCallbackMethod_SubscribeVideoStreamInfo<ExperimentalWithCallbackMethod_SubscribeCaptureInfo<ExperimentalWithCallbackMethod_SubscribeStatus<ExperimentalWithCallbackMethod_SubscribeCurrentSettings<ExperimentalWithCallbackMethod_SubscribePossibleSettingOptions<ExperimentalWithCallbackMethod_SetSetting<ExperimentalWithCallbackMethod_GetSetting<ExperimentalWithCallbackMethod_FormatStorage<Service > > > > > > > > > > > > > > > > > > ExperimentalCallbackService;
+  typedef ExperimentalWithCallbackMethod_TakePhoto<ExperimentalWithCallbackMethod_StartPhotoInterval<ExperimentalWithCallbackMethod_StopPhotoInterval<ExperimentalWithCallbackMethod_StartVideo<ExperimentalWithCallbackMethod_StopVideo<ExperimentalWithCallbackMethod_StartVideoStreaming<ExperimentalWithCallbackMethod_StopVideoStreaming<ExperimentalWithCallbackMethod_SetMode<ExperimentalWithCallbackMethod_ListPhotos<ExperimentalWithCallbackMethod_SubscribeMode<ExperimentalWithCallbackMethod_SubscribeInformation<ExperimentalWithCallbackMethod_SubscribeVideoStreamInfo<ExperimentalWithCallbackMethod_SubscribeCaptureInfo<ExperimentalWithCallbackMethod_SubscribeStatus<ExperimentalWithCallbackMethod_SubscribeCurrentSettings<ExperimentalWithCallbackMethod_SubscribePossibleSettingOptions<ExperimentalWithCallbackMethod_SetSetting<ExperimentalWithCallbackMethod_GetSetting<ExperimentalWithCallbackMethod_FormatStorage<Service > > > > > > > > > > > > > > > > > > > ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_TakePhoto : public BaseClass {
    private:
@@ -2100,12 +2205,29 @@ class CameraService final {
     }
   };
   template <class BaseClass>
+  class WithGenericMethod_ListPhotos : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_ListPhotos() {
+      ::grpc::Service::MarkMethodGeneric(8);
+    }
+    ~WithGenericMethod_ListPhotos() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status ListPhotos(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::ListPhotosRequest* /*request*/, ::mavsdk::rpc::camera::ListPhotosResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
   class WithGenericMethod_SubscribeMode : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SubscribeMode() {
-      ::grpc::Service::MarkMethodGeneric(8);
+      ::grpc::Service::MarkMethodGeneric(9);
     }
     ~WithGenericMethod_SubscribeMode() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2122,7 +2244,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SubscribeInformation() {
-      ::grpc::Service::MarkMethodGeneric(9);
+      ::grpc::Service::MarkMethodGeneric(10);
     }
     ~WithGenericMethod_SubscribeInformation() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2139,7 +2261,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SubscribeVideoStreamInfo() {
-      ::grpc::Service::MarkMethodGeneric(10);
+      ::grpc::Service::MarkMethodGeneric(11);
     }
     ~WithGenericMethod_SubscribeVideoStreamInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2156,7 +2278,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SubscribeCaptureInfo() {
-      ::grpc::Service::MarkMethodGeneric(11);
+      ::grpc::Service::MarkMethodGeneric(12);
     }
     ~WithGenericMethod_SubscribeCaptureInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2173,7 +2295,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SubscribeStatus() {
-      ::grpc::Service::MarkMethodGeneric(12);
+      ::grpc::Service::MarkMethodGeneric(13);
     }
     ~WithGenericMethod_SubscribeStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2190,7 +2312,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SubscribeCurrentSettings() {
-      ::grpc::Service::MarkMethodGeneric(13);
+      ::grpc::Service::MarkMethodGeneric(14);
     }
     ~WithGenericMethod_SubscribeCurrentSettings() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2207,7 +2329,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SubscribePossibleSettingOptions() {
-      ::grpc::Service::MarkMethodGeneric(14);
+      ::grpc::Service::MarkMethodGeneric(15);
     }
     ~WithGenericMethod_SubscribePossibleSettingOptions() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2224,7 +2346,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetSetting() {
-      ::grpc::Service::MarkMethodGeneric(15);
+      ::grpc::Service::MarkMethodGeneric(16);
     }
     ~WithGenericMethod_SetSetting() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2241,7 +2363,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_GetSetting() {
-      ::grpc::Service::MarkMethodGeneric(16);
+      ::grpc::Service::MarkMethodGeneric(17);
     }
     ~WithGenericMethod_GetSetting() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2258,7 +2380,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_FormatStorage() {
-      ::grpc::Service::MarkMethodGeneric(17);
+      ::grpc::Service::MarkMethodGeneric(18);
     }
     ~WithGenericMethod_FormatStorage() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2430,12 +2552,32 @@ class CameraService final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_ListPhotos : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_ListPhotos() {
+      ::grpc::Service::MarkMethodRaw(8);
+    }
+    ~WithRawMethod_ListPhotos() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status ListPhotos(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::ListPhotosRequest* /*request*/, ::mavsdk::rpc::camera::ListPhotosResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestListPhotos(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithRawMethod_SubscribeMode : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SubscribeMode() {
-      ::grpc::Service::MarkMethodRaw(8);
+      ::grpc::Service::MarkMethodRaw(9);
     }
     ~WithRawMethod_SubscribeMode() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2446,7 +2588,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeMode(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(8, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(9, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2455,7 +2597,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SubscribeInformation() {
-      ::grpc::Service::MarkMethodRaw(9);
+      ::grpc::Service::MarkMethodRaw(10);
     }
     ~WithRawMethod_SubscribeInformation() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2466,7 +2608,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeInformation(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(9, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(10, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2475,7 +2617,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SubscribeVideoStreamInfo() {
-      ::grpc::Service::MarkMethodRaw(10);
+      ::grpc::Service::MarkMethodRaw(11);
     }
     ~WithRawMethod_SubscribeVideoStreamInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2486,7 +2628,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeVideoStreamInfo(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(10, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(11, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2495,7 +2637,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SubscribeCaptureInfo() {
-      ::grpc::Service::MarkMethodRaw(11);
+      ::grpc::Service::MarkMethodRaw(12);
     }
     ~WithRawMethod_SubscribeCaptureInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2506,7 +2648,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeCaptureInfo(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(11, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(12, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2515,7 +2657,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SubscribeStatus() {
-      ::grpc::Service::MarkMethodRaw(12);
+      ::grpc::Service::MarkMethodRaw(13);
     }
     ~WithRawMethod_SubscribeStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2526,7 +2668,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeStatus(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(12, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(13, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2535,7 +2677,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SubscribeCurrentSettings() {
-      ::grpc::Service::MarkMethodRaw(13);
+      ::grpc::Service::MarkMethodRaw(14);
     }
     ~WithRawMethod_SubscribeCurrentSettings() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2546,7 +2688,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeCurrentSettings(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(13, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(14, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2555,7 +2697,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SubscribePossibleSettingOptions() {
-      ::grpc::Service::MarkMethodRaw(14);
+      ::grpc::Service::MarkMethodRaw(15);
     }
     ~WithRawMethod_SubscribePossibleSettingOptions() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2566,7 +2708,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribePossibleSettingOptions(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(14, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(15, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2575,7 +2717,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetSetting() {
-      ::grpc::Service::MarkMethodRaw(15);
+      ::grpc::Service::MarkMethodRaw(16);
     }
     ~WithRawMethod_SetSetting() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2586,7 +2728,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetSetting(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2595,7 +2737,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_GetSetting() {
-      ::grpc::Service::MarkMethodRaw(16);
+      ::grpc::Service::MarkMethodRaw(17);
     }
     ~WithRawMethod_GetSetting() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2606,7 +2748,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetSetting(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(17, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2615,7 +2757,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_FormatStorage() {
-      ::grpc::Service::MarkMethodRaw(17);
+      ::grpc::Service::MarkMethodRaw(18);
     }
     ~WithRawMethod_FormatStorage() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2626,7 +2768,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestFormatStorage(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(17, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(18, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2934,6 +3076,44 @@ class CameraService final {
       { return nullptr; }
   };
   template <class BaseClass>
+  class ExperimentalWithRawCallbackMethod_ListPhotos : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    ExperimentalWithRawCallbackMethod_ListPhotos() {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodRawCallback(8,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->ListPhotos(context, request, response); }));
+    }
+    ~ExperimentalWithRawCallbackMethod_ListPhotos() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status ListPhotos(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::ListPhotosRequest* /*request*/, ::mavsdk::rpc::camera::ListPhotosResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerUnaryReactor* ListPhotos(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
+    #else
+    virtual ::grpc::experimental::ServerUnaryReactor* ListPhotos(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
+    #endif
+      { return nullptr; }
+  };
+  template <class BaseClass>
   class ExperimentalWithRawCallbackMethod_SubscribeMode : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
@@ -2944,7 +3124,7 @@ class CameraService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(8,
+        MarkMethodRawCallback(9,
           new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -2982,7 +3162,7 @@ class CameraService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(9,
+        MarkMethodRawCallback(10,
           new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3020,7 +3200,7 @@ class CameraService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(10,
+        MarkMethodRawCallback(11,
           new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3058,7 +3238,7 @@ class CameraService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(11,
+        MarkMethodRawCallback(12,
           new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3096,7 +3276,7 @@ class CameraService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(12,
+        MarkMethodRawCallback(13,
           new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3134,7 +3314,7 @@ class CameraService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(13,
+        MarkMethodRawCallback(14,
           new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3172,7 +3352,7 @@ class CameraService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(14,
+        MarkMethodRawCallback(15,
           new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3210,7 +3390,7 @@ class CameraService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(15,
+        MarkMethodRawCallback(16,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3248,7 +3428,7 @@ class CameraService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(16,
+        MarkMethodRawCallback(17,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3286,7 +3466,7 @@ class CameraService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(17,
+        MarkMethodRawCallback(18,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3530,12 +3710,39 @@ class CameraService final {
     virtual ::grpc::Status StreamedSetMode(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera::SetModeRequest,::mavsdk::rpc::camera::SetModeResponse>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
+  class WithStreamedUnaryMethod_ListPhotos : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_ListPhotos() {
+      ::grpc::Service::MarkMethodStreamed(8,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera::ListPhotosRequest, ::mavsdk::rpc::camera::ListPhotosResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera::ListPhotosRequest, ::mavsdk::rpc::camera::ListPhotosResponse>* streamer) {
+                       return this->StreamedListPhotos(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_ListPhotos() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status ListPhotos(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::ListPhotosRequest* /*request*/, ::mavsdk::rpc::camera::ListPhotosResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedListPhotos(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera::ListPhotosRequest,::mavsdk::rpc::camera::ListPhotosResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_SetSetting : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetSetting() {
-      ::grpc::Service::MarkMethodStreamed(15,
+      ::grpc::Service::MarkMethodStreamed(16,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera::SetSettingRequest, ::mavsdk::rpc::camera::SetSettingResponse>(
             [this](::grpc::ServerContext* context,
@@ -3562,7 +3769,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_GetSetting() {
-      ::grpc::Service::MarkMethodStreamed(16,
+      ::grpc::Service::MarkMethodStreamed(17,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera::GetSettingRequest, ::mavsdk::rpc::camera::GetSettingResponse>(
             [this](::grpc::ServerContext* context,
@@ -3589,7 +3796,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_FormatStorage() {
-      ::grpc::Service::MarkMethodStreamed(17,
+      ::grpc::Service::MarkMethodStreamed(18,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera::FormatStorageRequest, ::mavsdk::rpc::camera::FormatStorageResponse>(
             [this](::grpc::ServerContext* context,
@@ -3610,14 +3817,14 @@ class CameraService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedFormatStorage(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera::FormatStorageRequest,::mavsdk::rpc::camera::FormatStorageResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_TakePhoto<WithStreamedUnaryMethod_StartPhotoInterval<WithStreamedUnaryMethod_StopPhotoInterval<WithStreamedUnaryMethod_StartVideo<WithStreamedUnaryMethod_StopVideo<WithStreamedUnaryMethod_StartVideoStreaming<WithStreamedUnaryMethod_StopVideoStreaming<WithStreamedUnaryMethod_SetMode<WithStreamedUnaryMethod_SetSetting<WithStreamedUnaryMethod_GetSetting<WithStreamedUnaryMethod_FormatStorage<Service > > > > > > > > > > > StreamedUnaryService;
+  typedef WithStreamedUnaryMethod_TakePhoto<WithStreamedUnaryMethod_StartPhotoInterval<WithStreamedUnaryMethod_StopPhotoInterval<WithStreamedUnaryMethod_StartVideo<WithStreamedUnaryMethod_StopVideo<WithStreamedUnaryMethod_StartVideoStreaming<WithStreamedUnaryMethod_StopVideoStreaming<WithStreamedUnaryMethod_SetMode<WithStreamedUnaryMethod_ListPhotos<WithStreamedUnaryMethod_SetSetting<WithStreamedUnaryMethod_GetSetting<WithStreamedUnaryMethod_FormatStorage<Service > > > > > > > > > > > > StreamedUnaryService;
   template <class BaseClass>
   class WithSplitStreamingMethod_SubscribeMode : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithSplitStreamingMethod_SubscribeMode() {
-      ::grpc::Service::MarkMethodStreamed(8,
+      ::grpc::Service::MarkMethodStreamed(9,
         new ::grpc::internal::SplitServerStreamingHandler<
           ::mavsdk::rpc::camera::SubscribeModeRequest, ::mavsdk::rpc::camera::ModeResponse>(
             [this](::grpc::ServerContext* context,
@@ -3644,7 +3851,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithSplitStreamingMethod_SubscribeInformation() {
-      ::grpc::Service::MarkMethodStreamed(9,
+      ::grpc::Service::MarkMethodStreamed(10,
         new ::grpc::internal::SplitServerStreamingHandler<
           ::mavsdk::rpc::camera::SubscribeInformationRequest, ::mavsdk::rpc::camera::InformationResponse>(
             [this](::grpc::ServerContext* context,
@@ -3671,7 +3878,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithSplitStreamingMethod_SubscribeVideoStreamInfo() {
-      ::grpc::Service::MarkMethodStreamed(10,
+      ::grpc::Service::MarkMethodStreamed(11,
         new ::grpc::internal::SplitServerStreamingHandler<
           ::mavsdk::rpc::camera::SubscribeVideoStreamInfoRequest, ::mavsdk::rpc::camera::VideoStreamInfoResponse>(
             [this](::grpc::ServerContext* context,
@@ -3698,7 +3905,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithSplitStreamingMethod_SubscribeCaptureInfo() {
-      ::grpc::Service::MarkMethodStreamed(11,
+      ::grpc::Service::MarkMethodStreamed(12,
         new ::grpc::internal::SplitServerStreamingHandler<
           ::mavsdk::rpc::camera::SubscribeCaptureInfoRequest, ::mavsdk::rpc::camera::CaptureInfoResponse>(
             [this](::grpc::ServerContext* context,
@@ -3725,7 +3932,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithSplitStreamingMethod_SubscribeStatus() {
-      ::grpc::Service::MarkMethodStreamed(12,
+      ::grpc::Service::MarkMethodStreamed(13,
         new ::grpc::internal::SplitServerStreamingHandler<
           ::mavsdk::rpc::camera::SubscribeStatusRequest, ::mavsdk::rpc::camera::StatusResponse>(
             [this](::grpc::ServerContext* context,
@@ -3752,7 +3959,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithSplitStreamingMethod_SubscribeCurrentSettings() {
-      ::grpc::Service::MarkMethodStreamed(13,
+      ::grpc::Service::MarkMethodStreamed(14,
         new ::grpc::internal::SplitServerStreamingHandler<
           ::mavsdk::rpc::camera::SubscribeCurrentSettingsRequest, ::mavsdk::rpc::camera::CurrentSettingsResponse>(
             [this](::grpc::ServerContext* context,
@@ -3779,7 +3986,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithSplitStreamingMethod_SubscribePossibleSettingOptions() {
-      ::grpc::Service::MarkMethodStreamed(14,
+      ::grpc::Service::MarkMethodStreamed(15,
         new ::grpc::internal::SplitServerStreamingHandler<
           ::mavsdk::rpc::camera::SubscribePossibleSettingOptionsRequest, ::mavsdk::rpc::camera::PossibleSettingOptionsResponse>(
             [this](::grpc::ServerContext* context,
@@ -3801,7 +4008,7 @@ class CameraService final {
     virtual ::grpc::Status StreamedSubscribePossibleSettingOptions(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::camera::SubscribePossibleSettingOptionsRequest,::mavsdk::rpc::camera::PossibleSettingOptionsResponse>* server_split_streamer) = 0;
   };
   typedef WithSplitStreamingMethod_SubscribeMode<WithSplitStreamingMethod_SubscribeInformation<WithSplitStreamingMethod_SubscribeVideoStreamInfo<WithSplitStreamingMethod_SubscribeCaptureInfo<WithSplitStreamingMethod_SubscribeStatus<WithSplitStreamingMethod_SubscribeCurrentSettings<WithSplitStreamingMethod_SubscribePossibleSettingOptions<Service > > > > > > > SplitStreamedService;
-  typedef WithStreamedUnaryMethod_TakePhoto<WithStreamedUnaryMethod_StartPhotoInterval<WithStreamedUnaryMethod_StopPhotoInterval<WithStreamedUnaryMethod_StartVideo<WithStreamedUnaryMethod_StopVideo<WithStreamedUnaryMethod_StartVideoStreaming<WithStreamedUnaryMethod_StopVideoStreaming<WithStreamedUnaryMethod_SetMode<WithSplitStreamingMethod_SubscribeMode<WithSplitStreamingMethod_SubscribeInformation<WithSplitStreamingMethod_SubscribeVideoStreamInfo<WithSplitStreamingMethod_SubscribeCaptureInfo<WithSplitStreamingMethod_SubscribeStatus<WithSplitStreamingMethod_SubscribeCurrentSettings<WithSplitStreamingMethod_SubscribePossibleSettingOptions<WithStreamedUnaryMethod_SetSetting<WithStreamedUnaryMethod_GetSetting<WithStreamedUnaryMethod_FormatStorage<Service > > > > > > > > > > > > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_TakePhoto<WithStreamedUnaryMethod_StartPhotoInterval<WithStreamedUnaryMethod_StopPhotoInterval<WithStreamedUnaryMethod_StartVideo<WithStreamedUnaryMethod_StopVideo<WithStreamedUnaryMethod_StartVideoStreaming<WithStreamedUnaryMethod_StopVideoStreaming<WithStreamedUnaryMethod_SetMode<WithStreamedUnaryMethod_ListPhotos<WithSplitStreamingMethod_SubscribeMode<WithSplitStreamingMethod_SubscribeInformation<WithSplitStreamingMethod_SubscribeVideoStreamInfo<WithSplitStreamingMethod_SubscribeCaptureInfo<WithSplitStreamingMethod_SubscribeStatus<WithSplitStreamingMethod_SubscribeCurrentSettings<WithSplitStreamingMethod_SubscribePossibleSettingOptions<WithStreamedUnaryMethod_SetSetting<WithStreamedUnaryMethod_GetSetting<WithStreamedUnaryMethod_FormatStorage<Service > > > > > > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace camera

--- a/src/mavsdk_server/src/generated/camera/camera.pb.cc
+++ b/src/mavsdk_server/src/generated/camera/camera.pb.cc
@@ -93,6 +93,14 @@ class SetModeResponseDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<SetModeResponse> _instance;
 } _SetModeResponse_default_instance_;
+class ListPhotosRequestDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<ListPhotosRequest> _instance;
+} _ListPhotosRequest_default_instance_;
+class ListPhotosResponseDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<ListPhotosResponse> _instance;
+} _ListPhotosResponse_default_instance_;
 class SubscribeInformationRequestDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<SubscribeInformationRequest> _instance;
@@ -387,6 +395,36 @@ static void InitDefaultsscc_info_InformationResponse_camera_2fcamera_2eproto() {
 ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_InformationResponse_camera_2fcamera_2eproto =
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_InformationResponse_camera_2fcamera_2eproto}, {
       &scc_info_Information_camera_2fcamera_2eproto.base,}};
+
+static void InitDefaultsscc_info_ListPhotosRequest_camera_2fcamera_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::mavsdk::rpc::camera::_ListPhotosRequest_default_instance_;
+    new (ptr) ::mavsdk::rpc::camera::ListPhotosRequest();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::mavsdk::rpc::camera::ListPhotosRequest::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_ListPhotosRequest_camera_2fcamera_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_ListPhotosRequest_camera_2fcamera_2eproto}, {}};
+
+static void InitDefaultsscc_info_ListPhotosResponse_camera_2fcamera_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::mavsdk::rpc::camera::_ListPhotosResponse_default_instance_;
+    new (ptr) ::mavsdk::rpc::camera::ListPhotosResponse();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::mavsdk::rpc::camera::ListPhotosResponse::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<2> scc_info_ListPhotosResponse_camera_2fcamera_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 2, 0, InitDefaultsscc_info_ListPhotosResponse_camera_2fcamera_2eproto}, {
+      &scc_info_CameraResult_camera_2fcamera_2eproto.base,
+      &scc_info_CaptureInfo_camera_2fcamera_2eproto.base,}};
 
 static void InitDefaultsscc_info_ModeResponse_camera_2fcamera_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -922,8 +960,8 @@ static void InitDefaultsscc_info_VideoStreamSettings_camera_2fcamera_2eproto() {
 ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_VideoStreamSettings_camera_2fcamera_2eproto =
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_VideoStreamSettings_camera_2fcamera_2eproto}, {}};
 
-static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_camera_2fcamera_2eproto[48];
-static const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* file_level_enum_descriptors_camera_2fcamera_2eproto[4];
+static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_camera_2fcamera_2eproto[50];
+static const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* file_level_enum_descriptors_camera_2fcamera_2eproto[5];
 static constexpr ::PROTOBUF_NAMESPACE_ID::ServiceDescriptor const** file_level_service_descriptors_camera_2fcamera_2eproto = nullptr;
 
 const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_camera_2fcamera_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
@@ -1017,6 +1055,19 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_camera_2fcamera_2eproto::offse
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::SetModeResponse, camera_result_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::ListPhotosRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::ListPhotosRequest, photos_range_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::ListPhotosResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::ListPhotosResponse, camera_result_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::ListPhotosResponse, capture_infos_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::SubscribeInformationRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -1256,38 +1307,40 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 72, -1, sizeof(::mavsdk::rpc::camera::StopVideoStreamingResponse)},
   { 78, -1, sizeof(::mavsdk::rpc::camera::SetModeRequest)},
   { 84, -1, sizeof(::mavsdk::rpc::camera::SetModeResponse)},
-  { 90, -1, sizeof(::mavsdk::rpc::camera::SubscribeInformationRequest)},
-  { 95, -1, sizeof(::mavsdk::rpc::camera::InformationResponse)},
-  { 101, -1, sizeof(::mavsdk::rpc::camera::SubscribeModeRequest)},
-  { 106, -1, sizeof(::mavsdk::rpc::camera::ModeResponse)},
-  { 112, -1, sizeof(::mavsdk::rpc::camera::SubscribeVideoStreamInfoRequest)},
-  { 117, -1, sizeof(::mavsdk::rpc::camera::VideoStreamInfoResponse)},
-  { 123, -1, sizeof(::mavsdk::rpc::camera::SubscribeCaptureInfoRequest)},
-  { 128, -1, sizeof(::mavsdk::rpc::camera::CaptureInfoResponse)},
-  { 134, -1, sizeof(::mavsdk::rpc::camera::SubscribeStatusRequest)},
-  { 139, -1, sizeof(::mavsdk::rpc::camera::StatusResponse)},
-  { 145, -1, sizeof(::mavsdk::rpc::camera::SubscribeCurrentSettingsRequest)},
-  { 150, -1, sizeof(::mavsdk::rpc::camera::CurrentSettingsResponse)},
-  { 156, -1, sizeof(::mavsdk::rpc::camera::SubscribePossibleSettingOptionsRequest)},
-  { 161, -1, sizeof(::mavsdk::rpc::camera::PossibleSettingOptionsResponse)},
-  { 167, -1, sizeof(::mavsdk::rpc::camera::SetSettingRequest)},
-  { 173, -1, sizeof(::mavsdk::rpc::camera::SetSettingResponse)},
-  { 179, -1, sizeof(::mavsdk::rpc::camera::GetSettingRequest)},
-  { 185, -1, sizeof(::mavsdk::rpc::camera::GetSettingResponse)},
-  { 192, -1, sizeof(::mavsdk::rpc::camera::FormatStorageRequest)},
-  { 197, -1, sizeof(::mavsdk::rpc::camera::FormatStorageResponse)},
-  { 203, -1, sizeof(::mavsdk::rpc::camera::CameraResult)},
-  { 210, -1, sizeof(::mavsdk::rpc::camera::Position)},
-  { 219, -1, sizeof(::mavsdk::rpc::camera::Quaternion)},
-  { 228, -1, sizeof(::mavsdk::rpc::camera::EulerAngle)},
-  { 236, -1, sizeof(::mavsdk::rpc::camera::CaptureInfo)},
-  { 248, -1, sizeof(::mavsdk::rpc::camera::VideoStreamSettings)},
-  { 259, -1, sizeof(::mavsdk::rpc::camera::VideoStreamInfo)},
-  { 266, -1, sizeof(::mavsdk::rpc::camera::Status)},
-  { 279, -1, sizeof(::mavsdk::rpc::camera::Option)},
-  { 286, -1, sizeof(::mavsdk::rpc::camera::Setting)},
-  { 295, -1, sizeof(::mavsdk::rpc::camera::SettingOptions)},
-  { 304, -1, sizeof(::mavsdk::rpc::camera::Information)},
+  { 90, -1, sizeof(::mavsdk::rpc::camera::ListPhotosRequest)},
+  { 96, -1, sizeof(::mavsdk::rpc::camera::ListPhotosResponse)},
+  { 103, -1, sizeof(::mavsdk::rpc::camera::SubscribeInformationRequest)},
+  { 108, -1, sizeof(::mavsdk::rpc::camera::InformationResponse)},
+  { 114, -1, sizeof(::mavsdk::rpc::camera::SubscribeModeRequest)},
+  { 119, -1, sizeof(::mavsdk::rpc::camera::ModeResponse)},
+  { 125, -1, sizeof(::mavsdk::rpc::camera::SubscribeVideoStreamInfoRequest)},
+  { 130, -1, sizeof(::mavsdk::rpc::camera::VideoStreamInfoResponse)},
+  { 136, -1, sizeof(::mavsdk::rpc::camera::SubscribeCaptureInfoRequest)},
+  { 141, -1, sizeof(::mavsdk::rpc::camera::CaptureInfoResponse)},
+  { 147, -1, sizeof(::mavsdk::rpc::camera::SubscribeStatusRequest)},
+  { 152, -1, sizeof(::mavsdk::rpc::camera::StatusResponse)},
+  { 158, -1, sizeof(::mavsdk::rpc::camera::SubscribeCurrentSettingsRequest)},
+  { 163, -1, sizeof(::mavsdk::rpc::camera::CurrentSettingsResponse)},
+  { 169, -1, sizeof(::mavsdk::rpc::camera::SubscribePossibleSettingOptionsRequest)},
+  { 174, -1, sizeof(::mavsdk::rpc::camera::PossibleSettingOptionsResponse)},
+  { 180, -1, sizeof(::mavsdk::rpc::camera::SetSettingRequest)},
+  { 186, -1, sizeof(::mavsdk::rpc::camera::SetSettingResponse)},
+  { 192, -1, sizeof(::mavsdk::rpc::camera::GetSettingRequest)},
+  { 198, -1, sizeof(::mavsdk::rpc::camera::GetSettingResponse)},
+  { 205, -1, sizeof(::mavsdk::rpc::camera::FormatStorageRequest)},
+  { 210, -1, sizeof(::mavsdk::rpc::camera::FormatStorageResponse)},
+  { 216, -1, sizeof(::mavsdk::rpc::camera::CameraResult)},
+  { 223, -1, sizeof(::mavsdk::rpc::camera::Position)},
+  { 232, -1, sizeof(::mavsdk::rpc::camera::Quaternion)},
+  { 241, -1, sizeof(::mavsdk::rpc::camera::EulerAngle)},
+  { 249, -1, sizeof(::mavsdk::rpc::camera::CaptureInfo)},
+  { 261, -1, sizeof(::mavsdk::rpc::camera::VideoStreamSettings)},
+  { 272, -1, sizeof(::mavsdk::rpc::camera::VideoStreamInfo)},
+  { 279, -1, sizeof(::mavsdk::rpc::camera::Status)},
+  { 292, -1, sizeof(::mavsdk::rpc::camera::Option)},
+  { 299, -1, sizeof(::mavsdk::rpc::camera::Setting)},
+  { 308, -1, sizeof(::mavsdk::rpc::camera::SettingOptions)},
+  { 317, -1, sizeof(::mavsdk::rpc::camera::Information)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -1307,6 +1360,8 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::camera::_StopVideoStreamingResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::camera::_SetModeRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::camera::_SetModeResponse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::camera::_ListPhotosRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::camera::_ListPhotosResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::camera::_SubscribeInformationRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::camera::_InformationResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::camera::_SubscribeModeRequest_default_instance_),
@@ -1366,140 +1421,150 @@ const char descriptor_table_protodef_camera_2fcamera_2eproto[] PROTOBUF_SECTION_
   "etModeRequest\022%\n\004mode\030\001 \001(\0162\027.mavsdk.rpc"
   ".camera.Mode\"I\n\017SetModeResponse\0226\n\rcamer"
   "a_result\030\001 \001(\0132\037.mavsdk.rpc.camera.Camer"
-  "aResult\"\035\n\033SubscribeInformationRequest\"J"
-  "\n\023InformationResponse\0223\n\013information\030\001 \001"
-  "(\0132\036.mavsdk.rpc.camera.Information\"\026\n\024Su"
-  "bscribeModeRequest\"5\n\014ModeResponse\022%\n\004mo"
-  "de\030\001 \001(\0162\027.mavsdk.rpc.camera.Mode\"!\n\037Sub"
-  "scribeVideoStreamInfoRequest\"X\n\027VideoStr"
-  "eamInfoResponse\022=\n\021video_stream_info\030\001 \001"
-  "(\0132\".mavsdk.rpc.camera.VideoStreamInfo\"\035"
-  "\n\033SubscribeCaptureInfoRequest\"K\n\023Capture"
-  "InfoResponse\0224\n\014capture_info\030\001 \001(\0132\036.mav"
-  "sdk.rpc.camera.CaptureInfo\"\030\n\026SubscribeS"
-  "tatusRequest\"B\n\016StatusResponse\0220\n\rcamera"
-  "_status\030\001 \001(\0132\031.mavsdk.rpc.camera.Status"
-  "\"!\n\037SubscribeCurrentSettingsRequest\"O\n\027C"
-  "urrentSettingsResponse\0224\n\020current_settin"
-  "gs\030\001 \003(\0132\032.mavsdk.rpc.camera.Setting\"(\n&"
-  "SubscribePossibleSettingOptionsRequest\"\\"
-  "\n\036PossibleSettingOptionsResponse\022:\n\017sett"
-  "ing_options\030\001 \003(\0132!.mavsdk.rpc.camera.Se"
-  "ttingOptions\"@\n\021SetSettingRequest\022+\n\007set"
-  "ting\030\001 \001(\0132\032.mavsdk.rpc.camera.Setting\"L"
-  "\n\022SetSettingResponse\0226\n\rcamera_result\030\001 "
-  "\001(\0132\037.mavsdk.rpc.camera.CameraResult\"@\n\021"
-  "GetSettingRequest\022+\n\007setting\030\001 \001(\0132\032.mav"
-  "sdk.rpc.camera.Setting\"y\n\022GetSettingResp"
-  "onse\0226\n\rcamera_result\030\001 \001(\0132\037.mavsdk.rpc"
-  ".camera.CameraResult\022+\n\007setting\030\002 \001(\0132\032."
-  "mavsdk.rpc.camera.Setting\"\026\n\024FormatStora"
-  "geRequest\"O\n\025FormatStorageResponse\0226\n\rca"
-  "mera_result\030\001 \001(\0132\037.mavsdk.rpc.camera.Ca"
-  "meraResult\"\212\002\n\014CameraResult\0226\n\006result\030\001 "
-  "\001(\0162&.mavsdk.rpc.camera.CameraResult.Res"
-  "ult\022\022\n\nresult_str\030\002 \001(\t\"\255\001\n\006Result\022\022\n\016RE"
-  "SULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\026\n\022RE"
-  "SULT_IN_PROGRESS\020\002\022\017\n\013RESULT_BUSY\020\003\022\021\n\rR"
-  "ESULT_DENIED\020\004\022\020\n\014RESULT_ERROR\020\005\022\022\n\016RESU"
-  "LT_TIMEOUT\020\006\022\031\n\025RESULT_WRONG_ARGUMENT\020\007\""
-  "q\n\010Position\022\024\n\014latitude_deg\030\001 \001(\001\022\025\n\rlon"
-  "gitude_deg\030\002 \001(\001\022\033\n\023absolute_altitude_m\030"
-  "\003 \001(\002\022\033\n\023relative_altitude_m\030\004 \001(\002\"8\n\nQu"
-  "aternion\022\t\n\001w\030\001 \001(\002\022\t\n\001x\030\002 \001(\002\022\t\n\001y\030\003 \001("
-  "\002\022\t\n\001z\030\004 \001(\002\"B\n\nEulerAngle\022\020\n\010roll_deg\030\001"
-  " \001(\002\022\021\n\tpitch_deg\030\002 \001(\002\022\017\n\007yaw_deg\030\003 \001(\002"
-  "\"\377\001\n\013CaptureInfo\022-\n\010position\030\001 \001(\0132\033.mav"
-  "sdk.rpc.camera.Position\022:\n\023attitude_quat"
-  "ernion\030\002 \001(\0132\035.mavsdk.rpc.camera.Quatern"
-  "ion\022;\n\024attitude_euler_angle\030\003 \001(\0132\035.mavs"
-  "dk.rpc.camera.EulerAngle\022\023\n\013time_utc_us\030"
-  "\004 \001(\004\022\022\n\nis_success\030\005 \001(\010\022\r\n\005index\030\006 \001(\005"
-  "\022\020\n\010file_url\030\007 \001(\t\"\251\001\n\023VideoStreamSettin"
-  "gs\022\025\n\rframe_rate_hz\030\001 \001(\002\022!\n\031horizontal_"
-  "resolution_pix\030\002 \001(\r\022\037\n\027vertical_resolut"
-  "ion_pix\030\003 \001(\r\022\024\n\014bit_rate_b_s\030\004 \001(\r\022\024\n\014r"
-  "otation_deg\030\005 \001(\r\022\013\n\003uri\030\006 \001(\t\"\300\001\n\017Video"
-  "StreamInfo\0228\n\010settings\030\001 \001(\0132&.mavsdk.rp"
-  "c.camera.VideoStreamSettings\0229\n\006status\030\002"
-  " \001(\0162).mavsdk.rpc.camera.VideoStreamInfo"
-  ".Status\"8\n\006Status\022\026\n\022STATUS_NOT_RUNNING\020"
-  "\000\022\026\n\022STATUS_IN_PROGRESS\020\001\"\360\002\n\006Status\022\020\n\010"
-  "video_on\030\001 \001(\010\022\031\n\021photo_interval_on\030\002 \001("
-  "\010\022\030\n\020used_storage_mib\030\003 \001(\002\022\035\n\025available"
-  "_storage_mib\030\004 \001(\002\022\031\n\021total_storage_mib\030"
-  "\005 \001(\002\022\030\n\020recording_time_s\030\006 \001(\002\022\031\n\021media"
-  "_folder_name\030\007 \001(\t\022\?\n\016storage_status\030\010 \001"
-  "(\0162\'.mavsdk.rpc.camera.Status.StorageSta"
-  "tus\"o\n\rStorageStatus\022 \n\034STORAGE_STATUS_N"
-  "OT_AVAILABLE\020\000\022\036\n\032STORAGE_STATUS_UNFORMA"
-  "TTED\020\001\022\034\n\030STORAGE_STATUS_FORMATTED\020\002\"7\n\006"
-  "Option\022\021\n\toption_id\030\001 \001(\t\022\032\n\022option_desc"
-  "ription\030\002 \001(\t\"w\n\007Setting\022\022\n\nsetting_id\030\001"
-  " \001(\t\022\033\n\023setting_description\030\002 \001(\t\022)\n\006opt"
-  "ion\030\003 \001(\0132\031.mavsdk.rpc.camera.Option\022\020\n\010"
-  "is_range\030\004 \001(\010\"\177\n\016SettingOptions\022\022\n\nsett"
-  "ing_id\030\001 \001(\t\022\033\n\023setting_description\030\002 \001("
-  "\t\022*\n\007options\030\003 \003(\0132\031.mavsdk.rpc.camera.O"
-  "ption\022\020\n\010is_range\030\004 \001(\010\"6\n\013Information\022\023"
-  "\n\013vendor_name\030\001 \001(\t\022\022\n\nmodel_name\030\002 \001(\t*"
-  "8\n\004Mode\022\020\n\014MODE_UNKNOWN\020\000\022\016\n\nMODE_PHOTO\020"
-  "\001\022\016\n\nMODE_VIDEO\020\0022\273\017\n\rCameraService\022X\n\tT"
-  "akePhoto\022#.mavsdk.rpc.camera.TakePhotoRe"
-  "quest\032$.mavsdk.rpc.camera.TakePhotoRespo"
-  "nse\"\000\022s\n\022StartPhotoInterval\022,.mavsdk.rpc"
-  ".camera.StartPhotoIntervalRequest\032-.mavs"
-  "dk.rpc.camera.StartPhotoIntervalResponse"
-  "\"\000\022p\n\021StopPhotoInterval\022+.mavsdk.rpc.cam"
-  "era.StopPhotoIntervalRequest\032,.mavsdk.rp"
-  "c.camera.StopPhotoIntervalResponse\"\000\022[\n\n"
-  "StartVideo\022$.mavsdk.rpc.camera.StartVide"
-  "oRequest\032%.mavsdk.rpc.camera.StartVideoR"
-  "esponse\"\000\022X\n\tStopVideo\022#.mavsdk.rpc.came"
-  "ra.StopVideoRequest\032$.mavsdk.rpc.camera."
-  "StopVideoResponse\"\000\022z\n\023StartVideoStreami"
-  "ng\022-.mavsdk.rpc.camera.StartVideoStreami"
-  "ngRequest\032..mavsdk.rpc.camera.StartVideo"
-  "StreamingResponse\"\004\200\265\030\001\022w\n\022StopVideoStre"
-  "aming\022,.mavsdk.rpc.camera.StopVideoStrea"
-  "mingRequest\032-.mavsdk.rpc.camera.StopVide"
-  "oStreamingResponse\"\004\200\265\030\001\022R\n\007SetMode\022!.ma"
-  "vsdk.rpc.camera.SetModeRequest\032\".mavsdk."
-  "rpc.camera.SetModeResponse\"\000\022]\n\rSubscrib"
-  "eMode\022\'.mavsdk.rpc.camera.SubscribeModeR"
-  "equest\032\037.mavsdk.rpc.camera.ModeResponse\""
-  "\0000\001\022r\n\024SubscribeInformation\022..mavsdk.rpc"
-  ".camera.SubscribeInformationRequest\032&.ma"
-  "vsdk.rpc.camera.InformationResponse\"\0000\001\022"
-  "~\n\030SubscribeVideoStreamInfo\0222.mavsdk.rpc"
-  ".camera.SubscribeVideoStreamInfoRequest\032"
-  "*.mavsdk.rpc.camera.VideoStreamInfoRespo"
-  "nse\"\0000\001\022v\n\024SubscribeCaptureInfo\022..mavsdk"
-  ".rpc.camera.SubscribeCaptureInfoRequest\032"
-  "&.mavsdk.rpc.camera.CaptureInfoResponse\""
-  "\004\200\265\030\0000\001\022c\n\017SubscribeStatus\022).mavsdk.rpc."
-  "camera.SubscribeStatusRequest\032!.mavsdk.r"
-  "pc.camera.StatusResponse\"\0000\001\022\202\001\n\030Subscri"
-  "beCurrentSettings\0222.mavsdk.rpc.camera.Su"
-  "bscribeCurrentSettingsRequest\032*.mavsdk.r"
-  "pc.camera.CurrentSettingsResponse\"\004\200\265\030\0000"
-  "\001\022\223\001\n\037SubscribePossibleSettingOptions\0229."
-  "mavsdk.rpc.camera.SubscribePossibleSetti"
-  "ngOptionsRequest\0321.mavsdk.rpc.camera.Pos"
-  "sibleSettingOptionsResponse\"\0000\001\022[\n\nSetSe"
-  "tting\022$.mavsdk.rpc.camera.SetSettingRequ"
-  "est\032%.mavsdk.rpc.camera.SetSettingRespon"
-  "se\"\000\022[\n\nGetSetting\022$.mavsdk.rpc.camera.G"
-  "etSettingRequest\032%.mavsdk.rpc.camera.Get"
-  "SettingResponse\"\000\022d\n\rFormatStorage\022\'.mav"
-  "sdk.rpc.camera.FormatStorageRequest\032(.ma"
-  "vsdk.rpc.camera.FormatStorageResponse\"\000B"
-  "\037\n\020io.mavsdk.cameraB\013CameraProtob\006proto3"
+  "aResult\"I\n\021ListPhotosRequest\0224\n\014photos_r"
+  "ange\030\001 \001(\0162\036.mavsdk.rpc.camera.PhotosRan"
+  "ge\"\203\001\n\022ListPhotosResponse\0226\n\rcamera_resu"
+  "lt\030\001 \001(\0132\037.mavsdk.rpc.camera.CameraResul"
+  "t\0225\n\rcapture_infos\030\002 \003(\0132\036.mavsdk.rpc.ca"
+  "mera.CaptureInfo\"\035\n\033SubscribeInformation"
+  "Request\"J\n\023InformationResponse\0223\n\013inform"
+  "ation\030\001 \001(\0132\036.mavsdk.rpc.camera.Informat"
+  "ion\"\026\n\024SubscribeModeRequest\"5\n\014ModeRespo"
+  "nse\022%\n\004mode\030\001 \001(\0162\027.mavsdk.rpc.camera.Mo"
+  "de\"!\n\037SubscribeVideoStreamInfoRequest\"X\n"
+  "\027VideoStreamInfoResponse\022=\n\021video_stream"
+  "_info\030\001 \001(\0132\".mavsdk.rpc.camera.VideoStr"
+  "eamInfo\"\035\n\033SubscribeCaptureInfoRequest\"K"
+  "\n\023CaptureInfoResponse\0224\n\014capture_info\030\001 "
+  "\001(\0132\036.mavsdk.rpc.camera.CaptureInfo\"\030\n\026S"
+  "ubscribeStatusRequest\"B\n\016StatusResponse\022"
+  "0\n\rcamera_status\030\001 \001(\0132\031.mavsdk.rpc.came"
+  "ra.Status\"!\n\037SubscribeCurrentSettingsReq"
+  "uest\"O\n\027CurrentSettingsResponse\0224\n\020curre"
+  "nt_settings\030\001 \003(\0132\032.mavsdk.rpc.camera.Se"
+  "tting\"(\n&SubscribePossibleSettingOptions"
+  "Request\"\\\n\036PossibleSettingOptionsRespons"
+  "e\022:\n\017setting_options\030\001 \003(\0132!.mavsdk.rpc."
+  "camera.SettingOptions\"@\n\021SetSettingReque"
+  "st\022+\n\007setting\030\001 \001(\0132\032.mavsdk.rpc.camera."
+  "Setting\"L\n\022SetSettingResponse\0226\n\rcamera_"
+  "result\030\001 \001(\0132\037.mavsdk.rpc.camera.CameraR"
+  "esult\"@\n\021GetSettingRequest\022+\n\007setting\030\001 "
+  "\001(\0132\032.mavsdk.rpc.camera.Setting\"y\n\022GetSe"
+  "ttingResponse\0226\n\rcamera_result\030\001 \001(\0132\037.m"
+  "avsdk.rpc.camera.CameraResult\022+\n\007setting"
+  "\030\002 \001(\0132\032.mavsdk.rpc.camera.Setting\"\026\n\024Fo"
+  "rmatStorageRequest\"O\n\025FormatStorageRespo"
+  "nse\0226\n\rcamera_result\030\001 \001(\0132\037.mavsdk.rpc."
+  "camera.CameraResult\"\212\002\n\014CameraResult\0226\n\006"
+  "result\030\001 \001(\0162&.mavsdk.rpc.camera.CameraR"
+  "esult.Result\022\022\n\nresult_str\030\002 \001(\t\"\255\001\n\006Res"
+  "ult\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCCES"
+  "S\020\001\022\026\n\022RESULT_IN_PROGRESS\020\002\022\017\n\013RESULT_BU"
+  "SY\020\003\022\021\n\rRESULT_DENIED\020\004\022\020\n\014RESULT_ERROR\020"
+  "\005\022\022\n\016RESULT_TIMEOUT\020\006\022\031\n\025RESULT_WRONG_AR"
+  "GUMENT\020\007\"q\n\010Position\022\024\n\014latitude_deg\030\001 \001"
+  "(\001\022\025\n\rlongitude_deg\030\002 \001(\001\022\033\n\023absolute_al"
+  "titude_m\030\003 \001(\002\022\033\n\023relative_altitude_m\030\004 "
+  "\001(\002\"8\n\nQuaternion\022\t\n\001w\030\001 \001(\002\022\t\n\001x\030\002 \001(\002\022"
+  "\t\n\001y\030\003 \001(\002\022\t\n\001z\030\004 \001(\002\"B\n\nEulerAngle\022\020\n\010r"
+  "oll_deg\030\001 \001(\002\022\021\n\tpitch_deg\030\002 \001(\002\022\017\n\007yaw_"
+  "deg\030\003 \001(\002\"\377\001\n\013CaptureInfo\022-\n\010position\030\001 "
+  "\001(\0132\033.mavsdk.rpc.camera.Position\022:\n\023atti"
+  "tude_quaternion\030\002 \001(\0132\035.mavsdk.rpc.camer"
+  "a.Quaternion\022;\n\024attitude_euler_angle\030\003 \001"
+  "(\0132\035.mavsdk.rpc.camera.EulerAngle\022\023\n\013tim"
+  "e_utc_us\030\004 \001(\004\022\022\n\nis_success\030\005 \001(\010\022\r\n\005in"
+  "dex\030\006 \001(\005\022\020\n\010file_url\030\007 \001(\t\"\251\001\n\023VideoStr"
+  "eamSettings\022\025\n\rframe_rate_hz\030\001 \001(\002\022!\n\031ho"
+  "rizontal_resolution_pix\030\002 \001(\r\022\037\n\027vertica"
+  "l_resolution_pix\030\003 \001(\r\022\024\n\014bit_rate_b_s\030\004"
+  " \001(\r\022\024\n\014rotation_deg\030\005 \001(\r\022\013\n\003uri\030\006 \001(\t\""
+  "\300\001\n\017VideoStreamInfo\0228\n\010settings\030\001 \001(\0132&."
+  "mavsdk.rpc.camera.VideoStreamSettings\0229\n"
+  "\006status\030\002 \001(\0162).mavsdk.rpc.camera.VideoS"
+  "treamInfo.Status\"8\n\006Status\022\026\n\022STATUS_NOT"
+  "_RUNNING\020\000\022\026\n\022STATUS_IN_PROGRESS\020\001\"\360\002\n\006S"
+  "tatus\022\020\n\010video_on\030\001 \001(\010\022\031\n\021photo_interva"
+  "l_on\030\002 \001(\010\022\030\n\020used_storage_mib\030\003 \001(\002\022\035\n\025"
+  "available_storage_mib\030\004 \001(\002\022\031\n\021total_sto"
+  "rage_mib\030\005 \001(\002\022\030\n\020recording_time_s\030\006 \001(\002"
+  "\022\031\n\021media_folder_name\030\007 \001(\t\022\?\n\016storage_s"
+  "tatus\030\010 \001(\0162\'.mavsdk.rpc.camera.Status.S"
+  "torageStatus\"o\n\rStorageStatus\022 \n\034STORAGE"
+  "_STATUS_NOT_AVAILABLE\020\000\022\036\n\032STORAGE_STATU"
+  "S_UNFORMATTED\020\001\022\034\n\030STORAGE_STATUS_FORMAT"
+  "TED\020\002\"7\n\006Option\022\021\n\toption_id\030\001 \001(\t\022\032\n\022op"
+  "tion_description\030\002 \001(\t\"w\n\007Setting\022\022\n\nset"
+  "ting_id\030\001 \001(\t\022\033\n\023setting_description\030\002 \001"
+  "(\t\022)\n\006option\030\003 \001(\0132\031.mavsdk.rpc.camera.O"
+  "ption\022\020\n\010is_range\030\004 \001(\010\"\177\n\016SettingOption"
+  "s\022\022\n\nsetting_id\030\001 \001(\t\022\033\n\023setting_descrip"
+  "tion\030\002 \001(\t\022*\n\007options\030\003 \003(\0132\031.mavsdk.rpc"
+  ".camera.Option\022\020\n\010is_range\030\004 \001(\010\"6\n\013Info"
+  "rmation\022\023\n\013vendor_name\030\001 \001(\t\022\022\n\nmodel_na"
+  "me\030\002 \001(\t*8\n\004Mode\022\020\n\014MODE_UNKNOWN\020\000\022\016\n\nMO"
+  "DE_PHOTO\020\001\022\016\n\nMODE_VIDEO\020\002*F\n\013PhotosRang"
+  "e\022\024\n\020PHOTOS_RANGE_ALL\020\000\022!\n\035PHOTOS_RANGE_"
+  "SINCE_CONNECTION\020\0012\230\020\n\rCameraService\022X\n\t"
+  "TakePhoto\022#.mavsdk.rpc.camera.TakePhotoR"
+  "equest\032$.mavsdk.rpc.camera.TakePhotoResp"
+  "onse\"\000\022s\n\022StartPhotoInterval\022,.mavsdk.rp"
+  "c.camera.StartPhotoIntervalRequest\032-.mav"
+  "sdk.rpc.camera.StartPhotoIntervalRespons"
+  "e\"\000\022p\n\021StopPhotoInterval\022+.mavsdk.rpc.ca"
+  "mera.StopPhotoIntervalRequest\032,.mavsdk.r"
+  "pc.camera.StopPhotoIntervalResponse\"\000\022[\n"
+  "\nStartVideo\022$.mavsdk.rpc.camera.StartVid"
+  "eoRequest\032%.mavsdk.rpc.camera.StartVideo"
+  "Response\"\000\022X\n\tStopVideo\022#.mavsdk.rpc.cam"
+  "era.StopVideoRequest\032$.mavsdk.rpc.camera"
+  ".StopVideoResponse\"\000\022z\n\023StartVideoStream"
+  "ing\022-.mavsdk.rpc.camera.StartVideoStream"
+  "ingRequest\032..mavsdk.rpc.camera.StartVide"
+  "oStreamingResponse\"\004\200\265\030\001\022w\n\022StopVideoStr"
+  "eaming\022,.mavsdk.rpc.camera.StopVideoStre"
+  "amingRequest\032-.mavsdk.rpc.camera.StopVid"
+  "eoStreamingResponse\"\004\200\265\030\001\022R\n\007SetMode\022!.m"
+  "avsdk.rpc.camera.SetModeRequest\032\".mavsdk"
+  ".rpc.camera.SetModeResponse\"\000\022[\n\nListPho"
+  "tos\022$.mavsdk.rpc.camera.ListPhotosReques"
+  "t\032%.mavsdk.rpc.camera.ListPhotosResponse"
+  "\"\000\022]\n\rSubscribeMode\022\'.mavsdk.rpc.camera."
+  "SubscribeModeRequest\032\037.mavsdk.rpc.camera"
+  ".ModeResponse\"\0000\001\022r\n\024SubscribeInformatio"
+  "n\022..mavsdk.rpc.camera.SubscribeInformati"
+  "onRequest\032&.mavsdk.rpc.camera.Informatio"
+  "nResponse\"\0000\001\022~\n\030SubscribeVideoStreamInf"
+  "o\0222.mavsdk.rpc.camera.SubscribeVideoStre"
+  "amInfoRequest\032*.mavsdk.rpc.camera.VideoS"
+  "treamInfoResponse\"\0000\001\022v\n\024SubscribeCaptur"
+  "eInfo\022..mavsdk.rpc.camera.SubscribeCaptu"
+  "reInfoRequest\032&.mavsdk.rpc.camera.Captur"
+  "eInfoResponse\"\004\200\265\030\0000\001\022c\n\017SubscribeStatus"
+  "\022).mavsdk.rpc.camera.SubscribeStatusRequ"
+  "est\032!.mavsdk.rpc.camera.StatusResponse\"\000"
+  "0\001\022\202\001\n\030SubscribeCurrentSettings\0222.mavsdk"
+  ".rpc.camera.SubscribeCurrentSettingsRequ"
+  "est\032*.mavsdk.rpc.camera.CurrentSettingsR"
+  "esponse\"\004\200\265\030\0000\001\022\223\001\n\037SubscribePossibleSet"
+  "tingOptions\0229.mavsdk.rpc.camera.Subscrib"
+  "ePossibleSettingOptionsRequest\0321.mavsdk."
+  "rpc.camera.PossibleSettingOptionsRespons"
+  "e\"\0000\001\022[\n\nSetSetting\022$.mavsdk.rpc.camera."
+  "SetSettingRequest\032%.mavsdk.rpc.camera.Se"
+  "tSettingResponse\"\000\022[\n\nGetSetting\022$.mavsd"
+  "k.rpc.camera.GetSettingRequest\032%.mavsdk."
+  "rpc.camera.GetSettingResponse\"\000\022d\n\rForma"
+  "tStorage\022\'.mavsdk.rpc.camera.FormatStora"
+  "geRequest\032(.mavsdk.rpc.camera.FormatStor"
+  "ageResponse\"\000B\037\n\020io.mavsdk.cameraB\013Camer"
+  "aProtob\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_camera_2fcamera_2eproto_deps[1] = {
   &::descriptor_table_mavsdk_5foptions_2eproto,
 };
-static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_camera_2fcamera_2eproto_sccs[48] = {
+static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_camera_2fcamera_2eproto_sccs[50] = {
   &scc_info_CameraResult_camera_2fcamera_2eproto.base,
   &scc_info_CaptureInfo_camera_2fcamera_2eproto.base,
   &scc_info_CaptureInfoResponse_camera_2fcamera_2eproto.base,
@@ -1511,6 +1576,8 @@ static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_cam
   &scc_info_GetSettingResponse_camera_2fcamera_2eproto.base,
   &scc_info_Information_camera_2fcamera_2eproto.base,
   &scc_info_InformationResponse_camera_2fcamera_2eproto.base,
+  &scc_info_ListPhotosRequest_camera_2fcamera_2eproto.base,
+  &scc_info_ListPhotosResponse_camera_2fcamera_2eproto.base,
   &scc_info_ModeResponse_camera_2fcamera_2eproto.base,
   &scc_info_Option_camera_2fcamera_2eproto.base,
   &scc_info_Position_camera_2fcamera_2eproto.base,
@@ -1551,10 +1618,10 @@ static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_cam
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_camera_2fcamera_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_camera_2fcamera_2eproto = {
-  false, false, descriptor_table_protodef_camera_2fcamera_2eproto, "camera/camera.proto", 6120,
-  &descriptor_table_camera_2fcamera_2eproto_once, descriptor_table_camera_2fcamera_2eproto_sccs, descriptor_table_camera_2fcamera_2eproto_deps, 48, 1,
+  false, false, descriptor_table_protodef_camera_2fcamera_2eproto, "camera/camera.proto", 6494,
+  &descriptor_table_camera_2fcamera_2eproto_once, descriptor_table_camera_2fcamera_2eproto_sccs, descriptor_table_camera_2fcamera_2eproto_deps, 50, 1,
   schemas, file_default_instances, TableStruct_camera_2fcamera_2eproto::offsets,
-  file_level_metadata_camera_2fcamera_2eproto, 48, file_level_enum_descriptors_camera_2fcamera_2eproto, file_level_service_descriptors_camera_2fcamera_2eproto,
+  file_level_metadata_camera_2fcamera_2eproto, 50, file_level_enum_descriptors_camera_2fcamera_2eproto, file_level_service_descriptors_camera_2fcamera_2eproto,
 };
 
 // Force running AddDescriptors() at dynamic initialization time.
@@ -1648,6 +1715,20 @@ bool Mode_IsValid(int value) {
     case 0:
     case 1:
     case 2:
+      return true;
+    default:
+      return false;
+  }
+}
+
+const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* PhotosRange_descriptor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&descriptor_table_camera_2fcamera_2eproto);
+  return file_level_enum_descriptors_camera_2fcamera_2eproto[4];
+}
+bool PhotosRange_IsValid(int value) {
+  switch (value) {
+    case 0:
+    case 1:
       return true;
     default:
       return false;
@@ -4754,6 +4835,451 @@ void SetModeResponse::InternalSwap(SetModeResponse* other) {
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata SetModeResponse::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+void ListPhotosRequest::InitAsDefaultInstance() {
+}
+class ListPhotosRequest::_Internal {
+ public:
+};
+
+ListPhotosRequest::ListPhotosRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera.ListPhotosRequest)
+}
+ListPhotosRequest::ListPhotosRequest(const ListPhotosRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  photos_range_ = from.photos_range_;
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera.ListPhotosRequest)
+}
+
+void ListPhotosRequest::SharedCtor() {
+  photos_range_ = 0;
+}
+
+ListPhotosRequest::~ListPhotosRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera.ListPhotosRequest)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void ListPhotosRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+}
+
+void ListPhotosRequest::ArenaDtor(void* object) {
+  ListPhotosRequest* _this = reinterpret_cast< ListPhotosRequest* >(object);
+  (void)_this;
+}
+void ListPhotosRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void ListPhotosRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ListPhotosRequest& ListPhotosRequest::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_ListPhotosRequest_camera_2fcamera_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void ListPhotosRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera.ListPhotosRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  photos_range_ = 0;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* ListPhotosRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  ::PROTOBUF_NAMESPACE_ID::Arena* arena = GetArena(); (void)arena;
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // .mavsdk.rpc.camera.PhotosRange photos_range = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 8)) {
+          ::PROTOBUF_NAMESPACE_ID::uint64 val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+          _internal_set_photos_range(static_cast<::mavsdk::rpc::camera::PhotosRange>(val));
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* ListPhotosRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera.ListPhotosRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.camera.PhotosRange photos_range = 1;
+  if (this->photos_range() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteEnumToArray(
+      1, this->_internal_photos_range(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera.ListPhotosRequest)
+  return target;
+}
+
+size_t ListPhotosRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera.ListPhotosRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.camera.PhotosRange photos_range = 1;
+  if (this->photos_range() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::EnumSize(this->_internal_photos_range());
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ListPhotosRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:mavsdk.rpc.camera.ListPhotosRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ListPhotosRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<ListPhotosRequest>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:mavsdk.rpc.camera.ListPhotosRequest)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:mavsdk.rpc.camera.ListPhotosRequest)
+    MergeFrom(*source);
+  }
+}
+
+void ListPhotosRequest::MergeFrom(const ListPhotosRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera.ListPhotosRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.photos_range() != 0) {
+    _internal_set_photos_range(from._internal_photos_range());
+  }
+}
+
+void ListPhotosRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:mavsdk.rpc.camera.ListPhotosRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ListPhotosRequest::CopyFrom(const ListPhotosRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera.ListPhotosRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ListPhotosRequest::IsInitialized() const {
+  return true;
+}
+
+void ListPhotosRequest::InternalSwap(ListPhotosRequest* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  swap(photos_range_, other->photos_range_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata ListPhotosRequest::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+void ListPhotosResponse::InitAsDefaultInstance() {
+  ::mavsdk::rpc::camera::_ListPhotosResponse_default_instance_._instance.get_mutable()->camera_result_ = const_cast< ::mavsdk::rpc::camera::CameraResult*>(
+      ::mavsdk::rpc::camera::CameraResult::internal_default_instance());
+}
+class ListPhotosResponse::_Internal {
+ public:
+  static const ::mavsdk::rpc::camera::CameraResult& camera_result(const ListPhotosResponse* msg);
+};
+
+const ::mavsdk::rpc::camera::CameraResult&
+ListPhotosResponse::_Internal::camera_result(const ListPhotosResponse* msg) {
+  return *msg->camera_result_;
+}
+ListPhotosResponse::ListPhotosResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena),
+  capture_infos_(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera.ListPhotosResponse)
+}
+ListPhotosResponse::ListPhotosResponse(const ListPhotosResponse& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message(),
+      capture_infos_(from.capture_infos_) {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_camera_result()) {
+    camera_result_ = new ::mavsdk::rpc::camera::CameraResult(*from.camera_result_);
+  } else {
+    camera_result_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera.ListPhotosResponse)
+}
+
+void ListPhotosResponse::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_ListPhotosResponse_camera_2fcamera_2eproto.base);
+  camera_result_ = nullptr;
+}
+
+ListPhotosResponse::~ListPhotosResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera.ListPhotosResponse)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void ListPhotosResponse::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  if (this != internal_default_instance()) delete camera_result_;
+}
+
+void ListPhotosResponse::ArenaDtor(void* object) {
+  ListPhotosResponse* _this = reinterpret_cast< ListPhotosResponse* >(object);
+  (void)_this;
+}
+void ListPhotosResponse::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void ListPhotosResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ListPhotosResponse& ListPhotosResponse::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_ListPhotosResponse_camera_2fcamera_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void ListPhotosResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera.ListPhotosResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  capture_infos_.Clear();
+  if (GetArena() == nullptr && camera_result_ != nullptr) {
+    delete camera_result_;
+  }
+  camera_result_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* ListPhotosResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  ::PROTOBUF_NAMESPACE_ID::Arena* arena = GetArena(); (void)arena;
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_camera_result(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // repeated .mavsdk.rpc.camera.CaptureInfo capture_infos = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(_internal_add_capture_infos(), ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<18>(ptr));
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* ListPhotosResponse::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera.ListPhotosResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+  if (this->has_camera_result()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::camera_result(this), target, stream);
+  }
+
+  // repeated .mavsdk.rpc.camera.CaptureInfo capture_infos = 2;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->_internal_capture_infos_size()); i < n; i++) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(2, this->_internal_capture_infos(i), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera.ListPhotosResponse)
+  return target;
+}
+
+size_t ListPhotosResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera.ListPhotosResponse)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated .mavsdk.rpc.camera.CaptureInfo capture_infos = 2;
+  total_size += 1UL * this->_internal_capture_infos_size();
+  for (const auto& msg : this->capture_infos_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+  if (this->has_camera_result()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *camera_result_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ListPhotosResponse::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:mavsdk.rpc.camera.ListPhotosResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ListPhotosResponse* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<ListPhotosResponse>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:mavsdk.rpc.camera.ListPhotosResponse)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:mavsdk.rpc.camera.ListPhotosResponse)
+    MergeFrom(*source);
+  }
+}
+
+void ListPhotosResponse::MergeFrom(const ListPhotosResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera.ListPhotosResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  capture_infos_.MergeFrom(from.capture_infos_);
+  if (from.has_camera_result()) {
+    _internal_mutable_camera_result()->::mavsdk::rpc::camera::CameraResult::MergeFrom(from._internal_camera_result());
+  }
+}
+
+void ListPhotosResponse::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:mavsdk.rpc.camera.ListPhotosResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ListPhotosResponse::CopyFrom(const ListPhotosResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera.ListPhotosResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ListPhotosResponse::IsInitialized() const {
+  return true;
+}
+
+void ListPhotosResponse::InternalSwap(ListPhotosResponse* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  capture_infos_.InternalSwap(&other->capture_infos_);
+  swap(camera_result_, other->camera_result_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata ListPhotosResponse::GetMetadata() const {
   return GetMetadataStatic();
 }
 
@@ -12236,6 +12762,12 @@ template<> PROTOBUF_NOINLINE ::mavsdk::rpc::camera::SetModeRequest* Arena::Creat
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::camera::SetModeResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::camera::SetModeResponse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::camera::SetModeResponse >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::camera::ListPhotosRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::camera::ListPhotosRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::camera::ListPhotosRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::camera::ListPhotosResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::camera::ListPhotosResponse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::camera::ListPhotosResponse >(arena);
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::camera::SubscribeInformationRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::camera::SubscribeInformationRequest >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::camera::SubscribeInformationRequest >(arena);

--- a/src/mavsdk_server/src/generated/camera/camera.pb.h
+++ b/src/mavsdk_server/src/generated/camera/camera.pb.h
@@ -49,7 +49,7 @@ struct TableStruct_camera_2fcamera_2eproto {
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::AuxiliaryParseTableField aux[]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
-  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[48]
+  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[50]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::FieldMetadata field_metadata[];
   static const ::PROTOBUF_NAMESPACE_ID::internal::SerializationTable serialization_table[];
@@ -92,6 +92,12 @@ extern InformationDefaultTypeInternal _Information_default_instance_;
 class InformationResponse;
 class InformationResponseDefaultTypeInternal;
 extern InformationResponseDefaultTypeInternal _InformationResponse_default_instance_;
+class ListPhotosRequest;
+class ListPhotosRequestDefaultTypeInternal;
+extern ListPhotosRequestDefaultTypeInternal _ListPhotosRequest_default_instance_;
+class ListPhotosResponse;
+class ListPhotosResponseDefaultTypeInternal;
+extern ListPhotosResponseDefaultTypeInternal _ListPhotosResponse_default_instance_;
 class ModeResponse;
 class ModeResponseDefaultTypeInternal;
 extern ModeResponseDefaultTypeInternal _ModeResponse_default_instance_;
@@ -218,6 +224,8 @@ template<> ::mavsdk::rpc::camera::GetSettingRequest* Arena::CreateMaybeMessage<:
 template<> ::mavsdk::rpc::camera::GetSettingResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::camera::GetSettingResponse>(Arena*);
 template<> ::mavsdk::rpc::camera::Information* Arena::CreateMaybeMessage<::mavsdk::rpc::camera::Information>(Arena*);
 template<> ::mavsdk::rpc::camera::InformationResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::camera::InformationResponse>(Arena*);
+template<> ::mavsdk::rpc::camera::ListPhotosRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::camera::ListPhotosRequest>(Arena*);
+template<> ::mavsdk::rpc::camera::ListPhotosResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::camera::ListPhotosResponse>(Arena*);
 template<> ::mavsdk::rpc::camera::ModeResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::camera::ModeResponse>(Arena*);
 template<> ::mavsdk::rpc::camera::Option* Arena::CreateMaybeMessage<::mavsdk::rpc::camera::Option>(Arena*);
 template<> ::mavsdk::rpc::camera::Position* Arena::CreateMaybeMessage<::mavsdk::rpc::camera::Position>(Arena*);
@@ -367,6 +375,31 @@ inline bool Mode_Parse(
     ::PROTOBUF_NAMESPACE_ID::ConstStringParam name, Mode* value) {
   return ::PROTOBUF_NAMESPACE_ID::internal::ParseNamedEnum<Mode>(
     Mode_descriptor(), name, value);
+}
+enum PhotosRange : int {
+  PHOTOS_RANGE_ALL = 0,
+  PHOTOS_RANGE_SINCE_CONNECTION = 1,
+  PhotosRange_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::min(),
+  PhotosRange_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::max()
+};
+bool PhotosRange_IsValid(int value);
+constexpr PhotosRange PhotosRange_MIN = PHOTOS_RANGE_ALL;
+constexpr PhotosRange PhotosRange_MAX = PHOTOS_RANGE_SINCE_CONNECTION;
+constexpr int PhotosRange_ARRAYSIZE = PhotosRange_MAX + 1;
+
+const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* PhotosRange_descriptor();
+template<typename T>
+inline const std::string& PhotosRange_Name(T enum_t_value) {
+  static_assert(::std::is_same<T, PhotosRange>::value ||
+    ::std::is_integral<T>::value,
+    "Incorrect type passed to function PhotosRange_Name.");
+  return ::PROTOBUF_NAMESPACE_ID::internal::NameOfEnum(
+    PhotosRange_descriptor(), enum_t_value);
+}
+inline bool PhotosRange_Parse(
+    ::PROTOBUF_NAMESPACE_ID::ConstStringParam name, PhotosRange* value) {
+  return ::PROTOBUF_NAMESPACE_ID::internal::ParseNamedEnum<PhotosRange>(
+    PhotosRange_descriptor(), name, value);
 }
 // ===================================================================
 
@@ -2556,6 +2589,309 @@ class SetModeResponse PROTOBUF_FINAL :
 };
 // -------------------------------------------------------------------
 
+class ListPhotosRequest PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.ListPhotosRequest) */ {
+ public:
+  inline ListPhotosRequest() : ListPhotosRequest(nullptr) {}
+  virtual ~ListPhotosRequest();
+
+  ListPhotosRequest(const ListPhotosRequest& from);
+  ListPhotosRequest(ListPhotosRequest&& from) noexcept
+    : ListPhotosRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline ListPhotosRequest& operator=(const ListPhotosRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ListPhotosRequest& operator=(ListPhotosRequest&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const ListPhotosRequest& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const ListPhotosRequest* internal_default_instance() {
+    return reinterpret_cast<const ListPhotosRequest*>(
+               &_ListPhotosRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    16;
+
+  friend void swap(ListPhotosRequest& a, ListPhotosRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(ListPhotosRequest* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ListPhotosRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ListPhotosRequest* New() const final {
+    return CreateMaybeMessage<ListPhotosRequest>(nullptr);
+  }
+
+  ListPhotosRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<ListPhotosRequest>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const ListPhotosRequest& from);
+  void MergeFrom(const ListPhotosRequest& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ListPhotosRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.camera.ListPhotosRequest";
+  }
+  protected:
+  explicit ListPhotosRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_camera_2fcamera_2eproto);
+    return ::descriptor_table_camera_2fcamera_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kPhotosRangeFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera.PhotosRange photos_range = 1;
+  void clear_photos_range();
+  ::mavsdk::rpc::camera::PhotosRange photos_range() const;
+  void set_photos_range(::mavsdk::rpc::camera::PhotosRange value);
+  private:
+  ::mavsdk::rpc::camera::PhotosRange _internal_photos_range() const;
+  void _internal_set_photos_range(::mavsdk::rpc::camera::PhotosRange value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera.ListPhotosRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  int photos_range_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_camera_2fcamera_2eproto;
+};
+// -------------------------------------------------------------------
+
+class ListPhotosResponse PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.ListPhotosResponse) */ {
+ public:
+  inline ListPhotosResponse() : ListPhotosResponse(nullptr) {}
+  virtual ~ListPhotosResponse();
+
+  ListPhotosResponse(const ListPhotosResponse& from);
+  ListPhotosResponse(ListPhotosResponse&& from) noexcept
+    : ListPhotosResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline ListPhotosResponse& operator=(const ListPhotosResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ListPhotosResponse& operator=(ListPhotosResponse&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const ListPhotosResponse& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const ListPhotosResponse* internal_default_instance() {
+    return reinterpret_cast<const ListPhotosResponse*>(
+               &_ListPhotosResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    17;
+
+  friend void swap(ListPhotosResponse& a, ListPhotosResponse& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(ListPhotosResponse* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ListPhotosResponse* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ListPhotosResponse* New() const final {
+    return CreateMaybeMessage<ListPhotosResponse>(nullptr);
+  }
+
+  ListPhotosResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<ListPhotosResponse>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const ListPhotosResponse& from);
+  void MergeFrom(const ListPhotosResponse& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ListPhotosResponse* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.camera.ListPhotosResponse";
+  }
+  protected:
+  explicit ListPhotosResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_camera_2fcamera_2eproto);
+    return ::descriptor_table_camera_2fcamera_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kCaptureInfosFieldNumber = 2,
+    kCameraResultFieldNumber = 1,
+  };
+  // repeated .mavsdk.rpc.camera.CaptureInfo capture_infos = 2;
+  int capture_infos_size() const;
+  private:
+  int _internal_capture_infos_size() const;
+  public:
+  void clear_capture_infos();
+  ::mavsdk::rpc::camera::CaptureInfo* mutable_capture_infos(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::mavsdk::rpc::camera::CaptureInfo >*
+      mutable_capture_infos();
+  private:
+  const ::mavsdk::rpc::camera::CaptureInfo& _internal_capture_infos(int index) const;
+  ::mavsdk::rpc::camera::CaptureInfo* _internal_add_capture_infos();
+  public:
+  const ::mavsdk::rpc::camera::CaptureInfo& capture_infos(int index) const;
+  ::mavsdk::rpc::camera::CaptureInfo* add_capture_infos();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::mavsdk::rpc::camera::CaptureInfo >&
+      capture_infos() const;
+
+  // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+  bool has_camera_result() const;
+  private:
+  bool _internal_has_camera_result() const;
+  public:
+  void clear_camera_result();
+  const ::mavsdk::rpc::camera::CameraResult& camera_result() const;
+  ::mavsdk::rpc::camera::CameraResult* release_camera_result();
+  ::mavsdk::rpc::camera::CameraResult* mutable_camera_result();
+  void set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* camera_result);
+  private:
+  const ::mavsdk::rpc::camera::CameraResult& _internal_camera_result() const;
+  ::mavsdk::rpc::camera::CameraResult* _internal_mutable_camera_result();
+  public:
+  void unsafe_arena_set_allocated_camera_result(
+      ::mavsdk::rpc::camera::CameraResult* camera_result);
+  ::mavsdk::rpc::camera::CameraResult* unsafe_arena_release_camera_result();
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera.ListPhotosResponse)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::mavsdk::rpc::camera::CaptureInfo > capture_infos_;
+  ::mavsdk::rpc::camera::CameraResult* camera_result_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_camera_2fcamera_2eproto;
+};
+// -------------------------------------------------------------------
+
 class SubscribeInformationRequest PROTOBUF_FINAL :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.SubscribeInformationRequest) */ {
  public:
@@ -2598,7 +2934,7 @@ class SubscribeInformationRequest PROTOBUF_FINAL :
                &_SubscribeInformationRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    16;
+    18;
 
   friend void swap(SubscribeInformationRequest& a, SubscribeInformationRequest& b) {
     a.Swap(&b);
@@ -2722,7 +3058,7 @@ class InformationResponse PROTOBUF_FINAL :
                &_InformationResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    17;
+    19;
 
   friend void swap(InformationResponse& a, InformationResponse& b) {
     a.Swap(&b);
@@ -2868,7 +3204,7 @@ class SubscribeModeRequest PROTOBUF_FINAL :
                &_SubscribeModeRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    18;
+    20;
 
   friend void swap(SubscribeModeRequest& a, SubscribeModeRequest& b) {
     a.Swap(&b);
@@ -2992,7 +3328,7 @@ class ModeResponse PROTOBUF_FINAL :
                &_ModeResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    19;
+    21;
 
   friend void swap(ModeResponse& a, ModeResponse& b) {
     a.Swap(&b);
@@ -3129,7 +3465,7 @@ class SubscribeVideoStreamInfoRequest PROTOBUF_FINAL :
                &_SubscribeVideoStreamInfoRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    20;
+    22;
 
   friend void swap(SubscribeVideoStreamInfoRequest& a, SubscribeVideoStreamInfoRequest& b) {
     a.Swap(&b);
@@ -3253,7 +3589,7 @@ class VideoStreamInfoResponse PROTOBUF_FINAL :
                &_VideoStreamInfoResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    21;
+    23;
 
   friend void swap(VideoStreamInfoResponse& a, VideoStreamInfoResponse& b) {
     a.Swap(&b);
@@ -3399,7 +3735,7 @@ class SubscribeCaptureInfoRequest PROTOBUF_FINAL :
                &_SubscribeCaptureInfoRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    22;
+    24;
 
   friend void swap(SubscribeCaptureInfoRequest& a, SubscribeCaptureInfoRequest& b) {
     a.Swap(&b);
@@ -3523,7 +3859,7 @@ class CaptureInfoResponse PROTOBUF_FINAL :
                &_CaptureInfoResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    23;
+    25;
 
   friend void swap(CaptureInfoResponse& a, CaptureInfoResponse& b) {
     a.Swap(&b);
@@ -3669,7 +4005,7 @@ class SubscribeStatusRequest PROTOBUF_FINAL :
                &_SubscribeStatusRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    24;
+    26;
 
   friend void swap(SubscribeStatusRequest& a, SubscribeStatusRequest& b) {
     a.Swap(&b);
@@ -3793,7 +4129,7 @@ class StatusResponse PROTOBUF_FINAL :
                &_StatusResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    25;
+    27;
 
   friend void swap(StatusResponse& a, StatusResponse& b) {
     a.Swap(&b);
@@ -3939,7 +4275,7 @@ class SubscribeCurrentSettingsRequest PROTOBUF_FINAL :
                &_SubscribeCurrentSettingsRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    26;
+    28;
 
   friend void swap(SubscribeCurrentSettingsRequest& a, SubscribeCurrentSettingsRequest& b) {
     a.Swap(&b);
@@ -4063,7 +4399,7 @@ class CurrentSettingsResponse PROTOBUF_FINAL :
                &_CurrentSettingsResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    27;
+    29;
 
   friend void swap(CurrentSettingsResponse& a, CurrentSettingsResponse& b) {
     a.Swap(&b);
@@ -4209,7 +4545,7 @@ class SubscribePossibleSettingOptionsRequest PROTOBUF_FINAL :
                &_SubscribePossibleSettingOptionsRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    28;
+    30;
 
   friend void swap(SubscribePossibleSettingOptionsRequest& a, SubscribePossibleSettingOptionsRequest& b) {
     a.Swap(&b);
@@ -4333,7 +4669,7 @@ class PossibleSettingOptionsResponse PROTOBUF_FINAL :
                &_PossibleSettingOptionsResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    29;
+    31;
 
   friend void swap(PossibleSettingOptionsResponse& a, PossibleSettingOptionsResponse& b) {
     a.Swap(&b);
@@ -4479,7 +4815,7 @@ class SetSettingRequest PROTOBUF_FINAL :
                &_SetSettingRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    30;
+    32;
 
   friend void swap(SetSettingRequest& a, SetSettingRequest& b) {
     a.Swap(&b);
@@ -4625,7 +4961,7 @@ class SetSettingResponse PROTOBUF_FINAL :
                &_SetSettingResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    31;
+    33;
 
   friend void swap(SetSettingResponse& a, SetSettingResponse& b) {
     a.Swap(&b);
@@ -4771,7 +5107,7 @@ class GetSettingRequest PROTOBUF_FINAL :
                &_GetSettingRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    32;
+    34;
 
   friend void swap(GetSettingRequest& a, GetSettingRequest& b) {
     a.Swap(&b);
@@ -4917,7 +5253,7 @@ class GetSettingResponse PROTOBUF_FINAL :
                &_GetSettingResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    33;
+    35;
 
   friend void swap(GetSettingResponse& a, GetSettingResponse& b) {
     a.Swap(&b);
@@ -5083,7 +5419,7 @@ class FormatStorageRequest PROTOBUF_FINAL :
                &_FormatStorageRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    34;
+    36;
 
   friend void swap(FormatStorageRequest& a, FormatStorageRequest& b) {
     a.Swap(&b);
@@ -5207,7 +5543,7 @@ class FormatStorageResponse PROTOBUF_FINAL :
                &_FormatStorageResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    35;
+    37;
 
   friend void swap(FormatStorageResponse& a, FormatStorageResponse& b) {
     a.Swap(&b);
@@ -5353,7 +5689,7 @@ class CameraResult PROTOBUF_FINAL :
                &_CameraResult_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    36;
+    38;
 
   friend void swap(CameraResult& a, CameraResult& b) {
     a.Swap(&b);
@@ -5550,7 +5886,7 @@ class Position PROTOBUF_FINAL :
                &_Position_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    37;
+    39;
 
   friend void swap(Position& a, Position& b) {
     a.Swap(&b);
@@ -5720,7 +6056,7 @@ class Quaternion PROTOBUF_FINAL :
                &_Quaternion_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    38;
+    40;
 
   friend void swap(Quaternion& a, Quaternion& b) {
     a.Swap(&b);
@@ -5890,7 +6226,7 @@ class EulerAngle PROTOBUF_FINAL :
                &_EulerAngle_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    39;
+    41;
 
   friend void swap(EulerAngle& a, EulerAngle& b) {
     a.Swap(&b);
@@ -6049,7 +6385,7 @@ class CaptureInfo PROTOBUF_FINAL :
                &_CaptureInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    40;
+    42;
 
   friend void swap(CaptureInfo& a, CaptureInfo& b) {
     a.Swap(&b);
@@ -6286,7 +6622,7 @@ class VideoStreamSettings PROTOBUF_FINAL :
                &_VideoStreamSettings_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    41;
+    43;
 
   friend void swap(VideoStreamSettings& a, VideoStreamSettings& b) {
     a.Swap(&b);
@@ -6485,7 +6821,7 @@ class VideoStreamInfo PROTOBUF_FINAL :
                &_VideoStreamInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    42;
+    44;
 
   friend void swap(VideoStreamInfo& a, VideoStreamInfo& b) {
     a.Swap(&b);
@@ -6672,7 +7008,7 @@ class Status PROTOBUF_FINAL :
                &_Status_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    43;
+    45;
 
   friend void swap(Status& a, Status& b) {
     a.Swap(&b);
@@ -6925,7 +7261,7 @@ class Option PROTOBUF_FINAL :
                &_Option_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    44;
+    46;
 
   friend void swap(Option& a, Option& b) {
     a.Swap(&b);
@@ -7087,7 +7423,7 @@ class Setting PROTOBUF_FINAL :
                &_Setting_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    45;
+    47;
 
   friend void swap(Setting& a, Setting& b) {
     a.Swap(&b);
@@ -7280,7 +7616,7 @@ class SettingOptions PROTOBUF_FINAL :
                &_SettingOptions_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    46;
+    48;
 
   friend void swap(SettingOptions& a, SettingOptions& b) {
     a.Swap(&b);
@@ -7473,7 +7809,7 @@ class Information PROTOBUF_FINAL :
                &_Information_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    47;
+    49;
 
   friend void swap(Information& a, Information& b) {
     a.Swap(&b);
@@ -8364,6 +8700,156 @@ inline void SetModeResponse::set_allocated_camera_result(::mavsdk::rpc::camera::
   }
   camera_result_ = camera_result;
   // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera.SetModeResponse.camera_result)
+}
+
+// -------------------------------------------------------------------
+
+// ListPhotosRequest
+
+// .mavsdk.rpc.camera.PhotosRange photos_range = 1;
+inline void ListPhotosRequest::clear_photos_range() {
+  photos_range_ = 0;
+}
+inline ::mavsdk::rpc::camera::PhotosRange ListPhotosRequest::_internal_photos_range() const {
+  return static_cast< ::mavsdk::rpc::camera::PhotosRange >(photos_range_);
+}
+inline ::mavsdk::rpc::camera::PhotosRange ListPhotosRequest::photos_range() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera.ListPhotosRequest.photos_range)
+  return _internal_photos_range();
+}
+inline void ListPhotosRequest::_internal_set_photos_range(::mavsdk::rpc::camera::PhotosRange value) {
+  
+  photos_range_ = value;
+}
+inline void ListPhotosRequest::set_photos_range(::mavsdk::rpc::camera::PhotosRange value) {
+  _internal_set_photos_range(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera.ListPhotosRequest.photos_range)
+}
+
+// -------------------------------------------------------------------
+
+// ListPhotosResponse
+
+// .mavsdk.rpc.camera.CameraResult camera_result = 1;
+inline bool ListPhotosResponse::_internal_has_camera_result() const {
+  return this != internal_default_instance() && camera_result_ != nullptr;
+}
+inline bool ListPhotosResponse::has_camera_result() const {
+  return _internal_has_camera_result();
+}
+inline void ListPhotosResponse::clear_camera_result() {
+  if (GetArena() == nullptr && camera_result_ != nullptr) {
+    delete camera_result_;
+  }
+  camera_result_ = nullptr;
+}
+inline const ::mavsdk::rpc::camera::CameraResult& ListPhotosResponse::_internal_camera_result() const {
+  const ::mavsdk::rpc::camera::CameraResult* p = camera_result_;
+  return p != nullptr ? *p : *reinterpret_cast<const ::mavsdk::rpc::camera::CameraResult*>(
+      &::mavsdk::rpc::camera::_CameraResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera::CameraResult& ListPhotosResponse::camera_result() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera.ListPhotosResponse.camera_result)
+  return _internal_camera_result();
+}
+inline void ListPhotosResponse::unsafe_arena_set_allocated_camera_result(
+    ::mavsdk::rpc::camera::CameraResult* camera_result) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(camera_result_);
+  }
+  camera_result_ = camera_result;
+  if (camera_result) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera.ListPhotosResponse.camera_result)
+}
+inline ::mavsdk::rpc::camera::CameraResult* ListPhotosResponse::release_camera_result() {
+  
+  ::mavsdk::rpc::camera::CameraResult* temp = camera_result_;
+  camera_result_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::mavsdk::rpc::camera::CameraResult* ListPhotosResponse::unsafe_arena_release_camera_result() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera.ListPhotosResponse.camera_result)
+  
+  ::mavsdk::rpc::camera::CameraResult* temp = camera_result_;
+  camera_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera::CameraResult* ListPhotosResponse::_internal_mutable_camera_result() {
+  
+  if (camera_result_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::camera::CameraResult>(GetArena());
+    camera_result_ = p;
+  }
+  return camera_result_;
+}
+inline ::mavsdk::rpc::camera::CameraResult* ListPhotosResponse::mutable_camera_result() {
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera.ListPhotosResponse.camera_result)
+  return _internal_mutable_camera_result();
+}
+inline void ListPhotosResponse::set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* camera_result) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete camera_result_;
+  }
+  if (camera_result) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(camera_result);
+    if (message_arena != submessage_arena) {
+      camera_result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, camera_result, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  camera_result_ = camera_result;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera.ListPhotosResponse.camera_result)
+}
+
+// repeated .mavsdk.rpc.camera.CaptureInfo capture_infos = 2;
+inline int ListPhotosResponse::_internal_capture_infos_size() const {
+  return capture_infos_.size();
+}
+inline int ListPhotosResponse::capture_infos_size() const {
+  return _internal_capture_infos_size();
+}
+inline void ListPhotosResponse::clear_capture_infos() {
+  capture_infos_.Clear();
+}
+inline ::mavsdk::rpc::camera::CaptureInfo* ListPhotosResponse::mutable_capture_infos(int index) {
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera.ListPhotosResponse.capture_infos)
+  return capture_infos_.Mutable(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::mavsdk::rpc::camera::CaptureInfo >*
+ListPhotosResponse::mutable_capture_infos() {
+  // @@protoc_insertion_point(field_mutable_list:mavsdk.rpc.camera.ListPhotosResponse.capture_infos)
+  return &capture_infos_;
+}
+inline const ::mavsdk::rpc::camera::CaptureInfo& ListPhotosResponse::_internal_capture_infos(int index) const {
+  return capture_infos_.Get(index);
+}
+inline const ::mavsdk::rpc::camera::CaptureInfo& ListPhotosResponse::capture_infos(int index) const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera.ListPhotosResponse.capture_infos)
+  return _internal_capture_infos(index);
+}
+inline ::mavsdk::rpc::camera::CaptureInfo* ListPhotosResponse::_internal_add_capture_infos() {
+  return capture_infos_.Add();
+}
+inline ::mavsdk::rpc::camera::CaptureInfo* ListPhotosResponse::add_capture_infos() {
+  // @@protoc_insertion_point(field_add:mavsdk.rpc.camera.ListPhotosResponse.capture_infos)
+  return _internal_add_capture_infos();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::mavsdk::rpc::camera::CaptureInfo >&
+ListPhotosResponse::capture_infos() const {
+  // @@protoc_insertion_point(field_list:mavsdk.rpc.camera.ListPhotosResponse.capture_infos)
+  return capture_infos_;
 }
 
 // -------------------------------------------------------------------
@@ -11317,6 +11803,10 @@ inline void Information::set_allocated_model_name(std::string* model_name) {
 
 // -------------------------------------------------------------------
 
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 
 // @@protoc_insertion_point(namespace_scope)
 
@@ -11345,6 +11835,11 @@ template <> struct is_proto_enum< ::mavsdk::rpc::camera::Mode> : ::std::true_typ
 template <>
 inline const EnumDescriptor* GetEnumDescriptor< ::mavsdk::rpc::camera::Mode>() {
   return ::mavsdk::rpc::camera::Mode_descriptor();
+}
+template <> struct is_proto_enum< ::mavsdk::rpc::camera::PhotosRange> : ::std::true_type {};
+template <>
+inline const EnumDescriptor* GetEnumDescriptor< ::mavsdk::rpc::camera::PhotosRange>() {
+  return ::mavsdk::rpc::camera::PhotosRange_descriptor();
 }
 
 PROTOBUF_NAMESPACE_CLOSE

--- a/src/plugins/camera/camera.cpp
+++ b/src/plugins/camera/camera.cpp
@@ -97,6 +97,17 @@ Camera::Result Camera::set_mode(Mode mode) const
     return _impl->set_mode(mode);
 }
 
+void Camera::list_photos_async(PhotosRange photos_range, const ListPhotosCallback callback)
+{
+    _impl->list_photos_async(photos_range, callback);
+}
+
+std::pair<Camera::Result, std::vector<Camera::CaptureInfo>>
+Camera::list_photos(PhotosRange photos_range) const
+{
+    return _impl->list_photos(photos_range);
+}
+
 void Camera::subscribe_mode(ModeCallback callback)
 {
     _impl->subscribe_mode(callback);
@@ -475,6 +486,18 @@ std::ostream& operator<<(std::ostream& str, Camera::Mode const& mode)
             return str << "Photo";
         case Camera::Mode::Video:
             return str << "Video";
+        default:
+            return str << "Unknown";
+    }
+}
+
+std::ostream& operator<<(std::ostream& str, Camera::PhotosRange const& photos_range)
+{
+    switch (photos_range) {
+        case Camera::PhotosRange::All:
+            return str << "All";
+        case Camera::PhotosRange::SinceConnection:
+            return str << "Since Connection";
         default:
             return str << "Unknown";
     }

--- a/src/plugins/camera/camera_impl.h
+++ b/src/plugins/camera/camera_impl.h
@@ -190,7 +190,6 @@ private:
         bool received_storage_information{false};
         int image_count{-1};
         int image_count_at_connection{-1};
-        int last_advertised_image_index{-1};
         std::map<int, Camera::CaptureInfo> photo_list;
         bool is_fetching_photos{false};
 
@@ -215,6 +214,7 @@ private:
     struct {
         std::mutex mutex{};
         Camera::CaptureInfoCallback callback{nullptr};
+        int last_advertised_image_index{-1};
     } _capture_info{};
 
     struct {

--- a/src/plugins/camera/include/plugins/camera/camera.h
+++ b/src/plugins/camera/include/plugins/camera/camera.h
@@ -79,6 +79,21 @@ public:
     friend std::ostream& operator<<(std::ostream& str, Camera::Mode const& mode);
 
     /**
+     * @brief Photos range type.
+     */
+    enum class PhotosRange {
+        All, /**< @brief All the photos present on the camera. */
+        SinceConnection, /**< @brief Photos taken since MAVSDK got connected. */
+    };
+
+    /**
+     * @brief Stream operator to print information about a `Camera::PhotosRange`.
+     *
+     * @return A reference to the stream.
+     */
+    friend std::ostream& operator<<(std::ostream& str, Camera::PhotosRange const& photos_range);
+
+    /**
      * @brief Possible results returned for camera commands
      */
     enum class Result {
@@ -541,6 +556,27 @@ public:
      * @return Result of request.
      */
     Result set_mode(Mode mode) const;
+
+    /**
+     * @brief Callback type for list_photos_async.
+     */
+    using ListPhotosCallback = std::function<void(Result, std::vector<CaptureInfo>)>;
+
+    /**
+     * @brief List photos available on the camera.
+     *
+     * This function is non-blocking. See 'list_photos' for the blocking counterpart.
+     */
+    void list_photos_async(PhotosRange photos_range, const ListPhotosCallback callback);
+
+    /**
+     * @brief List photos available on the camera.
+     *
+     * This function is blocking. See 'list_photos_async' for the non-blocking counterpart.
+     *
+     * @return Result of request.
+     */
+    std::pair<Result, std::vector<Camera::CaptureInfo>> list_photos(PhotosRange photos_range) const;
 
     /**
      * @brief Callback type for subscribe_mode.

--- a/src/plugins/camera/mocks/camera_mock.h
+++ b/src/plugins/camera/mocks/camera_mock.h
@@ -29,6 +29,9 @@ public:
     MOCK_CONST_METHOD3(
         set_option_async, void(Camera::ResultCallback, const std::string&, const Camera::Option)){};
     MOCK_CONST_METHOD0(format_storage, Camera::Result()){};
+    MOCK_CONST_METHOD1(
+        list_photos,
+        std::pair<Camera::Result, std::vector<Camera::CaptureInfo>>(Camera::PhotosRange)){};
 };
 
 } // namespace testing

--- a/src/plugins/gimbal/gimbal_protocol_v2.h
+++ b/src/plugins/gimbal/gimbal_protocol_v2.h
@@ -59,8 +59,6 @@ private:
     Gimbal::ControlStatus _current_control_status{Gimbal::ControlMode::None, 0, 0, 0, 0};
     Gimbal::ControlCallback _control_callback;
 
-    std::condition_variable _control_thread_cv;
-    std::mutex _control_thread_mutex;
     bool _is_mavlink_manager_status_registered = false;
 };
 


### PR DESCRIPTION
Add a way to list photos either since the moment MAVSDK connected to the drone, or all the photos on the sdcard.

The camera plugin caches the information on the pictures that are taken, meaning that for getting the images SINCE_CONNECTION, it should mostly be in the cache. However, if an image is missing, MAVSDK will retrieve it.

When fetching all the images on the sdcard, it may take longer depending on how many images are there. The way it works is that it requests the "captured" message for the next photo, and waits until a (not necessarily this one) "captured" message is received. This way it does not take all the bandwidth by e.g. sending 2000 requests at once.

There are two mechanisms to avoid deadlocks:
1. If a "captured" message is not received 1 second after the request message has been sent, try again. After 3 tries, time out the whole `list_photos()` function.
2. It could happen that the condition_variable is unlocked by a "captured" message that is not the one we are expecting. In that case, the same image is being queried again. After three such trials, the `safety_count_boundary` counter makes it fail. I believe it should not happen unless the vehicle is behaving in a wrong way, but still we should not crash.

Tested against the Auterion Cloud Simulator and locally from MAVSDK-Python.