### PR TITLE
workflows: prevent coveralls JS out of memory

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
   coverage:
     name: coverage (ubuntu-18.04)
     runs-on: ubuntu-18.04
+    env:
+      NODE_OPTIONS: --max_old_space_size=4096
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This is an attempt to prevent the coveralls error:
```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

More ideas here: https://github.com/coverallsapp/github-action/issues/31