### PR TITLE
Fall back to tools found in PATH in `generate_from_protos.sh`

### DIFF
--- a/tools/generate_from_protos.sh
+++ b/tools/generate_from_protos.sh
@@ -10,6 +10,9 @@ third_party_dir="${script_dir}/../build/default/third_party"
 protoc_binary="${third_party_dir}/install/bin/protoc"
 protoc_grpc_binary="${third_party_dir}/install/bin/grpc_cpp_plugin"
 
+command -v ${protoc_binary} > /dev/null || protoc_binary="$(command -v protoc)"
+command -v ${protoc_grpc_binary} > /dev/null || protoc_grpc_binary="$(command -v grpc_cpp_plugin)"
+
 function snake_case_to_camel_case {
     echo $1 | awk -v FS="_" -v OFS="" '{for (i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)} 1'
 }


### PR DESCRIPTION
In Homebrew, we build MAVSDK with our own gRPC and Protobuf. [1]

However, since our Protobuf is often newer than the one you vendor, we
need to regenerate some source files using `generate_from_protos.sh`
before actually building MAVSDK.

This patch allows us to do so using our gRPC and Protobuf without having
to patch `generate_from_protos.sh` or otherwise create symlinks.

[1] https://github.com/Homebrew/homebrew-core/blob/65afeec88bc6b899b1ce9a4bf12d658bbc1f3570/Formula/mavsdk.rb