### PR TITLE
Add acceptance_radius back to MissionItem

### DIFF
--- a/src/integration_tests/mission.cpp
+++ b/src/integration_tests/mission.cpp
@@ -103,7 +103,7 @@ void test_mission(
             60.0f,
             NAN,
             Mission::MissionItem::CameraAction::None,
-            NAN));
+            0.5f));
 
         mission_plan.mission_items.push_back(add_mission_item(
             47.398241338125118,
@@ -115,7 +115,7 @@ void test_mission(
             -60.0f,
             5.0f,
             Mission::MissionItem::CameraAction::TakePhoto,
-            NAN));
+            4.0f));
 
         mission_plan.mission_items.push_back(add_mission_item(
             47.398139363821485,
@@ -127,7 +127,7 @@ void test_mission(
             0.0f,
             NAN,
             Mission::MissionItem::CameraAction::StartVideo,
-            NAN));
+            4.0f));
 
         mission_plan.mission_items.push_back(add_mission_item(
             47.398058617228855,
@@ -139,7 +139,7 @@ void test_mission(
             30.0f,
             NAN,
             Mission::MissionItem::CameraAction::StopVideo,
-            NAN));
+            0.5f));
 
         mission_plan.mission_items.push_back(add_mission_item(
             47.398100366082858,
@@ -151,7 +151,7 @@ void test_mission(
             -30.0f,
             NAN,
             Mission::MissionItem::CameraAction::StartPhotoInterval,
-            NAN));
+            0.5f));
 
         mission_plan.mission_items.push_back(add_mission_item(
             47.398001890458097,
@@ -163,7 +163,7 @@ void test_mission(
             0.0f,
             NAN,
             Mission::MissionItem::CameraAction::StopPhotoInterval,
-            NAN));
+            0.5f));
     }
 
     mission->set_return_to_launch_after_mission(true);

--- a/src/integration_tests/mission.cpp
+++ b/src/integration_tests/mission.cpp
@@ -27,7 +27,8 @@ static Mission::MissionItem add_mission_item(
     float gimbal_pitch_deg,
     float gimbal_yaw_deg,
     float loiter_time_s,
-    Mission::MissionItem::CameraAction camera_action);
+    Mission::MissionItem::CameraAction camera_action,
+    float acceptance_radius_m);
 
 static void pause_and_resume(std::shared_ptr<Mission> mission);
 
@@ -101,7 +102,8 @@ void test_mission(
             20.0f,
             60.0f,
             NAN,
-            Mission::MissionItem::CameraAction::None));
+            Mission::MissionItem::CameraAction::None,
+            NAN));
 
         mission_plan.mission_items.push_back(add_mission_item(
             47.398241338125118,
@@ -112,7 +114,8 @@ void test_mission(
             0.0f,
             -60.0f,
             5.0f,
-            Mission::MissionItem::CameraAction::TakePhoto));
+            Mission::MissionItem::CameraAction::TakePhoto,
+            NAN));
 
         mission_plan.mission_items.push_back(add_mission_item(
             47.398139363821485,
@@ -123,7 +126,8 @@ void test_mission(
             -46.0f,
             0.0f,
             NAN,
-            Mission::MissionItem::CameraAction::StartVideo));
+            Mission::MissionItem::CameraAction::StartVideo,
+            NAN));
 
         mission_plan.mission_items.push_back(add_mission_item(
             47.398058617228855,
@@ -134,7 +138,8 @@ void test_mission(
             -90.0f,
             30.0f,
             NAN,
-            Mission::MissionItem::CameraAction::StopVideo));
+            Mission::MissionItem::CameraAction::StopVideo,
+            NAN));
 
         mission_plan.mission_items.push_back(add_mission_item(
             47.398100366082858,
@@ -145,7 +150,8 @@ void test_mission(
             -45.0f,
             -30.0f,
             NAN,
-            Mission::MissionItem::CameraAction::StartPhotoInterval));
+            Mission::MissionItem::CameraAction::StartPhotoInterval,
+            NAN));
 
         mission_plan.mission_items.push_back(add_mission_item(
             47.398001890458097,
@@ -156,7 +162,8 @@ void test_mission(
             0.0f,
             0.0f,
             NAN,
-            Mission::MissionItem::CameraAction::StopPhotoInterval));
+            Mission::MissionItem::CameraAction::StopPhotoInterval,
+            NAN));
     }
 
     mission->set_return_to_launch_after_mission(true);
