### PR TITLE
Fix race in System initialization

### DIFF
--- a/src/core/mavsdk_impl.cpp
+++ b/src/core/mavsdk_impl.cpp
@@ -526,7 +526,8 @@ void MavsdkImpl::make_system_with_component(
 
     LogDebug() << "New: System ID: " << int(system_id) << " Comp ID: " << int(comp_id);
     // Make a system with its first component
-    auto new_system = std::make_shared<System>(*this, system_id, comp_id, always_connected);
+    auto new_system = std::make_shared<System>(*this);
+    new_system->init(system_id, comp_id, always_connected);
 
     _systems.insert(std::pair<uint8_t, std::shared_ptr<System>>(system_id, new_system));
 }

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -15,11 +15,14 @@ namespace mavsdk {
 
 using namespace std::placeholders; // for `_1`
 
-System::System(MavsdkImpl& parent, uint8_t system_id, uint8_t component_id, bool connected) :
-    _system_impl(std::make_shared<SystemImpl>(parent, system_id, component_id, connected))
-{}
+System::System(MavsdkImpl& parent) : _system_impl(std::make_shared<SystemImpl>(parent)) {}
 
 System::~System() {}
+
+void System::init(uint8_t system_id, uint8_t component_id, bool connected) const
+{
+    return _system_impl->init(system_id, component_id, connected);
+}
 
 bool System::is_standalone() const
 {

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -36,16 +36,24 @@ public:
      * This constructor is not (and should not be) directly called by application code.
      *
      * @param parent `MavsdkImpl` dependency.
-     * @param system_id System id.
-     * @param comp_id Component id.
-     * @param connected If true then the system doesn't wait for heartbeat to go into connected
-     * state
      */
-    explicit System(MavsdkImpl& parent, uint8_t system_id, uint8_t comp_id, bool connected);
+    explicit System(MavsdkImpl& parent);
     /**
      * @brief Destructor.
      */
     ~System();
+
+    /**
+     * @brief Initialize the system.
+     *
+     * This is not (and should not be) directly called by application code.
+     *
+     * @param system_id System id.
+     * @param component_id Component id.
+     * @param connected If true then the system doesn't wait for heartbeat to go into connected
+     * state
+     */
+    void init(uint8_t system_id, uint8_t component_id, bool connected) const;
 
     /**
      * @brief Checks whether the system has an autopilot.

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -50,9 +50,10 @@ public:
         Stabilized,
     };
 
-    explicit SystemImpl(
-        MavsdkImpl& parent, uint8_t system_id, uint8_t component_id, bool connected);
+    explicit SystemImpl(MavsdkImpl& parent);
     ~SystemImpl();
+
+    void init(uint8_t system_id, uint8_t comp_id, bool connected);
 
     void enable_timesync();
 


### PR DESCRIPTION
A system should not be discovered before the object is created, otherwise we end up with race conditions. Instead a system should be constructed first, and then started