### PR TITLE
Add file upload callback registration for mavlink FTP server

### DIFF
--- a/examples/ftp_server/ftp_server.cpp
+++ b/examples/ftp_server/ftp_server.cpp
@@ -50,6 +50,9 @@ int main(int argc, char** argv)
 
     auto ftp_server = Ftp{system_cc};
     ftp_server.set_root_directory(argv[3]);
+    ftp_server.register_file_uploaded_callback([](std::string file_path) {
+        std::cout << "New file uploaded to server: " << file_path << std::endl;
+    });
 
     std::cout << NORMAL_CONSOLE_TEXT << "Mavlink FTP server running." << std::endl
               << "Remote:       " << argv[1] << ":" << argv[2] << std::endl

--- a/src/plugins/ftp/ftp.cpp
+++ b/src/plugins/ftp/ftp.cpp
@@ -33,6 +33,11 @@ void Ftp::upload_async(std::string local_file_path, std::string remote_dir, Uplo
     _impl->upload_async(local_file_path, remote_dir, callback);
 }
 
+void Ftp::register_file_uploaded_callback(FileUploadedCallback callback)
+{
+    _impl->register_file_uploaded_callback(callback);
+}
+
 void Ftp::list_directory_async(std::string remote_dir, const ListDirectoryCallback callback)
 {
     _impl->list_directory_async(remote_dir, callback);

--- a/src/plugins/ftp/ftp_impl.h
+++ b/src/plugins/ftp/ftp_impl.h
@@ -52,6 +52,7 @@ public:
         const std::string& local_file_path,
         const std::string& remote_folder,
         Ftp::UploadCallback callback);
+    void register_file_uploaded_callback(Ftp::FileUploadedCallback callback);
     void list_directory_async(
         const std::string& path, Ftp::ListDirectoryCallback callback, uint32_t offset = 0);
     void create_directory_async(const std::string& path, Ftp::ResultCallback callback);
@@ -145,6 +146,7 @@ private:
 
     struct SessionInfo {
         int fd{-1};
+        std::string file_path{};
         uint32_t file_size{0};
         bool stream_download{false};
         uint32_t stream_offset{0};
@@ -182,6 +184,7 @@ private:
     uint32_t _bytes_transferred = 0;
     uint32_t _file_size = 0;
     std::vector<std::string> _curr_directory_list{};
+    Ftp::FileUploadedCallback _file_uploaded_callback{};
 
     Ftp::ResultCallback _curr_op_result_callback{};
     // _curr_op_progress_callback is used for download_callback_t as well as upload_callback_t

--- a/src/plugins/ftp/include/plugins/ftp/ftp.h
+++ b/src/plugins/ftp/include/plugins/ftp/ftp.h
@@ -140,6 +140,17 @@ public:
     void upload_async(std::string local_file_path, std::string remote_dir, UploadCallback callback);
 
     /**
+     * @brief Callback type for new file uploaded by remote.
+     */
+
+    using FileUploadedCallback = std::function<void(std::string)>;
+
+    /**
+     * @brief Register a callback to be triggered when remote uploads a file to FTP server
+     */
+    void register_file_uploaded_callback(FileUploadedCallback callback);
+
+    /**
      * @brief Callback type for list_directory_async.
      */
     using ListDirectoryCallback = std::function<void(Result, std::vector<std::string>)>;


### PR DESCRIPTION
This PR adds a method to register file uploaded to Mavlink FTP server callback.
When file is successfully uploaded the callback is called with the file path as parameter.