### PR TITLE
Fix two warnings recently introduced

### DIFF
--- a/src/core/mavsdk_impl.cpp
+++ b/src/core/mavsdk_impl.cpp
@@ -641,7 +641,7 @@ void MavsdkImpl::set_base_mode(uint8_t base_mode)
     _base_mode = base_mode;
 }
 
-bool MavsdkImpl::get_base_mode() const
+uint8_t MavsdkImpl::get_base_mode() const
 {
     return _base_mode;
 }

--- a/src/core/mavsdk_impl.h
+++ b/src/core/mavsdk_impl.h
@@ -86,7 +86,7 @@ public:
     MAVLinkAddress own_address{};
 
     void set_base_mode(uint8_t base_mode);
-    bool get_base_mode() const;
+    uint8_t get_base_mode() const;
     void set_custom_mode(uint32_t custom_mode);
     uint32_t get_custom_mode() const;
 

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -1381,7 +1381,7 @@ void SystemImpl::set_server_armed(bool armed)
 
 bool SystemImpl::is_server_armed() const
 {
-    return _parent.get_base_mode() & (MAV_MODE_FLAG_SAFETY_ARMED == MAV_MODE_FLAG_SAFETY_ARMED);
+    return (_parent.get_base_mode() & MAV_MODE_FLAG_SAFETY_ARMED) == MAV_MODE_FLAG_SAFETY_ARMED;
 }
 
 void SystemImpl::set_custom_mode(uint32_t custom_mode)

--- a/src/plugins/mission_raw_server/mission_raw_server_impl.cpp
+++ b/src/plugins/mission_raw_server/mission_raw_server_impl.cpp
@@ -310,7 +310,7 @@ void MissionRawServerImpl::set_current_item_complete()
         _parent->get_own_system_id(),
         _parent->get_own_component_id(),
         &mission_reached,
-        _current_seq);
+        static_cast<uint16_t>(_current_seq));
     _parent->send_message(mission_reached);
     if (_current_seq + 1 == _current_mission.size()) {
         _mission_completed = true;
@@ -320,7 +320,7 @@ void MissionRawServerImpl::set_current_item_complete()
     }
 }
 
-void MissionRawServerImpl::set_current_seq(uint16_t seq)
+void MissionRawServerImpl::set_current_seq(std::size_t seq)
 {
     if (_current_mission.size() <= static_cast<size_t>(seq)) {
         return;
@@ -337,7 +337,7 @@ void MissionRawServerImpl::set_current_seq(uint16_t seq)
         _parent->get_own_system_id(),
         _parent->get_own_component_id(),
         &mission_current,
-        _current_seq);
+        static_cast<uint16_t>(_current_seq));
     _parent->send_message(mission_current);
 }
 

--- a/src/plugins/mission_raw_server/mission_raw_server_impl.h
+++ b/src/plugins/mission_raw_server/mission_raw_server_impl.h
@@ -41,7 +41,7 @@ private:
     std::atomic<bool> _stop_work_thread = false;
 
     std::vector<MAVLinkMissionTransfer::ItemInt> _current_mission;
-    uint16_t _current_seq;
+    std::size_t _current_seq;
 
     struct MissionData {
         mutable std::recursive_mutex mutex{};
@@ -66,7 +66,7 @@ private:
         MAVLinkMissionTransfer::Result result,
         const std::vector<MAVLinkMissionTransfer::ItemInt>& int_items);
 
-    void set_current_seq(uint16_t seq);
+    void set_current_seq(std::size_t seq);
 
     void add_task(std::function<void()> task)
     {


### PR DESCRIPTION
Found by AppleClang:

```
/Users/julianoes/src/MAVSDK/src/core/system_impl.cpp:1384:66: warning: self-comparison always evaluates to true [-Wtautological-compare]
    return _parent.get_base_mode() & (MAV_MODE_FLAG_SAFETY_ARMED == MAV_MODE_FLAG_SAFETY_ARMED);
```

And GCC:

```
/home/julianoes/src/MAVSDK/src/plugins/mission_raw_server/mission_raw_server_impl.cpp:315:26: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<mavsdk::MAVLinkMissionTransfer::ItemInt>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
  315 |     if (_current_seq + 1 == _current_mission.size()) {
      |         ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
```