### PR TITLE
Cancel call_every when subscribing a second time

### DIFF
--- a/src/core/call_every_handler.cpp
+++ b/src/core/call_every_handler.cpp
@@ -56,6 +56,7 @@ void CallEveryHandler::remove(const void* cookie)
     auto it = _entries.find(const_cast<void*>(cookie));
     if (it != _entries.end()) {
         _entries.erase(const_cast<void*>(cookie));
+        cookie = nullptr;
         _iterator_invalidated = true;
     }
 }

--- a/src/plugins/camera/camera_impl.cpp
+++ b/src/plugins/camera/camera_impl.cpp
@@ -493,6 +493,11 @@ void CameraImpl::subscribe_information(const Camera::InformationCallback& callba
     std::lock_guard<std::mutex> lock(_information.mutex);
     _information.subscription_callback = callback;
 
+    // If there was already a subscription, cancel the call
+    if (_status.call_every_cookie) {
+        _parent->remove_call_every(_status.call_every_cookie);
+    }
+
     if (callback) {
         _parent->add_call_every([this]() { request_status(); }, 1.0, &_status.call_every_cookie);
     } else {


### PR DESCRIPTION
It's not fixing a bug I have, but I came across this while reading the code. I believe that if one subscribes twice in a row without unsubscribing, then the first subscription is never cancelled (which is therefore a leak).

The only way to cancel a subscription is by calling `subscribe_` again with `nullptr`, but I think it should support being replaced by another one.

@julianoes maybe to get your opinion on that, as it would probably affect all the subscriptions, and at that point I would maybe look into supporting multiple subscriptions? Not sure.