### PR TITLE
Fix library versioning

### DIFF
--- a/src/plugins/failure/CMakeLists.txt
+++ b/src/plugins/failure/CMakeLists.txt
@@ -9,6 +9,8 @@ target_link_libraries(mavsdk_failure
 
 set_target_properties(mavsdk_failure
     PROPERTIES COMPILE_FLAGS ${warnings}
+    VERSION ${MAVSDK_VERSION_STRING}
+    SOVERSION ${MAVSDK_SOVERSION_STRING}
 )
 
 target_include_directories(mavsdk_failure PUBLIC

--- a/src/plugins/manual_control/CMakeLists.txt
+++ b/src/plugins/manual_control/CMakeLists.txt
@@ -9,6 +9,8 @@ target_link_libraries(mavsdk_manual_control
 
 set_target_properties(mavsdk_manual_control
     PROPERTIES COMPILE_FLAGS ${warnings}
+    VERSION ${MAVSDK_VERSION_STRING}
+    SOVERSION ${MAVSDK_SOVERSION_STRING}
 )
 
 target_include_directories(mavsdk_manual_control PUBLIC


### PR DESCRIPTION
Got merged into `master` by mistake, cherry-picking it into `develop`