### PR TITLE
Add dependency on get_entries to force its use before downloading a log

### DIFF
--- a/src/integration_tests/log_files.cpp
+++ b/src/integration_tests/log_files.cpp
@@ -36,15 +36,14 @@ TEST(HardwareTest, LogFiles)
             LogInfo() << "Entry " << entry.id << ": "
                       << " at " << entry.date << ", " << size_mib
                       << " MiB, bytes: " << entry.size_bytes;
-            std::stringstream file_path_stream;
-            file_path_stream << "/tmp/logfile_" << entry.id << ".ulog";
+            std::string file_path = std::tmpnam(nullptr);
 
             auto prom = std::promise<void>();
             auto fut = prom.get_future();
 
             log_files->download_log_file_async(
-                entry.id,
-                file_path_stream.str(),
+                entry,
+                file_path,
                 [&prom](LogFiles::Result result, LogFiles::ProgressData progress_data) {
                     if (result == LogFiles::Result::Next) {
                         LogInfo() << "Download progress: " << 100.0f * progress_data.progress;
@@ -90,15 +89,15 @@ TEST(HardwareTest, LogFilesDownloadFailsIfPathIsDirectory)
             LogInfo() << "Entry " << entry.id << ": "
                       << " at " << entry.date << ", " << size_mib
                       << " MiB, bytes: " << entry.size_bytes;
-            std::stringstream file_path_stream;
-            file_path_stream << "/tmp";
+
+            std::string file_path = std::tmpnam(nullptr);
 
             auto prom = std::promise<void>();
             auto fut = prom.get_future();
 
             log_files->download_log_file_async(
-                entry.id,
-                file_path_stream.str(),
+                entry,
+                file_path,
                 [&prom](LogFiles::Result result, LogFiles::ProgressData progress_data) {
                     if (result == LogFiles::Result::Next) {
                         LogInfo() << "Download progress: " << 100.0f * progress_data.progress;
@@ -144,10 +143,9 @@ TEST(HardwareTest, LogFilesDownloadFailsIfFileAlreadyExists)
             LogInfo() << "Entry " << entry.id << ": "
                       << " at " << entry.date << ", " << size_mib
                       << " MiB, bytes: " << entry.size_bytes;
-            std::stringstream file_path_stream;
-            file_path_stream << "/tmp/logfile_" << entry.id << ".ulog";
+            std::string file_path = std::tmpnam(nullptr);
 
-            std::ofstream ofs(file_path_stream.str());
+            std::ofstream ofs(file_path);
             ofs << "This file should not be erased by the download\n";
             ofs.close();
 
@@ -155,8 +153,8 @@ TEST(HardwareTest, LogFilesDownloadFailsIfFileAlreadyExists)
             auto fut = prom.get_future();
 
             log_files->download_log_file_async(
-                entry.id,
-                file_path_stream.str(),
+                entry,
+                file_path,
                 [&prom](LogFiles::Result result, LogFiles::ProgressData progress_data) {
                     if (result == LogFiles::Result::Next) {
                         LogInfo() << "Download progress: " << 100.0f * progress_data.progress;

--- a/src/mavsdk_server/src/generated/log_files/log_files.pb.cc
+++ b/src/mavsdk_server/src/generated/log_files/log_files.pb.cc
@@ -46,7 +46,7 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT GetEntriesResponseDefaultTypeIn
 constexpr SubscribeDownloadLogFileRequest::SubscribeDownloadLogFileRequest(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
   : path_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
-  , id_(0u){}
+  , entry_(nullptr){}
 struct SubscribeDownloadLogFileRequestDefaultTypeInternal {
   constexpr SubscribeDownloadLogFileRequestDefaultTypeInternal()
     : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
@@ -134,7 +134,7 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_log_5ffiles_2flog_5ffiles_2epr
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::log_files::SubscribeDownloadLogFileRequest, id_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::log_files::SubscribeDownloadLogFileRequest, entry_),
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::log_files::SubscribeDownloadLogFileRequest, path_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::log_files::DownloadLogFileResponse, _internal_metadata_),
@@ -191,36 +191,37 @@ const char descriptor_table_protodef_log_5ffiles_2flog_5ffiles_2eproto[] PROTOBU
   "triesRequest\"\202\001\n\022GetEntriesResponse\022>\n\020l"
   "og_files_result\030\001 \001(\0132$.mavsdk.rpc.log_f"
   "iles.LogFilesResult\022,\n\007entries\030\002 \003(\0132\033.m"
-  "avsdk.rpc.log_files.Entry\";\n\037SubscribeDo"
-  "wnloadLogFileRequest\022\n\n\002id\030\001 \001(\r\022\014\n\004path"
-  "\030\002 \001(\t\"\217\001\n\027DownloadLogFileResponse\022>\n\020lo"
-  "g_files_result\030\001 \001(\0132$.mavsdk.rpc.log_fi"
-  "les.LogFilesResult\0224\n\010progress\030\002 \001(\0132\".m"
-  "avsdk.rpc.log_files.ProgressData\")\n\014Prog"
-  "ressData\022\031\n\010progress\030\001 \001(\002B\007\202\265\030\003NaN\"5\n\005E"
-  "ntry\022\n\n\002id\030\001 \001(\r\022\014\n\004date\030\002 \001(\t\022\022\n\nsize_b"
-  "ytes\030\003 \001(\r\"\213\002\n\016LogFilesResult\022;\n\006result\030"
-  "\001 \001(\0162+.mavsdk.rpc.log_files.LogFilesRes"
-  "ult.Result\022\022\n\nresult_str\030\002 \001(\t\"\247\001\n\006Resul"
-  "t\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCCESS\020"
-  "\001\022\017\n\013RESULT_NEXT\020\002\022\026\n\022RESULT_NO_LOGFILES"
-  "\020\003\022\022\n\016RESULT_TIMEOUT\020\004\022\033\n\027RESULT_INVALID"
-  "_ARGUMENT\020\005\022\033\n\027RESULT_FILE_OPEN_FAILED\020\006"
-  "2\203\002\n\017LogFilesService\022a\n\nGetEntries\022\'.mav"
-  "sdk.rpc.log_files.GetEntriesRequest\032(.ma"
-  "vsdk.rpc.log_files.GetEntriesResponse\"\000\022"
-  "\214\001\n\030SubscribeDownloadLogFile\0225.mavsdk.rp"
-  "c.log_files.SubscribeDownloadLogFileRequ"
-  "est\032-.mavsdk.rpc.log_files.DownloadLogFi"
-  "leResponse\"\010\200\265\030\000\210\265\030\0010\001B$\n\023io.mavsdk.log_"
-  "filesB\rLogFilesProtob\006proto3"
+  "avsdk.rpc.log_files.Entry\"[\n\037SubscribeDo"
+  "wnloadLogFileRequest\022*\n\005entry\030\001 \001(\0132\033.ma"
+  "vsdk.rpc.log_files.Entry\022\014\n\004path\030\002 \001(\t\"\217"
+  "\001\n\027DownloadLogFileResponse\022>\n\020log_files_"
+  "result\030\001 \001(\0132$.mavsdk.rpc.log_files.LogF"
+  "ilesResult\0224\n\010progress\030\002 \001(\0132\".mavsdk.rp"
+  "c.log_files.ProgressData\")\n\014ProgressData"
+  "\022\031\n\010progress\030\001 \001(\002B\007\202\265\030\003NaN\"5\n\005Entry\022\n\n\002"
+  "id\030\001 \001(\r\022\014\n\004date\030\002 \001(\t\022\022\n\nsize_bytes\030\003 \001"
+  "(\r\"\213\002\n\016LogFilesResult\022;\n\006result\030\001 \001(\0162+."
+  "mavsdk.rpc.log_files.LogFilesResult.Resu"
+  "lt\022\022\n\nresult_str\030\002 \001(\t\"\247\001\n\006Result\022\022\n\016RES"
+  "ULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\017\n\013RES"
+  "ULT_NEXT\020\002\022\026\n\022RESULT_NO_LOGFILES\020\003\022\022\n\016RE"
+  "SULT_TIMEOUT\020\004\022\033\n\027RESULT_INVALID_ARGUMEN"
+  "T\020\005\022\033\n\027RESULT_FILE_OPEN_FAILED\020\0062\203\002\n\017Log"
+  "FilesService\022a\n\nGetEntries\022\'.mavsdk.rpc."
+  "log_files.GetEntriesRequest\032(.mavsdk.rpc"
+  ".log_files.GetEntriesResponse\"\000\022\214\001\n\030Subs"
+  "cribeDownloadLogFile\0225.mavsdk.rpc.log_fi"
+  "les.SubscribeDownloadLogFileRequest\032-.ma"
+  "vsdk.rpc.log_files.DownloadLogFileRespon"
+  "se\"\010\200\265\030\000\210\265\030\0010\001B$\n\023io.mavsdk.log_filesB\rL"
+  "ogFilesProtob\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_log_5ffiles_2flog_5ffiles_2eproto_deps[1] = {
   &::descriptor_table_mavsdk_5foptions_2eproto,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_log_5ffiles_2flog_5ffiles_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_log_5ffiles_2flog_5ffiles_2eproto = {
-  false, false, 1108, descriptor_table_protodef_log_5ffiles_2flog_5ffiles_2eproto, "log_files/log_files.proto", 
+  false, false, 1140, descriptor_table_protodef_log_5ffiles_2flog_5ffiles_2eproto, "log_files/log_files.proto", 
   &descriptor_table_log_5ffiles_2flog_5ffiles_2eproto_once, descriptor_table_log_5ffiles_2flog_5ffiles_2eproto_deps, 1, 7,
   schemas, file_default_instances, TableStruct_log_5ffiles_2flog_5ffiles_2eproto::offsets,
   file_level_metadata_log_5ffiles_2flog_5ffiles_2eproto, file_level_enum_descriptors_log_5ffiles_2flog_5ffiles_2eproto, file_level_service_descriptors_log_5ffiles_2flog_5ffiles_2eproto,
@@ -665,8 +666,13 @@ void GetEntriesResponse::InternalSwap(GetEntriesResponse* other) {
 
 class SubscribeDownloadLogFileRequest::_Internal {
  public:
+  static const ::mavsdk::rpc::log_files::Entry& entry(const SubscribeDownloadLogFileRequest* msg);
 };
 
+const ::mavsdk::rpc::log_files::Entry&
+SubscribeDownloadLogFileRequest::_Internal::entry(const SubscribeDownloadLogFileRequest* msg) {
+  return *msg->entry_;
+}
 SubscribeDownloadLogFileRequest::SubscribeDownloadLogFileRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
   SharedCtor();
@@ -681,13 +687,17 @@ SubscribeDownloadLogFileRequest::SubscribeDownloadLogFileRequest(const Subscribe
     path_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_path(), 
       GetArena());
   }
-  id_ = from.id_;
+  if (from._internal_has_entry()) {
+    entry_ = new ::mavsdk::rpc::log_files::Entry(*from.entry_);
+  } else {
+    entry_ = nullptr;
+  }
   // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.log_files.SubscribeDownloadLogFileRequest)
 }
 
 void SubscribeDownloadLogFileRequest::SharedCtor() {
 path_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
-id_ = 0u;
+entry_ = nullptr;
 }
 
 SubscribeDownloadLogFileRequest::~SubscribeDownloadLogFileRequest() {
@@ -699,6 +709,7 @@ SubscribeDownloadLogFileRequest::~SubscribeDownloadLogFileRequest() {
 void SubscribeDownloadLogFileRequest::SharedDtor() {
   GOOGLE_DCHECK(GetArena() == nullptr);
   path_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (this != internal_default_instance()) delete entry_;
 }
 
 void SubscribeDownloadLogFileRequest::ArenaDtor(void* object) {
@@ -718,7 +729,10 @@ void SubscribeDownloadLogFileRequest::Clear() {
   (void) cached_has_bits;
 
   path_.ClearToEmpty();
-  id_ = 0u;
+  if (GetArena() == nullptr && entry_ != nullptr) {
+    delete entry_;
+  }
+  entry_ = nullptr;
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -729,10 +743,10 @@ const char* SubscribeDownloadLogFileRequest::_InternalParse(const char* ptr, ::P
     ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
     CHK_(ptr);
     switch (tag >> 3) {
-      // uint32 id = 1;
+      // .mavsdk.rpc.log_files.Entry entry = 1;
       case 1:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 8)) {
-          id_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_entry(), ptr);
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
@@ -773,10 +787,12 @@ failure:
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // uint32 id = 1;
-  if (this->id() != 0) {
+  // .mavsdk.rpc.log_files.Entry entry = 1;
+  if (this->has_entry()) {
     target = stream->EnsureSpace(target);
-    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt32ToArray(1, this->_internal_id(), target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::entry(this), target, stream);
   }
 
   // string path = 2;
@@ -812,11 +828,11 @@ size_t SubscribeDownloadLogFileRequest::ByteSizeLong() const {
         this->_internal_path());
   }
 
-  // uint32 id = 1;
-  if (this->id() != 0) {
+  // .mavsdk.rpc.log_files.Entry entry = 1;
+  if (this->has_entry()) {
     total_size += 1 +
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt32Size(
-        this->_internal_id());
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *entry_);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -853,8 +869,8 @@ void SubscribeDownloadLogFileRequest::MergeFrom(const SubscribeDownloadLogFileRe
   if (from.path().size() > 0) {
     _internal_set_path(from._internal_path());
   }
-  if (from.id() != 0) {
-    _internal_set_id(from._internal_id());
+  if (from.has_entry()) {
+    _internal_mutable_entry()->::mavsdk::rpc::log_files::Entry::MergeFrom(from._internal_entry());
   }
 }
 
@@ -880,7 +896,7 @@ void SubscribeDownloadLogFileRequest::InternalSwap(SubscribeDownloadLogFileReque
   using std::swap;
   _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
   path_.Swap(&other->path_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
-  swap(id_, other->id_);
+  swap(entry_, other->entry_);
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata SubscribeDownloadLogFileRequest::GetMetadata() const {

--- a/src/mavsdk_server/src/generated/log_files/log_files.pb.h
+++ b/src/mavsdk_server/src/generated/log_files/log_files.pb.h
@@ -532,7 +532,7 @@ class SubscribeDownloadLogFileRequest PROTOBUF_FINAL :
 
   enum : int {
     kPathFieldNumber = 2,
-    kIdFieldNumber = 1,
+    kEntryFieldNumber = 1,
   };
   // string path = 2;
   void clear_path();
@@ -550,14 +550,23 @@ class SubscribeDownloadLogFileRequest PROTOBUF_FINAL :
   std::string* _internal_mutable_path();
   public:
 
-  // uint32 id = 1;
-  void clear_id();
-  ::PROTOBUF_NAMESPACE_ID::uint32 id() const;
-  void set_id(::PROTOBUF_NAMESPACE_ID::uint32 value);
+  // .mavsdk.rpc.log_files.Entry entry = 1;
+  bool has_entry() const;
   private:
-  ::PROTOBUF_NAMESPACE_ID::uint32 _internal_id() const;
-  void _internal_set_id(::PROTOBUF_NAMESPACE_ID::uint32 value);
+  bool _internal_has_entry() const;
   public:
+  void clear_entry();
+  const ::mavsdk::rpc::log_files::Entry& entry() const;
+  ::mavsdk::rpc::log_files::Entry* release_entry();
+  ::mavsdk::rpc::log_files::Entry* mutable_entry();
+  void set_allocated_entry(::mavsdk::rpc::log_files::Entry* entry);
+  private:
+  const ::mavsdk::rpc::log_files::Entry& _internal_entry() const;
+  ::mavsdk::rpc::log_files::Entry* _internal_mutable_entry();
+  public:
+  void unsafe_arena_set_allocated_entry(
+      ::mavsdk::rpc::log_files::Entry* entry);
+  ::mavsdk::rpc::log_files::Entry* unsafe_arena_release_entry();
 
   // @@protoc_insertion_point(class_scope:mavsdk.rpc.log_files.SubscribeDownloadLogFileRequest)
  private:
@@ -567,7 +576,7 @@ class SubscribeDownloadLogFileRequest PROTOBUF_FINAL :
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr path_;
-  ::PROTOBUF_NAMESPACE_ID::uint32 id_;
+  ::mavsdk::rpc::log_files::Entry* entry_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_log_5ffiles_2flog_5ffiles_2eproto;
 };
@@ -1376,24 +1385,87 @@ GetEntriesResponse::entries() const {
 
 // SubscribeDownloadLogFileRequest
 
-// uint32 id = 1;
-inline void SubscribeDownloadLogFileRequest::clear_id() {
-  id_ = 0u;
+// .mavsdk.rpc.log_files.Entry entry = 1;
+inline bool SubscribeDownloadLogFileRequest::_internal_has_entry() const {
+  return this != internal_default_instance() && entry_ != nullptr;
 }
-inline ::PROTOBUF_NAMESPACE_ID::uint32 SubscribeDownloadLogFileRequest::_internal_id() const {
-  return id_;
+inline bool SubscribeDownloadLogFileRequest::has_entry() const {
+  return _internal_has_entry();
 }
-inline ::PROTOBUF_NAMESPACE_ID::uint32 SubscribeDownloadLogFileRequest::id() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.log_files.SubscribeDownloadLogFileRequest.id)
-  return _internal_id();
+inline void SubscribeDownloadLogFileRequest::clear_entry() {
+  if (GetArena() == nullptr && entry_ != nullptr) {
+    delete entry_;
+  }
+  entry_ = nullptr;
 }
-inline void SubscribeDownloadLogFileRequest::_internal_set_id(::PROTOBUF_NAMESPACE_ID::uint32 value) {
+inline const ::mavsdk::rpc::log_files::Entry& SubscribeDownloadLogFileRequest::_internal_entry() const {
+  const ::mavsdk::rpc::log_files::Entry* p = entry_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::log_files::Entry&>(
+      ::mavsdk::rpc::log_files::_Entry_default_instance_);
+}
+inline const ::mavsdk::rpc::log_files::Entry& SubscribeDownloadLogFileRequest::entry() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.log_files.SubscribeDownloadLogFileRequest.entry)
+  return _internal_entry();
+}
+inline void SubscribeDownloadLogFileRequest::unsafe_arena_set_allocated_entry(
+    ::mavsdk::rpc::log_files::Entry* entry) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(entry_);
+  }
+  entry_ = entry;
+  if (entry) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.log_files.SubscribeDownloadLogFileRequest.entry)
+}
+inline ::mavsdk::rpc::log_files::Entry* SubscribeDownloadLogFileRequest::release_entry() {
   
-  id_ = value;
+  ::mavsdk::rpc::log_files::Entry* temp = entry_;
+  entry_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
 }
-inline void SubscribeDownloadLogFileRequest::set_id(::PROTOBUF_NAMESPACE_ID::uint32 value) {
-  _internal_set_id(value);
-  // @@protoc_insertion_point(field_set:mavsdk.rpc.log_files.SubscribeDownloadLogFileRequest.id)
+inline ::mavsdk::rpc::log_files::Entry* SubscribeDownloadLogFileRequest::unsafe_arena_release_entry() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.log_files.SubscribeDownloadLogFileRequest.entry)
+  
+  ::mavsdk::rpc::log_files::Entry* temp = entry_;
+  entry_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::log_files::Entry* SubscribeDownloadLogFileRequest::_internal_mutable_entry() {
+  
+  if (entry_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::log_files::Entry>(GetArena());
+    entry_ = p;
+  }
+  return entry_;
+}
+inline ::mavsdk::rpc::log_files::Entry* SubscribeDownloadLogFileRequest::mutable_entry() {
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.log_files.SubscribeDownloadLogFileRequest.entry)
+  return _internal_mutable_entry();
+}
+inline void SubscribeDownloadLogFileRequest::set_allocated_entry(::mavsdk::rpc::log_files::Entry* entry) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete entry_;
+  }
+  if (entry) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(entry);
+    if (message_arena != submessage_arena) {
+      entry = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, entry, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  entry_ = entry;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.log_files.SubscribeDownloadLogFileRequest.entry)
 }
 
 // string path = 2;

--- a/src/mavsdk_server/src/plugins/log_files/log_files_service_impl.h
+++ b/src/mavsdk_server/src/plugins/log_files/log_files_service_impl.h
@@ -164,7 +164,7 @@ public:
         std::mutex subscribe_mutex{};
 
         _log_files.download_log_file_async(
-            request->id(),
+            translateFromRpcEntry(request->entry()),
             request->path(),
             [this, &writer, &stream_closed_promise, is_finished, &subscribe_mutex](
                 mavsdk::LogFiles::Result result,

--- a/src/plugins/log_files/include/plugins/log_files/log_files.h
+++ b/src/plugins/log_files/include/plugins/log_files/log_files.h
@@ -157,7 +157,7 @@ public:
     /**
      * @brief Download log file.
      */
-    void download_log_file_async(uint32_t id, std::string path, DownloadLogFileCallback callback);
+    void download_log_file_async(Entry entry, std::string path, DownloadLogFileCallback callback);
 
     /**
      * @brief Copy constructor.

--- a/src/plugins/log_files/log_files.cpp
+++ b/src/plugins/log_files/log_files.cpp
@@ -30,9 +30,9 @@ std::pair<LogFiles::Result, std::vector<LogFiles::Entry>> LogFiles::get_entries(
 }
 
 void LogFiles::download_log_file_async(
-    uint32_t id, std::string path, DownloadLogFileCallback callback)
+    Entry entry, std::string path, DownloadLogFileCallback callback)
 {
-    _impl->download_log_file_async(id, path, callback);
+    _impl->download_log_file_async(entry, path, callback);
 }
 
 bool operator==(const LogFiles::ProgressData& lhs, const LogFiles::ProgressData& rhs)

--- a/src/plugins/log_files/log_files_impl.cpp
+++ b/src/plugins/log_files/log_files_impl.cpp
@@ -213,15 +213,15 @@ void LogFilesImpl::list_timeout()
 }
 
 void LogFilesImpl::download_log_file_async(
-    unsigned id, const std::string& file_path, LogFiles::DownloadLogFileCallback callback)
+    LogFiles::Entry entry, const std::string& file_path, LogFiles::DownloadLogFileCallback callback)
 {
     unsigned bytes_to_get;
     {
         std::lock_guard<std::mutex> lock(_entries.mutex);
 
-        auto it = _entries.entry_map.find(id);
+        auto it = _entries.entry_map.find(entry.id);
         if (it == _entries.entry_map.end()) {
-            LogErr() << "Log entry id " << id << " not found";
+            LogErr() << "Log entry id " << entry.id << " not found";
             if (callback) {
                 const auto tmp_callback = callback;
                 _parent->call_user_callback([tmp_callback]() {
@@ -233,7 +233,7 @@ void LogFilesImpl::download_log_file_async(
             return;
         }
 
-        bytes_to_get = _entries.entry_map[id].size_bytes;
+        bytes_to_get = _entries.entry_map[entry.id].size_bytes;
     }
 
     {
@@ -278,7 +278,7 @@ void LogFilesImpl::download_log_file_async(
             return;
         }
 
-        _data.id = id;
+        _data.id = entry.id;
         _data.callback = callback;
         _data.time_started = _time.steady_time();
         _data.bytes_to_get = bytes_to_get;

--- a/src/plugins/log_files/log_files_impl.h
+++ b/src/plugins/log_files/log_files_impl.h
@@ -24,7 +24,9 @@ public:
     void get_entries_async(LogFiles::GetEntriesCallback callback);
 
     void download_log_file_async(
-        unsigned id, const std::string& file_path, LogFiles::DownloadLogFileCallback callback);
+        LogFiles::Entry entry,
+        const std::string& file_path,
+        LogFiles::DownloadLogFileCallback callback);
 
 private:
     void request_end();

--- a/templates/mavsdk_server/stream.j2
+++ b/templates/mavsdk_server/stream.j2
@@ -8,7 +8,7 @@ grpc::Status Subscribe{{ name.upper_camel_case }}(grpc::ServerContext* /* contex
 
     std::mutex subscribe_mutex{};
 
-    _{{ plugin_name.lower_snake_case }}.{% if not is_finite %}subscribe_{% endif %}{{ name.lower_snake_case }}{% if is_finite %}_async{% endif %}({% for param in params %}request->{{ param.name.lower_snake_case }}(), {% endfor %}
+    _{{ plugin_name.lower_snake_case }}.{% if not is_finite %}subscribe_{% endif %}{{ name.lower_snake_case }}{% if is_finite %}_async{% endif %}({% for param in params %}{% if not param.type_info.is_primitive %}translateFromRpc{{ param.name.upper_camel_case }}({% endif %}request->{{ param.name.lower_snake_case }}(){% if not param.type_info.is_primitive %}){% endif %}, {% endfor %}
         [this, &writer, &stream_closed_promise, is_finished, &subscribe_mutex](
             {%- if has_result -%}mavsdk::{{ plugin_name.upper_camel_case }}::Result result,{%- endif -%}
             const {% if return_type.is_repeated %}std::vector<{% if not return_type.is_primitive %}{{ package.lower_snake_case.split('.')[0] }}::{{ plugin_name.upper_camel_case }}::{% endif %}{{ return_type.inner_name }}>{% else %}{%- if not return_type.is_primitive %}{{ package.lower_snake_case.split('.')[0] }}::{{ plugin_name.upper_camel_case }}::{% endif %}{{ return_type.name }}{% endif %} {{ name.lower_snake_case }}) {


### PR DESCRIPTION
Also generate temporary file names with `std::tmpnam(nullptr)` in integration tests instead of hardcoding them.

Should help for issues like https://github.com/mavlink/MAVSDK-Python/issues/323 and https://github.com/mavlink/MAVSDK-Python/issues/312.

Depends on https://github.com/mavlink/MAVSDK-Proto/pull/218.