@@ -279,6 +286,7 @@ Mission::MissionItem add_mission_item(
     float gimbal_pitch_deg,
     float gimbal_yaw_deg,
     float loiter_time_s,
+    float acceptance_radius_m
     Mission::MissionItem::CameraAction camera_action)
 {
     Mission::MissionItem new_item{};
@@ -291,6 +299,7 @@ Mission::MissionItem add_mission_item(
     new_item.gimbal_yaw_deg = gimbal_yaw_deg;
     new_item.loiter_time_s = loiter_time_s;
     new_item.camera_action = camera_action;
+    new_item.acceptance_radius_m = camera_action;
 
     // In order to test setting the interval, add it here.
     if (camera_action == Mission::MissionItem::CameraAction::StartPhotoInterval) {

--- a/src/integration_tests/mission.cpp
+++ b/src/integration_tests/mission.cpp
@@ -286,7 +286,7 @@ Mission::MissionItem add_mission_item(
     float gimbal_pitch_deg,
     float gimbal_yaw_deg,
     float loiter_time_s,
-    float acceptance_radius_m
+    float acceptance_radius_m,
     Mission::MissionItem::CameraAction camera_action)
 {
     Mission::MissionItem new_item{};
@@ -299,7 +299,7 @@ Mission::MissionItem add_mission_item(
     new_item.gimbal_yaw_deg = gimbal_yaw_deg;
     new_item.loiter_time_s = loiter_time_s;
     new_item.camera_action = camera_action;
-    new_item.acceptance_radius_m = camera_action;
+    new_item.acceptance_radius_m = acceptance_radius_m;
 
     // In order to test setting the interval, add it here.
     if (camera_action == Mission::MissionItem::CameraAction::StartPhotoInterval) {

--- a/src/integration_tests/mission.cpp
+++ b/src/integration_tests/mission.cpp
@@ -286,8 +286,8 @@ Mission::MissionItem add_mission_item(
     float gimbal_pitch_deg,
     float gimbal_yaw_deg,
     float loiter_time_s,
-    float acceptance_radius_m,
-    Mission::MissionItem::CameraAction camera_action)
+    Mission::MissionItem::CameraAction camera_action,
+    float acceptance_radius_m)
 {
     Mission::MissionItem new_item{};
     new_item.latitude_deg = latitude_deg;

--- a/src/integration_tests/mission_change_speed.cpp
+++ b/src/integration_tests/mission_change_speed.cpp
@@ -142,6 +142,7 @@ add_waypoint(double latitude_deg, double longitude_deg, float relative_altitude_
     new_item.longitude_deg = longitude_deg;
     new_item.relative_altitude_m = relative_altitude_m;
     new_item.speed_m_s = speed_m_s;
+    new_item.acceptance_radius_m = 1.0f;
     return new_item;
 }
 

--- a/src/integration_tests/mission_transfer_lossy.cpp
+++ b/src/integration_tests/mission_transfer_lossy.cpp
@@ -84,6 +84,7 @@ std::vector<Mission::MissionItem> create_mission_items()
         new_item.longitude_deg = 8.5456490218639658 + (i * 1e-6);
         new_item.relative_altitude_m = 10.0f + (i * 0.2f);
         new_item.speed_m_s = 5.0f + (i * 0.1f);
+        new_item.acceptance_radius_m = 2.0f;
         mission_items.push_back(new_item);
     }
     return mission_items;

--- a/src/mavsdk_server/src/generated/mission/mission.pb.cc
+++ b/src/mavsdk_server/src/generated/mission/mission.pb.cc
@@ -313,7 +313,8 @@ constexpr MissionItem::MissionItem(
   , camera_action_(0)
 
   , camera_photo_interval_s_(0)
-  , loiter_time_s_(0){}
+  , loiter_time_s_(0)
+  , acceptance_radius_m_(0){}
 struct MissionItemDefaultTypeInternal {
   constexpr MissionItemDefaultTypeInternal()
     : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
@@ -523,6 +524,7 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_mission_2fmission_2eproto::off
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::MissionItem, camera_action_),
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::MissionItem, loiter_time_s_),
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::MissionItem, camera_photo_interval_s_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::MissionItem, acceptance_radius_m_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::MissionPlan, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -570,9 +572,9 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 126, -1, sizeof(::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionRequest)},
   { 132, -1, sizeof(::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionResponse)},
   { 138, -1, sizeof(::mavsdk::rpc::mission::MissionItem)},
-  { 153, -1, sizeof(::mavsdk::rpc::mission::MissionPlan)},
-  { 159, -1, sizeof(::mavsdk::rpc::mission::MissionProgress)},
-  { 166, -1, sizeof(::mavsdk::rpc::mission::MissionResult)},
+  { 154, -1, sizeof(::mavsdk::rpc::mission::MissionPlan)},
+  { 160, -1, sizeof(::mavsdk::rpc::mission::MissionProgress)},
+  { 167, -1, sizeof(::mavsdk::rpc::mission::MissionResult)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -648,7 +650,7 @@ const char descriptor_table_protodef_mission_2fmission_2eproto[] PROTOBUF_SECTIO
   "etReturnToLaunchAfterMissionRequest\022\016\n\006e"
   "nable\030\001 \001(\010\"b\n%SetReturnToLaunchAfterMis"
   "sionResponse\0229\n\016mission_result\030\001 \001(\0132!.m"
-  "avsdk.rpc.mission.MissionResult\"\203\005\n\013Miss"
+  "avsdk.rpc.mission.MissionResult\"\251\005\n\013Miss"
   "ionItem\022(\n\014latitude_deg\030\001 \001(\001B\022\202\265\030\003NaN\211\265"
   "\030H\257\274\232\362\327z>\022)\n\rlongitude_deg\030\002 \001(\001B\022\202\265\030\003Na"
   "N\211\265\030H\257\274\232\362\327z>\022$\n\023relative_altitude_m\030\003 \001("
@@ -659,71 +661,72 @@ const char descriptor_table_protodef_mission_2fmission_2eproto[] PROTOBUF_SECTIO
   "6\032\?\022C\n\rcamera_action\030\010 \001(\0162,.mavsdk.rpc."
   "mission.MissionItem.CameraAction\022\036\n\rloit"
   "er_time_s\030\t \001(\002B\007\202\265\030\003NaN\022(\n\027camera_photo"
-  "_interval_s\030\n \001(\001B\007\202\265\030\0031.0\"\320\001\n\014CameraAct"
-  "ion\022\026\n\022CAMERA_ACTION_NONE\020\000\022\034\n\030CAMERA_AC"
-  "TION_TAKE_PHOTO\020\001\022&\n\"CAMERA_ACTION_START"
-  "_PHOTO_INTERVAL\020\002\022%\n!CAMERA_ACTION_STOP_"
-  "PHOTO_INTERVAL\020\003\022\035\n\031CAMERA_ACTION_START_"
-  "VIDEO\020\004\022\034\n\030CAMERA_ACTION_STOP_VIDEO\020\005\"E\n"
-  "\013MissionPlan\0226\n\rmission_items\030\001 \003(\0132\037.ma"
-  "vsdk.rpc.mission.MissionItem\"1\n\017MissionP"
-  "rogress\022\017\n\007current\030\001 \001(\005\022\r\n\005total\030\002 \001(\005\""
-  "\231\003\n\rMissionResult\0228\n\006result\030\001 \001(\0162(.mavs"
-  "dk.rpc.mission.MissionResult.Result\022\022\n\nr"
-  "esult_str\030\002 \001(\t\"\271\002\n\006Result\022\022\n\016RESULT_UNK"
-  "NOWN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\020\n\014RESULT_ERR"
-  "OR\020\002\022!\n\035RESULT_TOO_MANY_MISSION_ITEMS\020\003\022"
-  "\017\n\013RESULT_BUSY\020\004\022\022\n\016RESULT_TIMEOUT\020\005\022\033\n\027"
-  "RESULT_INVALID_ARGUMENT\020\006\022\026\n\022RESULT_UNSU"
-  "PPORTED\020\007\022\037\n\033RESULT_NO_MISSION_AVAILABLE"
-  "\020\010\022\"\n\036RESULT_UNSUPPORTED_MISSION_CMD\020\013\022\035"
-  "\n\031RESULT_TRANSFER_CANCELLED\020\014\022\024\n\020RESULT_"
-  "NO_SYSTEM\020\r2\315\013\n\016MissionService\022f\n\rUpload"
-  "Mission\022(.mavsdk.rpc.mission.UploadMissi"
-  "onRequest\032).mavsdk.rpc.mission.UploadMis"
-  "sionResponse\"\000\022|\n\023CancelMissionUpload\022.."
-  "mavsdk.rpc.mission.CancelMissionUploadRe"
-  "quest\032/.mavsdk.rpc.mission.CancelMission"
-  "UploadResponse\"\004\200\265\030\001\022l\n\017DownloadMission\022"
-  "*.mavsdk.rpc.mission.DownloadMissionRequ"
-  "est\032+.mavsdk.rpc.mission.DownloadMission"
-  "Response\"\000\022\202\001\n\025CancelMissionDownload\0220.m"
-  "avsdk.rpc.mission.CancelMissionDownloadR"
-  "equest\0321.mavsdk.rpc.mission.CancelMissio"
-  "nDownloadResponse\"\004\200\265\030\001\022c\n\014StartMission\022"
-  "\'.mavsdk.rpc.mission.StartMissionRequest"
-  "\032(.mavsdk.rpc.mission.StartMissionRespon"
-  "se\"\000\022c\n\014PauseMission\022\'.mavsdk.rpc.missio"
-  "n.PauseMissionRequest\032(.mavsdk.rpc.missi"
-  "on.PauseMissionResponse\"\000\022c\n\014ClearMissio"
-  "n\022\'.mavsdk.rpc.mission.ClearMissionReque"
-  "st\032(.mavsdk.rpc.mission.ClearMissionResp"
-  "onse\"\000\022~\n\025SetCurrentMissionItem\0220.mavsdk"
-  ".rpc.mission.SetCurrentMissionItemReques"
-  "t\0321.mavsdk.rpc.mission.SetCurrentMission"
-  "ItemResponse\"\000\022v\n\021IsMissionFinished\022,.ma"
-  "vsdk.rpc.mission.IsMissionFinishedReques"
-  "t\032-.mavsdk.rpc.mission.IsMissionFinished"
-  "Response\"\004\200\265\030\001\022\200\001\n\030SubscribeMissionProgr"
-  "ess\0223.mavsdk.rpc.mission.SubscribeMissio"
-  "nProgressRequest\032+.mavsdk.rpc.mission.Mi"
-  "ssionProgressResponse\"\0000\001\022\232\001\n\035GetReturnT"
-  "oLaunchAfterMission\0228.mavsdk.rpc.mission"
-  ".GetReturnToLaunchAfterMissionRequest\0329."
-  "mavsdk.rpc.mission.GetReturnToLaunchAfte"
-  "rMissionResponse\"\004\200\265\030\001\022\232\001\n\035SetReturnToLa"
-  "unchAfterMission\0228.mavsdk.rpc.mission.Se"
-  "tReturnToLaunchAfterMissionRequest\0329.mav"
-  "sdk.rpc.mission.SetReturnToLaunchAfterMi"
-  "ssionResponse\"\004\200\265\030\001B!\n\021io.mavsdk.mission"
-  "B\014MissionProtob\006proto3"
+  "_interval_s\030\n \001(\001B\007\202\265\030\0031.0\022$\n\023acceptance"
+  "_radius_m\030\013 \001(\002B\007\202\265\030\003NaN\"\320\001\n\014CameraActio"
+  "n\022\026\n\022CAMERA_ACTION_NONE\020\000\022\034\n\030CAMERA_ACTI"
+  "ON_TAKE_PHOTO\020\001\022&\n\"CAMERA_ACTION_START_P"
+  "HOTO_INTERVAL\020\002\022%\n!CAMERA_ACTION_STOP_PH"
+  "OTO_INTERVAL\020\003\022\035\n\031CAMERA_ACTION_START_VI"
+  "DEO\020\004\022\034\n\030CAMERA_ACTION_STOP_VIDEO\020\005\"E\n\013M"
+  "issionPlan\0226\n\rmission_items\030\001 \003(\0132\037.mavs"
+  "dk.rpc.mission.MissionItem\"1\n\017MissionPro"
+  "gress\022\017\n\007current\030\001 \001(\005\022\r\n\005total\030\002 \001(\005\"\231\003"
+  "\n\rMissionResult\0228\n\006result\030\001 \001(\0162(.mavsdk"
+  ".rpc.mission.MissionResult.Result\022\022\n\nres"
+  "ult_str\030\002 \001(\t\"\271\002\n\006Result\022\022\n\016RESULT_UNKNO"
+  "WN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\020\n\014RESULT_ERROR"
+  "\020\002\022!\n\035RESULT_TOO_MANY_MISSION_ITEMS\020\003\022\017\n"
+  "\013RESULT_BUSY\020\004\022\022\n\016RESULT_TIMEOUT\020\005\022\033\n\027RE"
+  "SULT_INVALID_ARGUMENT\020\006\022\026\n\022RESULT_UNSUPP"
+  "ORTED\020\007\022\037\n\033RESULT_NO_MISSION_AVAILABLE\020\010"
+  "\022\"\n\036RESULT_UNSUPPORTED_MISSION_CMD\020\013\022\035\n\031"
+  "RESULT_TRANSFER_CANCELLED\020\014\022\024\n\020RESULT_NO"
+  "_SYSTEM\020\r2\315\013\n\016MissionService\022f\n\rUploadMi"
+  "ssion\022(.mavsdk.rpc.mission.UploadMission"
+  "Request\032).mavsdk.rpc.mission.UploadMissi"
+  "onResponse\"\000\022|\n\023CancelMissionUpload\022..ma"
+  "vsdk.rpc.mission.CancelMissionUploadRequ"
+  "est\032/.mavsdk.rpc.mission.CancelMissionUp"
+  "loadResponse\"\004\200\265\030\001\022l\n\017DownloadMission\022*."
+  "mavsdk.rpc.mission.DownloadMissionReques"
+  "t\032+.mavsdk.rpc.mission.DownloadMissionRe"
+  "sponse\"\000\022\202\001\n\025CancelMissionDownload\0220.mav"
+  "sdk.rpc.mission.CancelMissionDownloadReq"
+  "uest\0321.mavsdk.rpc.mission.CancelMissionD"
+  "ownloadResponse\"\004\200\265\030\001\022c\n\014StartMission\022\'."
+  "mavsdk.rpc.mission.StartMissionRequest\032("
+  ".mavsdk.rpc.mission.StartMissionResponse"
+  "\"\000\022c\n\014PauseMission\022\'.mavsdk.rpc.mission."
+  "PauseMissionRequest\032(.mavsdk.rpc.mission"
+  ".PauseMissionResponse\"\000\022c\n\014ClearMission\022"
+  "\'.mavsdk.rpc.mission.ClearMissionRequest"
+  "\032(.mavsdk.rpc.mission.ClearMissionRespon"
+  "se\"\000\022~\n\025SetCurrentMissionItem\0220.mavsdk.r"
+  "pc.mission.SetCurrentMissionItemRequest\032"
+  "1.mavsdk.rpc.mission.SetCurrentMissionIt"
+  "emResponse\"\000\022v\n\021IsMissionFinished\022,.mavs"
+  "dk.rpc.mission.IsMissionFinishedRequest\032"
+  "-.mavsdk.rpc.mission.IsMissionFinishedRe"
+  "sponse\"\004\200\265\030\001\022\200\001\n\030SubscribeMissionProgres"
+  "s\0223.mavsdk.rpc.mission.SubscribeMissionP"
+  "rogressRequest\032+.mavsdk.rpc.mission.Miss"
+  "ionProgressResponse\"\0000\001\022\232\001\n\035GetReturnToL"
+  "aunchAfterMission\0228.mavsdk.rpc.mission.G"
+  "etReturnToLaunchAfterMissionRequest\0329.ma"
+  "vsdk.rpc.mission.GetReturnToLaunchAfterM"
+  "issionResponse\"\004\200\265\030\001\022\232\001\n\035SetReturnToLaun"
+  "chAfterMission\0228.mavsdk.rpc.mission.SetR"
+  "eturnToLaunchAfterMissionRequest\0329.mavsd"
+  "k.rpc.mission.SetReturnToLaunchAfterMiss"
+  "ionResponse\"\004\200\265\030\001B!\n\021io.mavsdk.missionB\014"
+  "MissionProtob\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_mission_2fmission_2eproto_deps[1] = {
   &::descriptor_table_mavsdk_5foptions_2eproto,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_mission_2fmission_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_mission_2fmission_2eproto = {
-  false, false, 4382, descriptor_table_protodef_mission_2fmission_2eproto, "mission/mission.proto", 
+  false, false, 4420, descriptor_table_protodef_mission_2fmission_2eproto, "mission/mission.proto", 
   &descriptor_table_mission_2fmission_2eproto_once, descriptor_table_mission_2fmission_2eproto_deps, 1, 28,
   schemas, file_default_instances, TableStruct_mission_2fmission_2eproto::offsets,
   file_level_metadata_mission_2fmission_2eproto, file_level_enum_descriptors_mission_2fmission_2eproto, file_level_service_descriptors_mission_2fmission_2eproto,
@@ -5377,16 +5380,16 @@ MissionItem::MissionItem(const MissionItem& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
   ::memcpy(&latitude_deg_, &from.latitude_deg_,
-    static_cast<size_t>(reinterpret_cast<char*>(&loiter_time_s_) -
-    reinterpret_cast<char*>(&latitude_deg_)) + sizeof(loiter_time_s_));
+    static_cast<size_t>(reinterpret_cast<char*>(&acceptance_radius_m_) -
+    reinterpret_cast<char*>(&latitude_deg_)) + sizeof(acceptance_radius_m_));
   // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.mission.MissionItem)
 }
 
 void MissionItem::SharedCtor() {
 ::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
     reinterpret_cast<char*>(&latitude_deg_) - reinterpret_cast<char*>(this)),
-    0, static_cast<size_t>(reinterpret_cast<char*>(&loiter_time_s_) -
-    reinterpret_cast<char*>(&latitude_deg_)) + sizeof(loiter_time_s_));
+    0, static_cast<size_t>(reinterpret_cast<char*>(&acceptance_radius_m_) -
+    reinterpret_cast<char*>(&latitude_deg_)) + sizeof(acceptance_radius_m_));
 }
 
 MissionItem::~MissionItem() {
@@ -5416,8 +5419,8 @@ void MissionItem::Clear() {
   (void) cached_has_bits;
 
   ::memset(&latitude_deg_, 0, static_cast<size_t>(
-      reinterpret_cast<char*>(&loiter_time_s_) -
-      reinterpret_cast<char*>(&latitude_deg_)) + sizeof(loiter_time_s_));
+      reinterpret_cast<char*>(&acceptance_radius_m_) -
+      reinterpret_cast<char*>(&latitude_deg_)) + sizeof(acceptance_radius_m_));
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -5497,6 +5500,13 @@ const char* MissionItem::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 81)) {
           camera_photo_interval_s_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<double>(ptr);
           ptr += sizeof(double);
+        } else goto handle_unusual;
+        continue;
+      // float acceptance_radius_m = 11 [(.mavsdk.options.default_value) = "NaN"];
+      case 11:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 93)) {
+          acceptance_radius_m_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<float>(ptr);
+          ptr += sizeof(float);
         } else goto handle_unusual;
         continue;
       default: {
@@ -5588,6 +5598,12 @@ failure:
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteDoubleToArray(10, this->_internal_camera_photo_interval_s(), target);
   }
 
