### PR TITLE
Update README: link to build guide moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Quick Links:
 - [QuickStart](https://mavsdk.mavlink.io/main/en/cpp/#getting-started)
 - [C++ API Overview](https://mavsdk.mavlink.io/main/en/cpp/#api-overview)
 - [API Reference](https://mavsdk.mavlink.io/main/en/api_reference/)
-- [Building the Library](https://mavsdk.mavlink.io/main/en/contributing/build.html)
+- [Building the Library](https://mavsdk.mavlink.io/main/en/cpp/guide/build.html)
 - [Examples](https://mavsdk.mavlink.io/main/en/examples/)
 - [FAQ](https://mavsdk.mavlink.io/main/en/getting_started/faq.html)
 


### PR DESCRIPTION
I believe this should be the link, correct? https://mavsdk.mavlink.io/main/en/cpp/guide/build.html

EDIT: Here's another link :thinking:  https://mavsdk.mavlink.io/develop/en/contributing/build.html