### PR TITLE
mission: add support for DO_GIMBAL_MANAGER_CONFIGURE in mission download

### DIFF
--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -569,6 +569,10 @@ std::pair<Mission::Result, Mission::MissionPlan> MissionImpl::convert_to_result_
                 new_mission_item.gimbal_pitch_deg = int_item.param1;
                 new_mission_item.gimbal_yaw_deg = int_item.param2;
 
+            } else if (int_item.command == MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE) {
+                // We need to ignore it in order to not throw an "Unsupported" error
+                break;
+
             } else if (int_item.command == MAV_CMD_DO_MOUNT_CONFIGURE) {
                 if (int(int_item.param1) != MAV_MOUNT_MODE_MAVLINK_TARGETING) {
                     LogErr() << "Gimbal mount configure mode unsupported";


### PR DESCRIPTION
It should just be ignored when downloading because that's an implementation detail as far as the Mission plugin is concerned. It will be added back when uploading, if I understand the code correctly :+1:.