### PR TITLE
Logfiles: test if target is an unexisting file before download

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -432,7 +432,7 @@ jobs:
         run: |
           echo "SDKROOT=$(xcrun --sdk ${{ matrix.sdk }} --show-sdk-path)" >> $GITHUB_ENV
       - name: configure
-        run: cmake $superbuild $cmake_prefix_path -DENABLE_STRICT_TRY_COMPILE=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$(pwd)/tools/ios.toolchain.cmake -DPLATFORM=${{ matrix.platform }} -DDEPLOYMENT_TARGET=11.0 -DBUILD_MAVSDK_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DWERROR=OFF -j 2 -Bbuild/${{ matrix.name }} -H.
+        run: cmake $superbuild $cmake_prefix_path -DENABLE_STRICT_TRY_COMPILE=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$(pwd)/tools/ios.toolchain.cmake -DPLATFORM=${{ matrix.platform }} -DDEPLOYMENT_TARGET=13.0 -DBUILD_MAVSDK_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DWERROR=OFF -j 2 -Bbuild/${{ matrix.name }} -H.
       - name: build
         run: cmake --build build/${{ matrix.name }} -j 2
       - uses: actions/upload-artifact@v2

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -137,12 +137,12 @@ void SystemImpl::process_mavlink_message(mavlink_message_t& message)
 
 void SystemImpl::add_call_every(std::function<void()> callback, float interval_s, void** cookie)
 {
-    _parent.call_every_handler.add(callback, interval_s, cookie);
+    _parent.call_every_handler.add(callback, static_cast<double>(interval_s), cookie);
 }
 
 void SystemImpl::change_call_every(float interval_s, const void* cookie)
 {
-    _parent.call_every_handler.change(interval_s, cookie);
+    _parent.call_every_handler.change(static_cast<double>(interval_s), cookie);
 }
 
 void SystemImpl::reset_call_every(const void* cookie)

--- a/src/integration_tests/log_files.cpp
+++ b/src/integration_tests/log_files.cpp
@@ -1,6 +1,8 @@
 #include <iostream>
 #include <future>
+#include <fstream>
 #include <sstream>
+
 #include "mavsdk.h"
 #include "integration_test_helper.h"
 #include "plugins/log_files/log_files.h"