+  // float acceptance_radius_m = 11 [(.mavsdk.options.default_value) = "NaN"];
+  if (!(this->acceptance_radius_m() <= 0 && this->acceptance_radius_m() >= 0)) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteFloatToArray(11, this->_internal_acceptance_radius_m(), target);
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
@@ -5655,6 +5671,11 @@ size_t MissionItem::ByteSizeLong() const {
     total_size += 1 + 4;
   }
 
+  // float acceptance_radius_m = 11 [(.mavsdk.options.default_value) = "NaN"];
+  if (!(this->acceptance_radius_m() <= 0 && this->acceptance_radius_m() >= 0)) {
+    total_size += 1 + 4;
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
         _internal_metadata_, total_size, &_cached_size_);
@@ -5716,6 +5737,9 @@ void MissionItem::MergeFrom(const MissionItem& from) {
   if (!(from.loiter_time_s() <= 0 && from.loiter_time_s() >= 0)) {
     _internal_set_loiter_time_s(from._internal_loiter_time_s());
   }
+  if (!(from.acceptance_radius_m() <= 0 && from.acceptance_radius_m() >= 0)) {
+    _internal_set_acceptance_radius_m(from._internal_acceptance_radius_m());
+  }
 }
 
 void MissionItem::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
@@ -5740,8 +5764,8 @@ void MissionItem::InternalSwap(MissionItem* other) {
   using std::swap;
   _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(MissionItem, loiter_time_s_)
-      + sizeof(MissionItem::loiter_time_s_)
+      PROTOBUF_FIELD_OFFSET(MissionItem, acceptance_radius_m_)
+      + sizeof(MissionItem::acceptance_radius_m_)
       - PROTOBUF_FIELD_OFFSET(MissionItem, latitude_deg_)>(
           reinterpret_cast<char*>(&latitude_deg_),
           reinterpret_cast<char*>(&other->latitude_deg_));

--- a/src/mavsdk_server/src/generated/mission/mission.pb.h
+++ b/src/mavsdk_server/src/generated/mission/mission.pb.h
@@ -3737,6 +3737,7 @@ class MissionItem PROTOBUF_FINAL :
     kCameraActionFieldNumber = 8,
     kCameraPhotoIntervalSFieldNumber = 10,
     kLoiterTimeSFieldNumber = 9,
+    kAcceptanceRadiusMFieldNumber = 11,
   };
   // double latitude_deg = 1 [(.mavsdk.options.default_value) = "NaN", (.mavsdk.options.epsilon) = 1e-07];
   void clear_latitude_deg();
