### PR TITLE
core: fix invalid sysid/compid on trimmed messages

### DIFF
--- a/src/core/mavsdk_impl.h
+++ b/src/core/mavsdk_impl.h
@@ -104,6 +104,9 @@ private:
 
     void send_heartbeat();
 
+    static uint8_t get_target_system_id(const mavlink_message_t& message);
+    static uint8_t get_target_component_id(const mavlink_message_t& message);
+
     std::mutex _connections_mutex{};
     std::vector<std::shared_ptr<Connection>> _connections{};
 


### PR DESCRIPTION
It turns out that the fields target_system and target_component can be trimmed if they are zero. In that case we need to assume zero instead of e.g. reading into the CRC of the MAVLink message.

Found together with @JonasVautherin.