### PR TITLE
core: fix ever increasing heartbeats

### DIFF
--- a/src/core/mavsdk_impl.cpp
+++ b/src/core/mavsdk_impl.cpp
@@ -394,9 +394,7 @@ void MavsdkImpl::set_configuration(Mavsdk::Configuration configuration)
 {
     _configuration = configuration;
 
-    if (configuration.get_always_send_heartbeats()) {
-        start_sending_heartbeat();
-    }
+    start_stop_sending_heartbeats();
 }
 
 std::vector<uint64_t> MavsdkImpl::get_system_uuids() const
@@ -680,10 +678,22 @@ void MavsdkImpl::process_user_callbacks_thread()
     }
 }
 
-void MavsdkImpl::start_sending_heartbeat()
+void MavsdkImpl::start_stop_sending_heartbeats()
 {
-    call_every_handler.add(
-        [this]() { send_heartbeat(); }, _HEARTBEAT_SEND_INTERVAL_S, &_heartbeat_send_cookie);
+    if (_configuration.get_always_send_heartbeats() || is_connected()) {
+        if (_heartbeat_send_cookie == nullptr) {
+            call_every_handler.add(
+                [this]() { send_heartbeat(); },
+                _HEARTBEAT_SEND_INTERVAL_S,
+                &_heartbeat_send_cookie);
+        }
+
+    } else {
+        if (_heartbeat_send_cookie != nullptr) {
+            call_every_handler.remove(_heartbeat_send_cookie);
+            _heartbeat_send_cookie = nullptr;
+        }
+    }
 }
 
 void MavsdkImpl::send_heartbeat()

--- a/src/core/mavsdk_impl.cpp
+++ b/src/core/mavsdk_impl.cpp
@@ -390,11 +390,18 @@ void MavsdkImpl::add_connection(std::shared_ptr<Connection> new_connection)
     _connections.push_back(new_connection);
 }
 
-void MavsdkImpl::set_configuration(Mavsdk::Configuration configuration)
+void MavsdkImpl::set_configuration(Mavsdk::Configuration new_configuration)
 {
-    _configuration = configuration;
-
-    start_stop_sending_heartbeats();
+    if (new_configuration.get_always_send_heartbeats() &&
+        !_configuration.get_always_send_heartbeats()) {
+        _configuration = new_configuration;
+        start_sending_heartbeats();
+    } else if (
+        !new_configuration.get_always_send_heartbeats() &&
+        _configuration.get_always_send_heartbeats() && !is_connected()) {
+        _configuration = new_configuration;
+        stop_sending_heartbeats();
+    }
 }
 
 std::vector<uint64_t> MavsdkImpl::get_system_uuids() const
@@ -678,21 +685,19 @@ void MavsdkImpl::process_user_callbacks_thread()
     }
 }
 
-void MavsdkImpl::start_stop_sending_heartbeats()
+void MavsdkImpl::start_sending_heartbeats()
 {
-    if (_configuration.get_always_send_heartbeats() || is_connected()) {
-        if (_heartbeat_send_cookie == nullptr) {
-            call_every_handler.add(
-                [this]() { send_heartbeat(); },
-                _HEARTBEAT_SEND_INTERVAL_S,
-                &_heartbeat_send_cookie);
-        }
+    if (_heartbeat_send_cookie == nullptr) {
+        call_every_handler.add(
+            [this]() { send_heartbeat(); }, _HEARTBEAT_SEND_INTERVAL_S, &_heartbeat_send_cookie);
+    }
+}
 
-    } else {
-        if (_heartbeat_send_cookie != nullptr) {
-            call_every_handler.remove(_heartbeat_send_cookie);
-            _heartbeat_send_cookie = nullptr;
-        }
+void MavsdkImpl::stop_sending_heartbeats()
+{
+    if (!_configuration.get_always_send_heartbeats()) {
+        call_every_handler.remove(_heartbeat_send_cookie);
+        _heartbeat_send_cookie = nullptr;
     }
 }
 

--- a/src/core/mavsdk_impl.h
+++ b/src/core/mavsdk_impl.h
@@ -60,7 +60,7 @@ public:
 
     std::vector<std::shared_ptr<System>> systems() const;
 
-    void set_configuration(Mavsdk::Configuration configuration);
+    void set_configuration(Mavsdk::Configuration new_configuration);
 
     std::vector<uint64_t> get_system_uuids() const;
     System& get_system();
@@ -80,7 +80,8 @@ public:
     void notify_on_discover(uint64_t uuid);
     void notify_on_timeout(uint64_t uuid);
 
-    void start_stop_sending_heartbeats();
+    void start_sending_heartbeats();
+    void stop_sending_heartbeats();
 
     TimeoutHandler timeout_handler;
     CallEveryHandler call_every_handler;

--- a/src/core/mavsdk_impl.h
+++ b/src/core/mavsdk_impl.h
@@ -80,7 +80,7 @@ public:
     void notify_on_discover(uint64_t uuid);
     void notify_on_timeout(uint64_t uuid);
 
-    void start_sending_heartbeat();
+    void start_stop_sending_heartbeats();
 
     TimeoutHandler timeout_handler;
     CallEveryHandler call_every_handler;
@@ -148,8 +148,7 @@ private:
     std::atomic<double> _timeout_s{Mavsdk::DEFAULT_TIMEOUT_S};
 
     static constexpr double _HEARTBEAT_SEND_INTERVAL_S = 1.0;
-    std::atomic<bool> _sending_heartbeats{false};
-    void* _heartbeat_send_cookie = nullptr;
+    void* _heartbeat_send_cookie{nullptr};
 
     std::atomic<bool> _should_exit = {false};
 };

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -516,7 +516,7 @@ void SystemImpl::set_connected()
             _parent.notify_on_discover(_uuid);
 
             // Send a heartbeat back immediately.
-            _parent.start_sending_heartbeat();
+            _parent.start_stop_sending_heartbeats();
 
             if (!_always_connected) {
                 register_timeout_handler(
@@ -561,6 +561,8 @@ void SystemImpl::set_disconnected()
             _parent.call_user_callback([temp_callback]() { temp_callback(false); });
         }
     }
+
+    _parent.start_stop_sending_heartbeats();
 
     {
         std::lock_guard<std::mutex> lock(_plugin_impls_mutex);

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -516,7 +516,7 @@ void SystemImpl::set_connected()
             _parent.notify_on_discover(_uuid);
 
             // Send a heartbeat back immediately.
-            _parent.start_stop_sending_heartbeats();
+            _parent.start_sending_heartbeats();
 
             if (!_always_connected) {
                 register_timeout_handler(
@@ -562,7 +562,7 @@ void SystemImpl::set_disconnected()
         }
     }
 
-    _parent.start_stop_sending_heartbeats();
+    _parent.stop_sending_heartbeats();
 
     {
         std::lock_guard<std::mutex> lock(_plugin_impls_mutex);


### PR DESCRIPTION
When a system was lost and re-discovered we would yet again start to send heartbeats but never actually stop the call_every. This leads to more and more traffic, memory, and CPU used.

Manually tested in normal configuration where heartbeats stop, and onboard configuration where heartbeats are always sent.