@@ -3828,6 +3829,15 @@ class MissionItem PROTOBUF_FINAL :
   void _internal_set_loiter_time_s(float value);
   public:
 
+  // float acceptance_radius_m = 11 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_acceptance_radius_m();
+  float acceptance_radius_m() const;
+  void set_acceptance_radius_m(float value);
+  private:
+  float _internal_acceptance_radius_m() const;
+  void _internal_set_acceptance_radius_m(float value);
+  public:
+
   // @@protoc_insertion_point(class_scope:mavsdk.rpc.mission.MissionItem)
  private:
   class _Internal;
@@ -3845,6 +3855,7 @@ class MissionItem PROTOBUF_FINAL :
   int camera_action_;
   double camera_photo_interval_s_;
   float loiter_time_s_;
+  float acceptance_radius_m_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_mission_2fmission_2eproto;
 };
@@ -5894,6 +5905,26 @@ inline void MissionItem::_internal_set_camera_photo_interval_s(double value) {
 inline void MissionItem::set_camera_photo_interval_s(double value) {
   _internal_set_camera_photo_interval_s(value);
   // @@protoc_insertion_point(field_set:mavsdk.rpc.mission.MissionItem.camera_photo_interval_s)
+}
+
+// float acceptance_radius_m = 11 [(.mavsdk.options.default_value) = "NaN"];
+inline void MissionItem::clear_acceptance_radius_m() {
+  acceptance_radius_m_ = 0;
+}
+inline float MissionItem::_internal_acceptance_radius_m() const {
+  return acceptance_radius_m_;
+}
+inline float MissionItem::acceptance_radius_m() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.mission.MissionItem.acceptance_radius_m)
+  return _internal_acceptance_radius_m();
+}
+inline void MissionItem::_internal_set_acceptance_radius_m(float value) {
+  
+  acceptance_radius_m_ = value;
+}
+inline void MissionItem::set_acceptance_radius_m(float value) {
+  _internal_set_acceptance_radius_m(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.mission.MissionItem.acceptance_radius_m)
 }
 
 // -------------------------------------------------------------------

