### PR TITLE
Fix jsoncpp Werror with NDK r22b

### DIFF
--- a/third_party/jsoncpp/CMakeLists.txt
+++ b/third_party/jsoncpp/CMakeLists.txt
@@ -31,6 +31,6 @@ ExternalProject_Add(
     GIT_REPOSITORY https://github.com/open-source-parsers/jsoncpp
     GIT_TAG 1.8.4
     PREFIX jsoncpp
-    PATCH_COMMAND git checkout . && git apply ${PROJECT_SOURCE_DIR}/fixlibname.patch
+    PATCH_COMMAND git checkout . && git apply ${PROJECT_SOURCE_DIR}/fixlibname.patch && git apply ${PROJECT_SOURCE_DIR}/fix_werror.patch
     CMAKE_ARGS "${CMAKE_ARGS}"
     )

--- a/third_party/jsoncpp/fix_werror.patch
+++ b/third_party/jsoncpp/fix_werror.patch
@@ -1,0 +1,14 @@
+diff --git a/src/lib_json/json_value.cpp b/src/lib_json/json_value.cpp
+index 91d4802..62b9475 100644
+--- a/src/lib_json/json_value.cpp
++++ b/src/lib_json/json_value.cpp
+@@ -69,8 +69,7 @@ template <typename T, typename U>
+ static inline bool InRange(double d, T min, U max) {
+   // The casts can lose precision, but we are looking only for
+   // an approximate range. Might fail on edge cases though. ~cdunn
+-  //return d >= static_cast<double>(min) && d <= static_cast<double>(max);
+-  return d >= min && d <= max;
++  return d >= static_cast<double>(min) && d <= static_cast<double>(max);
+ }
+ #else  // if !defined(JSON_USE_INT64_DOUBLE_CONVERSION)
+ static inline double integerToDouble(Json::UInt64 value) {


### PR DESCRIPTION
JsonCpp fails to build on Android with NDK r22b. This is not a problem for the CI yet, but it will come soon (the CI is on r21). This fixes it.

I am also looking into updating JsonCpp, which may allow us to remove all the patches. But that may take longer, so I fixed this issue first.