### PR TITLE
core: remove deprecated UID methods

### DIFF
--- a/src/core/mavlink_mission_transfer.cpp
+++ b/src/core/mavlink_mission_transfer.cpp
@@ -20,6 +20,13 @@ MAVLinkMissionTransfer::~MAVLinkMissionTransfer() {}
 std::weak_ptr<MAVLinkMissionTransfer::WorkItem> MAVLinkMissionTransfer::upload_items_async(
     uint8_t type, const std::vector<ItemInt>& items, ResultCallback callback)
 {
+    if (!_int_messages_supported) {
+        if (callback) {
+            callback(Result::IntMessagesNotSupported);
+        }
+        return {};
+    }
+
     auto ptr = std::make_shared<UploadWorkItem>(
         _sender, _message_handler, _timeout_handler, type, items, _timeout_s_callback(), callback);
 
@@ -31,6 +38,13 @@ std::weak_ptr<MAVLinkMissionTransfer::WorkItem> MAVLinkMissionTransfer::upload_i
 std::weak_ptr<MAVLinkMissionTransfer::WorkItem>
 MAVLinkMissionTransfer::download_items_async(uint8_t type, ResultAndItemsCallback callback)
 {
+    if (!_int_messages_supported) {
+        if (callback) {
+            callback(Result::IntMessagesNotSupported, {});
+        }
+        return {};
+    }
+
     auto ptr = std::make_shared<DownloadWorkItem>(
         _sender, _message_handler, _timeout_handler, type, _timeout_s_callback(), callback);
 
@@ -804,6 +818,11 @@ void MAVLinkMissionTransfer::ClearWorkItem::callback_and_reset(Result result)
     }
     _callback = nullptr;
     _done = true;
+}
+
+void MAVLinkMissionTransfer::set_int_messages_supported(bool supported)
+{
+    _int_messages_supported = supported;
 }
 
 MAVLinkMissionTransfer::SetCurrentWorkItem::SetCurrentWorkItem(

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -43,6 +43,7 @@ public:
         CurrentInvalid,
         ProtocolError,
         InvalidParam,
+        IntMessagesNotSupported
     };
 
     struct ItemInt {
@@ -275,6 +276,8 @@ public:
     void do_work();
     bool is_idle();
 
+    void set_int_messages_supported(bool supported);
+
     // Non-copyable
     MAVLinkMissionTransfer(const MAVLinkMissionTransfer&) = delete;
     const MAVLinkMissionTransfer& operator=(const MAVLinkMissionTransfer&) = delete;
@@ -286,6 +289,8 @@ private:
     TimeoutSCallback _timeout_s_callback;
 
     LockedQueue<WorkItem> _work_queue{};
+
+    bool _int_messages_supported{true};
 };
 
 } // namespace mavsdk

--- a/src/core/mavsdk.cpp
+++ b/src/core/mavsdk.cpp
@@ -70,44 +70,9 @@ void Mavsdk::set_timeout_s(double timeout_s)
     _impl->set_timeout_s(timeout_s);
 }
 