@@ -48,6 +50,118 @@ TEST(HardwareTest, LogFiles)
                         LogInfo() << "Download progress: " << 100.0f * progress_data.progress;
                     } else {
                         EXPECT_EQ(result, LogFiles::Result::Success);
+                        prom.set_value();
+                    }
+                });
+
+            fut.wait();
+
+            if (++num_downloaded_files >= 2) {
+                break;
+            }
+        }
+    }
+}
+
+TEST(HardwareTest, LogFilesDownloadFailsIfPathIsDirectory)
+{
+    Mavsdk mavsdk;
+
+    // ConnectionResult ret = mavsdk.add_serial_connection("/dev/ttyACM0");
+    ConnectionResult ret = mavsdk.add_udp_connection();
+    ASSERT_EQ(ret, ConnectionResult::Success);
+
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    auto system = mavsdk.systems().at(0);
+    ASSERT_TRUE(system->has_autopilot());
+    auto log_files = std::make_shared<LogFiles>(system);
+
+    std::pair<LogFiles::Result, std::vector<LogFiles::Entry>> entry_result =
+        log_files->get_entries();
+
+    EXPECT_EQ(entry_result.first, LogFiles::Result::Success);
+
+    if (entry_result.first == LogFiles::Result::Success) {
+        unsigned num_downloaded_files = 0;
+
+        for (auto& entry : entry_result.second) {
+            float size_mib = entry.size_bytes / 1024.0f / 1024.0f;
+            LogInfo() << "Entry " << entry.id << ": "
+                      << " at " << entry.date << ", " << size_mib
+                      << " MiB, bytes: " << entry.size_bytes;
+            std::stringstream file_path_stream;
+            file_path_stream << "/tmp";
+
+            auto prom = std::promise<void>();
+            auto fut = prom.get_future();
+
+            log_files->download_log_file_async(
+                entry.id,
+                file_path_stream.str(),
+                [&prom](LogFiles::Result result, LogFiles::ProgressData progress_data) {
+                    if (result == LogFiles::Result::Next) {
+                        LogInfo() << "Download progress: " << 100.0f * progress_data.progress;
+                    } else {
+                        EXPECT_EQ(result, LogFiles::Result::InvalidArgument);
+                        prom.set_value();
+                    }
+                });
+
+            fut.wait();
+
+            if (++num_downloaded_files >= 2) {
+                break;
+            }
+        }
+    }
+}
+
+TEST(HardwareTest, LogFilesDownloadFailsIfFileAlreadyExists)
+{
+    Mavsdk mavsdk;
+
+    // ConnectionResult ret = mavsdk.add_serial_connection("/dev/ttyACM0");
+    ConnectionResult ret = mavsdk.add_udp_connection();
+    ASSERT_EQ(ret, ConnectionResult::Success);
+
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    auto system = mavsdk.systems().at(0);
+    ASSERT_TRUE(system->has_autopilot());
+    auto log_files = std::make_shared<LogFiles>(system);
+
+    std::pair<LogFiles::Result, std::vector<LogFiles::Entry>> entry_result =
+        log_files->get_entries();
+
+    EXPECT_EQ(entry_result.first, LogFiles::Result::Success);
+
+    if (entry_result.first == LogFiles::Result::Success) {
+        unsigned num_downloaded_files = 0;
+
+        for (auto& entry : entry_result.second) {
+            float size_mib = entry.size_bytes / 1024.0f / 1024.0f;
+            LogInfo() << "Entry " << entry.id << ": "
+                      << " at " << entry.date << ", " << size_mib
+                      << " MiB, bytes: " << entry.size_bytes;
+            std::stringstream file_path_stream;
+            file_path_stream << "/tmp/logfile_" << entry.id << ".ulog";
+
+            std::ofstream ofs(file_path_stream.str());
+            ofs << "This file should not be erased by the download\n";
+            ofs.close();
+
+            auto prom = std::promise<void>();
+            auto fut = prom.get_future();
+
+            log_files->download_log_file_async(
+                entry.id,
+                file_path_stream.str(),
+                [&prom](LogFiles::Result result, LogFiles::ProgressData progress_data) {
+                    if (result == LogFiles::Result::Next) {
+                        LogInfo() << "Download progress: " << 100.0f * progress_data.progress;
+                    } else {
+                        EXPECT_EQ(result, LogFiles::Result::InvalidArgument);
                         prom.set_value();
                     }
                 });

--- a/src/plugins/log_files/CMakeLists.txt
+++ b/src/plugins/log_files/CMakeLists.txt
@@ -7,6 +7,12 @@ target_link_libraries(mavsdk_log_files
     mavsdk
 )
 
+if (NOT APPLE AND NOT ANDROID AND NOT MSVC)
+    target_link_libraries(mavsdk_log_files
+        stdc++fs
+    )
+endif()
+
 set_target_properties(mavsdk_log_files
     PROPERTIES COMPILE_FLAGS ${warnings}
     VERSION ${MAVSDK_VERSION_STRING}

--- a/src/plugins/log_files/log_files_impl.cpp
+++ b/src/plugins/log_files/log_files_impl.cpp
@@ -8,13 +8,13 @@
 #include <cstring>
 
 #if __has_include(<filesystem>)
-  #include <filesystem>
-  namespace fs = std::filesystem;
+#include <filesystem>
+namespace fs = std::filesystem;
 #elif __has_include(<experimental/filesystem>)
-  #include <experimental/filesystem>
-  namespace fs = std::experimental::filesystem;
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
 #else
-  error "Missing the <filesystem> header."
+error "Missing the <filesystem> header."
 #endif
 
 namespace mavsdk {

--- a/src/plugins/log_files/log_files_impl.cpp
+++ b/src/plugins/log_files/log_files_impl.cpp
@@ -6,7 +6,16 @@
 #include <cmath>
 #include <ctime>
 #include <cstring>
-#include <filesystem>
+
+#if __has_include(<filesystem>)
+  #include <filesystem>
+  namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+  #include <experimental/filesystem>
+  namespace fs = std::experimental::filesystem;
+#else
+  error "Missing the <filesystem> header."
+#endif
 
 namespace mavsdk {
 
@@ -451,16 +460,16 @@ void LogFilesImpl::data_timeout()
 
 bool LogFilesImpl::is_directory(const std::string& path) const
 {
-    std::filesystem::path file_path(path);
+    fs::path file_path(path);
     std::error_code ignored;
-    return std::filesystem::is_directory(file_path, ignored);
+    return fs::is_directory(file_path, ignored);
 }
 
 bool LogFilesImpl::file_exists(const std::string& path) const
 {
-    std::filesystem::path file_path(path);
+    fs::path file_path(path);
     std::error_code ignored;
-    return std::filesystem::exists(file_path, ignored);
+    return fs::exists(file_path, ignored);
 }
 
 bool LogFilesImpl::start_logfile(const std::string& path)

--- a/src/plugins/log_files/log_files_impl.cpp
+++ b/src/plugins/log_files/log_files_impl.cpp
@@ -14,7 +14,7 @@ namespace fs = std::filesystem;
 #include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
 #else
-error "Missing the <filesystem> header."
+#error "Missing the <filesystem> header."
 #endif
 
 namespace mavsdk {

--- a/src/plugins/log_files/log_files_impl.cpp
+++ b/src/plugins/log_files/log_files_impl.cpp
@@ -1,10 +1,12 @@
 #include "global_include.h"
 #include "log_files_impl.h"
 #include "mavsdk_impl.h"
+
 #include <algorithm>
 #include <cmath>
 #include <ctime>
 #include <cstring>
+#include <filesystem>
 
 namespace mavsdk {
 
@@ -228,6 +230,33 @@ void LogFilesImpl::download_log_file_async(
     {
         std::lock_guard<std::mutex> lock(_data.mutex);
 
+        if (is_directory(file_path)) {
+            if (callback) {
+                const auto tmp_callback = callback;
+                _parent->call_user_callback([tmp_callback]() {
+                    LogFiles::ProgressData progress;
+                    progress.progress = NAN;
+                    LogErr()
+                        << "Invalid path! The path must point to an unexisting file, and it points to a directory!";
+                    tmp_callback(LogFiles::Result::InvalidArgument, progress);
+                });
+            }
+            return;
+        }
+
+        if (file_exists(file_path)) {
+            if (callback) {
+                const auto tmp_callback = callback;
+                _parent->call_user_callback([tmp_callback]() {
+                    LogFiles::ProgressData progress;
+                    progress.progress = NAN;
+                    LogErr() << "Target log file already exists!";
+                    tmp_callback(LogFiles::Result::InvalidArgument, progress);
+                });
+            }
+            return;
+        }
+
         if (!start_logfile(file_path)) {
             if (callback) {
                 const auto tmp_callback = callback;
@@ -420,9 +449,24 @@ void LogFilesImpl::data_timeout()
     }
 }
 
+bool LogFilesImpl::is_directory(const std::string& path) const
+{
+    std::filesystem::path file_path(path);
+    std::error_code ignored;
+    return std::filesystem::is_directory(file_path, ignored);
+}
+
+bool LogFilesImpl::file_exists(const std::string& path) const
+{
+    std::filesystem::path file_path(path);
+    std::error_code ignored;
+    return std::filesystem::exists(file_path, ignored);
+}
+
 bool LogFilesImpl::start_logfile(const std::string& path)
 {
     // Assumes to have the lock for _data.mutex.
+    // Assumes that the path is valid and points to a file (not a directory)
 
     _data.file.open(path, std::ios::out | std::ios::binary);
 

--- a/src/plugins/log_files/log_files_impl.h
+++ b/src/plugins/log_files/log_files_impl.h
@@ -39,6 +39,8 @@ private:
     void request_log_data(unsigned id, unsigned start, unsigned count);
     void data_timeout();
 
+    bool is_directory(const std::string& path) const;
+    bool file_exists(const std::string& path) const;
     bool start_logfile(const std::string& path);
     void write_part_to_disk();
     void finish_logfile();


### PR DESCRIPTION
This is checking if the target log file is not a directory and if it does not already exist. It errors with an InvalidArgument error if the argument is not appropriate.

This hopes to improve issues like https://github.com/mavlink/MAVSDK-Python/issues/323 and https://github.com/mavlink/MAVSDK-Python/issues/312 where it was not clear how to use the arguments.