### PR TITLE
Temporary fix for CI build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,6 +105,7 @@ jobs:
         run: |
              cd proto/pb_plugins
              pip3 install --user -r requirements.txt
+             pip3 install protobuf --upgrade
              pip3 install --user -e .
       - uses: actions/cache@v2
         id: cache


### PR DESCRIPTION
On Ubuntu we need a newer version of python-protobuf than what comes with the system