### PR TITLE
core: fix own sysid/compid in mission transfer

### DIFF
--- a/src/core/mavlink_mission_transfer.cpp
+++ b/src/core/mavlink_mission_transfer.cpp
@@ -211,11 +211,11 @@ void MAVLinkMissionTransfer::UploadWorkItem::send_count()
 {
     mavlink_message_t message;
     mavlink_msg_mission_count_pack(
-        _sender.own_address.system_id,
-        _sender.own_address.component_id,
+        _sender.get_own_system_id(),
+        _sender.get_own_component_id(),
         &message,
-        _sender.target_address.system_id,
-        _sender.target_address.component_id,
+        _sender.get_system_id(),
+        MAV_COMP_ID_AUTOPILOT1,
         _items.size(),
         _type);
 
@@ -232,11 +232,11 @@ void MAVLinkMissionTransfer::UploadWorkItem::send_cancel_and_finish()
 {
     mavlink_message_t message;
     mavlink_msg_mission_ack_pack(
-        _sender.own_address.system_id,
-        _sender.own_address.component_id,
+        _sender.get_own_system_id(),
+        _sender.get_own_component_id(),
         &message,
-        _sender.target_address.system_id,
-        _sender.target_address.component_id,
+        _sender.get_system_id(),
+        MAV_COMP_ID_AUTOPILOT1,
         MAV_MISSION_OPERATION_CANCELLED,
         _type);
 
@@ -279,11 +279,11 @@ void MAVLinkMissionTransfer::UploadWorkItem::process_mission_request(
 
     mavlink_message_t message;
     mavlink_msg_mission_ack_pack(
-        _sender.own_address.system_id,
-        _sender.own_address.component_id,
+        _sender.get_own_system_id(),
+        _sender.get_own_component_id(),
         &message,
-        _sender.target_address.system_id,
-        _sender.target_address.component_id,
+        _sender.get_system_id(),
+        MAV_COMP_ID_AUTOPILOT1,
         MAV_MISSION_UNSUPPORTED,
         _type);
 
@@ -341,11 +341,11 @@ void MAVLinkMissionTransfer::UploadWorkItem::send_mission_item()
 
     mavlink_message_t message;
     mavlink_msg_mission_item_int_pack(
-        _sender.own_address.system_id,
-        _sender.own_address.component_id,
+        _sender.get_own_system_id(),
+        _sender.get_own_component_id(),
         &message,
-        _sender.target_address.system_id,
-        _sender.target_address.component_id,
+        _sender.get_system_id(),
+        MAV_COMP_ID_AUTOPILOT1,
         _next_sequence,
         _items[_next_sequence].frame,
         _items[_next_sequence].command,
@@ -512,11 +512,11 @@ void MAVLinkMissionTransfer::DownloadWorkItem::request_list()
 {
     mavlink_message_t message;
     mavlink_msg_mission_request_list_pack(
-        _sender.own_address.system_id,
-        _sender.own_address.component_id,
+        _sender.get_own_system_id(),
+        _sender.get_own_component_id(),
         &message,
-        _sender.target_address.system_id,
-        _sender.target_address.component_id,
+        _sender.get_system_id(),
+        MAV_COMP_ID_AUTOPILOT1,
         _type);
 
     if (!_sender.send_message(message)) {
@@ -532,11 +532,11 @@ void MAVLinkMissionTransfer::DownloadWorkItem::request_item()
 {
     mavlink_message_t message;
     mavlink_msg_mission_request_int_pack(
-        _sender.own_address.system_id,
-        _sender.own_address.component_id,
+        _sender.get_own_system_id(),
+        _sender.get_own_component_id(),
         &message,
-        _sender.target_address.system_id,
-        _sender.target_address.component_id,
+        _sender.get_system_id(),
+        MAV_COMP_ID_AUTOPILOT1,
         _next_sequence,
         _type);
 
@@ -553,11 +553,11 @@ void MAVLinkMissionTransfer::DownloadWorkItem::send_ack_and_finish()
 {
     mavlink_message_t message;
     mavlink_msg_mission_ack_pack(
-        _sender.own_address.system_id,
-        _sender.own_address.component_id,
+        _sender.get_own_system_id(),
+        _sender.get_own_component_id(),
         &message,
-        _sender.target_address.system_id,
-        _sender.target_address.component_id,
+        _sender.get_system_id(),
+        MAV_COMP_ID_AUTOPILOT1,
         MAV_MISSION_ACCEPTED,
         _type);
 
@@ -574,11 +574,11 @@ void MAVLinkMissionTransfer::DownloadWorkItem::send_cancel_and_finish()
 {
     mavlink_message_t message;
     mavlink_msg_mission_ack_pack(
-        _sender.own_address.system_id,
-        _sender.own_address.component_id,
+        _sender.get_own_system_id(),
+        _sender.get_own_component_id(),
         &message,
-        _sender.target_address.system_id,
-        _sender.target_address.component_id,
+        _sender.get_system_id(),
+        MAV_COMP_ID_AUTOPILOT1,
         MAV_MISSION_OPERATION_CANCELLED,
         _type);
 
@@ -728,11 +728,11 @@ void MAVLinkMissionTransfer::ClearWorkItem::send_clear()
 {
     mavlink_message_t message;
     mavlink_msg_mission_clear_all_pack(
-        _sender.own_address.system_id,
-        _sender.own_address.component_id,
+        _sender.get_own_system_id(),
+        _sender.get_own_component_id(),
         &message,
-        _sender.target_address.system_id,
-        _sender.target_address.component_id,
+        _sender.get_system_id(),
+        MAV_COMP_ID_AUTOPILOT1,
         _type);
 
     if (!_sender.send_message(message)) {
@@ -880,11 +880,11 @@ void MAVLinkMissionTransfer::SetCurrentWorkItem::send_current_mission_item()
 {
     mavlink_message_t message;
     mavlink_msg_mission_set_current_pack(
-        _sender.own_address.system_id,
-        _sender.own_address.component_id,
+        _sender.get_own_system_id(),
+        _sender.get_own_component_id(),
         &message,
-        _sender.target_address.system_id,
-        _sender.target_address.component_id,
+        _sender.get_system_id(),
+        MAV_COMP_ID_AUTOPILOT1,
         _current);
 
     if (!_sender.send_message(message)) {

--- a/src/core/mavlink_mission_transfer.h
+++ b/src/core/mavlink_mission_transfer.h
@@ -16,14 +16,12 @@ namespace mavsdk {
 
 class Sender {
 public:
-    Sender(MAVLinkAddress& new_own_address, MAVLinkAddress& new_target_address) :
-        own_address(new_own_address),
-        target_address(new_target_address)
-    {}
+    Sender() = default;
     virtual ~Sender() = default;
     virtual bool send_message(mavlink_message_t& message) = 0;
-    MAVLinkAddress& own_address;
-    MAVLinkAddress& target_address;
+    virtual uint8_t get_own_system_id() const = 0;
+    virtual uint8_t get_own_component_id() const = 0;
+    virtual uint8_t get_system_id() const = 0;
 };
 
 class MAVLinkMissionTransfer {

--- a/src/core/mocks/sender_mock.h
+++ b/src/core/mocks/sender_mock.h
@@ -6,10 +6,11 @@ namespace testing {
 
 class MockSender : public Sender {
 public:
-    MockSender(MAVLinkAddress& new_own_address, MAVLinkAddress& new_target_address) :
-        Sender(new_own_address, new_target_address)
-    {}
-    MOCK_METHOD(bool, send_message, (mavlink_message_t&), (override)){};
+    MockSender() : Sender() {}
+    MOCK_METHOD(bool, send_message, (mavlink_message_t&), (override));
+    MOCK_METHOD(uint8_t, get_own_system_id, (), (const, override));
+    MOCK_METHOD(uint8_t, get_own_component_id, (), (const, override));
+    MOCK_METHOD(uint8_t, get_system_id, (), (const, override));
 };
 
 } // namespace testing

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -18,7 +18,7 @@ namespace mavsdk {
 using namespace std::placeholders; // for `_1`
 
 SystemImpl::SystemImpl(MavsdkImpl& parent) :
-    Sender(parent.own_address, _target_address),
+    Sender(),
     _parent(parent),
     _params(*this),
     _send_commands(*this),

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -121,12 +121,12 @@ public:
     bool has_camera(int camera_id = -1) const;
     bool has_gimbal() const;
 
-    uint8_t get_system_id() const;
+    uint8_t get_system_id() const override;
 
     void set_system_id(uint8_t system_id);
 
-    uint8_t get_own_system_id() const;
-    uint8_t get_own_component_id() const;
+    uint8_t get_own_system_id() const override;
+    uint8_t get_own_component_id() const override;
     uint8_t get_own_mav_type() const;
 
     bool is_armed() const { return _armed; }


### PR DESCRIPTION
It turns out that SystemImpl did not properly implement the Sender class and therefore own sysid and compid were always 0.

This refactoring fixes that by using methods instead of variable references of variables that are not set and these abstract methods then need to be implemented, otherwise the compiler would complain.

I also had to remove on check in the unit tests, why is a mystery to me.