### PR TITLE
Identify docs generator script as Python3

### DIFF
--- a/tools/generate_markdown_from_doxygen_xml.py
+++ b/tools/generate_markdown_from_doxygen_xml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 This script converts Doxygen XML output into gitbook-compatible markdown.


### PR DESCRIPTION
This allows the docs to be built on recent Ubuntu builds, which have Python3 rather than Python. However I am not sure it is "right" fix. 