### PR TITLE
[master] Fix the iterator not in same container bug when compiling with MSVC2019

### DIFF
--- a/src/core/mavsdk_impl.cpp
+++ b/src/core/mavsdk_impl.cpp
@@ -466,7 +466,8 @@ void MavsdkImpl::subscribe_on_new_system(Mavsdk::NewSystemCallback callback)
     _new_system_callback = callback;
 
     const auto is_any_system_connected = [this]() {
-        return std::any_of(systems().cbegin(), systems().cend(), [](auto& system) {
+        std::vector<std::shared_ptr<System>> connected_systems = systems();
+        return std::any_of(connected_systems.cbegin(), connected_systems.cend(), [](auto& system) {
             return system->is_connected();
         });
     };


### PR DESCRIPTION
Fixed a crash when compile with MSVC2019.

Resolves #1357.