### PR TITLE
core: add has_ground_station method to system_impl and system

### DIFF
--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -44,6 +44,11 @@ bool System::has_gimbal() const
     return _system_impl->has_gimbal();
 }
 
+bool System::has_ground_station() const
+{
+    return _system_impl->has_ground_station();
+}
+
 bool System::is_connected() const
 {
     return _system_impl->is_connected();

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -75,6 +75,12 @@ public:
     bool has_gimbal() const;
 
     /**
+     * @brief Checks whether the system has a ground station.
+     * @return `true` if it has a ground station, `false` otherwise.
+     */
+    bool has_ground_station() const;
+
+    /**
      * @brief Checks if the system is connected.
      *
      * A system is connected when heartbeats are arriving (discovered and not timed out).

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -421,6 +421,11 @@ bool SystemImpl::has_gimbal() const
     return get_gimbal_id() == MAV_COMP_ID_GIMBAL;
 }
 
+bool SystemImpl::has_ground_station() const
+{
+    return get_ground_station_id() != uint8_t(0);
+}
+
 bool SystemImpl::send_message(mavlink_message_t& message)
 {
     // This is a low level interface where incoming messages can be tampered
@@ -1072,6 +1077,15 @@ uint8_t SystemImpl::get_gimbal_id() const
 {
     for (auto compid : _components)
         if (compid == MAV_COMP_ID_GIMBAL) {
+            return compid;
+        }
+    return uint8_t(0);
+}
+
+uint8_t SystemImpl::get_ground_station_id() const
+{
+    for (auto compid : _components)
+        if (compid == MAV_COMP_ID_MISSIONPLANNER) {
             return compid;
         }
     return uint8_t(0);

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -115,11 +115,13 @@ public:
     uint8_t get_autopilot_id() const;
     std::vector<uint8_t> get_camera_ids() const;
     uint8_t get_gimbal_id() const;
+    uint8_t get_ground_station_id() const;
 
     bool is_standalone() const;
     bool has_autopilot() const;
     bool has_camera(int camera_id = -1) const;
     bool has_gimbal() const;
+    bool has_ground_station() const;
 
     uint64_t get_uuid() const;
     uint8_t get_system_id() const;


### PR DESCRIPTION
This PR introduces the method `has_ground_station` in system_impl and system so we can detect if there is a ground station (mission planner) in the system.