### PR TITLE
docker/workflows: add PX4 v1.12 release to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -554,7 +554,7 @@ jobs:
     container: mavsdk/mavsdk-ubuntu-20.04-px4-sitl-${{ matrix.px4_version }}
     strategy:
       matrix:
-        px4_version: [v1.11]
+        px4_version: [v1.11, v1.12]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/docker/Dockerfile-Ubuntu-20.04-PX4-SITL-v1.12
+++ b/docker/Dockerfile-Ubuntu-20.04-PX4-SITL-v1.12
@@ -1,0 +1,25 @@
+#
+# PX4 v1.12.0 SITL testing environment for MAVSDK based on Ubuntu 20.04.
+# Author: Julian Oes <julian@oes.ch>
+#
+FROM mavsdk/mavsdk-ubuntu-20.04
+MAINTAINER Julian Oes <julian@oes.ch>
+
+ENV FIRMWARE_DIR ${WORKDIR}../Firmware
+
+RUN apt-get update && \
+    apt-get install -y git locales \
+    && apt-get -y autoremove \
+    && apt-get clean autoclean \
+    && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+RUN git clone https://github.com/PX4/Firmware.git ${FIRMWARE_DIR}
+RUN git -C ${FIRMWARE_DIR} checkout v1.12.0
+RUN git -C ${FIRMWARE_DIR} submodule update --init --recursive
+RUN cd ${FIRMWARE_DIR} && Tools/setup/ubuntu.sh --no-nuttx
+RUN cd ${FIRMWARE_DIR} && DONT_RUN=1 make px4_sitl gazebo && DONT_RUN=1 make px4_sitl gazebo

--- a/docker/build_and_push_docker_images.sh
+++ b/docker/build_and_push_docker_images.sh
@@ -9,6 +9,7 @@ docker build -f Dockerfile-Ubuntu-20.04 -t mavsdk/mavsdk-ubuntu-20.04 .
 docker build -f Dockerfile-Ubuntu-18.04-PX4-SITL-v1.9 -t mavsdk/mavsdk-ubuntu-18.04-px4-sitl-v1.9 .
 docker build -f Dockerfile-Ubuntu-18.04-PX4-SITL-v1.10 -t mavsdk/mavsdk-ubuntu-18.04-px4-sitl-v1.10 .
 docker build -f Dockerfile-Ubuntu-20.04-PX4-SITL-v1.11 -t mavsdk/mavsdk-ubuntu-20.04-px4-sitl-v1.11 .
+docker build -f Dockerfile-Ubuntu-20.04-PX4-SITL-v1.12 -t mavsdk/mavsdk-ubuntu-20.04-px4-sitl-v1.12 .
 
 docker push mavsdk/mavsdk-fedora-32:latest
 docker push mavsdk/mavsdk-fedora-33:latest
@@ -17,3 +18,4 @@ docker push mavsdk/mavsdk-ubuntu-20.04:latest
 docker push mavsdk/mavsdk-ubuntu-18.04-px4-sitl-v1.9:latest
 docker push mavsdk/mavsdk-ubuntu-18.04-px4-sitl-v1.10:latest
 docker push mavsdk/mavsdk-ubuntu-20.04-px4-sitl-v1.11:latest
+docker push mavsdk/mavsdk-ubuntu-20.04-px4-sitl-v1.12:latest


### PR DESCRIPTION
This adds the latest PX4 v1.12 release to the docker images and CI.