### PR TITLE
Check for MSG_NOSIGNAL instead of WINDOWS

### DIFF
--- a/src/core/tcp_connection.cpp
+++ b/src/core/tcp_connection.cpp
@@ -158,7 +158,7 @@ bool TcpConnection::send_message(const mavlink_message_t& message)
     // TODO: remove this assert again
     assert(buffer_len <= MAVLINK_MAX_PACKET_LEN);
 
-#if defined(WINDOWS)
+#if !defined(MSG_NOSIGNAL)
     auto flags = 0;
 #else
     auto flags = MSG_NOSIGNAL;


### PR DESCRIPTION
This resolves a build failure on macOS 10.15. Without it, attempting to build MAVSDK v0.38.0 produces the following error:

```
/tmp/mavsdk-20210325-1418-1sgyr7x/src/core/tcp_connection.cpp:164:18: error: use of undeclared identifier 'MSG_NOSIGNAL'
    auto flags = MSG_NOSIGNAL;
                 ^
1 error generated.
```

Related: https://github.com/Homebrew/homebrew-core/pull/73923