--- a/src/mavsdk_server/src/plugins/mission/mission_service_impl.h
+++ b/src/mavsdk_server/src/plugins/mission/mission_service_impl.h
@@ -107,6 +107,8 @@ public:
 
         rpc_obj->set_camera_photo_interval_s(mission_item.camera_photo_interval_s);
 
+        rpc_obj->set_acceptance_radius_m(mission_item.acceptance_radius_m);
+
         return rpc_obj;
     }
 
@@ -134,6 +136,8 @@ public:
         obj.loiter_time_s = mission_item.loiter_time_s();
 
         obj.camera_photo_interval_s = mission_item.camera_photo_interval_s();
+
+        obj.acceptance_radius_m = mission_item.acceptance_radius_m();
 
         return obj;
     }

--- a/src/plugins/mission/include/plugins/mission/mission.h
+++ b/src/plugins/mission/include/plugins/mission/mission.h
@@ -100,6 +100,7 @@ public:
         float loiter_time_s{float(NAN)}; /**< @brief Loiter time (in seconds) */
         double camera_photo_interval_s{
             1.0}; /**< @brief Camera photo interval to use after this mission item (in seconds) */
+        float acceptance_radius_m{float(NAN)}; /**< @brief Radius for completing a mission item (in metres) */
     };
 
     /**

--- a/src/plugins/mission/include/plugins/mission/mission.h
+++ b/src/plugins/mission/include/plugins/mission/mission.h
@@ -100,7 +100,8 @@ public:
         float loiter_time_s{float(NAN)}; /**< @brief Loiter time (in seconds) */
         double camera_photo_interval_s{
             1.0}; /**< @brief Camera photo interval to use after this mission item (in seconds) */
