### PR TITLE
Fix legacy_uid 

### DIFF
--- a/src/plugins/info/info_impl.cpp
+++ b/src/plugins/info/info_impl.cpp
@@ -150,7 +150,10 @@ void InfoImpl::process_autopilot_version(const mavlink_message_t& message)
     _identification.hardware_uid =
         translate_binary_to_str(autopilot_version.uid2, sizeof(autopilot_version.uid2));
 
-    _identification.legacy_uid = autopilot_version.uid;
+    std::memcpy(
+        _identification.legacy_uid,
+        reinterpret_cast<uint8_t*>(&autopilot_version.uid),
+        sizeof(autopilot_version.uid));
 
     _information_received = true;
 }


### PR DESCRIPTION
Looking at 31523ce4d04759a12b54dd1ff9f781e63a4b6888, we used to do it differently, and it turns out that the new way seems to return a "00000000000000" value with the H520

I'll try to get this tested on an H520 before merging it :smile: 