### PR TITLE
TrackingServer - Fixed is_command_sender_ok result checking

### DIFF
--- a/src/plugins/tracking_server/tracking_server_impl.cpp
+++ b/src/plugins/tracking_server/tracking_server_impl.cpp
@@ -201,7 +201,7 @@ TrackingServerImpl::respond_tracking_off_command(TrackingServer::CommandAnswer c
 std::optional<mavlink_message_t>
 TrackingServerImpl::process_track_point_command(const MavlinkCommandReceiver::CommandLong& command)
 {
-    if (is_command_sender_ok(command)) {
+    if (!is_command_sender_ok(command)) {
         LogWarn() << "Incoming track point command is for target sysid "
                   << int(command.target_system_id) << " instead of "
                   << int(_parent->get_own_system_id());
@@ -226,7 +226,7 @@ TrackingServerImpl::process_track_point_command(const MavlinkCommandReceiver::Co
 std::optional<mavlink_message_t> TrackingServerImpl::process_track_rectangle_command(
     const MavlinkCommandReceiver::CommandLong& command)
 {
-    if (is_command_sender_ok(command)) {
+    if (!is_command_sender_ok(command)) {
         LogWarn() << "Incoming track rectangle command is for target sysid "
                   << int(command.target_system_id) << " instead of "
                   << int(_parent->get_own_system_id());
@@ -252,7 +252,7 @@ std::optional<mavlink_message_t> TrackingServerImpl::process_track_rectangle_com
 std::optional<mavlink_message_t>
 TrackingServerImpl::process_track_off_command(const MavlinkCommandReceiver::CommandLong& command)
 {
-    if (is_command_sender_ok(command)) {
+    if (!is_command_sender_ok(command)) {
         LogWarn() << "Incoming track off command is for target sysid "
                   << int(command.target_system_id) << " instead of "
                   << int(_parent->get_own_system_id());
@@ -274,9 +274,6 @@ TrackingServerImpl::process_track_off_command(const MavlinkCommandReceiver::Comm
 bool TrackingServerImpl::is_command_sender_ok(const MavlinkCommandReceiver::CommandLong& command)
 {
     if (command.target_system_id != 0 && command.target_system_id != _parent->get_own_system_id()) {
-        LogWarn() << "Incoming track rectangle command is for target sysid "
-                  << int(command.target_system_id) << " instead of "
-                  << int(_parent->get_own_system_id());
         return false;
     } else {
         return true;


### PR DESCRIPTION
Typo in checking the result of is_command_sender_ok method prevented tracking commands from being executed.
Also removed duplicated log output.