-        float acceptance_radius_m{float(NAN)}; /**< @brief Radius for completing a mission item (in metres) */
+        float acceptance_radius_m{
+            float(NAN)}; /**< @brief Radius for completing a mission item (in metres) */
     };
 
     /**

--- a/src/plugins/mission/mission.cpp
+++ b/src/plugins/mission/mission.cpp
@@ -155,7 +155,9 @@ bool operator==(const Mission::MissionItem& lhs, const Mission::MissionItem& rhs
            ((std::isnan(rhs.loiter_time_s) && std::isnan(lhs.loiter_time_s)) ||
             rhs.loiter_time_s == lhs.loiter_time_s) &&
            ((std::isnan(rhs.camera_photo_interval_s) && std::isnan(lhs.camera_photo_interval_s)) ||
-            rhs.camera_photo_interval_s == lhs.camera_photo_interval_s);
+            rhs.camera_photo_interval_s == lhs.camera_photo_interval_s) &&
+           ((std::isnan(rhs.acceptance_radius_m) && std::isnan(lhs.acceptance_radius_m)) ||
+            rhs.acceptance_radius_m == lhs.acceptance_radius_m);
 }
 
 std::ostream& operator<<(std::ostream& str, Mission::MissionItem const& mission_item)
@@ -172,6 +174,7 @@ std::ostream& operator<<(std::ostream& str, Mission::MissionItem const& mission_
     str << "    camera_action: " << mission_item.camera_action << '\n';
     str << "    loiter_time_s: " << mission_item.loiter_time_s << '\n';
     str << "    camera_photo_interval_s: " << mission_item.camera_photo_interval_s << '\n';
+    str << "    acceptance_radius_m: " << mission_item.acceptance_radius_m << '\n';
     str << '}';
     return str;
 }

--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -547,6 +547,7 @@ std::pair<Mission::Result, Mission::MissionPlan> MissionImpl::convert_to_result_
                 new_mission_item.relative_altitude_m = int_item.z;
 
                 new_mission_item.is_fly_through = !(int_item.param1 > 0);
+                new_mission_item.acceptance_radius_m = int_item.param2;
 
                 have_set_position = true;
 

--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -266,18 +266,7 @@ float MissionImpl::hold_time(const MissionItem& item)
 
 float MissionImpl::acceptance_radius(const MissionItem& item)
 {
-    float acceptance_radius_m;
-    if (std::isfinite(item.acceptance_radius_m)) {
-        acceptance_radius_m = item.acceptance_radius_m;
-    } else if (item.is_fly_through) {
-        // _acceptance_radius_m is 0, determine the radius using fly_through
-        acceptance_radius_m = 3.0f;
-    } else {
-        // _acceptance_radius_m is 0, determine the radius using fly_through
-        acceptance_radius_m = 1.0f;
-    }
-
-    return acceptance_radius_m;
+    return item.acceptance_radius_m;
 }
 
 std::vector<MAVLinkMissionTransfer::ItemInt>

--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -266,7 +266,18 @@ float MissionImpl::hold_time(const MissionItem& item)
 
 float MissionImpl::acceptance_radius(const MissionItem& item)
 {
-    return item.acceptance_radius_m;
+    float acceptance_radius_m;
+    if (std::isfinite(item.acceptance_radius_m)) {
+        acceptance_radius_m = item.acceptance_radius_m;
+    } else if (item.is_fly_through) {
+        // _acceptance_radius_m is 0, determine the radius using fly_through
+        acceptance_radius_m = 3.0f;
+    } else {
+        // _acceptance_radius_m is 0, determine the radius using fly_through
+        acceptance_radius_m = 1.0f;
+    }
+
+    return acceptance_radius_m;
 }
 
 std::vector<MAVLinkMissionTransfer::ItemInt>

--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -269,8 +269,7 @@ float MissionImpl::acceptance_radius(const MissionItem& item)
     float acceptance_radius_m;
     if (std::isfinite(item.acceptance_radius_m)) {
         acceptance_radius_m = item.acceptance_radius_m;
-    }
-    else if (item.is_fly_through) {
+    } else if (item.is_fly_through) {
         // _acceptance_radius_m is 0, determine the radius using fly_through
         acceptance_radius_m = 3.0f;
     } else {

--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -267,7 +267,10 @@ float MissionImpl::hold_time(const MissionItem& item)
 float MissionImpl::acceptance_radius(const MissionItem& item)
 {
     float acceptance_radius_m;
-    if (item.is_fly_through) {
+    if (std::isfinite(item.acceptance_radius_m)) {
+        acceptance_radius_m = item.acceptance_radius_m;
+    }
+    else if (item.is_fly_through) {
         // _acceptance_radius_m is 0, determine the radius using fly_through
         acceptance_radius_m = 3.0f;
     } else {


### PR DESCRIPTION
Appears this added in a previous PR but disappeared during a refactor. It's a useful option to have as sometimes the defaults are causing some items to never be achieved in our SITL testing (We've now swapped to MissionRaw)

Happy to update the factory funcs + proto to include this, unless there's a reason it was removed :)