### PR TITLE
Fix run-docker.sh for `sh`

### DIFF
--- a/tools/run-docker.sh
+++ b/tools/run-docker.sh
@@ -2,13 +2,13 @@
 
 dockerimage=mavsdk/mavsdk-ubuntu-20.04-px4-sitl-v1.11
 
-if command -v podman &> /dev/null
+if type podman > /dev/null
 then
     podman run -it --rm -v $(pwd):/home/user/MAVSDK:z $dockerimage "$@"
     echo "sudo needed to repair file ownership after podman ran: sudo chown -R $USER:$USER ."
     sudo chown -R $USER:$USER .
 
-elif command -v docker &> /dev/null
+elif type docker > /dev/null
 then
     docker run -it --rm -v $(pwd):/home/user/MAVSDK:z -e LOCAL_USER_ID=`id -u` $dockerimage "$@"
 


### PR DESCRIPTION
On Ubuntu 20.04, it seems that `command -v podman &> /dev/null` works with bash, but not with sh. This way works for both.