### PR TITLE
Ability to customize logging output with a user-defined callback

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -98,6 +98,7 @@ install(FILES
     deprecated.h
     system.h
     mavsdk.h
+    log_callback.h
     plugin_base.h
     geometry.h
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/mavsdk"

--- a/src/core/log.cpp
+++ b/src/core/log.cpp
@@ -20,6 +20,10 @@
 
 namespace mavsdk {
 
+namespace log {
+  Callback callback = nullptr;
+}
+
 void set_color(Color color)
 {
 #if defined(WINDOWS)

--- a/src/core/log.h
+++ b/src/core/log.h
@@ -2,6 +2,7 @@
 
 #include <sstream>
 #include "global_include.h"
+#include "log_callback.h"
 
 #if defined(ANDROID)
 #include <android/log.h>
@@ -37,18 +38,24 @@ public:
 
     virtual ~LogDetailed()
     {
+        if (log::callback &&
+            log::callback(_log_level, _s.str(), _caller_filename, _caller_filenumber))
+        {
+          return;
+        }
+
 #if ANDROID
         switch (_log_level) {
-            case LogLevel::Debug:
+            case log::Level::Debug:
                 __android_log_print(ANDROID_LOG_DEBUG, "Mavsdk", "%s", _s.str().c_str());
                 break;
-            case LogLevel::Info:
+            case log::Level::Info:
                 __android_log_print(ANDROID_LOG_INFO, "Mavsdk", "%s", _s.str().c_str());
                 break;
-            case LogLevel::Warn:
+            case log::Level::Warn:
                 __android_log_print(ANDROID_LOG_WARN, "Mavsdk", "%s", _s.str().c_str());
                 break;
-            case LogLevel::Err:
+            case log::Level::Err:
                 __android_log_print(ANDROID_LOG_ERROR, "Mavsdk", "%s", _s.str().c_str());
                 break;
         }
@@ -58,16 +65,16 @@ public:
 #else
 
         switch (_log_level) {
-            case LogLevel::Debug:
+            case log::Level::Debug:
                 set_color(Color::Green);
                 break;
-            case LogLevel::Info:
+            case log::Level::Info:
                 set_color(Color::Blue);
                 break;
-            case LogLevel::Warn:
+            case log::Level::Warn:
                 set_color(Color::Yellow);
                 break;
-            case LogLevel::Err:
+            case log::Level::Err:
                 set_color(Color::Red);
                 break;
         }
@@ -82,16 +89,16 @@ public:
         std::cout << "[" << time_buffer;
 
         switch (_log_level) {
-            case LogLevel::Debug:
+            case log::Level::Debug:
                 std::cout << "|Debug] ";
                 break;
-            case LogLevel::Info:
+            case log::Level::Info:
                 std::cout << "|Info ] ";
                 break;
-            case LogLevel::Warn:
+            case log::Level::Warn:
                 std::cout << "|Warn ] ";
                 break;
-            case LogLevel::Err:
+            case log::Level::Err:
                 std::cout << "|Error] ";
                 break;
         }
@@ -109,7 +116,7 @@ public:
     void operator=(const mavsdk::LogDetailed&) = delete;
 
 protected:
-    enum LogLevel { Debug, Info, Warn, Err } _log_level = LogLevel::Debug;
+  log::Level _log_level = log::Level::Debug;
 
 private:
     std::stringstream _s;
@@ -121,7 +128,7 @@ class LogDebugDetailed : public LogDetailed {
 public:
     LogDebugDetailed(const char* filename, int filenumber) : LogDetailed(filename, filenumber)
     {
-        _log_level = LogLevel::Debug;
+        _log_level = log::Level::Debug;
     }
 };
 
@@ -129,7 +136,7 @@ class LogInfoDetailed : public LogDetailed {
 public:
     LogInfoDetailed(const char* filename, int filenumber) : LogDetailed(filename, filenumber)
     {
-        _log_level = LogLevel::Info;
+        _log_level = log::Level::Info;
     }
 };
 
@@ -137,7 +144,7 @@ class LogWarnDetailed : public LogDetailed {
 public:
     LogWarnDetailed(const char* filename, int filenumber) : LogDetailed(filename, filenumber)
     {
-        _log_level = LogLevel::Warn;
+        _log_level = log::Level::Warn;
     }
 };
 
@@ -145,7 +152,7 @@ class LogErrDetailed : public LogDetailed {
 public:
     LogErrDetailed(const char* filename, int filenumber) : LogDetailed(filename, filenumber)
     {
-        _log_level = LogLevel::Err;
+        _log_level = log::Level::Err;
     }
 };
 

--- a/src/core/log_callback.h
+++ b/src/core/log_callback.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+#include <functional>
+
+namespace mavsdk::log {
+
+// defined numeric values can be useful for filtering message by severity
+typedef enum {
+  Debug = 0,
+  Info = 1,
+  Warn = 2,
+  Err = 3
+} Level;
+
+/** @brief User-defined callback for logging. Returning true from this callback
+ * prevents default mavsdk`s logging to stdout. Returning false keeps it.
+ */
+typedef std::function<bool(Level level, const std::string &message,
+                           const std::string &file, int line)> Callback;
+
+extern Callback callback;
+
+}


### PR DESCRIPTION
Problem:
- uncontrollable logging to stdout may be undesirable
- some applications may want to store logs in some kind of permanent storage for later investigations

Proposed solution:
- give users an ability to define custom callback which is called for every log message. The callback is able to discard default logging to stdout, or keep it and just add some another output