### PR TITLE
Add `param_set` handling

### DIFF
--- a/src/core/mavlink_parameters.cpp
+++ b/src/core/mavlink_parameters.cpp
@@ -726,7 +726,7 @@ void MAVLinkParameters::process_param_set(const mavlink_message_t& message)
         if (_param_server_store.find(safe_param_id) != _param_server_store.end()) {
             ParamValue value{};
             if (!value.set_from_mavlink_param_set(set_request)) {
-                LogDebug() << "Invalid Param Set Request: " << safe_param_id;
+                LogWarn() << "Invalid Param Set Request: " << safe_param_id;
                 return;
             }
             _param_server_store.at(safe_param_id) = value;
@@ -739,6 +739,8 @@ void MAVLinkParameters::process_param_set(const mavlink_message_t& message)
         } else {
             LogDebug() << "Missing Param: " << safe_param_id;
         }
+    } else {
+        LogWarn() << "Invalid Param Set ID Request: " << safe_param_id;
     }
 }
 

--- a/src/core/mavlink_parameters.h
+++ b/src/core/mavlink_parameters.h
@@ -23,7 +23,7 @@ public:
 
     class ParamValue {
     public:
-        void set_from_mavlink_param_value(mavlink_param_value_t mavlink_value)
+        bool set_from_mavlink_param_value(mavlink_param_value_t mavlink_value)
         {
             union {
                 float float_value;
@@ -43,8 +43,17 @@ public:
                 default:
                     // This would be worrying
                     LogErr() << "Error: unknown mavlink param type";
-                    break;
+                    return false;
             }
+            return true;
+        }
+
+        bool set_from_mavlink_param_set(mavlink_param_set_t mavlink_set)
+        {
+            mavlink_param_value_t mavlink_value{};
+            mavlink_value.param_value = mavlink_set.param_value;
+            mavlink_value.param_type = mavlink_set.param_type;
+            return set_from_mavlink_param_value(mavlink_value);
         }
 
         void set_from_mavlink_param_ext_value(mavlink_param_ext_value_t mavlink_ext_value)
@@ -498,6 +507,7 @@ public:
 
 private:
     void process_param_value(const mavlink_message_t& message);
+    void process_param_set(const mavlink_message_t& message);
     void process_param_ext_value(const mavlink_message_t& message);
     void process_param_ext_ack(const mavlink_message_t& message);
     void receive_timeout();
@@ -558,7 +568,6 @@ private:
     void process_param_request_read(const mavlink_message_t& message);
     void process_param_ext_request_read(const mavlink_message_t& message);
     void process_param_request_list(const mavlink_message_t& message);
-    void process_param_set(const mavlink_message_t& message);
 };
 
 } // namespace mavsdk


### PR DESCRIPTION
Missed the ability to set parameters clientside when I added the `param_server` plugin. 

Handles `param_set` requests and returns the value to confirm if successful.

Fills that gap :)