### PR TITLE
follow_me: fix double sending of location

### DIFF
--- a/src/integration_tests/follow_me.cpp
+++ b/src/integration_tests/follow_me.cpp
@@ -17,7 +17,7 @@ using namespace std::placeholders;
 
 void print(const FollowMe::Config& config);
 void send_location_updates(
-    std::shared_ptr<FollowMe> follow_me, size_t count = 25ul, float rate = 1.f);
+    std::shared_ptr<FollowMe> follow_me, size_t count = 25ul, float rate = 2.f);
 
 const size_t N_LOCATIONS = 100ul;
 

--- a/src/plugins/follow_me/follow_me_impl.cpp
+++ b/src/plugins/follow_me/follow_me_impl.cpp
@@ -156,14 +156,11 @@ FollowMe::Result FollowMeImpl::set_target_location(const FollowMe::TargetLocatio
         if (_target_location_cookie) {
             _parent->reset_call_every(_target_location_cookie);
         } else {
-            // Register now for sending in the next cycle.
+            // Register to send it immediately as well as in the next cycle.
             _parent->add_call_every(
                 [this]() { send_target_location(); }, SENDER_RATE, &_target_location_cookie);
         }
     }
-
-    // Send it immediately for now.
-    send_target_location();
 
     return FollowMe::Result::Success;
 }


### PR DESCRIPTION
We changed the behavior of add_call_every a while ago. It now triggeres immedately as well as later. This means that the manual immediate trigger is no longer necessary. Otherwise, this leads to weird double bursts.