### PR TITLE
Few compatibility improvements for Ardupilot

### DIFF
--- a/src/core/mavlink_commands.cpp
+++ b/src/core/mavlink_commands.cpp
@@ -133,8 +133,8 @@ void MavlinkCommandSender::receive_command_ack(mavlink_message_t message)
     mavlink_command_ack_t command_ack;
     mavlink_msg_command_ack_decode(&message, &command_ack);
 
-    if (command_ack.target_system != _parent.get_own_system_id() &&
-        command_ack.target_component != _parent.get_own_component_id()) {
+    if ((command_ack.target_system && command_ack.target_system != _parent.get_own_system_id()) ||
+        (command_ack.target_component && command_ack.target_component != _parent.get_own_component_id())) {
         return;
     }
 

--- a/src/core/mavlink_commands.cpp
+++ b/src/core/mavlink_commands.cpp
@@ -133,8 +133,7 @@ void MavlinkCommandSender::receive_command_ack(mavlink_message_t message)
     mavlink_command_ack_t command_ack;
     mavlink_msg_command_ack_decode(&message, &command_ack);
 
-    if ((command_ack.target_system &&
-         command_ack.target_system != _parent.get_own_system_id()) ||
+    if ((command_ack.target_system && command_ack.target_system != _parent.get_own_system_id()) ||
         (command_ack.target_component &&
          command_ack.target_component != _parent.get_own_component_id())) {
         return;

--- a/src/core/mavlink_commands.cpp
+++ b/src/core/mavlink_commands.cpp
@@ -133,8 +133,10 @@ void MavlinkCommandSender::receive_command_ack(mavlink_message_t message)
     mavlink_command_ack_t command_ack;
     mavlink_msg_command_ack_decode(&message, &command_ack);
 
-    if ((command_ack.target_system && command_ack.target_system != _parent.get_own_system_id()) ||
-        (command_ack.target_component && command_ack.target_component != _parent.get_own_component_id())) {
+    if ((command_ack.target_system &&
+         command_ack.target_system != _parent.get_own_system_id()) ||
+        (command_ack.target_component &&
+         command_ack.target_component != _parent.get_own_component_id())) {
         return;
     }
 

--- a/src/core/mavlink_commands.h
+++ b/src/core/mavlink_commands.h
@@ -65,19 +65,25 @@ public:
         }
     };
 
+#ifdef ARDUPILOT
+#define COMMAND_LONG_PARAM_UNSET 0
+#else
+#define COMMAND_LONG_PARAM_UNSET NAN
+#endif
+
     struct CommandLong {
         uint8_t target_system_id{0};
         uint8_t target_component_id{0};
         uint16_t command{0};
         uint8_t confirmation = 0;
         struct Params {
-            float param1 = NAN;
-            float param2 = NAN;
-            float param3 = NAN;
-            float param4 = NAN;
-            float param5 = NAN;
-            float param6 = NAN;
-            float param7 = NAN;
+            float param1 = COMMAND_LONG_PARAM_UNSET;
+            float param2 = COMMAND_LONG_PARAM_UNSET;
+            float param3 = COMMAND_LONG_PARAM_UNSET;
+            float param4 = COMMAND_LONG_PARAM_UNSET;
+            float param5 = COMMAND_LONG_PARAM_UNSET;
+            float param6 = COMMAND_LONG_PARAM_UNSET;
+            float param7 = COMMAND_LONG_PARAM_UNSET;
         } params{};
 
         // TODO: rename to set_all

--- a/src/core/mavlink_mission_transfer.cpp
+++ b/src/core/mavlink_mission_transfer.cpp
@@ -251,7 +251,10 @@ void MAVLinkMissionTransfer::UploadWorkItem::process_mission_request(
 
     mavlink_message_t request_int_message;
     mavlink_msg_mission_request_int_encode(
-        request_int.target_system, request_int.target_component, request_int_message, &request_int);
+        request_int.target_system,
+        request_int.target_component,
+        &request_int_message,
+        &request_int);
 
     process_mission_request_int(request_int_message);
 #else // ifdef ARDUPILOT

--- a/src/plugins/action/action_impl.cpp
+++ b/src/plugins/action/action_impl.cpp
@@ -350,7 +350,7 @@ void ActionImpl::takeoff_async(const Action::ResultCallback& callback) const
     command.target_component_id = _parent->get_autopilot_id();
 
 #ifdef ARDUPILOT
-    command.params.param7 = 1.0; // Ardupilot doesn't take off without altitude set
+    command.params.param7 = get_takeoff_altitude().second;
 #endif
 
     _parent->send_command_async(
@@ -577,13 +577,14 @@ void ActionImpl::process_extended_sys_state(const mavlink_message_t& message)
 }
 
 void ActionImpl::set_takeoff_altitude_async(
-    const float relative_altitude_m, const Action::ResultCallback& callback) const
+    const float relative_altitude_m, const Action::ResultCallback& callback)
 {
     callback(set_takeoff_altitude(relative_altitude_m));
 }
 
-Action::Result ActionImpl::set_takeoff_altitude(float relative_altitude_m) const
+Action::Result ActionImpl::set_takeoff_altitude(float relative_altitude_m)
 {
+    _takeoff_altitude = relative_altitude_m;
     const MAVLinkParameters::Result result =
         _parent->set_param_float(TAKEOFF_ALT_PARAM, relative_altitude_m);
     return (result == MAVLinkParameters::Result::Success) ? Action::Result::Success :
@@ -599,11 +600,15 @@ void ActionImpl::get_takeoff_altitude_async(
 
 std::pair<Action::Result, float> ActionImpl::get_takeoff_altitude() const
 {
+#ifdef ARDUPILOT
+    return std::make_pair<>(Action::Result::Success, _takeoff_altitude);
+#else
     auto result = _parent->get_param_float(TAKEOFF_ALT_PARAM);
     return std::make_pair<>(
         (result.first == MAVLinkParameters::Result::Success) ? Action::Result::Success :
                                                                Action::Result::ParameterError,
         result.second);
+#endif
 }
 
 void ActionImpl::set_maximum_speed_async(

--- a/src/plugins/action/action_impl.cpp
+++ b/src/plugins/action/action_impl.cpp
@@ -349,6 +349,10 @@ void ActionImpl::takeoff_async(const Action::ResultCallback& callback) const
     command.command = MAV_CMD_NAV_TAKEOFF;
     command.target_component_id = _parent->get_autopilot_id();
 
+#ifdef ARDUPILOT
+    command.params.param7 = 1.0; // Ardupilot doesn't take off without altitude set
+#endif
+
     _parent->send_command_async(
         command, [this, callback](MavlinkCommandSender::Result result, float) {
             command_result_callback(result, callback);

--- a/src/plugins/action/action_impl.h
+++ b/src/plugins/action/action_impl.h
@@ -76,10 +76,10 @@ public:
     void transition_to_multicopter_async(const Action::ResultCallback& callback) const;
 
     void set_takeoff_altitude_async(
-        const float relative_altitude_m, const Action::ResultCallback& callback) const;
+        const float relative_altitude_m, const Action::ResultCallback& callback);
     void get_takeoff_altitude_async(const Action::GetTakeoffAltitudeCallback& callback) const;
 
-    Action::Result set_takeoff_altitude(float relative_altitude_m) const;
+    Action::Result set_takeoff_altitude(float relative_altitude_m);
     std::pair<Action::Result, float> get_takeoff_altitude() const;
 
     void
@@ -113,6 +113,8 @@ private:
 
     std::atomic<bool> _vtol_transition_support_known{false};
     std::atomic<bool> _vtol_transition_possible{false};
+
+    float _takeoff_altitude{2.0};
 
     static constexpr uint8_t VEHICLE_MODE_FLAG_CUSTOM_MODE_ENABLED = 1;
     static constexpr auto TAKEOFF_ALT_PARAM = "MIS_TAKEOFF_ALT";

--- a/src/plugins/telemetry/telemetry_impl.cpp
+++ b/src/plugins/telemetry/telemetry_impl.cpp
@@ -160,6 +160,7 @@ void TelemetryImpl::enable()
     // FIXME: The calibration check should eventually be better than this.
     //        For now, we just do the same as QGC does.
 
+#ifndef ARDUPILOT
     if (_parent->has_autopilot()) {
         _parent->get_param_int_async(
             std::string("CAL_GYRO0_ID"),
@@ -197,6 +198,7 @@ void TelemetryImpl::enable()
                 std::placeholders::_2),
             this);
     }
+#endif // ifndef ARDUPILOT
 }
 
 void TelemetryImpl::disable() {}


### PR DESCRIPTION
- ACKs from Ardupilot weren't received after https://github.com/mavlink/MAVSDK/pull/1455
- Ardupilot doesn't have CAL_* params, removed requesting them from Telemetry
- some actions (e.g. Action::takeoff) caused Ardupilot to crash because of all command_long params set to NaN by default
- Action::takeoff was denied because no positive altitude was sent
- Mission uploading wasn't working because Ardupilot sends MISSION_REQUEST instead of MISSION_REQUEST_INT

Unfortunately I didn't find a good way to determine if a system is Ardupilot to apply this in real time, so I just used a macro ARDUPILOT set at compilation time. It is probably ok because it's highly unlikely that somebody will use different autopilots at the same time