### PR TITLE
Add support for multiple batteries

### DIFF
--- a/src/integration_tests/telemetry_async.cpp
+++ b/src/integration_tests/telemetry_async.cpp
@@ -295,8 +295,7 @@ void print_gps_info(Telemetry::GpsInfo gps_info)
 
 void print_battery(Telemetry::Battery battery)
 {
-    std::cout << "Battery " << battery.id << ": "
-              << battery.voltage_v << " v,"
+    std::cout << "Battery " << battery.id << ": " << battery.voltage_v << " v,"
               << "remaining: " << int(battery.remaining_percent * 1e2f) << " %" << '\n';
 
     _received_battery = true;

--- a/src/integration_tests/telemetry_async.cpp
+++ b/src/integration_tests/telemetry_async.cpp
@@ -295,7 +295,8 @@ void print_gps_info(Telemetry::GpsInfo gps_info)
 
 void print_battery(Telemetry::Battery battery)
 {
-    std::cout << "Battery: " << battery.voltage_v << " v,"
+    std::cout << "Battery " << battery.id << ": "
+              << battery.voltage_v << " v,"
               << "remaining: " << int(battery.remaining_percent * 1e2f) << " %" << '\n';
 
     _received_battery = true;

--- a/src/mavsdk_server/src/generated/telemetry/telemetry.pb.cc
+++ b/src/mavsdk_server/src/generated/telemetry/telemetry.pb.cc
@@ -1424,7 +1424,8 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT RawGpsDefaultTypeInternal _RawG
 constexpr Battery::Battery(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
   : voltage_v_(0)
-  , remaining_percent_(0){}
+  , remaining_percent_(0)
+  , id_(0u){}
 struct BatteryDefaultTypeInternal {
   constexpr BatteryDefaultTypeInternal()
     : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
@@ -2466,6 +2467,7 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_telemetry_2ftelemetry_2eproto:
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::Battery, id_),
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::Battery, voltage_v_),
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::Battery, remaining_percent_),
   ~0u,  // no _has_bits_
@@ -2771,28 +2773,28 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 671, -1, sizeof(::mavsdk::rpc::telemetry::GpsInfo)},
   { 678, -1, sizeof(::mavsdk::rpc::telemetry::RawGps)},
   { 697, -1, sizeof(::mavsdk::rpc::telemetry::Battery)},
