### PR TITLE
Remove tmpnam

### DIFF
--- a/src/core/filesystem_include.h
+++ b/src/core/filesystem_include.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#error "Missing the <filesystem> header."
+#endif

--- a/src/integration_tests/log_files.cpp
+++ b/src/integration_tests/log_files.cpp
@@ -37,14 +37,15 @@ TEST(HardwareTest, LogFiles)
             LogInfo() << "Entry " << entry.id << ": "
                       << " at " << entry.date << ", " << size_mib
                       << " MiB, bytes: " << entry.size_bytes;
-            std::string file_path = std::tmpnam(nullptr);
+            std::stringstream file_path_stream;
+            file_path_stream << "./logfile_" << entry.id << ".ulog";
 
             auto prom = std::promise<void>();
             auto fut = prom.get_future();
 
             log_files->download_log_file_async(
                 entry,
-                file_path,
+                file_path_stream.str(),
                 [&prom](LogFiles::Result result, LogFiles::ProgressData progress_data) {
                     if (result == LogFiles::Result::Next) {
                         LogInfo() << "Download progress: " << 100.0f * progress_data.progress;
@@ -92,14 +93,15 @@ TEST(HardwareTest, LogFilesDownloadFailsIfPathIsDirectory)
                       << " at " << entry.date << ", " << size_mib
                       << " MiB, bytes: " << entry.size_bytes;
 
-            std::string file_path = std::tmpnam(nullptr);
+            std::stringstream file_path_stream;
+            file_path_stream << "./logfile_" << entry.id << ".ulog";
 
             auto prom = std::promise<void>();
             auto fut = prom.get_future();
 
             log_files->download_log_file_async(
                 entry,
-                file_path,
+                file_path_stream.str(),
                 [&prom](LogFiles::Result result, LogFiles::ProgressData progress_data) {
                     if (result == LogFiles::Result::Next) {
                         LogInfo() << "Download progress: " << 100.0f * progress_data.progress;
@@ -146,9 +148,10 @@ TEST(HardwareTest, LogFilesDownloadFailsIfFileAlreadyExists)
             LogInfo() << "Entry " << entry.id << ": "
                       << " at " << entry.date << ", " << size_mib
                       << " MiB, bytes: " << entry.size_bytes;
-            std::string file_path = std::tmpnam(nullptr);
+            std::stringstream file_path_stream;
+            file_path_stream << "./logfile_" << entry.id << ".ulog";
 
-            std::ofstream ofs(file_path);
+            std::ofstream ofs(file_path_stream.str());
             ofs << "This file should not be erased by the download\n";
             ofs.close();
 
@@ -157,7 +160,7 @@ TEST(HardwareTest, LogFilesDownloadFailsIfFileAlreadyExists)
 
             log_files->download_log_file_async(
                 entry,
-                file_path,
+                file_path_stream.str(),
                 [&prom](LogFiles::Result result, LogFiles::ProgressData progress_data) {
                     if (result == LogFiles::Result::Next) {
                         LogInfo() << "Download progress: " << 100.0f * progress_data.progress;

--- a/src/plugins/log_files/log_files_impl.cpp
+++ b/src/plugins/log_files/log_files_impl.cpp
@@ -1,21 +1,12 @@
 #include "global_include.h"
 #include "log_files_impl.h"
 #include "mavsdk_impl.h"
+#include "filesystem_include.h"
 
 #include <algorithm>
 #include <cmath>
 #include <ctime>
 #include <cstring>
-
-#if __has_include(<filesystem>)
-#include <filesystem>
-namespace fs = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#else
-#error "Missing the <filesystem> header."
-#endif
 
 namespace mavsdk {
 


### PR DESCRIPTION
This removes the warning about tmpnam that I get at linking, and it means I can actually see and check the files that I downloaded.