### PR TITLE
offering the ability to set a component description 

### DIFF
--- a/src/core/mavsdk.cpp
+++ b/src/core/mavsdk.cpp
@@ -136,6 +136,21 @@ Mavsdk::Configuration::Configuration(UsageType usage_type) :
             _component_id = MavsdkImpl::DEFAULT_COMPONENT_ID_CC;
             _always_send_heartbeats = true;
             break;
+        case Mavsdk::Configuration::UsageType::CompanionComputer2:
+            _system_id = MavsdkImpl::DEFAULT_SYSTEM_ID_CC;
+            _component_id = MAV_COMPONENT::MAV_COMP_ID_ONBOARD_COMPUTER2;
+            _always_send_heartbeats = true;
+            break;
+        case Mavsdk::Configuration::UsageType::CompanionComputer3:
+            _system_id = MavsdkImpl::DEFAULT_SYSTEM_ID_CC;
+            _component_id = MAV_COMPONENT::MAV_COMP_ID_ONBOARD_COMPUTER3;
+            _always_send_heartbeats = true;
+            break;
+        case Mavsdk::Configuration::UsageType::CompanionComputer4:
+            _system_id = MavsdkImpl::DEFAULT_SYSTEM_ID_CC;
+            _component_id = MAV_COMPONENT::MAV_COMP_ID_ONBOARD_COMPUTER4;
+            _always_send_heartbeats = true;
+            break;
         case Mavsdk::Configuration::UsageType::Autopilot:
             _system_id = MavsdkImpl::DEFAULT_SYSTEM_ID_AUTOPILOT;
             _component_id = MavsdkImpl::DEFAULT_COMPONENT_ID_AUTOPILOT;
@@ -184,6 +199,16 @@ Mavsdk::Configuration::UsageType Mavsdk::Configuration::get_usage_type() const
 void Mavsdk::Configuration::set_usage_type(Mavsdk::Configuration::UsageType usage_type)
 {
     _usage_type = usage_type;
+}
+
+std::optional<std::string const> Mavsdk::Configuration::get_component_description() const
+{
+    return _component_description;
+}
+
+void Mavsdk::Configuration::set_component_description(std::string const & component_description)
+{
+    _component_description = component_description;
 }
 
 } // namespace mavsdk

--- a/src/core/mavsdk.h
+++ b/src/core/mavsdk.h
@@ -1,13 +1,14 @@
 #pragma once
 
-#include <string>
-#include <memory>
-#include <vector>
 #include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
 
+#include "connection_result.h"
 #include "deprecated.h"
 #include "system.h"
-#include "connection_result.h"
 
 namespace mavsdk {
 
@@ -185,9 +186,12 @@ public:
         enum class UsageType {
             Autopilot, /**< @brief SDK is used as an autopilot. */
             GroundStation, /**< @brief SDK is used as a ground station. */
-            CompanionComputer, /**< @brief SDK is used as a companion computer on board the MAV. */
-            Custom /**< @brief the SDK is used in a custom configuration, no automatic ID will be
+            CompanionComputer, /**< @brief SDK is used as a companion computer element 1 on board the MAV. */
+            Custom, /**< @brief the SDK is used in a custom configuration, no automatic ID will be
                       provided */
+            CompanionComputer2, /**< @brief SDK is used as a companion computer element 2 on board the MAV. */
+            CompanionComputer3, /**< @brief SDK is used as a companion computer element 3 on board the MAV. */
+            CompanionComputer4 /**< @brief SDK is used as a companion computer element 4 on board the MAV. */
         };
 
         /**
@@ -250,11 +254,24 @@ public:
          */
         void set_usage_type(UsageType usage_type);
 
+        /**
+         * @brief Retrieve the component's description of this configuration if it has one
+         * UUseful to set a more custom name than the eventually too generic component_id
+         */
+        std::optional<std::string const> get_component_description() const;
+
+        /**
+         * @brief Set the component's description of this configuration
+         * Useful to set a more custom name than the eventually too generic component_id
+         */
+        void set_component_description(std::string const & component_description);
+
     private:
         uint8_t _system_id;
         uint8_t _component_id;
         bool _always_send_heartbeats;
         UsageType _usage_type;
+        std::optional<std::string> _component_description;
     };
 
     /**

--- a/src/core/mavsdk_impl.cpp
+++ b/src/core/mavsdk_impl.cpp
@@ -492,7 +492,12 @@ uint8_t MavsdkImpl::get_mav_type() const
 
         case Mavsdk::Configuration::UsageType::CompanionComputer:
             return MAV_TYPE_ONBOARD_CONTROLLER;
-
+        case Mavsdk::Configuration::UsageType::CompanionComputer2:
+            return MAV_TYPE_ONBOARD_CONTROLLER;
+        case Mavsdk::Configuration::UsageType::CompanionComputer3:
+            return MAV_TYPE_ONBOARD_CONTROLLER;
+        case Mavsdk::Configuration::UsageType::CompanionComputer4:
+            return MAV_TYPE_ONBOARD_CONTROLLER;
         case Mavsdk::Configuration::UsageType::Custom:
             return MAV_TYPE_GENERIC;
 


### PR DESCRIPTION
and adding new Companion Computer ids for configuration

the component description should allow to define in a more explicit way the component than the component id

accorfing @TSC21  recommendations