### PR TITLE
mavsdk_server: tracking_server was missing

### DIFF
--- a/src/mavsdk_server/src/CMakeLists.txt
+++ b/src/mavsdk_server/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)
 
-set(COMPONENTS_LIST action calibration camera core failure follow_me ftp geofence gimbal info log_files manual_control mission mission_raw mocap offboard param shell telemetry tune)
+set(COMPONENTS_LIST action calibration camera core failure follow_me ftp geofence gimbal info log_files manual_control mission mission_raw mocap offboard param shell telemetry tracking_server tune)
 
 foreach(COMPONENT_NAME ${COMPONENTS_LIST})
     add_library(${COMPONENT_NAME}_proto_gens STATIC
@@ -62,6 +62,7 @@ target_link_libraries(mavsdk_server
     mavsdk_param
     mavsdk_shell
     mavsdk_telemetry
+    mavsdk_tracking_server
     mavsdk_tune
     mavsdk
     gRPC::grpc++

--- a/src/mavsdk_server/src/grpc_server.cpp
+++ b/src/mavsdk_server/src/grpc_server.cpp
@@ -37,6 +37,7 @@ int GRPCServer::run()
     builder.RegisterService(&_param_service);
     builder.RegisterService(&_shell_service);
     builder.RegisterService(&_telemetry_service);
+    builder.RegisterService(&_tracking_server_service);
     builder.RegisterService(&_tune_service);
 
     _server = builder.BuildAndStart();
@@ -82,6 +83,7 @@ void GRPCServer::stop()
         _param_service.stop();
         _shell_service.stop();
         _telemetry_service.stop();
+        _tracking_server_service.stop();
         _tune_service.stop();
         _server->Shutdown();
     } else {

--- a/src/mavsdk_server/src/grpc_server.h
+++ b/src/mavsdk_server/src/grpc_server.h
@@ -42,6 +42,8 @@
 #include "shell/shell_service_impl.h"
 #include "plugins/telemetry/telemetry.h"
 #include "telemetry/telemetry_service_impl.h"
+#include "plugins/tracking_server/tracking_server.h"
+#include "tracking_server/tracking_server_service_impl.h"
 #include "plugins/tune/tune.h"
 #include "tune/tune_service_impl.h"
 
@@ -89,6 +91,8 @@ public:
         _shell_service(_shell),
         _telemetry(_mavsdk.system()),
         _telemetry_service(_telemetry),
+        _tracking_server(_mavsdk.system()),
+        _tracking_server_service(_tracking_server),
         _tune(_mavsdk.system()),
         _tune_service(_tune)
     {}
@@ -139,6 +143,8 @@ private:
     ShellServiceImpl<> _shell_service;
     Telemetry _telemetry;
     TelemetryServiceImpl<> _telemetry_service;
+    TrackingServer _tracking_server;
+    TrackingServerServiceImpl<> _tracking_server_service;
     Tune _tune;
     TuneServiceImpl<> _tune_service;
 


### PR DESCRIPTION
@MatejFranceskin this is required for it work with Python as well.