### PR TITLE
Add heading to global_position telemetry plugins

### DIFF
--- a/src/mavsdk_server/src/generated/telemetry/telemetry.grpc.pb.cc
+++ b/src/mavsdk_server/src/generated/telemetry/telemetry.grpc.pb.cc
@@ -55,6 +55,7 @@ static const char* TelemetryService_method_names[] = {
   "/mavsdk.rpc.telemetry.TelemetryService/SubscribeUnixEpochTime",
   "/mavsdk.rpc.telemetry.TelemetryService/SubscribeDistanceSensor",
   "/mavsdk.rpc.telemetry.TelemetryService/SubscribeScaledPressure",
+  "/mavsdk.rpc.telemetry.TelemetryService/SubscribeHeading",
   "/mavsdk.rpc.telemetry.TelemetryService/SetRatePosition",
   "/mavsdk.rpc.telemetry.TelemetryService/SetRateHome",
   "/mavsdk.rpc.telemetry.TelemetryService/SetRateInAir",
@@ -117,28 +118,29 @@ TelemetryService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& c
   , rpcmethod_SubscribeUnixEpochTime_(TelemetryService_method_names[28], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
   , rpcmethod_SubscribeDistanceSensor_(TelemetryService_method_names[29], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
   , rpcmethod_SubscribeScaledPressure_(TelemetryService_method_names[30], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
-  , rpcmethod_SetRatePosition_(TelemetryService_method_names[31], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRateHome_(TelemetryService_method_names[32], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRateInAir_(TelemetryService_method_names[33], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRateLandedState_(TelemetryService_method_names[34], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRateAttitude_(TelemetryService_method_names[35], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRateCameraAttitude_(TelemetryService_method_names[36], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRateVelocityNed_(TelemetryService_method_names[37], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRateGpsInfo_(TelemetryService_method_names[38], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRateBattery_(TelemetryService_method_names[39], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRateRcStatus_(TelemetryService_method_names[40], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRateActuatorControlTarget_(TelemetryService_method_names[41], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRateActuatorOutputStatus_(TelemetryService_method_names[42], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRateOdometry_(TelemetryService_method_names[43], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRatePositionVelocityNed_(TelemetryService_method_names[44], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRateGroundTruth_(TelemetryService_method_names[45], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRateFixedwingMetrics_(TelemetryService_method_names[46], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRateImu_(TelemetryService_method_names[47], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRateScaledImu_(TelemetryService_method_names[48], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRateRawImu_(TelemetryService_method_names[49], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRateUnixEpochTime_(TelemetryService_method_names[50], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRateDistanceSensor_(TelemetryService_method_names[51], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_GetGpsGlobalOrigin_(TelemetryService_method_names[52], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubscribeHeading_(TelemetryService_method_names[31], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_SetRatePosition_(TelemetryService_method_names[32], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRateHome_(TelemetryService_method_names[33], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRateInAir_(TelemetryService_method_names[34], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRateLandedState_(TelemetryService_method_names[35], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRateAttitude_(TelemetryService_method_names[36], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRateCameraAttitude_(TelemetryService_method_names[37], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRateVelocityNed_(TelemetryService_method_names[38], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRateGpsInfo_(TelemetryService_method_names[39], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRateBattery_(TelemetryService_method_names[40], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRateRcStatus_(TelemetryService_method_names[41], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRateActuatorControlTarget_(TelemetryService_method_names[42], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRateActuatorOutputStatus_(TelemetryService_method_names[43], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRateOdometry_(TelemetryService_method_names[44], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRatePositionVelocityNed_(TelemetryService_method_names[45], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRateGroundTruth_(TelemetryService_method_names[46], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRateFixedwingMetrics_(TelemetryService_method_names[47], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRateImu_(TelemetryService_method_names[48], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRateScaledImu_(TelemetryService_method_names[49], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRateRawImu_(TelemetryService_method_names[50], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRateUnixEpochTime_(TelemetryService_method_names[51], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRateDistanceSensor_(TelemetryService_method_names[52], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetGpsGlobalOrigin_(TelemetryService_method_names[53], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::ClientReader< ::mavsdk::rpc::telemetry::PositionResponse>* TelemetryService::Stub::SubscribePositionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribePositionRequest& request) {
@@ -635,6 +637,22 @@ void TelemetryService::Stub::experimental_async::SubscribeScaledPressure(::grpc:
 
 ::grpc::ClientAsyncReader< ::mavsdk::rpc::telemetry::ScaledPressureResponse>* TelemetryService::Stub::PrepareAsyncSubscribeScaledPressureRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeScaledPressureRequest& request, ::grpc::CompletionQueue* cq) {
   return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::telemetry::ScaledPressureResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeScaledPressure_, context, request, false, nullptr);
+}
+
+::grpc::ClientReader< ::mavsdk::rpc::telemetry::HeadingResponse>* TelemetryService::Stub::SubscribeHeadingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest& request) {
+  return ::grpc::internal::ClientReaderFactory< ::mavsdk::rpc::telemetry::HeadingResponse>::Create(channel_.get(), rpcmethod_SubscribeHeading_, context, request);
+}
+
+void TelemetryService::Stub::experimental_async::SubscribeHeading(::grpc::ClientContext* context, ::mavsdk::rpc::telemetry::SubscribeHeadingRequest* request, ::grpc::experimental::ClientReadReactor< ::mavsdk::rpc::telemetry::HeadingResponse>* reactor) {
+  ::grpc::internal::ClientCallbackReaderFactory< ::mavsdk::rpc::telemetry::HeadingResponse>::Create(stub_->channel_.get(), stub_->rpcmethod_SubscribeHeading_, context, request, reactor);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::telemetry::HeadingResponse>* TelemetryService::Stub::AsyncSubscribeHeadingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::telemetry::HeadingResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeHeading_, context, request, true, tag);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::telemetry::HeadingResponse>* TelemetryService::Stub::PrepareAsyncSubscribeHeadingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::telemetry::HeadingResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeHeading_, context, request, false, nullptr);
 }
 
 ::grpc::Status TelemetryService::Stub::SetRatePosition(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRatePositionRequest& request, ::mavsdk::rpc::telemetry::SetRatePositionResponse* response) {
@@ -1456,6 +1474,16 @@ TelemetryService::Service::Service() {
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       TelemetryService_method_names[31],
+      ::grpc::internal::RpcMethod::SERVER_STREAMING,
+      new ::grpc::internal::ServerStreamingHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SubscribeHeadingRequest, ::mavsdk::rpc::telemetry::HeadingResponse>(
+          [](TelemetryService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest* req,
+             ::grpc::ServerWriter<::mavsdk::rpc::telemetry::HeadingResponse>* writer) {
+               return service->SubscribeHeading(ctx, req, writer);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      TelemetryService_method_names[32],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRatePositionRequest, ::mavsdk::rpc::telemetry::SetRatePositionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1465,7 +1493,7 @@ TelemetryService::Service::Service() {
                return service->SetRatePosition(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[32],
+      TelemetryService_method_names[33],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRateHomeRequest, ::mavsdk::rpc::telemetry::SetRateHomeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1475,7 +1503,7 @@ TelemetryService::Service::Service() {
                return service->SetRateHome(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[33],
+      TelemetryService_method_names[34],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRateInAirRequest, ::mavsdk::rpc::telemetry::SetRateInAirResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1485,7 +1513,7 @@ TelemetryService::Service::Service() {
                return service->SetRateInAir(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[34],
+      TelemetryService_method_names[35],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRateLandedStateRequest, ::mavsdk::rpc::telemetry::SetRateLandedStateResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1495,7 +1523,7 @@ TelemetryService::Service::Service() {
                return service->SetRateLandedState(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[35],
+      TelemetryService_method_names[36],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRateAttitudeRequest, ::mavsdk::rpc::telemetry::SetRateAttitudeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1505,7 +1533,7 @@ TelemetryService::Service::Service() {
                return service->SetRateAttitude(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[36],
+      TelemetryService_method_names[37],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRateCameraAttitudeRequest, ::mavsdk::rpc::telemetry::SetRateCameraAttitudeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1515,7 +1543,7 @@ TelemetryService::Service::Service() {
                return service->SetRateCameraAttitude(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[37],
+      TelemetryService_method_names[38],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRateVelocityNedRequest, ::mavsdk::rpc::telemetry::SetRateVelocityNedResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1525,7 +1553,7 @@ TelemetryService::Service::Service() {
                return service->SetRateVelocityNed(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[38],
+      TelemetryService_method_names[39],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRateGpsInfoRequest, ::mavsdk::rpc::telemetry::SetRateGpsInfoResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1535,7 +1563,7 @@ TelemetryService::Service::Service() {
                return service->SetRateGpsInfo(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[39],
+      TelemetryService_method_names[40],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRateBatteryRequest, ::mavsdk::rpc::telemetry::SetRateBatteryResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1545,7 +1573,7 @@ TelemetryService::Service::Service() {
                return service->SetRateBattery(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[40],
+      TelemetryService_method_names[41],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRateRcStatusRequest, ::mavsdk::rpc::telemetry::SetRateRcStatusResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1555,7 +1583,7 @@ TelemetryService::Service::Service() {
                return service->SetRateRcStatus(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[41],
+      TelemetryService_method_names[42],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRateActuatorControlTargetRequest, ::mavsdk::rpc::telemetry::SetRateActuatorControlTargetResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1565,7 +1593,7 @@ TelemetryService::Service::Service() {
                return service->SetRateActuatorControlTarget(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[42],
+      TelemetryService_method_names[43],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRateActuatorOutputStatusRequest, ::mavsdk::rpc::telemetry::SetRateActuatorOutputStatusResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1575,7 +1603,7 @@ TelemetryService::Service::Service() {
                return service->SetRateActuatorOutputStatus(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[43],
+      TelemetryService_method_names[44],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRateOdometryRequest, ::mavsdk::rpc::telemetry::SetRateOdometryResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1585,7 +1613,7 @@ TelemetryService::Service::Service() {
                return service->SetRateOdometry(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[44],
+      TelemetryService_method_names[45],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRatePositionVelocityNedRequest, ::mavsdk::rpc::telemetry::SetRatePositionVelocityNedResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1595,7 +1623,7 @@ TelemetryService::Service::Service() {
                return service->SetRatePositionVelocityNed(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[45],
+      TelemetryService_method_names[46],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRateGroundTruthRequest, ::mavsdk::rpc::telemetry::SetRateGroundTruthResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1605,7 +1633,7 @@ TelemetryService::Service::Service() {
                return service->SetRateGroundTruth(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[46],
+      TelemetryService_method_names[47],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRateFixedwingMetricsRequest, ::mavsdk::rpc::telemetry::SetRateFixedwingMetricsResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1615,7 +1643,7 @@ TelemetryService::Service::Service() {
                return service->SetRateFixedwingMetrics(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[47],
+      TelemetryService_method_names[48],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRateImuRequest, ::mavsdk::rpc::telemetry::SetRateImuResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1625,7 +1653,7 @@ TelemetryService::Service::Service() {
                return service->SetRateImu(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[48],
+      TelemetryService_method_names[49],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRateScaledImuRequest, ::mavsdk::rpc::telemetry::SetRateScaledImuResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1635,7 +1663,7 @@ TelemetryService::Service::Service() {
                return service->SetRateScaledImu(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[49],
+      TelemetryService_method_names[50],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRateRawImuRequest, ::mavsdk::rpc::telemetry::SetRateRawImuResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1645,7 +1673,7 @@ TelemetryService::Service::Service() {
                return service->SetRateRawImu(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[50],
+      TelemetryService_method_names[51],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRateUnixEpochTimeRequest, ::mavsdk::rpc::telemetry::SetRateUnixEpochTimeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1655,7 +1683,7 @@ TelemetryService::Service::Service() {
                return service->SetRateUnixEpochTime(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[51],
+      TelemetryService_method_names[52],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest, ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1665,7 +1693,7 @@ TelemetryService::Service::Service() {
                return service->SetRateDistanceSensor(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      TelemetryService_method_names[52],
+      TelemetryService_method_names[53],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< TelemetryService::Service, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](TelemetryService::Service* service,
@@ -1890,6 +1918,13 @@ TelemetryService::Service::~Service() {
 }
 
 ::grpc::Status TelemetryService::Service::SubscribeScaledPressure(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry::SubscribeScaledPressureRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::telemetry::ScaledPressureResponse>* writer) {
+  (void) context;
+  (void) request;
+  (void) writer;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status TelemetryService::Service::SubscribeHeading(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::telemetry::HeadingResponse>* writer) {
   (void) context;
   (void) request;
   (void) writer;

--- a/src/mavsdk_server/src/generated/telemetry/telemetry.grpc.pb.h
+++ b/src/mavsdk_server/src/generated/telemetry/telemetry.grpc.pb.h
@@ -351,6 +351,16 @@ class TelemetryService final {
     std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::telemetry::ScaledPressureResponse>> PrepareAsyncSubscribeScaledPressure(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeScaledPressureRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::telemetry::ScaledPressureResponse>>(PrepareAsyncSubscribeScaledPressureRaw(context, request, cq));
     }
+    // Subscribe to 'Heading' updates.
+    std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::telemetry::HeadingResponse>> SubscribeHeading(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::telemetry::HeadingResponse>>(SubscribeHeadingRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::telemetry::HeadingResponse>> AsyncSubscribeHeading(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::telemetry::HeadingResponse>>(AsyncSubscribeHeadingRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::telemetry::HeadingResponse>> PrepareAsyncSubscribeHeading(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::telemetry::HeadingResponse>>(PrepareAsyncSubscribeHeadingRaw(context, request, cq));
+    }
     // Set rate to 'position' updates.
     virtual ::grpc::Status SetRatePosition(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRatePositionRequest& request, ::mavsdk::rpc::telemetry::SetRatePositionResponse* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry::SetRatePositionResponse>> AsyncSetRatePosition(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRatePositionRequest& request, ::grpc::CompletionQueue* cq) {
@@ -716,6 +726,12 @@ class TelemetryService final {
       #else
       virtual void SubscribeScaledPressure(::grpc::ClientContext* context, ::mavsdk::rpc::telemetry::SubscribeScaledPressureRequest* request, ::grpc::experimental::ClientReadReactor< ::mavsdk::rpc::telemetry::ScaledPressureResponse>* reactor) = 0;
       #endif
+      // Subscribe to 'Heading' updates.
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      virtual void SubscribeHeading(::grpc::ClientContext* context, ::mavsdk::rpc::telemetry::SubscribeHeadingRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::telemetry::HeadingResponse>* reactor) = 0;
+      #else
+      virtual void SubscribeHeading(::grpc::ClientContext* context, ::mavsdk::rpc::telemetry::SubscribeHeadingRequest* request, ::grpc::experimental::ClientReadReactor< ::mavsdk::rpc::telemetry::HeadingResponse>* reactor) = 0;
+      #endif
       // Set rate to 'position' updates.
       virtual void SetRatePosition(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRatePositionRequest* request, ::mavsdk::rpc::telemetry::SetRatePositionResponse* response, std::function<void(::grpc::Status)>) = 0;
       #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -972,6 +988,9 @@ class TelemetryService final {
     virtual ::grpc::ClientReaderInterface< ::mavsdk::rpc::telemetry::ScaledPressureResponse>* SubscribeScaledPressureRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeScaledPressureRequest& request) = 0;
     virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::telemetry::ScaledPressureResponse>* AsyncSubscribeScaledPressureRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeScaledPressureRequest& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
     virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::telemetry::ScaledPressureResponse>* PrepareAsyncSubscribeScaledPressureRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeScaledPressureRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientReaderInterface< ::mavsdk::rpc::telemetry::HeadingResponse>* SubscribeHeadingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest& request) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::telemetry::HeadingResponse>* AsyncSubscribeHeadingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::telemetry::HeadingResponse>* PrepareAsyncSubscribeHeadingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry::SetRatePositionResponse>* AsyncSetRatePositionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRatePositionRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry::SetRatePositionResponse>* PrepareAsyncSetRatePositionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRatePositionRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry::SetRateHomeResponse>* AsyncSetRateHomeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRateHomeRequest& request, ::grpc::CompletionQueue* cq) = 0;
@@ -1299,6 +1318,15 @@ class TelemetryService final {
     std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::telemetry::ScaledPressureResponse>> PrepareAsyncSubscribeScaledPressure(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeScaledPressureRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::telemetry::ScaledPressureResponse>>(PrepareAsyncSubscribeScaledPressureRaw(context, request, cq));
     }
+    std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::telemetry::HeadingResponse>> SubscribeHeading(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::telemetry::HeadingResponse>>(SubscribeHeadingRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::telemetry::HeadingResponse>> AsyncSubscribeHeading(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::telemetry::HeadingResponse>>(AsyncSubscribeHeadingRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::telemetry::HeadingResponse>> PrepareAsyncSubscribeHeading(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::telemetry::HeadingResponse>>(PrepareAsyncSubscribeHeadingRaw(context, request, cq));
+    }
     ::grpc::Status SetRatePosition(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRatePositionRequest& request, ::mavsdk::rpc::telemetry::SetRatePositionResponse* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry::SetRatePositionResponse>> AsyncSetRatePosition(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRatePositionRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry::SetRatePositionResponse>>(AsyncSetRatePositionRaw(context, request, cq));
@@ -1611,6 +1639,11 @@ class TelemetryService final {
       #else
       void SubscribeScaledPressure(::grpc::ClientContext* context, ::mavsdk::rpc::telemetry::SubscribeScaledPressureRequest* request, ::grpc::experimental::ClientReadReactor< ::mavsdk::rpc::telemetry::ScaledPressureResponse>* reactor) override;
       #endif
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      void SubscribeHeading(::grpc::ClientContext* context, ::mavsdk::rpc::telemetry::SubscribeHeadingRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::telemetry::HeadingResponse>* reactor) override;
+      #else
+      void SubscribeHeading(::grpc::ClientContext* context, ::mavsdk::rpc::telemetry::SubscribeHeadingRequest* request, ::grpc::experimental::ClientReadReactor< ::mavsdk::rpc::telemetry::HeadingResponse>* reactor) override;
+      #endif
       void SetRatePosition(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRatePositionRequest* request, ::mavsdk::rpc::telemetry::SetRatePositionResponse* response, std::function<void(::grpc::Status)>) override;
       #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       void SetRatePosition(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRatePositionRequest* request, ::mavsdk::rpc::telemetry::SetRatePositionResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
@@ -1847,6 +1880,9 @@ class TelemetryService final {
     ::grpc::ClientReader< ::mavsdk::rpc::telemetry::ScaledPressureResponse>* SubscribeScaledPressureRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeScaledPressureRequest& request) override;
     ::grpc::ClientAsyncReader< ::mavsdk::rpc::telemetry::ScaledPressureResponse>* AsyncSubscribeScaledPressureRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeScaledPressureRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
     ::grpc::ClientAsyncReader< ::mavsdk::rpc::telemetry::ScaledPressureResponse>* PrepareAsyncSubscribeScaledPressureRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeScaledPressureRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientReader< ::mavsdk::rpc::telemetry::HeadingResponse>* SubscribeHeadingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest& request) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::telemetry::HeadingResponse>* AsyncSubscribeHeadingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::telemetry::HeadingResponse>* PrepareAsyncSubscribeHeadingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry::SetRatePositionResponse>* AsyncSetRatePositionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRatePositionRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry::SetRatePositionResponse>* PrepareAsyncSetRatePositionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRatePositionRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry::SetRateHomeResponse>* AsyncSetRateHomeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SetRateHomeRequest& request, ::grpc::CompletionQueue* cq) override;
@@ -1922,6 +1958,7 @@ class TelemetryService final {
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeUnixEpochTime_;
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeDistanceSensor_;
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeScaledPressure_;
+    const ::grpc::internal::RpcMethod rpcmethod_SubscribeHeading_;
     const ::grpc::internal::RpcMethod rpcmethod_SetRatePosition_;
     const ::grpc::internal::RpcMethod rpcmethod_SetRateHome_;
     const ::grpc::internal::RpcMethod rpcmethod_SetRateInAir_;
@@ -2013,6 +2050,8 @@ class TelemetryService final {
     virtual ::grpc::Status SubscribeDistanceSensor(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry::SubscribeDistanceSensorRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::telemetry::DistanceSensorResponse>* writer);
     // Subscribe to 'Scaled Pressure' updates.
     virtual ::grpc::Status SubscribeScaledPressure(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry::SubscribeScaledPressureRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::telemetry::ScaledPressureResponse>* writer);
+    // Subscribe to 'Heading' updates.
+    virtual ::grpc::Status SubscribeHeading(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::telemetry::HeadingResponse>* writer);
     // Set rate to 'position' updates.
     virtual ::grpc::Status SetRatePosition(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry::SetRatePositionRequest* request, ::mavsdk::rpc::telemetry::SetRatePositionResponse* response);
     // Set rate to 'home position' updates.
@@ -2679,12 +2718,32 @@ class TelemetryService final {
     }
   };
   template <class BaseClass>
+  class WithAsyncMethod_SubscribeHeading : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SubscribeHeading() {
+      ::grpc::Service::MarkMethodAsync(31);
+    }
+    ~WithAsyncMethod_SubscribeHeading() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeHeading(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::telemetry::HeadingResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeHeading(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SubscribeHeadingRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::telemetry::HeadingResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(31, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithAsyncMethod_SetRatePosition : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRatePosition() {
-      ::grpc::Service::MarkMethodAsync(31);
+      ::grpc::Service::MarkMethodAsync(32);
     }
     ~WithAsyncMethod_SetRatePosition() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2695,7 +2754,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRatePosition(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRatePositionRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRatePositionResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(31, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(32, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2704,7 +2763,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRateHome() {
-      ::grpc::Service::MarkMethodAsync(32);
+      ::grpc::Service::MarkMethodAsync(33);
     }
     ~WithAsyncMethod_SetRateHome() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2715,7 +2774,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateHome(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRateHomeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRateHomeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(32, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(33, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2724,7 +2783,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRateInAir() {
-      ::grpc::Service::MarkMethodAsync(33);
+      ::grpc::Service::MarkMethodAsync(34);
     }
     ~WithAsyncMethod_SetRateInAir() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2735,7 +2794,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateInAir(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRateInAirRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRateInAirResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(33, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(34, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2744,7 +2803,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRateLandedState() {
-      ::grpc::Service::MarkMethodAsync(34);
+      ::grpc::Service::MarkMethodAsync(35);
     }
     ~WithAsyncMethod_SetRateLandedState() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2755,7 +2814,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateLandedState(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRateLandedStateRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRateLandedStateResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(34, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(35, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2764,7 +2823,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRateAttitude() {
-      ::grpc::Service::MarkMethodAsync(35);
+      ::grpc::Service::MarkMethodAsync(36);
     }
     ~WithAsyncMethod_SetRateAttitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2775,7 +2834,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateAttitude(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRateAttitudeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRateAttitudeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(35, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(36, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2784,7 +2843,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRateCameraAttitude() {
-      ::grpc::Service::MarkMethodAsync(36);
+      ::grpc::Service::MarkMethodAsync(37);
     }
     ~WithAsyncMethod_SetRateCameraAttitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2795,7 +2854,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateCameraAttitude(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRateCameraAttitudeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRateCameraAttitudeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(36, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(37, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2804,7 +2863,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRateVelocityNed() {
-      ::grpc::Service::MarkMethodAsync(37);
+      ::grpc::Service::MarkMethodAsync(38);
     }
     ~WithAsyncMethod_SetRateVelocityNed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2815,7 +2874,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateVelocityNed(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRateVelocityNedRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRateVelocityNedResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(37, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(38, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2824,7 +2883,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRateGpsInfo() {
-      ::grpc::Service::MarkMethodAsync(38);
+      ::grpc::Service::MarkMethodAsync(39);
     }
     ~WithAsyncMethod_SetRateGpsInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2835,7 +2894,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateGpsInfo(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRateGpsInfoRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRateGpsInfoResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(38, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(39, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2844,7 +2903,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRateBattery() {
-      ::grpc::Service::MarkMethodAsync(39);
+      ::grpc::Service::MarkMethodAsync(40);
     }
     ~WithAsyncMethod_SetRateBattery() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2855,7 +2914,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateBattery(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRateBatteryRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRateBatteryResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(39, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(40, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2864,7 +2923,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRateRcStatus() {
-      ::grpc::Service::MarkMethodAsync(40);
+      ::grpc::Service::MarkMethodAsync(41);
     }
     ~WithAsyncMethod_SetRateRcStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2875,7 +2934,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateRcStatus(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRateRcStatusRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRateRcStatusResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(40, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(41, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2884,7 +2943,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRateActuatorControlTarget() {
-      ::grpc::Service::MarkMethodAsync(41);
+      ::grpc::Service::MarkMethodAsync(42);
     }
     ~WithAsyncMethod_SetRateActuatorControlTarget() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2895,7 +2954,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateActuatorControlTarget(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRateActuatorControlTargetRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRateActuatorControlTargetResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(41, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(42, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2904,7 +2963,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRateActuatorOutputStatus() {
-      ::grpc::Service::MarkMethodAsync(42);
+      ::grpc::Service::MarkMethodAsync(43);
     }
     ~WithAsyncMethod_SetRateActuatorOutputStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2915,7 +2974,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateActuatorOutputStatus(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRateActuatorOutputStatusRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRateActuatorOutputStatusResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(42, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(43, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2924,7 +2983,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRateOdometry() {
-      ::grpc::Service::MarkMethodAsync(43);
+      ::grpc::Service::MarkMethodAsync(44);
     }
     ~WithAsyncMethod_SetRateOdometry() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2935,7 +2994,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateOdometry(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRateOdometryRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRateOdometryResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(43, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(44, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2944,7 +3003,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRatePositionVelocityNed() {
-      ::grpc::Service::MarkMethodAsync(44);
+      ::grpc::Service::MarkMethodAsync(45);
     }
     ~WithAsyncMethod_SetRatePositionVelocityNed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2955,7 +3014,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRatePositionVelocityNed(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRatePositionVelocityNedRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRatePositionVelocityNedResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(44, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(45, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2964,7 +3023,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRateGroundTruth() {
-      ::grpc::Service::MarkMethodAsync(45);
+      ::grpc::Service::MarkMethodAsync(46);
     }
     ~WithAsyncMethod_SetRateGroundTruth() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2975,7 +3034,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateGroundTruth(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRateGroundTruthRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRateGroundTruthResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(45, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(46, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2984,7 +3043,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRateFixedwingMetrics() {
-      ::grpc::Service::MarkMethodAsync(46);
+      ::grpc::Service::MarkMethodAsync(47);
     }
     ~WithAsyncMethod_SetRateFixedwingMetrics() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2995,7 +3054,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateFixedwingMetrics(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRateFixedwingMetricsRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRateFixedwingMetricsResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(46, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(47, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -3004,7 +3063,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRateImu() {
-      ::grpc::Service::MarkMethodAsync(47);
+      ::grpc::Service::MarkMethodAsync(48);
     }
     ~WithAsyncMethod_SetRateImu() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3015,7 +3074,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateImu(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRateImuRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRateImuResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(47, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(48, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -3024,7 +3083,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRateScaledImu() {
-      ::grpc::Service::MarkMethodAsync(48);
+      ::grpc::Service::MarkMethodAsync(49);
     }
     ~WithAsyncMethod_SetRateScaledImu() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3035,7 +3094,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateScaledImu(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRateScaledImuRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRateScaledImuResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(48, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(49, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -3044,7 +3103,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRateRawImu() {
-      ::grpc::Service::MarkMethodAsync(49);
+      ::grpc::Service::MarkMethodAsync(50);
     }
     ~WithAsyncMethod_SetRateRawImu() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3055,7 +3114,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateRawImu(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRateRawImuRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRateRawImuResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(49, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(50, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -3064,7 +3123,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRateUnixEpochTime() {
-      ::grpc::Service::MarkMethodAsync(50);
+      ::grpc::Service::MarkMethodAsync(51);
     }
     ~WithAsyncMethod_SetRateUnixEpochTime() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3075,7 +3134,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateUnixEpochTime(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRateUnixEpochTimeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRateUnixEpochTimeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(50, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(51, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -3084,7 +3143,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRateDistanceSensor() {
-      ::grpc::Service::MarkMethodAsync(51);
+      ::grpc::Service::MarkMethodAsync(52);
     }
     ~WithAsyncMethod_SetRateDistanceSensor() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3095,7 +3154,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateDistanceSensor(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(51, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(52, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -3104,7 +3163,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_GetGpsGlobalOrigin() {
-      ::grpc::Service::MarkMethodAsync(52);
+      ::grpc::Service::MarkMethodAsync(53);
     }
     ~WithAsyncMethod_GetGpsGlobalOrigin() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3115,10 +3174,10 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetGpsGlobalOrigin(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(52, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(53, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_SubscribePosition<WithAsyncMethod_SubscribeHome<WithAsyncMethod_SubscribeInAir<WithAsyncMethod_SubscribeLandedState<WithAsyncMethod_SubscribeArmed<WithAsyncMethod_SubscribeAttitudeQuaternion<WithAsyncMethod_SubscribeAttitudeEuler<WithAsyncMethod_SubscribeAttitudeAngularVelocityBody<WithAsyncMethod_SubscribeCameraAttitudeQuaternion<WithAsyncMethod_SubscribeCameraAttitudeEuler<WithAsyncMethod_SubscribeVelocityNed<WithAsyncMethod_SubscribeGpsInfo<WithAsyncMethod_SubscribeRawGps<WithAsyncMethod_SubscribeBattery<WithAsyncMethod_SubscribeFlightMode<WithAsyncMethod_SubscribeHealth<WithAsyncMethod_SubscribeRcStatus<WithAsyncMethod_SubscribeStatusText<WithAsyncMethod_SubscribeActuatorControlTarget<WithAsyncMethod_SubscribeActuatorOutputStatus<WithAsyncMethod_SubscribeOdometry<WithAsyncMethod_SubscribePositionVelocityNed<WithAsyncMethod_SubscribeGroundTruth<WithAsyncMethod_SubscribeFixedwingMetrics<WithAsyncMethod_SubscribeImu<WithAsyncMethod_SubscribeScaledImu<WithAsyncMethod_SubscribeRawImu<WithAsyncMethod_SubscribeHealthAllOk<WithAsyncMethod_SubscribeUnixEpochTime<WithAsyncMethod_SubscribeDistanceSensor<WithAsyncMethod_SubscribeScaledPressure<WithAsyncMethod_SetRatePosition<WithAsyncMethod_SetRateHome<WithAsyncMethod_SetRateInAir<WithAsyncMethod_SetRateLandedState<WithAsyncMethod_SetRateAttitude<WithAsyncMethod_SetRateCameraAttitude<WithAsyncMethod_SetRateVelocityNed<WithAsyncMethod_SetRateGpsInfo<WithAsyncMethod_SetRateBattery<WithAsyncMethod_SetRateRcStatus<WithAsyncMethod_SetRateActuatorControlTarget<WithAsyncMethod_SetRateActuatorOutputStatus<WithAsyncMethod_SetRateOdometry<WithAsyncMethod_SetRatePositionVelocityNed<WithAsyncMethod_SetRateGroundTruth<WithAsyncMethod_SetRateFixedwingMetrics<WithAsyncMethod_SetRateImu<WithAsyncMethod_SetRateScaledImu<WithAsyncMethod_SetRateRawImu<WithAsyncMethod_SetRateUnixEpochTime<WithAsyncMethod_SetRateDistanceSensor<WithAsyncMethod_GetGpsGlobalOrigin<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
+  typedef WithAsyncMethod_SubscribePosition<WithAsyncMethod_SubscribeHome<WithAsyncMethod_SubscribeInAir<WithAsyncMethod_SubscribeLandedState<WithAsyncMethod_SubscribeArmed<WithAsyncMethod_SubscribeAttitudeQuaternion<WithAsyncMethod_SubscribeAttitudeEuler<WithAsyncMethod_SubscribeAttitudeAngularVelocityBody<WithAsyncMethod_SubscribeCameraAttitudeQuaternion<WithAsyncMethod_SubscribeCameraAttitudeEuler<WithAsyncMethod_SubscribeVelocityNed<WithAsyncMethod_SubscribeGpsInfo<WithAsyncMethod_SubscribeRawGps<WithAsyncMethod_SubscribeBattery<WithAsyncMethod_SubscribeFlightMode<WithAsyncMethod_SubscribeHealth<WithAsyncMethod_SubscribeRcStatus<WithAsyncMethod_SubscribeStatusText<WithAsyncMethod_SubscribeActuatorControlTarget<WithAsyncMethod_SubscribeActuatorOutputStatus<WithAsyncMethod_SubscribeOdometry<WithAsyncMethod_SubscribePositionVelocityNed<WithAsyncMethod_SubscribeGroundTruth<WithAsyncMethod_SubscribeFixedwingMetrics<WithAsyncMethod_SubscribeImu<WithAsyncMethod_SubscribeScaledImu<WithAsyncMethod_SubscribeRawImu<WithAsyncMethod_SubscribeHealthAllOk<WithAsyncMethod_SubscribeUnixEpochTime<WithAsyncMethod_SubscribeDistanceSensor<WithAsyncMethod_SubscribeScaledPressure<WithAsyncMethod_SubscribeHeading<WithAsyncMethod_SetRatePosition<WithAsyncMethod_SetRateHome<WithAsyncMethod_SetRateInAir<WithAsyncMethod_SetRateLandedState<WithAsyncMethod_SetRateAttitude<WithAsyncMethod_SetRateCameraAttitude<WithAsyncMethod_SetRateVelocityNed<WithAsyncMethod_SetRateGpsInfo<WithAsyncMethod_SetRateBattery<WithAsyncMethod_SetRateRcStatus<WithAsyncMethod_SetRateActuatorControlTarget<WithAsyncMethod_SetRateActuatorOutputStatus<WithAsyncMethod_SetRateOdometry<WithAsyncMethod_SetRatePositionVelocityNed<WithAsyncMethod_SetRateGroundTruth<WithAsyncMethod_SetRateFixedwingMetrics<WithAsyncMethod_SetRateImu<WithAsyncMethod_SetRateScaledImu<WithAsyncMethod_SetRateRawImu<WithAsyncMethod_SetRateUnixEpochTime<WithAsyncMethod_SetRateDistanceSensor<WithAsyncMethod_GetGpsGlobalOrigin<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class ExperimentalWithCallbackMethod_SubscribePosition : public BaseClass {
    private:
@@ -4298,6 +4357,44 @@ class TelemetryService final {
       { return nullptr; }
   };
   template <class BaseClass>
+  class ExperimentalWithCallbackMethod_SubscribeHeading : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    ExperimentalWithCallbackMethod_SubscribeHeading() {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodCallback(31,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::telemetry::SubscribeHeadingRequest, ::mavsdk::rpc::telemetry::HeadingResponse>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest* request) { return this->SubscribeHeading(context, request); }));
+    }
+    ~ExperimentalWithCallbackMethod_SubscribeHeading() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeHeading(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::telemetry::HeadingResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerWriteReactor< ::mavsdk::rpc::telemetry::HeadingResponse>* SubscribeHeading(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest* /*request*/)
+    #else
+    virtual ::grpc::experimental::ServerWriteReactor< ::mavsdk::rpc::telemetry::HeadingResponse>* SubscribeHeading(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest* /*request*/)
+    #endif
+      { return nullptr; }
+  };
+  template <class BaseClass>
   class ExperimentalWithCallbackMethod_SetRatePosition : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
@@ -4308,7 +4405,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(31,
+        MarkMethodCallback(32,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRatePositionRequest, ::mavsdk::rpc::telemetry::SetRatePositionResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -4320,9 +4417,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRatePosition(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRatePositionRequest, ::mavsdk::rpc::telemetry::SetRatePositionResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(31);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(32);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(31);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(32);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRatePositionRequest, ::mavsdk::rpc::telemetry::SetRatePositionResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -4355,7 +4452,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(32,
+        MarkMethodCallback(33,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateHomeRequest, ::mavsdk::rpc::telemetry::SetRateHomeResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -4367,9 +4464,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRateHome(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRateHomeRequest, ::mavsdk::rpc::telemetry::SetRateHomeResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(32);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(33);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(32);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(33);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateHomeRequest, ::mavsdk::rpc::telemetry::SetRateHomeResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -4402,7 +4499,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(33,
+        MarkMethodCallback(34,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateInAirRequest, ::mavsdk::rpc::telemetry::SetRateInAirResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -4414,9 +4511,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRateInAir(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRateInAirRequest, ::mavsdk::rpc::telemetry::SetRateInAirResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(33);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(34);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(33);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(34);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateInAirRequest, ::mavsdk::rpc::telemetry::SetRateInAirResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -4449,7 +4546,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(34,
+        MarkMethodCallback(35,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateLandedStateRequest, ::mavsdk::rpc::telemetry::SetRateLandedStateResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -4461,9 +4558,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRateLandedState(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRateLandedStateRequest, ::mavsdk::rpc::telemetry::SetRateLandedStateResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(34);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(35);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(34);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(35);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateLandedStateRequest, ::mavsdk::rpc::telemetry::SetRateLandedStateResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -4496,7 +4593,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(35,
+        MarkMethodCallback(36,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateAttitudeRequest, ::mavsdk::rpc::telemetry::SetRateAttitudeResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -4508,9 +4605,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRateAttitude(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRateAttitudeRequest, ::mavsdk::rpc::telemetry::SetRateAttitudeResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(35);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(36);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(35);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(36);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateAttitudeRequest, ::mavsdk::rpc::telemetry::SetRateAttitudeResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -4543,7 +4640,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(36,
+        MarkMethodCallback(37,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateCameraAttitudeRequest, ::mavsdk::rpc::telemetry::SetRateCameraAttitudeResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -4555,9 +4652,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRateCameraAttitude(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRateCameraAttitudeRequest, ::mavsdk::rpc::telemetry::SetRateCameraAttitudeResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(36);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(37);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(36);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(37);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateCameraAttitudeRequest, ::mavsdk::rpc::telemetry::SetRateCameraAttitudeResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -4590,7 +4687,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(37,
+        MarkMethodCallback(38,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateVelocityNedRequest, ::mavsdk::rpc::telemetry::SetRateVelocityNedResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -4602,9 +4699,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRateVelocityNed(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRateVelocityNedRequest, ::mavsdk::rpc::telemetry::SetRateVelocityNedResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(37);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(38);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(37);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(38);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateVelocityNedRequest, ::mavsdk::rpc::telemetry::SetRateVelocityNedResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -4637,7 +4734,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(38,
+        MarkMethodCallback(39,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateGpsInfoRequest, ::mavsdk::rpc::telemetry::SetRateGpsInfoResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -4649,9 +4746,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRateGpsInfo(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRateGpsInfoRequest, ::mavsdk::rpc::telemetry::SetRateGpsInfoResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(38);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(39);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(38);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(39);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateGpsInfoRequest, ::mavsdk::rpc::telemetry::SetRateGpsInfoResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -4684,7 +4781,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(39,
+        MarkMethodCallback(40,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateBatteryRequest, ::mavsdk::rpc::telemetry::SetRateBatteryResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -4696,9 +4793,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRateBattery(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRateBatteryRequest, ::mavsdk::rpc::telemetry::SetRateBatteryResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(39);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(40);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(39);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(40);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateBatteryRequest, ::mavsdk::rpc::telemetry::SetRateBatteryResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -4731,7 +4828,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(40,
+        MarkMethodCallback(41,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateRcStatusRequest, ::mavsdk::rpc::telemetry::SetRateRcStatusResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -4743,9 +4840,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRateRcStatus(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRateRcStatusRequest, ::mavsdk::rpc::telemetry::SetRateRcStatusResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(40);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(41);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(40);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(41);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateRcStatusRequest, ::mavsdk::rpc::telemetry::SetRateRcStatusResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -4778,7 +4875,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(41,
+        MarkMethodCallback(42,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateActuatorControlTargetRequest, ::mavsdk::rpc::telemetry::SetRateActuatorControlTargetResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -4790,9 +4887,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRateActuatorControlTarget(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRateActuatorControlTargetRequest, ::mavsdk::rpc::telemetry::SetRateActuatorControlTargetResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(41);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(42);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(41);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(42);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateActuatorControlTargetRequest, ::mavsdk::rpc::telemetry::SetRateActuatorControlTargetResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -4825,7 +4922,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(42,
+        MarkMethodCallback(43,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateActuatorOutputStatusRequest, ::mavsdk::rpc::telemetry::SetRateActuatorOutputStatusResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -4837,9 +4934,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRateActuatorOutputStatus(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRateActuatorOutputStatusRequest, ::mavsdk::rpc::telemetry::SetRateActuatorOutputStatusResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(42);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(43);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(42);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(43);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateActuatorOutputStatusRequest, ::mavsdk::rpc::telemetry::SetRateActuatorOutputStatusResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -4872,7 +4969,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(43,
+        MarkMethodCallback(44,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateOdometryRequest, ::mavsdk::rpc::telemetry::SetRateOdometryResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -4884,9 +4981,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRateOdometry(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRateOdometryRequest, ::mavsdk::rpc::telemetry::SetRateOdometryResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(43);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(44);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(43);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(44);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateOdometryRequest, ::mavsdk::rpc::telemetry::SetRateOdometryResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -4919,7 +5016,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(44,
+        MarkMethodCallback(45,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRatePositionVelocityNedRequest, ::mavsdk::rpc::telemetry::SetRatePositionVelocityNedResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -4931,9 +5028,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRatePositionVelocityNed(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRatePositionVelocityNedRequest, ::mavsdk::rpc::telemetry::SetRatePositionVelocityNedResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(44);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(45);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(44);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(45);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRatePositionVelocityNedRequest, ::mavsdk::rpc::telemetry::SetRatePositionVelocityNedResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -4966,7 +5063,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(45,
+        MarkMethodCallback(46,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateGroundTruthRequest, ::mavsdk::rpc::telemetry::SetRateGroundTruthResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -4978,9 +5075,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRateGroundTruth(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRateGroundTruthRequest, ::mavsdk::rpc::telemetry::SetRateGroundTruthResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(45);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(46);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(45);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(46);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateGroundTruthRequest, ::mavsdk::rpc::telemetry::SetRateGroundTruthResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -5013,7 +5110,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(46,
+        MarkMethodCallback(47,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateFixedwingMetricsRequest, ::mavsdk::rpc::telemetry::SetRateFixedwingMetricsResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5025,9 +5122,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRateFixedwingMetrics(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRateFixedwingMetricsRequest, ::mavsdk::rpc::telemetry::SetRateFixedwingMetricsResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(46);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(47);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(46);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(47);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateFixedwingMetricsRequest, ::mavsdk::rpc::telemetry::SetRateFixedwingMetricsResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -5060,7 +5157,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(47,
+        MarkMethodCallback(48,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateImuRequest, ::mavsdk::rpc::telemetry::SetRateImuResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5072,9 +5169,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRateImu(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRateImuRequest, ::mavsdk::rpc::telemetry::SetRateImuResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(47);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(48);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(47);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(48);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateImuRequest, ::mavsdk::rpc::telemetry::SetRateImuResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -5107,7 +5204,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(48,
+        MarkMethodCallback(49,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateScaledImuRequest, ::mavsdk::rpc::telemetry::SetRateScaledImuResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5119,9 +5216,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRateScaledImu(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRateScaledImuRequest, ::mavsdk::rpc::telemetry::SetRateScaledImuResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(48);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(49);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(48);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(49);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateScaledImuRequest, ::mavsdk::rpc::telemetry::SetRateScaledImuResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -5154,7 +5251,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(49,
+        MarkMethodCallback(50,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateRawImuRequest, ::mavsdk::rpc::telemetry::SetRateRawImuResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5166,9 +5263,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRateRawImu(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRateRawImuRequest, ::mavsdk::rpc::telemetry::SetRateRawImuResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(49);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(50);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(49);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(50);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateRawImuRequest, ::mavsdk::rpc::telemetry::SetRateRawImuResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -5201,7 +5298,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(50,
+        MarkMethodCallback(51,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateUnixEpochTimeRequest, ::mavsdk::rpc::telemetry::SetRateUnixEpochTimeResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5213,9 +5310,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRateUnixEpochTime(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRateUnixEpochTimeRequest, ::mavsdk::rpc::telemetry::SetRateUnixEpochTimeResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(50);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(51);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(50);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(51);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateUnixEpochTimeRequest, ::mavsdk::rpc::telemetry::SetRateUnixEpochTimeResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -5248,7 +5345,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(51,
+        MarkMethodCallback(52,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest, ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5260,9 +5357,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_SetRateDistanceSensor(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest, ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(51);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(52);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(51);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(52);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest, ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -5295,7 +5392,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(52,
+        MarkMethodCallback(53,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5307,9 +5404,9 @@ class TelemetryService final {
     void SetMessageAllocatorFor_GetGpsGlobalOrigin(
         ::grpc::experimental::MessageAllocator< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(52);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(53);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(52);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(53);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -5332,10 +5429,10 @@ class TelemetryService final {
       { return nullptr; }
   };
   #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-  typedef ExperimentalWithCallbackMethod_SubscribePosition<ExperimentalWithCallbackMethod_SubscribeHome<ExperimentalWithCallbackMethod_SubscribeInAir<ExperimentalWithCallbackMethod_SubscribeLandedState<ExperimentalWithCallbackMethod_SubscribeArmed<ExperimentalWithCallbackMethod_SubscribeAttitudeQuaternion<ExperimentalWithCallbackMethod_SubscribeAttitudeEuler<ExperimentalWithCallbackMethod_SubscribeAttitudeAngularVelocityBody<ExperimentalWithCallbackMethod_SubscribeCameraAttitudeQuaternion<ExperimentalWithCallbackMethod_SubscribeCameraAttitudeEuler<ExperimentalWithCallbackMethod_SubscribeVelocityNed<ExperimentalWithCallbackMethod_SubscribeGpsInfo<ExperimentalWithCallbackMethod_SubscribeRawGps<ExperimentalWithCallbackMethod_SubscribeBattery<ExperimentalWithCallbackMethod_SubscribeFlightMode<ExperimentalWithCallbackMethod_SubscribeHealth<ExperimentalWithCallbackMethod_SubscribeRcStatus<ExperimentalWithCallbackMethod_SubscribeStatusText<ExperimentalWithCallbackMethod_SubscribeActuatorControlTarget<ExperimentalWithCallbackMethod_SubscribeActuatorOutputStatus<ExperimentalWithCallbackMethod_SubscribeOdometry<ExperimentalWithCallbackMethod_SubscribePositionVelocityNed<ExperimentalWithCallbackMethod_SubscribeGroundTruth<ExperimentalWithCallbackMethod_SubscribeFixedwingMetrics<ExperimentalWithCallbackMethod_SubscribeImu<ExperimentalWithCallbackMethod_SubscribeScaledImu<ExperimentalWithCallbackMethod_SubscribeRawImu<ExperimentalWithCallbackMethod_SubscribeHealthAllOk<ExperimentalWithCallbackMethod_SubscribeUnixEpochTime<ExperimentalWithCallbackMethod_SubscribeDistanceSensor<ExperimentalWithCallbackMethod_SubscribeScaledPressure<ExperimentalWithCallbackMethod_SetRatePosition<ExperimentalWithCallbackMethod_SetRateHome<ExperimentalWithCallbackMethod_SetRateInAir<ExperimentalWithCallbackMethod_SetRateLandedState<ExperimentalWithCallbackMethod_SetRateAttitude<ExperimentalWithCallbackMethod_SetRateCameraAttitude<ExperimentalWithCallbackMethod_SetRateVelocityNed<ExperimentalWithCallbackMethod_SetRateGpsInfo<ExperimentalWithCallbackMethod_SetRateBattery<ExperimentalWithCallbackMethod_SetRateRcStatus<ExperimentalWithCallbackMethod_SetRateActuatorControlTarget<ExperimentalWithCallbackMethod_SetRateActuatorOutputStatus<ExperimentalWithCallbackMethod_SetRateOdometry<ExperimentalWithCallbackMethod_SetRatePositionVelocityNed<ExperimentalWithCallbackMethod_SetRateGroundTruth<ExperimentalWithCallbackMethod_SetRateFixedwingMetrics<ExperimentalWithCallbackMethod_SetRateImu<ExperimentalWithCallbackMethod_SetRateScaledImu<ExperimentalWithCallbackMethod_SetRateRawImu<ExperimentalWithCallbackMethod_SetRateUnixEpochTime<ExperimentalWithCallbackMethod_SetRateDistanceSensor<ExperimentalWithCallbackMethod_GetGpsGlobalOrigin<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
+  typedef ExperimentalWithCallbackMethod_SubscribePosition<ExperimentalWithCallbackMethod_SubscribeHome<ExperimentalWithCallbackMethod_SubscribeInAir<ExperimentalWithCallbackMethod_SubscribeLandedState<ExperimentalWithCallbackMethod_SubscribeArmed<ExperimentalWithCallbackMethod_SubscribeAttitudeQuaternion<ExperimentalWithCallbackMethod_SubscribeAttitudeEuler<ExperimentalWithCallbackMethod_SubscribeAttitudeAngularVelocityBody<ExperimentalWithCallbackMethod_SubscribeCameraAttitudeQuaternion<ExperimentalWithCallbackMethod_SubscribeCameraAttitudeEuler<ExperimentalWithCallbackMethod_SubscribeVelocityNed<ExperimentalWithCallbackMethod_SubscribeGpsInfo<ExperimentalWithCallbackMethod_SubscribeRawGps<ExperimentalWithCallbackMethod_SubscribeBattery<ExperimentalWithCallbackMethod_SubscribeFlightMode<ExperimentalWithCallbackMethod_SubscribeHealth<ExperimentalWithCallbackMethod_SubscribeRcStatus<ExperimentalWithCallbackMethod_SubscribeStatusText<ExperimentalWithCallbackMethod_SubscribeActuatorControlTarget<ExperimentalWithCallbackMethod_SubscribeActuatorOutputStatus<ExperimentalWithCallbackMethod_SubscribeOdometry<ExperimentalWithCallbackMethod_SubscribePositionVelocityNed<ExperimentalWithCallbackMethod_SubscribeGroundTruth<ExperimentalWithCallbackMethod_SubscribeFixedwingMetrics<ExperimentalWithCallbackMethod_SubscribeImu<ExperimentalWithCallbackMethod_SubscribeScaledImu<ExperimentalWithCallbackMethod_SubscribeRawImu<ExperimentalWithCallbackMethod_SubscribeHealthAllOk<ExperimentalWithCallbackMethod_SubscribeUnixEpochTime<ExperimentalWithCallbackMethod_SubscribeDistanceSensor<ExperimentalWithCallbackMethod_SubscribeScaledPressure<ExperimentalWithCallbackMethod_SubscribeHeading<ExperimentalWithCallbackMethod_SetRatePosition<ExperimentalWithCallbackMethod_SetRateHome<ExperimentalWithCallbackMethod_SetRateInAir<ExperimentalWithCallbackMethod_SetRateLandedState<ExperimentalWithCallbackMethod_SetRateAttitude<ExperimentalWithCallbackMethod_SetRateCameraAttitude<ExperimentalWithCallbackMethod_SetRateVelocityNed<ExperimentalWithCallbackMethod_SetRateGpsInfo<ExperimentalWithCallbackMethod_SetRateBattery<ExperimentalWithCallbackMethod_SetRateRcStatus<ExperimentalWithCallbackMethod_SetRateActuatorControlTarget<ExperimentalWithCallbackMethod_SetRateActuatorOutputStatus<ExperimentalWithCallbackMethod_SetRateOdometry<ExperimentalWithCallbackMethod_SetRatePositionVelocityNed<ExperimentalWithCallbackMethod_SetRateGroundTruth<ExperimentalWithCallbackMethod_SetRateFixedwingMetrics<ExperimentalWithCallbackMethod_SetRateImu<ExperimentalWithCallbackMethod_SetRateScaledImu<ExperimentalWithCallbackMethod_SetRateRawImu<ExperimentalWithCallbackMethod_SetRateUnixEpochTime<ExperimentalWithCallbackMethod_SetRateDistanceSensor<ExperimentalWithCallbackMethod_GetGpsGlobalOrigin<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
   #endif
 
-  typedef ExperimentalWithCallbackMethod_SubscribePosition<ExperimentalWithCallbackMethod_SubscribeHome<ExperimentalWithCallbackMethod_SubscribeInAir<ExperimentalWithCallbackMethod_SubscribeLandedState<ExperimentalWithCallbackMethod_SubscribeArmed<ExperimentalWithCallbackMethod_SubscribeAttitudeQuaternion<ExperimentalWithCallbackMethod_SubscribeAttitudeEuler<ExperimentalWithCallbackMethod_SubscribeAttitudeAngularVelocityBody<ExperimentalWithCallbackMethod_SubscribeCameraAttitudeQuaternion<ExperimentalWithCallbackMethod_SubscribeCameraAttitudeEuler<ExperimentalWithCallbackMethod_SubscribeVelocityNed<ExperimentalWithCallbackMethod_SubscribeGpsInfo<ExperimentalWithCallbackMethod_SubscribeRawGps<ExperimentalWithCallbackMethod_SubscribeBattery<ExperimentalWithCallbackMethod_SubscribeFlightMode<ExperimentalWithCallbackMethod_SubscribeHealth<ExperimentalWithCallbackMethod_SubscribeRcStatus<ExperimentalWithCallbackMethod_SubscribeStatusText<ExperimentalWithCallbackMethod_SubscribeActuatorControlTarget<ExperimentalWithCallbackMethod_SubscribeActuatorOutputStatus<ExperimentalWithCallbackMethod_SubscribeOdometry<ExperimentalWithCallbackMethod_SubscribePositionVelocityNed<ExperimentalWithCallbackMethod_SubscribeGroundTruth<ExperimentalWithCallbackMethod_SubscribeFixedwingMetrics<ExperimentalWithCallbackMethod_SubscribeImu<ExperimentalWithCallbackMethod_SubscribeScaledImu<ExperimentalWithCallbackMethod_SubscribeRawImu<ExperimentalWithCallbackMethod_SubscribeHealthAllOk<ExperimentalWithCallbackMethod_SubscribeUnixEpochTime<ExperimentalWithCallbackMethod_SubscribeDistanceSensor<ExperimentalWithCallbackMethod_SubscribeScaledPressure<ExperimentalWithCallbackMethod_SetRatePosition<ExperimentalWithCallbackMethod_SetRateHome<ExperimentalWithCallbackMethod_SetRateInAir<ExperimentalWithCallbackMethod_SetRateLandedState<ExperimentalWithCallbackMethod_SetRateAttitude<ExperimentalWithCallbackMethod_SetRateCameraAttitude<ExperimentalWithCallbackMethod_SetRateVelocityNed<ExperimentalWithCallbackMethod_SetRateGpsInfo<ExperimentalWithCallbackMethod_SetRateBattery<ExperimentalWithCallbackMethod_SetRateRcStatus<ExperimentalWithCallbackMethod_SetRateActuatorControlTarget<ExperimentalWithCallbackMethod_SetRateActuatorOutputStatus<ExperimentalWithCallbackMethod_SetRateOdometry<ExperimentalWithCallbackMethod_SetRatePositionVelocityNed<ExperimentalWithCallbackMethod_SetRateGroundTruth<ExperimentalWithCallbackMethod_SetRateFixedwingMetrics<ExperimentalWithCallbackMethod_SetRateImu<ExperimentalWithCallbackMethod_SetRateScaledImu<ExperimentalWithCallbackMethod_SetRateRawImu<ExperimentalWithCallbackMethod_SetRateUnixEpochTime<ExperimentalWithCallbackMethod_SetRateDistanceSensor<ExperimentalWithCallbackMethod_GetGpsGlobalOrigin<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > ExperimentalCallbackService;
+  typedef ExperimentalWithCallbackMethod_SubscribePosition<ExperimentalWithCallbackMethod_SubscribeHome<ExperimentalWithCallbackMethod_SubscribeInAir<ExperimentalWithCallbackMethod_SubscribeLandedState<ExperimentalWithCallbackMethod_SubscribeArmed<ExperimentalWithCallbackMethod_SubscribeAttitudeQuaternion<ExperimentalWithCallbackMethod_SubscribeAttitudeEuler<ExperimentalWithCallbackMethod_SubscribeAttitudeAngularVelocityBody<ExperimentalWithCallbackMethod_SubscribeCameraAttitudeQuaternion<ExperimentalWithCallbackMethod_SubscribeCameraAttitudeEuler<ExperimentalWithCallbackMethod_SubscribeVelocityNed<ExperimentalWithCallbackMethod_SubscribeGpsInfo<ExperimentalWithCallbackMethod_SubscribeRawGps<ExperimentalWithCallbackMethod_SubscribeBattery<ExperimentalWithCallbackMethod_SubscribeFlightMode<ExperimentalWithCallbackMethod_SubscribeHealth<ExperimentalWithCallbackMethod_SubscribeRcStatus<ExperimentalWithCallbackMethod_SubscribeStatusText<ExperimentalWithCallbackMethod_SubscribeActuatorControlTarget<ExperimentalWithCallbackMethod_SubscribeActuatorOutputStatus<ExperimentalWithCallbackMethod_SubscribeOdometry<ExperimentalWithCallbackMethod_SubscribePositionVelocityNed<ExperimentalWithCallbackMethod_SubscribeGroundTruth<ExperimentalWithCallbackMethod_SubscribeFixedwingMetrics<ExperimentalWithCallbackMethod_SubscribeImu<ExperimentalWithCallbackMethod_SubscribeScaledImu<ExperimentalWithCallbackMethod_SubscribeRawImu<ExperimentalWithCallbackMethod_SubscribeHealthAllOk<ExperimentalWithCallbackMethod_SubscribeUnixEpochTime<ExperimentalWithCallbackMethod_SubscribeDistanceSensor<ExperimentalWithCallbackMethod_SubscribeScaledPressure<ExperimentalWithCallbackMethod_SubscribeHeading<ExperimentalWithCallbackMethod_SetRatePosition<ExperimentalWithCallbackMethod_SetRateHome<ExperimentalWithCallbackMethod_SetRateInAir<ExperimentalWithCallbackMethod_SetRateLandedState<ExperimentalWithCallbackMethod_SetRateAttitude<ExperimentalWithCallbackMethod_SetRateCameraAttitude<ExperimentalWithCallbackMethod_SetRateVelocityNed<ExperimentalWithCallbackMethod_SetRateGpsInfo<ExperimentalWithCallbackMethod_SetRateBattery<ExperimentalWithCallbackMethod_SetRateRcStatus<ExperimentalWithCallbackMethod_SetRateActuatorControlTarget<ExperimentalWithCallbackMethod_SetRateActuatorOutputStatus<ExperimentalWithCallbackMethod_SetRateOdometry<ExperimentalWithCallbackMethod_SetRatePositionVelocityNed<ExperimentalWithCallbackMethod_SetRateGroundTruth<ExperimentalWithCallbackMethod_SetRateFixedwingMetrics<ExperimentalWithCallbackMethod_SetRateImu<ExperimentalWithCallbackMethod_SetRateScaledImu<ExperimentalWithCallbackMethod_SetRateRawImu<ExperimentalWithCallbackMethod_SetRateUnixEpochTime<ExperimentalWithCallbackMethod_SetRateDistanceSensor<ExperimentalWithCallbackMethod_GetGpsGlobalOrigin<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_SubscribePosition : public BaseClass {
    private:
@@ -5864,12 +5961,29 @@ class TelemetryService final {
     }
   };
   template <class BaseClass>
+  class WithGenericMethod_SubscribeHeading : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SubscribeHeading() {
+      ::grpc::Service::MarkMethodGeneric(31);
+    }
+    ~WithGenericMethod_SubscribeHeading() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeHeading(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::telemetry::HeadingResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
   class WithGenericMethod_SetRatePosition : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRatePosition() {
-      ::grpc::Service::MarkMethodGeneric(31);
+      ::grpc::Service::MarkMethodGeneric(32);
     }
     ~WithGenericMethod_SetRatePosition() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5886,7 +6000,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRateHome() {
-      ::grpc::Service::MarkMethodGeneric(32);
+      ::grpc::Service::MarkMethodGeneric(33);
     }
     ~WithGenericMethod_SetRateHome() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5903,7 +6017,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRateInAir() {
-      ::grpc::Service::MarkMethodGeneric(33);
+      ::grpc::Service::MarkMethodGeneric(34);
     }
     ~WithGenericMethod_SetRateInAir() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5920,7 +6034,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRateLandedState() {
-      ::grpc::Service::MarkMethodGeneric(34);
+      ::grpc::Service::MarkMethodGeneric(35);
     }
     ~WithGenericMethod_SetRateLandedState() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5937,7 +6051,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRateAttitude() {
-      ::grpc::Service::MarkMethodGeneric(35);
+      ::grpc::Service::MarkMethodGeneric(36);
     }
     ~WithGenericMethod_SetRateAttitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5954,7 +6068,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRateCameraAttitude() {
-      ::grpc::Service::MarkMethodGeneric(36);
+      ::grpc::Service::MarkMethodGeneric(37);
     }
     ~WithGenericMethod_SetRateCameraAttitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5971,7 +6085,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRateVelocityNed() {
-      ::grpc::Service::MarkMethodGeneric(37);
+      ::grpc::Service::MarkMethodGeneric(38);
     }
     ~WithGenericMethod_SetRateVelocityNed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5988,7 +6102,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRateGpsInfo() {
-      ::grpc::Service::MarkMethodGeneric(38);
+      ::grpc::Service::MarkMethodGeneric(39);
     }
     ~WithGenericMethod_SetRateGpsInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6005,7 +6119,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRateBattery() {
-      ::grpc::Service::MarkMethodGeneric(39);
+      ::grpc::Service::MarkMethodGeneric(40);
     }
     ~WithGenericMethod_SetRateBattery() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6022,7 +6136,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRateRcStatus() {
-      ::grpc::Service::MarkMethodGeneric(40);
+      ::grpc::Service::MarkMethodGeneric(41);
     }
     ~WithGenericMethod_SetRateRcStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6039,7 +6153,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRateActuatorControlTarget() {
-      ::grpc::Service::MarkMethodGeneric(41);
+      ::grpc::Service::MarkMethodGeneric(42);
     }
     ~WithGenericMethod_SetRateActuatorControlTarget() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6056,7 +6170,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRateActuatorOutputStatus() {
-      ::grpc::Service::MarkMethodGeneric(42);
+      ::grpc::Service::MarkMethodGeneric(43);
     }
     ~WithGenericMethod_SetRateActuatorOutputStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6073,7 +6187,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRateOdometry() {
-      ::grpc::Service::MarkMethodGeneric(43);
+      ::grpc::Service::MarkMethodGeneric(44);
     }
     ~WithGenericMethod_SetRateOdometry() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6090,7 +6204,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRatePositionVelocityNed() {
-      ::grpc::Service::MarkMethodGeneric(44);
+      ::grpc::Service::MarkMethodGeneric(45);
     }
     ~WithGenericMethod_SetRatePositionVelocityNed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6107,7 +6221,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRateGroundTruth() {
-      ::grpc::Service::MarkMethodGeneric(45);
+      ::grpc::Service::MarkMethodGeneric(46);
     }
     ~WithGenericMethod_SetRateGroundTruth() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6124,7 +6238,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRateFixedwingMetrics() {
-      ::grpc::Service::MarkMethodGeneric(46);
+      ::grpc::Service::MarkMethodGeneric(47);
     }
     ~WithGenericMethod_SetRateFixedwingMetrics() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6141,7 +6255,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRateImu() {
-      ::grpc::Service::MarkMethodGeneric(47);
+      ::grpc::Service::MarkMethodGeneric(48);
     }
     ~WithGenericMethod_SetRateImu() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6158,7 +6272,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRateScaledImu() {
-      ::grpc::Service::MarkMethodGeneric(48);
+      ::grpc::Service::MarkMethodGeneric(49);
     }
     ~WithGenericMethod_SetRateScaledImu() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6175,7 +6289,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRateRawImu() {
-      ::grpc::Service::MarkMethodGeneric(49);
+      ::grpc::Service::MarkMethodGeneric(50);
     }
     ~WithGenericMethod_SetRateRawImu() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6192,7 +6306,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRateUnixEpochTime() {
-      ::grpc::Service::MarkMethodGeneric(50);
+      ::grpc::Service::MarkMethodGeneric(51);
     }
     ~WithGenericMethod_SetRateUnixEpochTime() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6209,7 +6323,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRateDistanceSensor() {
-      ::grpc::Service::MarkMethodGeneric(51);
+      ::grpc::Service::MarkMethodGeneric(52);
     }
     ~WithGenericMethod_SetRateDistanceSensor() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6226,7 +6340,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_GetGpsGlobalOrigin() {
-      ::grpc::Service::MarkMethodGeneric(52);
+      ::grpc::Service::MarkMethodGeneric(53);
     }
     ~WithGenericMethod_GetGpsGlobalOrigin() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6858,12 +6972,32 @@ class TelemetryService final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_SubscribeHeading : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SubscribeHeading() {
+      ::grpc::Service::MarkMethodRaw(31);
+    }
+    ~WithRawMethod_SubscribeHeading() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeHeading(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::telemetry::HeadingResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeHeading(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(31, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithRawMethod_SetRatePosition : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRatePosition() {
-      ::grpc::Service::MarkMethodRaw(31);
+      ::grpc::Service::MarkMethodRaw(32);
     }
     ~WithRawMethod_SetRatePosition() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6874,7 +7008,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRatePosition(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(31, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(32, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -6883,7 +7017,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRateHome() {
-      ::grpc::Service::MarkMethodRaw(32);
+      ::grpc::Service::MarkMethodRaw(33);
     }
     ~WithRawMethod_SetRateHome() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6894,7 +7028,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateHome(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(32, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(33, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -6903,7 +7037,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRateInAir() {
-      ::grpc::Service::MarkMethodRaw(33);
+      ::grpc::Service::MarkMethodRaw(34);
     }
     ~WithRawMethod_SetRateInAir() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6914,7 +7048,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateInAir(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(33, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(34, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -6923,7 +7057,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRateLandedState() {
-      ::grpc::Service::MarkMethodRaw(34);
+      ::grpc::Service::MarkMethodRaw(35);
     }
     ~WithRawMethod_SetRateLandedState() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6934,7 +7068,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateLandedState(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(34, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(35, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -6943,7 +7077,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRateAttitude() {
-      ::grpc::Service::MarkMethodRaw(35);
+      ::grpc::Service::MarkMethodRaw(36);
     }
     ~WithRawMethod_SetRateAttitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6954,7 +7088,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateAttitude(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(35, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(36, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -6963,7 +7097,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRateCameraAttitude() {
-      ::grpc::Service::MarkMethodRaw(36);
+      ::grpc::Service::MarkMethodRaw(37);
     }
     ~WithRawMethod_SetRateCameraAttitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6974,7 +7108,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateCameraAttitude(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(36, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(37, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -6983,7 +7117,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRateVelocityNed() {
-      ::grpc::Service::MarkMethodRaw(37);
+      ::grpc::Service::MarkMethodRaw(38);
     }
     ~WithRawMethod_SetRateVelocityNed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6994,7 +7128,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateVelocityNed(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(37, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(38, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -7003,7 +7137,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRateGpsInfo() {
-      ::grpc::Service::MarkMethodRaw(38);
+      ::grpc::Service::MarkMethodRaw(39);
     }
     ~WithRawMethod_SetRateGpsInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -7014,7 +7148,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateGpsInfo(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(38, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(39, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -7023,7 +7157,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRateBattery() {
-      ::grpc::Service::MarkMethodRaw(39);
+      ::grpc::Service::MarkMethodRaw(40);
     }
     ~WithRawMethod_SetRateBattery() override {
       BaseClassMustBeDerivedFromService(this);
@@ -7034,7 +7168,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateBattery(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(39, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(40, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -7043,7 +7177,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRateRcStatus() {
-      ::grpc::Service::MarkMethodRaw(40);
+      ::grpc::Service::MarkMethodRaw(41);
     }
     ~WithRawMethod_SetRateRcStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -7054,7 +7188,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateRcStatus(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(40, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(41, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -7063,7 +7197,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRateActuatorControlTarget() {
-      ::grpc::Service::MarkMethodRaw(41);
+      ::grpc::Service::MarkMethodRaw(42);
     }
     ~WithRawMethod_SetRateActuatorControlTarget() override {
       BaseClassMustBeDerivedFromService(this);
@@ -7074,7 +7208,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateActuatorControlTarget(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(41, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(42, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -7083,7 +7217,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRateActuatorOutputStatus() {
-      ::grpc::Service::MarkMethodRaw(42);
+      ::grpc::Service::MarkMethodRaw(43);
     }
     ~WithRawMethod_SetRateActuatorOutputStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -7094,7 +7228,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateActuatorOutputStatus(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(42, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(43, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -7103,7 +7237,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRateOdometry() {
-      ::grpc::Service::MarkMethodRaw(43);
+      ::grpc::Service::MarkMethodRaw(44);
     }
     ~WithRawMethod_SetRateOdometry() override {
       BaseClassMustBeDerivedFromService(this);
@@ -7114,7 +7248,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateOdometry(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(43, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(44, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -7123,7 +7257,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRatePositionVelocityNed() {
-      ::grpc::Service::MarkMethodRaw(44);
+      ::grpc::Service::MarkMethodRaw(45);
     }
     ~WithRawMethod_SetRatePositionVelocityNed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -7134,7 +7268,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRatePositionVelocityNed(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(44, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(45, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -7143,7 +7277,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRateGroundTruth() {
-      ::grpc::Service::MarkMethodRaw(45);
+      ::grpc::Service::MarkMethodRaw(46);
     }
     ~WithRawMethod_SetRateGroundTruth() override {
       BaseClassMustBeDerivedFromService(this);
@@ -7154,7 +7288,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateGroundTruth(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(45, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(46, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -7163,7 +7297,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRateFixedwingMetrics() {
-      ::grpc::Service::MarkMethodRaw(46);
+      ::grpc::Service::MarkMethodRaw(47);
     }
     ~WithRawMethod_SetRateFixedwingMetrics() override {
       BaseClassMustBeDerivedFromService(this);
@@ -7174,7 +7308,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateFixedwingMetrics(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(46, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(47, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -7183,7 +7317,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRateImu() {
-      ::grpc::Service::MarkMethodRaw(47);
+      ::grpc::Service::MarkMethodRaw(48);
     }
     ~WithRawMethod_SetRateImu() override {
       BaseClassMustBeDerivedFromService(this);
@@ -7194,7 +7328,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateImu(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(47, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(48, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -7203,7 +7337,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRateScaledImu() {
-      ::grpc::Service::MarkMethodRaw(48);
+      ::grpc::Service::MarkMethodRaw(49);
     }
     ~WithRawMethod_SetRateScaledImu() override {
       BaseClassMustBeDerivedFromService(this);
@@ -7214,7 +7348,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateScaledImu(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(48, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(49, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -7223,7 +7357,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRateRawImu() {
-      ::grpc::Service::MarkMethodRaw(49);
+      ::grpc::Service::MarkMethodRaw(50);
     }
     ~WithRawMethod_SetRateRawImu() override {
       BaseClassMustBeDerivedFromService(this);
@@ -7234,7 +7368,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateRawImu(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(49, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(50, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -7243,7 +7377,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRateUnixEpochTime() {
-      ::grpc::Service::MarkMethodRaw(50);
+      ::grpc::Service::MarkMethodRaw(51);
     }
     ~WithRawMethod_SetRateUnixEpochTime() override {
       BaseClassMustBeDerivedFromService(this);
@@ -7254,7 +7388,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateUnixEpochTime(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(50, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(51, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -7263,7 +7397,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRateDistanceSensor() {
-      ::grpc::Service::MarkMethodRaw(51);
+      ::grpc::Service::MarkMethodRaw(52);
     }
     ~WithRawMethod_SetRateDistanceSensor() override {
       BaseClassMustBeDerivedFromService(this);
@@ -7274,7 +7408,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRateDistanceSensor(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(51, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(52, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -7283,7 +7417,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_GetGpsGlobalOrigin() {
-      ::grpc::Service::MarkMethodRaw(52);
+      ::grpc::Service::MarkMethodRaw(53);
     }
     ~WithRawMethod_GetGpsGlobalOrigin() override {
       BaseClassMustBeDerivedFromService(this);
@@ -7294,7 +7428,7 @@ class TelemetryService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetGpsGlobalOrigin(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(52, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(53, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -8476,6 +8610,44 @@ class TelemetryService final {
       { return nullptr; }
   };
   template <class BaseClass>
+  class ExperimentalWithRawCallbackMethod_SubscribeHeading : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    ExperimentalWithRawCallbackMethod_SubscribeHeading() {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodRawCallback(31,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const::grpc::ByteBuffer* request) { return this->SubscribeHeading(context, request); }));
+    }
+    ~ExperimentalWithRawCallbackMethod_SubscribeHeading() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeHeading(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::telemetry::HeadingResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerWriteReactor< ::grpc::ByteBuffer>* SubscribeHeading(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)
+    #else
+    virtual ::grpc::experimental::ServerWriteReactor< ::grpc::ByteBuffer>* SubscribeHeading(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)
+    #endif
+      { return nullptr; }
+  };
+  template <class BaseClass>
   class ExperimentalWithRawCallbackMethod_SetRatePosition : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
@@ -8486,7 +8658,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(31,
+        MarkMethodRawCallback(32,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -8524,7 +8696,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(32,
+        MarkMethodRawCallback(33,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -8562,7 +8734,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(33,
+        MarkMethodRawCallback(34,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -8600,7 +8772,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(34,
+        MarkMethodRawCallback(35,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -8638,7 +8810,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(35,
+        MarkMethodRawCallback(36,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -8676,7 +8848,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(36,
+        MarkMethodRawCallback(37,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -8714,7 +8886,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(37,
+        MarkMethodRawCallback(38,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -8752,7 +8924,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(38,
+        MarkMethodRawCallback(39,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -8790,7 +8962,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(39,
+        MarkMethodRawCallback(40,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -8828,7 +9000,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(40,
+        MarkMethodRawCallback(41,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -8866,7 +9038,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(41,
+        MarkMethodRawCallback(42,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -8904,7 +9076,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(42,
+        MarkMethodRawCallback(43,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -8942,7 +9114,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(43,
+        MarkMethodRawCallback(44,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -8980,7 +9152,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(44,
+        MarkMethodRawCallback(45,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -9018,7 +9190,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(45,
+        MarkMethodRawCallback(46,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -9056,7 +9228,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(46,
+        MarkMethodRawCallback(47,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -9094,7 +9266,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(47,
+        MarkMethodRawCallback(48,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -9132,7 +9304,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(48,
+        MarkMethodRawCallback(49,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -9170,7 +9342,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(49,
+        MarkMethodRawCallback(50,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -9208,7 +9380,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(50,
+        MarkMethodRawCallback(51,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -9246,7 +9418,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(51,
+        MarkMethodRawCallback(52,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -9284,7 +9456,7 @@ class TelemetryService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(52,
+        MarkMethodRawCallback(53,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -9317,7 +9489,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRatePosition() {
-      ::grpc::Service::MarkMethodStreamed(31,
+      ::grpc::Service::MarkMethodStreamed(32,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRatePositionRequest, ::mavsdk::rpc::telemetry::SetRatePositionResponse>(
             [this](::grpc::ServerContext* context,
@@ -9344,7 +9516,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRateHome() {
-      ::grpc::Service::MarkMethodStreamed(32,
+      ::grpc::Service::MarkMethodStreamed(33,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRateHomeRequest, ::mavsdk::rpc::telemetry::SetRateHomeResponse>(
             [this](::grpc::ServerContext* context,
@@ -9371,7 +9543,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRateInAir() {
-      ::grpc::Service::MarkMethodStreamed(33,
+      ::grpc::Service::MarkMethodStreamed(34,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRateInAirRequest, ::mavsdk::rpc::telemetry::SetRateInAirResponse>(
             [this](::grpc::ServerContext* context,
@@ -9398,7 +9570,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRateLandedState() {
-      ::grpc::Service::MarkMethodStreamed(34,
+      ::grpc::Service::MarkMethodStreamed(35,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRateLandedStateRequest, ::mavsdk::rpc::telemetry::SetRateLandedStateResponse>(
             [this](::grpc::ServerContext* context,
@@ -9425,7 +9597,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRateAttitude() {
-      ::grpc::Service::MarkMethodStreamed(35,
+      ::grpc::Service::MarkMethodStreamed(36,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRateAttitudeRequest, ::mavsdk::rpc::telemetry::SetRateAttitudeResponse>(
             [this](::grpc::ServerContext* context,
@@ -9452,7 +9624,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRateCameraAttitude() {
-      ::grpc::Service::MarkMethodStreamed(36,
+      ::grpc::Service::MarkMethodStreamed(37,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRateCameraAttitudeRequest, ::mavsdk::rpc::telemetry::SetRateCameraAttitudeResponse>(
             [this](::grpc::ServerContext* context,
@@ -9479,7 +9651,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRateVelocityNed() {
-      ::grpc::Service::MarkMethodStreamed(37,
+      ::grpc::Service::MarkMethodStreamed(38,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRateVelocityNedRequest, ::mavsdk::rpc::telemetry::SetRateVelocityNedResponse>(
             [this](::grpc::ServerContext* context,
@@ -9506,7 +9678,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRateGpsInfo() {
-      ::grpc::Service::MarkMethodStreamed(38,
+      ::grpc::Service::MarkMethodStreamed(39,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRateGpsInfoRequest, ::mavsdk::rpc::telemetry::SetRateGpsInfoResponse>(
             [this](::grpc::ServerContext* context,
@@ -9533,7 +9705,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRateBattery() {
-      ::grpc::Service::MarkMethodStreamed(39,
+      ::grpc::Service::MarkMethodStreamed(40,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRateBatteryRequest, ::mavsdk::rpc::telemetry::SetRateBatteryResponse>(
             [this](::grpc::ServerContext* context,
@@ -9560,7 +9732,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRateRcStatus() {
-      ::grpc::Service::MarkMethodStreamed(40,
+      ::grpc::Service::MarkMethodStreamed(41,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRateRcStatusRequest, ::mavsdk::rpc::telemetry::SetRateRcStatusResponse>(
             [this](::grpc::ServerContext* context,
@@ -9587,7 +9759,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRateActuatorControlTarget() {
-      ::grpc::Service::MarkMethodStreamed(41,
+      ::grpc::Service::MarkMethodStreamed(42,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRateActuatorControlTargetRequest, ::mavsdk::rpc::telemetry::SetRateActuatorControlTargetResponse>(
             [this](::grpc::ServerContext* context,
@@ -9614,7 +9786,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRateActuatorOutputStatus() {
-      ::grpc::Service::MarkMethodStreamed(42,
+      ::grpc::Service::MarkMethodStreamed(43,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRateActuatorOutputStatusRequest, ::mavsdk::rpc::telemetry::SetRateActuatorOutputStatusResponse>(
             [this](::grpc::ServerContext* context,
@@ -9641,7 +9813,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRateOdometry() {
-      ::grpc::Service::MarkMethodStreamed(43,
+      ::grpc::Service::MarkMethodStreamed(44,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRateOdometryRequest, ::mavsdk::rpc::telemetry::SetRateOdometryResponse>(
             [this](::grpc::ServerContext* context,
@@ -9668,7 +9840,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRatePositionVelocityNed() {
-      ::grpc::Service::MarkMethodStreamed(44,
+      ::grpc::Service::MarkMethodStreamed(45,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRatePositionVelocityNedRequest, ::mavsdk::rpc::telemetry::SetRatePositionVelocityNedResponse>(
             [this](::grpc::ServerContext* context,
@@ -9695,7 +9867,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRateGroundTruth() {
-      ::grpc::Service::MarkMethodStreamed(45,
+      ::grpc::Service::MarkMethodStreamed(46,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRateGroundTruthRequest, ::mavsdk::rpc::telemetry::SetRateGroundTruthResponse>(
             [this](::grpc::ServerContext* context,
@@ -9722,7 +9894,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRateFixedwingMetrics() {
-      ::grpc::Service::MarkMethodStreamed(46,
+      ::grpc::Service::MarkMethodStreamed(47,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRateFixedwingMetricsRequest, ::mavsdk::rpc::telemetry::SetRateFixedwingMetricsResponse>(
             [this](::grpc::ServerContext* context,
@@ -9749,7 +9921,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRateImu() {
-      ::grpc::Service::MarkMethodStreamed(47,
+      ::grpc::Service::MarkMethodStreamed(48,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRateImuRequest, ::mavsdk::rpc::telemetry::SetRateImuResponse>(
             [this](::grpc::ServerContext* context,
@@ -9776,7 +9948,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRateScaledImu() {
-      ::grpc::Service::MarkMethodStreamed(48,
+      ::grpc::Service::MarkMethodStreamed(49,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRateScaledImuRequest, ::mavsdk::rpc::telemetry::SetRateScaledImuResponse>(
             [this](::grpc::ServerContext* context,
@@ -9803,7 +9975,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRateRawImu() {
-      ::grpc::Service::MarkMethodStreamed(49,
+      ::grpc::Service::MarkMethodStreamed(50,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRateRawImuRequest, ::mavsdk::rpc::telemetry::SetRateRawImuResponse>(
             [this](::grpc::ServerContext* context,
@@ -9830,7 +10002,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRateUnixEpochTime() {
-      ::grpc::Service::MarkMethodStreamed(50,
+      ::grpc::Service::MarkMethodStreamed(51,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRateUnixEpochTimeRequest, ::mavsdk::rpc::telemetry::SetRateUnixEpochTimeResponse>(
             [this](::grpc::ServerContext* context,
@@ -9857,7 +10029,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRateDistanceSensor() {
-      ::grpc::Service::MarkMethodStreamed(51,
+      ::grpc::Service::MarkMethodStreamed(52,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest, ::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse>(
             [this](::grpc::ServerContext* context,
@@ -9884,7 +10056,7 @@ class TelemetryService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_GetGpsGlobalOrigin() {
-      ::grpc::Service::MarkMethodStreamed(52,
+      ::grpc::Service::MarkMethodStreamed(53,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest, ::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse>(
             [this](::grpc::ServerContext* context,
@@ -10743,8 +10915,35 @@ class TelemetryService final {
     // replace default version of method with split streamed
     virtual ::grpc::Status StreamedSubscribeScaledPressure(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::telemetry::SubscribeScaledPressureRequest,::mavsdk::rpc::telemetry::ScaledPressureResponse>* server_split_streamer) = 0;
   };
-  typedef WithSplitStreamingMethod_SubscribePosition<WithSplitStreamingMethod_SubscribeHome<WithSplitStreamingMethod_SubscribeInAir<WithSplitStreamingMethod_SubscribeLandedState<WithSplitStreamingMethod_SubscribeArmed<WithSplitStreamingMethod_SubscribeAttitudeQuaternion<WithSplitStreamingMethod_SubscribeAttitudeEuler<WithSplitStreamingMethod_SubscribeAttitudeAngularVelocityBody<WithSplitStreamingMethod_SubscribeCameraAttitudeQuaternion<WithSplitStreamingMethod_SubscribeCameraAttitudeEuler<WithSplitStreamingMethod_SubscribeVelocityNed<WithSplitStreamingMethod_SubscribeGpsInfo<WithSplitStreamingMethod_SubscribeRawGps<WithSplitStreamingMethod_SubscribeBattery<WithSplitStreamingMethod_SubscribeFlightMode<WithSplitStreamingMethod_SubscribeHealth<WithSplitStreamingMethod_SubscribeRcStatus<WithSplitStreamingMethod_SubscribeStatusText<WithSplitStreamingMethod_SubscribeActuatorControlTarget<WithSplitStreamingMethod_SubscribeActuatorOutputStatus<WithSplitStreamingMethod_SubscribeOdometry<WithSplitStreamingMethod_SubscribePositionVelocityNed<WithSplitStreamingMethod_SubscribeGroundTruth<WithSplitStreamingMethod_SubscribeFixedwingMetrics<WithSplitStreamingMethod_SubscribeImu<WithSplitStreamingMethod_SubscribeScaledImu<WithSplitStreamingMethod_SubscribeRawImu<WithSplitStreamingMethod_SubscribeHealthAllOk<WithSplitStreamingMethod_SubscribeUnixEpochTime<WithSplitStreamingMethod_SubscribeDistanceSensor<WithSplitStreamingMethod_SubscribeScaledPressure<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > SplitStreamedService;
-  typedef WithSplitStreamingMethod_SubscribePosition<WithSplitStreamingMethod_SubscribeHome<WithSplitStreamingMethod_SubscribeInAir<WithSplitStreamingMethod_SubscribeLandedState<WithSplitStreamingMethod_SubscribeArmed<WithSplitStreamingMethod_SubscribeAttitudeQuaternion<WithSplitStreamingMethod_SubscribeAttitudeEuler<WithSplitStreamingMethod_SubscribeAttitudeAngularVelocityBody<WithSplitStreamingMethod_SubscribeCameraAttitudeQuaternion<WithSplitStreamingMethod_SubscribeCameraAttitudeEuler<WithSplitStreamingMethod_SubscribeVelocityNed<WithSplitStreamingMethod_SubscribeGpsInfo<WithSplitStreamingMethod_SubscribeRawGps<WithSplitStreamingMethod_SubscribeBattery<WithSplitStreamingMethod_SubscribeFlightMode<WithSplitStreamingMethod_SubscribeHealth<WithSplitStreamingMethod_SubscribeRcStatus<WithSplitStreamingMethod_SubscribeStatusText<WithSplitStreamingMethod_SubscribeActuatorControlTarget<WithSplitStreamingMethod_SubscribeActuatorOutputStatus<WithSplitStreamingMethod_SubscribeOdometry<WithSplitStreamingMethod_SubscribePositionVelocityNed<WithSplitStreamingMethod_SubscribeGroundTruth<WithSplitStreamingMethod_SubscribeFixedwingMetrics<WithSplitStreamingMethod_SubscribeImu<WithSplitStreamingMethod_SubscribeScaledImu<WithSplitStreamingMethod_SubscribeRawImu<WithSplitStreamingMethod_SubscribeHealthAllOk<WithSplitStreamingMethod_SubscribeUnixEpochTime<WithSplitStreamingMethod_SubscribeDistanceSensor<WithSplitStreamingMethod_SubscribeScaledPressure<WithStreamedUnaryMethod_SetRatePosition<WithStreamedUnaryMethod_SetRateHome<WithStreamedUnaryMethod_SetRateInAir<WithStreamedUnaryMethod_SetRateLandedState<WithStreamedUnaryMethod_SetRateAttitude<WithStreamedUnaryMethod_SetRateCameraAttitude<WithStreamedUnaryMethod_SetRateVelocityNed<WithStreamedUnaryMethod_SetRateGpsInfo<WithStreamedUnaryMethod_SetRateBattery<WithStreamedUnaryMethod_SetRateRcStatus<WithStreamedUnaryMethod_SetRateActuatorControlTarget<WithStreamedUnaryMethod_SetRateActuatorOutputStatus<WithStreamedUnaryMethod_SetRateOdometry<WithStreamedUnaryMethod_SetRatePositionVelocityNed<WithStreamedUnaryMethod_SetRateGroundTruth<WithStreamedUnaryMethod_SetRateFixedwingMetrics<WithStreamedUnaryMethod_SetRateImu<WithStreamedUnaryMethod_SetRateScaledImu<WithStreamedUnaryMethod_SetRateRawImu<WithStreamedUnaryMethod_SetRateUnixEpochTime<WithStreamedUnaryMethod_SetRateDistanceSensor<WithStreamedUnaryMethod_GetGpsGlobalOrigin<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
+  template <class BaseClass>
+  class WithSplitStreamingMethod_SubscribeHeading : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithSplitStreamingMethod_SubscribeHeading() {
+      ::grpc::Service::MarkMethodStreamed(31,
+        new ::grpc::internal::SplitServerStreamingHandler<
+          ::mavsdk::rpc::telemetry::SubscribeHeadingRequest, ::mavsdk::rpc::telemetry::HeadingResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerSplitStreamer<
+                     ::mavsdk::rpc::telemetry::SubscribeHeadingRequest, ::mavsdk::rpc::telemetry::HeadingResponse>* streamer) {
+                       return this->StreamedSubscribeHeading(context,
+                         streamer);
+                  }));
+    }
+    ~WithSplitStreamingMethod_SubscribeHeading() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SubscribeHeading(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry::SubscribeHeadingRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::telemetry::HeadingResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with split streamed
+    virtual ::grpc::Status StreamedSubscribeHeading(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::telemetry::SubscribeHeadingRequest,::mavsdk::rpc::telemetry::HeadingResponse>* server_split_streamer) = 0;
+  };
+  typedef WithSplitStreamingMethod_SubscribePosition<WithSplitStreamingMethod_SubscribeHome<WithSplitStreamingMethod_SubscribeInAir<WithSplitStreamingMethod_SubscribeLandedState<WithSplitStreamingMethod_SubscribeArmed<WithSplitStreamingMethod_SubscribeAttitudeQuaternion<WithSplitStreamingMethod_SubscribeAttitudeEuler<WithSplitStreamingMethod_SubscribeAttitudeAngularVelocityBody<WithSplitStreamingMethod_SubscribeCameraAttitudeQuaternion<WithSplitStreamingMethod_SubscribeCameraAttitudeEuler<WithSplitStreamingMethod_SubscribeVelocityNed<WithSplitStreamingMethod_SubscribeGpsInfo<WithSplitStreamingMethod_SubscribeRawGps<WithSplitStreamingMethod_SubscribeBattery<WithSplitStreamingMethod_SubscribeFlightMode<WithSplitStreamingMethod_SubscribeHealth<WithSplitStreamingMethod_SubscribeRcStatus<WithSplitStreamingMethod_SubscribeStatusText<WithSplitStreamingMethod_SubscribeActuatorControlTarget<WithSplitStreamingMethod_SubscribeActuatorOutputStatus<WithSplitStreamingMethod_SubscribeOdometry<WithSplitStreamingMethod_SubscribePositionVelocityNed<WithSplitStreamingMethod_SubscribeGroundTruth<WithSplitStreamingMethod_SubscribeFixedwingMetrics<WithSplitStreamingMethod_SubscribeImu<WithSplitStreamingMethod_SubscribeScaledImu<WithSplitStreamingMethod_SubscribeRawImu<WithSplitStreamingMethod_SubscribeHealthAllOk<WithSplitStreamingMethod_SubscribeUnixEpochTime<WithSplitStreamingMethod_SubscribeDistanceSensor<WithSplitStreamingMethod_SubscribeScaledPressure<WithSplitStreamingMethod_SubscribeHeading<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > SplitStreamedService;
+  typedef WithSplitStreamingMethod_SubscribePosition<WithSplitStreamingMethod_SubscribeHome<WithSplitStreamingMethod_SubscribeInAir<WithSplitStreamingMethod_SubscribeLandedState<WithSplitStreamingMethod_SubscribeArmed<WithSplitStreamingMethod_SubscribeAttitudeQuaternion<WithSplitStreamingMethod_SubscribeAttitudeEuler<WithSplitStreamingMethod_SubscribeAttitudeAngularVelocityBody<WithSplitStreamingMethod_SubscribeCameraAttitudeQuaternion<WithSplitStreamingMethod_SubscribeCameraAttitudeEuler<WithSplitStreamingMethod_SubscribeVelocityNed<WithSplitStreamingMethod_SubscribeGpsInfo<WithSplitStreamingMethod_SubscribeRawGps<WithSplitStreamingMethod_SubscribeBattery<WithSplitStreamingMethod_SubscribeFlightMode<WithSplitStreamingMethod_SubscribeHealth<WithSplitStreamingMethod_SubscribeRcStatus<WithSplitStreamingMethod_SubscribeStatusText<WithSplitStreamingMethod_SubscribeActuatorControlTarget<WithSplitStreamingMethod_SubscribeActuatorOutputStatus<WithSplitStreamingMethod_SubscribeOdometry<WithSplitStreamingMethod_SubscribePositionVelocityNed<WithSplitStreamingMethod_SubscribeGroundTruth<WithSplitStreamingMethod_SubscribeFixedwingMetrics<WithSplitStreamingMethod_SubscribeImu<WithSplitStreamingMethod_SubscribeScaledImu<WithSplitStreamingMethod_SubscribeRawImu<WithSplitStreamingMethod_SubscribeHealthAllOk<WithSplitStreamingMethod_SubscribeUnixEpochTime<WithSplitStreamingMethod_SubscribeDistanceSensor<WithSplitStreamingMethod_SubscribeScaledPressure<WithSplitStreamingMethod_SubscribeHeading<WithStreamedUnaryMethod_SetRatePosition<WithStreamedUnaryMethod_SetRateHome<WithStreamedUnaryMethod_SetRateInAir<WithStreamedUnaryMethod_SetRateLandedState<WithStreamedUnaryMethod_SetRateAttitude<WithStreamedUnaryMethod_SetRateCameraAttitude<WithStreamedUnaryMethod_SetRateVelocityNed<WithStreamedUnaryMethod_SetRateGpsInfo<WithStreamedUnaryMethod_SetRateBattery<WithStreamedUnaryMethod_SetRateRcStatus<WithStreamedUnaryMethod_SetRateActuatorControlTarget<WithStreamedUnaryMethod_SetRateActuatorOutputStatus<WithStreamedUnaryMethod_SetRateOdometry<WithStreamedUnaryMethod_SetRatePositionVelocityNed<WithStreamedUnaryMethod_SetRateGroundTruth<WithStreamedUnaryMethod_SetRateFixedwingMetrics<WithStreamedUnaryMethod_SetRateImu<WithStreamedUnaryMethod_SetRateScaledImu<WithStreamedUnaryMethod_SetRateRawImu<WithStreamedUnaryMethod_SetRateUnixEpochTime<WithStreamedUnaryMethod_SetRateDistanceSensor<WithStreamedUnaryMethod_GetGpsGlobalOrigin<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace telemetry

--- a/src/mavsdk_server/src/generated/telemetry/telemetry.pb.cc
+++ b/src/mavsdk_server/src/generated/telemetry/telemetry.pb.cc
@@ -734,6 +734,29 @@ struct ScaledPressureResponseDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT ScaledPressureResponseDefaultTypeInternal _ScaledPressureResponse_default_instance_;
+constexpr SubscribeHeadingRequest::SubscribeHeadingRequest(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized){}
+struct SubscribeHeadingRequestDefaultTypeInternal {
+  constexpr SubscribeHeadingRequestDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~SubscribeHeadingRequestDefaultTypeInternal() {}
+  union {
+    SubscribeHeadingRequest _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SubscribeHeadingRequestDefaultTypeInternal _SubscribeHeadingRequest_default_instance_;
+constexpr HeadingResponse::HeadingResponse(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : heading_deg_(nullptr){}
+struct HeadingResponseDefaultTypeInternal {
+  constexpr HeadingResponseDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~HeadingResponseDefaultTypeInternal() {}
+  union {
+    HeadingResponse _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT HeadingResponseDefaultTypeInternal _HeadingResponse_default_instance_;
 constexpr SetRatePositionRequest::SetRatePositionRequest(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
   : rate_hz_(0){}
@@ -1337,6 +1360,18 @@ struct PositionDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PositionDefaultTypeInternal _Position_default_instance_;
+constexpr Heading::Heading(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : heading_deg_(0){}
+struct HeadingDefaultTypeInternal {
+  constexpr HeadingDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~HeadingDefaultTypeInternal() {}
+  union {
+    Heading _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT HeadingDefaultTypeInternal _Heading_default_instance_;
 constexpr Quaternion::Quaternion(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
   : w_(0)
@@ -1760,7 +1795,7 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT TelemetryResultDefaultTypeInter
 }  // namespace telemetry
 }  // namespace rpc
 }  // namespace mavsdk
-static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_telemetry_2ftelemetry_2eproto[140];
+static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_telemetry_2ftelemetry_2eproto[143];
 static const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* file_level_enum_descriptors_telemetry_2ftelemetry_2eproto[6];
 static constexpr ::PROTOBUF_NAMESPACE_ID::ServiceDescriptor const** file_level_service_descriptors_telemetry_2ftelemetry_2eproto = nullptr;
 
@@ -2107,6 +2142,17 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_telemetry_2ftelemetry_2eproto:
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::ScaledPressureResponse, scaled_pressure_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::SubscribeHeadingRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::HeadingResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::HeadingResponse, heading_deg_),
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::SetRatePositionRequest, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -2409,6 +2455,12 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_telemetry_2ftelemetry_2eproto:
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::Position, longitude_deg_),
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::Position, absolute_altitude_m_),
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::Position, relative_altitude_m_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::Heading, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::Heading, heading_deg_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::Quaternion, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -2717,84 +2769,87 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 324, -1, sizeof(::mavsdk::rpc::telemetry::DistanceSensorResponse)},
   { 330, -1, sizeof(::mavsdk::rpc::telemetry::SubscribeScaledPressureRequest)},
   { 335, -1, sizeof(::mavsdk::rpc::telemetry::ScaledPressureResponse)},
-  { 341, -1, sizeof(::mavsdk::rpc::telemetry::SetRatePositionRequest)},
-  { 347, -1, sizeof(::mavsdk::rpc::telemetry::SetRatePositionResponse)},
-  { 353, -1, sizeof(::mavsdk::rpc::telemetry::SetRateHomeRequest)},
-  { 359, -1, sizeof(::mavsdk::rpc::telemetry::SetRateHomeResponse)},
-  { 365, -1, sizeof(::mavsdk::rpc::telemetry::SetRateInAirRequest)},
-  { 371, -1, sizeof(::mavsdk::rpc::telemetry::SetRateInAirResponse)},
-  { 377, -1, sizeof(::mavsdk::rpc::telemetry::SetRateLandedStateRequest)},
-  { 383, -1, sizeof(::mavsdk::rpc::telemetry::SetRateLandedStateResponse)},
-  { 389, -1, sizeof(::mavsdk::rpc::telemetry::SetRateAttitudeRequest)},
-  { 395, -1, sizeof(::mavsdk::rpc::telemetry::SetRateAttitudeResponse)},
-  { 401, -1, sizeof(::mavsdk::rpc::telemetry::SetRateAttitudeAngularVelocityBodyRequest)},
-  { 407, -1, sizeof(::mavsdk::rpc::telemetry::SetRateAttitudeAngularVelocityBodyResponse)},
-  { 413, -1, sizeof(::mavsdk::rpc::telemetry::SetRateCameraAttitudeQuaternionRequest)},
-  { 419, -1, sizeof(::mavsdk::rpc::telemetry::SetRateCameraAttitudeQuaternionResponse)},
-  { 425, -1, sizeof(::mavsdk::rpc::telemetry::SetRateCameraAttitudeRequest)},
-  { 431, -1, sizeof(::mavsdk::rpc::telemetry::SetRateCameraAttitudeResponse)},
-  { 437, -1, sizeof(::mavsdk::rpc::telemetry::SetRateVelocityNedRequest)},
-  { 443, -1, sizeof(::mavsdk::rpc::telemetry::SetRateVelocityNedResponse)},
-  { 449, -1, sizeof(::mavsdk::rpc::telemetry::SetRateGpsInfoRequest)},
-  { 455, -1, sizeof(::mavsdk::rpc::telemetry::SetRateGpsInfoResponse)},
-  { 461, -1, sizeof(::mavsdk::rpc::telemetry::SetRateRawGpsRequest)},
-  { 467, -1, sizeof(::mavsdk::rpc::telemetry::SetRateBatteryRequest)},
-  { 473, -1, sizeof(::mavsdk::rpc::telemetry::SetRateBatteryResponse)},
-  { 479, -1, sizeof(::mavsdk::rpc::telemetry::SetRateRcStatusRequest)},
-  { 485, -1, sizeof(::mavsdk::rpc::telemetry::SetRateRcStatusResponse)},
-  { 491, -1, sizeof(::mavsdk::rpc::telemetry::SetRateActuatorControlTargetRequest)},
-  { 497, -1, sizeof(::mavsdk::rpc::telemetry::SetRateActuatorControlTargetResponse)},
-  { 503, -1, sizeof(::mavsdk::rpc::telemetry::SetRateActuatorOutputStatusRequest)},
-  { 509, -1, sizeof(::mavsdk::rpc::telemetry::SetRateActuatorOutputStatusResponse)},
-  { 515, -1, sizeof(::mavsdk::rpc::telemetry::SetRateOdometryRequest)},
-  { 521, -1, sizeof(::mavsdk::rpc::telemetry::SetRateOdometryResponse)},
-  { 527, -1, sizeof(::mavsdk::rpc::telemetry::SetRatePositionVelocityNedRequest)},
-  { 533, -1, sizeof(::mavsdk::rpc::telemetry::SetRatePositionVelocityNedResponse)},
-  { 539, -1, sizeof(::mavsdk::rpc::telemetry::SetRateGroundTruthRequest)},
-  { 545, -1, sizeof(::mavsdk::rpc::telemetry::SetRateGroundTruthResponse)},
-  { 551, -1, sizeof(::mavsdk::rpc::telemetry::SetRateFixedwingMetricsRequest)},
-  { 557, -1, sizeof(::mavsdk::rpc::telemetry::SetRateFixedwingMetricsResponse)},
-  { 563, -1, sizeof(::mavsdk::rpc::telemetry::SetRateImuRequest)},
-  { 569, -1, sizeof(::mavsdk::rpc::telemetry::SetRateImuResponse)},
-  { 575, -1, sizeof(::mavsdk::rpc::telemetry::SetRateScaledImuRequest)},
-  { 581, -1, sizeof(::mavsdk::rpc::telemetry::SetRateScaledImuResponse)},
-  { 587, -1, sizeof(::mavsdk::rpc::telemetry::SetRateRawImuRequest)},
-  { 593, -1, sizeof(::mavsdk::rpc::telemetry::SetRateRawImuResponse)},
-  { 599, -1, sizeof(::mavsdk::rpc::telemetry::SetRateUnixEpochTimeRequest)},
-  { 605, -1, sizeof(::mavsdk::rpc::telemetry::SetRateUnixEpochTimeResponse)},
-  { 611, -1, sizeof(::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest)},
-  { 617, -1, sizeof(::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse)},
-  { 623, -1, sizeof(::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest)},
-  { 628, -1, sizeof(::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse)},
-  { 635, -1, sizeof(::mavsdk::rpc::telemetry::Position)},
-  { 644, -1, sizeof(::mavsdk::rpc::telemetry::Quaternion)},
-  { 654, -1, sizeof(::mavsdk::rpc::telemetry::EulerAngle)},
-  { 663, -1, sizeof(::mavsdk::rpc::telemetry::AngularVelocityBody)},
-  { 671, -1, sizeof(::mavsdk::rpc::telemetry::GpsInfo)},
-  { 678, -1, sizeof(::mavsdk::rpc::telemetry::RawGps)},
-  { 697, -1, sizeof(::mavsdk::rpc::telemetry::Battery)},
-  { 705, -1, sizeof(::mavsdk::rpc::telemetry::Health)},
-  { 717, -1, sizeof(::mavsdk::rpc::telemetry::RcStatus)},
-  { 725, -1, sizeof(::mavsdk::rpc::telemetry::StatusText)},
-  { 732, -1, sizeof(::mavsdk::rpc::telemetry::ActuatorControlTarget)},
-  { 739, -1, sizeof(::mavsdk::rpc::telemetry::ActuatorOutputStatus)},
-  { 746, -1, sizeof(::mavsdk::rpc::telemetry::Covariance)},
-  { 752, -1, sizeof(::mavsdk::rpc::telemetry::VelocityBody)},
-  { 760, -1, sizeof(::mavsdk::rpc::telemetry::PositionBody)},
-  { 768, -1, sizeof(::mavsdk::rpc::telemetry::Odometry)},
-  { 782, -1, sizeof(::mavsdk::rpc::telemetry::DistanceSensor)},
-  { 790, -1, sizeof(::mavsdk::rpc::telemetry::ScaledPressure)},
-  { 800, -1, sizeof(::mavsdk::rpc::telemetry::PositionNed)},
-  { 808, -1, sizeof(::mavsdk::rpc::telemetry::VelocityNed)},
-  { 816, -1, sizeof(::mavsdk::rpc::telemetry::PositionVelocityNed)},
-  { 823, -1, sizeof(::mavsdk::rpc::telemetry::GroundTruth)},
-  { 831, -1, sizeof(::mavsdk::rpc::telemetry::FixedwingMetrics)},
-  { 839, -1, sizeof(::mavsdk::rpc::telemetry::AccelerationFrd)},
-  { 847, -1, sizeof(::mavsdk::rpc::telemetry::AngularVelocityFrd)},
-  { 855, -1, sizeof(::mavsdk::rpc::telemetry::MagneticFieldFrd)},
-  { 863, -1, sizeof(::mavsdk::rpc::telemetry::Imu)},
-  { 873, -1, sizeof(::mavsdk::rpc::telemetry::GpsGlobalOrigin)},
-  { 881, -1, sizeof(::mavsdk::rpc::telemetry::TelemetryResult)},
+  { 341, -1, sizeof(::mavsdk::rpc::telemetry::SubscribeHeadingRequest)},
+  { 346, -1, sizeof(::mavsdk::rpc::telemetry::HeadingResponse)},
+  { 352, -1, sizeof(::mavsdk::rpc::telemetry::SetRatePositionRequest)},
+  { 358, -1, sizeof(::mavsdk::rpc::telemetry::SetRatePositionResponse)},
+  { 364, -1, sizeof(::mavsdk::rpc::telemetry::SetRateHomeRequest)},
+  { 370, -1, sizeof(::mavsdk::rpc::telemetry::SetRateHomeResponse)},
+  { 376, -1, sizeof(::mavsdk::rpc::telemetry::SetRateInAirRequest)},
+  { 382, -1, sizeof(::mavsdk::rpc::telemetry::SetRateInAirResponse)},
+  { 388, -1, sizeof(::mavsdk::rpc::telemetry::SetRateLandedStateRequest)},
+  { 394, -1, sizeof(::mavsdk::rpc::telemetry::SetRateLandedStateResponse)},
+  { 400, -1, sizeof(::mavsdk::rpc::telemetry::SetRateAttitudeRequest)},
+  { 406, -1, sizeof(::mavsdk::rpc::telemetry::SetRateAttitudeResponse)},
+  { 412, -1, sizeof(::mavsdk::rpc::telemetry::SetRateAttitudeAngularVelocityBodyRequest)},
+  { 418, -1, sizeof(::mavsdk::rpc::telemetry::SetRateAttitudeAngularVelocityBodyResponse)},
+  { 424, -1, sizeof(::mavsdk::rpc::telemetry::SetRateCameraAttitudeQuaternionRequest)},
+  { 430, -1, sizeof(::mavsdk::rpc::telemetry::SetRateCameraAttitudeQuaternionResponse)},
+  { 436, -1, sizeof(::mavsdk::rpc::telemetry::SetRateCameraAttitudeRequest)},
+  { 442, -1, sizeof(::mavsdk::rpc::telemetry::SetRateCameraAttitudeResponse)},
+  { 448, -1, sizeof(::mavsdk::rpc::telemetry::SetRateVelocityNedRequest)},
+  { 454, -1, sizeof(::mavsdk::rpc::telemetry::SetRateVelocityNedResponse)},
+  { 460, -1, sizeof(::mavsdk::rpc::telemetry::SetRateGpsInfoRequest)},
+  { 466, -1, sizeof(::mavsdk::rpc::telemetry::SetRateGpsInfoResponse)},
+  { 472, -1, sizeof(::mavsdk::rpc::telemetry::SetRateRawGpsRequest)},
+  { 478, -1, sizeof(::mavsdk::rpc::telemetry::SetRateBatteryRequest)},
+  { 484, -1, sizeof(::mavsdk::rpc::telemetry::SetRateBatteryResponse)},
+  { 490, -1, sizeof(::mavsdk::rpc::telemetry::SetRateRcStatusRequest)},
+  { 496, -1, sizeof(::mavsdk::rpc::telemetry::SetRateRcStatusResponse)},
+  { 502, -1, sizeof(::mavsdk::rpc::telemetry::SetRateActuatorControlTargetRequest)},
+  { 508, -1, sizeof(::mavsdk::rpc::telemetry::SetRateActuatorControlTargetResponse)},
+  { 514, -1, sizeof(::mavsdk::rpc::telemetry::SetRateActuatorOutputStatusRequest)},
+  { 520, -1, sizeof(::mavsdk::rpc::telemetry::SetRateActuatorOutputStatusResponse)},
+  { 526, -1, sizeof(::mavsdk::rpc::telemetry::SetRateOdometryRequest)},
+  { 532, -1, sizeof(::mavsdk::rpc::telemetry::SetRateOdometryResponse)},
+  { 538, -1, sizeof(::mavsdk::rpc::telemetry::SetRatePositionVelocityNedRequest)},
+  { 544, -1, sizeof(::mavsdk::rpc::telemetry::SetRatePositionVelocityNedResponse)},
+  { 550, -1, sizeof(::mavsdk::rpc::telemetry::SetRateGroundTruthRequest)},
+  { 556, -1, sizeof(::mavsdk::rpc::telemetry::SetRateGroundTruthResponse)},
+  { 562, -1, sizeof(::mavsdk::rpc::telemetry::SetRateFixedwingMetricsRequest)},
+  { 568, -1, sizeof(::mavsdk::rpc::telemetry::SetRateFixedwingMetricsResponse)},
+  { 574, -1, sizeof(::mavsdk::rpc::telemetry::SetRateImuRequest)},
+  { 580, -1, sizeof(::mavsdk::rpc::telemetry::SetRateImuResponse)},
+  { 586, -1, sizeof(::mavsdk::rpc::telemetry::SetRateScaledImuRequest)},
+  { 592, -1, sizeof(::mavsdk::rpc::telemetry::SetRateScaledImuResponse)},
+  { 598, -1, sizeof(::mavsdk::rpc::telemetry::SetRateRawImuRequest)},
+  { 604, -1, sizeof(::mavsdk::rpc::telemetry::SetRateRawImuResponse)},
+  { 610, -1, sizeof(::mavsdk::rpc::telemetry::SetRateUnixEpochTimeRequest)},
+  { 616, -1, sizeof(::mavsdk::rpc::telemetry::SetRateUnixEpochTimeResponse)},
+  { 622, -1, sizeof(::mavsdk::rpc::telemetry::SetRateDistanceSensorRequest)},
+  { 628, -1, sizeof(::mavsdk::rpc::telemetry::SetRateDistanceSensorResponse)},
+  { 634, -1, sizeof(::mavsdk::rpc::telemetry::GetGpsGlobalOriginRequest)},
+  { 639, -1, sizeof(::mavsdk::rpc::telemetry::GetGpsGlobalOriginResponse)},
+  { 646, -1, sizeof(::mavsdk::rpc::telemetry::Position)},
+  { 655, -1, sizeof(::mavsdk::rpc::telemetry::Heading)},
+  { 661, -1, sizeof(::mavsdk::rpc::telemetry::Quaternion)},
+  { 671, -1, sizeof(::mavsdk::rpc::telemetry::EulerAngle)},
+  { 680, -1, sizeof(::mavsdk::rpc::telemetry::AngularVelocityBody)},
+  { 688, -1, sizeof(::mavsdk::rpc::telemetry::GpsInfo)},
+  { 695, -1, sizeof(::mavsdk::rpc::telemetry::RawGps)},
+  { 714, -1, sizeof(::mavsdk::rpc::telemetry::Battery)},
+  { 722, -1, sizeof(::mavsdk::rpc::telemetry::Health)},
+  { 734, -1, sizeof(::mavsdk::rpc::telemetry::RcStatus)},
+  { 742, -1, sizeof(::mavsdk::rpc::telemetry::StatusText)},
+  { 749, -1, sizeof(::mavsdk::rpc::telemetry::ActuatorControlTarget)},
+  { 756, -1, sizeof(::mavsdk::rpc::telemetry::ActuatorOutputStatus)},
+  { 763, -1, sizeof(::mavsdk::rpc::telemetry::Covariance)},
+  { 769, -1, sizeof(::mavsdk::rpc::telemetry::VelocityBody)},
+  { 777, -1, sizeof(::mavsdk::rpc::telemetry::PositionBody)},
+  { 785, -1, sizeof(::mavsdk::rpc::telemetry::Odometry)},
+  { 799, -1, sizeof(::mavsdk::rpc::telemetry::DistanceSensor)},
+  { 807, -1, sizeof(::mavsdk::rpc::telemetry::ScaledPressure)},
+  { 817, -1, sizeof(::mavsdk::rpc::telemetry::PositionNed)},
+  { 825, -1, sizeof(::mavsdk::rpc::telemetry::VelocityNed)},
+  { 833, -1, sizeof(::mavsdk::rpc::telemetry::PositionVelocityNed)},
+  { 840, -1, sizeof(::mavsdk::rpc::telemetry::GroundTruth)},
+  { 848, -1, sizeof(::mavsdk::rpc::telemetry::FixedwingMetrics)},
+  { 856, -1, sizeof(::mavsdk::rpc::telemetry::AccelerationFrd)},
+  { 864, -1, sizeof(::mavsdk::rpc::telemetry::AngularVelocityFrd)},
+  { 872, -1, sizeof(::mavsdk::rpc::telemetry::MagneticFieldFrd)},
+  { 880, -1, sizeof(::mavsdk::rpc::telemetry::Imu)},
+  { 890, -1, sizeof(::mavsdk::rpc::telemetry::GpsGlobalOrigin)},
+  { 898, -1, sizeof(::mavsdk::rpc::telemetry::TelemetryResult)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -2860,6 +2915,8 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_DistanceSensorResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_SubscribeScaledPressureRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_ScaledPressureResponse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_SubscribeHeadingRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_HeadingResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_SetRatePositionRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_SetRatePositionResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_SetRateHomeRequest_default_instance_),
@@ -2910,6 +2967,7 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_GetGpsGlobalOriginRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_GetGpsGlobalOriginResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_Position_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_Heading_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_Quaternion_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_EulerAngle_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry::_AngularVelocityBody_default_instance_),
@@ -3026,400 +3084,406 @@ const char descriptor_table_protodef_telemetry_2ftelemetry_2eproto[] PROTOBUF_SE
   "or\" \n\036SubscribeScaledPressureRequest\"W\n\026"
   "ScaledPressureResponse\022=\n\017scaled_pressur"
   "e\030\001 \001(\0132$.mavsdk.rpc.telemetry.ScaledPre"
-  "ssure\")\n\026SetRatePositionRequest\022\017\n\007rate_"
-  "hz\030\001 \001(\001\"Z\n\027SetRatePositionResponse\022\?\n\020t"
-  "elemetry_result\030\001 \001(\0132%.mavsdk.rpc.telem"
-  "etry.TelemetryResult\"%\n\022SetRateHomeReque"
-  "st\022\017\n\007rate_hz\030\001 \001(\001\"V\n\023SetRateHomeRespon"
-  "se\022\?\n\020telemetry_result\030\001 \001(\0132%.mavsdk.rp"
-  "c.telemetry.TelemetryResult\"&\n\023SetRateIn"
-  "AirRequest\022\017\n\007rate_hz\030\001 \001(\001\"W\n\024SetRateIn"
-  "AirResponse\022\?\n\020telemetry_result\030\001 \001(\0132%."
-  "mavsdk.rpc.telemetry.TelemetryResult\",\n\031"
-  "SetRateLandedStateRequest\022\017\n\007rate_hz\030\001 \001"
-  "(\001\"]\n\032SetRateLandedStateResponse\022\?\n\020tele"
-  "metry_result\030\001 \001(\0132%.mavsdk.rpc.telemetr"
-  "y.TelemetryResult\")\n\026SetRateAttitudeRequ"
-  "est\022\017\n\007rate_hz\030\001 \001(\001\"Z\n\027SetRateAttitudeR"
-  "esponse\022\?\n\020telemetry_result\030\001 \001(\0132%.mavs"
-  "dk.rpc.telemetry.TelemetryResult\"<\n)SetR"
-  "ateAttitudeAngularVelocityBodyRequest\022\017\n"
-  "\007rate_hz\030\001 \001(\001\"m\n*SetRateAttitudeAngular"
-  "VelocityBodyResponse\022\?\n\020telemetry_result"
+  "ssure\"\031\n\027SubscribeHeadingRequest\"E\n\017Head"
+  "ingResponse\0222\n\013heading_deg\030\001 \001(\0132\035.mavsd"
+  "k.rpc.telemetry.Heading\")\n\026SetRatePositi"
+  "onRequest\022\017\n\007rate_hz\030\001 \001(\001\"Z\n\027SetRatePos"
+  "itionResponse\022\?\n\020telemetry_result\030\001 \001(\0132"
+  "%.mavsdk.rpc.telemetry.TelemetryResult\"%"
+  "\n\022SetRateHomeRequest\022\017\n\007rate_hz\030\001 \001(\001\"V\n"
+  "\023SetRateHomeResponse\022\?\n\020telemetry_result"
   "\030\001 \001(\0132%.mavsdk.rpc.telemetry.TelemetryR"
-  "esult\"9\n&SetRateCameraAttitudeQuaternion"
-  "Request\022\017\n\007rate_hz\030\001 \001(\001\"j\n\'SetRateCamer"
-  "aAttitudeQuaternionResponse\022\?\n\020telemetry"
-  "_result\030\001 \001(\0132%.mavsdk.rpc.telemetry.Tel"
-  "emetryResult\"/\n\034SetRateCameraAttitudeReq"
-  "uest\022\017\n\007rate_hz\030\001 \001(\001\"`\n\035SetRateCameraAt"
-  "titudeResponse\022\?\n\020telemetry_result\030\001 \001(\013"
-  "2%.mavsdk.rpc.telemetry.TelemetryResult\""
-  ",\n\031SetRateVelocityNedRequest\022\017\n\007rate_hz\030"
-  "\001 \001(\001\"]\n\032SetRateVelocityNedResponse\022\?\n\020t"
-  "elemetry_result\030\001 \001(\0132%.mavsdk.rpc.telem"
-  "etry.TelemetryResult\"(\n\025SetRateGpsInfoRe"
-  "quest\022\017\n\007rate_hz\030\001 \001(\001\"Y\n\026SetRateGpsInfo"
-  "Response\022\?\n\020telemetry_result\030\001 \001(\0132%.mav"
-  "sdk.rpc.telemetry.TelemetryResult\"\'\n\024Set"
-  "RateRawGpsRequest\022\017\n\007rate_hz\030\001 \001(\001\"(\n\025Se"
-  "tRateBatteryRequest\022\017\n\007rate_hz\030\001 \001(\001\"Y\n\026"
-  "SetRateBatteryResponse\022\?\n\020telemetry_resu"
-  "lt\030\001 \001(\0132%.mavsdk.rpc.telemetry.Telemetr"
-  "yResult\")\n\026SetRateRcStatusRequest\022\017\n\007rat"
-  "e_hz\030\001 \001(\001\"Z\n\027SetRateRcStatusResponse\022\?\n"
-  "\020telemetry_result\030\001 \001(\0132%.mavsdk.rpc.tel"
-  "emetry.TelemetryResult\"6\n#SetRateActuato"
-  "rControlTargetRequest\022\017\n\007rate_hz\030\001 \001(\001\"g"
-  "\n$SetRateActuatorControlTargetResponse\022\?"
+  "esult\"&\n\023SetRateInAirRequest\022\017\n\007rate_hz\030"
+  "\001 \001(\001\"W\n\024SetRateInAirResponse\022\?\n\020telemet"
+  "ry_result\030\001 \001(\0132%.mavsdk.rpc.telemetry.T"
+  "elemetryResult\",\n\031SetRateLandedStateRequ"
+  "est\022\017\n\007rate_hz\030\001 \001(\001\"]\n\032SetRateLandedSta"
+  "teResponse\022\?\n\020telemetry_result\030\001 \001(\0132%.m"
+  "avsdk.rpc.telemetry.TelemetryResult\")\n\026S"
+  "etRateAttitudeRequest\022\017\n\007rate_hz\030\001 \001(\001\"Z"
+  "\n\027SetRateAttitudeResponse\022\?\n\020telemetry_r"
+  "esult\030\001 \001(\0132%.mavsdk.rpc.telemetry.Telem"
+  "etryResult\"<\n)SetRateAttitudeAngularVelo"
+  "cityBodyRequest\022\017\n\007rate_hz\030\001 \001(\001\"m\n*SetR"
+  "ateAttitudeAngularVelocityBodyResponse\022\?"
   "\n\020telemetry_result\030\001 \001(\0132%.mavsdk.rpc.te"
-  "lemetry.TelemetryResult\"5\n\"SetRateActuat"
-  "orOutputStatusRequest\022\017\n\007rate_hz\030\001 \001(\001\"f"
-  "\n#SetRateActuatorOutputStatusResponse\022\?\n"
-  "\020telemetry_result\030\001 \001(\0132%.mavsdk.rpc.tel"
-  "emetry.TelemetryResult\")\n\026SetRateOdometr"
-  "yRequest\022\017\n\007rate_hz\030\001 \001(\001\"Z\n\027SetRateOdom"
-  "etryResponse\022\?\n\020telemetry_result\030\001 \001(\0132%"
-  ".mavsdk.rpc.telemetry.TelemetryResult\"4\n"
-  "!SetRatePositionVelocityNedRequest\022\017\n\007ra"
-  "te_hz\030\001 \001(\001\"e\n\"SetRatePositionVelocityNe"
-  "dResponse\022\?\n\020telemetry_result\030\001 \001(\0132%.ma"
-  "vsdk.rpc.telemetry.TelemetryResult\",\n\031Se"
-  "tRateGroundTruthRequest\022\017\n\007rate_hz\030\001 \001(\001"
-  "\"]\n\032SetRateGroundTruthResponse\022\?\n\020teleme"
+  "lemetry.TelemetryResult\"9\n&SetRateCamera"
+  "AttitudeQuaternionRequest\022\017\n\007rate_hz\030\001 \001"
+  "(\001\"j\n\'SetRateCameraAttitudeQuaternionRes"
+  "ponse\022\?\n\020telemetry_result\030\001 \001(\0132%.mavsdk"
+  ".rpc.telemetry.TelemetryResult\"/\n\034SetRat"
+  "eCameraAttitudeRequest\022\017\n\007rate_hz\030\001 \001(\001\""
+  "`\n\035SetRateCameraAttitudeResponse\022\?\n\020tele"
+  "metry_result\030\001 \001(\0132%.mavsdk.rpc.telemetr"
+  "y.TelemetryResult\",\n\031SetRateVelocityNedR"
+  "equest\022\017\n\007rate_hz\030\001 \001(\001\"]\n\032SetRateVeloci"
+  "tyNedResponse\022\?\n\020telemetry_result\030\001 \001(\0132"
+  "%.mavsdk.rpc.telemetry.TelemetryResult\"("
+  "\n\025SetRateGpsInfoRequest\022\017\n\007rate_hz\030\001 \001(\001"
+  "\"Y\n\026SetRateGpsInfoResponse\022\?\n\020telemetry_"
+  "result\030\001 \001(\0132%.mavsdk.rpc.telemetry.Tele"
+  "metryResult\"\'\n\024SetRateRawGpsRequest\022\017\n\007r"
+  "ate_hz\030\001 \001(\001\"(\n\025SetRateBatteryRequest\022\017\n"
+  "\007rate_hz\030\001 \001(\001\"Y\n\026SetRateBatteryResponse"
+  "\022\?\n\020telemetry_result\030\001 \001(\0132%.mavsdk.rpc."
+  "telemetry.TelemetryResult\")\n\026SetRateRcSt"
+  "atusRequest\022\017\n\007rate_hz\030\001 \001(\001\"Z\n\027SetRateR"
+  "cStatusResponse\022\?\n\020telemetry_result\030\001 \001("
+  "\0132%.mavsdk.rpc.telemetry.TelemetryResult"
+  "\"6\n#SetRateActuatorControlTargetRequest\022"
+  "\017\n\007rate_hz\030\001 \001(\001\"g\n$SetRateActuatorContr"
+  "olTargetResponse\022\?\n\020telemetry_result\030\001 \001"
+  "(\0132%.mavsdk.rpc.telemetry.TelemetryResul"
+  "t\"5\n\"SetRateActuatorOutputStatusRequest\022"
+  "\017\n\007rate_hz\030\001 \001(\001\"f\n#SetRateActuatorOutpu"
+  "tStatusResponse\022\?\n\020telemetry_result\030\001 \001("
+  "\0132%.mavsdk.rpc.telemetry.TelemetryResult"
+  "\")\n\026SetRateOdometryRequest\022\017\n\007rate_hz\030\001 "
+  "\001(\001\"Z\n\027SetRateOdometryResponse\022\?\n\020teleme"
   "try_result\030\001 \001(\0132%.mavsdk.rpc.telemetry."
-  "TelemetryResult\"1\n\036SetRateFixedwingMetri"
-  "csRequest\022\017\n\007rate_hz\030\001 \001(\001\"b\n\037SetRateFix"
-  "edwingMetricsResponse\022\?\n\020telemetry_resul"
-  "t\030\001 \001(\0132%.mavsdk.rpc.telemetry.Telemetry"
-  "Result\"$\n\021SetRateImuRequest\022\017\n\007rate_hz\030\001"
-  " \001(\001\"U\n\022SetRateImuResponse\022\?\n\020telemetry_"
-  "result\030\001 \001(\0132%.mavsdk.rpc.telemetry.Tele"
-  "metryResult\"*\n\027SetRateScaledImuRequest\022\017"
-  "\n\007rate_hz\030\001 \001(\001\"[\n\030SetRateScaledImuRespo"
-  "nse\022\?\n\020telemetry_result\030\001 \001(\0132%.mavsdk.r"
-  "pc.telemetry.TelemetryResult\"\'\n\024SetRateR"
-  "awImuRequest\022\017\n\007rate_hz\030\001 \001(\001\"X\n\025SetRate"
-  "RawImuResponse\022\?\n\020telemetry_result\030\001 \001(\013"
-  "2%.mavsdk.rpc.telemetry.TelemetryResult\""
-  ".\n\033SetRateUnixEpochTimeRequest\022\017\n\007rate_h"
-  "z\030\001 \001(\001\"_\n\034SetRateUnixEpochTimeResponse\022"
+  "TelemetryResult\"4\n!SetRatePositionVeloci"
+  "tyNedRequest\022\017\n\007rate_hz\030\001 \001(\001\"e\n\"SetRate"
+  "PositionVelocityNedResponse\022\?\n\020telemetry"
+  "_result\030\001 \001(\0132%.mavsdk.rpc.telemetry.Tel"
+  "emetryResult\",\n\031SetRateGroundTruthReques"
+  "t\022\017\n\007rate_hz\030\001 \001(\001\"]\n\032SetRateGroundTruth"
+  "Response\022\?\n\020telemetry_result\030\001 \001(\0132%.mav"
+  "sdk.rpc.telemetry.TelemetryResult\"1\n\036Set"
+  "RateFixedwingMetricsRequest\022\017\n\007rate_hz\030\001"
+  " \001(\001\"b\n\037SetRateFixedwingMetricsResponse\022"
   "\?\n\020telemetry_result\030\001 \001(\0132%.mavsdk.rpc.t"
-  "elemetry.TelemetryResult\"/\n\034SetRateDista"
-  "nceSensorRequest\022\017\n\007rate_hz\030\001 \001(\001\"`\n\035Set"
-  "RateDistanceSensorResponse\022\?\n\020telemetry_"
-  "result\030\001 \001(\0132%.mavsdk.rpc.telemetry.Tele"
-  "metryResult\"\033\n\031GetGpsGlobalOriginRequest"
-  "\"\237\001\n\032GetGpsGlobalOriginResponse\022\?\n\020telem"
-  "etry_result\030\001 \001(\0132%.mavsdk.rpc.telemetry"
-  ".TelemetryResult\022@\n\021gps_global_origin\030\002 "
-  "\001(\0132%.mavsdk.rpc.telemetry.GpsGlobalOrig"
-  "in\"\225\001\n\010Position\022\035\n\014latitude_deg\030\001 \001(\001B\007\202"
-  "\265\030\003NaN\022\036\n\rlongitude_deg\030\002 \001(\001B\007\202\265\030\003NaN\022$"
-  "\n\023absolute_altitude_m\030\003 \001(\002B\007\202\265\030\003NaN\022$\n\023"
-  "relative_altitude_m\030\004 \001(\002B\007\202\265\030\003NaN\"r\n\nQu"
-  "aternion\022\022\n\001w\030\001 \001(\002B\007\202\265\030\003NaN\022\022\n\001x\030\002 \001(\002B"
-  "\007\202\265\030\003NaN\022\022\n\001y\030\003 \001(\002B\007\202\265\030\003NaN\022\022\n\001z\030\004 \001(\002B"
-  "\007\202\265\030\003NaN\022\024\n\014timestamp_us\030\005 \001(\004\"s\n\nEulerA"
-  "ngle\022\031\n\010roll_deg\030\001 \001(\002B\007\202\265\030\003NaN\022\032\n\tpitch"
-  "_deg\030\002 \001(\002B\007\202\265\030\003NaN\022\030\n\007yaw_deg\030\003 \001(\002B\007\202\265"
-  "\030\003NaN\022\024\n\014timestamp_us\030\004 \001(\004\"l\n\023AngularVe"
-  "locityBody\022\033\n\nroll_rad_s\030\001 \001(\002B\007\202\265\030\003NaN\022"
-  "\034\n\013pitch_rad_s\030\002 \001(\002B\007\202\265\030\003NaN\022\032\n\tyaw_rad"
-  "_s\030\003 \001(\002B\007\202\265\030\003NaN\"Y\n\007GpsInfo\022\035\n\016num_sate"
-  "llites\030\001 \001(\005B\005\202\265\030\0010\022/\n\010fix_type\030\002 \001(\0162\035."
-  "mavsdk.rpc.telemetry.FixType\"\337\002\n\006RawGps\022"
-  "\024\n\014timestamp_us\030\001 \001(\004\022\024\n\014latitude_deg\030\002 "
-  "\001(\001\022\025\n\rlongitude_deg\030\003 \001(\001\022\033\n\023absolute_a"
-  "ltitude_m\030\004 \001(\002\022\014\n\004hdop\030\005 \001(\002\022\014\n\004vdop\030\006 "
-  "\001(\002\022\024\n\014velocity_m_s\030\007 \001(\002\022\017\n\007cog_deg\030\010 \001"
-  "(\002\022\034\n\024altitude_ellipsoid_m\030\t \001(\002\022 \n\030hori"
-  "zontal_uncertainty_m\030\n \001(\002\022\036\n\026vertical_u"
-  "ncertainty_m\030\013 \001(\002\022 \n\030velocity_uncertain"
-  "ty_m_s\030\014 \001(\002\022\037\n\027heading_uncertainty_deg\030"
-  "\r \001(\002\022\017\n\007yaw_deg\030\016 \001(\002\"\\\n\007Battery\022\021\n\002id\030"
-  "\003 \001(\rB\005\202\265\030\0010\022\032\n\tvoltage_v\030\001 \001(\002B\007\202\265\030\003NaN"
-  "\022\"\n\021remaining_percent\030\002 \001(\002B\007\202\265\030\003NaN\"\271\002\n"
-  "\006Health\022.\n\033is_gyrometer_calibration_ok\030\001"
-  " \001(\010B\t\202\265\030\005false\0222\n\037is_accelerometer_cali"
-  "bration_ok\030\002 \001(\010B\t\202\265\030\005false\0221\n\036is_magnet"
-  "ometer_calibration_ok\030\003 \001(\010B\t\202\265\030\005false\022\'"
-  "\n\024is_local_position_ok\030\005 \001(\010B\t\202\265\030\005false\022"
-  "(\n\025is_global_position_ok\030\006 \001(\010B\t\202\265\030\005fals"
-  "e\022&\n\023is_home_position_ok\030\007 \001(\010B\t\202\265\030\005fals"
-  "e\022\035\n\nis_armable\030\010 \001(\010B\t\202\265\030\005false\"|\n\010RcSt"
-  "atus\022%\n\022was_available_once\030\001 \001(\010B\t\202\265\030\005fa"
-  "lse\022\037\n\014is_available\030\002 \001(\010B\t\202\265\030\005false\022(\n\027"
-  "signal_strength_percent\030\003 \001(\002B\007\202\265\030\003NaN\"N"
-  "\n\nStatusText\0222\n\004type\030\001 \001(\0162$.mavsdk.rpc."
-  "telemetry.StatusTextType\022\014\n\004text\030\002 \001(\t\"\?"
-  "\n\025ActuatorControlTarget\022\024\n\005group\030\001 \001(\005B\005"
-  "\202\265\030\0010\022\020\n\010controls\030\002 \003(\002\"\?\n\024ActuatorOutpu"
-  "tStatus\022\025\n\006active\030\001 \001(\rB\005\202\265\030\0010\022\020\n\010actuat"
-  "or\030\002 \003(\002\"\'\n\nCovariance\022\031\n\021covariance_mat"
-  "rix\030\001 \003(\002\";\n\014VelocityBody\022\r\n\005x_m_s\030\001 \001(\002"
-  "\022\r\n\005y_m_s\030\002 \001(\002\022\r\n\005z_m_s\030\003 \001(\002\"5\n\014Positi"
-  "onBody\022\013\n\003x_m\030\001 \001(\002\022\013\n\003y_m\030\002 \001(\002\022\013\n\003z_m\030"
-  "\003 \001(\002\"\354\004\n\010Odometry\022\021\n\ttime_usec\030\001 \001(\004\0229\n"
-  "\010frame_id\030\002 \001(\0162\'.mavsdk.rpc.telemetry.O"
-  "dometry.MavFrame\022\?\n\016child_frame_id\030\003 \001(\016"
-  "2\'.mavsdk.rpc.telemetry.Odometry.MavFram"
-  "e\0229\n\rposition_body\030\004 \001(\0132\".mavsdk.rpc.te"
-  "lemetry.PositionBody\022+\n\001q\030\005 \001(\0132 .mavsdk"
-  ".rpc.telemetry.Quaternion\0229\n\rvelocity_bo"
-  "dy\030\006 \001(\0132\".mavsdk.rpc.telemetry.Velocity"
-  "Body\022H\n\025angular_velocity_body\030\007 \001(\0132).ma"
-  "vsdk.rpc.telemetry.AngularVelocityBody\0229"
-  "\n\017pose_covariance\030\010 \001(\0132 .mavsdk.rpc.tel"
-  "emetry.Covariance\022=\n\023velocity_covariance"
-  "\030\t \001(\0132 .mavsdk.rpc.telemetry.Covariance"
-  "\"j\n\010MavFrame\022\023\n\017MAV_FRAME_UNDEF\020\000\022\026\n\022MAV"
-  "_FRAME_BODY_NED\020\010\022\030\n\024MAV_FRAME_VISION_NE"
-  "D\020\020\022\027\n\023MAV_FRAME_ESTIM_NED\020\022\"\177\n\016Distance"
-  "Sensor\022#\n\022minimum_distance_m\030\001 \001(\002B\007\202\265\030\003"
-  "NaN\022#\n\022maximum_distance_m\030\002 \001(\002B\007\202\265\030\003NaN"
-  "\022#\n\022current_distance_m\030\003 \001(\002B\007\202\265\030\003NaN\"\260\001"
-  "\n\016ScaledPressure\022\024\n\014timestamp_us\030\001 \001(\004\022\035"
-  "\n\025absolute_pressure_hpa\030\002 \001(\002\022!\n\031differe"
-  "ntial_pressure_hpa\030\003 \001(\002\022\027\n\017temperature_"
-  "deg\030\004 \001(\002\022-\n%differential_pressure_tempe"
-  "rature_deg\030\005 \001(\002\"Y\n\013PositionNed\022\030\n\007north"
-  "_m\030\001 \001(\002B\007\202\265\030\003NaN\022\027\n\006east_m\030\002 \001(\002B\007\202\265\030\003N"
-  "aN\022\027\n\006down_m\030\003 \001(\002B\007\202\265\030\003NaN\"D\n\013VelocityN"
-  "ed\022\021\n\tnorth_m_s\030\001 \001(\002\022\020\n\010east_m_s\030\002 \001(\002\022"
-  "\020\n\010down_m_s\030\003 \001(\002\"\177\n\023PositionVelocityNed"
-  "\0223\n\010position\030\001 \001(\0132!.mavsdk.rpc.telemetr"
-  "y.PositionNed\0223\n\010velocity\030\002 \001(\0132!.mavsdk"
-  ".rpc.telemetry.VelocityNed\"r\n\013GroundTrut"
-  "h\022\035\n\014latitude_deg\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlong"
-  "itude_deg\030\002 \001(\001B\007\202\265\030\003NaN\022$\n\023absolute_alt"
-  "itude_m\030\003 \001(\002B\007\202\265\030\003NaN\"x\n\020FixedwingMetri"
-  "cs\022\035\n\014airspeed_m_s\030\001 \001(\002B\007\202\265\030\003NaN\022$\n\023thr"
-  "ottle_percentage\030\002 \001(\002B\007\202\265\030\003NaN\022\037\n\016climb"
-  "_rate_m_s\030\003 \001(\002B\007\202\265\030\003NaN\"i\n\017Acceleration"
-  "Frd\022\035\n\014forward_m_s2\030\001 \001(\002B\007\202\265\030\003NaN\022\033\n\nri"
-  "ght_m_s2\030\002 \001(\002B\007\202\265\030\003NaN\022\032\n\tdown_m_s2\030\003 \001"
-  "(\002B\007\202\265\030\003NaN\"o\n\022AngularVelocityFrd\022\036\n\rfor"
-  "ward_rad_s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right_rad_s"
-  "\030\002 \001(\002B\007\202\265\030\003NaN\022\033\n\ndown_rad_s\030\003 \001(\002B\007\202\265\030"
-  "\003NaN\"m\n\020MagneticFieldFrd\022\036\n\rforward_gaus"
-  "s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right_gauss\030\002 \001(\002B\007\202"
-  "\265\030\003NaN\022\033\n\ndown_gauss\030\003 \001(\002B\007\202\265\030\003NaN\"\213\002\n\003"
-  "Imu\022\?\n\020acceleration_frd\030\001 \001(\0132%.mavsdk.r"
-  "pc.telemetry.AccelerationFrd\022F\n\024angular_"
-  "velocity_frd\030\002 \001(\0132(.mavsdk.rpc.telemetr"
-  "y.AngularVelocityFrd\022B\n\022magnetic_field_f"
-  "rd\030\003 \001(\0132&.mavsdk.rpc.telemetry.Magnetic"
-  "FieldFrd\022!\n\020temperature_degc\030\004 \001(\002B\007\202\265\030\003"
-  "NaN\022\024\n\014timestamp_us\030\005 \001(\004\"m\n\017GpsGlobalOr"
-  "igin\022\035\n\014latitude_deg\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rl"
-  "ongitude_deg\030\002 \001(\001B\007\202\265\030\003NaN\022\033\n\naltitude_"
-  "m\030\003 \001(\002B\007\202\265\030\003NaN\"\241\002\n\017TelemetryResult\022<\n\006"
-  "result\030\001 \001(\0162,.mavsdk.rpc.telemetry.Tele"
-  "metryResult.Result\022\022\n\nresult_str\030\002 \001(\t\"\273"
-  "\001\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESULT_"
-  "SUCCESS\020\001\022\024\n\020RESULT_NO_SYSTEM\020\002\022\033\n\027RESUL"
-  "T_CONNECTION_ERROR\020\003\022\017\n\013RESULT_BUSY\020\004\022\031\n"
-  "\025RESULT_COMMAND_DENIED\020\005\022\022\n\016RESULT_TIMEO"
-  "UT\020\006\022\026\n\022RESULT_UNSUPPORTED\020\007*\244\001\n\007FixType"
-  "\022\023\n\017FIX_TYPE_NO_GPS\020\000\022\023\n\017FIX_TYPE_NO_FIX"
-  "\020\001\022\023\n\017FIX_TYPE_FIX_2D\020\002\022\023\n\017FIX_TYPE_FIX_"
-  "3D\020\003\022\025\n\021FIX_TYPE_FIX_DGPS\020\004\022\026\n\022FIX_TYPE_"
-  "RTK_FLOAT\020\005\022\026\n\022FIX_TYPE_RTK_FIXED\020\006*\206\003\n\n"
-  "FlightMode\022\027\n\023FLIGHT_MODE_UNKNOWN\020\000\022\025\n\021F"
-  "LIGHT_MODE_READY\020\001\022\027\n\023FLIGHT_MODE_TAKEOF"
-  "F\020\002\022\024\n\020FLIGHT_MODE_HOLD\020\003\022\027\n\023FLIGHT_MODE"
-  "_MISSION\020\004\022 \n\034FLIGHT_MODE_RETURN_TO_LAUN"
-  "CH\020\005\022\024\n\020FLIGHT_MODE_LAND\020\006\022\030\n\024FLIGHT_MOD"
-  "E_OFFBOARD\020\007\022\031\n\025FLIGHT_MODE_FOLLOW_ME\020\010\022"
-  "\026\n\022FLIGHT_MODE_MANUAL\020\t\022\026\n\022FLIGHT_MODE_A"
-  "LTCTL\020\n\022\026\n\022FLIGHT_MODE_POSCTL\020\013\022\024\n\020FLIGH"
-  "T_MODE_ACRO\020\014\022\032\n\026FLIGHT_MODE_STABILIZED\020"
-  "\r\022\031\n\025FLIGHT_MODE_RATTITUDE\020\016*\371\001\n\016StatusT"
-  "extType\022\032\n\026STATUS_TEXT_TYPE_DEBUG\020\000\022\031\n\025S"
-  "TATUS_TEXT_TYPE_INFO\020\001\022\033\n\027STATUS_TEXT_TY"
-  "PE_NOTICE\020\002\022\034\n\030STATUS_TEXT_TYPE_WARNING\020"
-  "\003\022\032\n\026STATUS_TEXT_TYPE_ERROR\020\004\022\035\n\031STATUS_"
-  "TEXT_TYPE_CRITICAL\020\005\022\032\n\026STATUS_TEXT_TYPE"
-  "_ALERT\020\006\022\036\n\032STATUS_TEXT_TYPE_EMERGENCY\020\007"
-  "*\223\001\n\013LandedState\022\030\n\024LANDED_STATE_UNKNOWN"
-  "\020\000\022\032\n\026LANDED_STATE_ON_GROUND\020\001\022\027\n\023LANDED"
-  "_STATE_IN_AIR\020\002\022\033\n\027LANDED_STATE_TAKING_O"
-  "FF\020\003\022\030\n\024LANDED_STATE_LANDING\020\0042\2473\n\020Telem"
-  "etryService\022o\n\021SubscribePosition\022..mavsd"
-  "k.rpc.telemetry.SubscribePositionRequest"
-  "\032&.mavsdk.rpc.telemetry.PositionResponse"
-  "\"\0000\001\022c\n\rSubscribeHome\022*.mavsdk.rpc.telem"
-  "etry.SubscribeHomeRequest\032\".mavsdk.rpc.t"
-  "elemetry.HomeResponse\"\0000\001\022f\n\016SubscribeIn"
-  "Air\022+.mavsdk.rpc.telemetry.SubscribeInAi"
-  "rRequest\032#.mavsdk.rpc.telemetry.InAirRes"
-  "ponse\"\0000\001\022x\n\024SubscribeLandedState\0221.mavs"
-  "dk.rpc.telemetry.SubscribeLandedStateReq"
-  "uest\032).mavsdk.rpc.telemetry.LandedStateR"
-  "esponse\"\0000\001\022f\n\016SubscribeArmed\022+.mavsdk.r"
-  "pc.telemetry.SubscribeArmedRequest\032#.mav"
-  "sdk.rpc.telemetry.ArmedResponse\"\0000\001\022\215\001\n\033"
-  "SubscribeAttitudeQuaternion\0228.mavsdk.rpc"
-  ".telemetry.SubscribeAttitudeQuaternionRe"
-  "quest\0320.mavsdk.rpc.telemetry.AttitudeQua"
-  "ternionResponse\"\0000\001\022~\n\026SubscribeAttitude"
-  "Euler\0223.mavsdk.rpc.telemetry.SubscribeAt"
-  "titudeEulerRequest\032+.mavsdk.rpc.telemetr"
-  "y.AttitudeEulerResponse\"\0000\001\022\250\001\n$Subscrib"
-  "eAttitudeAngularVelocityBody\022A.mavsdk.rp"
-  "c.telemetry.SubscribeAttitudeAngularVelo"
-  "cityBodyRequest\0329.mavsdk.rpc.telemetry.A"
-  "ttitudeAngularVelocityBodyResponse\"\0000\001\022\237"
-  "\001\n!SubscribeCameraAttitudeQuaternion\022>.m"
-  "avsdk.rpc.telemetry.SubscribeCameraAttit"
-  "udeQuaternionRequest\0326.mavsdk.rpc.teleme"
-  "try.CameraAttitudeQuaternionResponse\"\0000\001"
-  "\022\220\001\n\034SubscribeCameraAttitudeEuler\0229.mavs"
-  "dk.rpc.telemetry.SubscribeCameraAttitude"
-  "EulerRequest\0321.mavsdk.rpc.telemetry.Came"
-  "raAttitudeEulerResponse\"\0000\001\022x\n\024Subscribe"
-  "VelocityNed\0221.mavsdk.rpc.telemetry.Subsc"
-  "ribeVelocityNedRequest\032).mavsdk.rpc.tele"
-  "metry.VelocityNedResponse\"\0000\001\022l\n\020Subscri"
-  "beGpsInfo\022-.mavsdk.rpc.telemetry.Subscri"
-  "beGpsInfoRequest\032%.mavsdk.rpc.telemetry."
-  "GpsInfoResponse\"\0000\001\022i\n\017SubscribeRawGps\022,"
-  ".mavsdk.rpc.telemetry.SubscribeRawGpsReq"
-  "uest\032$.mavsdk.rpc.telemetry.RawGpsRespon"
-  "se\"\0000\001\022l\n\020SubscribeBattery\022-.mavsdk.rpc."
-  "telemetry.SubscribeBatteryRequest\032%.mavs"
-  "dk.rpc.telemetry.BatteryResponse\"\0000\001\022u\n\023"
-  "SubscribeFlightMode\0220.mavsdk.rpc.telemet"
-  "ry.SubscribeFlightModeRequest\032(.mavsdk.r"
-  "pc.telemetry.FlightModeResponse\"\0000\001\022i\n\017S"
-  "ubscribeHealth\022,.mavsdk.rpc.telemetry.Su"
-  "bscribeHealthRequest\032$.mavsdk.rpc.teleme"
-  "try.HealthResponse\"\0000\001\022o\n\021SubscribeRcSta"
-  "tus\022..mavsdk.rpc.telemetry.SubscribeRcSt"
-  "atusRequest\032&.mavsdk.rpc.telemetry.RcSta"
-  "tusResponse\"\0000\001\022u\n\023SubscribeStatusText\0220"
-  ".mavsdk.rpc.telemetry.SubscribeStatusTex"
-  "tRequest\032(.mavsdk.rpc.telemetry.StatusTe"
-  "xtResponse\"\0000\001\022\226\001\n\036SubscribeActuatorCont"
-  "rolTarget\022;.mavsdk.rpc.telemetry.Subscri"
-  "beActuatorControlTargetRequest\0323.mavsdk."
-  "rpc.telemetry.ActuatorControlTargetRespo"
-  "nse\"\0000\001\022\223\001\n\035SubscribeActuatorOutputStatu"
-  "s\022:.mavsdk.rpc.telemetry.SubscribeActuat"
-  "orOutputStatusRequest\0322.mavsdk.rpc.telem"
-  "etry.ActuatorOutputStatusResponse\"\0000\001\022o\n"
-  "\021SubscribeOdometry\022..mavsdk.rpc.telemetr"
-  "y.SubscribeOdometryRequest\032&.mavsdk.rpc."
-  "telemetry.OdometryResponse\"\0000\001\022\220\001\n\034Subsc"
-  "ribePositionVelocityNed\0229.mavsdk.rpc.tel"
-  "emetry.SubscribePositionVelocityNedReque"
-  "st\0321.mavsdk.rpc.telemetry.PositionVeloci"
-  "tyNedResponse\"\0000\001\022x\n\024SubscribeGroundTrut"
-  "h\0221.mavsdk.rpc.telemetry.SubscribeGround"
-  "TruthRequest\032).mavsdk.rpc.telemetry.Grou"
-  "ndTruthResponse\"\0000\001\022\207\001\n\031SubscribeFixedwi"
-  "ngMetrics\0226.mavsdk.rpc.telemetry.Subscri"
-  "beFixedwingMetricsRequest\032..mavsdk.rpc.t"
-  "elemetry.FixedwingMetricsResponse\"\0000\001\022`\n"
-  "\014SubscribeImu\022).mavsdk.rpc.telemetry.Sub"
-  "scribeImuRequest\032!.mavsdk.rpc.telemetry."
-  "ImuResponse\"\0000\001\022r\n\022SubscribeScaledImu\022/."
-  "mavsdk.rpc.telemetry.SubscribeScaledImuR"
-  "equest\032\'.mavsdk.rpc.telemetry.ScaledImuR"
-  "esponse\"\0000\001\022i\n\017SubscribeRawImu\022,.mavsdk."
-  "rpc.telemetry.SubscribeRawImuRequest\032$.m"
-  "avsdk.rpc.telemetry.RawImuResponse\"\0000\001\022x"
-  "\n\024SubscribeHealthAllOk\0221.mavsdk.rpc.tele"
-  "metry.SubscribeHealthAllOkRequest\032).mavs"
-  "dk.rpc.telemetry.HealthAllOkResponse\"\0000\001"
-  "\022~\n\026SubscribeUnixEpochTime\0223.mavsdk.rpc."
-  "telemetry.SubscribeUnixEpochTimeRequest\032"
-  "+.mavsdk.rpc.telemetry.UnixEpochTimeResp"
-  "onse\"\0000\001\022\201\001\n\027SubscribeDistanceSensor\0224.m"
-  "avsdk.rpc.telemetry.SubscribeDistanceSen"
-  "sorRequest\032,.mavsdk.rpc.telemetry.Distan"
-  "ceSensorResponse\"\0000\001\022\201\001\n\027SubscribeScaled"
-  "Pressure\0224.mavsdk.rpc.telemetry.Subscrib"
-  "eScaledPressureRequest\032,.mavsdk.rpc.tele"
-  "metry.ScaledPressureResponse\"\0000\001\022p\n\017SetR"
-  "atePosition\022,.mavsdk.rpc.telemetry.SetRa"
-  "tePositionRequest\032-.mavsdk.rpc.telemetry"
-  ".SetRatePositionResponse\"\000\022d\n\013SetRateHom"
-  "e\022(.mavsdk.rpc.telemetry.SetRateHomeRequ"
-  "est\032).mavsdk.rpc.telemetry.SetRateHomeRe"
-  "sponse\"\000\022g\n\014SetRateInAir\022).mavsdk.rpc.te"
-  "lemetry.SetRateInAirRequest\032*.mavsdk.rpc"
-  ".telemetry.SetRateInAirResponse\"\000\022y\n\022Set"
-  "RateLandedState\022/.mavsdk.rpc.telemetry.S"
-  "etRateLandedStateRequest\0320.mavsdk.rpc.te"
-  "lemetry.SetRateLandedStateResponse\"\000\022p\n\017"
-  "SetRateAttitude\022,.mavsdk.rpc.telemetry.S"
-  "etRateAttitudeRequest\032-.mavsdk.rpc.telem"
-  "etry.SetRateAttitudeResponse\"\000\022\202\001\n\025SetRa"
-  "teCameraAttitude\0222.mavsdk.rpc.telemetry."
-  "SetRateCameraAttitudeRequest\0323.mavsdk.rp"
-  "c.telemetry.SetRateCameraAttitudeRespons"
-  "e\"\000\022y\n\022SetRateVelocityNed\022/.mavsdk.rpc.t"
-  "elemetry.SetRateVelocityNedRequest\0320.mav"
-  "sdk.rpc.telemetry.SetRateVelocityNedResp"
-  "onse\"\000\022m\n\016SetRateGpsInfo\022+.mavsdk.rpc.te"
-  "lemetry.SetRateGpsInfoRequest\032,.mavsdk.r"
-  "pc.telemetry.SetRateGpsInfoResponse\"\000\022m\n"
-  "\016SetRateBattery\022+.mavsdk.rpc.telemetry.S"
-  "etRateBatteryRequest\032,.mavsdk.rpc.teleme"
-  "try.SetRateBatteryResponse\"\000\022p\n\017SetRateR"
-  "cStatus\022,.mavsdk.rpc.telemetry.SetRateRc"
-  "StatusRequest\032-.mavsdk.rpc.telemetry.Set"
-  "RateRcStatusResponse\"\000\022\227\001\n\034SetRateActuat"
-  "orControlTarget\0229.mavsdk.rpc.telemetry.S"
-  "etRateActuatorControlTargetRequest\032:.mav"
-  "sdk.rpc.telemetry.SetRateActuatorControl"
-  "TargetResponse\"\000\022\224\001\n\033SetRateActuatorOutp"
-  "utStatus\0228.mavsdk.rpc.telemetry.SetRateA"
-  "ctuatorOutputStatusRequest\0329.mavsdk.rpc."
-  "telemetry.SetRateActuatorOutputStatusRes"
-  "ponse\"\000\022p\n\017SetRateOdometry\022,.mavsdk.rpc."
-  "telemetry.SetRateOdometryRequest\032-.mavsd"
-  "k.rpc.telemetry.SetRateOdometryResponse\""
-  "\000\022\221\001\n\032SetRatePositionVelocityNed\0227.mavsd"
-  "k.rpc.telemetry.SetRatePositionVelocityN"
-  "edRequest\0328.mavsdk.rpc.telemetry.SetRate"
-  "PositionVelocityNedResponse\"\000\022y\n\022SetRate"
-  "GroundTruth\022/.mavsdk.rpc.telemetry.SetRa"
-  "teGroundTruthRequest\0320.mavsdk.rpc.teleme"
-  "try.SetRateGroundTruthResponse\"\000\022\210\001\n\027Set"
-  "RateFixedwingMetrics\0224.mavsdk.rpc.teleme"
-  "try.SetRateFixedwingMetricsRequest\0325.mav"
-  "sdk.rpc.telemetry.SetRateFixedwingMetric"
-  "sResponse\"\000\022a\n\nSetRateImu\022\'.mavsdk.rpc.t"
-  "elemetry.SetRateImuRequest\032(.mavsdk.rpc."
-  "telemetry.SetRateImuResponse\"\000\022s\n\020SetRat"
-  "eScaledImu\022-.mavsdk.rpc.telemetry.SetRat"
-  "eScaledImuRequest\032..mavsdk.rpc.telemetry"
-  ".SetRateScaledImuResponse\"\000\022j\n\rSetRateRa"
-  "wImu\022*.mavsdk.rpc.telemetry.SetRateRawIm"
-  "uRequest\032+.mavsdk.rpc.telemetry.SetRateR"
-  "awImuResponse\"\000\022\177\n\024SetRateUnixEpochTime\022"
-  "1.mavsdk.rpc.telemetry.SetRateUnixEpochT"
-  "imeRequest\0322.mavsdk.rpc.telemetry.SetRat"
-  "eUnixEpochTimeResponse\"\000\022\202\001\n\025SetRateDist"
-  "anceSensor\0222.mavsdk.rpc.telemetry.SetRat"
-  "eDistanceSensorRequest\0323.mavsdk.rpc.tele"
-  "metry.SetRateDistanceSensorResponse\"\000\022y\n"
-  "\022GetGpsGlobalOrigin\022/.mavsdk.rpc.telemet"
-  "ry.GetGpsGlobalOriginRequest\0320.mavsdk.rp"
-  "c.telemetry.GetGpsGlobalOriginResponse\"\000"
-  "B%\n\023io.mavsdk.telemetryB\016TelemetryProtob"
-  "\006proto3"
+  "elemetry.TelemetryResult\"$\n\021SetRateImuRe"
+  "quest\022\017\n\007rate_hz\030\001 \001(\001\"U\n\022SetRateImuResp"
+  "onse\022\?\n\020telemetry_result\030\001 \001(\0132%.mavsdk."
+  "rpc.telemetry.TelemetryResult\"*\n\027SetRate"
+  "ScaledImuRequest\022\017\n\007rate_hz\030\001 \001(\001\"[\n\030Set"
+  "RateScaledImuResponse\022\?\n\020telemetry_resul"
+  "t\030\001 \001(\0132%.mavsdk.rpc.telemetry.Telemetry"
+  "Result\"\'\n\024SetRateRawImuRequest\022\017\n\007rate_h"
+  "z\030\001 \001(\001\"X\n\025SetRateRawImuResponse\022\?\n\020tele"
+  "metry_result\030\001 \001(\0132%.mavsdk.rpc.telemetr"
+  "y.TelemetryResult\".\n\033SetRateUnixEpochTim"
+  "eRequest\022\017\n\007rate_hz\030\001 \001(\001\"_\n\034SetRateUnix"
+  "EpochTimeResponse\022\?\n\020telemetry_result\030\001 "
+  "\001(\0132%.mavsdk.rpc.telemetry.TelemetryResu"
+  "lt\"/\n\034SetRateDistanceSensorRequest\022\017\n\007ra"
+  "te_hz\030\001 \001(\001\"`\n\035SetRateDistanceSensorResp"
+  "onse\022\?\n\020telemetry_result\030\001 \001(\0132%.mavsdk."
+  "rpc.telemetry.TelemetryResult\"\033\n\031GetGpsG"
+  "lobalOriginRequest\"\237\001\n\032GetGpsGlobalOrigi"
+  "nResponse\022\?\n\020telemetry_result\030\001 \001(\0132%.ma"
+  "vsdk.rpc.telemetry.TelemetryResult\022@\n\021gp"
+  "s_global_origin\030\002 \001(\0132%.mavsdk.rpc.telem"
+  "etry.GpsGlobalOrigin\"\225\001\n\010Position\022\035\n\014lat"
+  "itude_deg\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlongitude_de"
+  "g\030\002 \001(\001B\007\202\265\030\003NaN\022$\n\023absolute_altitude_m\030"
+  "\003 \001(\002B\007\202\265\030\003NaN\022$\n\023relative_altitude_m\030\004 "
+  "\001(\002B\007\202\265\030\003NaN\"\'\n\007Heading\022\034\n\013heading_deg\030\001"
+  " \001(\001B\007\202\265\030\003NaN\"r\n\nQuaternion\022\022\n\001w\030\001 \001(\002B\007"
+  "\202\265\030\003NaN\022\022\n\001x\030\002 \001(\002B\007\202\265\030\003NaN\022\022\n\001y\030\003 \001(\002B\007"
+  "\202\265\030\003NaN\022\022\n\001z\030\004 \001(\002B\007\202\265\030\003NaN\022\024\n\014timestamp"
+  "_us\030\005 \001(\004\"s\n\nEulerAngle\022\031\n\010roll_deg\030\001 \001("
+  "\002B\007\202\265\030\003NaN\022\032\n\tpitch_deg\030\002 \001(\002B\007\202\265\030\003NaN\022\030"
+  "\n\007yaw_deg\030\003 \001(\002B\007\202\265\030\003NaN\022\024\n\014timestamp_us"
+  "\030\004 \001(\004\"l\n\023AngularVelocityBody\022\033\n\nroll_ra"
+  "d_s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013pitch_rad_s\030\002 \001(\002B"
+  "\007\202\265\030\003NaN\022\032\n\tyaw_rad_s\030\003 \001(\002B\007\202\265\030\003NaN\"Y\n\007"
+  "GpsInfo\022\035\n\016num_satellites\030\001 \001(\005B\005\202\265\030\0010\022/"
+  "\n\010fix_type\030\002 \001(\0162\035.mavsdk.rpc.telemetry."
+  "FixType\"\337\002\n\006RawGps\022\024\n\014timestamp_us\030\001 \001(\004"
+  "\022\024\n\014latitude_deg\030\002 \001(\001\022\025\n\rlongitude_deg\030"
+  "\003 \001(\001\022\033\n\023absolute_altitude_m\030\004 \001(\002\022\014\n\004hd"
+  "op\030\005 \001(\002\022\014\n\004vdop\030\006 \001(\002\022\024\n\014velocity_m_s\030\007"
+  " \001(\002\022\017\n\007cog_deg\030\010 \001(\002\022\034\n\024altitude_ellips"
+  "oid_m\030\t \001(\002\022 \n\030horizontal_uncertainty_m\030"
+  "\n \001(\002\022\036\n\026vertical_uncertainty_m\030\013 \001(\002\022 \n"
+  "\030velocity_uncertainty_m_s\030\014 \001(\002\022\037\n\027headi"
+  "ng_uncertainty_deg\030\r \001(\002\022\017\n\007yaw_deg\030\016 \001("
+  "\002\"\\\n\007Battery\022\021\n\002id\030\003 \001(\rB\005\202\265\030\0010\022\032\n\tvolta"
+  "ge_v\030\001 \001(\002B\007\202\265\030\003NaN\022\"\n\021remaining_percent"
+  "\030\002 \001(\002B\007\202\265\030\003NaN\"\271\002\n\006Health\022.\n\033is_gyromet"
+  "er_calibration_ok\030\001 \001(\010B\t\202\265\030\005false\0222\n\037is"
+  "_accelerometer_calibration_ok\030\002 \001(\010B\t\202\265\030"
+  "\005false\0221\n\036is_magnetometer_calibration_ok"
+  "\030\003 \001(\010B\t\202\265\030\005false\022\'\n\024is_local_position_o"
+  "k\030\005 \001(\010B\t\202\265\030\005false\022(\n\025is_global_position"
+  "_ok\030\006 \001(\010B\t\202\265\030\005false\022&\n\023is_home_position"
+  "_ok\030\007 \001(\010B\t\202\265\030\005false\022\035\n\nis_armable\030\010 \001(\010"
+  "B\t\202\265\030\005false\"|\n\010RcStatus\022%\n\022was_available"
+  "_once\030\001 \001(\010B\t\202\265\030\005false\022\037\n\014is_available\030\002"
+  " \001(\010B\t\202\265\030\005false\022(\n\027signal_strength_perce"
+  "nt\030\003 \001(\002B\007\202\265\030\003NaN\"N\n\nStatusText\0222\n\004type\030"
+  "\001 \001(\0162$.mavsdk.rpc.telemetry.StatusTextT"
+  "ype\022\014\n\004text\030\002 \001(\t\"\?\n\025ActuatorControlTarg"
+  "et\022\024\n\005group\030\001 \001(\005B\005\202\265\030\0010\022\020\n\010controls\030\002 \003"
+  "(\002\"\?\n\024ActuatorOutputStatus\022\025\n\006active\030\001 \001"
+  "(\rB\005\202\265\030\0010\022\020\n\010actuator\030\002 \003(\002\"\'\n\nCovarianc"
+  "e\022\031\n\021covariance_matrix\030\001 \003(\002\";\n\014Velocity"
+  "Body\022\r\n\005x_m_s\030\001 \001(\002\022\r\n\005y_m_s\030\002 \001(\002\022\r\n\005z_"
+  "m_s\030\003 \001(\002\"5\n\014PositionBody\022\013\n\003x_m\030\001 \001(\002\022\013"
+  "\n\003y_m\030\002 \001(\002\022\013\n\003z_m\030\003 \001(\002\"\354\004\n\010Odometry\022\021\n"
+  "\ttime_usec\030\001 \001(\004\0229\n\010frame_id\030\002 \001(\0162\'.mav"
+  "sdk.rpc.telemetry.Odometry.MavFrame\022\?\n\016c"
+  "hild_frame_id\030\003 \001(\0162\'.mavsdk.rpc.telemet"
+  "ry.Odometry.MavFrame\0229\n\rposition_body\030\004 "
+  "\001(\0132\".mavsdk.rpc.telemetry.PositionBody\022"
+  "+\n\001q\030\005 \001(\0132 .mavsdk.rpc.telemetry.Quater"
+  "nion\0229\n\rvelocity_body\030\006 \001(\0132\".mavsdk.rpc"
+  ".telemetry.VelocityBody\022H\n\025angular_veloc"
+  "ity_body\030\007 \001(\0132).mavsdk.rpc.telemetry.An"
+  "gularVelocityBody\0229\n\017pose_covariance\030\010 \001"
+  "(\0132 .mavsdk.rpc.telemetry.Covariance\022=\n\023"
+  "velocity_covariance\030\t \001(\0132 .mavsdk.rpc.t"
+  "elemetry.Covariance\"j\n\010MavFrame\022\023\n\017MAV_F"
+  "RAME_UNDEF\020\000\022\026\n\022MAV_FRAME_BODY_NED\020\010\022\030\n\024"
+  "MAV_FRAME_VISION_NED\020\020\022\027\n\023MAV_FRAME_ESTI"
+  "M_NED\020\022\"\177\n\016DistanceSensor\022#\n\022minimum_dis"
+  "tance_m\030\001 \001(\002B\007\202\265\030\003NaN\022#\n\022maximum_distan"
+  "ce_m\030\002 \001(\002B\007\202\265\030\003NaN\022#\n\022current_distance_"
+  "m\030\003 \001(\002B\007\202\265\030\003NaN\"\260\001\n\016ScaledPressure\022\024\n\014t"
+  "imestamp_us\030\001 \001(\004\022\035\n\025absolute_pressure_h"
+  "pa\030\002 \001(\002\022!\n\031differential_pressure_hpa\030\003 "
+  "\001(\002\022\027\n\017temperature_deg\030\004 \001(\002\022-\n%differen"
+  "tial_pressure_temperature_deg\030\005 \001(\002\"Y\n\013P"
+  "ositionNed\022\030\n\007north_m\030\001 \001(\002B\007\202\265\030\003NaN\022\027\n\006"
+  "east_m\030\002 \001(\002B\007\202\265\030\003NaN\022\027\n\006down_m\030\003 \001(\002B\007\202"
+  "\265\030\003NaN\"D\n\013VelocityNed\022\021\n\tnorth_m_s\030\001 \001(\002"
+  "\022\020\n\010east_m_s\030\002 \001(\002\022\020\n\010down_m_s\030\003 \001(\002\"\177\n\023"
+  "PositionVelocityNed\0223\n\010position\030\001 \001(\0132!."
+  "mavsdk.rpc.telemetry.PositionNed\0223\n\010velo"
+  "city\030\002 \001(\0132!.mavsdk.rpc.telemetry.Veloci"
+  "tyNed\"r\n\013GroundTruth\022\035\n\014latitude_deg\030\001 \001"
+  "(\001B\007\202\265\030\003NaN\022\036\n\rlongitude_deg\030\002 \001(\001B\007\202\265\030\003"
+  "NaN\022$\n\023absolute_altitude_m\030\003 \001(\002B\007\202\265\030\003Na"
+  "N\"x\n\020FixedwingMetrics\022\035\n\014airspeed_m_s\030\001 "
+  "\001(\002B\007\202\265\030\003NaN\022$\n\023throttle_percentage\030\002 \001("
+  "\002B\007\202\265\030\003NaN\022\037\n\016climb_rate_m_s\030\003 \001(\002B\007\202\265\030\003"
+  "NaN\"i\n\017AccelerationFrd\022\035\n\014forward_m_s2\030\001"
+  " \001(\002B\007\202\265\030\003NaN\022\033\n\nright_m_s2\030\002 \001(\002B\007\202\265\030\003N"
+  "aN\022\032\n\tdown_m_s2\030\003 \001(\002B\007\202\265\030\003NaN\"o\n\022Angula"
+  "rVelocityFrd\022\036\n\rforward_rad_s\030\001 \001(\002B\007\202\265\030"
+  "\003NaN\022\034\n\013right_rad_s\030\002 \001(\002B\007\202\265\030\003NaN\022\033\n\ndo"
+  "wn_rad_s\030\003 \001(\002B\007\202\265\030\003NaN\"m\n\020MagneticField"
+  "Frd\022\036\n\rforward_gauss\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013r"
+  "ight_gauss\030\002 \001(\002B\007\202\265\030\003NaN\022\033\n\ndown_gauss\030"
+  "\003 \001(\002B\007\202\265\030\003NaN\"\213\002\n\003Imu\022\?\n\020acceleration_f"
+  "rd\030\001 \001(\0132%.mavsdk.rpc.telemetry.Accelera"
+  "tionFrd\022F\n\024angular_velocity_frd\030\002 \001(\0132(."
+  "mavsdk.rpc.telemetry.AngularVelocityFrd\022"
+  "B\n\022magnetic_field_frd\030\003 \001(\0132&.mavsdk.rpc"
+  ".telemetry.MagneticFieldFrd\022!\n\020temperatu"
+  "re_degc\030\004 \001(\002B\007\202\265\030\003NaN\022\024\n\014timestamp_us\030\005"
+  " \001(\004\"m\n\017GpsGlobalOrigin\022\035\n\014latitude_deg\030"
+  "\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlongitude_deg\030\002 \001(\001B\007\202"
+  "\265\030\003NaN\022\033\n\naltitude_m\030\003 \001(\002B\007\202\265\030\003NaN\"\241\002\n\017"
+  "TelemetryResult\022<\n\006result\030\001 \001(\0162,.mavsdk"
+  ".rpc.telemetry.TelemetryResult.Result\022\022\n"
+  "\nresult_str\030\002 \001(\t\"\273\001\n\006Result\022\022\n\016RESULT_U"
+  "NKNOWN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\024\n\020RESULT_N"
+  "O_SYSTEM\020\002\022\033\n\027RESULT_CONNECTION_ERROR\020\003\022"
+  "\017\n\013RESULT_BUSY\020\004\022\031\n\025RESULT_COMMAND_DENIE"
+  "D\020\005\022\022\n\016RESULT_TIMEOUT\020\006\022\026\n\022RESULT_UNSUPP"
+  "ORTED\020\007*\244\001\n\007FixType\022\023\n\017FIX_TYPE_NO_GPS\020\000"
+  "\022\023\n\017FIX_TYPE_NO_FIX\020\001\022\023\n\017FIX_TYPE_FIX_2D"
+  "\020\002\022\023\n\017FIX_TYPE_FIX_3D\020\003\022\025\n\021FIX_TYPE_FIX_"
+  "DGPS\020\004\022\026\n\022FIX_TYPE_RTK_FLOAT\020\005\022\026\n\022FIX_TY"
+  "PE_RTK_FIXED\020\006*\206\003\n\nFlightMode\022\027\n\023FLIGHT_"
+  "MODE_UNKNOWN\020\000\022\025\n\021FLIGHT_MODE_READY\020\001\022\027\n"
+  "\023FLIGHT_MODE_TAKEOFF\020\002\022\024\n\020FLIGHT_MODE_HO"
+  "LD\020\003\022\027\n\023FLIGHT_MODE_MISSION\020\004\022 \n\034FLIGHT_"
+  "MODE_RETURN_TO_LAUNCH\020\005\022\024\n\020FLIGHT_MODE_L"
+  "AND\020\006\022\030\n\024FLIGHT_MODE_OFFBOARD\020\007\022\031\n\025FLIGH"
+  "T_MODE_FOLLOW_ME\020\010\022\026\n\022FLIGHT_MODE_MANUAL"
+  "\020\t\022\026\n\022FLIGHT_MODE_ALTCTL\020\n\022\026\n\022FLIGHT_MOD"
+  "E_POSCTL\020\013\022\024\n\020FLIGHT_MODE_ACRO\020\014\022\032\n\026FLIG"
+  "HT_MODE_STABILIZED\020\r\022\031\n\025FLIGHT_MODE_RATT"
+  "ITUDE\020\016*\371\001\n\016StatusTextType\022\032\n\026STATUS_TEX"
+  "T_TYPE_DEBUG\020\000\022\031\n\025STATUS_TEXT_TYPE_INFO\020"
+  "\001\022\033\n\027STATUS_TEXT_TYPE_NOTICE\020\002\022\034\n\030STATUS"
+  "_TEXT_TYPE_WARNING\020\003\022\032\n\026STATUS_TEXT_TYPE"
+  "_ERROR\020\004\022\035\n\031STATUS_TEXT_TYPE_CRITICAL\020\005\022"
+  "\032\n\026STATUS_TEXT_TYPE_ALERT\020\006\022\036\n\032STATUS_TE"
+  "XT_TYPE_EMERGENCY\020\007*\223\001\n\013LandedState\022\030\n\024L"
+  "ANDED_STATE_UNKNOWN\020\000\022\032\n\026LANDED_STATE_ON"
+  "_GROUND\020\001\022\027\n\023LANDED_STATE_IN_AIR\020\002\022\033\n\027LA"
+  "NDED_STATE_TAKING_OFF\020\003\022\030\n\024LANDED_STATE_"
+  "LANDING\020\0042\2254\n\020TelemetryService\022o\n\021Subscr"
+  "ibePosition\022..mavsdk.rpc.telemetry.Subsc"
+  "ribePositionRequest\032&.mavsdk.rpc.telemet"
+  "ry.PositionResponse\"\0000\001\022c\n\rSubscribeHome"
+  "\022*.mavsdk.rpc.telemetry.SubscribeHomeReq"
+  "uest\032\".mavsdk.rpc.telemetry.HomeResponse"
+  "\"\0000\001\022f\n\016SubscribeInAir\022+.mavsdk.rpc.tele"
+  "metry.SubscribeInAirRequest\032#.mavsdk.rpc"
+  ".telemetry.InAirResponse\"\0000\001\022x\n\024Subscrib"
+  "eLandedState\0221.mavsdk.rpc.telemetry.Subs"
+  "cribeLandedStateRequest\032).mavsdk.rpc.tel"
+  "emetry.LandedStateResponse\"\0000\001\022f\n\016Subscr"
+  "ibeArmed\022+.mavsdk.rpc.telemetry.Subscrib"
+  "eArmedRequest\032#.mavsdk.rpc.telemetry.Arm"
+  "edResponse\"\0000\001\022\215\001\n\033SubscribeAttitudeQuat"
+  "ernion\0228.mavsdk.rpc.telemetry.SubscribeA"
+  "ttitudeQuaternionRequest\0320.mavsdk.rpc.te"
+  "lemetry.AttitudeQuaternionResponse\"\0000\001\022~"
+  "\n\026SubscribeAttitudeEuler\0223.mavsdk.rpc.te"
+  "lemetry.SubscribeAttitudeEulerRequest\032+."
+  "mavsdk.rpc.telemetry.AttitudeEulerRespon"
+  "se\"\0000\001\022\250\001\n$SubscribeAttitudeAngularVeloc"
+  "ityBody\022A.mavsdk.rpc.telemetry.Subscribe"
+  "AttitudeAngularVelocityBodyRequest\0329.mav"
+  "sdk.rpc.telemetry.AttitudeAngularVelocit"
+  "yBodyResponse\"\0000\001\022\237\001\n!SubscribeCameraAtt"
+  "itudeQuaternion\022>.mavsdk.rpc.telemetry.S"
+  "ubscribeCameraAttitudeQuaternionRequest\032"
+  "6.mavsdk.rpc.telemetry.CameraAttitudeQua"
+  "ternionResponse\"\0000\001\022\220\001\n\034SubscribeCameraA"
+  "ttitudeEuler\0229.mavsdk.rpc.telemetry.Subs"
+  "cribeCameraAttitudeEulerRequest\0321.mavsdk"
+  ".rpc.telemetry.CameraAttitudeEulerRespon"
+  "se\"\0000\001\022x\n\024SubscribeVelocityNed\0221.mavsdk."
+  "rpc.telemetry.SubscribeVelocityNedReques"
+  "t\032).mavsdk.rpc.telemetry.VelocityNedResp"
+  "onse\"\0000\001\022l\n\020SubscribeGpsInfo\022-.mavsdk.rp"
+  "c.telemetry.SubscribeGpsInfoRequest\032%.ma"
+  "vsdk.rpc.telemetry.GpsInfoResponse\"\0000\001\022i"
+  "\n\017SubscribeRawGps\022,.mavsdk.rpc.telemetry"
+  ".SubscribeRawGpsRequest\032$.mavsdk.rpc.tel"
+  "emetry.RawGpsResponse\"\0000\001\022l\n\020SubscribeBa"
+  "ttery\022-.mavsdk.rpc.telemetry.SubscribeBa"
+  "tteryRequest\032%.mavsdk.rpc.telemetry.Batt"
+  "eryResponse\"\0000\001\022u\n\023SubscribeFlightMode\0220"
+  ".mavsdk.rpc.telemetry.SubscribeFlightMod"
+  "eRequest\032(.mavsdk.rpc.telemetry.FlightMo"
+  "deResponse\"\0000\001\022i\n\017SubscribeHealth\022,.mavs"
+  "dk.rpc.telemetry.SubscribeHealthRequest\032"
+  "$.mavsdk.rpc.telemetry.HealthResponse\"\0000"
+  "\001\022o\n\021SubscribeRcStatus\022..mavsdk.rpc.tele"
+  "metry.SubscribeRcStatusRequest\032&.mavsdk."
+  "rpc.telemetry.RcStatusResponse\"\0000\001\022u\n\023Su"
+  "bscribeStatusText\0220.mavsdk.rpc.telemetry"
+  ".SubscribeStatusTextRequest\032(.mavsdk.rpc"
+  ".telemetry.StatusTextResponse\"\0000\001\022\226\001\n\036Su"
+  "bscribeActuatorControlTarget\022;.mavsdk.rp"
+  "c.telemetry.SubscribeActuatorControlTarg"
+  "etRequest\0323.mavsdk.rpc.telemetry.Actuato"
+  "rControlTargetResponse\"\0000\001\022\223\001\n\035Subscribe"
+  "ActuatorOutputStatus\022:.mavsdk.rpc.teleme"
+  "try.SubscribeActuatorOutputStatusRequest"
+  "\0322.mavsdk.rpc.telemetry.ActuatorOutputSt"
+  "atusResponse\"\0000\001\022o\n\021SubscribeOdometry\022.."
+  "mavsdk.rpc.telemetry.SubscribeOdometryRe"
+  "quest\032&.mavsdk.rpc.telemetry.OdometryRes"
+  "ponse\"\0000\001\022\220\001\n\034SubscribePositionVelocityN"
+  "ed\0229.mavsdk.rpc.telemetry.SubscribePosit"
+  "ionVelocityNedRequest\0321.mavsdk.rpc.telem"
+  "etry.PositionVelocityNedResponse\"\0000\001\022x\n\024"
+  "SubscribeGroundTruth\0221.mavsdk.rpc.teleme"
+  "try.SubscribeGroundTruthRequest\032).mavsdk"
+  ".rpc.telemetry.GroundTruthResponse\"\0000\001\022\207"
+  "\001\n\031SubscribeFixedwingMetrics\0226.mavsdk.rp"
+  "c.telemetry.SubscribeFixedwingMetricsReq"
+  "uest\032..mavsdk.rpc.telemetry.FixedwingMet"
+  "ricsResponse\"\0000\001\022`\n\014SubscribeImu\022).mavsd"
+  "k.rpc.telemetry.SubscribeImuRequest\032!.ma"
+  "vsdk.rpc.telemetry.ImuResponse\"\0000\001\022r\n\022Su"
+  "bscribeScaledImu\022/.mavsdk.rpc.telemetry."
+  "SubscribeScaledImuRequest\032\'.mavsdk.rpc.t"
+  "elemetry.ScaledImuResponse\"\0000\001\022i\n\017Subscr"
+  "ibeRawImu\022,.mavsdk.rpc.telemetry.Subscri"
+  "beRawImuRequest\032$.mavsdk.rpc.telemetry.R"
+  "awImuResponse\"\0000\001\022x\n\024SubscribeHealthAllO"
+  "k\0221.mavsdk.rpc.telemetry.SubscribeHealth"
+  "AllOkRequest\032).mavsdk.rpc.telemetry.Heal"
+  "thAllOkResponse\"\0000\001\022~\n\026SubscribeUnixEpoc"
+  "hTime\0223.mavsdk.rpc.telemetry.SubscribeUn"
+  "ixEpochTimeRequest\032+.mavsdk.rpc.telemetr"
+  "y.UnixEpochTimeResponse\"\0000\001\022\201\001\n\027Subscrib"
+  "eDistanceSensor\0224.mavsdk.rpc.telemetry.S"
+  "ubscribeDistanceSensorRequest\032,.mavsdk.r"
+  "pc.telemetry.DistanceSensorResponse\"\0000\001\022"
+  "\201\001\n\027SubscribeScaledPressure\0224.mavsdk.rpc"
+  ".telemetry.SubscribeScaledPressureReques"
+  "t\032,.mavsdk.rpc.telemetry.ScaledPressureR"
+  "esponse\"\0000\001\022l\n\020SubscribeHeading\022-.mavsdk"
+  ".rpc.telemetry.SubscribeHeadingRequest\032%"
+  ".mavsdk.rpc.telemetry.HeadingResponse\"\0000"
+  "\001\022p\n\017SetRatePosition\022,.mavsdk.rpc.teleme"
+  "try.SetRatePositionRequest\032-.mavsdk.rpc."
+  "telemetry.SetRatePositionResponse\"\000\022d\n\013S"
+  "etRateHome\022(.mavsdk.rpc.telemetry.SetRat"
+  "eHomeRequest\032).mavsdk.rpc.telemetry.SetR"
+  "ateHomeResponse\"\000\022g\n\014SetRateInAir\022).mavs"
+  "dk.rpc.telemetry.SetRateInAirRequest\032*.m"
+  "avsdk.rpc.telemetry.SetRateInAirResponse"
+  "\"\000\022y\n\022SetRateLandedState\022/.mavsdk.rpc.te"
+  "lemetry.SetRateLandedStateRequest\0320.mavs"
+  "dk.rpc.telemetry.SetRateLandedStateRespo"
+  "nse\"\000\022p\n\017SetRateAttitude\022,.mavsdk.rpc.te"
+  "lemetry.SetRateAttitudeRequest\032-.mavsdk."
+  "rpc.telemetry.SetRateAttitudeResponse\"\000\022"
+  "\202\001\n\025SetRateCameraAttitude\0222.mavsdk.rpc.t"
+  "elemetry.SetRateCameraAttitudeRequest\0323."
+  "mavsdk.rpc.telemetry.SetRateCameraAttitu"
+  "deResponse\"\000\022y\n\022SetRateVelocityNed\022/.mav"
+  "sdk.rpc.telemetry.SetRateVelocityNedRequ"
+  "est\0320.mavsdk.rpc.telemetry.SetRateVeloci"
+  "tyNedResponse\"\000\022m\n\016SetRateGpsInfo\022+.mavs"
+  "dk.rpc.telemetry.SetRateGpsInfoRequest\032,"
+  ".mavsdk.rpc.telemetry.SetRateGpsInfoResp"
+  "onse\"\000\022m\n\016SetRateBattery\022+.mavsdk.rpc.te"
+  "lemetry.SetRateBatteryRequest\032,.mavsdk.r"
+  "pc.telemetry.SetRateBatteryResponse\"\000\022p\n"
+  "\017SetRateRcStatus\022,.mavsdk.rpc.telemetry."
+  "SetRateRcStatusRequest\032-.mavsdk.rpc.tele"
+  "metry.SetRateRcStatusResponse\"\000\022\227\001\n\034SetR"
+  "ateActuatorControlTarget\0229.mavsdk.rpc.te"
+  "lemetry.SetRateActuatorControlTargetRequ"
+  "est\032:.mavsdk.rpc.telemetry.SetRateActuat"
+  "orControlTargetResponse\"\000\022\224\001\n\033SetRateAct"
+  "uatorOutputStatus\0228.mavsdk.rpc.telemetry"
+  ".SetRateActuatorOutputStatusRequest\0329.ma"
+  "vsdk.rpc.telemetry.SetRateActuatorOutput"
+  "StatusResponse\"\000\022p\n\017SetRateOdometry\022,.ma"
+  "vsdk.rpc.telemetry.SetRateOdometryReques"
+  "t\032-.mavsdk.rpc.telemetry.SetRateOdometry"
+  "Response\"\000\022\221\001\n\032SetRatePositionVelocityNe"
+  "d\0227.mavsdk.rpc.telemetry.SetRatePosition"
+  "VelocityNedRequest\0328.mavsdk.rpc.telemetr"
+  "y.SetRatePositionVelocityNedResponse\"\000\022y"
+  "\n\022SetRateGroundTruth\022/.mavsdk.rpc.teleme"
+  "try.SetRateGroundTruthRequest\0320.mavsdk.r"
+  "pc.telemetry.SetRateGroundTruthResponse\""
+  "\000\022\210\001\n\027SetRateFixedwingMetrics\0224.mavsdk.r"
+  "pc.telemetry.SetRateFixedwingMetricsRequ"
+  "est\0325.mavsdk.rpc.telemetry.SetRateFixedw"
+  "ingMetricsResponse\"\000\022a\n\nSetRateImu\022\'.mav"
+  "sdk.rpc.telemetry.SetRateImuRequest\032(.ma"
+  "vsdk.rpc.telemetry.SetRateImuResponse\"\000\022"
+  "s\n\020SetRateScaledImu\022-.mavsdk.rpc.telemet"
+  "ry.SetRateScaledImuRequest\032..mavsdk.rpc."
+  "telemetry.SetRateScaledImuResponse\"\000\022j\n\r"
+  "SetRateRawImu\022*.mavsdk.rpc.telemetry.Set"
+  "RateRawImuRequest\032+.mavsdk.rpc.telemetry"
+  ".SetRateRawImuResponse\"\000\022\177\n\024SetRateUnixE"
+  "pochTime\0221.mavsdk.rpc.telemetry.SetRateU"
+  "nixEpochTimeRequest\0322.mavsdk.rpc.telemet"
+  "ry.SetRateUnixEpochTimeResponse\"\000\022\202\001\n\025Se"
+  "tRateDistanceSensor\0222.mavsdk.rpc.telemet"
+  "ry.SetRateDistanceSensorRequest\0323.mavsdk"
+  ".rpc.telemetry.SetRateDistanceSensorResp"
+  "onse\"\000\022y\n\022GetGpsGlobalOrigin\022/.mavsdk.rp"
+  "c.telemetry.GetGpsGlobalOriginRequest\0320."
+  "mavsdk.rpc.telemetry.GetGpsGlobalOriginR"
+  "esponse\"\000B%\n\023io.mavsdk.telemetryB\016Teleme"
+  "tryProtob\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_telemetry_2ftelemetry_2eproto_deps[1] = {
   &::descriptor_table_mavsdk_5foptions_2eproto,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_telemetry_2ftelemetry_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_telemetry_2ftelemetry_2eproto = {
-  false, false, 18807, descriptor_table_protodef_telemetry_2ftelemetry_2eproto, "telemetry/telemetry.proto", 
-  &descriptor_table_telemetry_2ftelemetry_2eproto_once, descriptor_table_telemetry_2ftelemetry_2eproto_deps, 1, 140,
+  false, false, 19056, descriptor_table_protodef_telemetry_2ftelemetry_2eproto, "telemetry/telemetry.proto", 
+  &descriptor_table_telemetry_2ftelemetry_2eproto_once, descriptor_table_telemetry_2ftelemetry_2eproto_deps, 1, 143,
   schemas, file_default_instances, TableStruct_telemetry_2ftelemetry_2eproto::offsets,
   file_level_metadata_telemetry_2ftelemetry_2eproto, file_level_enum_descriptors_telemetry_2ftelemetry_2eproto, file_level_service_descriptors_telemetry_2ftelemetry_2eproto,
 };
@@ -14675,6 +14739,367 @@ void ScaledPressureResponse::InternalSwap(ScaledPressureResponse* other) {
 
 // ===================================================================
 
+class SubscribeHeadingRequest::_Internal {
+ public:
+};
+
+SubscribeHeadingRequest::SubscribeHeadingRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.telemetry.SubscribeHeadingRequest)
+}
+SubscribeHeadingRequest::SubscribeHeadingRequest(const SubscribeHeadingRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.telemetry.SubscribeHeadingRequest)
+}
+
+void SubscribeHeadingRequest::SharedCtor() {
+}
+
+SubscribeHeadingRequest::~SubscribeHeadingRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.telemetry.SubscribeHeadingRequest)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void SubscribeHeadingRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+}
+
+void SubscribeHeadingRequest::ArenaDtor(void* object) {
+  SubscribeHeadingRequest* _this = reinterpret_cast< SubscribeHeadingRequest* >(object);
+  (void)_this;
+}
+void SubscribeHeadingRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void SubscribeHeadingRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void SubscribeHeadingRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.telemetry.SubscribeHeadingRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* SubscribeHeadingRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* SubscribeHeadingRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.telemetry.SubscribeHeadingRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.telemetry.SubscribeHeadingRequest)
+  return target;
+}
+
+size_t SubscribeHeadingRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.telemetry.SubscribeHeadingRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void SubscribeHeadingRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:mavsdk.rpc.telemetry.SubscribeHeadingRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const SubscribeHeadingRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<SubscribeHeadingRequest>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:mavsdk.rpc.telemetry.SubscribeHeadingRequest)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:mavsdk.rpc.telemetry.SubscribeHeadingRequest)
+    MergeFrom(*source);
+  }
+}
+
+void SubscribeHeadingRequest::MergeFrom(const SubscribeHeadingRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.telemetry.SubscribeHeadingRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+}
+
+void SubscribeHeadingRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:mavsdk.rpc.telemetry.SubscribeHeadingRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void SubscribeHeadingRequest::CopyFrom(const SubscribeHeadingRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.telemetry.SubscribeHeadingRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SubscribeHeadingRequest::IsInitialized() const {
+  return true;
+}
+
+void SubscribeHeadingRequest::InternalSwap(SubscribeHeadingRequest* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata SubscribeHeadingRequest::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class HeadingResponse::_Internal {
+ public:
+  static const ::mavsdk::rpc::telemetry::Heading& heading_deg(const HeadingResponse* msg);
+};
+
+const ::mavsdk::rpc::telemetry::Heading&
+HeadingResponse::_Internal::heading_deg(const HeadingResponse* msg) {
+  return *msg->heading_deg_;
+}
+HeadingResponse::HeadingResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.telemetry.HeadingResponse)
+}
+HeadingResponse::HeadingResponse(const HeadingResponse& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_heading_deg()) {
+    heading_deg_ = new ::mavsdk::rpc::telemetry::Heading(*from.heading_deg_);
+  } else {
+    heading_deg_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.telemetry.HeadingResponse)
+}
+
+void HeadingResponse::SharedCtor() {
+heading_deg_ = nullptr;
+}
+
+HeadingResponse::~HeadingResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.telemetry.HeadingResponse)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void HeadingResponse::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  if (this != internal_default_instance()) delete heading_deg_;
+}
+
+void HeadingResponse::ArenaDtor(void* object) {
+  HeadingResponse* _this = reinterpret_cast< HeadingResponse* >(object);
+  (void)_this;
+}
+void HeadingResponse::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void HeadingResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void HeadingResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.telemetry.HeadingResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArena() == nullptr && heading_deg_ != nullptr) {
+    delete heading_deg_;
+  }
+  heading_deg_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* HeadingResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // .mavsdk.rpc.telemetry.Heading heading_deg = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_heading_deg(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* HeadingResponse::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.telemetry.HeadingResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.telemetry.Heading heading_deg = 1;
+  if (this->has_heading_deg()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::heading_deg(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.telemetry.HeadingResponse)
+  return target;
+}
+
+size_t HeadingResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.telemetry.HeadingResponse)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.telemetry.Heading heading_deg = 1;
+  if (this->has_heading_deg()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *heading_deg_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void HeadingResponse::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:mavsdk.rpc.telemetry.HeadingResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  const HeadingResponse* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<HeadingResponse>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:mavsdk.rpc.telemetry.HeadingResponse)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:mavsdk.rpc.telemetry.HeadingResponse)
+    MergeFrom(*source);
+  }
+}
+
+void HeadingResponse::MergeFrom(const HeadingResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.telemetry.HeadingResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.has_heading_deg()) {
+    _internal_mutable_heading_deg()->::mavsdk::rpc::telemetry::Heading::MergeFrom(from._internal_heading_deg());
+  }
+}
+
+void HeadingResponse::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:mavsdk.rpc.telemetry.HeadingResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void HeadingResponse::CopyFrom(const HeadingResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.telemetry.HeadingResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool HeadingResponse::IsInitialized() const {
+  return true;
+}
+
+void HeadingResponse::InternalSwap(HeadingResponse* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  swap(heading_deg_, other->heading_deg_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata HeadingResponse::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
 class SetRatePositionRequest::_Internal {
  public:
 };
@@ -24526,6 +24951,193 @@ void Position::InternalSwap(Position* other) {
 
 // ===================================================================
 
+class Heading::_Internal {
+ public:
+};
+
+Heading::Heading(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.telemetry.Heading)
+}
+Heading::Heading(const Heading& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  heading_deg_ = from.heading_deg_;
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.telemetry.Heading)
+}
+
+void Heading::SharedCtor() {
+heading_deg_ = 0;
+}
+
+Heading::~Heading() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.telemetry.Heading)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void Heading::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+}
+
+void Heading::ArenaDtor(void* object) {
+  Heading* _this = reinterpret_cast< Heading* >(object);
+  (void)_this;
+}
+void Heading::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void Heading::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void Heading::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.telemetry.Heading)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  heading_deg_ = 0;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* Heading::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // double heading_deg = 1 [(.mavsdk.options.default_value) = "NaN"];
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 9)) {
+          heading_deg_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<double>(ptr);
+          ptr += sizeof(double);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* Heading::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.telemetry.Heading)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // double heading_deg = 1 [(.mavsdk.options.default_value) = "NaN"];
+  if (!(this->heading_deg() <= 0 && this->heading_deg() >= 0)) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteDoubleToArray(1, this->_internal_heading_deg(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.telemetry.Heading)
+  return target;
+}
+
+size_t Heading::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.telemetry.Heading)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // double heading_deg = 1 [(.mavsdk.options.default_value) = "NaN"];
+  if (!(this->heading_deg() <= 0 && this->heading_deg() >= 0)) {
+    total_size += 1 + 8;
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void Heading::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:mavsdk.rpc.telemetry.Heading)
+  GOOGLE_DCHECK_NE(&from, this);
+  const Heading* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<Heading>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:mavsdk.rpc.telemetry.Heading)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:mavsdk.rpc.telemetry.Heading)
+    MergeFrom(*source);
+  }
+}
+
+void Heading::MergeFrom(const Heading& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.telemetry.Heading)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!(from.heading_deg() <= 0 && from.heading_deg() >= 0)) {
+    _internal_set_heading_deg(from._internal_heading_deg());
+  }
+}
+
+void Heading::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:mavsdk.rpc.telemetry.Heading)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void Heading::CopyFrom(const Heading& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.telemetry.Heading)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool Heading::IsInitialized() const {
+  return true;
+}
+
+void Heading::InternalSwap(Heading* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  swap(heading_deg_, other->heading_deg_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata Heading::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
 class Quaternion::_Internal {
  public:
 };
@@ -32133,6 +32745,12 @@ template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry::SubscribeScaledPressureRe
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry::ScaledPressureResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::telemetry::ScaledPressureResponse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::telemetry::ScaledPressureResponse >(arena);
 }
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry::SubscribeHeadingRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::telemetry::SubscribeHeadingRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::telemetry::SubscribeHeadingRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry::HeadingResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::telemetry::HeadingResponse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::telemetry::HeadingResponse >(arena);
+}
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry::SetRatePositionRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::telemetry::SetRatePositionRequest >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::telemetry::SetRatePositionRequest >(arena);
 }
@@ -32282,6 +32900,9 @@ template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry::GetGpsGlobalOriginRespons
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry::Position* Arena::CreateMaybeMessage< ::mavsdk::rpc::telemetry::Position >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::telemetry::Position >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry::Heading* Arena::CreateMaybeMessage< ::mavsdk::rpc::telemetry::Heading >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::telemetry::Heading >(arena);
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry::Quaternion* Arena::CreateMaybeMessage< ::mavsdk::rpc::telemetry::Quaternion >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::telemetry::Quaternion >(arena);

--- a/src/mavsdk_server/src/generated/telemetry/telemetry.pb.h
+++ b/src/mavsdk_server/src/generated/telemetry/telemetry.pb.h
@@ -48,7 +48,7 @@ struct TableStruct_telemetry_2ftelemetry_2eproto {
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::AuxiliaryParseTableField aux[]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
-  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[140]
+  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[143]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::FieldMetadata field_metadata[];
   static const ::PROTOBUF_NAMESPACE_ID::internal::SerializationTable serialization_table[];
@@ -146,6 +146,12 @@ extern GroundTruthDefaultTypeInternal _GroundTruth_default_instance_;
 class GroundTruthResponse;
 struct GroundTruthResponseDefaultTypeInternal;
 extern GroundTruthResponseDefaultTypeInternal _GroundTruthResponse_default_instance_;
+class Heading;
+struct HeadingDefaultTypeInternal;
+extern HeadingDefaultTypeInternal _Heading_default_instance_;
+class HeadingResponse;
+struct HeadingResponseDefaultTypeInternal;
+extern HeadingResponseDefaultTypeInternal _HeadingResponse_default_instance_;
 class Health;
 struct HealthDefaultTypeInternal;
 extern HealthDefaultTypeInternal _Health_default_instance_;
@@ -413,6 +419,9 @@ extern SubscribeGpsInfoRequestDefaultTypeInternal _SubscribeGpsInfoRequest_defau
 class SubscribeGroundTruthRequest;
 struct SubscribeGroundTruthRequestDefaultTypeInternal;
 extern SubscribeGroundTruthRequestDefaultTypeInternal _SubscribeGroundTruthRequest_default_instance_;
+class SubscribeHeadingRequest;
+struct SubscribeHeadingRequestDefaultTypeInternal;
+extern SubscribeHeadingRequestDefaultTypeInternal _SubscribeHeadingRequest_default_instance_;
 class SubscribeHealthAllOkRequest;
 struct SubscribeHealthAllOkRequestDefaultTypeInternal;
 extern SubscribeHealthAllOkRequestDefaultTypeInternal _SubscribeHealthAllOkRequest_default_instance_;
@@ -512,6 +521,8 @@ template<> ::mavsdk::rpc::telemetry::GpsInfo* Arena::CreateMaybeMessage<::mavsdk
 template<> ::mavsdk::rpc::telemetry::GpsInfoResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::GpsInfoResponse>(Arena*);
 template<> ::mavsdk::rpc::telemetry::GroundTruth* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::GroundTruth>(Arena*);
 template<> ::mavsdk::rpc::telemetry::GroundTruthResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::GroundTruthResponse>(Arena*);
+template<> ::mavsdk::rpc::telemetry::Heading* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::Heading>(Arena*);
+template<> ::mavsdk::rpc::telemetry::HeadingResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::HeadingResponse>(Arena*);
 template<> ::mavsdk::rpc::telemetry::Health* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::Health>(Arena*);
 template<> ::mavsdk::rpc::telemetry::HealthAllOkResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::HealthAllOkResponse>(Arena*);
 template<> ::mavsdk::rpc::telemetry::HealthResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::HealthResponse>(Arena*);
@@ -601,6 +612,7 @@ template<> ::mavsdk::rpc::telemetry::SubscribeFixedwingMetricsRequest* Arena::Cr
 template<> ::mavsdk::rpc::telemetry::SubscribeFlightModeRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::SubscribeFlightModeRequest>(Arena*);
 template<> ::mavsdk::rpc::telemetry::SubscribeGpsInfoRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::SubscribeGpsInfoRequest>(Arena*);
 template<> ::mavsdk::rpc::telemetry::SubscribeGroundTruthRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::SubscribeGroundTruthRequest>(Arena*);
+template<> ::mavsdk::rpc::telemetry::SubscribeHeadingRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::SubscribeHeadingRequest>(Arena*);
 template<> ::mavsdk::rpc::telemetry::SubscribeHealthAllOkRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::SubscribeHealthAllOkRequest>(Arena*);
 template<> ::mavsdk::rpc::telemetry::SubscribeHealthRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::SubscribeHealthRequest>(Arena*);
 template<> ::mavsdk::rpc::telemetry::SubscribeHomeRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry::SubscribeHomeRequest>(Arena*);
@@ -9131,6 +9143,276 @@ class ScaledPressureResponse PROTOBUF_FINAL :
 };
 // -------------------------------------------------------------------
 
+class SubscribeHeadingRequest PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.telemetry.SubscribeHeadingRequest) */ {
+ public:
+  inline SubscribeHeadingRequest() : SubscribeHeadingRequest(nullptr) {}
+  virtual ~SubscribeHeadingRequest();
+  explicit constexpr SubscribeHeadingRequest(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  SubscribeHeadingRequest(const SubscribeHeadingRequest& from);
+  SubscribeHeadingRequest(SubscribeHeadingRequest&& from) noexcept
+    : SubscribeHeadingRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline SubscribeHeadingRequest& operator=(const SubscribeHeadingRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SubscribeHeadingRequest& operator=(SubscribeHeadingRequest&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const SubscribeHeadingRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SubscribeHeadingRequest* internal_default_instance() {
+    return reinterpret_cast<const SubscribeHeadingRequest*>(
+               &_SubscribeHeadingRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    62;
+
+  friend void swap(SubscribeHeadingRequest& a, SubscribeHeadingRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(SubscribeHeadingRequest* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SubscribeHeadingRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline SubscribeHeadingRequest* New() const final {
+    return CreateMaybeMessage<SubscribeHeadingRequest>(nullptr);
+  }
+
+  SubscribeHeadingRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<SubscribeHeadingRequest>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const SubscribeHeadingRequest& from);
+  void MergeFrom(const SubscribeHeadingRequest& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(SubscribeHeadingRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.telemetry.SubscribeHeadingRequest";
+  }
+  protected:
+  explicit SubscribeHeadingRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    return ::descriptor_table_telemetry_2ftelemetry_2eproto_metadata_getter(kIndexInFileMessages);
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.telemetry.SubscribeHeadingRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_telemetry_2ftelemetry_2eproto;
+};
+// -------------------------------------------------------------------
+
+class HeadingResponse PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.telemetry.HeadingResponse) */ {
+ public:
+  inline HeadingResponse() : HeadingResponse(nullptr) {}
+  virtual ~HeadingResponse();
+  explicit constexpr HeadingResponse(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  HeadingResponse(const HeadingResponse& from);
+  HeadingResponse(HeadingResponse&& from) noexcept
+    : HeadingResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline HeadingResponse& operator=(const HeadingResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline HeadingResponse& operator=(HeadingResponse&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const HeadingResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const HeadingResponse* internal_default_instance() {
+    return reinterpret_cast<const HeadingResponse*>(
+               &_HeadingResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    63;
+
+  friend void swap(HeadingResponse& a, HeadingResponse& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(HeadingResponse* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(HeadingResponse* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline HeadingResponse* New() const final {
+    return CreateMaybeMessage<HeadingResponse>(nullptr);
+  }
+
+  HeadingResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<HeadingResponse>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const HeadingResponse& from);
+  void MergeFrom(const HeadingResponse& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(HeadingResponse* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.telemetry.HeadingResponse";
+  }
+  protected:
+  explicit HeadingResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    return ::descriptor_table_telemetry_2ftelemetry_2eproto_metadata_getter(kIndexInFileMessages);
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kHeadingDegFieldNumber = 1,
+  };
+  // .mavsdk.rpc.telemetry.Heading heading_deg = 1;
+  bool has_heading_deg() const;
+  private:
+  bool _internal_has_heading_deg() const;
+  public:
+  void clear_heading_deg();
+  const ::mavsdk::rpc::telemetry::Heading& heading_deg() const;
+  ::mavsdk::rpc::telemetry::Heading* release_heading_deg();
+  ::mavsdk::rpc::telemetry::Heading* mutable_heading_deg();
+  void set_allocated_heading_deg(::mavsdk::rpc::telemetry::Heading* heading_deg);
+  private:
+  const ::mavsdk::rpc::telemetry::Heading& _internal_heading_deg() const;
+  ::mavsdk::rpc::telemetry::Heading* _internal_mutable_heading_deg();
+  public:
+  void unsafe_arena_set_allocated_heading_deg(
+      ::mavsdk::rpc::telemetry::Heading* heading_deg);
+  ::mavsdk::rpc::telemetry::Heading* unsafe_arena_release_heading_deg();
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.telemetry.HeadingResponse)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::mavsdk::rpc::telemetry::Heading* heading_deg_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_telemetry_2ftelemetry_2eproto;
+};
+// -------------------------------------------------------------------
+
 class SetRatePositionRequest PROTOBUF_FINAL :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.telemetry.SetRatePositionRequest) */ {
  public:
@@ -9174,7 +9456,7 @@ class SetRatePositionRequest PROTOBUF_FINAL :
                &_SetRatePositionRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    62;
+    64;
 
   friend void swap(SetRatePositionRequest& a, SetRatePositionRequest& b) {
     a.Swap(&b);
@@ -9311,7 +9593,7 @@ class SetRatePositionResponse PROTOBUF_FINAL :
                &_SetRatePositionResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    63;
+    65;
 
   friend void swap(SetRatePositionResponse& a, SetRatePositionResponse& b) {
     a.Swap(&b);
@@ -9457,7 +9739,7 @@ class SetRateHomeRequest PROTOBUF_FINAL :
                &_SetRateHomeRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    64;
+    66;
 
   friend void swap(SetRateHomeRequest& a, SetRateHomeRequest& b) {
     a.Swap(&b);
@@ -9594,7 +9876,7 @@ class SetRateHomeResponse PROTOBUF_FINAL :
                &_SetRateHomeResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    65;
+    67;
 
   friend void swap(SetRateHomeResponse& a, SetRateHomeResponse& b) {
     a.Swap(&b);
@@ -9740,7 +10022,7 @@ class SetRateInAirRequest PROTOBUF_FINAL :
                &_SetRateInAirRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    66;
+    68;
 
   friend void swap(SetRateInAirRequest& a, SetRateInAirRequest& b) {
     a.Swap(&b);
@@ -9877,7 +10159,7 @@ class SetRateInAirResponse PROTOBUF_FINAL :
                &_SetRateInAirResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    67;
+    69;
 
   friend void swap(SetRateInAirResponse& a, SetRateInAirResponse& b) {
     a.Swap(&b);
@@ -10023,7 +10305,7 @@ class SetRateLandedStateRequest PROTOBUF_FINAL :
                &_SetRateLandedStateRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    68;
+    70;
 
   friend void swap(SetRateLandedStateRequest& a, SetRateLandedStateRequest& b) {
     a.Swap(&b);
@@ -10160,7 +10442,7 @@ class SetRateLandedStateResponse PROTOBUF_FINAL :
                &_SetRateLandedStateResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    69;
+    71;
 
   friend void swap(SetRateLandedStateResponse& a, SetRateLandedStateResponse& b) {
     a.Swap(&b);
@@ -10306,7 +10588,7 @@ class SetRateAttitudeRequest PROTOBUF_FINAL :
                &_SetRateAttitudeRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    70;
+    72;
 
   friend void swap(SetRateAttitudeRequest& a, SetRateAttitudeRequest& b) {
     a.Swap(&b);
@@ -10443,7 +10725,7 @@ class SetRateAttitudeResponse PROTOBUF_FINAL :
                &_SetRateAttitudeResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    71;
+    73;
 
   friend void swap(SetRateAttitudeResponse& a, SetRateAttitudeResponse& b) {
     a.Swap(&b);
@@ -10589,7 +10871,7 @@ class SetRateAttitudeAngularVelocityBodyRequest PROTOBUF_FINAL :
                &_SetRateAttitudeAngularVelocityBodyRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    72;
+    74;
 
   friend void swap(SetRateAttitudeAngularVelocityBodyRequest& a, SetRateAttitudeAngularVelocityBodyRequest& b) {
     a.Swap(&b);
@@ -10726,7 +11008,7 @@ class SetRateAttitudeAngularVelocityBodyResponse PROTOBUF_FINAL :
                &_SetRateAttitudeAngularVelocityBodyResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    73;
+    75;
 
   friend void swap(SetRateAttitudeAngularVelocityBodyResponse& a, SetRateAttitudeAngularVelocityBodyResponse& b) {
     a.Swap(&b);
@@ -10872,7 +11154,7 @@ class SetRateCameraAttitudeQuaternionRequest PROTOBUF_FINAL :
                &_SetRateCameraAttitudeQuaternionRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    74;
+    76;
 
   friend void swap(SetRateCameraAttitudeQuaternionRequest& a, SetRateCameraAttitudeQuaternionRequest& b) {
     a.Swap(&b);
@@ -11009,7 +11291,7 @@ class SetRateCameraAttitudeQuaternionResponse PROTOBUF_FINAL :
                &_SetRateCameraAttitudeQuaternionResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    75;
+    77;
 
   friend void swap(SetRateCameraAttitudeQuaternionResponse& a, SetRateCameraAttitudeQuaternionResponse& b) {
     a.Swap(&b);
@@ -11155,7 +11437,7 @@ class SetRateCameraAttitudeRequest PROTOBUF_FINAL :
                &_SetRateCameraAttitudeRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    76;
+    78;
 
   friend void swap(SetRateCameraAttitudeRequest& a, SetRateCameraAttitudeRequest& b) {
     a.Swap(&b);
@@ -11292,7 +11574,7 @@ class SetRateCameraAttitudeResponse PROTOBUF_FINAL :
                &_SetRateCameraAttitudeResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    77;
+    79;
 
   friend void swap(SetRateCameraAttitudeResponse& a, SetRateCameraAttitudeResponse& b) {
     a.Swap(&b);
@@ -11438,7 +11720,7 @@ class SetRateVelocityNedRequest PROTOBUF_FINAL :
                &_SetRateVelocityNedRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    78;
+    80;
 
   friend void swap(SetRateVelocityNedRequest& a, SetRateVelocityNedRequest& b) {
     a.Swap(&b);
@@ -11575,7 +11857,7 @@ class SetRateVelocityNedResponse PROTOBUF_FINAL :
                &_SetRateVelocityNedResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    79;
+    81;
 
   friend void swap(SetRateVelocityNedResponse& a, SetRateVelocityNedResponse& b) {
     a.Swap(&b);
@@ -11721,7 +12003,7 @@ class SetRateGpsInfoRequest PROTOBUF_FINAL :
                &_SetRateGpsInfoRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    80;
+    82;
 
   friend void swap(SetRateGpsInfoRequest& a, SetRateGpsInfoRequest& b) {
     a.Swap(&b);
@@ -11858,7 +12140,7 @@ class SetRateGpsInfoResponse PROTOBUF_FINAL :
                &_SetRateGpsInfoResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    81;
+    83;
 
   friend void swap(SetRateGpsInfoResponse& a, SetRateGpsInfoResponse& b) {
     a.Swap(&b);
@@ -12004,7 +12286,7 @@ class SetRateRawGpsRequest PROTOBUF_FINAL :
                &_SetRateRawGpsRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    82;
+    84;
 
   friend void swap(SetRateRawGpsRequest& a, SetRateRawGpsRequest& b) {
     a.Swap(&b);
@@ -12141,7 +12423,7 @@ class SetRateBatteryRequest PROTOBUF_FINAL :
                &_SetRateBatteryRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    83;
+    85;
 
   friend void swap(SetRateBatteryRequest& a, SetRateBatteryRequest& b) {
     a.Swap(&b);
@@ -12278,7 +12560,7 @@ class SetRateBatteryResponse PROTOBUF_FINAL :
                &_SetRateBatteryResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    84;
+    86;
 
   friend void swap(SetRateBatteryResponse& a, SetRateBatteryResponse& b) {
     a.Swap(&b);
@@ -12424,7 +12706,7 @@ class SetRateRcStatusRequest PROTOBUF_FINAL :
                &_SetRateRcStatusRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    85;
+    87;
 
   friend void swap(SetRateRcStatusRequest& a, SetRateRcStatusRequest& b) {
     a.Swap(&b);
@@ -12561,7 +12843,7 @@ class SetRateRcStatusResponse PROTOBUF_FINAL :
                &_SetRateRcStatusResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    86;
+    88;
 
   friend void swap(SetRateRcStatusResponse& a, SetRateRcStatusResponse& b) {
     a.Swap(&b);
@@ -12707,7 +12989,7 @@ class SetRateActuatorControlTargetRequest PROTOBUF_FINAL :
                &_SetRateActuatorControlTargetRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    87;
+    89;
 
   friend void swap(SetRateActuatorControlTargetRequest& a, SetRateActuatorControlTargetRequest& b) {
     a.Swap(&b);
@@ -12844,7 +13126,7 @@ class SetRateActuatorControlTargetResponse PROTOBUF_FINAL :
                &_SetRateActuatorControlTargetResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    88;
+    90;
 
   friend void swap(SetRateActuatorControlTargetResponse& a, SetRateActuatorControlTargetResponse& b) {
     a.Swap(&b);
@@ -12990,7 +13272,7 @@ class SetRateActuatorOutputStatusRequest PROTOBUF_FINAL :
                &_SetRateActuatorOutputStatusRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    89;
+    91;
 
   friend void swap(SetRateActuatorOutputStatusRequest& a, SetRateActuatorOutputStatusRequest& b) {
     a.Swap(&b);
@@ -13127,7 +13409,7 @@ class SetRateActuatorOutputStatusResponse PROTOBUF_FINAL :
                &_SetRateActuatorOutputStatusResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    90;
+    92;
 
   friend void swap(SetRateActuatorOutputStatusResponse& a, SetRateActuatorOutputStatusResponse& b) {
     a.Swap(&b);
@@ -13273,7 +13555,7 @@ class SetRateOdometryRequest PROTOBUF_FINAL :
                &_SetRateOdometryRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    91;
+    93;
 
   friend void swap(SetRateOdometryRequest& a, SetRateOdometryRequest& b) {
     a.Swap(&b);
@@ -13410,7 +13692,7 @@ class SetRateOdometryResponse PROTOBUF_FINAL :
                &_SetRateOdometryResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    92;
+    94;
 
   friend void swap(SetRateOdometryResponse& a, SetRateOdometryResponse& b) {
     a.Swap(&b);
@@ -13556,7 +13838,7 @@ class SetRatePositionVelocityNedRequest PROTOBUF_FINAL :
                &_SetRatePositionVelocityNedRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    93;
+    95;
 
   friend void swap(SetRatePositionVelocityNedRequest& a, SetRatePositionVelocityNedRequest& b) {
     a.Swap(&b);
@@ -13693,7 +13975,7 @@ class SetRatePositionVelocityNedResponse PROTOBUF_FINAL :
                &_SetRatePositionVelocityNedResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    94;
+    96;
 
   friend void swap(SetRatePositionVelocityNedResponse& a, SetRatePositionVelocityNedResponse& b) {
     a.Swap(&b);
@@ -13839,7 +14121,7 @@ class SetRateGroundTruthRequest PROTOBUF_FINAL :
                &_SetRateGroundTruthRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    95;
+    97;
 
   friend void swap(SetRateGroundTruthRequest& a, SetRateGroundTruthRequest& b) {
     a.Swap(&b);
@@ -13976,7 +14258,7 @@ class SetRateGroundTruthResponse PROTOBUF_FINAL :
                &_SetRateGroundTruthResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    96;
+    98;
 
   friend void swap(SetRateGroundTruthResponse& a, SetRateGroundTruthResponse& b) {
     a.Swap(&b);
@@ -14122,7 +14404,7 @@ class SetRateFixedwingMetricsRequest PROTOBUF_FINAL :
                &_SetRateFixedwingMetricsRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    97;
+    99;
 
   friend void swap(SetRateFixedwingMetricsRequest& a, SetRateFixedwingMetricsRequest& b) {
     a.Swap(&b);
@@ -14259,7 +14541,7 @@ class SetRateFixedwingMetricsResponse PROTOBUF_FINAL :
                &_SetRateFixedwingMetricsResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    98;
+    100;
 
   friend void swap(SetRateFixedwingMetricsResponse& a, SetRateFixedwingMetricsResponse& b) {
     a.Swap(&b);
@@ -14405,7 +14687,7 @@ class SetRateImuRequest PROTOBUF_FINAL :
                &_SetRateImuRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    99;
+    101;
 
   friend void swap(SetRateImuRequest& a, SetRateImuRequest& b) {
     a.Swap(&b);
@@ -14542,7 +14824,7 @@ class SetRateImuResponse PROTOBUF_FINAL :
                &_SetRateImuResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    100;
+    102;
 
   friend void swap(SetRateImuResponse& a, SetRateImuResponse& b) {
     a.Swap(&b);
@@ -14688,7 +14970,7 @@ class SetRateScaledImuRequest PROTOBUF_FINAL :
                &_SetRateScaledImuRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    101;
+    103;
 
   friend void swap(SetRateScaledImuRequest& a, SetRateScaledImuRequest& b) {
     a.Swap(&b);
@@ -14825,7 +15107,7 @@ class SetRateScaledImuResponse PROTOBUF_FINAL :
                &_SetRateScaledImuResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    102;
+    104;
 
   friend void swap(SetRateScaledImuResponse& a, SetRateScaledImuResponse& b) {
     a.Swap(&b);
@@ -14971,7 +15253,7 @@ class SetRateRawImuRequest PROTOBUF_FINAL :
                &_SetRateRawImuRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    103;
+    105;
 
   friend void swap(SetRateRawImuRequest& a, SetRateRawImuRequest& b) {
     a.Swap(&b);
@@ -15108,7 +15390,7 @@ class SetRateRawImuResponse PROTOBUF_FINAL :
                &_SetRateRawImuResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    104;
+    106;
 
   friend void swap(SetRateRawImuResponse& a, SetRateRawImuResponse& b) {
     a.Swap(&b);
@@ -15254,7 +15536,7 @@ class SetRateUnixEpochTimeRequest PROTOBUF_FINAL :
                &_SetRateUnixEpochTimeRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    105;
+    107;
 
   friend void swap(SetRateUnixEpochTimeRequest& a, SetRateUnixEpochTimeRequest& b) {
     a.Swap(&b);
@@ -15391,7 +15673,7 @@ class SetRateUnixEpochTimeResponse PROTOBUF_FINAL :
                &_SetRateUnixEpochTimeResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    106;
+    108;
 
   friend void swap(SetRateUnixEpochTimeResponse& a, SetRateUnixEpochTimeResponse& b) {
     a.Swap(&b);
@@ -15537,7 +15819,7 @@ class SetRateDistanceSensorRequest PROTOBUF_FINAL :
                &_SetRateDistanceSensorRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    107;
+    109;
 
   friend void swap(SetRateDistanceSensorRequest& a, SetRateDistanceSensorRequest& b) {
     a.Swap(&b);
@@ -15674,7 +15956,7 @@ class SetRateDistanceSensorResponse PROTOBUF_FINAL :
                &_SetRateDistanceSensorResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    108;
+    110;
 
   friend void swap(SetRateDistanceSensorResponse& a, SetRateDistanceSensorResponse& b) {
     a.Swap(&b);
@@ -15820,7 +16102,7 @@ class GetGpsGlobalOriginRequest PROTOBUF_FINAL :
                &_GetGpsGlobalOriginRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    109;
+    111;
 
   friend void swap(GetGpsGlobalOriginRequest& a, GetGpsGlobalOriginRequest& b) {
     a.Swap(&b);
@@ -15944,7 +16226,7 @@ class GetGpsGlobalOriginResponse PROTOBUF_FINAL :
                &_GetGpsGlobalOriginResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    110;
+    112;
 
   friend void swap(GetGpsGlobalOriginResponse& a, GetGpsGlobalOriginResponse& b) {
     a.Swap(&b);
@@ -16110,7 +16392,7 @@ class Position PROTOBUF_FINAL :
                &_Position_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    111;
+    113;
 
   friend void swap(Position& a, Position& b) {
     a.Swap(&b);
@@ -16237,6 +16519,143 @@ class Position PROTOBUF_FINAL :
 };
 // -------------------------------------------------------------------
 
+class Heading PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.telemetry.Heading) */ {
+ public:
+  inline Heading() : Heading(nullptr) {}
+  virtual ~Heading();
+  explicit constexpr Heading(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  Heading(const Heading& from);
+  Heading(Heading&& from) noexcept
+    : Heading() {
+    *this = ::std::move(from);
+  }
+
+  inline Heading& operator=(const Heading& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline Heading& operator=(Heading&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const Heading& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const Heading* internal_default_instance() {
+    return reinterpret_cast<const Heading*>(
+               &_Heading_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    114;
+
+  friend void swap(Heading& a, Heading& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(Heading* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(Heading* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline Heading* New() const final {
+    return CreateMaybeMessage<Heading>(nullptr);
+  }
+
+  Heading* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<Heading>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const Heading& from);
+  void MergeFrom(const Heading& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(Heading* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.telemetry.Heading";
+  }
+  protected:
+  explicit Heading(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    return ::descriptor_table_telemetry_2ftelemetry_2eproto_metadata_getter(kIndexInFileMessages);
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kHeadingDegFieldNumber = 1,
+  };
+  // double heading_deg = 1 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_heading_deg();
+  double heading_deg() const;
+  void set_heading_deg(double value);
+  private:
+  double _internal_heading_deg() const;
+  void _internal_set_heading_deg(double value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.telemetry.Heading)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  double heading_deg_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_telemetry_2ftelemetry_2eproto;
+};
+// -------------------------------------------------------------------
+
 class Quaternion PROTOBUF_FINAL :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.telemetry.Quaternion) */ {
  public:
@@ -16280,7 +16699,7 @@ class Quaternion PROTOBUF_FINAL :
                &_Quaternion_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    112;
+    115;
 
   friend void swap(Quaternion& a, Quaternion& b) {
     a.Swap(&b);
@@ -16461,7 +16880,7 @@ class EulerAngle PROTOBUF_FINAL :
                &_EulerAngle_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    113;
+    116;
 
   friend void swap(EulerAngle& a, EulerAngle& b) {
     a.Swap(&b);
@@ -16631,7 +17050,7 @@ class AngularVelocityBody PROTOBUF_FINAL :
                &_AngularVelocityBody_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    114;
+    117;
 
   friend void swap(AngularVelocityBody& a, AngularVelocityBody& b) {
     a.Swap(&b);
@@ -16790,7 +17209,7 @@ class GpsInfo PROTOBUF_FINAL :
                &_GpsInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    115;
+    118;
 
   friend void swap(GpsInfo& a, GpsInfo& b) {
     a.Swap(&b);
@@ -16938,7 +17357,7 @@ class RawGps PROTOBUF_FINAL :
                &_RawGps_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    116;
+    119;
 
   friend void swap(RawGps& a, RawGps& b) {
     a.Swap(&b);
@@ -17218,7 +17637,7 @@ class Battery PROTOBUF_FINAL :
                &_Battery_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    117;
+    120;
 
   friend void swap(Battery& a, Battery& b) {
     a.Swap(&b);
@@ -17377,7 +17796,7 @@ class Health PROTOBUF_FINAL :
                &_Health_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    118;
+    121;
 
   friend void swap(Health& a, Health& b) {
     a.Swap(&b);
@@ -17580,7 +17999,7 @@ class RcStatus PROTOBUF_FINAL :
                &_RcStatus_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    119;
+    122;
 
   friend void swap(RcStatus& a, RcStatus& b) {
     a.Swap(&b);
@@ -17739,7 +18158,7 @@ class StatusText PROTOBUF_FINAL :
                &_StatusText_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    120;
+    123;
 
   friend void swap(StatusText& a, StatusText& b) {
     a.Swap(&b);
@@ -17894,7 +18313,7 @@ class ActuatorControlTarget PROTOBUF_FINAL :
                &_ActuatorControlTarget_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    121;
+    124;
 
   friend void swap(ActuatorControlTarget& a, ActuatorControlTarget& b) {
     a.Swap(&b);
@@ -18056,7 +18475,7 @@ class ActuatorOutputStatus PROTOBUF_FINAL :
                &_ActuatorOutputStatus_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    122;
+    125;
 
   friend void swap(ActuatorOutputStatus& a, ActuatorOutputStatus& b) {
     a.Swap(&b);
@@ -18218,7 +18637,7 @@ class Covariance PROTOBUF_FINAL :
                &_Covariance_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    123;
+    126;
 
   friend void swap(Covariance& a, Covariance& b) {
     a.Swap(&b);
@@ -18369,7 +18788,7 @@ class VelocityBody PROTOBUF_FINAL :
                &_VelocityBody_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    124;
+    127;
 
   friend void swap(VelocityBody& a, VelocityBody& b) {
     a.Swap(&b);
@@ -18528,7 +18947,7 @@ class PositionBody PROTOBUF_FINAL :
                &_PositionBody_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    125;
+    128;
 
   friend void swap(PositionBody& a, PositionBody& b) {
     a.Swap(&b);
@@ -18687,7 +19106,7 @@ class Odometry PROTOBUF_FINAL :
                &_Odometry_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    126;
+    129;
 
   friend void swap(Odometry& a, Odometry& b) {
     a.Swap(&b);
@@ -19000,7 +19419,7 @@ class DistanceSensor PROTOBUF_FINAL :
                &_DistanceSensor_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    127;
+    130;
 
   friend void swap(DistanceSensor& a, DistanceSensor& b) {
     a.Swap(&b);
@@ -19159,7 +19578,7 @@ class ScaledPressure PROTOBUF_FINAL :
                &_ScaledPressure_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    128;
+    131;
 
   friend void swap(ScaledPressure& a, ScaledPressure& b) {
     a.Swap(&b);
@@ -19340,7 +19759,7 @@ class PositionNed PROTOBUF_FINAL :
                &_PositionNed_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    129;
+    132;
 
   friend void swap(PositionNed& a, PositionNed& b) {
     a.Swap(&b);
@@ -19499,7 +19918,7 @@ class VelocityNed PROTOBUF_FINAL :
                &_VelocityNed_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    130;
+    133;
 
   friend void swap(VelocityNed& a, VelocityNed& b) {
     a.Swap(&b);
@@ -19658,7 +20077,7 @@ class PositionVelocityNed PROTOBUF_FINAL :
                &_PositionVelocityNed_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    131;
+    134;
 
   friend void swap(PositionVelocityNed& a, PositionVelocityNed& b) {
     a.Swap(&b);
@@ -19824,7 +20243,7 @@ class GroundTruth PROTOBUF_FINAL :
                &_GroundTruth_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    132;
+    135;
 
   friend void swap(GroundTruth& a, GroundTruth& b) {
     a.Swap(&b);
@@ -19983,7 +20402,7 @@ class FixedwingMetrics PROTOBUF_FINAL :
                &_FixedwingMetrics_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    133;
+    136;
 
   friend void swap(FixedwingMetrics& a, FixedwingMetrics& b) {
     a.Swap(&b);
@@ -20142,7 +20561,7 @@ class AccelerationFrd PROTOBUF_FINAL :
                &_AccelerationFrd_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    134;
+    137;
 
   friend void swap(AccelerationFrd& a, AccelerationFrd& b) {
     a.Swap(&b);
@@ -20301,7 +20720,7 @@ class AngularVelocityFrd PROTOBUF_FINAL :
                &_AngularVelocityFrd_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    135;
+    138;
 
   friend void swap(AngularVelocityFrd& a, AngularVelocityFrd& b) {
     a.Swap(&b);
@@ -20460,7 +20879,7 @@ class MagneticFieldFrd PROTOBUF_FINAL :
                &_MagneticFieldFrd_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    136;
+    139;
 
   friend void swap(MagneticFieldFrd& a, MagneticFieldFrd& b) {
     a.Swap(&b);
@@ -20619,7 +21038,7 @@ class Imu PROTOBUF_FINAL :
                &_Imu_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    137;
+    140;
 
   friend void swap(Imu& a, Imu& b) {
     a.Swap(&b);
@@ -20827,7 +21246,7 @@ class GpsGlobalOrigin PROTOBUF_FINAL :
                &_GpsGlobalOrigin_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    138;
+    141;
 
   friend void swap(GpsGlobalOrigin& a, GpsGlobalOrigin& b) {
     a.Swap(&b);
@@ -20986,7 +21405,7 @@ class TelemetryResult PROTOBUF_FINAL :
                &_TelemetryResult_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    139;
+    142;
 
   friend void swap(TelemetryResult& a, TelemetryResult& b) {
     a.Swap(&b);
@@ -23586,6 +24005,97 @@ inline void ScaledPressureResponse::set_allocated_scaled_pressure(::mavsdk::rpc:
   }
   scaled_pressure_ = scaled_pressure;
   // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.telemetry.ScaledPressureResponse.scaled_pressure)
+}
+
+// -------------------------------------------------------------------
+
+// SubscribeHeadingRequest
+
+// -------------------------------------------------------------------
+
+// HeadingResponse
+
+// .mavsdk.rpc.telemetry.Heading heading_deg = 1;
+inline bool HeadingResponse::_internal_has_heading_deg() const {
+  return this != internal_default_instance() && heading_deg_ != nullptr;
+}
+inline bool HeadingResponse::has_heading_deg() const {
+  return _internal_has_heading_deg();
+}
+inline void HeadingResponse::clear_heading_deg() {
+  if (GetArena() == nullptr && heading_deg_ != nullptr) {
+    delete heading_deg_;
+  }
+  heading_deg_ = nullptr;
+}
+inline const ::mavsdk::rpc::telemetry::Heading& HeadingResponse::_internal_heading_deg() const {
+  const ::mavsdk::rpc::telemetry::Heading* p = heading_deg_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::telemetry::Heading&>(
+      ::mavsdk::rpc::telemetry::_Heading_default_instance_);
+}
+inline const ::mavsdk::rpc::telemetry::Heading& HeadingResponse::heading_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry.HeadingResponse.heading_deg)
+  return _internal_heading_deg();
+}
+inline void HeadingResponse::unsafe_arena_set_allocated_heading_deg(
+    ::mavsdk::rpc::telemetry::Heading* heading_deg) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(heading_deg_);
+  }
+  heading_deg_ = heading_deg;
+  if (heading_deg) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.telemetry.HeadingResponse.heading_deg)
+}
+inline ::mavsdk::rpc::telemetry::Heading* HeadingResponse::release_heading_deg() {
+  
+  ::mavsdk::rpc::telemetry::Heading* temp = heading_deg_;
+  heading_deg_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::mavsdk::rpc::telemetry::Heading* HeadingResponse::unsafe_arena_release_heading_deg() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.telemetry.HeadingResponse.heading_deg)
+  
+  ::mavsdk::rpc::telemetry::Heading* temp = heading_deg_;
+  heading_deg_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::telemetry::Heading* HeadingResponse::_internal_mutable_heading_deg() {
+  
+  if (heading_deg_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::telemetry::Heading>(GetArena());
+    heading_deg_ = p;
+  }
+  return heading_deg_;
+}
+inline ::mavsdk::rpc::telemetry::Heading* HeadingResponse::mutable_heading_deg() {
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.telemetry.HeadingResponse.heading_deg)
+  return _internal_mutable_heading_deg();
+}
+inline void HeadingResponse::set_allocated_heading_deg(::mavsdk::rpc::telemetry::Heading* heading_deg) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete heading_deg_;
+  }
+  if (heading_deg) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(heading_deg);
+    if (message_arena != submessage_arena) {
+      heading_deg = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, heading_deg, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  heading_deg_ = heading_deg;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.telemetry.HeadingResponse.heading_deg)
 }
 
 // -------------------------------------------------------------------
@@ -26421,6 +26931,30 @@ inline void Position::_internal_set_relative_altitude_m(float value) {
 inline void Position::set_relative_altitude_m(float value) {
   _internal_set_relative_altitude_m(value);
   // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry.Position.relative_altitude_m)
+}
+
+// -------------------------------------------------------------------
+
+// Heading
+
+// double heading_deg = 1 [(.mavsdk.options.default_value) = "NaN"];
+inline void Heading::clear_heading_deg() {
+  heading_deg_ = 0;
+}
+inline double Heading::_internal_heading_deg() const {
+  return heading_deg_;
+}
+inline double Heading::heading_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry.Heading.heading_deg)
+  return _internal_heading_deg();
+}
+inline void Heading::_internal_set_heading_deg(double value) {
+  
+  heading_deg_ = value;
+}
+inline void Heading::set_heading_deg(double value) {
+  _internal_set_heading_deg(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry.Heading.heading_deg)
 }
 
 // -------------------------------------------------------------------
@@ -29474,6 +30008,12 @@ inline void TelemetryResult::set_allocated_result_str(std::string* result_str) {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/src/mavsdk_server/src/generated/telemetry_server/telemetry_server.pb.cc
+++ b/src/mavsdk_server/src/generated/telemetry_server/telemetry_server.pb.cc
@@ -22,7 +22,8 @@ namespace telemetry_server {
 constexpr PublishPositionRequest::PublishPositionRequest(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
   : position_(nullptr)
-  , velocity_ned_(nullptr){}
+  , velocity_ned_(nullptr)
+  , heading_(nullptr){}
 struct PublishPositionRequestDefaultTypeInternal {
   constexpr PublishPositionRequestDefaultTypeInternal()
     : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
@@ -417,6 +418,18 @@ struct PositionDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PositionDefaultTypeInternal _Position_default_instance_;
+constexpr Heading::Heading(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : heading_deg_(0){}
+struct HeadingDefaultTypeInternal {
+  constexpr HeadingDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~HeadingDefaultTypeInternal() {}
+  union {
+    Heading _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT HeadingDefaultTypeInternal _Heading_default_instance_;
 constexpr Quaternion::Quaternion(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
   : w_(0)
@@ -807,7 +820,7 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT TelemetryServerResultDefaultTyp
 }  // namespace telemetry_server
 }  // namespace rpc
 }  // namespace mavsdk
-static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_telemetry_5fserver_2ftelemetry_5fserver_2eproto[58];
+static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_telemetry_5fserver_2ftelemetry_5fserver_2eproto[59];
 static const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* file_level_enum_descriptors_telemetry_5fserver_2ftelemetry_5fserver_2eproto[6];
 static constexpr ::PROTOBUF_NAMESPACE_ID::ServiceDescriptor const** file_level_service_descriptors_telemetry_5fserver_2ftelemetry_5fserver_2eproto = nullptr;
 
@@ -819,6 +832,7 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_telemetry_5fserver_2ftelemetry
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishPositionRequest, position_),
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishPositionRequest, velocity_ned_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishPositionRequest, heading_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishHomeRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -1015,6 +1029,12 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_telemetry_5fserver_2ftelemetry
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::Position, longitude_deg_),
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::Position, absolute_altitude_m_),
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::Position, relative_altitude_m_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::Heading, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::Heading, heading_deg_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::Quaternion, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -1241,63 +1261,64 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_telemetry_5fserver_2ftelemetry
 };
 static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishPositionRequest)},
-  { 7, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishHomeRequest)},
-  { 13, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishSysStatusRequest)},
-  { 24, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishExtendedSysStateRequest)},
-  { 31, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishInAirRequest)},
-  { 37, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishLandedStateRequest)},
-  { 43, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishRawGpsRequest)},
-  { 50, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishBatteryRequest)},
-  { 56, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishRcStatusRequest)},
-  { 62, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishStatusTextRequest)},
-  { 68, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishOdometryRequest)},
-  { 74, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishPositionVelocityNedRequest)},
-  { 80, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishGroundTruthRequest)},
-  { 86, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishImuRequest)},
-  { 92, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishScaledImuRequest)},
-  { 98, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishRawImuRequest)},
-  { 104, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishUnixEpochTimeRequest)},
-  { 110, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishPositionResponse)},
-  { 116, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishHomeResponse)},
-  { 122, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishSysStatusResponse)},
-  { 128, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishExtendedSysStateResponse)},
-  { 134, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishRawGpsResponse)},
-  { 140, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishBatteryResponse)},
-  { 146, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishStatusTextResponse)},
-  { 152, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishOdometryResponse)},
-  { 158, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishPositionVelocityNedResponse)},
-  { 164, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishGroundTruthResponse)},
-  { 170, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishImuResponse)},
-  { 176, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishScaledImuResponse)},
-  { 182, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishRawImuResponse)},
-  { 188, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishUnixEpochTimeResponse)},
-  { 194, -1, sizeof(::mavsdk::rpc::telemetry_server::Position)},
-  { 203, -1, sizeof(::mavsdk::rpc::telemetry_server::Quaternion)},
-  { 213, -1, sizeof(::mavsdk::rpc::telemetry_server::EulerAngle)},
-  { 222, -1, sizeof(::mavsdk::rpc::telemetry_server::AngularVelocityBody)},
-  { 230, -1, sizeof(::mavsdk::rpc::telemetry_server::GpsInfo)},
-  { 237, -1, sizeof(::mavsdk::rpc::telemetry_server::RawGps)},
-  { 256, -1, sizeof(::mavsdk::rpc::telemetry_server::Battery)},
-  { 263, -1, sizeof(::mavsdk::rpc::telemetry_server::RcStatus)},
-  { 271, -1, sizeof(::mavsdk::rpc::telemetry_server::StatusText)},
-  { 278, -1, sizeof(::mavsdk::rpc::telemetry_server::ActuatorControlTarget)},
-  { 285, -1, sizeof(::mavsdk::rpc::telemetry_server::ActuatorOutputStatus)},
-  { 292, -1, sizeof(::mavsdk::rpc::telemetry_server::Covariance)},
-  { 298, -1, sizeof(::mavsdk::rpc::telemetry_server::VelocityBody)},
-  { 306, -1, sizeof(::mavsdk::rpc::telemetry_server::PositionBody)},
-  { 314, -1, sizeof(::mavsdk::rpc::telemetry_server::Odometry)},
-  { 328, -1, sizeof(::mavsdk::rpc::telemetry_server::DistanceSensor)},
-  { 336, -1, sizeof(::mavsdk::rpc::telemetry_server::ScaledPressure)},
-  { 346, -1, sizeof(::mavsdk::rpc::telemetry_server::PositionNed)},
-  { 354, -1, sizeof(::mavsdk::rpc::telemetry_server::VelocityNed)},
-  { 362, -1, sizeof(::mavsdk::rpc::telemetry_server::PositionVelocityNed)},
-  { 369, -1, sizeof(::mavsdk::rpc::telemetry_server::GroundTruth)},
-  { 377, -1, sizeof(::mavsdk::rpc::telemetry_server::FixedwingMetrics)},
-  { 385, -1, sizeof(::mavsdk::rpc::telemetry_server::AccelerationFrd)},
-  { 393, -1, sizeof(::mavsdk::rpc::telemetry_server::AngularVelocityFrd)},
-  { 401, -1, sizeof(::mavsdk::rpc::telemetry_server::MagneticFieldFrd)},
-  { 409, -1, sizeof(::mavsdk::rpc::telemetry_server::Imu)},
-  { 419, -1, sizeof(::mavsdk::rpc::telemetry_server::TelemetryServerResult)},
+  { 8, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishHomeRequest)},
+  { 14, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishSysStatusRequest)},
+  { 25, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishExtendedSysStateRequest)},
+  { 32, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishInAirRequest)},
+  { 38, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishLandedStateRequest)},
+  { 44, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishRawGpsRequest)},
+  { 51, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishBatteryRequest)},
+  { 57, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishRcStatusRequest)},
+  { 63, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishStatusTextRequest)},
+  { 69, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishOdometryRequest)},
+  { 75, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishPositionVelocityNedRequest)},
+  { 81, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishGroundTruthRequest)},
+  { 87, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishImuRequest)},
+  { 93, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishScaledImuRequest)},
+  { 99, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishRawImuRequest)},
+  { 105, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishUnixEpochTimeRequest)},
+  { 111, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishPositionResponse)},
+  { 117, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishHomeResponse)},
+  { 123, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishSysStatusResponse)},
+  { 129, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishExtendedSysStateResponse)},
+  { 135, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishRawGpsResponse)},
+  { 141, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishBatteryResponse)},
+  { 147, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishStatusTextResponse)},
+  { 153, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishOdometryResponse)},
+  { 159, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishPositionVelocityNedResponse)},
+  { 165, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishGroundTruthResponse)},
+  { 171, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishImuResponse)},
+  { 177, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishScaledImuResponse)},
+  { 183, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishRawImuResponse)},
+  { 189, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishUnixEpochTimeResponse)},
+  { 195, -1, sizeof(::mavsdk::rpc::telemetry_server::Position)},
+  { 204, -1, sizeof(::mavsdk::rpc::telemetry_server::Heading)},
+  { 210, -1, sizeof(::mavsdk::rpc::telemetry_server::Quaternion)},
+  { 220, -1, sizeof(::mavsdk::rpc::telemetry_server::EulerAngle)},
+  { 229, -1, sizeof(::mavsdk::rpc::telemetry_server::AngularVelocityBody)},
+  { 237, -1, sizeof(::mavsdk::rpc::telemetry_server::GpsInfo)},
+  { 244, -1, sizeof(::mavsdk::rpc::telemetry_server::RawGps)},
+  { 263, -1, sizeof(::mavsdk::rpc::telemetry_server::Battery)},
+  { 270, -1, sizeof(::mavsdk::rpc::telemetry_server::RcStatus)},
+  { 278, -1, sizeof(::mavsdk::rpc::telemetry_server::StatusText)},
+  { 285, -1, sizeof(::mavsdk::rpc::telemetry_server::ActuatorControlTarget)},
+  { 292, -1, sizeof(::mavsdk::rpc::telemetry_server::ActuatorOutputStatus)},
+  { 299, -1, sizeof(::mavsdk::rpc::telemetry_server::Covariance)},
+  { 305, -1, sizeof(::mavsdk::rpc::telemetry_server::VelocityBody)},
+  { 313, -1, sizeof(::mavsdk::rpc::telemetry_server::PositionBody)},
+  { 321, -1, sizeof(::mavsdk::rpc::telemetry_server::Odometry)},
+  { 335, -1, sizeof(::mavsdk::rpc::telemetry_server::DistanceSensor)},
+  { 343, -1, sizeof(::mavsdk::rpc::telemetry_server::ScaledPressure)},
+  { 353, -1, sizeof(::mavsdk::rpc::telemetry_server::PositionNed)},
+  { 361, -1, sizeof(::mavsdk::rpc::telemetry_server::VelocityNed)},
+  { 369, -1, sizeof(::mavsdk::rpc::telemetry_server::PositionVelocityNed)},
+  { 376, -1, sizeof(::mavsdk::rpc::telemetry_server::GroundTruth)},
+  { 384, -1, sizeof(::mavsdk::rpc::telemetry_server::FixedwingMetrics)},
+  { 392, -1, sizeof(::mavsdk::rpc::telemetry_server::AccelerationFrd)},
+  { 400, -1, sizeof(::mavsdk::rpc::telemetry_server::AngularVelocityFrd)},
+  { 408, -1, sizeof(::mavsdk::rpc::telemetry_server::MagneticFieldFrd)},
+  { 416, -1, sizeof(::mavsdk::rpc::telemetry_server::Imu)},
+  { 426, -1, sizeof(::mavsdk::rpc::telemetry_server::TelemetryServerResult)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -1333,6 +1354,7 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry_server::_PublishRawImuResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry_server::_PublishUnixEpochTimeResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry_server::_Position_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry_server::_Heading_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry_server::_Quaternion_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry_server::_EulerAngle_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::telemetry_server::_AngularVelocityBody_default_instance_),
@@ -1364,262 +1386,265 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
 const char descriptor_table_protodef_telemetry_5fserver_2ftelemetry_5fserver_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) =
   "\n\'telemetry_server/telemetry_server.prot"
   "o\022\033mavsdk.rpc.telemetry_server\032\024mavsdk_o"
-  "ptions.proto\"\221\001\n\026PublishPositionRequest\022"
+  "ptions.proto\"\310\001\n\026PublishPositionRequest\022"
   "7\n\010position\030\001 \001(\0132%.mavsdk.rpc.telemetry"
   "_server.Position\022>\n\014velocity_ned\030\002 \001(\0132("
   ".mavsdk.rpc.telemetry_server.VelocityNed"
-  "\"I\n\022PublishHomeRequest\0223\n\004home\030\001 \001(\0132%.m"
-  "avsdk.rpc.telemetry_server.Position\"\277\001\n\027"
-  "PublishSysStatusRequest\0225\n\007battery\030\001 \001(\013"
-  "2$.mavsdk.rpc.telemetry_server.Battery\022\032"
-  "\n\022rc_receiver_status\030\002 \001(\010\022\023\n\013gyro_statu"
-  "s\030\003 \001(\010\022\024\n\014accel_status\030\004 \001(\010\022\022\n\nmag_sta"
-  "tus\030\005 \001(\010\022\022\n\ngps_status\030\006 \001(\010\"\234\001\n\036Publis"
-  "hExtendedSysStateRequest\022:\n\nvtol_state\030\001"
-  " \001(\0162&.mavsdk.rpc.telemetry_server.VtolS"
-  "tate\022>\n\014landed_state\030\002 \001(\0162(.mavsdk.rpc."
-  "telemetry_server.LandedState\"(\n\023PublishI"
-  "nAirRequest\022\021\n\tis_in_air\030\001 \001(\010\"[\n\031Publis"
-  "hLandedStateRequest\022>\n\014landed_state\030\001 \001("
+  "\0225\n\007heading\030\003 \001(\0132$.mavsdk.rpc.telemetry"
+  "_server.Heading\"I\n\022PublishHomeRequest\0223\n"
+  "\004home\030\001 \001(\0132%.mavsdk.rpc.telemetry_serve"
+  "r.Position\"\277\001\n\027PublishSysStatusRequest\0225"
+  "\n\007battery\030\001 \001(\0132$.mavsdk.rpc.telemetry_s"
+  "erver.Battery\022\032\n\022rc_receiver_status\030\002 \001("
+  "\010\022\023\n\013gyro_status\030\003 \001(\010\022\024\n\014accel_status\030\004"
+  " \001(\010\022\022\n\nmag_status\030\005 \001(\010\022\022\n\ngps_status\030\006"
+  " \001(\010\"\234\001\n\036PublishExtendedSysStateRequest\022"
+  ":\n\nvtol_state\030\001 \001(\0162&.mavsdk.rpc.telemet"
+  "ry_server.VtolState\022>\n\014landed_state\030\002 \001("
   "\0162(.mavsdk.rpc.telemetry_server.LandedSt"
-  "ate\"\204\001\n\024PublishRawGpsRequest\0224\n\007raw_gps\030"
-  "\001 \001(\0132#.mavsdk.rpc.telemetry_server.RawG"
-  "ps\0226\n\010gps_info\030\002 \001(\0132$.mavsdk.rpc.teleme"
-  "try_server.GpsInfo\"N\n\025PublishBatteryRequ"
-  "est\0225\n\007battery\030\001 \001(\0132$.mavsdk.rpc.teleme"
-  "try_server.Battery\"R\n\026PublishRcStatusReq"
-  "uest\0228\n\trc_status\030\001 \001(\0132%.mavsdk.rpc.tel"
-  "emetry_server.RcStatus\"X\n\030PublishStatusT"
-  "extRequest\022<\n\013status_text\030\001 \001(\0132\'.mavsdk"
-  ".rpc.telemetry_server.StatusText\"Q\n\026Publ"
-  "ishOdometryRequest\0227\n\010odometry\030\001 \001(\0132%.m"
-  "avsdk.rpc.telemetry_server.Odometry\"t\n!P"
-  "ublishPositionVelocityNedRequest\022O\n\025posi"
-  "tion_velocity_ned\030\001 \001(\01320.mavsdk.rpc.tel"
-  "emetry_server.PositionVelocityNed\"[\n\031Pub"
-  "lishGroundTruthRequest\022>\n\014ground_truth\030\001"
-  " \001(\0132(.mavsdk.rpc.telemetry_server.Groun"
-  "dTruth\"B\n\021PublishImuRequest\022-\n\003imu\030\001 \001(\013"
-  "2 .mavsdk.rpc.telemetry_server.Imu\"H\n\027Pu"
-  "blishScaledImuRequest\022-\n\003imu\030\001 \001(\0132 .mav"
-  "sdk.rpc.telemetry_server.Imu\"E\n\024PublishR"
-  "awImuRequest\022-\n\003imu\030\001 \001(\0132 .mavsdk.rpc.t"
-  "elemetry_server.Imu\".\n\033PublishUnixEpochT"
-  "imeRequest\022\017\n\007time_us\030\001 \001(\004\"n\n\027PublishPo"
-  "sitionResponse\022S\n\027telemetry_server_resul"
-  "t\030\001 \001(\01322.mavsdk.rpc.telemetry_server.Te"
-  "lemetryServerResult\"j\n\023PublishHomeRespon"
-  "se\022S\n\027telemetry_server_result\030\001 \001(\01322.ma"
-  "vsdk.rpc.telemetry_server.TelemetryServe"
-  "rResult\"o\n\030PublishSysStatusResponse\022S\n\027t"
-  "elemetry_server_result\030\001 \001(\01322.mavsdk.rp"
-  "c.telemetry_server.TelemetryServerResult"
-  "\"v\n\037PublishExtendedSysStateResponse\022S\n\027t"
-  "elemetry_server_result\030\001 \001(\01322.mavsdk.rp"
-  "c.telemetry_server.TelemetryServerResult"
-  "\"l\n\025PublishRawGpsResponse\022S\n\027telemetry_s"
-  "erver_result\030\001 \001(\01322.mavsdk.rpc.telemetr"
-  "y_server.TelemetryServerResult\"m\n\026Publis"
-  "hBatteryResponse\022S\n\027telemetry_server_res"
-  "ult\030\001 \001(\01322.mavsdk.rpc.telemetry_server."
-  "TelemetryServerResult\"p\n\031PublishStatusTe"
-  "xtResponse\022S\n\027telemetry_server_result\030\001 "
+  "ate\"(\n\023PublishInAirRequest\022\021\n\tis_in_air\030"
+  "\001 \001(\010\"[\n\031PublishLandedStateRequest\022>\n\014la"
+  "nded_state\030\001 \001(\0162(.mavsdk.rpc.telemetry_"
+  "server.LandedState\"\204\001\n\024PublishRawGpsRequ"
+  "est\0224\n\007raw_gps\030\001 \001(\0132#.mavsdk.rpc.teleme"
+  "try_server.RawGps\0226\n\010gps_info\030\002 \001(\0132$.ma"
+  "vsdk.rpc.telemetry_server.GpsInfo\"N\n\025Pub"
+  "lishBatteryRequest\0225\n\007battery\030\001 \001(\0132$.ma"
+  "vsdk.rpc.telemetry_server.Battery\"R\n\026Pub"
+  "lishRcStatusRequest\0228\n\trc_status\030\001 \001(\0132%"
+  ".mavsdk.rpc.telemetry_server.RcStatus\"X\n"
+  "\030PublishStatusTextRequest\022<\n\013status_text"
+  "\030\001 \001(\0132\'.mavsdk.rpc.telemetry_server.Sta"
+  "tusText\"Q\n\026PublishOdometryRequest\0227\n\010odo"
+  "metry\030\001 \001(\0132%.mavsdk.rpc.telemetry_serve"
+  "r.Odometry\"t\n!PublishPositionVelocityNed"
+  "Request\022O\n\025position_velocity_ned\030\001 \001(\01320"
+  ".mavsdk.rpc.telemetry_server.PositionVel"
+  "ocityNed\"[\n\031PublishGroundTruthRequest\022>\n"
+  "\014ground_truth\030\001 \001(\0132(.mavsdk.rpc.telemet"
+  "ry_server.GroundTruth\"B\n\021PublishImuReque"
+  "st\022-\n\003imu\030\001 \001(\0132 .mavsdk.rpc.telemetry_s"
+  "erver.Imu\"H\n\027PublishScaledImuRequest\022-\n\003"
+  "imu\030\001 \001(\0132 .mavsdk.rpc.telemetry_server."
+  "Imu\"E\n\024PublishRawImuRequest\022-\n\003imu\030\001 \001(\013"
+  "2 .mavsdk.rpc.telemetry_server.Imu\".\n\033Pu"
+  "blishUnixEpochTimeRequest\022\017\n\007time_us\030\001 \001"
+  "(\004\"n\n\027PublishPositionResponse\022S\n\027telemet"
+  "ry_server_result\030\001 \001(\01322.mavsdk.rpc.tele"
+  "metry_server.TelemetryServerResult\"j\n\023Pu"
+  "blishHomeResponse\022S\n\027telemetry_server_re"
+  "sult\030\001 \001(\01322.mavsdk.rpc.telemetry_server"
+  ".TelemetryServerResult\"o\n\030PublishSysStat"
+  "usResponse\022S\n\027telemetry_server_result\030\001 "
   "\001(\01322.mavsdk.rpc.telemetry_server.Teleme"
-  "tryServerResult\"n\n\027PublishOdometryRespon"
-  "se\022S\n\027telemetry_server_result\030\001 \001(\01322.ma"
-  "vsdk.rpc.telemetry_server.TelemetryServe"
-  "rResult\"y\n\"PublishPositionVelocityNedRes"
-  "ponse\022S\n\027telemetry_server_result\030\001 \001(\01322"
-  ".mavsdk.rpc.telemetry_server.TelemetrySe"
-  "rverResult\"q\n\032PublishGroundTruthResponse"
+  "tryServerResult\"v\n\037PublishExtendedSysSta"
+  "teResponse\022S\n\027telemetry_server_result\030\001 "
+  "\001(\01322.mavsdk.rpc.telemetry_server.Teleme"
+  "tryServerResult\"l\n\025PublishRawGpsResponse"
   "\022S\n\027telemetry_server_result\030\001 \001(\01322.mavs"
   "dk.rpc.telemetry_server.TelemetryServerR"
-  "esult\"i\n\022PublishImuResponse\022S\n\027telemetry"
-  "_server_result\030\001 \001(\01322.mavsdk.rpc.teleme"
-  "try_server.TelemetryServerResult\"o\n\030Publ"
-  "ishScaledImuResponse\022S\n\027telemetry_server"
+  "esult\"m\n\026PublishBatteryResponse\022S\n\027telem"
+  "etry_server_result\030\001 \001(\01322.mavsdk.rpc.te"
+  "lemetry_server.TelemetryServerResult\"p\n\031"
+  "PublishStatusTextResponse\022S\n\027telemetry_s"
+  "erver_result\030\001 \001(\01322.mavsdk.rpc.telemetr"
+  "y_server.TelemetryServerResult\"n\n\027Publis"
+  "hOdometryResponse\022S\n\027telemetry_server_re"
+  "sult\030\001 \001(\01322.mavsdk.rpc.telemetry_server"
+  ".TelemetryServerResult\"y\n\"PublishPositio"
+  "nVelocityNedResponse\022S\n\027telemetry_server"
   "_result\030\001 \001(\01322.mavsdk.rpc.telemetry_ser"
-  "ver.TelemetryServerResult\"l\n\025PublishRawI"
-  "muResponse\022S\n\027telemetry_server_result\030\001 "
-  "\001(\01322.mavsdk.rpc.telemetry_server.Teleme"
-  "tryServerResult\"s\n\034PublishUnixEpochTimeR"
-  "esponse\022S\n\027telemetry_server_result\030\001 \001(\013"
-  "22.mavsdk.rpc.telemetry_server.Telemetry"
-  "ServerResult\"\225\001\n\010Position\022\035\n\014latitude_de"
-  "g\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlongitude_deg\030\002 \001(\001B"
-  "\007\202\265\030\003NaN\022$\n\023absolute_altitude_m\030\003 \001(\002B\007\202"
-  "\265\030\003NaN\022$\n\023relative_altitude_m\030\004 \001(\002B\007\202\265\030"
-  "\003NaN\"r\n\nQuaternion\022\022\n\001w\030\001 \001(\002B\007\202\265\030\003NaN\022\022"
-  "\n\001x\030\002 \001(\002B\007\202\265\030\003NaN\022\022\n\001y\030\003 \001(\002B\007\202\265\030\003NaN\022\022"
-  "\n\001z\030\004 \001(\002B\007\202\265\030\003NaN\022\024\n\014timestamp_us\030\005 \001(\004"
-  "\"s\n\nEulerAngle\022\031\n\010roll_deg\030\001 \001(\002B\007\202\265\030\003Na"
-  "N\022\032\n\tpitch_deg\030\002 \001(\002B\007\202\265\030\003NaN\022\030\n\007yaw_deg"
-  "\030\003 \001(\002B\007\202\265\030\003NaN\022\024\n\014timestamp_us\030\004 \001(\004\"l\n"
-  "\023AngularVelocityBody\022\033\n\nroll_rad_s\030\001 \001(\002"
-  "B\007\202\265\030\003NaN\022\034\n\013pitch_rad_s\030\002 \001(\002B\007\202\265\030\003NaN\022"
-  "\032\n\tyaw_rad_s\030\003 \001(\002B\007\202\265\030\003NaN\"`\n\007GpsInfo\022\035"
-  "\n\016num_satellites\030\001 \001(\005B\005\202\265\030\0010\0226\n\010fix_typ"
-  "e\030\002 \001(\0162$.mavsdk.rpc.telemetry_server.Fi"
-  "xType\"\337\002\n\006RawGps\022\024\n\014timestamp_us\030\001 \001(\004\022\024"
-  "\n\014latitude_deg\030\002 \001(\001\022\025\n\rlongitude_deg\030\003 "
-  "\001(\001\022\033\n\023absolute_altitude_m\030\004 \001(\002\022\014\n\004hdop"
-  "\030\005 \001(\002\022\014\n\004vdop\030\006 \001(\002\022\024\n\014velocity_m_s\030\007 \001"
-  "(\002\022\017\n\007cog_deg\030\010 \001(\002\022\034\n\024altitude_ellipsoi"
-  "d_m\030\t \001(\002\022 \n\030horizontal_uncertainty_m\030\n "
-  "\001(\002\022\036\n\026vertical_uncertainty_m\030\013 \001(\002\022 \n\030v"
-  "elocity_uncertainty_m_s\030\014 \001(\002\022\037\n\027heading"
-  "_uncertainty_deg\030\r \001(\002\022\017\n\007yaw_deg\030\016 \001(\002\""
-  "I\n\007Battery\022\032\n\tvoltage_v\030\001 \001(\002B\007\202\265\030\003NaN\022\""
-  "\n\021remaining_percent\030\002 \001(\002B\007\202\265\030\003NaN\"|\n\010Rc"
-  "Status\022%\n\022was_available_once\030\001 \001(\010B\t\202\265\030\005"
-  "false\022\037\n\014is_available\030\002 \001(\010B\t\202\265\030\005false\022("
-  "\n\027signal_strength_percent\030\003 \001(\002B\007\202\265\030\003NaN"
-  "\"U\n\nStatusText\0229\n\004type\030\001 \001(\0162+.mavsdk.rp"
-  "c.telemetry_server.StatusTextType\022\014\n\004tex"
-  "t\030\002 \001(\t\"\?\n\025ActuatorControlTarget\022\024\n\005grou"
-  "p\030\001 \001(\005B\005\202\265\030\0010\022\020\n\010controls\030\002 \003(\002\"\?\n\024Actu"
-  "atorOutputStatus\022\025\n\006active\030\001 \001(\rB\005\202\265\030\0010\022"
-  "\020\n\010actuator\030\002 \003(\002\"\'\n\nCovariance\022\031\n\021covar"
-  "iance_matrix\030\001 \003(\002\";\n\014VelocityBody\022\r\n\005x_"
-  "m_s\030\001 \001(\002\022\r\n\005y_m_s\030\002 \001(\002\022\r\n\005z_m_s\030\003 \001(\002\""
-  "5\n\014PositionBody\022\013\n\003x_m\030\001 \001(\002\022\013\n\003y_m\030\002 \001("
-  "\002\022\013\n\003z_m\030\003 \001(\002\"\244\005\n\010Odometry\022\021\n\ttime_usec"
-  "\030\001 \001(\004\022@\n\010frame_id\030\002 \001(\0162..mavsdk.rpc.te"
-  "lemetry_server.Odometry.MavFrame\022F\n\016chil"
-  "d_frame_id\030\003 \001(\0162..mavsdk.rpc.telemetry_"
-  "server.Odometry.MavFrame\022@\n\rposition_bod"
-  "y\030\004 \001(\0132).mavsdk.rpc.telemetry_server.Po"
-  "sitionBody\0222\n\001q\030\005 \001(\0132\'.mavsdk.rpc.telem"
-  "etry_server.Quaternion\022@\n\rvelocity_body\030"
-  "\006 \001(\0132).mavsdk.rpc.telemetry_server.Velo"
-  "cityBody\022O\n\025angular_velocity_body\030\007 \001(\0132"
-  "0.mavsdk.rpc.telemetry_server.AngularVel"
-  "ocityBody\022@\n\017pose_covariance\030\010 \001(\0132\'.mav"
-  "sdk.rpc.telemetry_server.Covariance\022D\n\023v"
-  "elocity_covariance\030\t \001(\0132\'.mavsdk.rpc.te"
-  "lemetry_server.Covariance\"j\n\010MavFrame\022\023\n"
-  "\017MAV_FRAME_UNDEF\020\000\022\026\n\022MAV_FRAME_BODY_NED"
-  "\020\010\022\030\n\024MAV_FRAME_VISION_NED\020\020\022\027\n\023MAV_FRAM"
-  "E_ESTIM_NED\020\022\"\177\n\016DistanceSensor\022#\n\022minim"
-  "um_distance_m\030\001 \001(\002B\007\202\265\030\003NaN\022#\n\022maximum_"
-  "distance_m\030\002 \001(\002B\007\202\265\030\003NaN\022#\n\022current_dis"
-  "tance_m\030\003 \001(\002B\007\202\265\030\003NaN\"\260\001\n\016ScaledPressur"
-  "e\022\024\n\014timestamp_us\030\001 \001(\004\022\035\n\025absolute_pres"
-  "sure_hpa\030\002 \001(\002\022!\n\031differential_pressure_"
-  "hpa\030\003 \001(\002\022\027\n\017temperature_deg\030\004 \001(\002\022-\n%di"
-  "fferential_pressure_temperature_deg\030\005 \001("
-  "\002\"Y\n\013PositionNed\022\030\n\007north_m\030\001 \001(\002B\007\202\265\030\003N"
-  "aN\022\027\n\006east_m\030\002 \001(\002B\007\202\265\030\003NaN\022\027\n\006down_m\030\003 "
-  "\001(\002B\007\202\265\030\003NaN\"D\n\013VelocityNed\022\021\n\tnorth_m_s"
-  "\030\001 \001(\002\022\020\n\010east_m_s\030\002 \001(\002\022\020\n\010down_m_s\030\003 \001"
-  "(\002\"\215\001\n\023PositionVelocityNed\022:\n\010position\030\001"
-  " \001(\0132(.mavsdk.rpc.telemetry_server.Posit"
-  "ionNed\022:\n\010velocity\030\002 \001(\0132(.mavsdk.rpc.te"
-  "lemetry_server.VelocityNed\"r\n\013GroundTrut"
-  "h\022\035\n\014latitude_deg\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlong"
-  "itude_deg\030\002 \001(\001B\007\202\265\030\003NaN\022$\n\023absolute_alt"
-  "itude_m\030\003 \001(\002B\007\202\265\030\003NaN\"x\n\020FixedwingMetri"
-  "cs\022\035\n\014airspeed_m_s\030\001 \001(\002B\007\202\265\030\003NaN\022$\n\023thr"
-  "ottle_percentage\030\002 \001(\002B\007\202\265\030\003NaN\022\037\n\016climb"
-  "_rate_m_s\030\003 \001(\002B\007\202\265\030\003NaN\"i\n\017Acceleration"
-  "Frd\022\035\n\014forward_m_s2\030\001 \001(\002B\007\202\265\030\003NaN\022\033\n\nri"
-  "ght_m_s2\030\002 \001(\002B\007\202\265\030\003NaN\022\032\n\tdown_m_s2\030\003 \001"
-  "(\002B\007\202\265\030\003NaN\"o\n\022AngularVelocityFrd\022\036\n\rfor"
-  "ward_rad_s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right_rad_s"
-  "\030\002 \001(\002B\007\202\265\030\003NaN\022\033\n\ndown_rad_s\030\003 \001(\002B\007\202\265\030"
-  "\003NaN\"m\n\020MagneticFieldFrd\022\036\n\rforward_gaus"
-  "s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right_gauss\030\002 \001(\002B\007\202"
-  "\265\030\003NaN\022\033\n\ndown_gauss\030\003 \001(\002B\007\202\265\030\003NaN\"\240\002\n\003"
-  "Imu\022F\n\020acceleration_frd\030\001 \001(\0132,.mavsdk.r"
-  "pc.telemetry_server.AccelerationFrd\022M\n\024a"
-  "ngular_velocity_frd\030\002 \001(\0132/.mavsdk.rpc.t"
-  "elemetry_server.AngularVelocityFrd\022I\n\022ma"
-  "gnetic_field_frd\030\003 \001(\0132-.mavsdk.rpc.tele"
-  "metry_server.MagneticFieldFrd\022!\n\020tempera"
-  "ture_degc\030\004 \001(\002B\007\202\265\030\003NaN\022\024\n\014timestamp_us"
-  "\030\005 \001(\004\"\264\002\n\025TelemetryServerResult\022I\n\006resu"
-  "lt\030\001 \001(\01629.mavsdk.rpc.telemetry_server.T"
-  "elemetryServerResult.Result\022\022\n\nresult_st"
-  "r\030\002 \001(\t\"\273\001\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022"
-  "\n\016RESULT_SUCCESS\020\001\022\024\n\020RESULT_NO_SYSTEM\020\002"
-  "\022\033\n\027RESULT_CONNECTION_ERROR\020\003\022\017\n\013RESULT_"
-  "BUSY\020\004\022\031\n\025RESULT_COMMAND_DENIED\020\005\022\022\n\016RES"
-  "ULT_TIMEOUT\020\006\022\026\n\022RESULT_UNSUPPORTED\020\007*\244\001"
-  "\n\007FixType\022\023\n\017FIX_TYPE_NO_GPS\020\000\022\023\n\017FIX_TY"
-  "PE_NO_FIX\020\001\022\023\n\017FIX_TYPE_FIX_2D\020\002\022\023\n\017FIX_"
-  "TYPE_FIX_3D\020\003\022\025\n\021FIX_TYPE_FIX_DGPS\020\004\022\026\n\022"
-  "FIX_TYPE_RTK_FLOAT\020\005\022\026\n\022FIX_TYPE_RTK_FIX"
-  "ED\020\006*o\n\tVtolState\022\022\n\016VTOL_UNDEFINED\020\000\022\031\n"
-  "\025VTOL_TRANSITION_TO_FW\020\001\022\031\n\025VTOL_TRANSIT"
-  "ION_TO_MC\020\002\022\013\n\007VTOL_MC\020\003\022\013\n\007VTOL_FW\020\004*\371\001"
-  "\n\016StatusTextType\022\032\n\026STATUS_TEXT_TYPE_DEB"
-  "UG\020\000\022\031\n\025STATUS_TEXT_TYPE_INFO\020\001\022\033\n\027STATU"
-  "S_TEXT_TYPE_NOTICE\020\002\022\034\n\030STATUS_TEXT_TYPE"
-  "_WARNING\020\003\022\032\n\026STATUS_TEXT_TYPE_ERROR\020\004\022\035"
-  "\n\031STATUS_TEXT_TYPE_CRITICAL\020\005\022\032\n\026STATUS_"
-  "TEXT_TYPE_ALERT\020\006\022\036\n\032STATUS_TEXT_TYPE_EM"
-  "ERGENCY\020\007*\223\001\n\013LandedState\022\030\n\024LANDED_STAT"
-  "E_UNKNOWN\020\000\022\032\n\026LANDED_STATE_ON_GROUND\020\001\022"
-  "\027\n\023LANDED_STATE_IN_AIR\020\002\022\033\n\027LANDED_STATE"
-  "_TAKING_OFF\020\003\022\030\n\024LANDED_STATE_LANDING\020\0042"
-  "\214\017\n\026TelemetryServerService\022\202\001\n\017PublishPo"
-  "sition\0223.mavsdk.rpc.telemetry_server.Pub"
-  "lishPositionRequest\0324.mavsdk.rpc.telemet"
-  "ry_server.PublishPositionResponse\"\004\200\265\030\001\022"
-  "v\n\013PublishHome\022/.mavsdk.rpc.telemetry_se"
-  "rver.PublishHomeRequest\0320.mavsdk.rpc.tel"
-  "emetry_server.PublishHomeResponse\"\004\200\265\030\001\022"
-  "\205\001\n\020PublishSysStatus\0224.mavsdk.rpc.teleme"
-  "try_server.PublishSysStatusRequest\0325.mav"
-  "sdk.rpc.telemetry_server.PublishSysStatu"
-  "sResponse\"\004\200\265\030\001\022\232\001\n\027PublishExtendedSysSt"
-  "ate\022;.mavsdk.rpc.telemetry_server.Publis"
-  "hExtendedSysStateRequest\032<.mavsdk.rpc.te"
-  "lemetry_server.PublishExtendedSysStateRe"
-  "sponse\"\004\200\265\030\001\022|\n\rPublishRawGps\0221.mavsdk.r"
-  "pc.telemetry_server.PublishRawGpsRequest"
-  "\0322.mavsdk.rpc.telemetry_server.PublishRa"
-  "wGpsResponse\"\004\200\265\030\001\022\177\n\016PublishBattery\0222.m"
-  "avsdk.rpc.telemetry_server.PublishBatter"
-  "yRequest\0323.mavsdk.rpc.telemetry_server.P"
-  "ublishBatteryResponse\"\004\200\265\030\001\022\210\001\n\021PublishS"
-  "tatusText\0225.mavsdk.rpc.telemetry_server."
-  "PublishStatusTextRequest\0326.mavsdk.rpc.te"
-  "lemetry_server.PublishStatusTextResponse"
-  "\"\004\200\265\030\001\022\202\001\n\017PublishOdometry\0223.mavsdk.rpc."
-  "telemetry_server.PublishOdometryRequest\032"
-  "4.mavsdk.rpc.telemetry_server.PublishOdo"
-  "metryResponse\"\004\200\265\030\001\022\243\001\n\032PublishPositionV"
-  "elocityNed\022>.mavsdk.rpc.telemetry_server"
-  ".PublishPositionVelocityNedRequest\032\?.mav"
-  "sdk.rpc.telemetry_server.PublishPosition"
-  "VelocityNedResponse\"\004\200\265\030\001\022\213\001\n\022PublishGro"
-  "undTruth\0226.mavsdk.rpc.telemetry_server.P"
-  "ublishGroundTruthRequest\0327.mavsdk.rpc.te"
-  "lemetry_server.PublishGroundTruthRespons"
-  "e\"\004\200\265\030\001\022s\n\nPublishImu\022..mavsdk.rpc.telem"
-  "etry_server.PublishImuRequest\032/.mavsdk.r"
-  "pc.telemetry_server.PublishImuResponse\"\004"
-  "\200\265\030\001\022\205\001\n\020PublishScaledImu\0224.mavsdk.rpc.t"
-  "elemetry_server.PublishScaledImuRequest\032"
-  "5.mavsdk.rpc.telemetry_server.PublishSca"
-  "ledImuResponse\"\004\200\265\030\001\022|\n\rPublishRawImu\0221."
-  "mavsdk.rpc.telemetry_server.PublishRawIm"
-  "uRequest\0322.mavsdk.rpc.telemetry_server.P"
-  "ublishRawImuResponse\"\004\200\265\030\001\022\221\001\n\024PublishUn"
-  "ixEpochTime\0228.mavsdk.rpc.telemetry_serve"
-  "r.PublishUnixEpochTimeRequest\0329.mavsdk.r"
-  "pc.telemetry_server.PublishUnixEpochTime"
-  "Response\"\004\200\265\030\001B2\n\032io.mavsdk.telemetry_se"
-  "rverB\024TelemetryServerProtob\006proto3"
+  "ver.TelemetryServerResult\"q\n\032PublishGrou"
+  "ndTruthResponse\022S\n\027telemetry_server_resu"
+  "lt\030\001 \001(\01322.mavsdk.rpc.telemetry_server.T"
+  "elemetryServerResult\"i\n\022PublishImuRespon"
+  "se\022S\n\027telemetry_server_result\030\001 \001(\01322.ma"
+  "vsdk.rpc.telemetry_server.TelemetryServe"
+  "rResult\"o\n\030PublishScaledImuResponse\022S\n\027t"
+  "elemetry_server_result\030\001 \001(\01322.mavsdk.rp"
+  "c.telemetry_server.TelemetryServerResult"
+  "\"l\n\025PublishRawImuResponse\022S\n\027telemetry_s"
+  "erver_result\030\001 \001(\01322.mavsdk.rpc.telemetr"
+  "y_server.TelemetryServerResult\"s\n\034Publis"
+  "hUnixEpochTimeResponse\022S\n\027telemetry_serv"
+  "er_result\030\001 \001(\01322.mavsdk.rpc.telemetry_s"
+  "erver.TelemetryServerResult\"\225\001\n\010Position"
+  "\022\035\n\014latitude_deg\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlongi"
+  "tude_deg\030\002 \001(\001B\007\202\265\030\003NaN\022$\n\023absolute_alti"
+  "tude_m\030\003 \001(\002B\007\202\265\030\003NaN\022$\n\023relative_altitu"
+  "de_m\030\004 \001(\002B\007\202\265\030\003NaN\"\'\n\007Heading\022\034\n\013headin"
+  "g_deg\030\001 \001(\001B\007\202\265\030\003NaN\"r\n\nQuaternion\022\022\n\001w\030"
+  "\001 \001(\002B\007\202\265\030\003NaN\022\022\n\001x\030\002 \001(\002B\007\202\265\030\003NaN\022\022\n\001y\030"
+  "\003 \001(\002B\007\202\265\030\003NaN\022\022\n\001z\030\004 \001(\002B\007\202\265\030\003NaN\022\024\n\014ti"
+  "mestamp_us\030\005 \001(\004\"s\n\nEulerAngle\022\031\n\010roll_d"
+  "eg\030\001 \001(\002B\007\202\265\030\003NaN\022\032\n\tpitch_deg\030\002 \001(\002B\007\202\265"
+  "\030\003NaN\022\030\n\007yaw_deg\030\003 \001(\002B\007\202\265\030\003NaN\022\024\n\014times"
+  "tamp_us\030\004 \001(\004\"l\n\023AngularVelocityBody\022\033\n\n"
+  "roll_rad_s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013pitch_rad_s"
+  "\030\002 \001(\002B\007\202\265\030\003NaN\022\032\n\tyaw_rad_s\030\003 \001(\002B\007\202\265\030\003"
+  "NaN\"`\n\007GpsInfo\022\035\n\016num_satellites\030\001 \001(\005B\005"
+  "\202\265\030\0010\0226\n\010fix_type\030\002 \001(\0162$.mavsdk.rpc.tel"
+  "emetry_server.FixType\"\337\002\n\006RawGps\022\024\n\014time"
+  "stamp_us\030\001 \001(\004\022\024\n\014latitude_deg\030\002 \001(\001\022\025\n\r"
+  "longitude_deg\030\003 \001(\001\022\033\n\023absolute_altitude"
+  "_m\030\004 \001(\002\022\014\n\004hdop\030\005 \001(\002\022\014\n\004vdop\030\006 \001(\002\022\024\n\014"
+  "velocity_m_s\030\007 \001(\002\022\017\n\007cog_deg\030\010 \001(\002\022\034\n\024a"
+  "ltitude_ellipsoid_m\030\t \001(\002\022 \n\030horizontal_"
+  "uncertainty_m\030\n \001(\002\022\036\n\026vertical_uncertai"
+  "nty_m\030\013 \001(\002\022 \n\030velocity_uncertainty_m_s\030"
+  "\014 \001(\002\022\037\n\027heading_uncertainty_deg\030\r \001(\002\022\017"
+  "\n\007yaw_deg\030\016 \001(\002\"I\n\007Battery\022\032\n\tvoltage_v\030"
+  "\001 \001(\002B\007\202\265\030\003NaN\022\"\n\021remaining_percent\030\002 \001("
+  "\002B\007\202\265\030\003NaN\"|\n\010RcStatus\022%\n\022was_available_"
+  "once\030\001 \001(\010B\t\202\265\030\005false\022\037\n\014is_available\030\002 "
+  "\001(\010B\t\202\265\030\005false\022(\n\027signal_strength_percen"
+  "t\030\003 \001(\002B\007\202\265\030\003NaN\"U\n\nStatusText\0229\n\004type\030\001"
+  " \001(\0162+.mavsdk.rpc.telemetry_server.Statu"
+  "sTextType\022\014\n\004text\030\002 \001(\t\"\?\n\025ActuatorContr"
+  "olTarget\022\024\n\005group\030\001 \001(\005B\005\202\265\030\0010\022\020\n\010contro"
+  "ls\030\002 \003(\002\"\?\n\024ActuatorOutputStatus\022\025\n\006acti"
+  "ve\030\001 \001(\rB\005\202\265\030\0010\022\020\n\010actuator\030\002 \003(\002\"\'\n\nCov"
+  "ariance\022\031\n\021covariance_matrix\030\001 \003(\002\";\n\014Ve"
+  "locityBody\022\r\n\005x_m_s\030\001 \001(\002\022\r\n\005y_m_s\030\002 \001(\002"
+  "\022\r\n\005z_m_s\030\003 \001(\002\"5\n\014PositionBody\022\013\n\003x_m\030\001"
+  " \001(\002\022\013\n\003y_m\030\002 \001(\002\022\013\n\003z_m\030\003 \001(\002\"\244\005\n\010Odome"
+  "try\022\021\n\ttime_usec\030\001 \001(\004\022@\n\010frame_id\030\002 \001(\016"
+  "2..mavsdk.rpc.telemetry_server.Odometry."
+  "MavFrame\022F\n\016child_frame_id\030\003 \001(\0162..mavsd"
+  "k.rpc.telemetry_server.Odometry.MavFrame"
+  "\022@\n\rposition_body\030\004 \001(\0132).mavsdk.rpc.tel"
+  "emetry_server.PositionBody\0222\n\001q\030\005 \001(\0132\'."
+  "mavsdk.rpc.telemetry_server.Quaternion\022@"
+  "\n\rvelocity_body\030\006 \001(\0132).mavsdk.rpc.telem"
+  "etry_server.VelocityBody\022O\n\025angular_velo"
+  "city_body\030\007 \001(\01320.mavsdk.rpc.telemetry_s"
+  "erver.AngularVelocityBody\022@\n\017pose_covari"
+  "ance\030\010 \001(\0132\'.mavsdk.rpc.telemetry_server"
+  ".Covariance\022D\n\023velocity_covariance\030\t \001(\013"
+  "2\'.mavsdk.rpc.telemetry_server.Covarianc"
+  "e\"j\n\010MavFrame\022\023\n\017MAV_FRAME_UNDEF\020\000\022\026\n\022MA"
+  "V_FRAME_BODY_NED\020\010\022\030\n\024MAV_FRAME_VISION_N"
+  "ED\020\020\022\027\n\023MAV_FRAME_ESTIM_NED\020\022\"\177\n\016Distanc"
+  "eSensor\022#\n\022minimum_distance_m\030\001 \001(\002B\007\202\265\030"
+  "\003NaN\022#\n\022maximum_distance_m\030\002 \001(\002B\007\202\265\030\003Na"
+  "N\022#\n\022current_distance_m\030\003 \001(\002B\007\202\265\030\003NaN\"\260"
+  "\001\n\016ScaledPressure\022\024\n\014timestamp_us\030\001 \001(\004\022"
+  "\035\n\025absolute_pressure_hpa\030\002 \001(\002\022!\n\031differ"
+  "ential_pressure_hpa\030\003 \001(\002\022\027\n\017temperature"
+  "_deg\030\004 \001(\002\022-\n%differential_pressure_temp"
+  "erature_deg\030\005 \001(\002\"Y\n\013PositionNed\022\030\n\007nort"
+  "h_m\030\001 \001(\002B\007\202\265\030\003NaN\022\027\n\006east_m\030\002 \001(\002B\007\202\265\030\003"
+  "NaN\022\027\n\006down_m\030\003 \001(\002B\007\202\265\030\003NaN\"D\n\013Velocity"
+  "Ned\022\021\n\tnorth_m_s\030\001 \001(\002\022\020\n\010east_m_s\030\002 \001(\002"
+  "\022\020\n\010down_m_s\030\003 \001(\002\"\215\001\n\023PositionVelocityN"
+  "ed\022:\n\010position\030\001 \001(\0132(.mavsdk.rpc.teleme"
+  "try_server.PositionNed\022:\n\010velocity\030\002 \001(\013"
+  "2(.mavsdk.rpc.telemetry_server.VelocityN"
+  "ed\"r\n\013GroundTruth\022\035\n\014latitude_deg\030\001 \001(\001B"
+  "\007\202\265\030\003NaN\022\036\n\rlongitude_deg\030\002 \001(\001B\007\202\265\030\003NaN"
+  "\022$\n\023absolute_altitude_m\030\003 \001(\002B\007\202\265\030\003NaN\"x"
+  "\n\020FixedwingMetrics\022\035\n\014airspeed_m_s\030\001 \001(\002"
+  "B\007\202\265\030\003NaN\022$\n\023throttle_percentage\030\002 \001(\002B\007"
+  "\202\265\030\003NaN\022\037\n\016climb_rate_m_s\030\003 \001(\002B\007\202\265\030\003NaN"
+  "\"i\n\017AccelerationFrd\022\035\n\014forward_m_s2\030\001 \001("
+  "\002B\007\202\265\030\003NaN\022\033\n\nright_m_s2\030\002 \001(\002B\007\202\265\030\003NaN\022"
+  "\032\n\tdown_m_s2\030\003 \001(\002B\007\202\265\030\003NaN\"o\n\022AngularVe"
+  "locityFrd\022\036\n\rforward_rad_s\030\001 \001(\002B\007\202\265\030\003Na"
+  "N\022\034\n\013right_rad_s\030\002 \001(\002B\007\202\265\030\003NaN\022\033\n\ndown_"
+  "rad_s\030\003 \001(\002B\007\202\265\030\003NaN\"m\n\020MagneticFieldFrd"
+  "\022\036\n\rforward_gauss\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013righ"
+  "t_gauss\030\002 \001(\002B\007\202\265\030\003NaN\022\033\n\ndown_gauss\030\003 \001"
+  "(\002B\007\202\265\030\003NaN\"\240\002\n\003Imu\022F\n\020acceleration_frd\030"
+  "\001 \001(\0132,.mavsdk.rpc.telemetry_server.Acce"
+  "lerationFrd\022M\n\024angular_velocity_frd\030\002 \001("
+  "\0132/.mavsdk.rpc.telemetry_server.AngularV"
+  "elocityFrd\022I\n\022magnetic_field_frd\030\003 \001(\0132-"
+  ".mavsdk.rpc.telemetry_server.MagneticFie"
+  "ldFrd\022!\n\020temperature_degc\030\004 \001(\002B\007\202\265\030\003NaN"
+  "\022\024\n\014timestamp_us\030\005 \001(\004\"\264\002\n\025TelemetryServ"
+  "erResult\022I\n\006result\030\001 \001(\01629.mavsdk.rpc.te"
+  "lemetry_server.TelemetryServerResult.Res"
+  "ult\022\022\n\nresult_str\030\002 \001(\t\"\273\001\n\006Result\022\022\n\016RE"
+  "SULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\024\n\020RE"
+  "SULT_NO_SYSTEM\020\002\022\033\n\027RESULT_CONNECTION_ER"
+  "ROR\020\003\022\017\n\013RESULT_BUSY\020\004\022\031\n\025RESULT_COMMAND"
+  "_DENIED\020\005\022\022\n\016RESULT_TIMEOUT\020\006\022\026\n\022RESULT_"
+  "UNSUPPORTED\020\007*\244\001\n\007FixType\022\023\n\017FIX_TYPE_NO"
+  "_GPS\020\000\022\023\n\017FIX_TYPE_NO_FIX\020\001\022\023\n\017FIX_TYPE_"
+  "FIX_2D\020\002\022\023\n\017FIX_TYPE_FIX_3D\020\003\022\025\n\021FIX_TYP"
+  "E_FIX_DGPS\020\004\022\026\n\022FIX_TYPE_RTK_FLOAT\020\005\022\026\n\022"
+  "FIX_TYPE_RTK_FIXED\020\006*o\n\tVtolState\022\022\n\016VTO"
+  "L_UNDEFINED\020\000\022\031\n\025VTOL_TRANSITION_TO_FW\020\001"
+  "\022\031\n\025VTOL_TRANSITION_TO_MC\020\002\022\013\n\007VTOL_MC\020\003"
+  "\022\013\n\007VTOL_FW\020\004*\371\001\n\016StatusTextType\022\032\n\026STAT"
+  "US_TEXT_TYPE_DEBUG\020\000\022\031\n\025STATUS_TEXT_TYPE"
+  "_INFO\020\001\022\033\n\027STATUS_TEXT_TYPE_NOTICE\020\002\022\034\n\030"
+  "STATUS_TEXT_TYPE_WARNING\020\003\022\032\n\026STATUS_TEX"
+  "T_TYPE_ERROR\020\004\022\035\n\031STATUS_TEXT_TYPE_CRITI"
+  "CAL\020\005\022\032\n\026STATUS_TEXT_TYPE_ALERT\020\006\022\036\n\032STA"
+  "TUS_TEXT_TYPE_EMERGENCY\020\007*\223\001\n\013LandedStat"
+  "e\022\030\n\024LANDED_STATE_UNKNOWN\020\000\022\032\n\026LANDED_ST"
+  "ATE_ON_GROUND\020\001\022\027\n\023LANDED_STATE_IN_AIR\020\002"
+  "\022\033\n\027LANDED_STATE_TAKING_OFF\020\003\022\030\n\024LANDED_"
+  "STATE_LANDING\020\0042\214\017\n\026TelemetryServerServi"
+  "ce\022\202\001\n\017PublishPosition\0223.mavsdk.rpc.tele"
+  "metry_server.PublishPositionRequest\0324.ma"
+  "vsdk.rpc.telemetry_server.PublishPositio"
+  "nResponse\"\004\200\265\030\001\022v\n\013PublishHome\022/.mavsdk."
+  "rpc.telemetry_server.PublishHomeRequest\032"
+  "0.mavsdk.rpc.telemetry_server.PublishHom"
+  "eResponse\"\004\200\265\030\001\022\205\001\n\020PublishSysStatus\0224.m"
+  "avsdk.rpc.telemetry_server.PublishSysSta"
+  "tusRequest\0325.mavsdk.rpc.telemetry_server"
+  ".PublishSysStatusResponse\"\004\200\265\030\001\022\232\001\n\027Publ"
+  "ishExtendedSysState\022;.mavsdk.rpc.telemet"
+  "ry_server.PublishExtendedSysStateRequest"
+  "\032<.mavsdk.rpc.telemetry_server.PublishEx"
+  "tendedSysStateResponse\"\004\200\265\030\001\022|\n\rPublishR"
+  "awGps\0221.mavsdk.rpc.telemetry_server.Publ"
+  "ishRawGpsRequest\0322.mavsdk.rpc.telemetry_"
+  "server.PublishRawGpsResponse\"\004\200\265\030\001\022\177\n\016Pu"
+  "blishBattery\0222.mavsdk.rpc.telemetry_serv"
+  "er.PublishBatteryRequest\0323.mavsdk.rpc.te"
+  "lemetry_server.PublishBatteryResponse\"\004\200"
+  "\265\030\001\022\210\001\n\021PublishStatusText\0225.mavsdk.rpc.t"
+  "elemetry_server.PublishStatusTextRequest"
+  "\0326.mavsdk.rpc.telemetry_server.PublishSt"
+  "atusTextResponse\"\004\200\265\030\001\022\202\001\n\017PublishOdomet"
+  "ry\0223.mavsdk.rpc.telemetry_server.Publish"
+  "OdometryRequest\0324.mavsdk.rpc.telemetry_s"
+  "erver.PublishOdometryResponse\"\004\200\265\030\001\022\243\001\n\032"
+  "PublishPositionVelocityNed\022>.mavsdk.rpc."
+  "telemetry_server.PublishPositionVelocity"
+  "NedRequest\032\?.mavsdk.rpc.telemetry_server"
+  ".PublishPositionVelocityNedResponse\"\004\200\265\030"
+  "\001\022\213\001\n\022PublishGroundTruth\0226.mavsdk.rpc.te"
+  "lemetry_server.PublishGroundTruthRequest"
+  "\0327.mavsdk.rpc.telemetry_server.PublishGr"
+  "oundTruthResponse\"\004\200\265\030\001\022s\n\nPublishImu\022.."
+  "mavsdk.rpc.telemetry_server.PublishImuRe"
+  "quest\032/.mavsdk.rpc.telemetry_server.Publ"
+  "ishImuResponse\"\004\200\265\030\001\022\205\001\n\020PublishScaledIm"
+  "u\0224.mavsdk.rpc.telemetry_server.PublishS"
+  "caledImuRequest\0325.mavsdk.rpc.telemetry_s"
+  "erver.PublishScaledImuResponse\"\004\200\265\030\001\022|\n\r"
+  "PublishRawImu\0221.mavsdk.rpc.telemetry_ser"
+  "ver.PublishRawImuRequest\0322.mavsdk.rpc.te"
+  "lemetry_server.PublishRawImuResponse\"\004\200\265"
+  "\030\001\022\221\001\n\024PublishUnixEpochTime\0228.mavsdk.rpc"
+  ".telemetry_server.PublishUnixEpochTimeRe"
+  "quest\0329.mavsdk.rpc.telemetry_server.Publ"
+  "ishUnixEpochTimeResponse\"\004\200\265\030\001B2\n\032io.mav"
+  "sdk.telemetry_serverB\024TelemetryServerPro"
+  "tob\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_telemetry_5fserver_2ftelemetry_5fserver_2eproto_deps[1] = {
   &::descriptor_table_mavsdk_5foptions_2eproto,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_telemetry_5fserver_2ftelemetry_5fserver_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_telemetry_5fserver_2ftelemetry_5fserver_2eproto = {
-  false, false, 9994, descriptor_table_protodef_telemetry_5fserver_2ftelemetry_5fserver_2eproto, "telemetry_server/telemetry_server.proto", 
-  &descriptor_table_telemetry_5fserver_2ftelemetry_5fserver_2eproto_once, descriptor_table_telemetry_5fserver_2ftelemetry_5fserver_2eproto_deps, 1, 58,
+  false, false, 10090, descriptor_table_protodef_telemetry_5fserver_2ftelemetry_5fserver_2eproto, "telemetry_server/telemetry_server.proto", 
+  &descriptor_table_telemetry_5fserver_2ftelemetry_5fserver_2eproto_once, descriptor_table_telemetry_5fserver_2ftelemetry_5fserver_2eproto_deps, 1, 59,
   schemas, file_default_instances, TableStruct_telemetry_5fserver_2ftelemetry_5fserver_2eproto::offsets,
   file_level_metadata_telemetry_5fserver_2ftelemetry_5fserver_2eproto, file_level_enum_descriptors_telemetry_5fserver_2ftelemetry_5fserver_2eproto, file_level_service_descriptors_telemetry_5fserver_2ftelemetry_5fserver_2eproto,
 };
@@ -1772,6 +1797,7 @@ class PublishPositionRequest::_Internal {
  public:
   static const ::mavsdk::rpc::telemetry_server::Position& position(const PublishPositionRequest* msg);
   static const ::mavsdk::rpc::telemetry_server::VelocityNed& velocity_ned(const PublishPositionRequest* msg);
+  static const ::mavsdk::rpc::telemetry_server::Heading& heading(const PublishPositionRequest* msg);
 };
 
 const ::mavsdk::rpc::telemetry_server::Position&
@@ -1781,6 +1807,10 @@ PublishPositionRequest::_Internal::position(const PublishPositionRequest* msg) {
 const ::mavsdk::rpc::telemetry_server::VelocityNed&
 PublishPositionRequest::_Internal::velocity_ned(const PublishPositionRequest* msg) {
   return *msg->velocity_ned_;
+}
+const ::mavsdk::rpc::telemetry_server::Heading&
+PublishPositionRequest::_Internal::heading(const PublishPositionRequest* msg) {
+  return *msg->heading_;
 }
 PublishPositionRequest::PublishPositionRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
@@ -1801,14 +1831,19 @@ PublishPositionRequest::PublishPositionRequest(const PublishPositionRequest& fro
   } else {
     velocity_ned_ = nullptr;
   }
+  if (from._internal_has_heading()) {
+    heading_ = new ::mavsdk::rpc::telemetry_server::Heading(*from.heading_);
+  } else {
+    heading_ = nullptr;
+  }
   // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.telemetry_server.PublishPositionRequest)
 }
 
 void PublishPositionRequest::SharedCtor() {
 ::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
     reinterpret_cast<char*>(&position_) - reinterpret_cast<char*>(this)),
-    0, static_cast<size_t>(reinterpret_cast<char*>(&velocity_ned_) -
-    reinterpret_cast<char*>(&position_)) + sizeof(velocity_ned_));
+    0, static_cast<size_t>(reinterpret_cast<char*>(&heading_) -
+    reinterpret_cast<char*>(&position_)) + sizeof(heading_));
 }
 
 PublishPositionRequest::~PublishPositionRequest() {
@@ -1821,6 +1856,7 @@ void PublishPositionRequest::SharedDtor() {
   GOOGLE_DCHECK(GetArena() == nullptr);
   if (this != internal_default_instance()) delete position_;
   if (this != internal_default_instance()) delete velocity_ned_;
+  if (this != internal_default_instance()) delete heading_;
 }
 
 void PublishPositionRequest::ArenaDtor(void* object) {
@@ -1847,6 +1883,10 @@ void PublishPositionRequest::Clear() {
     delete velocity_ned_;
   }
   velocity_ned_ = nullptr;
+  if (GetArena() == nullptr && heading_ != nullptr) {
+    delete heading_;
+  }
+  heading_ = nullptr;
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -1868,6 +1908,13 @@ const char* PublishPositionRequest::_InternalParse(const char* ptr, ::PROTOBUF_N
       case 2:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
           ptr = ctx->ParseMessage(_internal_mutable_velocity_ned(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .mavsdk.rpc.telemetry_server.Heading heading = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 26)) {
+          ptr = ctx->ParseMessage(_internal_mutable_heading(), ptr);
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
@@ -1915,6 +1962,14 @@ failure:
         2, _Internal::velocity_ned(this), target, stream);
   }
 
+  // .mavsdk.rpc.telemetry_server.Heading heading = 3;
+  if (this->has_heading()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        3, _Internal::heading(this), target, stream);
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
@@ -1943,6 +1998,13 @@ size_t PublishPositionRequest::ByteSizeLong() const {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
         *velocity_ned_);
+  }
+
+  // .mavsdk.rpc.telemetry_server.Heading heading = 3;
+  if (this->has_heading()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *heading_);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -1982,6 +2044,9 @@ void PublishPositionRequest::MergeFrom(const PublishPositionRequest& from) {
   if (from.has_velocity_ned()) {
     _internal_mutable_velocity_ned()->::mavsdk::rpc::telemetry_server::VelocityNed::MergeFrom(from._internal_velocity_ned());
   }
+  if (from.has_heading()) {
+    _internal_mutable_heading()->::mavsdk::rpc::telemetry_server::Heading::MergeFrom(from._internal_heading());
+  }
 }
 
 void PublishPositionRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
@@ -2006,8 +2071,8 @@ void PublishPositionRequest::InternalSwap(PublishPositionRequest* other) {
   using std::swap;
   _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(PublishPositionRequest, velocity_ned_)
-      + sizeof(PublishPositionRequest::velocity_ned_)
+      PROTOBUF_FIELD_OFFSET(PublishPositionRequest, heading_)
+      + sizeof(PublishPositionRequest::heading_)
       - PROTOBUF_FIELD_OFFSET(PublishPositionRequest, position_)>(
           reinterpret_cast<char*>(&position_),
           reinterpret_cast<char*>(&other->position_));
@@ -8539,6 +8604,193 @@ void Position::InternalSwap(Position* other) {
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata Position::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class Heading::_Internal {
+ public:
+};
+
+Heading::Heading(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.telemetry_server.Heading)
+}
+Heading::Heading(const Heading& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  heading_deg_ = from.heading_deg_;
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.telemetry_server.Heading)
+}
+
+void Heading::SharedCtor() {
+heading_deg_ = 0;
+}
+
+Heading::~Heading() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.telemetry_server.Heading)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void Heading::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+}
+
+void Heading::ArenaDtor(void* object) {
+  Heading* _this = reinterpret_cast< Heading* >(object);
+  (void)_this;
+}
+void Heading::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void Heading::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void Heading::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.telemetry_server.Heading)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  heading_deg_ = 0;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* Heading::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // double heading_deg = 1 [(.mavsdk.options.default_value) = "NaN"];
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 9)) {
+          heading_deg_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<double>(ptr);
+          ptr += sizeof(double);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* Heading::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.telemetry_server.Heading)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // double heading_deg = 1 [(.mavsdk.options.default_value) = "NaN"];
+  if (!(this->heading_deg() <= 0 && this->heading_deg() >= 0)) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteDoubleToArray(1, this->_internal_heading_deg(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.telemetry_server.Heading)
+  return target;
+}
+
+size_t Heading::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.telemetry_server.Heading)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // double heading_deg = 1 [(.mavsdk.options.default_value) = "NaN"];
+  if (!(this->heading_deg() <= 0 && this->heading_deg() >= 0)) {
+    total_size += 1 + 8;
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void Heading::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:mavsdk.rpc.telemetry_server.Heading)
+  GOOGLE_DCHECK_NE(&from, this);
+  const Heading* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<Heading>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:mavsdk.rpc.telemetry_server.Heading)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:mavsdk.rpc.telemetry_server.Heading)
+    MergeFrom(*source);
+  }
+}
+
+void Heading::MergeFrom(const Heading& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.telemetry_server.Heading)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!(from.heading_deg() <= 0 && from.heading_deg() >= 0)) {
+    _internal_set_heading_deg(from._internal_heading_deg());
+  }
+}
+
+void Heading::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:mavsdk.rpc.telemetry_server.Heading)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void Heading::CopyFrom(const Heading& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.telemetry_server.Heading)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool Heading::IsInitialized() const {
+  return true;
+}
+
+void Heading::InternalSwap(Heading* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  swap(heading_deg_, other->heading_deg_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata Heading::GetMetadata() const {
   return GetMetadataStatic();
 }
 
@@ -15472,6 +15724,9 @@ template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry_server::PublishUnixEpochTi
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry_server::Position* Arena::CreateMaybeMessage< ::mavsdk::rpc::telemetry_server::Position >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::telemetry_server::Position >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry_server::Heading* Arena::CreateMaybeMessage< ::mavsdk::rpc::telemetry_server::Heading >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::telemetry_server::Heading >(arena);
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::telemetry_server::Quaternion* Arena::CreateMaybeMessage< ::mavsdk::rpc::telemetry_server::Quaternion >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::telemetry_server::Quaternion >(arena);

--- a/src/mavsdk_server/src/generated/telemetry_server/telemetry_server.pb.h
+++ b/src/mavsdk_server/src/generated/telemetry_server/telemetry_server.pb.h
@@ -48,7 +48,7 @@ struct TableStruct_telemetry_5fserver_2ftelemetry_5fserver_2eproto {
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::AuxiliaryParseTableField aux[]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
-  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[58]
+  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[59]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::FieldMetadata field_metadata[];
   static const ::PROTOBUF_NAMESPACE_ID::internal::SerializationTable serialization_table[];
@@ -95,6 +95,9 @@ extern GpsInfoDefaultTypeInternal _GpsInfo_default_instance_;
 class GroundTruth;
 struct GroundTruthDefaultTypeInternal;
 extern GroundTruthDefaultTypeInternal _GroundTruth_default_instance_;
+class Heading;
+struct HeadingDefaultTypeInternal;
+extern HeadingDefaultTypeInternal _Heading_default_instance_;
 class Imu;
 struct ImuDefaultTypeInternal;
 extern ImuDefaultTypeInternal _Imu_default_instance_;
@@ -249,6 +252,7 @@ template<> ::mavsdk::rpc::telemetry_server::EulerAngle* Arena::CreateMaybeMessag
 template<> ::mavsdk::rpc::telemetry_server::FixedwingMetrics* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry_server::FixedwingMetrics>(Arena*);
 template<> ::mavsdk::rpc::telemetry_server::GpsInfo* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry_server::GpsInfo>(Arena*);
 template<> ::mavsdk::rpc::telemetry_server::GroundTruth* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry_server::GroundTruth>(Arena*);
+template<> ::mavsdk::rpc::telemetry_server::Heading* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry_server::Heading>(Arena*);
 template<> ::mavsdk::rpc::telemetry_server::Imu* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry_server::Imu>(Arena*);
 template<> ::mavsdk::rpc::telemetry_server::MagneticFieldFrd* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry_server::MagneticFieldFrd>(Arena*);
 template<> ::mavsdk::rpc::telemetry_server::Odometry* Arena::CreateMaybeMessage<::mavsdk::rpc::telemetry_server::Odometry>(Arena*);
@@ -592,6 +596,7 @@ class PublishPositionRequest PROTOBUF_FINAL :
   enum : int {
     kPositionFieldNumber = 1,
     kVelocityNedFieldNumber = 2,
+    kHeadingFieldNumber = 3,
   };
   // .mavsdk.rpc.telemetry_server.Position position = 1;
   bool has_position() const;
@@ -629,6 +634,24 @@ class PublishPositionRequest PROTOBUF_FINAL :
       ::mavsdk::rpc::telemetry_server::VelocityNed* velocity_ned);
   ::mavsdk::rpc::telemetry_server::VelocityNed* unsafe_arena_release_velocity_ned();
 
+  // .mavsdk.rpc.telemetry_server.Heading heading = 3;
+  bool has_heading() const;
+  private:
+  bool _internal_has_heading() const;
+  public:
+  void clear_heading();
+  const ::mavsdk::rpc::telemetry_server::Heading& heading() const;
+  ::mavsdk::rpc::telemetry_server::Heading* release_heading();
+  ::mavsdk::rpc::telemetry_server::Heading* mutable_heading();
+  void set_allocated_heading(::mavsdk::rpc::telemetry_server::Heading* heading);
+  private:
+  const ::mavsdk::rpc::telemetry_server::Heading& _internal_heading() const;
+  ::mavsdk::rpc::telemetry_server::Heading* _internal_mutable_heading();
+  public:
+  void unsafe_arena_set_allocated_heading(
+      ::mavsdk::rpc::telemetry_server::Heading* heading);
+  ::mavsdk::rpc::telemetry_server::Heading* unsafe_arena_release_heading();
+
   // @@protoc_insertion_point(class_scope:mavsdk.rpc.telemetry_server.PublishPositionRequest)
  private:
   class _Internal;
@@ -638,6 +661,7 @@ class PublishPositionRequest PROTOBUF_FINAL :
   typedef void DestructorSkippable_;
   ::mavsdk::rpc::telemetry_server::Position* position_;
   ::mavsdk::rpc::telemetry_server::VelocityNed* velocity_ned_;
+  ::mavsdk::rpc::telemetry_server::Heading* heading_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_telemetry_5fserver_2ftelemetry_5fserver_2eproto;
 };
@@ -5243,6 +5267,143 @@ class Position PROTOBUF_FINAL :
 };
 // -------------------------------------------------------------------
 
+class Heading PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.telemetry_server.Heading) */ {
+ public:
+  inline Heading() : Heading(nullptr) {}
+  virtual ~Heading();
+  explicit constexpr Heading(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  Heading(const Heading& from);
+  Heading(Heading&& from) noexcept
+    : Heading() {
+    *this = ::std::move(from);
+  }
+
+  inline Heading& operator=(const Heading& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline Heading& operator=(Heading&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const Heading& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const Heading* internal_default_instance() {
+    return reinterpret_cast<const Heading*>(
+               &_Heading_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    32;
+
+  friend void swap(Heading& a, Heading& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(Heading* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(Heading* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline Heading* New() const final {
+    return CreateMaybeMessage<Heading>(nullptr);
+  }
+
+  Heading* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<Heading>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const Heading& from);
+  void MergeFrom(const Heading& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(Heading* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.telemetry_server.Heading";
+  }
+  protected:
+  explicit Heading(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    return ::descriptor_table_telemetry_5fserver_2ftelemetry_5fserver_2eproto_metadata_getter(kIndexInFileMessages);
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kHeadingDegFieldNumber = 1,
+  };
+  // double heading_deg = 1 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_heading_deg();
+  double heading_deg() const;
+  void set_heading_deg(double value);
+  private:
+  double _internal_heading_deg() const;
+  void _internal_set_heading_deg(double value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.telemetry_server.Heading)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  double heading_deg_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_telemetry_5fserver_2ftelemetry_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
 class Quaternion PROTOBUF_FINAL :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.telemetry_server.Quaternion) */ {
  public:
@@ -5286,7 +5447,7 @@ class Quaternion PROTOBUF_FINAL :
                &_Quaternion_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    32;
+    33;
 
   friend void swap(Quaternion& a, Quaternion& b) {
     a.Swap(&b);
@@ -5467,7 +5628,7 @@ class EulerAngle PROTOBUF_FINAL :
                &_EulerAngle_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    33;
+    34;
 
   friend void swap(EulerAngle& a, EulerAngle& b) {
     a.Swap(&b);
@@ -5637,7 +5798,7 @@ class AngularVelocityBody PROTOBUF_FINAL :
                &_AngularVelocityBody_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    34;
+    35;
 
   friend void swap(AngularVelocityBody& a, AngularVelocityBody& b) {
     a.Swap(&b);
@@ -5796,7 +5957,7 @@ class GpsInfo PROTOBUF_FINAL :
                &_GpsInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    35;
+    36;
 
   friend void swap(GpsInfo& a, GpsInfo& b) {
     a.Swap(&b);
@@ -5944,7 +6105,7 @@ class RawGps PROTOBUF_FINAL :
                &_RawGps_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    36;
+    37;
 
   friend void swap(RawGps& a, RawGps& b) {
     a.Swap(&b);
@@ -6224,7 +6385,7 @@ class Battery PROTOBUF_FINAL :
                &_Battery_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    37;
+    38;
 
   friend void swap(Battery& a, Battery& b) {
     a.Swap(&b);
@@ -6372,7 +6533,7 @@ class RcStatus PROTOBUF_FINAL :
                &_RcStatus_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    38;
+    39;
 
   friend void swap(RcStatus& a, RcStatus& b) {
     a.Swap(&b);
@@ -6531,7 +6692,7 @@ class StatusText PROTOBUF_FINAL :
                &_StatusText_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    39;
+    40;
 
   friend void swap(StatusText& a, StatusText& b) {
     a.Swap(&b);
@@ -6686,7 +6847,7 @@ class ActuatorControlTarget PROTOBUF_FINAL :
                &_ActuatorControlTarget_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    40;
+    41;
 
   friend void swap(ActuatorControlTarget& a, ActuatorControlTarget& b) {
     a.Swap(&b);
@@ -6848,7 +7009,7 @@ class ActuatorOutputStatus PROTOBUF_FINAL :
                &_ActuatorOutputStatus_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    41;
+    42;
 
   friend void swap(ActuatorOutputStatus& a, ActuatorOutputStatus& b) {
     a.Swap(&b);
@@ -7010,7 +7171,7 @@ class Covariance PROTOBUF_FINAL :
                &_Covariance_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    42;
+    43;
 
   friend void swap(Covariance& a, Covariance& b) {
     a.Swap(&b);
@@ -7161,7 +7322,7 @@ class VelocityBody PROTOBUF_FINAL :
                &_VelocityBody_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    43;
+    44;
 
   friend void swap(VelocityBody& a, VelocityBody& b) {
     a.Swap(&b);
@@ -7320,7 +7481,7 @@ class PositionBody PROTOBUF_FINAL :
                &_PositionBody_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    44;
+    45;
 
   friend void swap(PositionBody& a, PositionBody& b) {
     a.Swap(&b);
@@ -7479,7 +7640,7 @@ class Odometry PROTOBUF_FINAL :
                &_Odometry_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    45;
+    46;
 
   friend void swap(Odometry& a, Odometry& b) {
     a.Swap(&b);
@@ -7792,7 +7953,7 @@ class DistanceSensor PROTOBUF_FINAL :
                &_DistanceSensor_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    46;
+    47;
 
   friend void swap(DistanceSensor& a, DistanceSensor& b) {
     a.Swap(&b);
@@ -7951,7 +8112,7 @@ class ScaledPressure PROTOBUF_FINAL :
                &_ScaledPressure_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    47;
+    48;
 
   friend void swap(ScaledPressure& a, ScaledPressure& b) {
     a.Swap(&b);
@@ -8132,7 +8293,7 @@ class PositionNed PROTOBUF_FINAL :
                &_PositionNed_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    48;
+    49;
 
   friend void swap(PositionNed& a, PositionNed& b) {
     a.Swap(&b);
@@ -8291,7 +8452,7 @@ class VelocityNed PROTOBUF_FINAL :
                &_VelocityNed_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    49;
+    50;
 
   friend void swap(VelocityNed& a, VelocityNed& b) {
     a.Swap(&b);
@@ -8450,7 +8611,7 @@ class PositionVelocityNed PROTOBUF_FINAL :
                &_PositionVelocityNed_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    50;
+    51;
 
   friend void swap(PositionVelocityNed& a, PositionVelocityNed& b) {
     a.Swap(&b);
@@ -8616,7 +8777,7 @@ class GroundTruth PROTOBUF_FINAL :
                &_GroundTruth_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    51;
+    52;
 
   friend void swap(GroundTruth& a, GroundTruth& b) {
     a.Swap(&b);
@@ -8775,7 +8936,7 @@ class FixedwingMetrics PROTOBUF_FINAL :
                &_FixedwingMetrics_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    52;
+    53;
 
   friend void swap(FixedwingMetrics& a, FixedwingMetrics& b) {
     a.Swap(&b);
@@ -8934,7 +9095,7 @@ class AccelerationFrd PROTOBUF_FINAL :
                &_AccelerationFrd_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    53;
+    54;
 
   friend void swap(AccelerationFrd& a, AccelerationFrd& b) {
     a.Swap(&b);
@@ -9093,7 +9254,7 @@ class AngularVelocityFrd PROTOBUF_FINAL :
                &_AngularVelocityFrd_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    54;
+    55;
 
   friend void swap(AngularVelocityFrd& a, AngularVelocityFrd& b) {
     a.Swap(&b);
@@ -9252,7 +9413,7 @@ class MagneticFieldFrd PROTOBUF_FINAL :
                &_MagneticFieldFrd_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    55;
+    56;
 
   friend void swap(MagneticFieldFrd& a, MagneticFieldFrd& b) {
     a.Swap(&b);
@@ -9411,7 +9572,7 @@ class Imu PROTOBUF_FINAL :
                &_Imu_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    56;
+    57;
 
   friend void swap(Imu& a, Imu& b) {
     a.Swap(&b);
@@ -9619,7 +9780,7 @@ class TelemetryServerResult PROTOBUF_FINAL :
                &_TelemetryServerResult_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    57;
+    58;
 
   friend void swap(TelemetryServerResult& a, TelemetryServerResult& b) {
     a.Swap(&b);
@@ -9946,6 +10107,89 @@ inline void PublishPositionRequest::set_allocated_velocity_ned(::mavsdk::rpc::te
   }
   velocity_ned_ = velocity_ned;
   // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.telemetry_server.PublishPositionRequest.velocity_ned)
+}
+
+// .mavsdk.rpc.telemetry_server.Heading heading = 3;
+inline bool PublishPositionRequest::_internal_has_heading() const {
+  return this != internal_default_instance() && heading_ != nullptr;
+}
+inline bool PublishPositionRequest::has_heading() const {
+  return _internal_has_heading();
+}
+inline void PublishPositionRequest::clear_heading() {
+  if (GetArena() == nullptr && heading_ != nullptr) {
+    delete heading_;
+  }
+  heading_ = nullptr;
+}
+inline const ::mavsdk::rpc::telemetry_server::Heading& PublishPositionRequest::_internal_heading() const {
+  const ::mavsdk::rpc::telemetry_server::Heading* p = heading_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::telemetry_server::Heading&>(
+      ::mavsdk::rpc::telemetry_server::_Heading_default_instance_);
+}
+inline const ::mavsdk::rpc::telemetry_server::Heading& PublishPositionRequest::heading() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry_server.PublishPositionRequest.heading)
+  return _internal_heading();
+}
+inline void PublishPositionRequest::unsafe_arena_set_allocated_heading(
+    ::mavsdk::rpc::telemetry_server::Heading* heading) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(heading_);
+  }
+  heading_ = heading;
+  if (heading) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.telemetry_server.PublishPositionRequest.heading)
+}
+inline ::mavsdk::rpc::telemetry_server::Heading* PublishPositionRequest::release_heading() {
+  
+  ::mavsdk::rpc::telemetry_server::Heading* temp = heading_;
+  heading_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::mavsdk::rpc::telemetry_server::Heading* PublishPositionRequest::unsafe_arena_release_heading() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.telemetry_server.PublishPositionRequest.heading)
+  
+  ::mavsdk::rpc::telemetry_server::Heading* temp = heading_;
+  heading_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::telemetry_server::Heading* PublishPositionRequest::_internal_mutable_heading() {
+  
+  if (heading_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::telemetry_server::Heading>(GetArena());
+    heading_ = p;
+  }
+  return heading_;
+}
+inline ::mavsdk::rpc::telemetry_server::Heading* PublishPositionRequest::mutable_heading() {
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.telemetry_server.PublishPositionRequest.heading)
+  return _internal_mutable_heading();
+}
+inline void PublishPositionRequest::set_allocated_heading(::mavsdk::rpc::telemetry_server::Heading* heading) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete heading_;
+  }
+  if (heading) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(heading);
+    if (message_arena != submessage_arena) {
+      heading = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, heading, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  heading_ = heading;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.telemetry_server.PublishPositionRequest.heading)
 }
 
 // -------------------------------------------------------------------
@@ -12591,6 +12835,30 @@ inline void Position::_internal_set_relative_altitude_m(float value) {
 inline void Position::set_relative_altitude_m(float value) {
   _internal_set_relative_altitude_m(value);
   // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry_server.Position.relative_altitude_m)
+}
+
+// -------------------------------------------------------------------
+
+// Heading
+
+// double heading_deg = 1 [(.mavsdk.options.default_value) = "NaN"];
+inline void Heading::clear_heading_deg() {
+  heading_deg_ = 0;
+}
+inline double Heading::_internal_heading_deg() const {
+  return heading_deg_;
+}
+inline double Heading::heading_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry_server.Heading.heading_deg)
+  return _internal_heading_deg();
+}
+inline void Heading::_internal_set_heading_deg(double value) {
+  
+  heading_deg_ = value;
+}
+inline void Heading::set_heading_deg(double value) {
+  _internal_set_heading_deg(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry_server.Heading.heading_deg)
 }
 
 // -------------------------------------------------------------------
@@ -15416,6 +15684,8 @@ inline void TelemetryServerResult::set_allocated_result_str(std::string* result_
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/src/mavsdk_server/src/plugins/telemetry/telemetry_service_impl.h
+++ b/src/mavsdk_server/src/plugins/telemetry/telemetry_service_impl.h
@@ -291,6 +291,26 @@ public:
         return obj;
     }
 
+    static std::unique_ptr<rpc::telemetry::Heading>
+    translateToRpcHeading(const mavsdk::Telemetry::Heading& heading)
+    {
+        auto rpc_obj = std::make_unique<rpc::telemetry::Heading>();
+
+        rpc_obj->set_heading_deg(heading.heading_deg);
+
+        return rpc_obj;
+    }
+
+    static mavsdk::Telemetry::Heading
+    translateFromRpcHeading(const rpc::telemetry::Heading& heading)
+    {
+        mavsdk::Telemetry::Heading obj;
+
+        obj.heading_deg = heading.heading_deg();
+
+        return obj;
+    }
+
     static std::unique_ptr<rpc::telemetry::Quaternion>
     translateToRpcQuaternion(const mavsdk::Telemetry::Quaternion& quaternion)
     {
@@ -2481,6 +2501,46 @@ public:
                 std::unique_lock<std::mutex> lock(*subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
                     _lazy_plugin.maybe_plugin()->subscribe_scaled_pressure(nullptr);
+
+                    *is_finished = true;
+                    unregister_stream_stop_promise(stream_closed_promise);
+                    stream_closed_promise->set_value();
+                }
+            });
+
+        stream_closed_future.wait();
+        std::unique_lock<std::mutex> lock(*subscribe_mutex);
+        *is_finished = true;
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status SubscribeHeading(
+        grpc::ServerContext* /* context */,
+        const mavsdk::rpc::telemetry::SubscribeHeadingRequest* /* request */,
+        grpc::ServerWriter<rpc::telemetry::HeadingResponse>* writer) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            return grpc::Status::OK;
+        }
+
+        auto stream_closed_promise = std::make_shared<std::promise<void>>();
+        auto stream_closed_future = stream_closed_promise->get_future();
+        register_stream_stop_promise(stream_closed_promise);
+
+        auto is_finished = std::make_shared<bool>(false);
+        auto subscribe_mutex = std::make_shared<std::mutex>();
+
+        _lazy_plugin.maybe_plugin()->subscribe_heading(
+            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex](
+                const mavsdk::Telemetry::Heading heading) {
+                rpc::telemetry::HeadingResponse rpc_response;
+
+                rpc_response.set_allocated_heading_deg(translateToRpcHeading(heading).release());
+
+                std::unique_lock<std::mutex> lock(*subscribe_mutex);
+                if (!*is_finished && !writer->Write(rpc_response)) {
+                    _lazy_plugin.maybe_plugin()->subscribe_heading(nullptr);
 
                     *is_finished = true;
                     unregister_stream_stop_promise(stream_closed_promise);

--- a/src/mavsdk_server/src/plugins/telemetry_server/telemetry_server_service_impl.h
+++ b/src/mavsdk_server/src/plugins/telemetry_server/telemetry_server_service_impl.h
@@ -257,6 +257,26 @@ public:
         return obj;
     }
 
+    static std::unique_ptr<rpc::telemetry_server::Heading>
+    translateToRpcHeading(const mavsdk::TelemetryServer::Heading& heading)
+    {
+        auto rpc_obj = std::make_unique<rpc::telemetry_server::Heading>();
+
+        rpc_obj->set_heading_deg(heading.heading_deg);
+
+        return rpc_obj;
+    }
+
+    static mavsdk::TelemetryServer::Heading
+    translateFromRpcHeading(const rpc::telemetry_server::Heading& heading)
+    {
+        mavsdk::TelemetryServer::Heading obj;
+
+        obj.heading_deg = heading.heading_deg();
+
+        return obj;
+    }
+
     static std::unique_ptr<rpc::telemetry_server::Quaternion>
     translateToRpcQuaternion(const mavsdk::TelemetryServer::Quaternion& quaternion)
     {
@@ -1159,7 +1179,8 @@ public:
 
         auto result = _lazy_plugin.maybe_plugin()->publish_position(
             translateFromRpcPosition(request->position()),
-            translateFromRpcVelocityNed(request->velocity_ned()));
+            translateFromRpcVelocityNed(request->velocity_ned()),
+            translateFromRpcHeading(request->heading()));
 
         if (response != nullptr) {
             fillResponseWithResult(response, result);

--- a/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -175,6 +175,27 @@ public:
     friend std::ostream& operator<<(std::ostream& str, Telemetry::Position const& position);
 
     /**
+     * @brief Heading type used for global position
+     */
+    struct Heading {
+        double heading_deg{double(NAN)}; /**< @brief Heading in degrees (range: 0 to +360) */
+    };
+
+    /**
+     * @brief Equal operator to compare two `Telemetry::Heading` objects.
+     *
+     * @return `true` if items are equal.
+     */
+    friend bool operator==(const Telemetry::Heading& lhs, const Telemetry::Heading& rhs);
+
+    /**
+     * @brief Stream operator to print information about a `Telemetry::Heading`.
+     *
+     * @return A reference to the stream.
+     */
+    friend std::ostream& operator<<(std::ostream& str, Telemetry::Heading const& heading);
+
+    /**
      * @brief Quaternion type.
      *
      * All rotations and axis systems follow the right-hand rule.
@@ -1499,6 +1520,24 @@ public:
      * @return One ScaledPressure update.
      */
     ScaledPressure scaled_pressure() const;
+
+    /**
+     * @brief Callback type for subscribe_heading.
+     */
+
+    using HeadingCallback = std::function<void(Heading)>;
+
+    /**
+     * @brief Subscribe to 'Heading' updates.
+     */
+    void subscribe_heading(HeadingCallback callback);
+
+    /**
+     * @brief Poll for 'Heading' (blocking).
+     *
+     * @return One Heading update.
+     */
+    Heading heading() const;
 
     /**
      * @brief Set rate to 'position' updates.

--- a/src/plugins/telemetry/mocks/telemetry_mock.h
+++ b/src/plugins/telemetry/mocks/telemetry_mock.h
@@ -9,6 +9,7 @@ class MockTelemetry {
 public:
     MOCK_CONST_METHOD1(subscribe_position, void(Telemetry::PositionCallback)){};
     MOCK_CONST_METHOD1(subscribe_health, void(Telemetry::HealthCallback)){};
+    MOCK_CONST_METHOD1(subscribe_heading, void(Telemetry::HeadingCallback)){};
     MOCK_CONST_METHOD1(subscribe_home, void(Telemetry::PositionCallback)){};
     MOCK_CONST_METHOD1(subscribe_in_air, void(Telemetry::InAirCallback)){};
     MOCK_CONST_METHOD1(subscribe_status_text, void(Telemetry::StatusTextCallback)){};

--- a/src/plugins/telemetry/telemetry.cpp
+++ b/src/plugins/telemetry/telemetry.cpp
@@ -10,6 +10,7 @@
 namespace mavsdk {
 
 using Position = Telemetry::Position;
+using Heading = Telemetry::Heading;
 using Quaternion = Telemetry::Quaternion;
 using EulerAngle = Telemetry::EulerAngle;
 using AngularVelocityBody = Telemetry::AngularVelocityBody;
@@ -359,6 +360,16 @@ Telemetry::ScaledPressure Telemetry::scaled_pressure() const
     return _impl->scaled_pressure();
 }
 
+void Telemetry::subscribe_heading(HeadingCallback callback)
+{
+    _impl->subscribe_heading(callback);
+}
+
+Telemetry::Heading Telemetry::heading() const
+{
+    return _impl->heading();
+}
+
 void Telemetry::set_rate_position_async(double rate_hz, const ResultCallback callback)
 {
     _impl->set_rate_position_async(rate_hz, callback);
@@ -600,6 +611,22 @@ std::ostream& operator<<(std::ostream& str, Telemetry::Position const& position)
     str << "    longitude_deg: " << position.longitude_deg << '\n';
     str << "    absolute_altitude_m: " << position.absolute_altitude_m << '\n';
     str << "    relative_altitude_m: " << position.relative_altitude_m << '\n';
+    str << '}';
+    return str;
+}
+
+bool operator==(const Telemetry::Heading& lhs, const Telemetry::Heading& rhs)
+{
+    return (
+        (std::isnan(rhs.heading_deg) && std::isnan(lhs.heading_deg)) ||
+        rhs.heading_deg == lhs.heading_deg);
+}
+
+std::ostream& operator<<(std::ostream& str, Telemetry::Heading const& heading)
+{
+    str << std::setprecision(15);
+    str << "heading:" << '\n' << "{\n";
+    str << "    heading_deg: " << heading.heading_deg << '\n';
     str << '}';
     return str;
 }

--- a/src/plugins/telemetry/telemetry_impl.h
+++ b/src/plugins/telemetry/telemetry_impl.h
@@ -105,6 +105,7 @@ public:
     Telemetry::DistanceSensor distance_sensor() const;
     Telemetry::ScaledPressure scaled_pressure() const;
     uint64_t unix_epoch_time() const;
+    Telemetry::Heading heading() const;
 
     void subscribe_position_velocity_ned(Telemetry::PositionVelocityNedCallback& callback);
     void subscribe_position(Telemetry::PositionCallback& callback);
@@ -138,6 +139,7 @@ public:
     void subscribe_odometry(Telemetry::OdometryCallback& callback);
     void subscribe_distance_sensor(Telemetry::DistanceSensorCallback& callback);
     void subscribe_scaled_pressure(Telemetry::ScaledPressureCallback& callback);
+    void subscribe_heading(Telemetry::HeadingCallback& callback);
 
     TelemetryImpl(const TelemetryImpl&) = delete;
     TelemetryImpl& operator=(const TelemetryImpl&) = delete;
@@ -176,6 +178,7 @@ private:
     void set_odometry(Telemetry::Odometry& odometry);
     void set_distance_sensor(Telemetry::DistanceSensor& distance_sensor);
     void set_scaled_pressure(Telemetry::ScaledPressure& scaled_pressure);
+    void set_heading(Telemetry::Heading heading);
 
     void process_position_velocity_ned(const mavlink_message_t& message);
     void process_global_position_int(const mavlink_message_t& message);
@@ -232,6 +235,9 @@ private:
     // methods marked const.
     mutable std::mutex _position_mutex{};
     Telemetry::Position _position{};
+
+    mutable std::mutex _heading_mutex{};
+    Telemetry::Heading _heading{};
 
     mutable std::mutex _position_velocity_ned_mutex{};
     Telemetry::PositionVelocityNed _position_velocity_ned{};
@@ -344,6 +350,7 @@ private:
     Telemetry::OdometryCallback _odometry_subscription{nullptr};
     Telemetry::DistanceSensorCallback _distance_sensor_subscription{nullptr};
     Telemetry::ScaledPressureCallback _scaled_pressure_subscription{nullptr};
+    Telemetry::HeadingCallback _heading_subscription{nullptr};
 
     // The velocity (former ground speed) and position are coupled to the same message, therefore,
     // we just use the faster between the two.

--- a/src/plugins/telemetry_server/include/plugins/telemetry_server/telemetry_server.h
+++ b/src/plugins/telemetry_server/include/plugins/telemetry_server/telemetry_server.h
@@ -166,6 +166,28 @@ public:
     friend std::ostream& operator<<(std::ostream& str, TelemetryServer::Position const& position);
 
     /**
+     * @brief Heading type used for global position
+     */
+    struct Heading {
+        double heading_deg{double(NAN)}; /**< @brief Heading in degrees (range: 0 to +360) */
+    };
+
+    /**
+     * @brief Equal operator to compare two `TelemetryServer::Heading` objects.
+     *
+     * @return `true` if items are equal.
+     */
+    friend bool
+    operator==(const TelemetryServer::Heading& lhs, const TelemetryServer::Heading& rhs);
+
+    /**
+     * @brief Stream operator to print information about a `TelemetryServer::Heading`.
+     *
+     * @return A reference to the stream.
+     */
+    friend std::ostream& operator<<(std::ostream& str, TelemetryServer::Heading const& heading);
+
+    /**
      * @brief Quaternion type.
      *
      * All rotations and axis systems follow the right-hand rule.
@@ -907,7 +929,7 @@ public:
      *
      * @return Result of request.
      */
-    Result publish_position(Position position, VelocityNed velocity_ned) const;
+    Result publish_position(Position position, VelocityNed velocity_ned, Heading heading) const;
 
     /**
      * @brief Publish to 'home position' updates.

--- a/src/plugins/telemetry_server/telemetry_server.cpp
+++ b/src/plugins/telemetry_server/telemetry_server.cpp
@@ -11,6 +11,7 @@
 namespace mavsdk {
 
 using Position = TelemetryServer::Position;
+using Heading = TelemetryServer::Heading;
 using Quaternion = TelemetryServer::Quaternion;
 using EulerAngle = TelemetryServer::EulerAngle;
 using AngularVelocityBody = TelemetryServer::AngularVelocityBody;
@@ -49,10 +50,10 @@ TelemetryServer::TelemetryServer(std::shared_ptr<System> system) :
 
 TelemetryServer::~TelemetryServer() {}
 
-TelemetryServer::Result
-TelemetryServer::publish_position(Position position, VelocityNed velocity_ned) const
+TelemetryServer::Result TelemetryServer::publish_position(
+    Position position, VelocityNed velocity_ned, Heading heading) const
 {
-    return _impl->publish_position(position, velocity_ned);
+    return _impl->publish_position(position, velocity_ned, heading);
 }
 
 TelemetryServer::Result TelemetryServer::publish_home(Position home) const
@@ -149,6 +150,22 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::Position const& pos
     str << "    longitude_deg: " << position.longitude_deg << '\n';
     str << "    absolute_altitude_m: " << position.absolute_altitude_m << '\n';
     str << "    relative_altitude_m: " << position.relative_altitude_m << '\n';
+    str << '}';
+    return str;
+}
+
+bool operator==(const TelemetryServer::Heading& lhs, const TelemetryServer::Heading& rhs)
+{
+    return (
+        (std::isnan(rhs.heading_deg) && std::isnan(lhs.heading_deg)) ||
+        rhs.heading_deg == lhs.heading_deg);
+}
+
+std::ostream& operator<<(std::ostream& str, TelemetryServer::Heading const& heading)
+{
+    str << std::setprecision(15);
+    str << "heading:" << '\n' << "{\n";
+    str << "    heading_deg: " << heading.heading_deg << '\n';
     str << '}';
     return str;
 }

--- a/src/plugins/telemetry_server/telemetry_server_impl.cpp
+++ b/src/plugins/telemetry_server/telemetry_server_impl.cpp
@@ -91,7 +91,9 @@ void TelemetryServerImpl::enable() {}
 void TelemetryServerImpl::disable() {}
 
 TelemetryServer::Result TelemetryServerImpl::publish_position(
-    TelemetryServer::Position position, TelemetryServer::VelocityNed velocity_ned)
+    TelemetryServer::Position position,
+    TelemetryServer::VelocityNed velocity_ned,
+    TelemetryServer::Heading heading)
 {
     mavlink_message_t msg;
     mavlink_msg_global_position_int_pack(
@@ -106,8 +108,7 @@ TelemetryServer::Result TelemetryServerImpl::publish_position(
         static_cast<uint32_t>(static_cast<double>(velocity_ned.north_m_s) * 1E2),
         static_cast<uint32_t>(static_cast<double>(velocity_ned.east_m_s) * 1E2),
         static_cast<uint32_t>(static_cast<double>(velocity_ned.down_m_s) * 1E2),
-        0 // T0-DO: heading
-    );
+        static_cast<uint32_t>(static_cast<double>(heading.heading_deg) * 1E2));
 
     add_msg_cache(MAVLINK_MSG_ID_GLOBAL_POSITION_INT, msg);
 

--- a/src/plugins/telemetry_server/telemetry_server_impl.h
+++ b/src/plugins/telemetry_server/telemetry_server_impl.h
@@ -31,8 +31,10 @@ public:
         TelemetryServer::VelocityNed velocity_ned,
         const TelemetryServer::ResultCallback callback);
 
-    TelemetryServer::Result
-    publish_position(TelemetryServer::Position position, TelemetryServer::VelocityNed velocity_ned);
+    TelemetryServer::Result publish_position(
+        TelemetryServer::Position position,
+        TelemetryServer::VelocityNed velocity_ned,
+        TelemetryServer::Heading heading);
 
     TelemetryServer::Result publish_home(TelemetryServer::Position home);
 


### PR DESCRIPTION
https://github.com/mavlink/MAVSDK-Proto/pull/246

We are not parsing or providing the heading value in the `global_position_int` message used in telemetry plugins. This add that functionality.