-  { 704, -1, sizeof(::mavsdk::rpc::telemetry::Health)},
-  { 716, -1, sizeof(::mavsdk::rpc::telemetry::RcStatus)},
-  { 724, -1, sizeof(::mavsdk::rpc::telemetry::StatusText)},
-  { 731, -1, sizeof(::mavsdk::rpc::telemetry::ActuatorControlTarget)},
-  { 738, -1, sizeof(::mavsdk::rpc::telemetry::ActuatorOutputStatus)},
-  { 745, -1, sizeof(::mavsdk::rpc::telemetry::Covariance)},
-  { 751, -1, sizeof(::mavsdk::rpc::telemetry::VelocityBody)},
-  { 759, -1, sizeof(::mavsdk::rpc::telemetry::PositionBody)},
-  { 767, -1, sizeof(::mavsdk::rpc::telemetry::Odometry)},
-  { 781, -1, sizeof(::mavsdk::rpc::telemetry::DistanceSensor)},
-  { 789, -1, sizeof(::mavsdk::rpc::telemetry::ScaledPressure)},
-  { 799, -1, sizeof(::mavsdk::rpc::telemetry::PositionNed)},
-  { 807, -1, sizeof(::mavsdk::rpc::telemetry::VelocityNed)},
-  { 815, -1, sizeof(::mavsdk::rpc::telemetry::PositionVelocityNed)},
-  { 822, -1, sizeof(::mavsdk::rpc::telemetry::GroundTruth)},
-  { 830, -1, sizeof(::mavsdk::rpc::telemetry::FixedwingMetrics)},
-  { 838, -1, sizeof(::mavsdk::rpc::telemetry::AccelerationFrd)},
-  { 846, -1, sizeof(::mavsdk::rpc::telemetry::AngularVelocityFrd)},
-  { 854, -1, sizeof(::mavsdk::rpc::telemetry::MagneticFieldFrd)},
-  { 862, -1, sizeof(::mavsdk::rpc::telemetry::Imu)},
-  { 872, -1, sizeof(::mavsdk::rpc::telemetry::GpsGlobalOrigin)},
-  { 880, -1, sizeof(::mavsdk::rpc::telemetry::TelemetryResult)},
+  { 705, -1, sizeof(::mavsdk::rpc::telemetry::Health)},
+  { 717, -1, sizeof(::mavsdk::rpc::telemetry::RcStatus)},
+  { 725, -1, sizeof(::mavsdk::rpc::telemetry::StatusText)},
+  { 732, -1, sizeof(::mavsdk::rpc::telemetry::ActuatorControlTarget)},
+  { 739, -1, sizeof(::mavsdk::rpc::telemetry::ActuatorOutputStatus)},
+  { 746, -1, sizeof(::mavsdk::rpc::telemetry::Covariance)},
+  { 752, -1, sizeof(::mavsdk::rpc::telemetry::VelocityBody)},
+  { 760, -1, sizeof(::mavsdk::rpc::telemetry::PositionBody)},
+  { 768, -1, sizeof(::mavsdk::rpc::telemetry::Odometry)},
+  { 782, -1, sizeof(::mavsdk::rpc::telemetry::DistanceSensor)},
+  { 790, -1, sizeof(::mavsdk::rpc::telemetry::ScaledPressure)},
+  { 800, -1, sizeof(::mavsdk::rpc::telemetry::PositionNed)},
+  { 808, -1, sizeof(::mavsdk::rpc::telemetry::VelocityNed)},
+  { 816, -1, sizeof(::mavsdk::rpc::telemetry::PositionVelocityNed)},
+  { 823, -1, sizeof(::mavsdk::rpc::telemetry::GroundTruth)},
+  { 831, -1, sizeof(::mavsdk::rpc::telemetry::FixedwingMetrics)},
+  { 839, -1, sizeof(::mavsdk::rpc::telemetry::AccelerationFrd)},
+  { 847, -1, sizeof(::mavsdk::rpc::telemetry::AngularVelocityFrd)},
+  { 855, -1, sizeof(::mavsdk::rpc::telemetry::MagneticFieldFrd)},
+  { 863, -1, sizeof(::mavsdk::rpc::telemetry::Imu)},
+  { 873, -1, sizeof(::mavsdk::rpc::telemetry::GpsGlobalOrigin)},
+  { 881, -1, sizeof(::mavsdk::rpc::telemetry::TelemetryResult)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -3135,287 +3137,288 @@ const char descriptor_table_protodef_telemetry_2ftelemetry_2eproto[] PROTOBUF_SE
   "zontal_uncertainty_m\030\n \001(\002\022\036\n\026vertical_u"
   "ncertainty_m\030\013 \001(\002\022 \n\030velocity_uncertain"
   "ty_m_s\030\014 \001(\002\022\037\n\027heading_uncertainty_deg\030"
-  "\r \001(\002\022\017\n\007yaw_deg\030\016 \001(\002\"I\n\007Battery\022\032\n\tvol"
-  "tage_v\030\001 \001(\002B\007\202\265\030\003NaN\022\"\n\021remaining_perce"
-  "nt\030\002 \001(\002B\007\202\265\030\003NaN\"\271\002\n\006Health\022.\n\033is_gyrom"
-  "eter_calibration_ok\030\001 \001(\010B\t\202\265\030\005false\0222\n\037"
-  "is_accelerometer_calibration_ok\030\002 \001(\010B\t\202"
-  "\265\030\005false\0221\n\036is_magnetometer_calibration_"
-  "ok\030\003 \001(\010B\t\202\265\030\005false\022\'\n\024is_local_position"
-  "_ok\030\005 \001(\010B\t\202\265\030\005false\022(\n\025is_global_positi"
-  "on_ok\030\006 \001(\010B\t\202\265\030\005false\022&\n\023is_home_positi"
-  "on_ok\030\007 \001(\010B\t\202\265\030\005false\022\035\n\nis_armable\030\010 \001"
-  "(\010B\t\202\265\030\005false\"|\n\010RcStatus\022%\n\022was_availab"
-  "le_once\030\001 \001(\010B\t\202\265\030\005false\022\037\n\014is_available"
-  "\030\002 \001(\010B\t\202\265\030\005false\022(\n\027signal_strength_per"
-  "cent\030\003 \001(\002B\007\202\265\030\003NaN\"N\n\nStatusText\0222\n\004typ"
-  "e\030\001 \001(\0162$.mavsdk.rpc.telemetry.StatusTex"
-  "tType\022\014\n\004text\030\002 \001(\t\"\?\n\025ActuatorControlTa"
-  "rget\022\024\n\005group\030\001 \001(\005B\005\202\265\030\0010\022\020\n\010controls\030\002"
-  " \003(\002\"\?\n\024ActuatorOutputStatus\022\025\n\006active\030\001"
-  " \001(\rB\005\202\265\030\0010\022\020\n\010actuator\030\002 \003(\002\"\'\n\nCovaria"
-  "nce\022\031\n\021covariance_matrix\030\001 \003(\002\";\n\014Veloci"
-  "tyBody\022\r\n\005x_m_s\030\001 \001(\002\022\r\n\005y_m_s\030\002 \001(\002\022\r\n\005"
-  "z_m_s\030\003 \001(\002\"5\n\014PositionBody\022\013\n\003x_m\030\001 \001(\002"
-  "\022\013\n\003y_m\030\002 \001(\002\022\013\n\003z_m\030\003 \001(\002\"\354\004\n\010Odometry\022"
-  "\021\n\ttime_usec\030\001 \001(\004\0229\n\010frame_id\030\002 \001(\0162\'.m"
-  "avsdk.rpc.telemetry.Odometry.MavFrame\022\?\n"
-  "\016child_frame_id\030\003 \001(\0162\'.mavsdk.rpc.telem"
-  "etry.Odometry.MavFrame\0229\n\rposition_body\030"
-  "\004 \001(\0132\".mavsdk.rpc.telemetry.PositionBod"
-  "y\022+\n\001q\030\005 \001(\0132 .mavsdk.rpc.telemetry.Quat"
-  "ernion\0229\n\rvelocity_body\030\006 \001(\0132\".mavsdk.r"
-  "pc.telemetry.VelocityBody\022H\n\025angular_vel"
-  "ocity_body\030\007 \001(\0132).mavsdk.rpc.telemetry."
-  "AngularVelocityBody\0229\n\017pose_covariance\030\010"
-  " \001(\0132 .mavsdk.rpc.telemetry.Covariance\022="
-  "\n\023velocity_covariance\030\t \001(\0132 .mavsdk.rpc"
-  ".telemetry.Covariance\"j\n\010MavFrame\022\023\n\017MAV"
-  "_FRAME_UNDEF\020\000\022\026\n\022MAV_FRAME_BODY_NED\020\010\022\030"
-  "\n\024MAV_FRAME_VISION_NED\020\020\022\027\n\023MAV_FRAME_ES"
-  "TIM_NED\020\022\"\177\n\016DistanceSensor\022#\n\022minimum_d"
-  "istance_m\030\001 \001(\002B\007\202\265\030\003NaN\022#\n\022maximum_dist"
-  "ance_m\030\002 \001(\002B\007\202\265\030\003NaN\022#\n\022current_distanc"
-  "e_m\030\003 \001(\002B\007\202\265\030\003NaN\"\260\001\n\016ScaledPressure\022\024\n"
-  "\014timestamp_us\030\001 \001(\004\022\035\n\025absolute_pressure"
-  "_hpa\030\002 \001(\002\022!\n\031differential_pressure_hpa\030"
-  "\003 \001(\002\022\027\n\017temperature_deg\030\004 \001(\002\022-\n%differ"
-  "ential_pressure_temperature_deg\030\005 \001(\002\"Y\n"
-  "\013PositionNed\022\030\n\007north_m\030\001 \001(\002B\007\202\265\030\003NaN\022\027"
-  "\n\006east_m\030\002 \001(\002B\007\202\265\030\003NaN\022\027\n\006down_m\030\003 \001(\002B"
-  "\007\202\265\030\003NaN\"D\n\013VelocityNed\022\021\n\tnorth_m_s\030\001 \001"
-  "(\002\022\020\n\010east_m_s\030\002 \001(\002\022\020\n\010down_m_s\030\003 \001(\002\"\177"
-  "\n\023PositionVelocityNed\0223\n\010position\030\001 \001(\0132"
-  "!.mavsdk.rpc.telemetry.PositionNed\0223\n\010ve"
-  "locity\030\002 \001(\0132!.mavsdk.rpc.telemetry.Velo"
-  "cityNed\"r\n\013GroundTruth\022\035\n\014latitude_deg\030\001"
-  " \001(\001B\007\202\265\030\003NaN\022\036\n\rlongitude_deg\030\002 \001(\001B\007\202\265"
-  "\030\003NaN\022$\n\023absolute_altitude_m\030\003 \001(\002B\007\202\265\030\003"
-  "NaN\"x\n\020FixedwingMetrics\022\035\n\014airspeed_m_s\030"
-  "\001 \001(\002B\007\202\265\030\003NaN\022$\n\023throttle_percentage\030\002 "
-  "\001(\002B\007\202\265\030\003NaN\022\037\n\016climb_rate_m_s\030\003 \001(\002B\007\202\265"
-  "\030\003NaN\"i\n\017AccelerationFrd\022\035\n\014forward_m_s2"
-  "\030\001 \001(\002B\007\202\265\030\003NaN\022\033\n\nright_m_s2\030\002 \001(\002B\007\202\265\030"
-  "\003NaN\022\032\n\tdown_m_s2\030\003 \001(\002B\007\202\265\030\003NaN\"o\n\022Angu"
-  "larVelocityFrd\022\036\n\rforward_rad_s\030\001 \001(\002B\007\202"
-  "\265\030\003NaN\022\034\n\013right_rad_s\030\002 \001(\002B\007\202\265\030\003NaN\022\033\n\n"
-  "down_rad_s\030\003 \001(\002B\007\202\265\030\003NaN\"m\n\020MagneticFie"
-  "ldFrd\022\036\n\rforward_gauss\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n"
-  "\013right_gauss\030\002 \001(\002B\007\202\265\030\003NaN\022\033\n\ndown_gaus"
-  "s\030\003 \001(\002B\007\202\265\030\003NaN\"\213\002\n\003Imu\022\?\n\020acceleration"
-  "_frd\030\001 \001(\0132%.mavsdk.rpc.telemetry.Accele"
-  "rationFrd\022F\n\024angular_velocity_frd\030\002 \001(\0132"
-  "(.mavsdk.rpc.telemetry.AngularVelocityFr"
-  "d\022B\n\022magnetic_field_frd\030\003 \001(\0132&.mavsdk.r"
-  "pc.telemetry.MagneticFieldFrd\022!\n\020tempera"
-  "ture_degc\030\004 \001(\002B\007\202\265\030\003NaN\022\024\n\014timestamp_us"
-  "\030\005 \001(\004\"m\n\017GpsGlobalOrigin\022\035\n\014latitude_de"
-  "g\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlongitude_deg\030\002 \001(\001B"
-  "\007\202\265\030\003NaN\022\033\n\naltitude_m\030\003 \001(\002B\007\202\265\030\003NaN\"\241\002"
-  "\n\017TelemetryResult\022<\n\006result\030\001 \001(\0162,.mavs"
-  "dk.rpc.telemetry.TelemetryResult.Result\022"
-  "\022\n\nresult_str\030\002 \001(\t\"\273\001\n\006Result\022\022\n\016RESULT"
-  "_UNKNOWN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\024\n\020RESULT"
-  "_NO_SYSTEM\020\002\022\033\n\027RESULT_CONNECTION_ERROR\020"
-  "\003\022\017\n\013RESULT_BUSY\020\004\022\031\n\025RESULT_COMMAND_DEN"
-  "IED\020\005\022\022\n\016RESULT_TIMEOUT\020\006\022\026\n\022RESULT_UNSU"
-  "PPORTED\020\007*\244\001\n\007FixType\022\023\n\017FIX_TYPE_NO_GPS"
-  "\020\000\022\023\n\017FIX_TYPE_NO_FIX\020\001\022\023\n\017FIX_TYPE_FIX_"
-  "2D\020\002\022\023\n\017FIX_TYPE_FIX_3D\020\003\022\025\n\021FIX_TYPE_FI"
-  "X_DGPS\020\004\022\026\n\022FIX_TYPE_RTK_FLOAT\020\005\022\026\n\022FIX_"
-  "TYPE_RTK_FIXED\020\006*\206\003\n\nFlightMode\022\027\n\023FLIGH"
-  "T_MODE_UNKNOWN\020\000\022\025\n\021FLIGHT_MODE_READY\020\001\022"
-  "\027\n\023FLIGHT_MODE_TAKEOFF\020\002\022\024\n\020FLIGHT_MODE_"
-  "HOLD\020\003\022\027\n\023FLIGHT_MODE_MISSION\020\004\022 \n\034FLIGH"
-  "T_MODE_RETURN_TO_LAUNCH\020\005\022\024\n\020FLIGHT_MODE"
-  "_LAND\020\006\022\030\n\024FLIGHT_MODE_OFFBOARD\020\007\022\031\n\025FLI"
-  "GHT_MODE_FOLLOW_ME\020\010\022\026\n\022FLIGHT_MODE_MANU"
-  "AL\020\t\022\026\n\022FLIGHT_MODE_ALTCTL\020\n\022\026\n\022FLIGHT_M"
-  "ODE_POSCTL\020\013\022\024\n\020FLIGHT_MODE_ACRO\020\014\022\032\n\026FL"
-  "IGHT_MODE_STABILIZED\020\r\022\031\n\025FLIGHT_MODE_RA"
-  "TTITUDE\020\016*\371\001\n\016StatusTextType\022\032\n\026STATUS_T"
-  "EXT_TYPE_DEBUG\020\000\022\031\n\025STATUS_TEXT_TYPE_INF"
-  "O\020\001\022\033\n\027STATUS_TEXT_TYPE_NOTICE\020\002\022\034\n\030STAT"
-  "US_TEXT_TYPE_WARNING\020\003\022\032\n\026STATUS_TEXT_TY"
-  "PE_ERROR\020\004\022\035\n\031STATUS_TEXT_TYPE_CRITICAL\020"
-  "\005\022\032\n\026STATUS_TEXT_TYPE_ALERT\020\006\022\036\n\032STATUS_"
-  "TEXT_TYPE_EMERGENCY\020\007*\223\001\n\013LandedState\022\030\n"
-  "\024LANDED_STATE_UNKNOWN\020\000\022\032\n\026LANDED_STATE_"
-  "ON_GROUND\020\001\022\027\n\023LANDED_STATE_IN_AIR\020\002\022\033\n\027"
-  "LANDED_STATE_TAKING_OFF\020\003\022\030\n\024LANDED_STAT"
-  "E_LANDING\020\0042\2473\n\020TelemetryService\022o\n\021Subs"
-  "cribePosition\022..mavsdk.rpc.telemetry.Sub"
-  "scribePositionRequest\032&.mavsdk.rpc.telem"
-  "etry.PositionResponse\"\0000\001\022c\n\rSubscribeHo"
-  "me\022*.mavsdk.rpc.telemetry.SubscribeHomeR"
-  "equest\032\".mavsdk.rpc.telemetry.HomeRespon"
-  "se\"\0000\001\022f\n\016SubscribeInAir\022+.mavsdk.rpc.te"
-  "lemetry.SubscribeInAirRequest\032#.mavsdk.r"
-  "pc.telemetry.InAirResponse\"\0000\001\022x\n\024Subscr"
-  "ibeLandedState\0221.mavsdk.rpc.telemetry.Su"
-  "bscribeLandedStateRequest\032).mavsdk.rpc.t"
-  "elemetry.LandedStateResponse\"\0000\001\022f\n\016Subs"
-  "cribeArmed\022+.mavsdk.rpc.telemetry.Subscr"
-  "ibeArmedRequest\032#.mavsdk.rpc.telemetry.A"
-  "rmedResponse\"\0000\001\022\215\001\n\033SubscribeAttitudeQu"
-  "aternion\0228.mavsdk.rpc.telemetry.Subscrib"
-  "eAttitudeQuaternionRequest\0320.mavsdk.rpc."
-  "telemetry.AttitudeQuaternionResponse\"\0000\001"
-  "\022~\n\026SubscribeAttitudeEuler\0223.mavsdk.rpc."
-  "telemetry.SubscribeAttitudeEulerRequest\032"
-  "+.mavsdk.rpc.telemetry.AttitudeEulerResp"
-  "onse\"\0000\001\022\250\001\n$SubscribeAttitudeAngularVel"
-  "ocityBody\022A.mavsdk.rpc.telemetry.Subscri"
-  "beAttitudeAngularVelocityBodyRequest\0329.m"
-  "avsdk.rpc.telemetry.AttitudeAngularVeloc"
-  "ityBodyResponse\"\0000\001\022\237\001\n!SubscribeCameraA"
-  "ttitudeQuaternion\022>.mavsdk.rpc.telemetry"
-  ".SubscribeCameraAttitudeQuaternionReques"
-  "t\0326.mavsdk.rpc.telemetry.CameraAttitudeQ"
-  "uaternionResponse\"\0000\001\022\220\001\n\034SubscribeCamer"
-  "aAttitudeEuler\0229.mavsdk.rpc.telemetry.Su"
-  "bscribeCameraAttitudeEulerRequest\0321.mavs"
-  "dk.rpc.telemetry.CameraAttitudeEulerResp"
-  "onse\"\0000\001\022x\n\024SubscribeVelocityNed\0221.mavsd"
-  "k.rpc.telemetry.SubscribeVelocityNedRequ"
-  "est\032).mavsdk.rpc.telemetry.VelocityNedRe"
-  "sponse\"\0000\001\022l\n\020SubscribeGpsInfo\022-.mavsdk."
-  "rpc.telemetry.SubscribeGpsInfoRequest\032%."
-  "mavsdk.rpc.telemetry.GpsInfoResponse\"\0000\001"
-  "\022i\n\017SubscribeRawGps\022,.mavsdk.rpc.telemet"
-  "ry.SubscribeRawGpsRequest\032$.mavsdk.rpc.t"
-  "elemetry.RawGpsResponse\"\0000\001\022l\n\020Subscribe"
-  "Battery\022-.mavsdk.rpc.telemetry.Subscribe"
-  "BatteryRequest\032%.mavsdk.rpc.telemetry.Ba"
-  "tteryResponse\"\0000\001\022u\n\023SubscribeFlightMode"
-  "\0220.mavsdk.rpc.telemetry.SubscribeFlightM"
-  "odeRequest\032(.mavsdk.rpc.telemetry.Flight"
-  "ModeResponse\"\0000\001\022i\n\017SubscribeHealth\022,.ma"
-  "vsdk.rpc.telemetry.SubscribeHealthReques"
-  "t\032$.mavsdk.rpc.telemetry.HealthResponse\""
-  "\0000\001\022o\n\021SubscribeRcStatus\022..mavsdk.rpc.te"
-  "lemetry.SubscribeRcStatusRequest\032&.mavsd"
-  "k.rpc.telemetry.RcStatusResponse\"\0000\001\022u\n\023"
-  "SubscribeStatusText\0220.mavsdk.rpc.telemet"
-  "ry.SubscribeStatusTextRequest\032(.mavsdk.r"
-  "pc.telemetry.StatusTextResponse\"\0000\001\022\226\001\n\036"
-  "SubscribeActuatorControlTarget\022;.mavsdk."
-  "rpc.telemetry.SubscribeActuatorControlTa"
-  "rgetRequest\0323.mavsdk.rpc.telemetry.Actua"
-  "torControlTargetResponse\"\0000\001\022\223\001\n\035Subscri"
-  "beActuatorOutputStatus\022:.mavsdk.rpc.tele"
-  "metry.SubscribeActuatorOutputStatusReque"
-  "st\0322.mavsdk.rpc.telemetry.ActuatorOutput"
-  "StatusResponse\"\0000\001\022o\n\021SubscribeOdometry\022"
-  "..mavsdk.rpc.telemetry.SubscribeOdometry"
-  "Request\032&.mavsdk.rpc.telemetry.OdometryR"
-  "esponse\"\0000\001\022\220\001\n\034SubscribePositionVelocit"
-  "yNed\0229.mavsdk.rpc.telemetry.SubscribePos"
-  "itionVelocityNedRequest\0321.mavsdk.rpc.tel"
-  "emetry.PositionVelocityNedResponse\"\0000\001\022x"
-  "\n\024SubscribeGroundTruth\0221.mavsdk.rpc.tele"
-  "metry.SubscribeGroundTruthRequest\032).mavs"
-  "dk.rpc.telemetry.GroundTruthResponse\"\0000\001"
-  "\022\207\001\n\031SubscribeFixedwingMetrics\0226.mavsdk."
-  "rpc.telemetry.SubscribeFixedwingMetricsR"
-  "equest\032..mavsdk.rpc.telemetry.FixedwingM"
-  "etricsResponse\"\0000\001\022`\n\014SubscribeImu\022).mav"
-  "sdk.rpc.telemetry.SubscribeImuRequest\032!."
-  "mavsdk.rpc.telemetry.ImuResponse\"\0000\001\022r\n\022"
-  "SubscribeScaledImu\022/.mavsdk.rpc.telemetr"
-  "y.SubscribeScaledImuRequest\032\'.mavsdk.rpc"
-  ".telemetry.ScaledImuResponse\"\0000\001\022i\n\017Subs"
-  "cribeRawImu\022,.mavsdk.rpc.telemetry.Subsc"
-  "ribeRawImuRequest\032$.mavsdk.rpc.telemetry"
-  ".RawImuResponse\"\0000\001\022x\n\024SubscribeHealthAl"
-  "lOk\0221.mavsdk.rpc.telemetry.SubscribeHeal"
-  "thAllOkRequest\032).mavsdk.rpc.telemetry.He"
-  "althAllOkResponse\"\0000\001\022~\n\026SubscribeUnixEp"
-  "ochTime\0223.mavsdk.rpc.telemetry.Subscribe"
-  "UnixEpochTimeRequest\032+.mavsdk.rpc.teleme"
-  "try.UnixEpochTimeResponse\"\0000\001\022\201\001\n\027Subscr"
-  "ibeDistanceSensor\0224.mavsdk.rpc.telemetry"
-  ".SubscribeDistanceSensorRequest\032,.mavsdk"
-  ".rpc.telemetry.DistanceSensorResponse\"\0000"
-  "\001\022\201\001\n\027SubscribeScaledPressure\0224.mavsdk.r"
-  "pc.telemetry.SubscribeScaledPressureRequ"
-  "est\032,.mavsdk.rpc.telemetry.ScaledPressur"
-  "eResponse\"\0000\001\022p\n\017SetRatePosition\022,.mavsd"
-  "k.rpc.telemetry.SetRatePositionRequest\032-"
-  ".mavsdk.rpc.telemetry.SetRatePositionRes"
-  "ponse\"\000\022d\n\013SetRateHome\022(.mavsdk.rpc.tele"
-  "metry.SetRateHomeRequest\032).mavsdk.rpc.te"
-  "lemetry.SetRateHomeResponse\"\000\022g\n\014SetRate"
-  "InAir\022).mavsdk.rpc.telemetry.SetRateInAi"
-  "rRequest\032*.mavsdk.rpc.telemetry.SetRateI"
-  "nAirResponse\"\000\022y\n\022SetRateLandedState\022/.m"
-  "avsdk.rpc.telemetry.SetRateLandedStateRe"
-  "quest\0320.mavsdk.rpc.telemetry.SetRateLand"
-  "edStateResponse\"\000\022p\n\017SetRateAttitude\022,.m"
-  "avsdk.rpc.telemetry.SetRateAttitudeReque"
-  "st\032-.mavsdk.rpc.telemetry.SetRateAttitud"
-  "eResponse\"\000\022\202\001\n\025SetRateCameraAttitude\0222."
-  "mavsdk.rpc.telemetry.SetRateCameraAttitu"
-  "deRequest\0323.mavsdk.rpc.telemetry.SetRate"
-  "CameraAttitudeResponse\"\000\022y\n\022SetRateVeloc"
-  "ityNed\022/.mavsdk.rpc.telemetry.SetRateVel"
-  "ocityNedRequest\0320.mavsdk.rpc.telemetry.S"
-  "etRateVelocityNedResponse\"\000\022m\n\016SetRateGp"
-  "sInfo\022+.mavsdk.rpc.telemetry.SetRateGpsI"
-  "nfoRequest\032,.mavsdk.rpc.telemetry.SetRat"
-  "eGpsInfoResponse\"\000\022m\n\016SetRateBattery\022+.m"
-  "avsdk.rpc.telemetry.SetRateBatteryReques"
-  "t\032,.mavsdk.rpc.telemetry.SetRateBatteryR"
-  "esponse\"\000\022p\n\017SetRateRcStatus\022,.mavsdk.rp"
-  "c.telemetry.SetRateRcStatusRequest\032-.mav"
-  "sdk.rpc.telemetry.SetRateRcStatusRespons"
-  "e\"\000\022\227\001\n\034SetRateActuatorControlTarget\0229.m"
-  "avsdk.rpc.telemetry.SetRateActuatorContr"
-  "olTargetRequest\032:.mavsdk.rpc.telemetry.S"
-  "etRateActuatorControlTargetResponse\"\000\022\224\001"
-  "\n\033SetRateActuatorOutputStatus\0228.mavsdk.r"
-  "pc.telemetry.SetRateActuatorOutputStatus"
-  "Request\0329.mavsdk.rpc.telemetry.SetRateAc"
-  "tuatorOutputStatusResponse\"\000\022p\n\017SetRateO"
-  "dometry\022,.mavsdk.rpc.telemetry.SetRateOd"
-  "ometryRequest\032-.mavsdk.rpc.telemetry.Set"
-  "RateOdometryResponse\"\000\022\221\001\n\032SetRatePositi"
-  "onVelocityNed\0227.mavsdk.rpc.telemetry.Set"
-  "RatePositionVelocityNedRequest\0328.mavsdk."
-  "rpc.telemetry.SetRatePositionVelocityNed"
-  "Response\"\000\022y\n\022SetRateGroundTruth\022/.mavsd"
-  "k.rpc.telemetry.SetRateGroundTruthReques"
-  "t\0320.mavsdk.rpc.telemetry.SetRateGroundTr"
-  "uthResponse\"\000\022\210\001\n\027SetRateFixedwingMetric"
-  "s\0224.mavsdk.rpc.telemetry.SetRateFixedwin"
-  "gMetricsRequest\0325.mavsdk.rpc.telemetry.S"
-  "etRateFixedwingMetricsResponse\"\000\022a\n\nSetR"
-  "ateImu\022\'.mavsdk.rpc.telemetry.SetRateImu"
-  "Request\032(.mavsdk.rpc.telemetry.SetRateIm"
-  "uResponse\"\000\022s\n\020SetRateScaledImu\022-.mavsdk"
-  ".rpc.telemetry.SetRateScaledImuRequest\032."
-  ".mavsdk.rpc.telemetry.SetRateScaledImuRe"
-  "sponse\"\000\022j\n\rSetRateRawImu\022*.mavsdk.rpc.t"
-  "elemetry.SetRateRawImuRequest\032+.mavsdk.r"
-  "pc.telemetry.SetRateRawImuResponse\"\000\022\177\n\024"
-  "SetRateUnixEpochTime\0221.mavsdk.rpc.teleme"
-  "try.SetRateUnixEpochTimeRequest\0322.mavsdk"
-  ".rpc.telemetry.SetRateUnixEpochTimeRespo"
-  "nse\"\000\022\202\001\n\025SetRateDistanceSensor\0222.mavsdk"
-  ".rpc.telemetry.SetRateDistanceSensorRequ"
-  "est\0323.mavsdk.rpc.telemetry.SetRateDistan"
-  "ceSensorResponse\"\000\022y\n\022GetGpsGlobalOrigin"
-  "\022/.mavsdk.rpc.telemetry.GetGpsGlobalOrig"
-  "inRequest\0320.mavsdk.rpc.telemetry.GetGpsG"
-  "lobalOriginResponse\"\000B%\n\023io.mavsdk.telem"
-  "etryB\016TelemetryProtob\006proto3"
+  "\r \001(\002\022\017\n\007yaw_deg\030\016 \001(\002\"\\\n\007Battery\022\021\n\002id\030"
+  "\003 \001(\rB\005\202\265\030\0010\022\032\n\tvoltage_v\030\001 \001(\002B\007\202\265\030\003NaN"
+  "\022\"\n\021remaining_percent\030\002 \001(\002B\007\202\265\030\003NaN\"\271\002\n"
+  "\006Health\022.\n\033is_gyrometer_calibration_ok\030\001"
+  " \001(\010B\t\202\265\030\005false\0222\n\037is_accelerometer_cali"
+  "bration_ok\030\002 \001(\010B\t\202\265\030\005false\0221\n\036is_magnet"
+  "ometer_calibration_ok\030\003 \001(\010B\t\202\265\030\005false\022\'"
+  "\n\024is_local_position_ok\030\005 \001(\010B\t\202\265\030\005false\022"
+  "(\n\025is_global_position_ok\030\006 \001(\010B\t\202\265\030\005fals"
+  "e\022&\n\023is_home_position_ok\030\007 \001(\010B\t\202\265\030\005fals"
+  "e\022\035\n\nis_armable\030\010 \001(\010B\t\202\265\030\005false\"|\n\010RcSt"
+  "atus\022%\n\022was_available_once\030\001 \001(\010B\t\202\265\030\005fa"
+  "lse\022\037\n\014is_available\030\002 \001(\010B\t\202\265\030\005false\022(\n\027"
+  "signal_strength_percent\030\003 \001(\002B\007\202\265\030\003NaN\"N"
+  "\n\nStatusText\0222\n\004type\030\001 \001(\0162$.mavsdk.rpc."
+  "telemetry.StatusTextType\022\014\n\004text\030\002 \001(\t\"\?"
+  "\n\025ActuatorControlTarget\022\024\n\005group\030\001 \001(\005B\005"
+  "\202\265\030\0010\022\020\n\010controls\030\002 \003(\002\"\?\n\024ActuatorOutpu"
+  "tStatus\022\025\n\006active\030\001 \001(\rB\005\202\265\030\0010\022\020\n\010actuat"
+  "or\030\002 \003(\002\"\'\n\nCovariance\022\031\n\021covariance_mat"
+  "rix\030\001 \003(\002\";\n\014VelocityBody\022\r\n\005x_m_s\030\001 \001(\002"
+  "\022\r\n\005y_m_s\030\002 \001(\002\022\r\n\005z_m_s\030\003 \001(\002\"5\n\014Positi"
+  "onBody\022\013\n\003x_m\030\001 \001(\002\022\013\n\003y_m\030\002 \001(\002\022\013\n\003z_m\030"
+  "\003 \001(\002\"\354\004\n\010Odometry\022\021\n\ttime_usec\030\001 \001(\004\0229\n"
+  "\010frame_id\030\002 \001(\0162\'.mavsdk.rpc.telemetry.O"
+  "dometry.MavFrame\022\?\n\016child_frame_id\030\003 \001(\016"
+  "2\'.mavsdk.rpc.telemetry.Odometry.MavFram"
+  "e\0229\n\rposition_body\030\004 \001(\0132\".mavsdk.rpc.te"
+  "lemetry.PositionBody\022+\n\001q\030\005 \001(\0132 .mavsdk"
+  ".rpc.telemetry.Quaternion\0229\n\rvelocity_bo"
+  "dy\030\006 \001(\0132\".mavsdk.rpc.telemetry.Velocity"
+  "Body\022H\n\025angular_velocity_body\030\007 \001(\0132).ma"
+  "vsdk.rpc.telemetry.AngularVelocityBody\0229"
+  "\n\017pose_covariance\030\010 \001(\0132 .mavsdk.rpc.tel"
+  "emetry.Covariance\022=\n\023velocity_covariance"
+  "\030\t \001(\0132 .mavsdk.rpc.telemetry.Covariance"
+  "\"j\n\010MavFrame\022\023\n\017MAV_FRAME_UNDEF\020\000\022\026\n\022MAV"
+  "_FRAME_BODY_NED\020\010\022\030\n\024MAV_FRAME_VISION_NE"
+  "D\020\020\022\027\n\023MAV_FRAME_ESTIM_NED\020\022\"\177\n\016Distance"
+  "Sensor\022#\n\022minimum_distance_m\030\001 \001(\002B\007\202\265\030\003"
+  "NaN\022#\n\022maximum_distance_m\030\002 \001(\002B\007\202\265\030\003NaN"
+  "\022#\n\022current_distance_m\030\003 \001(\002B\007\202\265\030\003NaN\"\260\001"
+  "\n\016ScaledPressure\022\024\n\014timestamp_us\030\001 \001(\004\022\035"
+  "\n\025absolute_pressure_hpa\030\002 \001(\002\022!\n\031differe"
+  "ntial_pressure_hpa\030\003 \001(\002\022\027\n\017temperature_"
+  "deg\030\004 \001(\002\022-\n%differential_pressure_tempe"
+  "rature_deg\030\005 \001(\002\"Y\n\013PositionNed\022\030\n\007north"
+  "_m\030\001 \001(\002B\007\202\265\030\003NaN\022\027\n\006east_m\030\002 \001(\002B\007\202\265\030\003N"
+  "aN\022\027\n\006down_m\030\003 \001(\002B\007\202\265\030\003NaN\"D\n\013VelocityN"
+  "ed\022\021\n\tnorth_m_s\030\001 \001(\002\022\020\n\010east_m_s\030\002 \001(\002\022"
+  "\020\n\010down_m_s\030\003 \001(\002\"\177\n\023PositionVelocityNed"
+  "\0223\n\010position\030\001 \001(\0132!.mavsdk.rpc.telemetr"
+  "y.PositionNed\0223\n\010velocity\030\002 \001(\0132!.mavsdk"
+  ".rpc.telemetry.VelocityNed\"r\n\013GroundTrut"
+  "h\022\035\n\014latitude_deg\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlong"
+  "itude_deg\030\002 \001(\001B\007\202\265\030\003NaN\022$\n\023absolute_alt"
+  "itude_m\030\003 \001(\002B\007\202\265\030\003NaN\"x\n\020FixedwingMetri"
+  "cs\022\035\n\014airspeed_m_s\030\001 \001(\002B\007\202\265\030\003NaN\022$\n\023thr"
+  "ottle_percentage\030\002 \001(\002B\007\202\265\030\003NaN\022\037\n\016climb"
+  "_rate_m_s\030\003 \001(\002B\007\202\265\030\003NaN\"i\n\017Acceleration"
+  "Frd\022\035\n\014forward_m_s2\030\001 \001(\002B\007\202\265\030\003NaN\022\033\n\nri"
+  "ght_m_s2\030\002 \001(\002B\007\202\265\030\003NaN\022\032\n\tdown_m_s2\030\003 \001"
+  "(\002B\007\202\265\030\003NaN\"o\n\022AngularVelocityFrd\022\036\n\rfor"
+  "ward_rad_s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right_rad_s"
+  "\030\002 \001(\002B\007\202\265\030\003NaN\022\033\n\ndown_rad_s\030\003 \001(\002B\007\202\265\030"
+  "\003NaN\"m\n\020MagneticFieldFrd\022\036\n\rforward_gaus"
+  "s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right_gauss\030\002 \001(\002B\007\202"
+  "\265\030\003NaN\022\033\n\ndown_gauss\030\003 \001(\002B\007\202\265\030\003NaN\"\213\002\n\003"
+  "Imu\022\?\n\020acceleration_frd\030\001 \001(\0132%.mavsdk.r"
+  "pc.telemetry.AccelerationFrd\022F\n\024angular_"
+  "velocity_frd\030\002 \001(\0132(.mavsdk.rpc.telemetr"
+  "y.AngularVelocityFrd\022B\n\022magnetic_field_f"
+  "rd\030\003 \001(\0132&.mavsdk.rpc.telemetry.Magnetic"
+  "FieldFrd\022!\n\020temperature_degc\030\004 \001(\002B\007\202\265\030\003"
+  "NaN\022\024\n\014timestamp_us\030\005 \001(\004\"m\n\017GpsGlobalOr"
+  "igin\022\035\n\014latitude_deg\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rl"
+  "ongitude_deg\030\002 \001(\001B\007\202\265\030\003NaN\022\033\n\naltitude_"
+  "m\030\003 \001(\002B\007\202\265\030\003NaN\"\241\002\n\017TelemetryResult\022<\n\006"
+  "result\030\001 \001(\0162,.mavsdk.rpc.telemetry.Tele"
+  "metryResult.Result\022\022\n\nresult_str\030\002 \001(\t\"\273"
+  "\001\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESULT_"
+  "SUCCESS\020\001\022\024\n\020RESULT_NO_SYSTEM\020\002\022\033\n\027RESUL"
+  "T_CONNECTION_ERROR\020\003\022\017\n\013RESULT_BUSY\020\004\022\031\n"
+  "\025RESULT_COMMAND_DENIED\020\005\022\022\n\016RESULT_TIMEO"
+  "UT\020\006\022\026\n\022RESULT_UNSUPPORTED\020\007*\244\001\n\007FixType"
+  "\022\023\n\017FIX_TYPE_NO_GPS\020\000\022\023\n\017FIX_TYPE_NO_FIX"
+  "\020\001\022\023\n\017FIX_TYPE_FIX_2D\020\002\022\023\n\017FIX_TYPE_FIX_"
+  "3D\020\003\022\025\n\021FIX_TYPE_FIX_DGPS\020\004\022\026\n\022FIX_TYPE_"
+  "RTK_FLOAT\020\005\022\026\n\022FIX_TYPE_RTK_FIXED\020\006*\206\003\n\n"
+  "FlightMode\022\027\n\023FLIGHT_MODE_UNKNOWN\020\000\022\025\n\021F"
+  "LIGHT_MODE_READY\020\001\022\027\n\023FLIGHT_MODE_TAKEOF"
+  "F\020\002\022\024\n\020FLIGHT_MODE_HOLD\020\003\022\027\n\023FLIGHT_MODE"
+  "_MISSION\020\004\022 \n\034FLIGHT_MODE_RETURN_TO_LAUN"
+  "CH\020\005\022\024\n\020FLIGHT_MODE_LAND\020\006\022\030\n\024FLIGHT_MOD"
+  "E_OFFBOARD\020\007\022\031\n\025FLIGHT_MODE_FOLLOW_ME\020\010\022"
+  "\026\n\022FLIGHT_MODE_MANUAL\020\t\022\026\n\022FLIGHT_MODE_A"
+  "LTCTL\020\n\022\026\n\022FLIGHT_MODE_POSCTL\020\013\022\024\n\020FLIGH"
+  "T_MODE_ACRO\020\014\022\032\n\026FLIGHT_MODE_STABILIZED\020"
+  "\r\022\031\n\025FLIGHT_MODE_RATTITUDE\020\016*\371\001\n\016StatusT"
+  "extType\022\032\n\026STATUS_TEXT_TYPE_DEBUG\020\000\022\031\n\025S"
+  "TATUS_TEXT_TYPE_INFO\020\001\022\033\n\027STATUS_TEXT_TY"
+  "PE_NOTICE\020\002\022\034\n\030STATUS_TEXT_TYPE_WARNING\020"
+  "\003\022\032\n\026STATUS_TEXT_TYPE_ERROR\020\004\022\035\n\031STATUS_"
+  "TEXT_TYPE_CRITICAL\020\005\022\032\n\026STATUS_TEXT_TYPE"
+  "_ALERT\020\006\022\036\n\032STATUS_TEXT_TYPE_EMERGENCY\020\007"
+  "*\223\001\n\013LandedState\022\030\n\024LANDED_STATE_UNKNOWN"
+  "\020\000\022\032\n\026LANDED_STATE_ON_GROUND\020\001\022\027\n\023LANDED"
+  "_STATE_IN_AIR\020\002\022\033\n\027LANDED_STATE_TAKING_O"
+  "FF\020\003\022\030\n\024LANDED_STATE_LANDING\020\0042\2473\n\020Telem"
+  "etryService\022o\n\021SubscribePosition\022..mavsd"
+  "k.rpc.telemetry.SubscribePositionRequest"
+  "\032&.mavsdk.rpc.telemetry.PositionResponse"
+  "\"\0000\001\022c\n\rSubscribeHome\022*.mavsdk.rpc.telem"
+  "etry.SubscribeHomeRequest\032\".mavsdk.rpc.t"
+  "elemetry.HomeResponse\"\0000\001\022f\n\016SubscribeIn"
+  "Air\022+.mavsdk.rpc.telemetry.SubscribeInAi"
+  "rRequest\032#.mavsdk.rpc.telemetry.InAirRes"
+  "ponse\"\0000\001\022x\n\024SubscribeLandedState\0221.mavs"
+  "dk.rpc.telemetry.SubscribeLandedStateReq"
+  "uest\032).mavsdk.rpc.telemetry.LandedStateR"
+  "esponse\"\0000\001\022f\n\016SubscribeArmed\022+.mavsdk.r"
+  "pc.telemetry.SubscribeArmedRequest\032#.mav"
+  "sdk.rpc.telemetry.ArmedResponse\"\0000\001\022\215\001\n\033"
+  "SubscribeAttitudeQuaternion\0228.mavsdk.rpc"
+  ".telemetry.SubscribeAttitudeQuaternionRe"
+  "quest\0320.mavsdk.rpc.telemetry.AttitudeQua"
+  "ternionResponse\"\0000\001\022~\n\026SubscribeAttitude"
+  "Euler\0223.mavsdk.rpc.telemetry.SubscribeAt"
+  "titudeEulerRequest\032+.mavsdk.rpc.telemetr"
+  "y.AttitudeEulerResponse\"\0000\001\022\250\001\n$Subscrib"
+  "eAttitudeAngularVelocityBody\022A.mavsdk.rp"
+  "c.telemetry.SubscribeAttitudeAngularVelo"
+  "cityBodyRequest\0329.mavsdk.rpc.telemetry.A"
+  "ttitudeAngularVelocityBodyResponse\"\0000\001\022\237"
+  "\001\n!SubscribeCameraAttitudeQuaternion\022>.m"
+  "avsdk.rpc.telemetry.SubscribeCameraAttit"
+  "udeQuaternionRequest\0326.mavsdk.rpc.teleme"
+  "try.CameraAttitudeQuaternionResponse\"\0000\001"
+  "\022\220\001\n\034SubscribeCameraAttitudeEuler\0229.mavs"
+  "dk.rpc.telemetry.SubscribeCameraAttitude"
+  "EulerRequest\0321.mavsdk.rpc.telemetry.Came"
+  "raAttitudeEulerResponse\"\0000\001\022x\n\024Subscribe"
+  "VelocityNed\0221.mavsdk.rpc.telemetry.Subsc"
+  "ribeVelocityNedRequest\032).mavsdk.rpc.tele"
+  "metry.VelocityNedResponse\"\0000\001\022l\n\020Subscri"
+  "beGpsInfo\022-.mavsdk.rpc.telemetry.Subscri"
+  "beGpsInfoRequest\032%.mavsdk.rpc.telemetry."
+  "GpsInfoResponse\"\0000\001\022i\n\017SubscribeRawGps\022,"
+  ".mavsdk.rpc.telemetry.SubscribeRawGpsReq"
+  "uest\032$.mavsdk.rpc.telemetry.RawGpsRespon"
+  "se\"\0000\001\022l\n\020SubscribeBattery\022-.mavsdk.rpc."
+  "telemetry.SubscribeBatteryRequest\032%.mavs"
+  "dk.rpc.telemetry.BatteryResponse\"\0000\001\022u\n\023"
+  "SubscribeFlightMode\0220.mavsdk.rpc.telemet"
+  "ry.SubscribeFlightModeRequest\032(.mavsdk.r"
+  "pc.telemetry.FlightModeResponse\"\0000\001\022i\n\017S"
+  "ubscribeHealth\022,.mavsdk.rpc.telemetry.Su"
+  "bscribeHealthRequest\032$.mavsdk.rpc.teleme"
+  "try.HealthResponse\"\0000\001\022o\n\021SubscribeRcSta"
+  "tus\022..mavsdk.rpc.telemetry.SubscribeRcSt"
+  "atusRequest\032&.mavsdk.rpc.telemetry.RcSta"
+  "tusResponse\"\0000\001\022u\n\023SubscribeStatusText\0220"
+  ".mavsdk.rpc.telemetry.SubscribeStatusTex"
+  "tRequest\032(.mavsdk.rpc.telemetry.StatusTe"
+  "xtResponse\"\0000\001\022\226\001\n\036SubscribeActuatorCont"
+  "rolTarget\022;.mavsdk.rpc.telemetry.Subscri"
+  "beActuatorControlTargetRequest\0323.mavsdk."
+  "rpc.telemetry.ActuatorControlTargetRespo"
+  "nse\"\0000\001\022\223\001\n\035SubscribeActuatorOutputStatu"
+  "s\022:.mavsdk.rpc.telemetry.SubscribeActuat"
+  "orOutputStatusRequest\0322.mavsdk.rpc.telem"
+  "etry.ActuatorOutputStatusResponse\"\0000\001\022o\n"
+  "\021SubscribeOdometry\022..mavsdk.rpc.telemetr"
+  "y.SubscribeOdometryRequest\032&.mavsdk.rpc."
+  "telemetry.OdometryResponse\"\0000\001\022\220\001\n\034Subsc"
+  "ribePositionVelocityNed\0229.mavsdk.rpc.tel"
+  "emetry.SubscribePositionVelocityNedReque"
+  "st\0321.mavsdk.rpc.telemetry.PositionVeloci"
+  "tyNedResponse\"\0000\001\022x\n\024SubscribeGroundTrut"
+  "h\0221.mavsdk.rpc.telemetry.SubscribeGround"
+  "TruthRequest\032).mavsdk.rpc.telemetry.Grou"
+  "ndTruthResponse\"\0000\001\022\207\001\n\031SubscribeFixedwi"
+  "ngMetrics\0226.mavsdk.rpc.telemetry.Subscri"
+  "beFixedwingMetricsRequest\032..mavsdk.rpc.t"
+  "elemetry.FixedwingMetricsResponse\"\0000\001\022`\n"
+  "\014SubscribeImu\022).mavsdk.rpc.telemetry.Sub"
+  "scribeImuRequest\032!.mavsdk.rpc.telemetry."
+  "ImuResponse\"\0000\001\022r\n\022SubscribeScaledImu\022/."
+  "mavsdk.rpc.telemetry.SubscribeScaledImuR"
+  "equest\032\'.mavsdk.rpc.telemetry.ScaledImuR"
+  "esponse\"\0000\001\022i\n\017SubscribeRawImu\022,.mavsdk."
+  "rpc.telemetry.SubscribeRawImuRequest\032$.m"
+  "avsdk.rpc.telemetry.RawImuResponse\"\0000\001\022x"
+  "\n\024SubscribeHealthAllOk\0221.mavsdk.rpc.tele"
+  "metry.SubscribeHealthAllOkRequest\032).mavs"
+  "dk.rpc.telemetry.HealthAllOkResponse\"\0000\001"
+  "\022~\n\026SubscribeUnixEpochTime\0223.mavsdk.rpc."
+  "telemetry.SubscribeUnixEpochTimeRequest\032"
+  "+.mavsdk.rpc.telemetry.UnixEpochTimeResp"
+  "onse\"\0000\001\022\201\001\n\027SubscribeDistanceSensor\0224.m"
+  "avsdk.rpc.telemetry.SubscribeDistanceSen"
+  "sorRequest\032,.mavsdk.rpc.telemetry.Distan"
+  "ceSensorResponse\"\0000\001\022\201\001\n\027SubscribeScaled"
+  "Pressure\0224.mavsdk.rpc.telemetry.Subscrib"
+  "eScaledPressureRequest\032,.mavsdk.rpc.tele"
+  "metry.ScaledPressureResponse\"\0000\001\022p\n\017SetR"
+  "atePosition\022,.mavsdk.rpc.telemetry.SetRa"
+  "tePositionRequest\032-.mavsdk.rpc.telemetry"
+  ".SetRatePositionResponse\"\000\022d\n\013SetRateHom"
+  "e\022(.mavsdk.rpc.telemetry.SetRateHomeRequ"
+  "est\032).mavsdk.rpc.telemetry.SetRateHomeRe"
+  "sponse\"\000\022g\n\014SetRateInAir\022).mavsdk.rpc.te"
+  "lemetry.SetRateInAirRequest\032*.mavsdk.rpc"
+  ".telemetry.SetRateInAirResponse\"\000\022y\n\022Set"
+  "RateLandedState\022/.mavsdk.rpc.telemetry.S"
+  "etRateLandedStateRequest\0320.mavsdk.rpc.te"
+  "lemetry.SetRateLandedStateResponse\"\000\022p\n\017"
+  "SetRateAttitude\022,.mavsdk.rpc.telemetry.S"
+  "etRateAttitudeRequest\032-.mavsdk.rpc.telem"
+  "etry.SetRateAttitudeResponse\"\000\022\202\001\n\025SetRa"
+  "teCameraAttitude\0222.mavsdk.rpc.telemetry."
+  "SetRateCameraAttitudeRequest\0323.mavsdk.rp"
+  "c.telemetry.SetRateCameraAttitudeRespons"
+  "e\"\000\022y\n\022SetRateVelocityNed\022/.mavsdk.rpc.t"
+  "elemetry.SetRateVelocityNedRequest\0320.mav"
+  "sdk.rpc.telemetry.SetRateVelocityNedResp"
+  "onse\"\000\022m\n\016SetRateGpsInfo\022+.mavsdk.rpc.te"
+  "lemetry.SetRateGpsInfoRequest\032,.mavsdk.r"
+  "pc.telemetry.SetRateGpsInfoResponse\"\000\022m\n"
+  "\016SetRateBattery\022+.mavsdk.rpc.telemetry.S"
+  "etRateBatteryRequest\032,.mavsdk.rpc.teleme"
+  "try.SetRateBatteryResponse\"\000\022p\n\017SetRateR"
+  "cStatus\022,.mavsdk.rpc.telemetry.SetRateRc"
+  "StatusRequest\032-.mavsdk.rpc.telemetry.Set"
+  "RateRcStatusResponse\"\000\022\227\001\n\034SetRateActuat"
+  "orControlTarget\0229.mavsdk.rpc.telemetry.S"
+  "etRateActuatorControlTargetRequest\032:.mav"
+  "sdk.rpc.telemetry.SetRateActuatorControl"
+  "TargetResponse\"\000\022\224\001\n\033SetRateActuatorOutp"
+  "utStatus\0228.mavsdk.rpc.telemetry.SetRateA"
+  "ctuatorOutputStatusRequest\0329.mavsdk.rpc."
+  "telemetry.SetRateActuatorOutputStatusRes"
+  "ponse\"\000\022p\n\017SetRateOdometry\022,.mavsdk.rpc."
+  "telemetry.SetRateOdometryRequest\032-.mavsd"
+  "k.rpc.telemetry.SetRateOdometryResponse\""
+  "\000\022\221\001\n\032SetRatePositionVelocityNed\0227.mavsd"
+  "k.rpc.telemetry.SetRatePositionVelocityN"
+  "edRequest\0328.mavsdk.rpc.telemetry.SetRate"
+  "PositionVelocityNedResponse\"\000\022y\n\022SetRate"
+  "GroundTruth\022/.mavsdk.rpc.telemetry.SetRa"
+  "teGroundTruthRequest\0320.mavsdk.rpc.teleme"
+  "try.SetRateGroundTruthResponse\"\000\022\210\001\n\027Set"
+  "RateFixedwingMetrics\0224.mavsdk.rpc.teleme"
+  "try.SetRateFixedwingMetricsRequest\0325.mav"
+  "sdk.rpc.telemetry.SetRateFixedwingMetric"
+  "sResponse\"\000\022a\n\nSetRateImu\022\'.mavsdk.rpc.t"
+  "elemetry.SetRateImuRequest\032(.mavsdk.rpc."
+  "telemetry.SetRateImuResponse\"\000\022s\n\020SetRat"
+  "eScaledImu\022-.mavsdk.rpc.telemetry.SetRat"
+  "eScaledImuRequest\032..mavsdk.rpc.telemetry"
+  ".SetRateScaledImuResponse\"\000\022j\n\rSetRateRa"
+  "wImu\022*.mavsdk.rpc.telemetry.SetRateRawIm"
+  "uRequest\032+.mavsdk.rpc.telemetry.SetRateR"
+  "awImuResponse\"\000\022\177\n\024SetRateUnixEpochTime\022"
+  "1.mavsdk.rpc.telemetry.SetRateUnixEpochT"
+  "imeRequest\0322.mavsdk.rpc.telemetry.SetRat"
+  "eUnixEpochTimeResponse\"\000\022\202\001\n\025SetRateDist"
+  "anceSensor\0222.mavsdk.rpc.telemetry.SetRat"
+  "eDistanceSensorRequest\0323.mavsdk.rpc.tele"
+  "metry.SetRateDistanceSensorResponse\"\000\022y\n"
+  "\022GetGpsGlobalOrigin\022/.mavsdk.rpc.telemet"
+  "ry.GetGpsGlobalOriginRequest\0320.mavsdk.rp"
+  "c.telemetry.GetGpsGlobalOriginResponse\"\000"
+  "B%\n\023io.mavsdk.telemetryB\016TelemetryProtob"
+  "\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_telemetry_2ftelemetry_2eproto_deps[1] = {
   &::descriptor_table_mavsdk_5foptions_2eproto,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_telemetry_2ftelemetry_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_telemetry_2ftelemetry_2eproto = {
-  false, false, 18788, descriptor_table_protodef_telemetry_2ftelemetry_2eproto, "telemetry/telemetry.proto", 
+  false, false, 18807, descriptor_table_protodef_telemetry_2ftelemetry_2eproto, "telemetry/telemetry.proto", 
   &descriptor_table_telemetry_2ftelemetry_2eproto_once, descriptor_table_telemetry_2ftelemetry_2eproto_deps, 1, 140,
   schemas, file_default_instances, TableStruct_telemetry_2ftelemetry_2eproto::offsets,
   file_level_metadata_telemetry_2ftelemetry_2eproto, file_level_enum_descriptors_telemetry_2ftelemetry_2eproto, file_level_service_descriptors_telemetry_2ftelemetry_2eproto,
@@ -26026,16 +26029,16 @@ Battery::Battery(const Battery& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
   ::memcpy(&voltage_v_, &from.voltage_v_,
-    static_cast<size_t>(reinterpret_cast<char*>(&remaining_percent_) -
-    reinterpret_cast<char*>(&voltage_v_)) + sizeof(remaining_percent_));
+    static_cast<size_t>(reinterpret_cast<char*>(&id_) -
+    reinterpret_cast<char*>(&voltage_v_)) + sizeof(id_));
   // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.telemetry.Battery)
 }
 
 void Battery::SharedCtor() {
 ::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
     reinterpret_cast<char*>(&voltage_v_) - reinterpret_cast<char*>(this)),
-    0, static_cast<size_t>(reinterpret_cast<char*>(&remaining_percent_) -
-    reinterpret_cast<char*>(&voltage_v_)) + sizeof(remaining_percent_));
+    0, static_cast<size_t>(reinterpret_cast<char*>(&id_) -
+    reinterpret_cast<char*>(&voltage_v_)) + sizeof(id_));
 }
 
 Battery::~Battery() {
@@ -26065,8 +26068,8 @@ void Battery::Clear() {
   (void) cached_has_bits;
 
   ::memset(&voltage_v_, 0, static_cast<size_t>(
-      reinterpret_cast<char*>(&remaining_percent_) -
-      reinterpret_cast<char*>(&voltage_v_)) + sizeof(remaining_percent_));
+      reinterpret_cast<char*>(&id_) -
+      reinterpret_cast<char*>(&voltage_v_)) + sizeof(id_));
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -26089,6 +26092,13 @@ const char* Battery::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::in
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 21)) {
           remaining_percent_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<float>(ptr);
           ptr += sizeof(float);
+        } else goto handle_unusual;
+        continue;
+      // uint32 id = 3 [(.mavsdk.options.default_value) = "0"];
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 24)) {
+          id_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
+          CHK_(ptr);
         } else goto handle_unusual;
         continue;
       default: {
@@ -26131,6 +26141,12 @@ failure:
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteFloatToArray(2, this->_internal_remaining_percent(), target);
   }
 
