### PR TITLE
Fix "iterator not in same container" build error when compiling with MSVC2019

### DIFF
--- a/src/core/mavsdk_impl.cpp
+++ b/src/core/mavsdk_impl.cpp
@@ -575,7 +575,8 @@ void MavsdkImpl::subscribe_on_new_system(Mavsdk::NewSystemCallback callback)
     _new_system_callback = callback;
 
     const auto is_any_system_connected = [this]() {
-        return std::any_of(systems().cbegin(), systems().cend(), [](auto& system) {
+        std::vector<std::shared_ptr<System>> connected_systems = systems();
+        return std::any_of(connected_systems.cbegin(), connected_systems.cend(), [](auto& system) {
             return system->is_connected();
         });
     };


### PR DESCRIPTION
Fix iterator not in same container bug when compiling with MSVC2019.

Resolves #1357.

Same as #1361 but pushed onto develop. Also recommend applying this change to the master branch as the master is labeled as "latest stable build" on the website, a lot of people (including me) were to use the master branch by default.