-std::vector<uint64_t> Mavsdk::system_uuids() const
-{
-    return _impl->get_system_uuids();
-}
-
-System& Mavsdk::system() const
-{
-    return _impl->get_system();
-}
-
-System& Mavsdk::system(const uint64_t uuid) const
-{
-    return _impl->get_system(uuid);
-}
-
-bool Mavsdk::is_connected() const
-{
-    return _impl->is_connected();
-}
-
-bool Mavsdk::is_connected(const uint64_t uuid) const
-{
-    return _impl->is_connected(uuid);
-}
-
 void Mavsdk::subscribe_on_new_system(const NewSystemCallback callback)
 {
     _impl->subscribe_on_new_system(callback);
-}
-
-void Mavsdk::register_on_discover(const event_callback_t callback)
-{
-    _impl->register_on_discover(callback);
-}
-
-void Mavsdk::register_on_timeout(const event_callback_t callback)
-{
-    _impl->register_on_timeout(callback);
 }
 
 Mavsdk::Configuration::Configuration(

--- a/src/core/mavsdk.h
+++ b/src/core/mavsdk.h
@@ -279,46 +279,6 @@ public:
     void set_timeout_s(double timeout_s);
 
     /**
-     * @brief Get vector of system UUIDs (deprecated).
-     *
-     * This returns a vector of the UUIDs of all systems that have been discovered.
-     * If a system doesn't have a UUID then Mavsdk will instead use its MAVLink system ID
-     * (range: 0..255).
-     *
-     * @note This method will be deprecated because the UUID will be replaced
-     *       by a uid with 18 bytes.
-     *
-     * @return A vector containing the UUIDs.
-     */
-    DEPRECATED std::vector<uint64_t> system_uuids() const;
-
-    /**
-     * @brief Get the first discovered system.
-     *
-     * This returns the first discovered system or a null system if no system has yet been found.
-     *
-     * @note This method will be deprecated because it will be replaced by a
-     * vector of system pointers.
-     *
-     * @return A reference to a system.
-     */
-    DEPRECATED System& system() const;
-
-    /**
-     * @brief Get the system with the specified UUID (deprecated).
-     *
-     * This returns a system for a given UUID if such a system has been discovered and a null
-     * system otherwise.
-     *
-     * @note This method will be deprecated because the UUID will be replaced
-     *       by a uid with 18 bytes.
-     *
-     * @param uuid UUID of system to get.
-     * @return A reference to the specified system.
-     */
-    DEPRECATED System& system(uint64_t uuid) const;
-
-    /**
      * @brief Callback type discover and timeout notifications.
      */
     using NewSystemCallback = std::function<void()>;
@@ -334,78 +294,6 @@ public:
      * @param callback Callback to subscribe.
      */
     void subscribe_on_new_system(NewSystemCallback callback);
-
-    /**
-     * @brief Callback type for discover and timeout notifications (deprecated).
-     *
-     * @note This typedef is deprecated because the UUID is replaced by uid with 18 bytes.
-     *
-     * @param uuid UUID of system (or MAVLink system ID for systems that don't have a UUID).
-     */
-    typedef std::function<void(uint64_t uuid)> event_callback_t;
-
-    /**
-     * @brief Returns `true` if exactly one system is currently connected.
-     *
-     * Connected means we are receiving heartbeats from this system.
-     * It means the same as "discovered" and "not timed out".
-     *
-     * If multiple systems have connected, this will return `false`.
-     *
-     * @note This method will be deprecated because is_connected will be a
-     *       method of the system, not of mavsdk.
-     *
-     * @return `true` if exactly one system is connected.
-     */
-    DEPRECATED bool is_connected() const;
-
-    /**
-     * @brief Returns `true` if a system is currently connected (deprecated).
-     *
-     * Connected means we are receiving heartbeats from this system.
-     * It means the same as "discovered" and "not timed out".
-     *
-     * @note This method will be deprecated because the UUID will be replaced
-     *       by uid with 18 bytes.
-     *
-     * @param uuid UUID of system to check.
-     * @return `true` if system is connected.
-     */
-    DEPRECATED bool is_connected(uint64_t uuid) const;
-
-    /**
-     * @brief Register callback for system discovery.
-     *
-     * This sets a callback that will be notified if a new system is discovered.
-     *
-     * If systems have been discovered before this callback is registered, they will be notified
-     * at the time this callback is registered.
-     *
-     * @note Only one callback can be registered at a time. If this function is called several
-     * times, previous callbacks will be overwritten.
-     *
-     * @note This method will be deprecated because event_callback_t is
-     *       deprecated and it will be replaced by `subscribe_on_new_system()`.
-     *
-     * @param callback Callback to register.
-     */
-    DEPRECATED void register_on_discover(event_callback_t callback);
-
-    /**
-     * @brief Register callback for system timeout.
-     *
-     * This sets a callback that will be notified if no heartbeat of the system has been received
-     * in 3 seconds.
-     *
-     * @note Only one callback can be registered at a time. If this function is called several
-     * times, previous callbacks will be overwritten.
-     *
-     * @note This method will be deprecated because event_callback_t is
-     *       deprecated and it will be replaced by `subscribe_on_new_system()`.
-     *
-     * @param callback Callback to register.
-     */
-    DEPRECATED void register_on_timeout(event_callback_t callback);
 
 private:
     /* @private. */

--- a/src/core/mavsdk_impl.h
+++ b/src/core/mavsdk_impl.h
@@ -61,23 +61,14 @@ public:
 
     void set_configuration(Mavsdk::Configuration new_configuration);
 
-    std::vector<uint64_t> get_system_uuids() const;
-    System& get_system();
-    System& get_system(uint64_t uuid);
-
     uint8_t get_own_system_id() const;
     uint8_t get_own_component_id() const;
     uint8_t get_mav_type() const;
 
-    bool is_connected() const;
-    bool is_connected(uint64_t uuid) const;
-
     void subscribe_on_new_system(Mavsdk::NewSystemCallback callback);
-    void register_on_discover(Mavsdk::event_callback_t callback);
-    void register_on_timeout(Mavsdk::event_callback_t callback);
 
-    void notify_on_discover(uint64_t uuid);
-    void notify_on_timeout(uint64_t uuid);
+    void notify_on_discover();
+    void notify_on_timeout();
 
     void start_sending_heartbeats();
     void stop_sending_heartbeats();
@@ -103,6 +94,7 @@ private:
     void process_user_callbacks_thread();
 
     void send_heartbeat();
+    bool is_any_system_connected();
 
     static uint8_t get_target_system_id(const mavlink_message_t& message);
     static uint8_t get_target_component_id(const mavlink_message_t& message);
@@ -116,9 +108,6 @@ private:
 
     std::mutex _new_system_callback_mutex{};
     Mavsdk::NewSystemCallback _new_system_callback{nullptr};
-
-    Mavsdk::event_callback_t _on_discover_callback{nullptr};
-    Mavsdk::event_callback_t _on_timeout_callback{nullptr};
 
     Time _time{};
 

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -49,12 +49,6 @@ bool System::is_connected() const
     return _system_impl->is_connected();
 }
 