+  // uint32 id = 3 [(.mavsdk.options.default_value) = "0"];
+  if (this->id() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt32ToArray(3, this->_internal_id(), target);
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
@@ -26155,6 +26171,13 @@ size_t Battery::ByteSizeLong() const {
   // float remaining_percent = 2 [(.mavsdk.options.default_value) = "NaN"];
   if (!(this->remaining_percent() <= 0 && this->remaining_percent() >= 0)) {
     total_size += 1 + 4;
+  }
+
+  // uint32 id = 3 [(.mavsdk.options.default_value) = "0"];
+  if (this->id() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt32Size(
+        this->_internal_id());
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -26194,6 +26217,9 @@ void Battery::MergeFrom(const Battery& from) {
   if (!(from.remaining_percent() <= 0 && from.remaining_percent() >= 0)) {
     _internal_set_remaining_percent(from._internal_remaining_percent());
   }
+  if (from.id() != 0) {
+    _internal_set_id(from._internal_id());
+  }
 }
 
 void Battery::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
@@ -26218,8 +26244,8 @@ void Battery::InternalSwap(Battery* other) {
   using std::swap;
   _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(Battery, remaining_percent_)
-      + sizeof(Battery::remaining_percent_)
+      PROTOBUF_FIELD_OFFSET(Battery, id_)
+      + sizeof(Battery::id_)
       - PROTOBUF_FIELD_OFFSET(Battery, voltage_v_)>(
           reinterpret_cast<char*>(&voltage_v_),
           reinterpret_cast<char*>(&other->voltage_v_));

--- a/src/mavsdk_server/src/generated/telemetry/telemetry.pb.h
+++ b/src/mavsdk_server/src/generated/telemetry/telemetry.pb.h
@@ -17290,6 +17290,7 @@ class Battery PROTOBUF_FINAL :
   enum : int {
     kVoltageVFieldNumber = 1,
     kRemainingPercentFieldNumber = 2,
+    kIdFieldNumber = 3,
   };
   // float voltage_v = 1 [(.mavsdk.options.default_value) = "NaN"];
   void clear_voltage_v();
@@ -17309,6 +17310,15 @@ class Battery PROTOBUF_FINAL :
   void _internal_set_remaining_percent(float value);
   public:
 
+  // uint32 id = 3 [(.mavsdk.options.default_value) = "0"];
+  void clear_id();
+  ::PROTOBUF_NAMESPACE_ID::uint32 id() const;
+  void set_id(::PROTOBUF_NAMESPACE_ID::uint32 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::uint32 _internal_id() const;
+  void _internal_set_id(::PROTOBUF_NAMESPACE_ID::uint32 value);
+  public:
+
   // @@protoc_insertion_point(class_scope:mavsdk.rpc.telemetry.Battery)
  private:
   class _Internal;
@@ -17318,6 +17328,7 @@ class Battery PROTOBUF_FINAL :
   typedef void DestructorSkippable_;
   float voltage_v_;
   float remaining_percent_;
+  ::PROTOBUF_NAMESPACE_ID::uint32 id_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_telemetry_2ftelemetry_2eproto;
 };
@@ -26995,6 +27006,26 @@ inline void RawGps::set_yaw_deg(float value) {
 // -------------------------------------------------------------------
 
 // Battery
+
+// uint32 id = 3 [(.mavsdk.options.default_value) = "0"];
+inline void Battery::clear_id() {
+  id_ = 0u;
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint32 Battery::_internal_id() const {
+  return id_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint32 Battery::id() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry.Battery.id)
+  return _internal_id();
+}
+inline void Battery::_internal_set_id(::PROTOBUF_NAMESPACE_ID::uint32 value) {
+  
+  id_ = value;
+}
+inline void Battery::set_id(::PROTOBUF_NAMESPACE_ID::uint32 value) {
+  _internal_set_id(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry.Battery.id)
+}
 
 // float voltage_v = 1 [(.mavsdk.options.default_value) = "NaN"];
 inline void Battery::clear_voltage_v() {

--- a/src/mavsdk_server/src/plugins/telemetry/telemetry_service_impl.h
+++ b/src/mavsdk_server/src/plugins/telemetry/telemetry_service_impl.h
@@ -487,6 +487,8 @@ public:
     {
         auto rpc_obj = std::make_unique<rpc::telemetry::Battery>();
 
+        rpc_obj->set_id(battery.id);
+
         rpc_obj->set_voltage_v(battery.voltage_v);
 
         rpc_obj->set_remaining_percent(battery.remaining_percent);
@@ -498,6 +500,8 @@ public:
     translateFromRpcBattery(const rpc::telemetry::Battery& battery)
     {
         mavsdk::Telemetry::Battery obj;
+
+        obj.id = battery.id();
 
         obj.voltage_v = battery.voltage_v();
 

--- a/src/mavsdk_server/test/telemetry_service_impl_test.cpp
+++ b/src/mavsdk_server/test/telemetry_service_impl_test.cpp
@@ -101,7 +101,8 @@ protected:
     FixType translateRPCGpsFixType(RPCFixType fixType) const;
 
     void checkSendsBatteryEvents(const std::vector<Battery>& battery_events) const;
-    Battery createBattery(const uint32_t id, const float voltage_v, const float remaining_percent) const;
+    Battery
+    createBattery(const uint32_t id, const float voltage_v, const float remaining_percent) const;
     std::future<void> subscribeBatteryAsync(std::vector<Battery>& battery_events) const;
 
     void checkSendsFlightModeEvents(const std::vector<FlightMode>& flight_mode_events) const;
@@ -827,8 +828,8 @@ TEST_F(TelemetryServiceImplTest, sendsOneBatteryEvent)
     checkSendsBatteryEvents(battery_events);
 }
 
-Battery
-TelemetryServiceImplTest::createBattery(const uint32_t id, const float voltage_v, const float remaining_percent) const
+Battery TelemetryServiceImplTest::createBattery(
+    const uint32_t id, const float voltage_v, const float remaining_percent) const
 {
     Battery battery;
     battery.id = id;

--- a/src/mavsdk_server/test/telemetry_service_impl_test.cpp
+++ b/src/mavsdk_server/test/telemetry_service_impl_test.cpp
@@ -101,7 +101,7 @@ protected:
     FixType translateRPCGpsFixType(RPCFixType fixType) const;
 
     void checkSendsBatteryEvents(const std::vector<Battery>& battery_events) const;
-    Battery createBattery(const float voltage_v, const float remaining_percent) const;
+    Battery createBattery(const uint32_t id, const float voltage_v, const float remaining_percent) const;
     std::future<void> subscribeBatteryAsync(std::vector<Battery>& battery_events) const;
 
     void checkSendsFlightModeEvents(const std::vector<FlightMode>& flight_mode_events) const;
@@ -797,6 +797,7 @@ TelemetryServiceImplTest::subscribeBatteryAsync(std::vector<Battery>& battery_ev
             auto battery_rpc = response.battery();
 
             Battery battery;
+            battery.id = battery_rpc.id();
             battery.voltage_v = battery_rpc.voltage_v();
             battery.remaining_percent = battery_rpc.remaining_percent();
 
@@ -821,15 +822,16 @@ TEST_F(TelemetryServiceImplTest, doesNotSendBatteryIfCallbackNotCalled)
 TEST_F(TelemetryServiceImplTest, sendsOneBatteryEvent)
 {
     std::vector<Battery> battery_events;
-    battery_events.push_back(createBattery(4.2f, 0.63f));
+    battery_events.push_back(createBattery(0, 4.2f, 0.63f));
 
     checkSendsBatteryEvents(battery_events);
 }
 
 Battery
-TelemetryServiceImplTest::createBattery(const float voltage_v, const float remaining_percent) const
+TelemetryServiceImplTest::createBattery(const uint32_t id, const float voltage_v, const float remaining_percent) const
 {
     Battery battery;
+    battery.id = id;
     battery.voltage_v = voltage_v;
     battery.remaining_percent = remaining_percent;
 
@@ -864,10 +866,10 @@ TEST_F(TelemetryServiceImplTest, sendsMultipleBatteryEvents)
 {
     std::vector<Battery> battery_events;
 
-    battery_events.push_back(createBattery(4.1f, 0.34f));
-    battery_events.push_back(createBattery(5.1f, 0.12f));
-    battery_events.push_back(createBattery(2.4f, 0.99f));
-    battery_events.push_back(createBattery(5.7f, 1.0f));
+    battery_events.push_back(createBattery(0, 4.1f, 0.34f));
+    battery_events.push_back(createBattery(1, 5.1f, 0.12f));
+    battery_events.push_back(createBattery(2, 2.4f, 0.99f));
+    battery_events.push_back(createBattery(3, 5.7f, 1.0f));
 
     checkSendsBatteryEvents(battery_events);
 }

--- a/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -331,6 +331,7 @@ public:
      * @brief Battery type.
      */
     struct Battery {
+        uint32_t id{0}; /**< @brief Battery ID, for systems with multiple batteries */
         float voltage_v{float(NAN)}; /**< @brief Voltage in volts */
         float remaining_percent{
             float(NAN)}; /**< @brief Estimated battery remaining (range: 0.0 to 1.0) */

--- a/src/plugins/telemetry/telemetry.cpp
+++ b/src/plugins/telemetry/telemetry.cpp
@@ -739,7 +739,8 @@ std::ostream& operator<<(std::ostream& str, Telemetry::RawGps const& raw_gps)
 
 bool operator==(const Telemetry::Battery& lhs, const Telemetry::Battery& rhs)
 {
-    return ((std::isnan(rhs.voltage_v) && std::isnan(lhs.voltage_v)) ||
+    return (rhs.id == lhs.id) &&
+           ((std::isnan(rhs.voltage_v) && std::isnan(lhs.voltage_v)) ||
             rhs.voltage_v == lhs.voltage_v) &&
            ((std::isnan(rhs.remaining_percent) && std::isnan(lhs.remaining_percent)) ||
             rhs.remaining_percent == lhs.remaining_percent);
@@ -749,6 +750,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::Battery const& battery)
 {
     str << std::setprecision(15);
     str << "battery:" << '\n' << "{\n";
+    str << "    id: " << battery.id << '\n';
     str << "    voltage_v: " << battery.voltage_v << '\n';
     str << "    remaining_percent: " << battery.remaining_percent << '\n';
     str << '}';

--- a/src/plugins/telemetry/telemetry_impl.cpp
+++ b/src/plugins/telemetry/telemetry_impl.cpp
@@ -1082,7 +1082,7 @@ void TelemetryImpl::process_battery_status(const mavlink_message_t& message)
     new_battery.remaining_percent = bat_status.battery_remaining * 1e-2f;
 
     set_battery(new_battery);
-    
+
     {
         std::lock_guard<std::mutex> lock(_subscription_mutex);
         if (_battery_subscription) {

--- a/src/plugins/telemetry/telemetry_impl.cpp
+++ b/src/plugins/telemetry/telemetry_impl.cpp
@@ -1027,21 +1027,21 @@ void TelemetryImpl::process_sys_status(const mavlink_message_t& message)
     mavlink_msg_sys_status_decode(&message, &sys_status);
 
     if (!_has_bat_status) {
-    Telemetry::Battery new_battery;
-    new_battery.voltage_v = sys_status.voltage_battery * 1e-3f;
-    // FIXME: it is strange calling it percent when the range goes from 0 to 1.
-    new_battery.remaining_percent = sys_status.battery_remaining * 1e-2f;
+        Telemetry::Battery new_battery;
+        new_battery.voltage_v = sys_status.voltage_battery * 1e-3f;
+        // FIXME: it is strange calling it percent when the range goes from 0 to 1.
+        new_battery.remaining_percent = sys_status.battery_remaining * 1e-2f;
 
-    set_battery(new_battery);
+        set_battery(new_battery);
 
-    {
-        std::lock_guard<std::mutex> lock(_subscription_mutex);
-        if (_battery_subscription) {
-            auto callback = _battery_subscription;
-            auto arg = battery();
-            _parent->call_user_callback([callback, arg]() { callback(arg); });
+        {
+            std::lock_guard<std::mutex> lock(_subscription_mutex);
+            if (_battery_subscription) {
+                auto callback = _battery_subscription;
+                auto arg = battery();
+                _parent->call_user_callback([callback, arg]() { callback(arg); });
+            }
         }
-    }
     }
 
     const bool rc_ok =
@@ -1082,12 +1082,14 @@ void TelemetryImpl::process_battery_status(const mavlink_message_t& message)
     new_battery.remaining_percent = bat_status.battery_remaining * 1e-2f;
 
     set_battery(new_battery);
-
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
-    if (_battery_subscription) {
-        auto callback = _battery_subscription;
-        auto arg = battery();
-        _parent->call_user_callback([callback, arg]() { callback(arg); });
+    
+    {
+        std::lock_guard<std::mutex> lock(_subscription_mutex);
+        if (_battery_subscription) {
+            auto callback = _battery_subscription;
+            auto arg = battery();
+            _parent->call_user_callback([callback, arg]() { callback(arg); });
+        }
     }
 }
 

--- a/src/plugins/telemetry/telemetry_impl.h
+++ b/src/plugins/telemetry/telemetry_impl.h
@@ -192,6 +192,7 @@ private:
     void process_extended_sys_state(const mavlink_message_t& message);
     void process_fixedwing_metrics(const mavlink_message_t& message);
     void process_sys_status(const mavlink_message_t& message);
+    void process_battery_status(const mavlink_message_t& message);
     void process_heartbeat(const mavlink_message_t& message);
     void process_rc_channels(const mavlink_message_t& message);
     void process_unix_epoch_time(const mavlink_message_t& message);
@@ -350,5 +351,9 @@ private:
     void* _rc_channels_timeout_cookie{nullptr};
     void* _gps_raw_timeout_cookie{nullptr};
     void* _unix_epoch_timeout_cookie{nullptr};
+
+    // Battery info can be extracted form SYS_STATUS or from BATTERY_STATUS.
+    // If no BATTERY_STATUS messages are received, use info from SYS_STATUS.
+    bool _has_bat_status{false};
 };
 } // namespace mavsdk

--- a/src/plugins/telemetry/telemetry_impl.h
+++ b/src/plugins/telemetry/telemetry_impl.h
@@ -352,7 +352,7 @@ private:
     void* _gps_raw_timeout_cookie{nullptr};
     void* _unix_epoch_timeout_cookie{nullptr};
 
-    // Battery info can be extracted form SYS_STATUS or from BATTERY_STATUS.
+    // Battery info can be extracted from SYS_STATUS or from BATTERY_STATUS.
     // If no BATTERY_STATUS messages are received, use info from SYS_STATUS.
     bool _has_bat_status{false};
 };


### PR DESCRIPTION
Requires https://github.com/mavlink/MAVSDK-Proto/pull/239
Adds support for multiple batteries, by handling BATTERY_STATUS message.
If no BATTERY_STATUS message is received, battery.id will default to 0, and SYS_STATUS values will be used.
Closes #1365 