### PR TITLE
third_party: fix patch does not apply

### DIFF
--- a/third_party/absl/CMakeLists.txt
+++ b/third_party/absl/CMakeLists.txt
@@ -28,6 +28,6 @@ ExternalProject_add(
     GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
     GIT_TAG 20200923.3
     PREFIX absl
-    PATCH_COMMAND git apply ${PROJECT_SOURCE_DIR}/absl_c++11.patch
+    PATCH_COMMAND git checkout . && git apply ${PROJECT_SOURCE_DIR}/absl_c++11.patch
     CMAKE_ARGS "${CMAKE_ARGS}"
     )

--- a/third_party/curl/CMakeLists.txt
+++ b/third_party/curl/CMakeLists.txt
@@ -42,6 +42,6 @@ ExternalProject_add(
     GIT_TAG curl-7_75_0
     GIT_SHALLOW ON
     PREFIX curl
-    PATCH_COMMAND git apply ${PROJECT_SOURCE_DIR}/curl.patch
+    PATCH_COMMAND git checkout . && git apply ${PROJECT_SOURCE_DIR}/curl.patch
     CMAKE_ARGS "${CMAKE_ARGS}"
     )

--- a/third_party/jsoncpp/CMakeLists.txt
+++ b/third_party/jsoncpp/CMakeLists.txt
@@ -31,6 +31,6 @@ ExternalProject_Add(
     GIT_REPOSITORY https://github.com/open-source-parsers/jsoncpp
     GIT_TAG 1.8.4
     PREFIX jsoncpp
-    PATCH_COMMAND git apply ${PROJECT_SOURCE_DIR}/fixlibname.patch
+    PATCH_COMMAND git checkout . && git apply ${PROJECT_SOURCE_DIR}/fixlibname.patch
     CMAKE_ARGS "${CMAKE_ARGS}"
     )

--- a/third_party/zlib/CMakeLists.txt
+++ b/third_party/zlib/CMakeLists.txt
@@ -28,6 +28,6 @@ ExternalProject_add(
     GIT_REPOSITORY https://github.com/madler/zlib
     GIT_TAG v1.2.11
     PREFIX zlib
-    PATCH_COMMAND git apply ${PROJECT_SOURCE_DIR}/build_shared_libs.patch
+    PATCH_COMMAND git checkout . && git apply ${PROJECT_SOURCE_DIR}/build_shared_libs.patch
     CMAKE_ARGS "${CMAKE_ARGS}"
     )


### PR DESCRIPTION
Cmake from version 3.18 tries to apply the patch every time anything in cmake files changed and it triggers a reconfigure. This then leads to "patch does not apply" errors. By checking out cleanly we can avoid this.