### PR TITLE
Patch tinyxml to run on stock Ubuntu 18.04 (with cmake 3.10.2)

### DIFF
--- a/third_party/tinyxml2/CMakeLists.txt
+++ b/third_party/tinyxml2/CMakeLists.txt
@@ -27,9 +27,9 @@ endforeach()
 
 ExternalProject_add(
     tinyxml2
-    #URL https://github.com/leethomason/tinyxml2/archive/8.1.0.tar.gz
-    GIT_REPOSITORY https://github.com/jonasvautherin/tinyxml2
-    GIT_TAG 87b1aac716f009df95c97bd1c365dc395ec4da19
+    GIT_REPOSITORY https://github.com/leethomason/tinyxml2
+    GIT_TAG 55716da04f2de307e01d84ed695bed86114f9136
     PREFIX tinyxml2
+    PATCH_COMMAND git checkout . && git apply ${PROJECT_SOURCE_DIR}/cmake-3.10.2.patch
     CMAKE_ARGS "${CMAKE_ARGS}"
     )

--- a/third_party/tinyxml2/cmake-3.10.2.patch
+++ b/third_party/tinyxml2/cmake-3.10.2.patch
@@ -1,0 +1,102 @@
+commit 2919fb4e5fe988c329e3af5801a9c74f1dcaf9e7
+Author: Jonas Vautherin <jonas.vautherin@gmail.com>
+Date:   Wed May 19 01:22:13 2021 +0200
+
+    Update cmake minimum version to 3.10.2 for Ubuntu 18.04
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4930f5c..11d6688 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.15)
++cmake_minimum_required(VERSION 3.10.2)
+ project(tinyxml2 VERSION 8.1.0)
+ 
+ include(CTest)
+@@ -71,14 +71,26 @@ set(tinyxml2_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/tinyxml2"
+ 
+ ## CMake targets and export scripts
+ 
+-install(
+-    TARGETS tinyxml2 EXPORT tinyxml2-targets
+-    RUNTIME COMPONENT tinyxml2_runtime
+-    LIBRARY COMPONENT tinyxml2_runtime
+-    NAMELINK_COMPONENT tinyxml2_development
+-    ARCHIVE COMPONENT tinyxml2_development
+-    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+-)
++# Set NAMELINK_COMPONENT only if cmake_version >= 3.12
++if(${CMAKE_VERSION} VERSION_LESS "3.12")
++    install(
++        TARGETS tinyxml2 EXPORT tinyxml2-targets
++        RUNTIME COMPONENT tinyxml2_runtime
++        LIBRARY COMPONENT tinyxml2_runtime
++        ARCHIVE COMPONENT tinyxml2_development
++                DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
++    )
++else()
++    install(
++        TARGETS tinyxml2 EXPORT tinyxml2-targets
++        RUNTIME COMPONENT tinyxml2_runtime
++        LIBRARY COMPONENT tinyxml2_runtime
++        NAMELINK_COMPONENT tinyxml2_development
++        ARCHIVE COMPONENT tinyxml2_development
++        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
++    )
++endif()
+ 
+ # Type-specific targets
+ 
+@@ -112,18 +124,28 @@ install(
+ 
+ ## Headers
+ 
+-install(
+-    FILES tinyxml2.h
+-    TYPE INCLUDE
+-    COMPONENT tinyxml2_development
+-)
++if(${CMAKE_VERSION} VERSION_LESS_EQUAL "3.13.5")
++    install(
++        FILES tinyxml2.h
++        COMPONENT tinyxml2_development
++        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
++    )
++else()
++    install(
++        FILES tinyxml2.h
++        TYPE INCLUDE
++        COMPONENT tinyxml2_development
++    )
++endif()
+ 
+ ## pkg-config
+ 
+-configure_file(cmake/tinyxml2.pc.in tinyxml2.pc.gen @ONLY)
+-file(GENERATE OUTPUT tinyxml2.pc INPUT "${CMAKE_CURRENT_BINARY_DIR}/tinyxml2.pc.gen")
+-install(
+-    FILES "${CMAKE_CURRENT_BINARY_DIR}/tinyxml2.pc"
+-    DESTINATION "${tinyxml2_INSTALL_PKGCONFIGDIR}"
+-    COMPONENT tinyxml2_development
+-)
++if(${CMAKE_VERSION} VERSION_GREATER "3.14.7")
++    configure_file(cmake/tinyxml2.pc.in tinyxml2.pc.gen @ONLY)
++    file(GENERATE OUTPUT tinyxml2.pc INPUT "${CMAKE_CURRENT_BINARY_DIR}/tinyxml2.pc.gen")
++    install(
++        FILES "${CMAKE_CURRENT_BINARY_DIR}/tinyxml2.pc"
++        DESTINATION "${tinyxml2_INSTALL_PKGCONFIGDIR}"
++        COMPONENT tinyxml2_development
++    )
++endif()
+diff --git a/cmake/tinyxml2-config.cmake b/cmake/tinyxml2-config.cmake
+index 5baa364..eecbb89 100644
+--- a/cmake/tinyxml2-config.cmake
++++ b/cmake/tinyxml2-config.cmake
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.15)
++cmake_minimum_required(VERSION 3.10.2)
+ 
+ set(tinyxml2_known_comps static shared)
+ set(tinyxml2_comp_static NO)


### PR DESCRIPTION
This uses the upstream repo instead of my fork. Because they don't have interest in supporting Ubuntu 18.04 (the opinion there is that users should update CMake, but I disagree), this uses a patch :see_no_evil: 