-uint64_t System::get_uuid() const
-{
-    // We want to support UUIDs if the autopilot tells us.
-    return _system_impl->get_uuid();
-}
-
 uint8_t System::get_system_id() const
 {
     return _system_impl->get_system_id();

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -83,16 +83,6 @@ public:
     bool is_connected() const;
 
     /**
-     * @brief Get the UUID of the system.
-     *
-     * @note This method will be deprecated because the UUID will be replaced
-     *       by a uid with 18 bytes which can be accessed from the info plugin.
-     *
-     * @return UUID of system.
-     */
-    DEPRECATED uint64_t get_uuid() const;
-
-    /**
      * @brief MAVLink System ID of connected system.
      *
      * @note: this is 0 if nothing is connected yet.

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -121,7 +121,6 @@ public:
     bool has_camera(int camera_id = -1) const;
     bool has_gimbal() const;
 
-    uint64_t get_uuid() const;
     uint8_t get_system_id() const;
 
     void set_system_id(uint8_t system_id);
@@ -262,8 +261,6 @@ private:
 
     void request_autopilot_version();
 
-    bool have_uuid() const { return _uuid != 0 && _uuid_initialized; }
-
     void process_heartbeat(const mavlink_message_t& message);
     void process_autopilot_version(const mavlink_message_t& message);
     void process_statustext(const mavlink_message_t& message);
@@ -311,11 +308,6 @@ private:
     };
     std::mutex _statustext_handler_callbacks_mutex{};
     std::vector<StatustextCallback> _statustext_handler_callbacks;
-
-    uint64_t _uuid{0};
-
-    int _uuid_retries = 0;
-    std::atomic<bool> _uuid_initialized{false};
 
     bool _supports_mission_int{false};
     std::atomic<bool> _armed{false};

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -129,8 +129,6 @@ public:
     uint8_t get_own_component_id() const;
     uint8_t get_own_mav_type() const;
 
-    bool does_support_mission_int() const { return _supports_mission_int; }
-
     bool is_armed() const { return _armed; }
 
     MAVLinkParameters::Result set_param_float(const std::string& name, float value);
@@ -309,7 +307,6 @@ private:
     std::mutex _statustext_handler_callbacks_mutex{};
     std::vector<StatustextCallback> _statustext_handler_callbacks;
 
-    bool _supports_mission_int{false};
     std::atomic<bool> _armed{false};
     std::atomic<bool> _hitl_enabled{false};
     bool _always_connected{false};

--- a/src/debug_helpers/drop_debug_main.cpp
+++ b/src/debug_helpers/drop_debug_main.cpp
@@ -7,19 +7,8 @@
 #error DROB_DEBUG needs to be set for this test to work
 #endif
 
-#define UNUSED(x) (void)(x)
-
-bool _discovered_system = false;
-bool _timeouted_system = false;
-
-void on_discover(uint64_t uuid);
-void on_timeout(uint64_t uuid);
-
-int main(int argc, const char* argv[])
+int main(int, const char**)
 {
-    UNUSED(argc);
-    UNUSED(argv);
-
     mavsdk::Mavsdk mavsdk;
 
     mavsdk::ConnectionResult ret = mavsdk.add_udp_connection();
@@ -28,27 +17,9 @@ int main(int argc, const char* argv[])
         return -1;
     }
 
-    mavsdk.register_on_discover(std::bind(&on_discover, std::placeholders::_1));
-    mavsdk.register_on_timeout(std::bind(&on_timeout, std::placeholders::_1));
-
     while (true) {
-        if (!_discovered_system) {
-            std::cout << "waiting for system to appear..." << '\n';
-        }
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 
     return 0;
-}
-
-void on_discover(uint64_t uuid)
-{
-    std::cout << "Found system with UUID: " << uuid << '\n';
-    _discovered_system = true;
-}
-
-void on_timeout(uint64_t uuid)
-{
-    std::cout << "Lost system with UUID: " << uuid << '\n';
-    _timeouted_system = true;
 }

--- a/src/integration_tests/action_hold.cpp
+++ b/src/integration_tests/action_hold.cpp
@@ -84,7 +84,7 @@ TEST_F(SitlTest, ActionHold)
         std::this_thread::sleep_for(std::chrono::seconds(1));
 
         // TODO: currently we need to wait a long time until landed is detected.
-        ASSERT_LT(++iteration, 20);
+        ASSERT_LT(++iteration, 30);
     }
 
     action_ret = action->disarm();

--- a/src/integration_tests/action_hover_sync.cpp
+++ b/src/integration_tests/action_hover_sync.cpp
@@ -92,7 +92,7 @@ void takeoff_and_hover_at_altitude(float altitude_m)
     EXPECT_EQ(action_ret, Action::Result::Success);
 
     EXPECT_TRUE(poll_condition_with_timeout(
-        [telemetry]() { return !telemetry->in_air(); }, std::chrono::seconds(10)));
+        [telemetry]() { return !telemetry->in_air(); }, std::chrono::seconds(20)));
 
     action_ret = action->disarm();
     EXPECT_EQ(action_ret, Action::Result::Success);

--- a/src/integration_tests/action_transition_multicopter_fixedwing.cpp
+++ b/src/integration_tests/action_transition_multicopter_fixedwing.cpp
@@ -7,18 +7,7 @@
 
 using namespace mavsdk;
 
-// static void connect(Mavsdk);
-static void takeoff(std::shared_ptr<Action> action, std::shared_ptr<Telemetry> telemetry);
-void wait_until_hovering(std::shared_ptr<Telemetry> telemetry);
-static void takeoff_and_transition_to_fixedwing();
-static void land_and_disarm(std::shared_ptr<Action> action, std::shared_ptr<Telemetry> telemetry);
-
 TEST_F(SitlTest, ActionTransitionSync_standard_vtol)
-{
-    takeoff_and_transition_to_fixedwing();
-}
-
-void takeoff_and_transition_to_fixedwing()
 {
     // Init & connect
     Mavsdk mavsdk;
@@ -44,11 +33,35 @@ void takeoff_and_transition_to_fixedwing()
     auto action = std::make_shared<Action>(system);
     auto telemetry = std::make_shared<Telemetry>(system);
 
+    while (!telemetry->health_all_ok()) {
+        std::cout << "waiting for system to be ready" << '\n';
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
     // We need to takeoff first, otherwise we can't actually transition
-    takeoff(action, telemetry);
+    float altitude_m = 10.0f;
+    action->set_takeoff_altitude(altitude_m);
+
+    Action::Result action_ret = action->arm();
+    ASSERT_EQ(action_ret, Action::Result::Success);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    LogInfo() << "Taking off";
+    action_ret = action->takeoff();
+    ASSERT_EQ(action_ret, Action::Result::Success);
 
     LogInfo() << "Waiting until hovering";
-    wait_until_hovering(telemetry);
+    auto prom = std::promise<void>{};
+    auto fut = prom.get_future();
+    // Wait until hovering.
+    telemetry->subscribe_flight_mode([&telemetry, &prom](Telemetry::FlightMode mode) {
+        if (mode == Telemetry::FlightMode::Hold) {
+            telemetry->subscribe_flight_mode(nullptr);
+            prom.set_value();
+        }
+    });
+
+    EXPECT_EQ(fut.wait_for(std::chrono::seconds(20)), std::future_status::ready);
 
     LogInfo() << "Transitioning to fixedwing";
     Action::Result transition_result = action->transition_to_fixedwing();
@@ -66,11 +79,6 @@ void takeoff_and_transition_to_fixedwing()
 
     // Return safely to launch position so the next test
     // can start with a clean slate
-    land_and_disarm(action, telemetry);
-}
-
-void land_and_disarm(std::shared_ptr<Action> action, std::shared_ptr<Telemetry> telemetry)
-{
     action->return_to_launch();
 
     // Wait until the vtol is disarmed.
@@ -78,38 +86,4 @@ void land_and_disarm(std::shared_ptr<Action> action, std::shared_ptr<Telemetry> 
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
     LogInfo() << "Disarmed, exiting.";
-}
-
-void takeoff(std::shared_ptr<Action> action, std::shared_ptr<Telemetry> telemetry)
-{
-    while (!telemetry->health_all_ok()) {
-        std::cout << "waiting for system to be ready" << '\n';
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-    }
-
-    float altitude_m = 10.0f;
-    action->set_takeoff_altitude(altitude_m);
-
-    Action::Result action_ret = action->arm();
-    ASSERT_EQ(action_ret, Action::Result::Success);
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-
-    LogInfo() << "Taking off";
-    action_ret = action->takeoff();
-    EXPECT_EQ(action_ret, Action::Result::Success);
-}
-
-void wait_until_hovering(std::shared_ptr<Telemetry> telemetry)
-{
-    auto prom = std::promise<void>{};
-    auto fut = prom.get_future();
-    // Wait until hovering.
-    telemetry->subscribe_flight_mode([&telemetry, &prom](Telemetry::FlightMode mode) {
-        if (mode == Telemetry::FlightMode::Hold) {
-            telemetry->subscribe_flight_mode(nullptr);
-            prom.set_value();
-        }
-    });
-
-    ASSERT_EQ(fut.wait_for(std::chrono::seconds(10)), std::future_status::ready);
 }

--- a/src/integration_tests/integration_test_helper.h
+++ b/src/integration_tests/integration_test_helper.h
@@ -18,6 +18,8 @@ protected:
         const int ret = system((std::string("./tools/start_px4_sitl.sh ") + model).c_str());
         if (ret != 0) {
             mavsdk::LogErr() << "./tools/start_px4_sitl.sh failed, giving up.";
+            fflush(stdout);
+            fflush(stderr);
             abort();
         }
 #else
@@ -32,6 +34,8 @@ protected:
         const int ret = system("./tools/stop_px4_sitl.sh");
         if (ret != 0) {
             mavsdk::LogErr() << "./tools/stop_px4_sitl.sh failed, giving up.";
+            fflush(stdout);
+            fflush(stderr);
             abort();
         }
 #else

--- a/src/integration_tests/path_checker.h
+++ b/src/integration_tests/path_checker.h
@@ -19,7 +19,7 @@ private:
     float _next_reach_altitude = NAN;
     float _last_altitude_m = NAN;
     bool _reached_altitude = false;
-    float _margin_m = 1.0f;
+    float _margin_m = 2.0f; // FIXME: high margin for filter faults happening on landing
 };
 
 } // namespace mavsdk

--- a/src/plugins/geofence/geofence_impl.cpp
+++ b/src/plugins/geofence/geofence_impl.cpp
@@ -129,6 +129,8 @@ Geofence::Result GeofenceImpl::convert_result(MAVLinkMissionTransfer::Result res
             return Geofence::Result::Error; // FIXME
         case MAVLinkMissionTransfer::Result::InvalidParam:
             return Geofence::Result::InvalidArgument; // FIXME
+        case MAVLinkMissionTransfer::Result::IntMessagesNotSupported:
+            return Geofence::Result::Error; // FIXME
         default:
             return Geofence::Result::Unknown;
     }

--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -151,12 +151,6 @@ void MissionImpl::upload_mission_async(
         return;
     }
 
-    if (!_parent->does_support_mission_int()) {
-        LogWarn() << "Mission int messages not supported";
-        // report_mission_result(callback, Mission::Result::Error);
-        return;
-    }
-
     reset_mission_progress();
 
     wait_for_protocol_async([callback, mission_plan, this]() {
@@ -939,6 +933,8 @@ Mission::Result MissionImpl::convert_result(MAVLinkMissionTransfer::Result resul
             return Mission::Result::Error; // FIXME
         case MAVLinkMissionTransfer::Result::InvalidParam:
             return Mission::Result::InvalidArgument; // FIXME
+        case MAVLinkMissionTransfer::Result::IntMessagesNotSupported:
+            return Mission::Result::Unsupported; // FIXME
         default:
             return Mission::Result::Unknown;
     }

--- a/src/plugins/mission_raw/mission_raw_impl.cpp
+++ b/src/plugins/mission_raw/mission_raw_impl.cpp
@@ -140,15 +140,6 @@ void MissionRawImpl::upload_mission_async(
         return;
     }
 
-    if (!_parent->does_support_mission_int()) {
-        _parent->call_user_callback([callback]() {
-            if (callback) {
-                callback(MissionRaw::Result::Unsupported);
-            }
-        });
-        return;
-    }
-
     reset_mission_progress();
 
     const auto int_items = convert_to_int_items(mission_raw);
@@ -522,6 +513,8 @@ MissionRaw::Result MissionRawImpl::convert_result(MAVLinkMissionTransfer::Result
             return MissionRaw::Result::Error; // FIXME
         case MAVLinkMissionTransfer::Result::InvalidParam:
             return MissionRaw::Result::InvalidArgument; // FIXME
+        case MAVLinkMissionTransfer::Result::IntMessagesNotSupported:
+            return MissionRaw::Result::Unsupported; // FIXME
         default:
             return MissionRaw::Result::Unknown;
     }

--- a/tools/stop_px4_sitl.sh
+++ b/tools/stop_px4_sitl.sh
@@ -11,12 +11,22 @@ fi
 
 # Silently shutdown all leftover stuff.
 
-if [[ "$unamestr" == 'Linux' ]]; then
-    killall -q gzviewer
-    killall -q gzserver
-    killall -q px4
+UNAMESTR=$(uname)
+
+if [[ "$UNAMESTR" == 'Linux' ]]; then
+    QUIET="-q"
 else
-    killall gzviewer &
-    killall gzserver &
-    killall px4 &
+    QUIET=""
 fi
+
+killall $QUIET gzviewer
+killall $QUIET gzserver
+killall $QUIET px4
+
+sleep 3
+
+killall $QUIET -SIGKILL gzviewer
+killall $QUIET -SIGKILL gzserver
+killall $QUIET -SIGKILL px4
+
+exit 0


### PR DESCRIPTION
This removes the old UUID stuff which has been marked deprecated for a while. The new way to access the uid is using the Info plugin.