### PR TITLE
follow_me: send velocity array

### DIFF
--- a/src/plugins/follow_me/follow_me_impl.cpp
+++ b/src/plugins/follow_me/follow_me_impl.cpp
@@ -279,7 +279,10 @@ void FollowMeImpl::send_target_location()
     const float alt = static_cast<float>(_target_location.absolute_altitude_m);
 
     const float pos_std_dev[] = {NAN, NAN, NAN};
-    const float vel[] = {static_cast<float>(_target_location.velocity_x_m_s), static_cast<float>(_target_location.velocity_y_m_s), static_cast<float>(_target_location.velocity_z_m_s)};
+    const float vel[] = {
+        static_cast<float>(_target_location.velocity_x_m_s),
+        static_cast<float>(_target_location.velocity_y_m_s),
+        static_cast<float>(_target_location.velocity_z_m_s)};
     const float accel_unknown[] = {NAN, NAN, NAN};
     const float attitude_q_unknown[] = {1.f, NAN, NAN, NAN};
     const float rates_unknown[] = {NAN, NAN, NAN};

--- a/src/plugins/follow_me/follow_me_impl.cpp
+++ b/src/plugins/follow_me/follow_me_impl.cpp
@@ -279,7 +279,7 @@ void FollowMeImpl::send_target_location()
     const float alt = static_cast<float>(_target_location.absolute_altitude_m);
 
     const float pos_std_dev[] = {NAN, NAN, NAN};
-    const float vel[] = {NAN, NAN, NAN};
+    const float vel[] = {static_cast<float>(_target_location.velocity_x_m_s), static_cast<float>(_target_location.velocity_y_m_s), static_cast<float>(_target_location.velocity_z_m_s)};
     const float accel_unknown[] = {NAN, NAN, NAN};
     const float attitude_q_unknown[] = {1.f, NAN, NAN, NAN};
     const float rates_unknown[] = {NAN, NAN, NAN};


### PR DESCRIPTION
The velocity fields of the follow-me mavlink message is currently hard-coded to `NAN`. With this PR mavsdk will send the actual values instead.

@julianoes sorry it took me so long.