### PR TITLE
Update proto submodule

### DIFF
--- a/src/mavsdk_server/src/generated/action_server/action_server.grpc.pb.cc
+++ b/src/mavsdk_server/src/generated/action_server/action_server.grpc.pb.cc
@@ -240,46 +240,46 @@ void ActionServerService::Stub::async::SetDisarmable(::grpc::ClientContext* cont
   return result;
 }
 
-::grpc::Status ActionServerService::Stub::SetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest& request, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* response) {
-  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_SetAllowableFlightModes_, context, request, response);
+::grpc::Status ActionServerService::Stub::SetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest& request, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_SetAllowableFlightModes_, context, request, response);
 }
 
-void ActionServerService::Stub::async::SetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest* request, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* response, std::function<void(::grpc::Status)> f) {
-  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetAllowableFlightModes_, context, request, response, std::move(f));
+void ActionServerService::Stub::async::SetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetAllowableFlightModes_, context, request, response, std::move(f));
 }
 
-void ActionServerService::Stub::async::SetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest* request, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+void ActionServerService::Stub::async::SetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* response, ::grpc::ClientUnaryReactor* reactor) {
   ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetAllowableFlightModes_, context, request, response, reactor);
 }
 
-::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>* ActionServerService::Stub::PrepareAsyncSetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse, ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_SetAllowableFlightModes_, context, request);
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>* ActionServerService::Stub::PrepareAsyncSetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse, ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_SetAllowableFlightModes_, context, request);
 }
 
-::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>* ActionServerService::Stub::AsyncSetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest& request, ::grpc::CompletionQueue* cq) {
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>* ActionServerService::Stub::AsyncSetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) {
   auto* result =
     this->PrepareAsyncSetAllowableFlightModesRaw(context, request, cq);
   result->StartCall();
   return result;
 }
 
-::grpc::Status ActionServerService::Stub::GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest& request, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* response) {
-  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_GetAllowableFlightModes_, context, request, response);
+::grpc::Status ActionServerService::Stub::GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest& request, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_GetAllowableFlightModes_, context, request, response);
 }
 
-void ActionServerService::Stub::async::GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* response, std::function<void(::grpc::Status)> f) {
-  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_GetAllowableFlightModes_, context, request, response, std::move(f));
+void ActionServerService::Stub::async::GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_GetAllowableFlightModes_, context, request, response, std::move(f));
 }
 
-void ActionServerService::Stub::async::GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+void ActionServerService::Stub::async::GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* response, ::grpc::ClientUnaryReactor* reactor) {
   ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_GetAllowableFlightModes_, context, request, response, reactor);
 }
 
-::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>* ActionServerService::Stub::PrepareAsyncGetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse, ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_GetAllowableFlightModes_, context, request);
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>* ActionServerService::Stub::PrepareAsyncGetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse, ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_GetAllowableFlightModes_, context, request);
 }
 
-::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>* ActionServerService::Stub::AsyncGetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest& request, ::grpc::CompletionQueue* cq) {
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>* ActionServerService::Stub::AsyncGetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) {
   auto* result =
     this->PrepareAsyncGetAllowableFlightModesRaw(context, request, cq);
   result->StartCall();
@@ -390,21 +390,21 @@ ActionServerService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       ActionServerService_method_names[10],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler< ActionServerService::Service, ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+      new ::grpc::internal::RpcMethodHandler< ActionServerService::Service, ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](ActionServerService::Service* service,
              ::grpc::ServerContext* ctx,
-             const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest* req,
-             ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* resp) {
+             const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* req,
+             ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* resp) {
                return service->SetAllowableFlightModes(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       ActionServerService_method_names[11],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler< ActionServerService::Service, ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+      new ::grpc::internal::RpcMethodHandler< ActionServerService::Service, ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](ActionServerService::Service* service,
              ::grpc::ServerContext* ctx,
-             const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest* req,
-             ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* resp) {
+             const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* req,
+             ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* resp) {
                return service->GetAllowableFlightModes(ctx, req, resp);
              }, this)));
 }
@@ -482,14 +482,14 @@ ActionServerService::Service::~Service() {
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
-::grpc::Status ActionServerService::Service::SetAllowableFlightModes(::grpc::ServerContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest* request, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* response) {
+::grpc::Status ActionServerService::Service::SetAllowableFlightModes(::grpc::ServerContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* response) {
   (void) context;
   (void) request;
   (void) response;
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
-::grpc::Status ActionServerService::Service::GetAllowableFlightModes(::grpc::ServerContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* response) {
+::grpc::Status ActionServerService::Service::GetAllowableFlightModes(::grpc::ServerContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/src/mavsdk_server/src/generated/action_server/action_server.grpc.pb.h
+++ b/src/mavsdk_server/src/generated/action_server/action_server.grpc.pb.h
@@ -133,20 +133,20 @@ class ActionServerService final {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetDisarmableResponse>>(PrepareAsyncSetDisarmableRaw(context, request, cq));
     }
     // Set which modes the vehicle can transition to (Manual always allowed)
-    virtual ::grpc::Status SetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest& request, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* response) = 0;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>> AsyncSetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>>(AsyncSetAllowableFlightModesRaw(context, request, cq));
+    virtual ::grpc::Status SetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest& request, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>> AsyncSetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>>(AsyncSetAllowableFlightModesRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>> PrepareAsyncSetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>>(PrepareAsyncSetAllowableFlightModesRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>> PrepareAsyncSetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>>(PrepareAsyncSetAllowableFlightModesRaw(context, request, cq));
     }
     // Get which modes the vehicle can transition to (Manual always allowed)
-    virtual ::grpc::Status GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest& request, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* response) = 0;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>> AsyncGetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>>(AsyncGetAllowableFlightModesRaw(context, request, cq));
+    virtual ::grpc::Status GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest& request, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>> AsyncGetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>>(AsyncGetAllowableFlightModesRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>> PrepareAsyncGetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>>(PrepareAsyncGetAllowableFlightModesRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>> PrepareAsyncGetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>>(PrepareAsyncGetAllowableFlightModesRaw(context, request, cq));
     }
     class async_interface {
      public:
@@ -175,11 +175,11 @@ class ActionServerService final {
       virtual void SetDisarmable(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetDisarmableRequest* request, ::mavsdk::rpc::action_server::SetDisarmableResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void SetDisarmable(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetDisarmableRequest* request, ::mavsdk::rpc::action_server::SetDisarmableResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       // Set which modes the vehicle can transition to (Manual always allowed)
-      virtual void SetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest* request, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* response, std::function<void(::grpc::Status)>) = 0;
-      virtual void SetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest* request, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      virtual void SetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void SetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       // Get which modes the vehicle can transition to (Manual always allowed)
-      virtual void GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* response, std::function<void(::grpc::Status)>) = 0;
-      virtual void GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      virtual void GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
     };
     typedef class async_interface experimental_async_interface;
     virtual class async_interface* async() { return nullptr; }
@@ -212,10 +212,10 @@ class ActionServerService final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetArmableResponse>* PrepareAsyncSetArmableRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmableRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetDisarmableResponse>* AsyncSetDisarmableRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetDisarmableRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetDisarmableResponse>* PrepareAsyncSetDisarmableRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetDisarmableRequest& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>* AsyncSetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>* PrepareAsyncSetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>* AsyncGetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>* PrepareAsyncGetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>* AsyncSetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>* PrepareAsyncSetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>* AsyncGetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>* PrepareAsyncGetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
@@ -304,19 +304,19 @@ class ActionServerService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetDisarmableResponse>> PrepareAsyncSetDisarmable(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetDisarmableRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetDisarmableResponse>>(PrepareAsyncSetDisarmableRaw(context, request, cq));
     }
-    ::grpc::Status SetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest& request, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* response) override;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>> AsyncSetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>>(AsyncSetAllowableFlightModesRaw(context, request, cq));
+    ::grpc::Status SetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest& request, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>> AsyncSetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>>(AsyncSetAllowableFlightModesRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>> PrepareAsyncSetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>>(PrepareAsyncSetAllowableFlightModesRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>> PrepareAsyncSetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>>(PrepareAsyncSetAllowableFlightModesRaw(context, request, cq));
     }
-    ::grpc::Status GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest& request, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* response) override;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>> AsyncGetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>>(AsyncGetAllowableFlightModesRaw(context, request, cq));
+    ::grpc::Status GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest& request, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>> AsyncGetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>>(AsyncGetAllowableFlightModesRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>> PrepareAsyncGetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>>(PrepareAsyncGetAllowableFlightModesRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>> PrepareAsyncGetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>>(PrepareAsyncGetAllowableFlightModesRaw(context, request, cq));
     }
     class async final :
       public StubInterface::async_interface {
@@ -334,10 +334,10 @@ class ActionServerService final {
       void SetArmable(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmableRequest* request, ::mavsdk::rpc::action_server::SetArmableResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void SetDisarmable(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetDisarmableRequest* request, ::mavsdk::rpc::action_server::SetDisarmableResponse* response, std::function<void(::grpc::Status)>) override;
       void SetDisarmable(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetDisarmableRequest* request, ::mavsdk::rpc::action_server::SetDisarmableResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
-      void SetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest* request, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* response, std::function<void(::grpc::Status)>) override;
-      void SetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest* request, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
-      void GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* response, std::function<void(::grpc::Status)>) override;
-      void GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* response, std::function<void(::grpc::Status)>) override;
+      void SetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* response, std::function<void(::grpc::Status)>) override;
+      void GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
      private:
       friend class Stub;
       explicit async(Stub* stub): stub_(stub) { }
@@ -376,10 +376,10 @@ class ActionServerService final {
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetArmableResponse>* PrepareAsyncSetArmableRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmableRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetDisarmableResponse>* AsyncSetDisarmableRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetDisarmableRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetDisarmableResponse>* PrepareAsyncSetDisarmableRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetDisarmableRequest& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>* AsyncSetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>* PrepareAsyncSetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>* AsyncGetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>* PrepareAsyncGetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>* AsyncSetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>* PrepareAsyncSetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>* AsyncGetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>* PrepareAsyncGetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeArmDisarm_;
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeFlightModeChange_;
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeTakeoff_;
@@ -420,9 +420,9 @@ class ActionServerService final {
     // Can the vehicle disarm when requested
     virtual ::grpc::Status SetDisarmable(::grpc::ServerContext* context, const ::mavsdk::rpc::action_server::SetDisarmableRequest* request, ::mavsdk::rpc::action_server::SetDisarmableResponse* response);
     // Set which modes the vehicle can transition to (Manual always allowed)
-    virtual ::grpc::Status SetAllowableFlightModes(::grpc::ServerContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest* request, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* response);
+    virtual ::grpc::Status SetAllowableFlightModes(::grpc::ServerContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* response);
     // Get which modes the vehicle can transition to (Manual always allowed)
-    virtual ::grpc::Status GetAllowableFlightModes(::grpc::ServerContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* response);
+    virtual ::grpc::Status GetAllowableFlightModes(::grpc::ServerContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* response);
   };
   template <class BaseClass>
   class WithAsyncMethod_SubscribeArmDisarm : public BaseClass {
@@ -636,11 +636,11 @@ class ActionServerService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status SetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* /*response*/) override {
+    ::grpc::Status SetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* /*request*/, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestSetAllowableFlightModes(::grpc::ServerContext* context, ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+    void RequestSetAllowableFlightModes(::grpc::ServerContext* context, ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
@@ -656,11 +656,11 @@ class ActionServerService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status GetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* /*response*/) override {
+    ::grpc::Status GetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* /*request*/, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestGetAllowableFlightModes(::grpc::ServerContext* context, ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+    void RequestGetAllowableFlightModes(::grpc::ServerContext* context, ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
@@ -907,25 +907,25 @@ class ActionServerService final {
    public:
     WithCallbackMethod_SetAllowableFlightModes() {
       ::grpc::Service::MarkMethodCallback(10,
-          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>(
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>(
             [this](
-                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest* request, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* response) { return this->SetAllowableFlightModes(context, request, response); }));}
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* response) { return this->SetAllowableFlightModes(context, request, response); }));}
     void SetMessageAllocatorFor_SetAllowableFlightModes(
-        ::grpc::MessageAllocator< ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>* allocator) {
+        ::grpc::MessageAllocator< ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>* allocator) {
       ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(10);
-      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>*>(handler)
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
     ~WithCallbackMethod_SetAllowableFlightModes() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status SetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* /*response*/) override {
+    ::grpc::Status SetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* /*request*/, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     virtual ::grpc::ServerUnaryReactor* SetAllowableFlightModes(
-      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* /*response*/)  { return nullptr; }
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* /*request*/, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
   class WithCallbackMethod_GetAllowableFlightModes : public BaseClass {
@@ -934,25 +934,25 @@ class ActionServerService final {
    public:
     WithCallbackMethod_GetAllowableFlightModes() {
       ::grpc::Service::MarkMethodCallback(11,
-          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>(
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>(
             [this](
-                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* response) { return this->GetAllowableFlightModes(context, request, response); }));}
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* response) { return this->GetAllowableFlightModes(context, request, response); }));}
     void SetMessageAllocatorFor_GetAllowableFlightModes(
-        ::grpc::MessageAllocator< ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>* allocator) {
+        ::grpc::MessageAllocator< ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>* allocator) {
       ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(11);
-      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>*>(handler)
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
     ~WithCallbackMethod_GetAllowableFlightModes() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status GetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* /*response*/) override {
+    ::grpc::Status GetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* /*request*/, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     virtual ::grpc::ServerUnaryReactor* GetAllowableFlightModes(
-      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* /*response*/)  { return nullptr; }
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* /*request*/, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* /*response*/)  { return nullptr; }
   };
   typedef WithCallbackMethod_SubscribeArmDisarm<WithCallbackMethod_SubscribeFlightModeChange<WithCallbackMethod_SubscribeTakeoff<WithCallbackMethod_SubscribeLand<WithCallbackMethod_SubscribeReboot<WithCallbackMethod_SubscribeShutdown<WithCallbackMethod_SubscribeTerminate<WithCallbackMethod_SetAllowTakeoff<WithCallbackMethod_SetArmable<WithCallbackMethod_SetDisarmable<WithCallbackMethod_SetAllowableFlightModes<WithCallbackMethod_GetAllowableFlightModes<Service > > > > > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
@@ -1138,7 +1138,7 @@ class ActionServerService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status SetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* /*response*/) override {
+    ::grpc::Status SetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* /*request*/, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -1155,7 +1155,7 @@ class ActionServerService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status GetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* /*response*/) override {
+    ::grpc::Status GetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* /*request*/, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -1372,7 +1372,7 @@ class ActionServerService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status SetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* /*response*/) override {
+    ::grpc::Status SetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* /*request*/, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -1392,7 +1392,7 @@ class ActionServerService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status GetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* /*response*/) override {
+    ::grpc::Status GetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* /*request*/, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -1635,7 +1635,7 @@ class ActionServerService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status SetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* /*response*/) override {
+    ::grpc::Status SetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* /*request*/, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -1657,7 +1657,7 @@ class ActionServerService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status GetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* /*response*/) override {
+    ::grpc::Status GetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* /*request*/, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -1753,10 +1753,10 @@ class ActionServerService final {
     WithStreamedUnaryMethod_SetAllowableFlightModes() {
       ::grpc::Service::MarkMethodStreamed(10,
         new ::grpc::internal::StreamedUnaryHandler<
-          ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>(
+          ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>(
             [this](::grpc::ServerContext* context,
                    ::grpc::ServerUnaryStreamer<
-                     ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>* streamer) {
+                     ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>* streamer) {
                        return this->StreamedSetAllowableFlightModes(context,
                          streamer);
                   }));
@@ -1765,12 +1765,12 @@ class ActionServerService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable regular version of this method
-    ::grpc::Status SetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* /*response*/) override {
+    ::grpc::Status SetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* /*request*/, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     // replace default version of method with streamed unary
-    virtual ::grpc::Status StreamedSetAllowableFlightModes(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest,::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>* server_unary_streamer) = 0;
+    virtual ::grpc::Status StreamedSetAllowableFlightModes(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest,::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
   class WithStreamedUnaryMethod_GetAllowableFlightModes : public BaseClass {
@@ -1780,10 +1780,10 @@ class ActionServerService final {
     WithStreamedUnaryMethod_GetAllowableFlightModes() {
       ::grpc::Service::MarkMethodStreamed(11,
         new ::grpc::internal::StreamedUnaryHandler<
-          ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>(
+          ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>(
             [this](::grpc::ServerContext* context,
                    ::grpc::ServerUnaryStreamer<
-                     ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>* streamer) {
+                     ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>* streamer) {
                        return this->StreamedGetAllowableFlightModes(context,
                          streamer);
                   }));
@@ -1792,12 +1792,12 @@ class ActionServerService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable regular version of this method
-    ::grpc::Status GetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* /*response*/) override {
+    ::grpc::Status GetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* /*request*/, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     // replace default version of method with streamed unary
-    virtual ::grpc::Status StreamedGetAllowableFlightModes(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest,::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>* server_unary_streamer) = 0;
+    virtual ::grpc::Status StreamedGetAllowableFlightModes(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest,::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>* server_unary_streamer) = 0;
   };
   typedef WithStreamedUnaryMethod_SetAllowTakeoff<WithStreamedUnaryMethod_SetArmable<WithStreamedUnaryMethod_SetDisarmable<WithStreamedUnaryMethod_SetAllowableFlightModes<WithStreamedUnaryMethod_GetAllowableFlightModes<Service > > > > > StreamedUnaryService;
   template <class BaseClass>

--- a/src/mavsdk_server/src/generated/action_server/action_server.pb.cc
+++ b/src/mavsdk_server/src/generated/action_server/action_server.pb.cc
@@ -57,29 +57,29 @@ struct SetDisarmableRequestDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SetDisarmableRequestDefaultTypeInternal _SetDisarmableRequest_default_instance_;
-constexpr SetAllowableFlightModeRequest::SetAllowableFlightModeRequest(
+constexpr SetAllowableFlightModesRequest::SetAllowableFlightModesRequest(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
   : flight_modes_(nullptr){}
-struct SetAllowableFlightModeRequestDefaultTypeInternal {
-  constexpr SetAllowableFlightModeRequestDefaultTypeInternal()
+struct SetAllowableFlightModesRequestDefaultTypeInternal {
+  constexpr SetAllowableFlightModesRequestDefaultTypeInternal()
     : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
-  ~SetAllowableFlightModeRequestDefaultTypeInternal() {}
+  ~SetAllowableFlightModesRequestDefaultTypeInternal() {}
   union {
-    SetAllowableFlightModeRequest _instance;
+    SetAllowableFlightModesRequest _instance;
   };
 };
-PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SetAllowableFlightModeRequestDefaultTypeInternal _SetAllowableFlightModeRequest_default_instance_;
-constexpr GetAllowableFlightModeRequest::GetAllowableFlightModeRequest(
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SetAllowableFlightModesRequestDefaultTypeInternal _SetAllowableFlightModesRequest_default_instance_;
+constexpr GetAllowableFlightModesRequest::GetAllowableFlightModesRequest(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized){}
-struct GetAllowableFlightModeRequestDefaultTypeInternal {
-  constexpr GetAllowableFlightModeRequestDefaultTypeInternal()
+struct GetAllowableFlightModesRequestDefaultTypeInternal {
+  constexpr GetAllowableFlightModesRequestDefaultTypeInternal()
     : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
-  ~GetAllowableFlightModeRequestDefaultTypeInternal() {}
+  ~GetAllowableFlightModesRequestDefaultTypeInternal() {}
   union {
-    GetAllowableFlightModeRequest _instance;
+    GetAllowableFlightModesRequest _instance;
   };
 };
-PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT GetAllowableFlightModeRequestDefaultTypeInternal _GetAllowableFlightModeRequest_default_instance_;
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT GetAllowableFlightModesRequestDefaultTypeInternal _GetAllowableFlightModesRequest_default_instance_;
 constexpr SubscribeArmDisarmRequest::SubscribeArmDisarmRequest(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized){}
 struct SubscribeArmDisarmRequestDefaultTypeInternal {
@@ -273,18 +273,18 @@ struct SetDisarmableResponseDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SetDisarmableResponseDefaultTypeInternal _SetDisarmableResponse_default_instance_;
-constexpr SetAllowableFlightModeResponse::SetAllowableFlightModeResponse(
+constexpr SetAllowableFlightModesResponse::SetAllowableFlightModesResponse(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
   : action_server_result_(nullptr){}
-struct SetAllowableFlightModeResponseDefaultTypeInternal {
-  constexpr SetAllowableFlightModeResponseDefaultTypeInternal()
+struct SetAllowableFlightModesResponseDefaultTypeInternal {
+  constexpr SetAllowableFlightModesResponseDefaultTypeInternal()
     : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
-  ~SetAllowableFlightModeResponseDefaultTypeInternal() {}
+  ~SetAllowableFlightModesResponseDefaultTypeInternal() {}
   union {
-    SetAllowableFlightModeResponse _instance;
+    SetAllowableFlightModesResponse _instance;
   };
 };
-PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SetAllowableFlightModeResponseDefaultTypeInternal _SetAllowableFlightModeResponse_default_instance_;
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SetAllowableFlightModesResponseDefaultTypeInternal _SetAllowableFlightModesResponse_default_instance_;
 constexpr SetAllowTakeoffResponse::SetAllowTakeoffResponse(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
   : action_server_result_(nullptr){}
@@ -297,18 +297,18 @@ struct SetAllowTakeoffResponseDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SetAllowTakeoffResponseDefaultTypeInternal _SetAllowTakeoffResponse_default_instance_;
-constexpr GetAllowableFlightModeResponse::GetAllowableFlightModeResponse(
+constexpr GetAllowableFlightModesResponse::GetAllowableFlightModesResponse(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
   : flight_modes_(nullptr){}
-struct GetAllowableFlightModeResponseDefaultTypeInternal {
-  constexpr GetAllowableFlightModeResponseDefaultTypeInternal()
+struct GetAllowableFlightModesResponseDefaultTypeInternal {
+  constexpr GetAllowableFlightModesResponseDefaultTypeInternal()
     : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
-  ~GetAllowableFlightModeResponseDefaultTypeInternal() {}
+  ~GetAllowableFlightModesResponseDefaultTypeInternal() {}
   union {
-    GetAllowableFlightModeResponse _instance;
+    GetAllowableFlightModesResponse _instance;
   };
 };
-PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT GetAllowableFlightModeResponseDefaultTypeInternal _GetAllowableFlightModeResponse_default_instance_;
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT GetAllowableFlightModesResponseDefaultTypeInternal _GetAllowableFlightModesResponse_default_instance_;
 constexpr AllowableFlightModes::AllowableFlightModes(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
   : can_auto_mode_(false)
@@ -379,13 +379,13 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_action_5fserver_2faction_5fser
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetDisarmableRequest, disarmable_),
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetDisarmableRequest, force_disarmable_),
   ~0u,  // no _has_bits_
-  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetAllowableFlightModeRequest, _internal_metadata_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetAllowableFlightModesRequest, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetAllowableFlightModeRequest, flight_modes_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetAllowableFlightModesRequest, flight_modes_),
   ~0u,  // no _has_bits_
-  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::GetAllowableFlightModeRequest, _internal_metadata_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::GetAllowableFlightModesRequest, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
@@ -486,11 +486,11 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_action_5fserver_2faction_5fser
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetDisarmableResponse, action_server_result_),
   ~0u,  // no _has_bits_
-  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetAllowableFlightModeResponse, _internal_metadata_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetAllowableFlightModesResponse, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetAllowableFlightModeResponse, action_server_result_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetAllowableFlightModesResponse, action_server_result_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetAllowTakeoffResponse, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -498,11 +498,11 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_action_5fserver_2faction_5fser
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetAllowTakeoffResponse, action_server_result_),
   ~0u,  // no _has_bits_
-  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::GetAllowableFlightModeResponse, _internal_metadata_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::GetAllowableFlightModesResponse, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::GetAllowableFlightModeResponse, flight_modes_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::GetAllowableFlightModesResponse, flight_modes_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::AllowableFlightModes, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -530,8 +530,8 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 0, -1, sizeof(::mavsdk::rpc::action_server::SetAllowTakeoffRequest)},
   { 6, -1, sizeof(::mavsdk::rpc::action_server::SetArmableRequest)},
   { 13, -1, sizeof(::mavsdk::rpc::action_server::SetDisarmableRequest)},
-  { 20, -1, sizeof(::mavsdk::rpc::action_server::SetAllowableFlightModeRequest)},
-  { 26, -1, sizeof(::mavsdk::rpc::action_server::GetAllowableFlightModeRequest)},
+  { 20, -1, sizeof(::mavsdk::rpc::action_server::SetAllowableFlightModesRequest)},
+  { 26, -1, sizeof(::mavsdk::rpc::action_server::GetAllowableFlightModesRequest)},
   { 31, -1, sizeof(::mavsdk::rpc::action_server::SubscribeArmDisarmRequest)},
   { 36, -1, sizeof(::mavsdk::rpc::action_server::SubscribeFlightModeChangeRequest)},
   { 41, -1, sizeof(::mavsdk::rpc::action_server::SubscribeTakeoffRequest)},
@@ -548,9 +548,9 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 108, -1, sizeof(::mavsdk::rpc::action_server::TerminateResponse)},
   { 115, -1, sizeof(::mavsdk::rpc::action_server::SetArmableResponse)},
   { 121, -1, sizeof(::mavsdk::rpc::action_server::SetDisarmableResponse)},
-  { 127, -1, sizeof(::mavsdk::rpc::action_server::SetAllowableFlightModeResponse)},
+  { 127, -1, sizeof(::mavsdk::rpc::action_server::SetAllowableFlightModesResponse)},
   { 133, -1, sizeof(::mavsdk::rpc::action_server::SetAllowTakeoffResponse)},
-  { 139, -1, sizeof(::mavsdk::rpc::action_server::GetAllowableFlightModeResponse)},
+  { 139, -1, sizeof(::mavsdk::rpc::action_server::GetAllowableFlightModesResponse)},
   { 145, -1, sizeof(::mavsdk::rpc::action_server::AllowableFlightModes)},
   { 153, -1, sizeof(::mavsdk::rpc::action_server::ArmDisarm)},
   { 160, -1, sizeof(::mavsdk::rpc::action_server::ActionServerResult)},
@@ -560,8 +560,8 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_SetAllowTakeoffRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_SetArmableRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_SetDisarmableRequest_default_instance_),
-  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_SetAllowableFlightModeRequest_default_instance_),
-  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_GetAllowableFlightModeRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_SetAllowableFlightModesRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_GetAllowableFlightModesRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_SubscribeArmDisarmRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_SubscribeFlightModeChangeRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_SubscribeTakeoffRequest_default_instance_),
@@ -578,9 +578,9 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_TerminateResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_SetArmableResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_SetDisarmableResponse_default_instance_),
-  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_SetAllowableFlightModeResponse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_SetAllowableFlightModesResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_SetAllowTakeoffResponse_default_instance_),
-  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_GetAllowableFlightModeResponse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_GetAllowableFlightModesResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_AllowableFlightModes_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_ArmDisarm_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::action_server::_ActionServerResult_default_instance_),
@@ -593,122 +593,123 @@ const char descriptor_table_protodef_action_5fserver_2faction_5fserver_2eproto[]
   "akeoff\030\001 \001(\010\";\n\021SetArmableRequest\022\017\n\007arm"
   "able\030\001 \001(\010\022\025\n\rforce_armable\030\002 \001(\010\"D\n\024Set"
   "DisarmableRequest\022\022\n\ndisarmable\030\001 \001(\010\022\030\n"
-  "\020force_disarmable\030\002 \001(\010\"e\n\035SetAllowableF"
-  "lightModeRequest\022D\n\014flight_modes\030\001 \001(\0132."
-  ".mavsdk.rpc.action_server.AllowableFligh"
-  "tModes\"\037\n\035GetAllowableFlightModeRequest\""
-  "\033\n\031SubscribeArmDisarmRequest\"\"\n Subscrib"
-  "eFlightModeChangeRequest\"\031\n\027SubscribeTak"
-  "eoffRequest\"\026\n\024SubscribeLandRequest\"\030\n\026S"
-  "ubscribeRebootRequest\"\032\n\030SubscribeShutdo"
-  "wnRequest\"\033\n\031SubscribeTerminateRequest\"\221"
-  "\001\n\021ArmDisarmResponse\022J\n\024action_server_re"
+  "\020force_disarmable\030\002 \001(\010\"f\n\036SetAllowableF"
+  "lightModesRequest\022D\n\014flight_modes\030\001 \001(\0132"
+  "..mavsdk.rpc.action_server.AllowableFlig"
+  "htModes\" \n\036GetAllowableFlightModesReques"
+  "t\"\033\n\031SubscribeArmDisarmRequest\"\"\n Subscr"
+  "ibeFlightModeChangeRequest\"\031\n\027SubscribeT"
+  "akeoffRequest\"\026\n\024SubscribeLandRequest\"\030\n"
+  "\026SubscribeRebootRequest\"\032\n\030SubscribeShut"
+  "downRequest\"\033\n\031SubscribeTerminateRequest"
+  "\"\221\001\n\021ArmDisarmResponse\022J\n\024action_server_"
+  "result\030\001 \001(\0132,.mavsdk.rpc.action_server."
+  "ActionServerResult\0220\n\003arm\030\002 \001(\0132#.mavsdk"
+  ".rpc.action_server.ArmDisarm\"\241\001\n\030FlightM"
+  "odeChangeResponse\022J\n\024action_server_resul"
+  "t\030\001 \001(\0132,.mavsdk.rpc.action_server.Actio"
+  "nServerResult\0229\n\013flight_mode\030\002 \001(\0162$.mav"
+  "sdk.rpc.action_server.FlightMode\"n\n\017Take"
+  "offResponse\022J\n\024action_server_result\030\001 \001("
+  "\0132,.mavsdk.rpc.action_server.ActionServe"
+  "rResult\022\017\n\007takeoff\030\002 \001(\010\"h\n\014LandResponse"
+  "\022J\n\024action_server_result\030\001 \001(\0132,.mavsdk."
+  "rpc.action_server.ActionServerResult\022\014\n\004"
+  "land\030\002 \001(\010\"l\n\016RebootResponse\022J\n\024action_s"
+  "erver_result\030\001 \001(\0132,.mavsdk.rpc.action_s"
+  "erver.ActionServerResult\022\016\n\006reboot\030\002 \001(\010"
+  "\"p\n\020ShutdownResponse\022J\n\024action_server_re"
   "sult\030\001 \001(\0132,.mavsdk.rpc.action_server.Ac"
-  "tionServerResult\0220\n\003arm\030\002 \001(\0132#.mavsdk.r"
-  "pc.action_server.ArmDisarm\"\241\001\n\030FlightMod"
-  "eChangeResponse\022J\n\024action_server_result\030"
+  "tionServerResult\022\020\n\010shutdown\030\002 \001(\010\"r\n\021Te"
+  "rminateResponse\022J\n\024action_server_result\030"
   "\001 \001(\0132,.mavsdk.rpc.action_server.ActionS"
-  "erverResult\0229\n\013flight_mode\030\002 \001(\0162$.mavsd"
-  "k.rpc.action_server.FlightMode\"n\n\017Takeof"
-  "fResponse\022J\n\024action_server_result\030\001 \001(\0132"
-  ",.mavsdk.rpc.action_server.ActionServerR"
-  "esult\022\017\n\007takeoff\030\002 \001(\010\"h\n\014LandResponse\022J"
-  "\n\024action_server_result\030\001 \001(\0132,.mavsdk.rp"
-  "c.action_server.ActionServerResult\022\014\n\004la"
-  "nd\030\002 \001(\010\"l\n\016RebootResponse\022J\n\024action_ser"
-  "ver_result\030\001 \001(\0132,.mavsdk.rpc.action_ser"
-  "ver.ActionServerResult\022\016\n\006reboot\030\002 \001(\010\"p"
-  "\n\020ShutdownResponse\022J\n\024action_server_resu"
-  "lt\030\001 \001(\0132,.mavsdk.rpc.action_server.Acti"
-  "onServerResult\022\020\n\010shutdown\030\002 \001(\010\"r\n\021Term"
-  "inateResponse\022J\n\024action_server_result\030\001 "
-  "\001(\0132,.mavsdk.rpc.action_server.ActionSer"
-  "verResult\022\021\n\tterminate\030\002 \001(\010\"`\n\022SetArmab"
-  "leResponse\022J\n\024action_server_result\030\001 \001(\013"
-  "2,.mavsdk.rpc.action_server.ActionServer"
-  "Result\"c\n\025SetDisarmableResponse\022J\n\024actio"
-  "n_server_result\030\001 \001(\0132,.mavsdk.rpc.actio"
-  "n_server.ActionServerResult\"l\n\036SetAllowa"
-  "bleFlightModeResponse\022J\n\024action_server_r"
-  "esult\030\001 \001(\0132,.mavsdk.rpc.action_server.A"
-  "ctionServerResult\"e\n\027SetAllowTakeoffResp"
-  "onse\022J\n\024action_server_result\030\001 \001(\0132,.mav"
-  "sdk.rpc.action_server.ActionServerResult"
-  "\"f\n\036GetAllowableFlightModeResponse\022D\n\014fl"
-  "ight_modes\030\001 \001(\0132..mavsdk.rpc.action_ser"
-  "ver.AllowableFlightModes\"b\n\024AllowableFli"
-  "ghtModes\022\025\n\rcan_auto_mode\030\001 \001(\010\022\027\n\017can_g"
-  "uided_mode\030\002 \001(\010\022\032\n\022can_stabilize_mode\030\003"
-  " \001(\010\"\'\n\tArmDisarm\022\013\n\003arm\030\001 \001(\010\022\r\n\005force\030"
-  "\002 \001(\010\"\330\003\n\022ActionServerResult\022C\n\006result\030\001"
-  " \001(\01623.mavsdk.rpc.action_server.ActionSe"
-  "rverResult.Result\022\022\n\nresult_str\030\002 \001(\t\"\350\002"
-  "\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESULT_S"
-  "UCCESS\020\001\022\024\n\020RESULT_NO_SYSTEM\020\002\022\033\n\027RESULT"
-  "_CONNECTION_ERROR\020\003\022\017\n\013RESULT_BUSY\020\004\022\031\n\025"
-  "RESULT_COMMAND_DENIED\020\005\022.\n*RESULT_COMMAN"
-  "D_DENIED_LANDED_STATE_UNKNOWN\020\006\022$\n RESUL"
-  "T_COMMAND_DENIED_NOT_LANDED\020\007\022\022\n\016RESULT_"
-  "TIMEOUT\020\010\022*\n&RESULT_VTOL_TRANSITION_SUPP"
-  "ORT_UNKNOWN\020\t\022%\n!RESULT_NO_VTOL_TRANSITI"
-  "ON_SUPPORT\020\n\022\032\n\026RESULT_PARAMETER_ERROR\020\013"
-  "*\353\002\n\nFlightMode\022\027\n\023FLIGHT_MODE_UNKNOWN\020\000"
-  "\022\025\n\021FLIGHT_MODE_READY\020\001\022\027\n\023FLIGHT_MODE_T"
-  "AKEOFF\020\002\022\024\n\020FLIGHT_MODE_HOLD\020\003\022\027\n\023FLIGHT"
-  "_MODE_MISSION\020\004\022 \n\034FLIGHT_MODE_RETURN_TO"
-  "_LAUNCH\020\005\022\024\n\020FLIGHT_MODE_LAND\020\006\022\030\n\024FLIGH"
-  "T_MODE_OFFBOARD\020\007\022\031\n\025FLIGHT_MODE_FOLLOW_"
-  "ME\020\010\022\026\n\022FLIGHT_MODE_MANUAL\020\t\022\026\n\022FLIGHT_M"
-  "ODE_ALTCTL\020\n\022\026\n\022FLIGHT_MODE_POSCTL\020\013\022\024\n\020"
-  "FLIGHT_MODE_ACRO\020\014\022\032\n\026FLIGHT_MODE_STABIL"
-  "IZED\020\r2\231\014\n\023ActionServerService\022~\n\022Subscr"
-  "ibeArmDisarm\0223.mavsdk.rpc.action_server."
-  "SubscribeArmDisarmRequest\032+.mavsdk.rpc.a"
-  "ction_server.ArmDisarmResponse\"\004\200\265\030\0000\001\022\223"
-  "\001\n\031SubscribeFlightModeChange\022:.mavsdk.rp"
-  "c.action_server.SubscribeFlightModeChang"
-  "eRequest\0322.mavsdk.rpc.action_server.Flig"
-  "htModeChangeResponse\"\004\200\265\030\0000\001\022x\n\020Subscrib"
-  "eTakeoff\0221.mavsdk.rpc.action_server.Subs"
-  "cribeTakeoffRequest\032).mavsdk.rpc.action_"
-  "server.TakeoffResponse\"\004\200\265\030\0000\001\022o\n\rSubscr"
-  "ibeLand\022..mavsdk.rpc.action_server.Subsc"
-  "ribeLandRequest\032&.mavsdk.rpc.action_serv"
-  "er.LandResponse\"\004\200\265\030\0000\001\022u\n\017SubscribeRebo"
-  "ot\0220.mavsdk.rpc.action_server.SubscribeR"
-  "ebootRequest\032(.mavsdk.rpc.action_server."
-  "RebootResponse\"\004\200\265\030\0000\001\022{\n\021SubscribeShutd"
-  "own\0222.mavsdk.rpc.action_server.Subscribe"
-  "ShutdownRequest\032*.mavsdk.rpc.action_serv"
-  "er.ShutdownResponse\"\004\200\265\030\0000\001\022~\n\022Subscribe"
-  "Terminate\0223.mavsdk.rpc.action_server.Sub"
-  "scribeTerminateRequest\032+.mavsdk.rpc.acti"
-  "on_server.TerminateResponse\"\004\200\265\030\0000\001\022|\n\017S"
-  "etAllowTakeoff\0220.mavsdk.rpc.action_serve"
-  "r.SetAllowTakeoffRequest\0321.mavsdk.rpc.ac"
-  "tion_server.SetAllowTakeoffResponse\"\004\200\265\030"
-  "\001\022m\n\nSetArmable\022+.mavsdk.rpc.action_serv"
-  "er.SetArmableRequest\032,.mavsdk.rpc.action"
-  "_server.SetArmableResponse\"\004\200\265\030\001\022v\n\rSetD"
-  "isarmable\022..mavsdk.rpc.action_server.Set"
-  "DisarmableRequest\032/.mavsdk.rpc.action_se"
-  "rver.SetDisarmableResponse\"\004\200\265\030\001\022\222\001\n\027Set"
-  "AllowableFlightModes\0227.mavsdk.rpc.action"
-  "_server.SetAllowableFlightModeRequest\0328."
-  "mavsdk.rpc.action_server.SetAllowableFli"
-  "ghtModeResponse\"\004\200\265\030\001\022\222\001\n\027GetAllowableFl"
-  "ightModes\0227.mavsdk.rpc.action_server.Get"
-  "AllowableFlightModeRequest\0328.mavsdk.rpc."
-  "action_server.GetAllowableFlightModeResp"
-  "onse\"\004\200\265\030\001B,\n\027io.mavsdk.action_serverB\021A"
-  "ctionServerProtob\006proto3"
+  "erverResult\022\021\n\tterminate\030\002 \001(\010\"`\n\022SetArm"
+  "ableResponse\022J\n\024action_server_result\030\001 \001"
+  "(\0132,.mavsdk.rpc.action_server.ActionServ"
+  "erResult\"c\n\025SetDisarmableResponse\022J\n\024act"
+  "ion_server_result\030\001 \001(\0132,.mavsdk.rpc.act"
+  "ion_server.ActionServerResult\"m\n\037SetAllo"
+  "wableFlightModesResponse\022J\n\024action_serve"
+  "r_result\030\001 \001(\0132,.mavsdk.rpc.action_serve"
+  "r.ActionServerResult\"e\n\027SetAllowTakeoffR"
+  "esponse\022J\n\024action_server_result\030\001 \001(\0132,."
+  "mavsdk.rpc.action_server.ActionServerRes"
+  "ult\"g\n\037GetAllowableFlightModesResponse\022D"
+  "\n\014flight_modes\030\001 \001(\0132..mavsdk.rpc.action"
+  "_server.AllowableFlightModes\"b\n\024Allowabl"
+  "eFlightModes\022\025\n\rcan_auto_mode\030\001 \001(\010\022\027\n\017c"
+  "an_guided_mode\030\002 \001(\010\022\032\n\022can_stabilize_mo"
+  "de\030\003 \001(\010\"\'\n\tArmDisarm\022\013\n\003arm\030\001 \001(\010\022\r\n\005fo"
+  "rce\030\002 \001(\010\"\351\003\n\022ActionServerResult\022C\n\006resu"
+  "lt\030\001 \001(\01623.mavsdk.rpc.action_server.Acti"
+  "onServerResult.Result\022\022\n\nresult_str\030\002 \001("
+  "\t\"\371\002\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESU"
+  "LT_SUCCESS\020\001\022\024\n\020RESULT_NO_SYSTEM\020\002\022\033\n\027RE"
+  "SULT_CONNECTION_ERROR\020\003\022\017\n\013RESULT_BUSY\020\004"
+  "\022\031\n\025RESULT_COMMAND_DENIED\020\005\022.\n*RESULT_CO"
+  "MMAND_DENIED_LANDED_STATE_UNKNOWN\020\006\022$\n R"
+  "ESULT_COMMAND_DENIED_NOT_LANDED\020\007\022\022\n\016RES"
+  "ULT_TIMEOUT\020\010\022*\n&RESULT_VTOL_TRANSITION_"
+  "SUPPORT_UNKNOWN\020\t\022%\n!RESULT_NO_VTOL_TRAN"
+  "SITION_SUPPORT\020\n\022\032\n\026RESULT_PARAMETER_ERR"
+  "OR\020\013\022\017\n\013RESULT_NEXT\020\014*\353\002\n\nFlightMode\022\027\n\023"
+  "FLIGHT_MODE_UNKNOWN\020\000\022\025\n\021FLIGHT_MODE_REA"
+  "DY\020\001\022\027\n\023FLIGHT_MODE_TAKEOFF\020\002\022\024\n\020FLIGHT_"
+  "MODE_HOLD\020\003\022\027\n\023FLIGHT_MODE_MISSION\020\004\022 \n\034"
+  "FLIGHT_MODE_RETURN_TO_LAUNCH\020\005\022\024\n\020FLIGHT"
+  "_MODE_LAND\020\006\022\030\n\024FLIGHT_MODE_OFFBOARD\020\007\022\031"
+  "\n\025FLIGHT_MODE_FOLLOW_ME\020\010\022\026\n\022FLIGHT_MODE"
+  "_MANUAL\020\t\022\026\n\022FLIGHT_MODE_ALTCTL\020\n\022\026\n\022FLI"
+  "GHT_MODE_POSCTL\020\013\022\024\n\020FLIGHT_MODE_ACRO\020\014\022"
+  "\032\n\026FLIGHT_MODE_STABILIZED\020\r2\235\014\n\023ActionSe"
+  "rverService\022~\n\022SubscribeArmDisarm\0223.mavs"
+  "dk.rpc.action_server.SubscribeArmDisarmR"
+  "equest\032+.mavsdk.rpc.action_server.ArmDis"
+  "armResponse\"\004\200\265\030\0000\001\022\223\001\n\031SubscribeFlightM"
+  "odeChange\022:.mavsdk.rpc.action_server.Sub"
+  "scribeFlightModeChangeRequest\0322.mavsdk.r"
+  "pc.action_server.FlightModeChangeRespons"
+  "e\"\004\200\265\030\0000\001\022x\n\020SubscribeTakeoff\0221.mavsdk.r"
+  "pc.action_server.SubscribeTakeoffRequest"
+  "\032).mavsdk.rpc.action_server.TakeoffRespo"
+  "nse\"\004\200\265\030\0000\001\022o\n\rSubscribeLand\022..mavsdk.rp"
+  "c.action_server.SubscribeLandRequest\032&.m"
+  "avsdk.rpc.action_server.LandResponse\"\004\200\265"
+  "\030\0000\001\022u\n\017SubscribeReboot\0220.mavsdk.rpc.act"
+  "ion_server.SubscribeRebootRequest\032(.mavs"
+  "dk.rpc.action_server.RebootResponse\"\004\200\265\030"
+  "\0000\001\022{\n\021SubscribeShutdown\0222.mavsdk.rpc.ac"
+  "tion_server.SubscribeShutdownRequest\032*.m"
+  "avsdk.rpc.action_server.ShutdownResponse"
+  "\"\004\200\265\030\0000\001\022~\n\022SubscribeTerminate\0223.mavsdk."
+  "rpc.action_server.SubscribeTerminateRequ"
+  "est\032+.mavsdk.rpc.action_server.Terminate"
+  "Response\"\004\200\265\030\0000\001\022|\n\017SetAllowTakeoff\0220.ma"
+  "vsdk.rpc.action_server.SetAllowTakeoffRe"
+  "quest\0321.mavsdk.rpc.action_server.SetAllo"
+  "wTakeoffResponse\"\004\200\265\030\001\022m\n\nSetArmable\022+.m"
+  "avsdk.rpc.action_server.SetArmableReques"
+  "t\032,.mavsdk.rpc.action_server.SetArmableR"
+  "esponse\"\004\200\265\030\001\022v\n\rSetDisarmable\022..mavsdk."
+  "rpc.action_server.SetDisarmableRequest\032/"
+  ".mavsdk.rpc.action_server.SetDisarmableR"
+  "esponse\"\004\200\265\030\001\022\224\001\n\027SetAllowableFlightMode"
+  "s\0228.mavsdk.rpc.action_server.SetAllowabl"
+  "eFlightModesRequest\0329.mavsdk.rpc.action_"
+  "server.SetAllowableFlightModesResponse\"\004"
+  "\200\265\030\001\022\224\001\n\027GetAllowableFlightModes\0228.mavsd"
+  "k.rpc.action_server.GetAllowableFlightMo"
+  "desRequest\0329.mavsdk.rpc.action_server.Ge"
+  "tAllowableFlightModesResponse\"\004\200\265\030\001B,\n\027i"
+  "o.mavsdk.action_serverB\021ActionServerProt"
+  "ob\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_action_5fserver_2faction_5fserver_2eproto_deps[1] = {
   &::descriptor_table_mavsdk_5foptions_2eproto,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_action_5fserver_2faction_5fserver_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_action_5fserver_2faction_5fserver_2eproto = {
-  false, false, 4584, descriptor_table_protodef_action_5fserver_2faction_5fserver_2eproto, "action_server/action_server.proto", 
+  false, false, 4609, descriptor_table_protodef_action_5fserver_2faction_5fserver_2eproto, "action_server/action_server.proto", 
   &descriptor_table_action_5fserver_2faction_5fserver_2eproto_once, descriptor_table_action_5fserver_2faction_5fserver_2eproto_deps, 1, 27,
   schemas, file_default_instances, TableStruct_action_5fserver_2faction_5fserver_2eproto::offsets,
   file_level_metadata_action_5fserver_2faction_5fserver_2eproto, file_level_enum_descriptors_action_5fserver_2faction_5fserver_2eproto, file_level_service_descriptors_action_5fserver_2faction_5fserver_2eproto,
@@ -740,6 +741,7 @@ bool ActionServerResult_Result_IsValid(int value) {
     case 9:
     case 10:
     case 11:
+    case 12:
       return true;
     default:
       return false;
@@ -759,6 +761,7 @@ constexpr ActionServerResult_Result ActionServerResult::RESULT_TIMEOUT;
 constexpr ActionServerResult_Result ActionServerResult::RESULT_VTOL_TRANSITION_SUPPORT_UNKNOWN;
 constexpr ActionServerResult_Result ActionServerResult::RESULT_NO_VTOL_TRANSITION_SUPPORT;
 constexpr ActionServerResult_Result ActionServerResult::RESULT_PARAMETER_ERROR;
+constexpr ActionServerResult_Result ActionServerResult::RESULT_NEXT;
 constexpr ActionServerResult_Result ActionServerResult::Result_MIN;
 constexpr ActionServerResult_Result ActionServerResult::Result_MAX;
 constexpr int ActionServerResult::Result_ARRAYSIZE;
@@ -1407,25 +1410,25 @@ void SetDisarmableRequest::InternalSwap(SetDisarmableRequest* other) {
 
 // ===================================================================
 
-class SetAllowableFlightModeRequest::_Internal {
+class SetAllowableFlightModesRequest::_Internal {
  public:
-  static const ::mavsdk::rpc::action_server::AllowableFlightModes& flight_modes(const SetAllowableFlightModeRequest* msg);
+  static const ::mavsdk::rpc::action_server::AllowableFlightModes& flight_modes(const SetAllowableFlightModesRequest* msg);
 };
 
 const ::mavsdk::rpc::action_server::AllowableFlightModes&
-SetAllowableFlightModeRequest::_Internal::flight_modes(const SetAllowableFlightModeRequest* msg) {
+SetAllowableFlightModesRequest::_Internal::flight_modes(const SetAllowableFlightModesRequest* msg) {
   return *msg->flight_modes_;
 }
-SetAllowableFlightModeRequest::SetAllowableFlightModeRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+SetAllowableFlightModesRequest::SetAllowableFlightModesRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
   SharedCtor();
   if (!is_message_owned) {
     RegisterArenaDtor(arena);
   }
-  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.action_server.SetAllowableFlightModeRequest)
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.action_server.SetAllowableFlightModesRequest)
 }
-SetAllowableFlightModeRequest::SetAllowableFlightModeRequest(const SetAllowableFlightModeRequest& from)
+SetAllowableFlightModesRequest::SetAllowableFlightModesRequest(const SetAllowableFlightModesRequest& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
   if (from._internal_has_flight_modes()) {
@@ -1433,37 +1436,37 @@ SetAllowableFlightModeRequest::SetAllowableFlightModeRequest(const SetAllowableF
   } else {
     flight_modes_ = nullptr;
   }
-  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.action_server.SetAllowableFlightModeRequest)
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.action_server.SetAllowableFlightModesRequest)
 }
 
-inline void SetAllowableFlightModeRequest::SharedCtor() {
+inline void SetAllowableFlightModesRequest::SharedCtor() {
 flight_modes_ = nullptr;
 }
 
-SetAllowableFlightModeRequest::~SetAllowableFlightModeRequest() {
-  // @@protoc_insertion_point(destructor:mavsdk.rpc.action_server.SetAllowableFlightModeRequest)
+SetAllowableFlightModesRequest::~SetAllowableFlightModesRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.action_server.SetAllowableFlightModesRequest)
   if (GetArenaForAllocation() != nullptr) return;
   SharedDtor();
   _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
-inline void SetAllowableFlightModeRequest::SharedDtor() {
+inline void SetAllowableFlightModesRequest::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
   if (this != internal_default_instance()) delete flight_modes_;
 }
 
-void SetAllowableFlightModeRequest::ArenaDtor(void* object) {
-  SetAllowableFlightModeRequest* _this = reinterpret_cast< SetAllowableFlightModeRequest* >(object);
+void SetAllowableFlightModesRequest::ArenaDtor(void* object) {
+  SetAllowableFlightModesRequest* _this = reinterpret_cast< SetAllowableFlightModesRequest* >(object);
   (void)_this;
 }
-void SetAllowableFlightModeRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+void SetAllowableFlightModesRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
 }
-void SetAllowableFlightModeRequest::SetCachedSize(int size) const {
+void SetAllowableFlightModesRequest::SetCachedSize(int size) const {
   _cached_size_.Set(size);
 }
 
-void SetAllowableFlightModeRequest::Clear() {
-// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action_server.SetAllowableFlightModeRequest)
+void SetAllowableFlightModesRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action_server.SetAllowableFlightModesRequest)
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -1475,7 +1478,7 @@ void SetAllowableFlightModeRequest::Clear() {
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
-const char* SetAllowableFlightModeRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+const char* SetAllowableFlightModesRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
 #define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
   while (!ctx->Done(&ptr)) {
     ::PROTOBUF_NAMESPACE_ID::uint32 tag;
@@ -1511,9 +1514,9 @@ failure:
 #undef CHK_
 }
 
-::PROTOBUF_NAMESPACE_ID::uint8* SetAllowableFlightModeRequest::_InternalSerialize(
+::PROTOBUF_NAMESPACE_ID::uint8* SetAllowableFlightModesRequest::_InternalSerialize(
     ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
-  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action_server.SetAllowableFlightModeRequest)
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action_server.SetAllowableFlightModesRequest)
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -1529,12 +1532,12 @@ failure:
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action_server.SetAllowableFlightModeRequest)
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action_server.SetAllowableFlightModesRequest)
   return target;
 }
 
-size_t SetAllowableFlightModeRequest::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action_server.SetAllowableFlightModeRequest)
+size_t SetAllowableFlightModesRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action_server.SetAllowableFlightModesRequest)
   size_t total_size = 0;
 
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
@@ -1557,21 +1560,21 @@ size_t SetAllowableFlightModeRequest::ByteSizeLong() const {
   return total_size;
 }
 
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData SetAllowableFlightModeRequest::_class_data_ = {
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData SetAllowableFlightModesRequest::_class_data_ = {
     ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSizeCheck,
-    SetAllowableFlightModeRequest::MergeImpl
+    SetAllowableFlightModesRequest::MergeImpl
 };
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*SetAllowableFlightModeRequest::GetClassData() const { return &_class_data_; }
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*SetAllowableFlightModesRequest::GetClassData() const { return &_class_data_; }
 
-void SetAllowableFlightModeRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
+void SetAllowableFlightModesRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
                       const ::PROTOBUF_NAMESPACE_ID::Message&from) {
-  static_cast<SetAllowableFlightModeRequest *>(to)->MergeFrom(
-      static_cast<const SetAllowableFlightModeRequest &>(from));
+  static_cast<SetAllowableFlightModesRequest *>(to)->MergeFrom(
+      static_cast<const SetAllowableFlightModesRequest &>(from));
 }
 
 
-void SetAllowableFlightModeRequest::MergeFrom(const SetAllowableFlightModeRequest& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action_server.SetAllowableFlightModeRequest)
+void SetAllowableFlightModesRequest::MergeFrom(const SetAllowableFlightModesRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action_server.SetAllowableFlightModesRequest)
   GOOGLE_DCHECK_NE(&from, this);
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
@@ -1582,24 +1585,24 @@ void SetAllowableFlightModeRequest::MergeFrom(const SetAllowableFlightModeReques
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
 
-void SetAllowableFlightModeRequest::CopyFrom(const SetAllowableFlightModeRequest& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action_server.SetAllowableFlightModeRequest)
+void SetAllowableFlightModesRequest::CopyFrom(const SetAllowableFlightModesRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action_server.SetAllowableFlightModesRequest)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool SetAllowableFlightModeRequest::IsInitialized() const {
+bool SetAllowableFlightModesRequest::IsInitialized() const {
   return true;
 }
 
-void SetAllowableFlightModeRequest::InternalSwap(SetAllowableFlightModeRequest* other) {
+void SetAllowableFlightModesRequest::InternalSwap(SetAllowableFlightModesRequest* other) {
   using std::swap;
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
   swap(flight_modes_, other->flight_modes_);
 }
 
-::PROTOBUF_NAMESPACE_ID::Metadata SetAllowableFlightModeRequest::GetMetadata() const {
+::PROTOBUF_NAMESPACE_ID::Metadata SetAllowableFlightModesRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_action_5fserver_2faction_5fserver_2eproto_getter, &descriptor_table_action_5fserver_2faction_5fserver_2eproto_once,
       file_level_metadata_action_5fserver_2faction_5fserver_2eproto[3]);
@@ -1607,51 +1610,51 @@ void SetAllowableFlightModeRequest::InternalSwap(SetAllowableFlightModeRequest* 
 
 // ===================================================================
 
-class GetAllowableFlightModeRequest::_Internal {
+class GetAllowableFlightModesRequest::_Internal {
  public:
 };
 
-GetAllowableFlightModeRequest::GetAllowableFlightModeRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+GetAllowableFlightModesRequest::GetAllowableFlightModesRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
   SharedCtor();
   if (!is_message_owned) {
     RegisterArenaDtor(arena);
   }
-  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.action_server.GetAllowableFlightModeRequest)
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.action_server.GetAllowableFlightModesRequest)
 }
-GetAllowableFlightModeRequest::GetAllowableFlightModeRequest(const GetAllowableFlightModeRequest& from)
+GetAllowableFlightModesRequest::GetAllowableFlightModesRequest(const GetAllowableFlightModesRequest& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
-  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.action_server.GetAllowableFlightModeRequest)
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.action_server.GetAllowableFlightModesRequest)
 }
 
-inline void GetAllowableFlightModeRequest::SharedCtor() {
+inline void GetAllowableFlightModesRequest::SharedCtor() {
 }
 
-GetAllowableFlightModeRequest::~GetAllowableFlightModeRequest() {
-  // @@protoc_insertion_point(destructor:mavsdk.rpc.action_server.GetAllowableFlightModeRequest)
+GetAllowableFlightModesRequest::~GetAllowableFlightModesRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.action_server.GetAllowableFlightModesRequest)
   if (GetArenaForAllocation() != nullptr) return;
   SharedDtor();
   _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
-inline void GetAllowableFlightModeRequest::SharedDtor() {
+inline void GetAllowableFlightModesRequest::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
 }
 
-void GetAllowableFlightModeRequest::ArenaDtor(void* object) {
-  GetAllowableFlightModeRequest* _this = reinterpret_cast< GetAllowableFlightModeRequest* >(object);
+void GetAllowableFlightModesRequest::ArenaDtor(void* object) {
+  GetAllowableFlightModesRequest* _this = reinterpret_cast< GetAllowableFlightModesRequest* >(object);
   (void)_this;
 }
-void GetAllowableFlightModeRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+void GetAllowableFlightModesRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
 }
-void GetAllowableFlightModeRequest::SetCachedSize(int size) const {
+void GetAllowableFlightModesRequest::SetCachedSize(int size) const {
   _cached_size_.Set(size);
 }
 
-void GetAllowableFlightModeRequest::Clear() {
-// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action_server.GetAllowableFlightModeRequest)
+void GetAllowableFlightModesRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action_server.GetAllowableFlightModesRequest)
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -1659,7 +1662,7 @@ void GetAllowableFlightModeRequest::Clear() {
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
-const char* GetAllowableFlightModeRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+const char* GetAllowableFlightModesRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
 #define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
   while (!ctx->Done(&ptr)) {
     ::PROTOBUF_NAMESPACE_ID::uint32 tag;
@@ -1683,9 +1686,9 @@ failure:
 #undef CHK_
 }
 
-::PROTOBUF_NAMESPACE_ID::uint8* GetAllowableFlightModeRequest::_InternalSerialize(
+::PROTOBUF_NAMESPACE_ID::uint8* GetAllowableFlightModesRequest::_InternalSerialize(
     ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
-  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action_server.GetAllowableFlightModeRequest)
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action_server.GetAllowableFlightModesRequest)
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -1693,12 +1696,12 @@ failure:
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action_server.GetAllowableFlightModeRequest)
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action_server.GetAllowableFlightModesRequest)
   return target;
 }
 
-size_t GetAllowableFlightModeRequest::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action_server.GetAllowableFlightModeRequest)
+size_t GetAllowableFlightModesRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action_server.GetAllowableFlightModesRequest)
   size_t total_size = 0;
 
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
@@ -1714,21 +1717,21 @@ size_t GetAllowableFlightModeRequest::ByteSizeLong() const {
   return total_size;
 }
 
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData GetAllowableFlightModeRequest::_class_data_ = {
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData GetAllowableFlightModesRequest::_class_data_ = {
     ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSizeCheck,
-    GetAllowableFlightModeRequest::MergeImpl
+    GetAllowableFlightModesRequest::MergeImpl
 };
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetAllowableFlightModeRequest::GetClassData() const { return &_class_data_; }
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetAllowableFlightModesRequest::GetClassData() const { return &_class_data_; }
 
-void GetAllowableFlightModeRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
+void GetAllowableFlightModesRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
                       const ::PROTOBUF_NAMESPACE_ID::Message&from) {
-  static_cast<GetAllowableFlightModeRequest *>(to)->MergeFrom(
-      static_cast<const GetAllowableFlightModeRequest &>(from));
+  static_cast<GetAllowableFlightModesRequest *>(to)->MergeFrom(
+      static_cast<const GetAllowableFlightModesRequest &>(from));
 }
 
 
-void GetAllowableFlightModeRequest::MergeFrom(const GetAllowableFlightModeRequest& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action_server.GetAllowableFlightModeRequest)
+void GetAllowableFlightModesRequest::MergeFrom(const GetAllowableFlightModesRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action_server.GetAllowableFlightModesRequest)
   GOOGLE_DCHECK_NE(&from, this);
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
@@ -1736,23 +1739,23 @@ void GetAllowableFlightModeRequest::MergeFrom(const GetAllowableFlightModeReques
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
 
-void GetAllowableFlightModeRequest::CopyFrom(const GetAllowableFlightModeRequest& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action_server.GetAllowableFlightModeRequest)
+void GetAllowableFlightModesRequest::CopyFrom(const GetAllowableFlightModesRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action_server.GetAllowableFlightModesRequest)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool GetAllowableFlightModeRequest::IsInitialized() const {
+bool GetAllowableFlightModesRequest::IsInitialized() const {
   return true;
 }
 
-void GetAllowableFlightModeRequest::InternalSwap(GetAllowableFlightModeRequest* other) {
+void GetAllowableFlightModesRequest::InternalSwap(GetAllowableFlightModesRequest* other) {
   using std::swap;
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
 }
 
-::PROTOBUF_NAMESPACE_ID::Metadata GetAllowableFlightModeRequest::GetMetadata() const {
+::PROTOBUF_NAMESPACE_ID::Metadata GetAllowableFlightModesRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_action_5fserver_2faction_5fserver_2eproto_getter, &descriptor_table_action_5fserver_2faction_5fserver_2eproto_once,
       file_level_metadata_action_5fserver_2faction_5fserver_2eproto[4]);
@@ -4868,25 +4871,25 @@ void SetDisarmableResponse::InternalSwap(SetDisarmableResponse* other) {
 
 // ===================================================================
 
-class SetAllowableFlightModeResponse::_Internal {
+class SetAllowableFlightModesResponse::_Internal {
  public:
-  static const ::mavsdk::rpc::action_server::ActionServerResult& action_server_result(const SetAllowableFlightModeResponse* msg);
+  static const ::mavsdk::rpc::action_server::ActionServerResult& action_server_result(const SetAllowableFlightModesResponse* msg);
 };
 
 const ::mavsdk::rpc::action_server::ActionServerResult&
-SetAllowableFlightModeResponse::_Internal::action_server_result(const SetAllowableFlightModeResponse* msg) {
+SetAllowableFlightModesResponse::_Internal::action_server_result(const SetAllowableFlightModesResponse* msg) {
   return *msg->action_server_result_;
 }
-SetAllowableFlightModeResponse::SetAllowableFlightModeResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+SetAllowableFlightModesResponse::SetAllowableFlightModesResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
   SharedCtor();
   if (!is_message_owned) {
     RegisterArenaDtor(arena);
   }
-  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.action_server.SetAllowableFlightModeResponse)
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.action_server.SetAllowableFlightModesResponse)
 }
-SetAllowableFlightModeResponse::SetAllowableFlightModeResponse(const SetAllowableFlightModeResponse& from)
+SetAllowableFlightModesResponse::SetAllowableFlightModesResponse(const SetAllowableFlightModesResponse& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
   if (from._internal_has_action_server_result()) {
@@ -4894,37 +4897,37 @@ SetAllowableFlightModeResponse::SetAllowableFlightModeResponse(const SetAllowabl
   } else {
     action_server_result_ = nullptr;
   }
-  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.action_server.SetAllowableFlightModeResponse)
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.action_server.SetAllowableFlightModesResponse)
 }
 
-inline void SetAllowableFlightModeResponse::SharedCtor() {
+inline void SetAllowableFlightModesResponse::SharedCtor() {
 action_server_result_ = nullptr;
 }
 
-SetAllowableFlightModeResponse::~SetAllowableFlightModeResponse() {
-  // @@protoc_insertion_point(destructor:mavsdk.rpc.action_server.SetAllowableFlightModeResponse)
+SetAllowableFlightModesResponse::~SetAllowableFlightModesResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.action_server.SetAllowableFlightModesResponse)
   if (GetArenaForAllocation() != nullptr) return;
   SharedDtor();
   _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
-inline void SetAllowableFlightModeResponse::SharedDtor() {
+inline void SetAllowableFlightModesResponse::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
   if (this != internal_default_instance()) delete action_server_result_;
 }
 
-void SetAllowableFlightModeResponse::ArenaDtor(void* object) {
-  SetAllowableFlightModeResponse* _this = reinterpret_cast< SetAllowableFlightModeResponse* >(object);
+void SetAllowableFlightModesResponse::ArenaDtor(void* object) {
+  SetAllowableFlightModesResponse* _this = reinterpret_cast< SetAllowableFlightModesResponse* >(object);
   (void)_this;
 }
-void SetAllowableFlightModeResponse::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+void SetAllowableFlightModesResponse::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
 }
-void SetAllowableFlightModeResponse::SetCachedSize(int size) const {
+void SetAllowableFlightModesResponse::SetCachedSize(int size) const {
   _cached_size_.Set(size);
 }
 
-void SetAllowableFlightModeResponse::Clear() {
-// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action_server.SetAllowableFlightModeResponse)
+void SetAllowableFlightModesResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action_server.SetAllowableFlightModesResponse)
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -4936,7 +4939,7 @@ void SetAllowableFlightModeResponse::Clear() {
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
-const char* SetAllowableFlightModeResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+const char* SetAllowableFlightModesResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
 #define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
   while (!ctx->Done(&ptr)) {
     ::PROTOBUF_NAMESPACE_ID::uint32 tag;
@@ -4972,9 +4975,9 @@ failure:
 #undef CHK_
 }
 
-::PROTOBUF_NAMESPACE_ID::uint8* SetAllowableFlightModeResponse::_InternalSerialize(
+::PROTOBUF_NAMESPACE_ID::uint8* SetAllowableFlightModesResponse::_InternalSerialize(
     ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
-  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action_server.SetAllowableFlightModeResponse)
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action_server.SetAllowableFlightModesResponse)
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -4990,12 +4993,12 @@ failure:
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action_server.SetAllowableFlightModeResponse)
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action_server.SetAllowableFlightModesResponse)
   return target;
 }
 
-size_t SetAllowableFlightModeResponse::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action_server.SetAllowableFlightModeResponse)
+size_t SetAllowableFlightModesResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action_server.SetAllowableFlightModesResponse)
   size_t total_size = 0;
 
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
@@ -5018,21 +5021,21 @@ size_t SetAllowableFlightModeResponse::ByteSizeLong() const {
   return total_size;
 }
 
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData SetAllowableFlightModeResponse::_class_data_ = {
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData SetAllowableFlightModesResponse::_class_data_ = {
     ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSizeCheck,
-    SetAllowableFlightModeResponse::MergeImpl
+    SetAllowableFlightModesResponse::MergeImpl
 };
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*SetAllowableFlightModeResponse::GetClassData() const { return &_class_data_; }
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*SetAllowableFlightModesResponse::GetClassData() const { return &_class_data_; }
 
-void SetAllowableFlightModeResponse::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
+void SetAllowableFlightModesResponse::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
                       const ::PROTOBUF_NAMESPACE_ID::Message&from) {
-  static_cast<SetAllowableFlightModeResponse *>(to)->MergeFrom(
-      static_cast<const SetAllowableFlightModeResponse &>(from));
+  static_cast<SetAllowableFlightModesResponse *>(to)->MergeFrom(
+      static_cast<const SetAllowableFlightModesResponse &>(from));
 }
 
 
-void SetAllowableFlightModeResponse::MergeFrom(const SetAllowableFlightModeResponse& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action_server.SetAllowableFlightModeResponse)
+void SetAllowableFlightModesResponse::MergeFrom(const SetAllowableFlightModesResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action_server.SetAllowableFlightModesResponse)
   GOOGLE_DCHECK_NE(&from, this);
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
@@ -5043,24 +5046,24 @@ void SetAllowableFlightModeResponse::MergeFrom(const SetAllowableFlightModeRespo
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
 
-void SetAllowableFlightModeResponse::CopyFrom(const SetAllowableFlightModeResponse& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action_server.SetAllowableFlightModeResponse)
+void SetAllowableFlightModesResponse::CopyFrom(const SetAllowableFlightModesResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action_server.SetAllowableFlightModesResponse)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool SetAllowableFlightModeResponse::IsInitialized() const {
+bool SetAllowableFlightModesResponse::IsInitialized() const {
   return true;
 }
 
-void SetAllowableFlightModeResponse::InternalSwap(SetAllowableFlightModeResponse* other) {
+void SetAllowableFlightModesResponse::InternalSwap(SetAllowableFlightModesResponse* other) {
   using std::swap;
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
   swap(action_server_result_, other->action_server_result_);
 }
 
-::PROTOBUF_NAMESPACE_ID::Metadata SetAllowableFlightModeResponse::GetMetadata() const {
+::PROTOBUF_NAMESPACE_ID::Metadata SetAllowableFlightModesResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_action_5fserver_2faction_5fserver_2eproto_getter, &descriptor_table_action_5fserver_2faction_5fserver_2eproto_once,
       file_level_metadata_action_5fserver_2faction_5fserver_2eproto[21]);
@@ -5268,25 +5271,25 @@ void SetAllowTakeoffResponse::InternalSwap(SetAllowTakeoffResponse* other) {
 
 // ===================================================================
 
-class GetAllowableFlightModeResponse::_Internal {
+class GetAllowableFlightModesResponse::_Internal {
  public:
-  static const ::mavsdk::rpc::action_server::AllowableFlightModes& flight_modes(const GetAllowableFlightModeResponse* msg);
+  static const ::mavsdk::rpc::action_server::AllowableFlightModes& flight_modes(const GetAllowableFlightModesResponse* msg);
 };
 
 const ::mavsdk::rpc::action_server::AllowableFlightModes&
-GetAllowableFlightModeResponse::_Internal::flight_modes(const GetAllowableFlightModeResponse* msg) {
+GetAllowableFlightModesResponse::_Internal::flight_modes(const GetAllowableFlightModesResponse* msg) {
   return *msg->flight_modes_;
 }
-GetAllowableFlightModeResponse::GetAllowableFlightModeResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+GetAllowableFlightModesResponse::GetAllowableFlightModesResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
   SharedCtor();
   if (!is_message_owned) {
     RegisterArenaDtor(arena);
   }
-  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.action_server.GetAllowableFlightModeResponse)
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.action_server.GetAllowableFlightModesResponse)
 }
-GetAllowableFlightModeResponse::GetAllowableFlightModeResponse(const GetAllowableFlightModeResponse& from)
+GetAllowableFlightModesResponse::GetAllowableFlightModesResponse(const GetAllowableFlightModesResponse& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
   if (from._internal_has_flight_modes()) {
@@ -5294,37 +5297,37 @@ GetAllowableFlightModeResponse::GetAllowableFlightModeResponse(const GetAllowabl
   } else {
     flight_modes_ = nullptr;
   }
-  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.action_server.GetAllowableFlightModeResponse)
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.action_server.GetAllowableFlightModesResponse)
 }
 
-inline void GetAllowableFlightModeResponse::SharedCtor() {
+inline void GetAllowableFlightModesResponse::SharedCtor() {
 flight_modes_ = nullptr;
 }
 
-GetAllowableFlightModeResponse::~GetAllowableFlightModeResponse() {
-  // @@protoc_insertion_point(destructor:mavsdk.rpc.action_server.GetAllowableFlightModeResponse)
+GetAllowableFlightModesResponse::~GetAllowableFlightModesResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.action_server.GetAllowableFlightModesResponse)
   if (GetArenaForAllocation() != nullptr) return;
   SharedDtor();
   _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
-inline void GetAllowableFlightModeResponse::SharedDtor() {
+inline void GetAllowableFlightModesResponse::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
   if (this != internal_default_instance()) delete flight_modes_;
 }
 
-void GetAllowableFlightModeResponse::ArenaDtor(void* object) {
-  GetAllowableFlightModeResponse* _this = reinterpret_cast< GetAllowableFlightModeResponse* >(object);
+void GetAllowableFlightModesResponse::ArenaDtor(void* object) {
+  GetAllowableFlightModesResponse* _this = reinterpret_cast< GetAllowableFlightModesResponse* >(object);
   (void)_this;
 }
-void GetAllowableFlightModeResponse::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+void GetAllowableFlightModesResponse::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
 }
-void GetAllowableFlightModeResponse::SetCachedSize(int size) const {
+void GetAllowableFlightModesResponse::SetCachedSize(int size) const {
   _cached_size_.Set(size);
 }
 
-void GetAllowableFlightModeResponse::Clear() {
-// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action_server.GetAllowableFlightModeResponse)
+void GetAllowableFlightModesResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action_server.GetAllowableFlightModesResponse)
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -5336,7 +5339,7 @@ void GetAllowableFlightModeResponse::Clear() {
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
-const char* GetAllowableFlightModeResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+const char* GetAllowableFlightModesResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
 #define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
   while (!ctx->Done(&ptr)) {
     ::PROTOBUF_NAMESPACE_ID::uint32 tag;
@@ -5372,9 +5375,9 @@ failure:
 #undef CHK_
 }
 
-::PROTOBUF_NAMESPACE_ID::uint8* GetAllowableFlightModeResponse::_InternalSerialize(
+::PROTOBUF_NAMESPACE_ID::uint8* GetAllowableFlightModesResponse::_InternalSerialize(
     ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
-  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action_server.GetAllowableFlightModeResponse)
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action_server.GetAllowableFlightModesResponse)
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -5390,12 +5393,12 @@ failure:
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action_server.GetAllowableFlightModeResponse)
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action_server.GetAllowableFlightModesResponse)
   return target;
 }
 
-size_t GetAllowableFlightModeResponse::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action_server.GetAllowableFlightModeResponse)
+size_t GetAllowableFlightModesResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action_server.GetAllowableFlightModesResponse)
   size_t total_size = 0;
 
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
@@ -5418,21 +5421,21 @@ size_t GetAllowableFlightModeResponse::ByteSizeLong() const {
   return total_size;
 }
 
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData GetAllowableFlightModeResponse::_class_data_ = {
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData GetAllowableFlightModesResponse::_class_data_ = {
     ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSizeCheck,
-    GetAllowableFlightModeResponse::MergeImpl
+    GetAllowableFlightModesResponse::MergeImpl
 };
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetAllowableFlightModeResponse::GetClassData() const { return &_class_data_; }
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetAllowableFlightModesResponse::GetClassData() const { return &_class_data_; }
 
-void GetAllowableFlightModeResponse::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
+void GetAllowableFlightModesResponse::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
                       const ::PROTOBUF_NAMESPACE_ID::Message&from) {
-  static_cast<GetAllowableFlightModeResponse *>(to)->MergeFrom(
-      static_cast<const GetAllowableFlightModeResponse &>(from));
+  static_cast<GetAllowableFlightModesResponse *>(to)->MergeFrom(
+      static_cast<const GetAllowableFlightModesResponse &>(from));
 }
 
 
-void GetAllowableFlightModeResponse::MergeFrom(const GetAllowableFlightModeResponse& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action_server.GetAllowableFlightModeResponse)
+void GetAllowableFlightModesResponse::MergeFrom(const GetAllowableFlightModesResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action_server.GetAllowableFlightModesResponse)
   GOOGLE_DCHECK_NE(&from, this);
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
@@ -5443,24 +5446,24 @@ void GetAllowableFlightModeResponse::MergeFrom(const GetAllowableFlightModeRespo
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
 
-void GetAllowableFlightModeResponse::CopyFrom(const GetAllowableFlightModeResponse& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action_server.GetAllowableFlightModeResponse)
+void GetAllowableFlightModesResponse::CopyFrom(const GetAllowableFlightModesResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action_server.GetAllowableFlightModesResponse)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool GetAllowableFlightModeResponse::IsInitialized() const {
+bool GetAllowableFlightModesResponse::IsInitialized() const {
   return true;
 }
 
-void GetAllowableFlightModeResponse::InternalSwap(GetAllowableFlightModeResponse* other) {
+void GetAllowableFlightModesResponse::InternalSwap(GetAllowableFlightModesResponse* other) {
   using std::swap;
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
   swap(flight_modes_, other->flight_modes_);
 }
 
-::PROTOBUF_NAMESPACE_ID::Metadata GetAllowableFlightModeResponse::GetMetadata() const {
+::PROTOBUF_NAMESPACE_ID::Metadata GetAllowableFlightModesResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_action_5fserver_2faction_5fserver_2eproto_getter, &descriptor_table_action_5fserver_2faction_5fserver_2eproto_once,
       file_level_metadata_action_5fserver_2faction_5fserver_2eproto[23]);
@@ -6161,11 +6164,11 @@ template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action_server::SetArmableRequest* Ar
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action_server::SetDisarmableRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::action_server::SetDisarmableRequest >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::action_server::SetDisarmableRequest >(arena);
 }
-template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest >(Arena* arena) {
-  return Arena::CreateMessageInternal< ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest >(arena);
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest >(arena);
 }
-template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest >(Arena* arena) {
-  return Arena::CreateMessageInternal< ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest >(arena);
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest >(arena);
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action_server::SubscribeArmDisarmRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::action_server::SubscribeArmDisarmRequest >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::action_server::SubscribeArmDisarmRequest >(arena);
@@ -6215,14 +6218,14 @@ template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action_server::SetArmableResponse* A
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action_server::SetDisarmableResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::action_server::SetDisarmableResponse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::action_server::SetDisarmableResponse >(arena);
 }
-template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse >(Arena* arena) {
-  return Arena::CreateMessageInternal< ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse >(arena);
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse >(arena);
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action_server::SetAllowTakeoffResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::action_server::SetAllowTakeoffResponse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::action_server::SetAllowTakeoffResponse >(arena);
 }
-template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse >(Arena* arena) {
-  return Arena::CreateMessageInternal< ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse >(arena);
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse >(arena);
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::action_server::AllowableFlightModes* Arena::CreateMaybeMessage< ::mavsdk::rpc::action_server::AllowableFlightModes >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::action_server::AllowableFlightModes >(arena);

--- a/src/mavsdk_server/src/generated/action_server/action_server.pb.h
+++ b/src/mavsdk_server/src/generated/action_server/action_server.pb.h
@@ -73,12 +73,12 @@ extern ArmDisarmResponseDefaultTypeInternal _ArmDisarmResponse_default_instance_
 class FlightModeChangeResponse;
 struct FlightModeChangeResponseDefaultTypeInternal;
 extern FlightModeChangeResponseDefaultTypeInternal _FlightModeChangeResponse_default_instance_;
-class GetAllowableFlightModeRequest;
-struct GetAllowableFlightModeRequestDefaultTypeInternal;
-extern GetAllowableFlightModeRequestDefaultTypeInternal _GetAllowableFlightModeRequest_default_instance_;
-class GetAllowableFlightModeResponse;
-struct GetAllowableFlightModeResponseDefaultTypeInternal;
-extern GetAllowableFlightModeResponseDefaultTypeInternal _GetAllowableFlightModeResponse_default_instance_;
+class GetAllowableFlightModesRequest;
+struct GetAllowableFlightModesRequestDefaultTypeInternal;
+extern GetAllowableFlightModesRequestDefaultTypeInternal _GetAllowableFlightModesRequest_default_instance_;
+class GetAllowableFlightModesResponse;
+struct GetAllowableFlightModesResponseDefaultTypeInternal;
+extern GetAllowableFlightModesResponseDefaultTypeInternal _GetAllowableFlightModesResponse_default_instance_;
 class LandResponse;
 struct LandResponseDefaultTypeInternal;
 extern LandResponseDefaultTypeInternal _LandResponse_default_instance_;
@@ -91,12 +91,12 @@ extern SetAllowTakeoffRequestDefaultTypeInternal _SetAllowTakeoffRequest_default
 class SetAllowTakeoffResponse;
 struct SetAllowTakeoffResponseDefaultTypeInternal;
 extern SetAllowTakeoffResponseDefaultTypeInternal _SetAllowTakeoffResponse_default_instance_;
-class SetAllowableFlightModeRequest;
-struct SetAllowableFlightModeRequestDefaultTypeInternal;
-extern SetAllowableFlightModeRequestDefaultTypeInternal _SetAllowableFlightModeRequest_default_instance_;
-class SetAllowableFlightModeResponse;
-struct SetAllowableFlightModeResponseDefaultTypeInternal;
-extern SetAllowableFlightModeResponseDefaultTypeInternal _SetAllowableFlightModeResponse_default_instance_;
+class SetAllowableFlightModesRequest;
+struct SetAllowableFlightModesRequestDefaultTypeInternal;
+extern SetAllowableFlightModesRequestDefaultTypeInternal _SetAllowableFlightModesRequest_default_instance_;
+class SetAllowableFlightModesResponse;
+struct SetAllowableFlightModesResponseDefaultTypeInternal;
+extern SetAllowableFlightModesResponseDefaultTypeInternal _SetAllowableFlightModesResponse_default_instance_;
 class SetArmableRequest;
 struct SetArmableRequestDefaultTypeInternal;
 extern SetArmableRequestDefaultTypeInternal _SetArmableRequest_default_instance_;
@@ -148,14 +148,14 @@ template<> ::mavsdk::rpc::action_server::AllowableFlightModes* Arena::CreateMayb
 template<> ::mavsdk::rpc::action_server::ArmDisarm* Arena::CreateMaybeMessage<::mavsdk::rpc::action_server::ArmDisarm>(Arena*);
 template<> ::mavsdk::rpc::action_server::ArmDisarmResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action_server::ArmDisarmResponse>(Arena*);
 template<> ::mavsdk::rpc::action_server::FlightModeChangeResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action_server::FlightModeChangeResponse>(Arena*);
-template<> ::mavsdk::rpc::action_server::GetAllowableFlightModeRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::action_server::GetAllowableFlightModeRequest>(Arena*);
-template<> ::mavsdk::rpc::action_server::GetAllowableFlightModeResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action_server::GetAllowableFlightModeResponse>(Arena*);
+template<> ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::action_server::GetAllowableFlightModesRequest>(Arena*);
+template<> ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>(Arena*);
 template<> ::mavsdk::rpc::action_server::LandResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action_server::LandResponse>(Arena*);
 template<> ::mavsdk::rpc::action_server::RebootResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action_server::RebootResponse>(Arena*);
 template<> ::mavsdk::rpc::action_server::SetAllowTakeoffRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::action_server::SetAllowTakeoffRequest>(Arena*);
 template<> ::mavsdk::rpc::action_server::SetAllowTakeoffResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action_server::SetAllowTakeoffResponse>(Arena*);
-template<> ::mavsdk::rpc::action_server::SetAllowableFlightModeRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::action_server::SetAllowableFlightModeRequest>(Arena*);
-template<> ::mavsdk::rpc::action_server::SetAllowableFlightModeResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action_server::SetAllowableFlightModeResponse>(Arena*);
+template<> ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::action_server::SetAllowableFlightModesRequest>(Arena*);
+template<> ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>(Arena*);
 template<> ::mavsdk::rpc::action_server::SetArmableRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::action_server::SetArmableRequest>(Arena*);
 template<> ::mavsdk::rpc::action_server::SetArmableResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::action_server::SetArmableResponse>(Arena*);
 template<> ::mavsdk::rpc::action_server::SetDisarmableRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::action_server::SetDisarmableRequest>(Arena*);
@@ -188,12 +188,13 @@ enum ActionServerResult_Result : int {
   ActionServerResult_Result_RESULT_VTOL_TRANSITION_SUPPORT_UNKNOWN = 9,
   ActionServerResult_Result_RESULT_NO_VTOL_TRANSITION_SUPPORT = 10,
   ActionServerResult_Result_RESULT_PARAMETER_ERROR = 11,
+  ActionServerResult_Result_RESULT_NEXT = 12,
   ActionServerResult_Result_ActionServerResult_Result_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::min(),
   ActionServerResult_Result_ActionServerResult_Result_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::max()
 };
 bool ActionServerResult_Result_IsValid(int value);
 constexpr ActionServerResult_Result ActionServerResult_Result_Result_MIN = ActionServerResult_Result_RESULT_UNKNOWN;
-constexpr ActionServerResult_Result ActionServerResult_Result_Result_MAX = ActionServerResult_Result_RESULT_PARAMETER_ERROR;
+constexpr ActionServerResult_Result ActionServerResult_Result_Result_MAX = ActionServerResult_Result_RESULT_NEXT;
 constexpr int ActionServerResult_Result_Result_ARRAYSIZE = ActionServerResult_Result_Result_MAX + 1;
 
 const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* ActionServerResult_Result_descriptor();
@@ -688,24 +689,24 @@ class SetDisarmableRequest final :
 };
 // -------------------------------------------------------------------
 
-class SetAllowableFlightModeRequest final :
-    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action_server.SetAllowableFlightModeRequest) */ {
+class SetAllowableFlightModesRequest final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action_server.SetAllowableFlightModesRequest) */ {
  public:
-  inline SetAllowableFlightModeRequest() : SetAllowableFlightModeRequest(nullptr) {}
-  ~SetAllowableFlightModeRequest() override;
-  explicit constexpr SetAllowableFlightModeRequest(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+  inline SetAllowableFlightModesRequest() : SetAllowableFlightModesRequest(nullptr) {}
+  ~SetAllowableFlightModesRequest() override;
+  explicit constexpr SetAllowableFlightModesRequest(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
 
-  SetAllowableFlightModeRequest(const SetAllowableFlightModeRequest& from);
-  SetAllowableFlightModeRequest(SetAllowableFlightModeRequest&& from) noexcept
-    : SetAllowableFlightModeRequest() {
+  SetAllowableFlightModesRequest(const SetAllowableFlightModesRequest& from);
+  SetAllowableFlightModesRequest(SetAllowableFlightModesRequest&& from) noexcept
+    : SetAllowableFlightModesRequest() {
     *this = ::std::move(from);
   }
 
-  inline SetAllowableFlightModeRequest& operator=(const SetAllowableFlightModeRequest& from) {
+  inline SetAllowableFlightModesRequest& operator=(const SetAllowableFlightModesRequest& from) {
     CopyFrom(from);
     return *this;
   }
-  inline SetAllowableFlightModeRequest& operator=(SetAllowableFlightModeRequest&& from) noexcept {
+  inline SetAllowableFlightModesRequest& operator=(SetAllowableFlightModesRequest&& from) noexcept {
     if (this == &from) return *this;
     if (GetOwningArena() == from.GetOwningArena()) {
       InternalSwap(&from);
@@ -724,20 +725,20 @@ class SetAllowableFlightModeRequest final :
   static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
     return default_instance().GetMetadata().reflection;
   }
-  static const SetAllowableFlightModeRequest& default_instance() {
+  static const SetAllowableFlightModesRequest& default_instance() {
     return *internal_default_instance();
   }
-  static inline const SetAllowableFlightModeRequest* internal_default_instance() {
-    return reinterpret_cast<const SetAllowableFlightModeRequest*>(
-               &_SetAllowableFlightModeRequest_default_instance_);
+  static inline const SetAllowableFlightModesRequest* internal_default_instance() {
+    return reinterpret_cast<const SetAllowableFlightModesRequest*>(
+               &_SetAllowableFlightModesRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
     3;
 
-  friend void swap(SetAllowableFlightModeRequest& a, SetAllowableFlightModeRequest& b) {
+  friend void swap(SetAllowableFlightModesRequest& a, SetAllowableFlightModesRequest& b) {
     a.Swap(&b);
   }
-  inline void Swap(SetAllowableFlightModeRequest* other) {
+  inline void Swap(SetAllowableFlightModesRequest* other) {
     if (other == this) return;
     if (GetOwningArena() == other->GetOwningArena()) {
       InternalSwap(other);
@@ -745,7 +746,7 @@ class SetAllowableFlightModeRequest final :
       ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
     }
   }
-  void UnsafeArenaSwap(SetAllowableFlightModeRequest* other) {
+  void UnsafeArenaSwap(SetAllowableFlightModesRequest* other) {
     if (other == this) return;
     GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
     InternalSwap(other);
@@ -753,17 +754,17 @@ class SetAllowableFlightModeRequest final :
 
   // implements Message ----------------------------------------------
 
-  inline SetAllowableFlightModeRequest* New() const final {
-    return new SetAllowableFlightModeRequest();
+  inline SetAllowableFlightModesRequest* New() const final {
+    return new SetAllowableFlightModesRequest();
   }
 
-  SetAllowableFlightModeRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
-    return CreateMaybeMessage<SetAllowableFlightModeRequest>(arena);
+  SetAllowableFlightModesRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<SetAllowableFlightModesRequest>(arena);
   }
   using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
-  void CopyFrom(const SetAllowableFlightModeRequest& from);
+  void CopyFrom(const SetAllowableFlightModesRequest& from);
   using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
-  void MergeFrom(const SetAllowableFlightModeRequest& from);
+  void MergeFrom(const SetAllowableFlightModesRequest& from);
   private:
   static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to, const ::PROTOBUF_NAMESPACE_ID::Message&from);
   public:
@@ -780,13 +781,13 @@ class SetAllowableFlightModeRequest final :
   void SharedCtor();
   void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(SetAllowableFlightModeRequest* other);
+  void InternalSwap(SetAllowableFlightModesRequest* other);
   friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
   static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
-    return "mavsdk.rpc.action_server.SetAllowableFlightModeRequest";
+    return "mavsdk.rpc.action_server.SetAllowableFlightModesRequest";
   }
   protected:
-  explicit SetAllowableFlightModeRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+  explicit SetAllowableFlightModesRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                        bool is_message_owned = false);
   private:
   static void ArenaDtor(void* object);
@@ -823,7 +824,7 @@ class SetAllowableFlightModeRequest final :
       ::mavsdk::rpc::action_server::AllowableFlightModes* flight_modes);
   ::mavsdk::rpc::action_server::AllowableFlightModes* unsafe_arena_release_flight_modes();
 
-  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action_server.SetAllowableFlightModeRequest)
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action_server.SetAllowableFlightModesRequest)
  private:
   class _Internal;
 
@@ -836,24 +837,24 @@ class SetAllowableFlightModeRequest final :
 };
 // -------------------------------------------------------------------
 
-class GetAllowableFlightModeRequest final :
-    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action_server.GetAllowableFlightModeRequest) */ {
+class GetAllowableFlightModesRequest final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action_server.GetAllowableFlightModesRequest) */ {
  public:
-  inline GetAllowableFlightModeRequest() : GetAllowableFlightModeRequest(nullptr) {}
-  ~GetAllowableFlightModeRequest() override;
-  explicit constexpr GetAllowableFlightModeRequest(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+  inline GetAllowableFlightModesRequest() : GetAllowableFlightModesRequest(nullptr) {}
+  ~GetAllowableFlightModesRequest() override;
+  explicit constexpr GetAllowableFlightModesRequest(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
 
-  GetAllowableFlightModeRequest(const GetAllowableFlightModeRequest& from);
-  GetAllowableFlightModeRequest(GetAllowableFlightModeRequest&& from) noexcept
-    : GetAllowableFlightModeRequest() {
+  GetAllowableFlightModesRequest(const GetAllowableFlightModesRequest& from);
+  GetAllowableFlightModesRequest(GetAllowableFlightModesRequest&& from) noexcept
+    : GetAllowableFlightModesRequest() {
     *this = ::std::move(from);
   }
 
-  inline GetAllowableFlightModeRequest& operator=(const GetAllowableFlightModeRequest& from) {
+  inline GetAllowableFlightModesRequest& operator=(const GetAllowableFlightModesRequest& from) {
     CopyFrom(from);
     return *this;
   }
-  inline GetAllowableFlightModeRequest& operator=(GetAllowableFlightModeRequest&& from) noexcept {
+  inline GetAllowableFlightModesRequest& operator=(GetAllowableFlightModesRequest&& from) noexcept {
     if (this == &from) return *this;
     if (GetOwningArena() == from.GetOwningArena()) {
       InternalSwap(&from);
@@ -872,20 +873,20 @@ class GetAllowableFlightModeRequest final :
   static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
     return default_instance().GetMetadata().reflection;
   }
-  static const GetAllowableFlightModeRequest& default_instance() {
+  static const GetAllowableFlightModesRequest& default_instance() {
     return *internal_default_instance();
   }
-  static inline const GetAllowableFlightModeRequest* internal_default_instance() {
-    return reinterpret_cast<const GetAllowableFlightModeRequest*>(
-               &_GetAllowableFlightModeRequest_default_instance_);
+  static inline const GetAllowableFlightModesRequest* internal_default_instance() {
+    return reinterpret_cast<const GetAllowableFlightModesRequest*>(
+               &_GetAllowableFlightModesRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
     4;
 
-  friend void swap(GetAllowableFlightModeRequest& a, GetAllowableFlightModeRequest& b) {
+  friend void swap(GetAllowableFlightModesRequest& a, GetAllowableFlightModesRequest& b) {
     a.Swap(&b);
   }
-  inline void Swap(GetAllowableFlightModeRequest* other) {
+  inline void Swap(GetAllowableFlightModesRequest* other) {
     if (other == this) return;
     if (GetOwningArena() == other->GetOwningArena()) {
       InternalSwap(other);
@@ -893,7 +894,7 @@ class GetAllowableFlightModeRequest final :
       ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
     }
   }
-  void UnsafeArenaSwap(GetAllowableFlightModeRequest* other) {
+  void UnsafeArenaSwap(GetAllowableFlightModesRequest* other) {
     if (other == this) return;
     GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
     InternalSwap(other);
@@ -901,17 +902,17 @@ class GetAllowableFlightModeRequest final :
 
   // implements Message ----------------------------------------------
 
-  inline GetAllowableFlightModeRequest* New() const final {
-    return new GetAllowableFlightModeRequest();
+  inline GetAllowableFlightModesRequest* New() const final {
+    return new GetAllowableFlightModesRequest();
   }
 
-  GetAllowableFlightModeRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
-    return CreateMaybeMessage<GetAllowableFlightModeRequest>(arena);
+  GetAllowableFlightModesRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<GetAllowableFlightModesRequest>(arena);
   }
   using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
-  void CopyFrom(const GetAllowableFlightModeRequest& from);
+  void CopyFrom(const GetAllowableFlightModesRequest& from);
   using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
-  void MergeFrom(const GetAllowableFlightModeRequest& from);
+  void MergeFrom(const GetAllowableFlightModesRequest& from);
   private:
   static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to, const ::PROTOBUF_NAMESPACE_ID::Message&from);
   public:
@@ -928,13 +929,13 @@ class GetAllowableFlightModeRequest final :
   void SharedCtor();
   void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(GetAllowableFlightModeRequest* other);
+  void InternalSwap(GetAllowableFlightModesRequest* other);
   friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
   static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
-    return "mavsdk.rpc.action_server.GetAllowableFlightModeRequest";
+    return "mavsdk.rpc.action_server.GetAllowableFlightModesRequest";
   }
   protected:
-  explicit GetAllowableFlightModeRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+  explicit GetAllowableFlightModesRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                        bool is_message_owned = false);
   private:
   static void ArenaDtor(void* object);
@@ -950,7 +951,7 @@ class GetAllowableFlightModeRequest final :
 
   // accessors -------------------------------------------------------
 
-  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action_server.GetAllowableFlightModeRequest)
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action_server.GetAllowableFlightModesRequest)
  private:
   class _Internal;
 
@@ -3262,24 +3263,24 @@ class SetDisarmableResponse final :
 };
 // -------------------------------------------------------------------
 
-class SetAllowableFlightModeResponse final :
-    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action_server.SetAllowableFlightModeResponse) */ {
+class SetAllowableFlightModesResponse final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action_server.SetAllowableFlightModesResponse) */ {
  public:
-  inline SetAllowableFlightModeResponse() : SetAllowableFlightModeResponse(nullptr) {}
-  ~SetAllowableFlightModeResponse() override;
-  explicit constexpr SetAllowableFlightModeResponse(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+  inline SetAllowableFlightModesResponse() : SetAllowableFlightModesResponse(nullptr) {}
+  ~SetAllowableFlightModesResponse() override;
+  explicit constexpr SetAllowableFlightModesResponse(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
 
-  SetAllowableFlightModeResponse(const SetAllowableFlightModeResponse& from);
-  SetAllowableFlightModeResponse(SetAllowableFlightModeResponse&& from) noexcept
-    : SetAllowableFlightModeResponse() {
+  SetAllowableFlightModesResponse(const SetAllowableFlightModesResponse& from);
+  SetAllowableFlightModesResponse(SetAllowableFlightModesResponse&& from) noexcept
+    : SetAllowableFlightModesResponse() {
     *this = ::std::move(from);
   }
 
-  inline SetAllowableFlightModeResponse& operator=(const SetAllowableFlightModeResponse& from) {
+  inline SetAllowableFlightModesResponse& operator=(const SetAllowableFlightModesResponse& from) {
     CopyFrom(from);
     return *this;
   }
-  inline SetAllowableFlightModeResponse& operator=(SetAllowableFlightModeResponse&& from) noexcept {
+  inline SetAllowableFlightModesResponse& operator=(SetAllowableFlightModesResponse&& from) noexcept {
     if (this == &from) return *this;
     if (GetOwningArena() == from.GetOwningArena()) {
       InternalSwap(&from);
@@ -3298,20 +3299,20 @@ class SetAllowableFlightModeResponse final :
   static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
     return default_instance().GetMetadata().reflection;
   }
-  static const SetAllowableFlightModeResponse& default_instance() {
+  static const SetAllowableFlightModesResponse& default_instance() {
     return *internal_default_instance();
   }
-  static inline const SetAllowableFlightModeResponse* internal_default_instance() {
-    return reinterpret_cast<const SetAllowableFlightModeResponse*>(
-               &_SetAllowableFlightModeResponse_default_instance_);
+  static inline const SetAllowableFlightModesResponse* internal_default_instance() {
+    return reinterpret_cast<const SetAllowableFlightModesResponse*>(
+               &_SetAllowableFlightModesResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
     21;
 
-  friend void swap(SetAllowableFlightModeResponse& a, SetAllowableFlightModeResponse& b) {
+  friend void swap(SetAllowableFlightModesResponse& a, SetAllowableFlightModesResponse& b) {
     a.Swap(&b);
   }
-  inline void Swap(SetAllowableFlightModeResponse* other) {
+  inline void Swap(SetAllowableFlightModesResponse* other) {
     if (other == this) return;
     if (GetOwningArena() == other->GetOwningArena()) {
       InternalSwap(other);
@@ -3319,7 +3320,7 @@ class SetAllowableFlightModeResponse final :
       ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
     }
   }
-  void UnsafeArenaSwap(SetAllowableFlightModeResponse* other) {
+  void UnsafeArenaSwap(SetAllowableFlightModesResponse* other) {
     if (other == this) return;
     GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
     InternalSwap(other);
@@ -3327,17 +3328,17 @@ class SetAllowableFlightModeResponse final :
 
   // implements Message ----------------------------------------------
 
-  inline SetAllowableFlightModeResponse* New() const final {
-    return new SetAllowableFlightModeResponse();
+  inline SetAllowableFlightModesResponse* New() const final {
+    return new SetAllowableFlightModesResponse();
   }
 
-  SetAllowableFlightModeResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
-    return CreateMaybeMessage<SetAllowableFlightModeResponse>(arena);
+  SetAllowableFlightModesResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<SetAllowableFlightModesResponse>(arena);
   }
   using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
-  void CopyFrom(const SetAllowableFlightModeResponse& from);
+  void CopyFrom(const SetAllowableFlightModesResponse& from);
   using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
-  void MergeFrom(const SetAllowableFlightModeResponse& from);
+  void MergeFrom(const SetAllowableFlightModesResponse& from);
   private:
   static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to, const ::PROTOBUF_NAMESPACE_ID::Message&from);
   public:
@@ -3354,13 +3355,13 @@ class SetAllowableFlightModeResponse final :
   void SharedCtor();
   void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(SetAllowableFlightModeResponse* other);
+  void InternalSwap(SetAllowableFlightModesResponse* other);
   friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
   static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
-    return "mavsdk.rpc.action_server.SetAllowableFlightModeResponse";
+    return "mavsdk.rpc.action_server.SetAllowableFlightModesResponse";
   }
   protected:
-  explicit SetAllowableFlightModeResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+  explicit SetAllowableFlightModesResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                        bool is_message_owned = false);
   private:
   static void ArenaDtor(void* object);
@@ -3397,7 +3398,7 @@ class SetAllowableFlightModeResponse final :
       ::mavsdk::rpc::action_server::ActionServerResult* action_server_result);
   ::mavsdk::rpc::action_server::ActionServerResult* unsafe_arena_release_action_server_result();
 
-  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action_server.SetAllowableFlightModeResponse)
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action_server.SetAllowableFlightModesResponse)
  private:
   class _Internal;
 
@@ -3558,24 +3559,24 @@ class SetAllowTakeoffResponse final :
 };
 // -------------------------------------------------------------------
 
-class GetAllowableFlightModeResponse final :
-    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action_server.GetAllowableFlightModeResponse) */ {
+class GetAllowableFlightModesResponse final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action_server.GetAllowableFlightModesResponse) */ {
  public:
-  inline GetAllowableFlightModeResponse() : GetAllowableFlightModeResponse(nullptr) {}
-  ~GetAllowableFlightModeResponse() override;
-  explicit constexpr GetAllowableFlightModeResponse(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+  inline GetAllowableFlightModesResponse() : GetAllowableFlightModesResponse(nullptr) {}
+  ~GetAllowableFlightModesResponse() override;
+  explicit constexpr GetAllowableFlightModesResponse(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
 
-  GetAllowableFlightModeResponse(const GetAllowableFlightModeResponse& from);
-  GetAllowableFlightModeResponse(GetAllowableFlightModeResponse&& from) noexcept
-    : GetAllowableFlightModeResponse() {
+  GetAllowableFlightModesResponse(const GetAllowableFlightModesResponse& from);
+  GetAllowableFlightModesResponse(GetAllowableFlightModesResponse&& from) noexcept
+    : GetAllowableFlightModesResponse() {
     *this = ::std::move(from);
   }
 
-  inline GetAllowableFlightModeResponse& operator=(const GetAllowableFlightModeResponse& from) {
+  inline GetAllowableFlightModesResponse& operator=(const GetAllowableFlightModesResponse& from) {
     CopyFrom(from);
     return *this;
   }
-  inline GetAllowableFlightModeResponse& operator=(GetAllowableFlightModeResponse&& from) noexcept {
+  inline GetAllowableFlightModesResponse& operator=(GetAllowableFlightModesResponse&& from) noexcept {
     if (this == &from) return *this;
     if (GetOwningArena() == from.GetOwningArena()) {
       InternalSwap(&from);
@@ -3594,20 +3595,20 @@ class GetAllowableFlightModeResponse final :
   static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
     return default_instance().GetMetadata().reflection;
   }
-  static const GetAllowableFlightModeResponse& default_instance() {
+  static const GetAllowableFlightModesResponse& default_instance() {
     return *internal_default_instance();
   }
-  static inline const GetAllowableFlightModeResponse* internal_default_instance() {
-    return reinterpret_cast<const GetAllowableFlightModeResponse*>(
-               &_GetAllowableFlightModeResponse_default_instance_);
+  static inline const GetAllowableFlightModesResponse* internal_default_instance() {
+    return reinterpret_cast<const GetAllowableFlightModesResponse*>(
+               &_GetAllowableFlightModesResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
     23;
 
-  friend void swap(GetAllowableFlightModeResponse& a, GetAllowableFlightModeResponse& b) {
+  friend void swap(GetAllowableFlightModesResponse& a, GetAllowableFlightModesResponse& b) {
     a.Swap(&b);
   }
-  inline void Swap(GetAllowableFlightModeResponse* other) {
+  inline void Swap(GetAllowableFlightModesResponse* other) {
     if (other == this) return;
     if (GetOwningArena() == other->GetOwningArena()) {
       InternalSwap(other);
@@ -3615,7 +3616,7 @@ class GetAllowableFlightModeResponse final :
       ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
     }
   }
-  void UnsafeArenaSwap(GetAllowableFlightModeResponse* other) {
+  void UnsafeArenaSwap(GetAllowableFlightModesResponse* other) {
     if (other == this) return;
     GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
     InternalSwap(other);
@@ -3623,17 +3624,17 @@ class GetAllowableFlightModeResponse final :
 
   // implements Message ----------------------------------------------
 
-  inline GetAllowableFlightModeResponse* New() const final {
-    return new GetAllowableFlightModeResponse();
+  inline GetAllowableFlightModesResponse* New() const final {
+    return new GetAllowableFlightModesResponse();
   }
 
-  GetAllowableFlightModeResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
-    return CreateMaybeMessage<GetAllowableFlightModeResponse>(arena);
+  GetAllowableFlightModesResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<GetAllowableFlightModesResponse>(arena);
   }
   using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
-  void CopyFrom(const GetAllowableFlightModeResponse& from);
+  void CopyFrom(const GetAllowableFlightModesResponse& from);
   using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
-  void MergeFrom(const GetAllowableFlightModeResponse& from);
+  void MergeFrom(const GetAllowableFlightModesResponse& from);
   private:
   static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to, const ::PROTOBUF_NAMESPACE_ID::Message&from);
   public:
@@ -3650,13 +3651,13 @@ class GetAllowableFlightModeResponse final :
   void SharedCtor();
   void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(GetAllowableFlightModeResponse* other);
+  void InternalSwap(GetAllowableFlightModesResponse* other);
   friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
   static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
-    return "mavsdk.rpc.action_server.GetAllowableFlightModeResponse";
+    return "mavsdk.rpc.action_server.GetAllowableFlightModesResponse";
   }
   protected:
-  explicit GetAllowableFlightModeResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+  explicit GetAllowableFlightModesResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                        bool is_message_owned = false);
   private:
   static void ArenaDtor(void* object);
@@ -3693,7 +3694,7 @@ class GetAllowableFlightModeResponse final :
       ::mavsdk::rpc::action_server::AllowableFlightModes* flight_modes);
   ::mavsdk::rpc::action_server::AllowableFlightModes* unsafe_arena_release_flight_modes();
 
-  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action_server.GetAllowableFlightModeResponse)
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action_server.GetAllowableFlightModesResponse)
  private:
   class _Internal;
 
@@ -4154,6 +4155,8 @@ class ActionServerResult final :
     ActionServerResult_Result_RESULT_NO_VTOL_TRANSITION_SUPPORT;
   static constexpr Result RESULT_PARAMETER_ERROR =
     ActionServerResult_Result_RESULT_PARAMETER_ERROR;
+  static constexpr Result RESULT_NEXT =
+    ActionServerResult_Result_RESULT_NEXT;
   static inline bool Result_IsValid(int value) {
     return ActionServerResult_Result_IsValid(value);
   }
@@ -4341,31 +4344,31 @@ inline void SetDisarmableRequest::set_force_disarmable(bool value) {
 
 // -------------------------------------------------------------------
 
-// SetAllowableFlightModeRequest
+// SetAllowableFlightModesRequest
 
 // .mavsdk.rpc.action_server.AllowableFlightModes flight_modes = 1;
-inline bool SetAllowableFlightModeRequest::_internal_has_flight_modes() const {
+inline bool SetAllowableFlightModesRequest::_internal_has_flight_modes() const {
   return this != internal_default_instance() && flight_modes_ != nullptr;
 }
-inline bool SetAllowableFlightModeRequest::has_flight_modes() const {
+inline bool SetAllowableFlightModesRequest::has_flight_modes() const {
   return _internal_has_flight_modes();
 }
-inline void SetAllowableFlightModeRequest::clear_flight_modes() {
+inline void SetAllowableFlightModesRequest::clear_flight_modes() {
   if (GetArenaForAllocation() == nullptr && flight_modes_ != nullptr) {
     delete flight_modes_;
   }
   flight_modes_ = nullptr;
 }
-inline const ::mavsdk::rpc::action_server::AllowableFlightModes& SetAllowableFlightModeRequest::_internal_flight_modes() const {
+inline const ::mavsdk::rpc::action_server::AllowableFlightModes& SetAllowableFlightModesRequest::_internal_flight_modes() const {
   const ::mavsdk::rpc::action_server::AllowableFlightModes* p = flight_modes_;
   return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::action_server::AllowableFlightModes&>(
       ::mavsdk::rpc::action_server::_AllowableFlightModes_default_instance_);
 }
-inline const ::mavsdk::rpc::action_server::AllowableFlightModes& SetAllowableFlightModeRequest::flight_modes() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.action_server.SetAllowableFlightModeRequest.flight_modes)
+inline const ::mavsdk::rpc::action_server::AllowableFlightModes& SetAllowableFlightModesRequest::flight_modes() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action_server.SetAllowableFlightModesRequest.flight_modes)
   return _internal_flight_modes();
 }
-inline void SetAllowableFlightModeRequest::unsafe_arena_set_allocated_flight_modes(
+inline void SetAllowableFlightModesRequest::unsafe_arena_set_allocated_flight_modes(
     ::mavsdk::rpc::action_server::AllowableFlightModes* flight_modes) {
   if (GetArenaForAllocation() == nullptr) {
     delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(flight_modes_);
@@ -4376,9 +4379,9 @@ inline void SetAllowableFlightModeRequest::unsafe_arena_set_allocated_flight_mod
   } else {
     
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.action_server.SetAllowableFlightModeRequest.flight_modes)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.action_server.SetAllowableFlightModesRequest.flight_modes)
 }
-inline ::mavsdk::rpc::action_server::AllowableFlightModes* SetAllowableFlightModeRequest::release_flight_modes() {
+inline ::mavsdk::rpc::action_server::AllowableFlightModes* SetAllowableFlightModesRequest::release_flight_modes() {
   
   ::mavsdk::rpc::action_server::AllowableFlightModes* temp = flight_modes_;
   flight_modes_ = nullptr;
@@ -4393,14 +4396,14 @@ inline ::mavsdk::rpc::action_server::AllowableFlightModes* SetAllowableFlightMod
 #endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
   return temp;
 }
-inline ::mavsdk::rpc::action_server::AllowableFlightModes* SetAllowableFlightModeRequest::unsafe_arena_release_flight_modes() {
-  // @@protoc_insertion_point(field_release:mavsdk.rpc.action_server.SetAllowableFlightModeRequest.flight_modes)
+inline ::mavsdk::rpc::action_server::AllowableFlightModes* SetAllowableFlightModesRequest::unsafe_arena_release_flight_modes() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.action_server.SetAllowableFlightModesRequest.flight_modes)
   
   ::mavsdk::rpc::action_server::AllowableFlightModes* temp = flight_modes_;
   flight_modes_ = nullptr;
   return temp;
 }
-inline ::mavsdk::rpc::action_server::AllowableFlightModes* SetAllowableFlightModeRequest::_internal_mutable_flight_modes() {
+inline ::mavsdk::rpc::action_server::AllowableFlightModes* SetAllowableFlightModesRequest::_internal_mutable_flight_modes() {
   
   if (flight_modes_ == nullptr) {
     auto* p = CreateMaybeMessage<::mavsdk::rpc::action_server::AllowableFlightModes>(GetArenaForAllocation());
@@ -4408,12 +4411,12 @@ inline ::mavsdk::rpc::action_server::AllowableFlightModes* SetAllowableFlightMod
   }
   return flight_modes_;
 }
-inline ::mavsdk::rpc::action_server::AllowableFlightModes* SetAllowableFlightModeRequest::mutable_flight_modes() {
+inline ::mavsdk::rpc::action_server::AllowableFlightModes* SetAllowableFlightModesRequest::mutable_flight_modes() {
   ::mavsdk::rpc::action_server::AllowableFlightModes* _msg = _internal_mutable_flight_modes();
-  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.action_server.SetAllowableFlightModeRequest.flight_modes)
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.action_server.SetAllowableFlightModesRequest.flight_modes)
   return _msg;
 }
-inline void SetAllowableFlightModeRequest::set_allocated_flight_modes(::mavsdk::rpc::action_server::AllowableFlightModes* flight_modes) {
+inline void SetAllowableFlightModesRequest::set_allocated_flight_modes(::mavsdk::rpc::action_server::AllowableFlightModes* flight_modes) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
   if (message_arena == nullptr) {
     delete flight_modes_;
@@ -4430,12 +4433,12 @@ inline void SetAllowableFlightModeRequest::set_allocated_flight_modes(::mavsdk::
     
   }
   flight_modes_ = flight_modes;
-  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.action_server.SetAllowableFlightModeRequest.flight_modes)
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.action_server.SetAllowableFlightModesRequest.flight_modes)
 }
 
 // -------------------------------------------------------------------
 
-// GetAllowableFlightModeRequest
+// GetAllowableFlightModesRequest
 
 // -------------------------------------------------------------------
 
@@ -5523,31 +5526,31 @@ inline void SetDisarmableResponse::set_allocated_action_server_result(::mavsdk::
 
 // -------------------------------------------------------------------
 
-// SetAllowableFlightModeResponse
+// SetAllowableFlightModesResponse
 
 // .mavsdk.rpc.action_server.ActionServerResult action_server_result = 1;
-inline bool SetAllowableFlightModeResponse::_internal_has_action_server_result() const {
+inline bool SetAllowableFlightModesResponse::_internal_has_action_server_result() const {
   return this != internal_default_instance() && action_server_result_ != nullptr;
 }
-inline bool SetAllowableFlightModeResponse::has_action_server_result() const {
+inline bool SetAllowableFlightModesResponse::has_action_server_result() const {
   return _internal_has_action_server_result();
 }
-inline void SetAllowableFlightModeResponse::clear_action_server_result() {
+inline void SetAllowableFlightModesResponse::clear_action_server_result() {
   if (GetArenaForAllocation() == nullptr && action_server_result_ != nullptr) {
     delete action_server_result_;
   }
   action_server_result_ = nullptr;
 }
-inline const ::mavsdk::rpc::action_server::ActionServerResult& SetAllowableFlightModeResponse::_internal_action_server_result() const {
+inline const ::mavsdk::rpc::action_server::ActionServerResult& SetAllowableFlightModesResponse::_internal_action_server_result() const {
   const ::mavsdk::rpc::action_server::ActionServerResult* p = action_server_result_;
   return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::action_server::ActionServerResult&>(
       ::mavsdk::rpc::action_server::_ActionServerResult_default_instance_);
 }
-inline const ::mavsdk::rpc::action_server::ActionServerResult& SetAllowableFlightModeResponse::action_server_result() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.action_server.SetAllowableFlightModeResponse.action_server_result)
+inline const ::mavsdk::rpc::action_server::ActionServerResult& SetAllowableFlightModesResponse::action_server_result() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action_server.SetAllowableFlightModesResponse.action_server_result)
   return _internal_action_server_result();
 }
-inline void SetAllowableFlightModeResponse::unsafe_arena_set_allocated_action_server_result(
+inline void SetAllowableFlightModesResponse::unsafe_arena_set_allocated_action_server_result(
     ::mavsdk::rpc::action_server::ActionServerResult* action_server_result) {
   if (GetArenaForAllocation() == nullptr) {
     delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(action_server_result_);
@@ -5558,9 +5561,9 @@ inline void SetAllowableFlightModeResponse::unsafe_arena_set_allocated_action_se
   } else {
     
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.action_server.SetAllowableFlightModeResponse.action_server_result)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.action_server.SetAllowableFlightModesResponse.action_server_result)
 }
-inline ::mavsdk::rpc::action_server::ActionServerResult* SetAllowableFlightModeResponse::release_action_server_result() {
+inline ::mavsdk::rpc::action_server::ActionServerResult* SetAllowableFlightModesResponse::release_action_server_result() {
   
   ::mavsdk::rpc::action_server::ActionServerResult* temp = action_server_result_;
   action_server_result_ = nullptr;
@@ -5575,14 +5578,14 @@ inline ::mavsdk::rpc::action_server::ActionServerResult* SetAllowableFlightModeR
 #endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
   return temp;
 }
-inline ::mavsdk::rpc::action_server::ActionServerResult* SetAllowableFlightModeResponse::unsafe_arena_release_action_server_result() {
-  // @@protoc_insertion_point(field_release:mavsdk.rpc.action_server.SetAllowableFlightModeResponse.action_server_result)
+inline ::mavsdk::rpc::action_server::ActionServerResult* SetAllowableFlightModesResponse::unsafe_arena_release_action_server_result() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.action_server.SetAllowableFlightModesResponse.action_server_result)
   
   ::mavsdk::rpc::action_server::ActionServerResult* temp = action_server_result_;
   action_server_result_ = nullptr;
   return temp;
 }
-inline ::mavsdk::rpc::action_server::ActionServerResult* SetAllowableFlightModeResponse::_internal_mutable_action_server_result() {
+inline ::mavsdk::rpc::action_server::ActionServerResult* SetAllowableFlightModesResponse::_internal_mutable_action_server_result() {
   
   if (action_server_result_ == nullptr) {
     auto* p = CreateMaybeMessage<::mavsdk::rpc::action_server::ActionServerResult>(GetArenaForAllocation());
@@ -5590,12 +5593,12 @@ inline ::mavsdk::rpc::action_server::ActionServerResult* SetAllowableFlightModeR
   }
   return action_server_result_;
 }
-inline ::mavsdk::rpc::action_server::ActionServerResult* SetAllowableFlightModeResponse::mutable_action_server_result() {
+inline ::mavsdk::rpc::action_server::ActionServerResult* SetAllowableFlightModesResponse::mutable_action_server_result() {
   ::mavsdk::rpc::action_server::ActionServerResult* _msg = _internal_mutable_action_server_result();
-  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.action_server.SetAllowableFlightModeResponse.action_server_result)
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.action_server.SetAllowableFlightModesResponse.action_server_result)
   return _msg;
 }
-inline void SetAllowableFlightModeResponse::set_allocated_action_server_result(::mavsdk::rpc::action_server::ActionServerResult* action_server_result) {
+inline void SetAllowableFlightModesResponse::set_allocated_action_server_result(::mavsdk::rpc::action_server::ActionServerResult* action_server_result) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
   if (message_arena == nullptr) {
     delete action_server_result_;
@@ -5612,7 +5615,7 @@ inline void SetAllowableFlightModeResponse::set_allocated_action_server_result(:
     
   }
   action_server_result_ = action_server_result;
-  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.action_server.SetAllowableFlightModeResponse.action_server_result)
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.action_server.SetAllowableFlightModesResponse.action_server_result)
 }
 
 // -------------------------------------------------------------------
@@ -5711,31 +5714,31 @@ inline void SetAllowTakeoffResponse::set_allocated_action_server_result(::mavsdk
 
 // -------------------------------------------------------------------
 
-// GetAllowableFlightModeResponse
+// GetAllowableFlightModesResponse
 
 // .mavsdk.rpc.action_server.AllowableFlightModes flight_modes = 1;
-inline bool GetAllowableFlightModeResponse::_internal_has_flight_modes() const {
+inline bool GetAllowableFlightModesResponse::_internal_has_flight_modes() const {
   return this != internal_default_instance() && flight_modes_ != nullptr;
 }
-inline bool GetAllowableFlightModeResponse::has_flight_modes() const {
+inline bool GetAllowableFlightModesResponse::has_flight_modes() const {
   return _internal_has_flight_modes();
 }
-inline void GetAllowableFlightModeResponse::clear_flight_modes() {
+inline void GetAllowableFlightModesResponse::clear_flight_modes() {
   if (GetArenaForAllocation() == nullptr && flight_modes_ != nullptr) {
     delete flight_modes_;
   }
   flight_modes_ = nullptr;
 }
-inline const ::mavsdk::rpc::action_server::AllowableFlightModes& GetAllowableFlightModeResponse::_internal_flight_modes() const {
+inline const ::mavsdk::rpc::action_server::AllowableFlightModes& GetAllowableFlightModesResponse::_internal_flight_modes() const {
   const ::mavsdk::rpc::action_server::AllowableFlightModes* p = flight_modes_;
   return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::action_server::AllowableFlightModes&>(
       ::mavsdk::rpc::action_server::_AllowableFlightModes_default_instance_);
 }
-inline const ::mavsdk::rpc::action_server::AllowableFlightModes& GetAllowableFlightModeResponse::flight_modes() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.action_server.GetAllowableFlightModeResponse.flight_modes)
+inline const ::mavsdk::rpc::action_server::AllowableFlightModes& GetAllowableFlightModesResponse::flight_modes() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action_server.GetAllowableFlightModesResponse.flight_modes)
   return _internal_flight_modes();
 }
-inline void GetAllowableFlightModeResponse::unsafe_arena_set_allocated_flight_modes(
+inline void GetAllowableFlightModesResponse::unsafe_arena_set_allocated_flight_modes(
     ::mavsdk::rpc::action_server::AllowableFlightModes* flight_modes) {
   if (GetArenaForAllocation() == nullptr) {
     delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(flight_modes_);
@@ -5746,9 +5749,9 @@ inline void GetAllowableFlightModeResponse::unsafe_arena_set_allocated_flight_mo
   } else {
     
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.action_server.GetAllowableFlightModeResponse.flight_modes)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.action_server.GetAllowableFlightModesResponse.flight_modes)
 }
-inline ::mavsdk::rpc::action_server::AllowableFlightModes* GetAllowableFlightModeResponse::release_flight_modes() {
+inline ::mavsdk::rpc::action_server::AllowableFlightModes* GetAllowableFlightModesResponse::release_flight_modes() {
   
   ::mavsdk::rpc::action_server::AllowableFlightModes* temp = flight_modes_;
   flight_modes_ = nullptr;
@@ -5763,14 +5766,14 @@ inline ::mavsdk::rpc::action_server::AllowableFlightModes* GetAllowableFlightMod
 #endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
   return temp;
 }
-inline ::mavsdk::rpc::action_server::AllowableFlightModes* GetAllowableFlightModeResponse::unsafe_arena_release_flight_modes() {
-  // @@protoc_insertion_point(field_release:mavsdk.rpc.action_server.GetAllowableFlightModeResponse.flight_modes)
+inline ::mavsdk::rpc::action_server::AllowableFlightModes* GetAllowableFlightModesResponse::unsafe_arena_release_flight_modes() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.action_server.GetAllowableFlightModesResponse.flight_modes)
   
   ::mavsdk::rpc::action_server::AllowableFlightModes* temp = flight_modes_;
   flight_modes_ = nullptr;
   return temp;
 }
-inline ::mavsdk::rpc::action_server::AllowableFlightModes* GetAllowableFlightModeResponse::_internal_mutable_flight_modes() {
+inline ::mavsdk::rpc::action_server::AllowableFlightModes* GetAllowableFlightModesResponse::_internal_mutable_flight_modes() {
   
   if (flight_modes_ == nullptr) {
     auto* p = CreateMaybeMessage<::mavsdk::rpc::action_server::AllowableFlightModes>(GetArenaForAllocation());
@@ -5778,12 +5781,12 @@ inline ::mavsdk::rpc::action_server::AllowableFlightModes* GetAllowableFlightMod
   }
   return flight_modes_;
 }
-inline ::mavsdk::rpc::action_server::AllowableFlightModes* GetAllowableFlightModeResponse::mutable_flight_modes() {
+inline ::mavsdk::rpc::action_server::AllowableFlightModes* GetAllowableFlightModesResponse::mutable_flight_modes() {
   ::mavsdk::rpc::action_server::AllowableFlightModes* _msg = _internal_mutable_flight_modes();
-  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.action_server.GetAllowableFlightModeResponse.flight_modes)
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.action_server.GetAllowableFlightModesResponse.flight_modes)
   return _msg;
 }
-inline void GetAllowableFlightModeResponse::set_allocated_flight_modes(::mavsdk::rpc::action_server::AllowableFlightModes* flight_modes) {
+inline void GetAllowableFlightModesResponse::set_allocated_flight_modes(::mavsdk::rpc::action_server::AllowableFlightModes* flight_modes) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
   if (message_arena == nullptr) {
     delete flight_modes_;
@@ -5800,7 +5803,7 @@ inline void GetAllowableFlightModeResponse::set_allocated_flight_modes(::mavsdk:
     
   }
   flight_modes_ = flight_modes;
-  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.action_server.GetAllowableFlightModeResponse.flight_modes)
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.action_server.GetAllowableFlightModesResponse.flight_modes)
 }
 
 // -------------------------------------------------------------------

--- a/src/mavsdk_server/src/generated/mission_raw_server/mission_raw_server.pb.cc
+++ b/src/mavsdk_server/src/generated/mission_raw_server/mission_raw_server.pb.cc
@@ -32,7 +32,7 @@ struct SubscribeIncomingMissionRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SubscribeIncomingMissionRequestDefaultTypeInternal _SubscribeIncomingMissionRequest_default_instance_;
 constexpr IncomingMissionResponse::IncomingMissionResponse(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
-  : mission_result_(nullptr)
+  : mission_raw_server_result_(nullptr)
   , mission_plan_(nullptr){}
 struct IncomingMissionResponseDefaultTypeInternal {
   constexpr IncomingMissionResponseDefaultTypeInternal()
@@ -160,20 +160,20 @@ struct MissionProgressDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT MissionProgressDefaultTypeInternal _MissionProgress_default_instance_;
-constexpr MissionResult::MissionResult(
+constexpr MissionRawServerResult::MissionRawServerResult(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
   : result_str_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
   , result_(0)
 {}
-struct MissionResultDefaultTypeInternal {
-  constexpr MissionResultDefaultTypeInternal()
+struct MissionRawServerResultDefaultTypeInternal {
+  constexpr MissionRawServerResultDefaultTypeInternal()
     : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
-  ~MissionResultDefaultTypeInternal() {}
+  ~MissionRawServerResultDefaultTypeInternal() {}
   union {
-    MissionResult _instance;
+    MissionRawServerResult _instance;
   };
 };
-PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT MissionResultDefaultTypeInternal _MissionResult_default_instance_;
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT MissionRawServerResultDefaultTypeInternal _MissionRawServerResult_default_instance_;
 }  // namespace mission_raw_server
 }  // namespace rpc
 }  // namespace mavsdk
@@ -192,7 +192,7 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_mission_5fraw_5fserver_2fmissi
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw_server::IncomingMissionResponse, mission_result_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw_server::IncomingMissionResponse, mission_raw_server_result_),
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw_server::IncomingMissionResponse, mission_plan_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw_server::SubscribeCurrentItemChangedRequest, _internal_metadata_),
@@ -258,12 +258,12 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_mission_5fraw_5fserver_2fmissi
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw_server::MissionProgress, current_),
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw_server::MissionProgress, total_),
   ~0u,  // no _has_bits_
-  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw_server::MissionResult, _internal_metadata_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw_server::MissionRawServerResult, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw_server::MissionResult, result_),
-  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw_server::MissionResult, result_str_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw_server::MissionRawServerResult, result_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw_server::MissionRawServerResult, result_str_),
 };
 static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, sizeof(::mavsdk::rpc::mission_raw_server::SubscribeIncomingMissionRequest)},
@@ -277,7 +277,7 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 44, -1, sizeof(::mavsdk::rpc::mission_raw_server::MissionItem)},
   { 62, -1, sizeof(::mavsdk::rpc::mission_raw_server::MissionPlan)},
   { 68, -1, sizeof(::mavsdk::rpc::mission_raw_server::MissionProgress)},
-  { 75, -1, sizeof(::mavsdk::rpc::mission_raw_server::MissionResult)},
+  { 75, -1, sizeof(::mavsdk::rpc::mission_raw_server::MissionRawServerResult)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -292,68 +292,70 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission_raw_server::_MissionItem_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission_raw_server::_MissionPlan_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission_raw_server::_MissionProgress_default_instance_),
-  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission_raw_server::_MissionResult_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission_raw_server::_MissionRawServerResult_default_instance_),
 };
 
 const char descriptor_table_protodef_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) =
   "\n+mission_raw_server/mission_raw_server."
   "proto\022\035mavsdk.rpc.mission_raw_server\032\024ma"
   "vsdk_options.proto\"!\n\037SubscribeIncomingM"
-  "issionRequest\"\241\001\n\027IncomingMissionRespons"
-  "e\022D\n\016mission_result\030\001 \001(\0132,.mavsdk.rpc.m"
-  "ission_raw_server.MissionResult\022@\n\014missi"
-  "on_plan\030\002 \001(\0132*.mavsdk.rpc.mission_raw_s"
-  "erver.MissionPlan\"$\n\"SubscribeCurrentIte"
-  "mChangedRequest\"^\n\032CurrentItemChangedRes"
-  "ponse\022@\n\014mission_item\030\001 \001(\0132*.mavsdk.rpc"
-  ".mission_raw_server.MissionItem\"\032\n\030Subsc"
-  "ribeClearAllRequest\"&\n\020ClearAllResponse\022"
-  "\022\n\nclear_type\030\001 \001(\r\"\037\n\035SetCurrentItemCom"
-  "pleteRequest\" \n\036SetCurrentItemCompleteRe"
-  "sponse\"\330\001\n\013MissionItem\022\013\n\003seq\030\001 \001(\r\022\r\n\005f"
-  "rame\030\002 \001(\r\022\017\n\007command\030\003 \001(\r\022\017\n\007current\030\004"
-  " \001(\r\022\024\n\014autocontinue\030\005 \001(\r\022\016\n\006param1\030\006 \001"
-  "(\002\022\016\n\006param2\030\007 \001(\002\022\016\n\006param3\030\010 \001(\002\022\016\n\006pa"
-  "ram4\030\t \001(\002\022\t\n\001x\030\n \001(\005\022\t\n\001y\030\013 \001(\005\022\t\n\001z\030\014 "
-  "\001(\002\022\024\n\014mission_type\030\r \001(\r\"P\n\013MissionPlan"
-  "\022A\n\rmission_items\030\001 \003(\0132*.mavsdk.rpc.mis"
-  "sion_raw_server.MissionItem\"1\n\017MissionPr"
-  "ogress\022\017\n\007current\030\001 \001(\005\022\r\n\005total\030\002 \001(\005\"\244"
-  "\003\n\rMissionResult\022C\n\006result\030\001 \001(\01623.mavsd"
-  "k.rpc.mission_raw_server.MissionResult.R"
-  "esult\022\022\n\nresult_str\030\002 \001(\t\"\271\002\n\006Result\022\022\n\016"
-  "RESULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\020\n\014"
-  "RESULT_ERROR\020\002\022!\n\035RESULT_TOO_MANY_MISSIO"
-  "N_ITEMS\020\003\022\017\n\013RESULT_BUSY\020\004\022\022\n\016RESULT_TIM"
-  "EOUT\020\005\022\033\n\027RESULT_INVALID_ARGUMENT\020\006\022\026\n\022R"
-  "ESULT_UNSUPPORTED\020\007\022\037\n\033RESULT_NO_MISSION"
-  "_AVAILABLE\020\010\022\"\n\036RESULT_UNSUPPORTED_MISSI"
-  "ON_CMD\020\013\022\035\n\031RESULT_TRANSFER_CANCELLED\020\014\022"
-  "\024\n\020RESULT_NO_SYSTEM\020\r2\366\004\n\027MissionRawServ"
-  "erService\022\226\001\n\030SubscribeIncomingMission\022>"
-  ".mavsdk.rpc.mission_raw_server.Subscribe"
-  "IncomingMissionRequest\0326.mavsdk.rpc.miss"
-  "ion_raw_server.IncomingMissionResponse\"\000"
-  "0\001\022\237\001\n\033SubscribeCurrentItemChanged\022A.mav"
-  "sdk.rpc.mission_raw_server.SubscribeCurr"
-  "entItemChangedRequest\0329.mavsdk.rpc.missi"
-  "on_raw_server.CurrentItemChangedResponse"
-  "\"\0000\001\022\233\001\n\026SetCurrentItemComplete\022<.mavsdk"
-  ".rpc.mission_raw_server.SetCurrentItemCo"
-  "mpleteRequest\032=.mavsdk.rpc.mission_raw_s"
-  "erver.SetCurrentItemCompleteResponse\"\004\200\265"
-  "\030\001\022\201\001\n\021SubscribeClearAll\0227.mavsdk.rpc.mi"
-  "ssion_raw_server.SubscribeClearAllReques"
-  "t\032/.mavsdk.rpc.mission_raw_server.ClearA"
-  "llResponse\"\0000\001B5\n\034io.mavsdk.mission_raw_"
-  "serverB\025MissionRawServerProtob\006proto3"
+  "issionRequest\"\265\001\n\027IncomingMissionRespons"
+  "e\022X\n\031mission_raw_server_result\030\001 \001(\01325.m"
+  "avsdk.rpc.mission_raw_server.MissionRawS"
+  "erverResult\022@\n\014mission_plan\030\002 \001(\0132*.mavs"
+  "dk.rpc.mission_raw_server.MissionPlan\"$\n"
+  "\"SubscribeCurrentItemChangedRequest\"^\n\032C"
+  "urrentItemChangedResponse\022@\n\014mission_ite"
+  "m\030\001 \001(\0132*.mavsdk.rpc.mission_raw_server."
+  "MissionItem\"\032\n\030SubscribeClearAllRequest\""
+  "&\n\020ClearAllResponse\022\022\n\nclear_type\030\001 \001(\r\""
+  "\037\n\035SetCurrentItemCompleteRequest\" \n\036SetC"
+  "urrentItemCompleteResponse\"\330\001\n\013MissionIt"
+  "em\022\013\n\003seq\030\001 \001(\r\022\r\n\005frame\030\002 \001(\r\022\017\n\007comman"
+  "d\030\003 \001(\r\022\017\n\007current\030\004 \001(\r\022\024\n\014autocontinue"
+  "\030\005 \001(\r\022\016\n\006param1\030\006 \001(\002\022\016\n\006param2\030\007 \001(\002\022\016"
+  "\n\006param3\030\010 \001(\002\022\016\n\006param4\030\t \001(\002\022\t\n\001x\030\n \001("
+  "\005\022\t\n\001y\030\013 \001(\005\022\t\n\001z\030\014 \001(\002\022\024\n\014mission_type\030"
+  "\r \001(\r\"P\n\013MissionPlan\022A\n\rmission_items\030\001 "
+  "\003(\0132*.mavsdk.rpc.mission_raw_server.Miss"
+  "ionItem\"1\n\017MissionProgress\022\017\n\007current\030\001 "
+  "\001(\005\022\r\n\005total\030\002 \001(\005\"\307\003\n\026MissionRawServerR"
+  "esult\022L\n\006result\030\001 \001(\0162<.mavsdk.rpc.missi"
+  "on_raw_server.MissionRawServerResult.Res"
+  "ult\022\022\n\nresult_str\030\002 \001(\t\"\312\002\n\006Result\022\022\n\016RE"
+  "SULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\020\n\014RE"
+  "SULT_ERROR\020\002\022!\n\035RESULT_TOO_MANY_MISSION_"
+  "ITEMS\020\003\022\017\n\013RESULT_BUSY\020\004\022\022\n\016RESULT_TIMEO"
+  "UT\020\005\022\033\n\027RESULT_INVALID_ARGUMENT\020\006\022\026\n\022RES"
+  "ULT_UNSUPPORTED\020\007\022\037\n\033RESULT_NO_MISSION_A"
+  "VAILABLE\020\010\022\"\n\036RESULT_UNSUPPORTED_MISSION"
+  "_CMD\020\013\022\035\n\031RESULT_TRANSFER_CANCELLED\020\014\022\024\n"
+  "\020RESULT_NO_SYSTEM\020\r\022\017\n\013RESULT_NEXT\020\0162\366\004\n"
+  "\027MissionRawServerService\022\226\001\n\030SubscribeIn"
+  "comingMission\022>.mavsdk.rpc.mission_raw_s"
+  "erver.SubscribeIncomingMissionRequest\0326."
+  "mavsdk.rpc.mission_raw_server.IncomingMi"
+  "ssionResponse\"\0000\001\022\237\001\n\033SubscribeCurrentIt"
+  "emChanged\022A.mavsdk.rpc.mission_raw_serve"
+  "r.SubscribeCurrentItemChangedRequest\0329.m"
+  "avsdk.rpc.mission_raw_server.CurrentItem"
+  "ChangedResponse\"\0000\001\022\233\001\n\026SetCurrentItemCo"
+  "mplete\022<.mavsdk.rpc.mission_raw_server.S"
+  "etCurrentItemCompleteRequest\032=.mavsdk.rp"
+  "c.mission_raw_server.SetCurrentItemCompl"
+  "eteResponse\"\004\200\265\030\001\022\201\001\n\021SubscribeClearAll\022"
+  "7.mavsdk.rpc.mission_raw_server.Subscrib"
+  "eClearAllRequest\032/.mavsdk.rpc.mission_ra"
+  "w_server.ClearAllResponse\"\0000\001B5\n\034io.mavs"
+  "dk.mission_raw_serverB\025MissionRawServerP"
+  "rotob\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto_deps[1] = {
   &::descriptor_table_mavsdk_5foptions_2eproto,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto = {
-  false, false, 2037, descriptor_table_protodef_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto, "mission_raw_server/mission_raw_server.proto", 
+  false, false, 2092, descriptor_table_protodef_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto, "mission_raw_server/mission_raw_server.proto", 
   &descriptor_table_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto_once, descriptor_table_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto_deps, 1, 12,
   schemas, file_default_instances, TableStruct_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto::offsets,
   file_level_metadata_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto, file_level_enum_descriptors_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto, file_level_service_descriptors_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto,
@@ -367,11 +369,11 @@ PROTOBUF_ATTRIBUTE_INIT_PRIORITY static ::PROTOBUF_NAMESPACE_ID::internal::AddDe
 namespace mavsdk {
 namespace rpc {
 namespace mission_raw_server {
-const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* MissionResult_Result_descriptor() {
+const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* MissionRawServerResult_Result_descriptor() {
   ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&descriptor_table_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto);
   return file_level_enum_descriptors_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto[0];
 }
-bool MissionResult_Result_IsValid(int value) {
+bool MissionRawServerResult_Result_IsValid(int value) {
   switch (value) {
     case 0:
     case 1:
@@ -385,6 +387,7 @@ bool MissionResult_Result_IsValid(int value) {
     case 11:
     case 12:
     case 13:
+    case 14:
       return true;
     default:
       return false;
@@ -392,21 +395,22 @@ bool MissionResult_Result_IsValid(int value) {
 }
 
 #if (__cplusplus < 201703) && (!defined(_MSC_VER) || _MSC_VER >= 1900)
-constexpr MissionResult_Result MissionResult::RESULT_UNKNOWN;
-constexpr MissionResult_Result MissionResult::RESULT_SUCCESS;
-constexpr MissionResult_Result MissionResult::RESULT_ERROR;
-constexpr MissionResult_Result MissionResult::RESULT_TOO_MANY_MISSION_ITEMS;
-constexpr MissionResult_Result MissionResult::RESULT_BUSY;
-constexpr MissionResult_Result MissionResult::RESULT_TIMEOUT;
-constexpr MissionResult_Result MissionResult::RESULT_INVALID_ARGUMENT;
-constexpr MissionResult_Result MissionResult::RESULT_UNSUPPORTED;
-constexpr MissionResult_Result MissionResult::RESULT_NO_MISSION_AVAILABLE;
-constexpr MissionResult_Result MissionResult::RESULT_UNSUPPORTED_MISSION_CMD;
-constexpr MissionResult_Result MissionResult::RESULT_TRANSFER_CANCELLED;
-constexpr MissionResult_Result MissionResult::RESULT_NO_SYSTEM;
-constexpr MissionResult_Result MissionResult::Result_MIN;
-constexpr MissionResult_Result MissionResult::Result_MAX;
-constexpr int MissionResult::Result_ARRAYSIZE;
+constexpr MissionRawServerResult_Result MissionRawServerResult::RESULT_UNKNOWN;
+constexpr MissionRawServerResult_Result MissionRawServerResult::RESULT_SUCCESS;
+constexpr MissionRawServerResult_Result MissionRawServerResult::RESULT_ERROR;
+constexpr MissionRawServerResult_Result MissionRawServerResult::RESULT_TOO_MANY_MISSION_ITEMS;
+constexpr MissionRawServerResult_Result MissionRawServerResult::RESULT_BUSY;
+constexpr MissionRawServerResult_Result MissionRawServerResult::RESULT_TIMEOUT;
+constexpr MissionRawServerResult_Result MissionRawServerResult::RESULT_INVALID_ARGUMENT;
+constexpr MissionRawServerResult_Result MissionRawServerResult::RESULT_UNSUPPORTED;
+constexpr MissionRawServerResult_Result MissionRawServerResult::RESULT_NO_MISSION_AVAILABLE;
+constexpr MissionRawServerResult_Result MissionRawServerResult::RESULT_UNSUPPORTED_MISSION_CMD;
+constexpr MissionRawServerResult_Result MissionRawServerResult::RESULT_TRANSFER_CANCELLED;
+constexpr MissionRawServerResult_Result MissionRawServerResult::RESULT_NO_SYSTEM;
+constexpr MissionRawServerResult_Result MissionRawServerResult::RESULT_NEXT;
+constexpr MissionRawServerResult_Result MissionRawServerResult::Result_MIN;
+constexpr MissionRawServerResult_Result MissionRawServerResult::Result_MAX;
+constexpr int MissionRawServerResult::Result_ARRAYSIZE;
 #endif  // (__cplusplus < 201703) && (!defined(_MSC_VER) || _MSC_VER >= 1900)
 
 // ===================================================================
@@ -566,13 +570,13 @@ void SubscribeIncomingMissionRequest::InternalSwap(SubscribeIncomingMissionReque
 
 class IncomingMissionResponse::_Internal {
  public:
-  static const ::mavsdk::rpc::mission_raw_server::MissionResult& mission_result(const IncomingMissionResponse* msg);
+  static const ::mavsdk::rpc::mission_raw_server::MissionRawServerResult& mission_raw_server_result(const IncomingMissionResponse* msg);
   static const ::mavsdk::rpc::mission_raw_server::MissionPlan& mission_plan(const IncomingMissionResponse* msg);
 };
 
-const ::mavsdk::rpc::mission_raw_server::MissionResult&
-IncomingMissionResponse::_Internal::mission_result(const IncomingMissionResponse* msg) {
-  return *msg->mission_result_;
+const ::mavsdk::rpc::mission_raw_server::MissionRawServerResult&
+IncomingMissionResponse::_Internal::mission_raw_server_result(const IncomingMissionResponse* msg) {
+  return *msg->mission_raw_server_result_;
 }
 const ::mavsdk::rpc::mission_raw_server::MissionPlan&
 IncomingMissionResponse::_Internal::mission_plan(const IncomingMissionResponse* msg) {
@@ -590,10 +594,10 @@ IncomingMissionResponse::IncomingMissionResponse(::PROTOBUF_NAMESPACE_ID::Arena*
 IncomingMissionResponse::IncomingMissionResponse(const IncomingMissionResponse& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
-  if (from._internal_has_mission_result()) {
-    mission_result_ = new ::mavsdk::rpc::mission_raw_server::MissionResult(*from.mission_result_);
+  if (from._internal_has_mission_raw_server_result()) {
+    mission_raw_server_result_ = new ::mavsdk::rpc::mission_raw_server::MissionRawServerResult(*from.mission_raw_server_result_);
   } else {
-    mission_result_ = nullptr;
+    mission_raw_server_result_ = nullptr;
   }
   if (from._internal_has_mission_plan()) {
     mission_plan_ = new ::mavsdk::rpc::mission_raw_server::MissionPlan(*from.mission_plan_);
@@ -605,9 +609,9 @@ IncomingMissionResponse::IncomingMissionResponse(const IncomingMissionResponse& 
 
 inline void IncomingMissionResponse::SharedCtor() {
 ::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
-    reinterpret_cast<char*>(&mission_result_) - reinterpret_cast<char*>(this)),
+    reinterpret_cast<char*>(&mission_raw_server_result_) - reinterpret_cast<char*>(this)),
     0, static_cast<size_t>(reinterpret_cast<char*>(&mission_plan_) -
-    reinterpret_cast<char*>(&mission_result_)) + sizeof(mission_plan_));
+    reinterpret_cast<char*>(&mission_raw_server_result_)) + sizeof(mission_plan_));
 }
 
 IncomingMissionResponse::~IncomingMissionResponse() {
@@ -619,7 +623,7 @@ IncomingMissionResponse::~IncomingMissionResponse() {
 
 inline void IncomingMissionResponse::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
-  if (this != internal_default_instance()) delete mission_result_;
+  if (this != internal_default_instance()) delete mission_raw_server_result_;
   if (this != internal_default_instance()) delete mission_plan_;
 }
 
@@ -639,10 +643,10 @@ void IncomingMissionResponse::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  if (GetArenaForAllocation() == nullptr && mission_result_ != nullptr) {
-    delete mission_result_;
+  if (GetArenaForAllocation() == nullptr && mission_raw_server_result_ != nullptr) {
+    delete mission_raw_server_result_;
   }
-  mission_result_ = nullptr;
+  mission_raw_server_result_ = nullptr;
   if (GetArenaForAllocation() == nullptr && mission_plan_ != nullptr) {
     delete mission_plan_;
   }
@@ -656,10 +660,10 @@ const char* IncomingMissionResponse::_InternalParse(const char* ptr, ::PROTOBUF_
     ::PROTOBUF_NAMESPACE_ID::uint32 tag;
     ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
     switch (tag >> 3) {
-      // .mavsdk.rpc.mission_raw_server.MissionResult mission_result = 1;
+      // .mavsdk.rpc.mission_raw_server.MissionRawServerResult mission_raw_server_result = 1;
       case 1:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
-          ptr = ctx->ParseMessage(_internal_mutable_mission_result(), ptr);
+          ptr = ctx->ParseMessage(_internal_mutable_mission_raw_server_result(), ptr);
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
@@ -699,12 +703,12 @@ failure:
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // .mavsdk.rpc.mission_raw_server.MissionResult mission_result = 1;
-  if (this->_internal_has_mission_result()) {
+  // .mavsdk.rpc.mission_raw_server.MissionRawServerResult mission_raw_server_result = 1;
+  if (this->_internal_has_mission_raw_server_result()) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
       InternalWriteMessage(
-        1, _Internal::mission_result(this), target, stream);
+        1, _Internal::mission_raw_server_result(this), target, stream);
   }
 
   // .mavsdk.rpc.mission_raw_server.MissionPlan mission_plan = 2;
@@ -731,11 +735,11 @@ size_t IncomingMissionResponse::ByteSizeLong() const {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  // .mavsdk.rpc.mission_raw_server.MissionResult mission_result = 1;
-  if (this->_internal_has_mission_result()) {
+  // .mavsdk.rpc.mission_raw_server.MissionRawServerResult mission_raw_server_result = 1;
+  if (this->_internal_has_mission_raw_server_result()) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-        *mission_result_);
+        *mission_raw_server_result_);
   }
 
   // .mavsdk.rpc.mission_raw_server.MissionPlan mission_plan = 2;
@@ -773,8 +777,8 @@ void IncomingMissionResponse::MergeFrom(const IncomingMissionResponse& from) {
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  if (from._internal_has_mission_result()) {
-    _internal_mutable_mission_result()->::mavsdk::rpc::mission_raw_server::MissionResult::MergeFrom(from._internal_mission_result());
+  if (from._internal_has_mission_raw_server_result()) {
+    _internal_mutable_mission_raw_server_result()->::mavsdk::rpc::mission_raw_server::MissionRawServerResult::MergeFrom(from._internal_mission_raw_server_result());
   }
   if (from._internal_has_mission_plan()) {
     _internal_mutable_mission_plan()->::mavsdk::rpc::mission_raw_server::MissionPlan::MergeFrom(from._internal_mission_plan());
@@ -799,9 +803,9 @@ void IncomingMissionResponse::InternalSwap(IncomingMissionResponse* other) {
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
       PROTOBUF_FIELD_OFFSET(IncomingMissionResponse, mission_plan_)
       + sizeof(IncomingMissionResponse::mission_plan_)
-      - PROTOBUF_FIELD_OFFSET(IncomingMissionResponse, mission_result_)>(
-          reinterpret_cast<char*>(&mission_result_),
-          reinterpret_cast<char*>(&other->mission_result_));
+      - PROTOBUF_FIELD_OFFSET(IncomingMissionResponse, mission_raw_server_result_)>(
+          reinterpret_cast<char*>(&mission_raw_server_result_),
+          reinterpret_cast<char*>(&other->mission_raw_server_result_));
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata IncomingMissionResponse::GetMetadata() const {
@@ -2682,20 +2686,20 @@ void MissionProgress::InternalSwap(MissionProgress* other) {
 
 // ===================================================================
 
-class MissionResult::_Internal {
+class MissionRawServerResult::_Internal {
  public:
 };
 
-MissionResult::MissionResult(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+MissionRawServerResult::MissionRawServerResult(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
   SharedCtor();
   if (!is_message_owned) {
     RegisterArenaDtor(arena);
   }
-  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.mission_raw_server.MissionResult)
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.mission_raw_server.MissionRawServerResult)
 }
-MissionResult::MissionResult(const MissionResult& from)
+MissionRawServerResult::MissionRawServerResult(const MissionRawServerResult& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
   result_str_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
@@ -2704,38 +2708,38 @@ MissionResult::MissionResult(const MissionResult& from)
       GetArenaForAllocation());
   }
   result_ = from.result_;
-  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.mission_raw_server.MissionResult)
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.mission_raw_server.MissionRawServerResult)
 }
 
-inline void MissionResult::SharedCtor() {
+inline void MissionRawServerResult::SharedCtor() {
 result_str_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
 result_ = 0;
 }
 
-MissionResult::~MissionResult() {
-  // @@protoc_insertion_point(destructor:mavsdk.rpc.mission_raw_server.MissionResult)
+MissionRawServerResult::~MissionRawServerResult() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.mission_raw_server.MissionRawServerResult)
   if (GetArenaForAllocation() != nullptr) return;
   SharedDtor();
   _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
-inline void MissionResult::SharedDtor() {
+inline void MissionRawServerResult::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
   result_str_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
 }
 
-void MissionResult::ArenaDtor(void* object) {
-  MissionResult* _this = reinterpret_cast< MissionResult* >(object);
+void MissionRawServerResult::ArenaDtor(void* object) {
+  MissionRawServerResult* _this = reinterpret_cast< MissionRawServerResult* >(object);
   (void)_this;
 }
-void MissionResult::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+void MissionRawServerResult::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
 }
-void MissionResult::SetCachedSize(int size) const {
+void MissionRawServerResult::SetCachedSize(int size) const {
   _cached_size_.Set(size);
 }
 
-void MissionResult::Clear() {
-// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.mission_raw_server.MissionResult)
+void MissionRawServerResult::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.mission_raw_server.MissionRawServerResult)
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -2745,18 +2749,18 @@ void MissionResult::Clear() {
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
-const char* MissionResult::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+const char* MissionRawServerResult::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
 #define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
   while (!ctx->Done(&ptr)) {
     ::PROTOBUF_NAMESPACE_ID::uint32 tag;
     ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
     switch (tag >> 3) {
-      // .mavsdk.rpc.mission_raw_server.MissionResult.Result result = 1;
+      // .mavsdk.rpc.mission_raw_server.MissionRawServerResult.Result result = 1;
       case 1:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 8)) {
           ::PROTOBUF_NAMESPACE_ID::uint64 val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
-          _internal_set_result(static_cast<::mavsdk::rpc::mission_raw_server::MissionResult_Result>(val));
+          _internal_set_result(static_cast<::mavsdk::rpc::mission_raw_server::MissionRawServerResult_Result>(val));
         } else goto handle_unusual;
         continue;
       // string result_str = 2;
@@ -2764,7 +2768,7 @@ const char* MissionResult::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
           auto str = _internal_mutable_result_str();
           ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
-          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "mavsdk.rpc.mission_raw_server.MissionResult.result_str"));
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "mavsdk.rpc.mission_raw_server.MissionRawServerResult.result_str"));
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
@@ -2791,13 +2795,13 @@ failure:
 #undef CHK_
 }
 
-::PROTOBUF_NAMESPACE_ID::uint8* MissionResult::_InternalSerialize(
+::PROTOBUF_NAMESPACE_ID::uint8* MissionRawServerResult::_InternalSerialize(
     ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
-  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.mission_raw_server.MissionResult)
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.mission_raw_server.MissionRawServerResult)
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // .mavsdk.rpc.mission_raw_server.MissionResult.Result result = 1;
+  // .mavsdk.rpc.mission_raw_server.MissionRawServerResult.Result result = 1;
   if (this->_internal_result() != 0) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteEnumToArray(
@@ -2809,7 +2813,7 @@ failure:
     ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
       this->_internal_result_str().data(), static_cast<int>(this->_internal_result_str().length()),
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
-      "mavsdk.rpc.mission_raw_server.MissionResult.result_str");
+      "mavsdk.rpc.mission_raw_server.MissionRawServerResult.result_str");
     target = stream->WriteStringMaybeAliased(
         2, this->_internal_result_str(), target);
   }
@@ -2818,12 +2822,12 @@ failure:
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.mission_raw_server.MissionResult)
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.mission_raw_server.MissionRawServerResult)
   return target;
 }
 
-size_t MissionResult::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.mission_raw_server.MissionResult)
+size_t MissionRawServerResult::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.mission_raw_server.MissionRawServerResult)
   size_t total_size = 0;
 
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
@@ -2837,7 +2841,7 @@ size_t MissionResult::ByteSizeLong() const {
         this->_internal_result_str());
   }
 
-  // .mavsdk.rpc.mission_raw_server.MissionResult.Result result = 1;
+  // .mavsdk.rpc.mission_raw_server.MissionRawServerResult.Result result = 1;
   if (this->_internal_result() != 0) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::EnumSize(this->_internal_result());
@@ -2852,21 +2856,21 @@ size_t MissionResult::ByteSizeLong() const {
   return total_size;
 }
 
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData MissionResult::_class_data_ = {
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData MissionRawServerResult::_class_data_ = {
     ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSizeCheck,
-    MissionResult::MergeImpl
+    MissionRawServerResult::MergeImpl
 };
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*MissionResult::GetClassData() const { return &_class_data_; }
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*MissionRawServerResult::GetClassData() const { return &_class_data_; }
 
-void MissionResult::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
+void MissionRawServerResult::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
                       const ::PROTOBUF_NAMESPACE_ID::Message&from) {
-  static_cast<MissionResult *>(to)->MergeFrom(
-      static_cast<const MissionResult &>(from));
+  static_cast<MissionRawServerResult *>(to)->MergeFrom(
+      static_cast<const MissionRawServerResult &>(from));
 }
 
 
-void MissionResult::MergeFrom(const MissionResult& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.mission_raw_server.MissionResult)
+void MissionRawServerResult::MergeFrom(const MissionRawServerResult& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.mission_raw_server.MissionRawServerResult)
   GOOGLE_DCHECK_NE(&from, this);
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
@@ -2880,18 +2884,18 @@ void MissionResult::MergeFrom(const MissionResult& from) {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
 
-void MissionResult::CopyFrom(const MissionResult& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.mission_raw_server.MissionResult)
+void MissionRawServerResult::CopyFrom(const MissionRawServerResult& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.mission_raw_server.MissionRawServerResult)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool MissionResult::IsInitialized() const {
+bool MissionRawServerResult::IsInitialized() const {
   return true;
 }
 
-void MissionResult::InternalSwap(MissionResult* other) {
+void MissionRawServerResult::InternalSwap(MissionRawServerResult* other) {
   using std::swap;
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
@@ -2902,7 +2906,7 @@ void MissionResult::InternalSwap(MissionResult* other) {
   swap(result_, other->result_);
 }
 
-::PROTOBUF_NAMESPACE_ID::Metadata MissionResult::GetMetadata() const {
+::PROTOBUF_NAMESPACE_ID::Metadata MissionRawServerResult::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto_getter, &descriptor_table_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto_once,
       file_level_metadata_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto[11]);
@@ -2946,8 +2950,8 @@ template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission_raw_server::MissionPlan* Are
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission_raw_server::MissionProgress* Arena::CreateMaybeMessage< ::mavsdk::rpc::mission_raw_server::MissionProgress >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::mission_raw_server::MissionProgress >(arena);
 }
-template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission_raw_server::MissionResult* Arena::CreateMaybeMessage< ::mavsdk::rpc::mission_raw_server::MissionResult >(Arena* arena) {
-  return Arena::CreateMessageInternal< ::mavsdk::rpc::mission_raw_server::MissionResult >(arena);
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission_raw_server::MissionRawServerResult* Arena::CreateMaybeMessage< ::mavsdk::rpc::mission_raw_server::MissionRawServerResult >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::mission_raw_server::MissionRawServerResult >(arena);
 }
 PROTOBUF_NAMESPACE_CLOSE
 

--- a/src/mavsdk_server/src/generated/mission_raw_server/mission_raw_server.pb.h
+++ b/src/mavsdk_server/src/generated/mission_raw_server/mission_raw_server.pb.h
@@ -76,9 +76,9 @@ extern MissionPlanDefaultTypeInternal _MissionPlan_default_instance_;
 class MissionProgress;
 struct MissionProgressDefaultTypeInternal;
 extern MissionProgressDefaultTypeInternal _MissionProgress_default_instance_;
-class MissionResult;
-struct MissionResultDefaultTypeInternal;
-extern MissionResultDefaultTypeInternal _MissionResult_default_instance_;
+class MissionRawServerResult;
+struct MissionRawServerResultDefaultTypeInternal;
+extern MissionRawServerResultDefaultTypeInternal _MissionRawServerResult_default_instance_;
 class SetCurrentItemCompleteRequest;
 struct SetCurrentItemCompleteRequestDefaultTypeInternal;
 extern SetCurrentItemCompleteRequestDefaultTypeInternal _SetCurrentItemCompleteRequest_default_instance_;
@@ -104,7 +104,7 @@ template<> ::mavsdk::rpc::mission_raw_server::IncomingMissionResponse* Arena::Cr
 template<> ::mavsdk::rpc::mission_raw_server::MissionItem* Arena::CreateMaybeMessage<::mavsdk::rpc::mission_raw_server::MissionItem>(Arena*);
 template<> ::mavsdk::rpc::mission_raw_server::MissionPlan* Arena::CreateMaybeMessage<::mavsdk::rpc::mission_raw_server::MissionPlan>(Arena*);
 template<> ::mavsdk::rpc::mission_raw_server::MissionProgress* Arena::CreateMaybeMessage<::mavsdk::rpc::mission_raw_server::MissionProgress>(Arena*);
-template<> ::mavsdk::rpc::mission_raw_server::MissionResult* Arena::CreateMaybeMessage<::mavsdk::rpc::mission_raw_server::MissionResult>(Arena*);
+template<> ::mavsdk::rpc::mission_raw_server::MissionRawServerResult* Arena::CreateMaybeMessage<::mavsdk::rpc::mission_raw_server::MissionRawServerResult>(Arena*);
 template<> ::mavsdk::rpc::mission_raw_server::SetCurrentItemCompleteRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::mission_raw_server::SetCurrentItemCompleteRequest>(Arena*);
 template<> ::mavsdk::rpc::mission_raw_server::SetCurrentItemCompleteResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::mission_raw_server::SetCurrentItemCompleteResponse>(Arena*);
 template<> ::mavsdk::rpc::mission_raw_server::SubscribeClearAllRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::mission_raw_server::SubscribeClearAllRequest>(Arena*);
@@ -115,40 +115,41 @@ namespace mavsdk {
 namespace rpc {
 namespace mission_raw_server {
 
-enum MissionResult_Result : int {
-  MissionResult_Result_RESULT_UNKNOWN = 0,
-  MissionResult_Result_RESULT_SUCCESS = 1,
-  MissionResult_Result_RESULT_ERROR = 2,
-  MissionResult_Result_RESULT_TOO_MANY_MISSION_ITEMS = 3,
-  MissionResult_Result_RESULT_BUSY = 4,
-  MissionResult_Result_RESULT_TIMEOUT = 5,
-  MissionResult_Result_RESULT_INVALID_ARGUMENT = 6,
-  MissionResult_Result_RESULT_UNSUPPORTED = 7,
-  MissionResult_Result_RESULT_NO_MISSION_AVAILABLE = 8,
-  MissionResult_Result_RESULT_UNSUPPORTED_MISSION_CMD = 11,
-  MissionResult_Result_RESULT_TRANSFER_CANCELLED = 12,
-  MissionResult_Result_RESULT_NO_SYSTEM = 13,
-  MissionResult_Result_MissionResult_Result_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::min(),
-  MissionResult_Result_MissionResult_Result_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::max()
+enum MissionRawServerResult_Result : int {
+  MissionRawServerResult_Result_RESULT_UNKNOWN = 0,
+  MissionRawServerResult_Result_RESULT_SUCCESS = 1,
+  MissionRawServerResult_Result_RESULT_ERROR = 2,
+  MissionRawServerResult_Result_RESULT_TOO_MANY_MISSION_ITEMS = 3,
+  MissionRawServerResult_Result_RESULT_BUSY = 4,
+  MissionRawServerResult_Result_RESULT_TIMEOUT = 5,
+  MissionRawServerResult_Result_RESULT_INVALID_ARGUMENT = 6,
+  MissionRawServerResult_Result_RESULT_UNSUPPORTED = 7,
+  MissionRawServerResult_Result_RESULT_NO_MISSION_AVAILABLE = 8,
+  MissionRawServerResult_Result_RESULT_UNSUPPORTED_MISSION_CMD = 11,
+  MissionRawServerResult_Result_RESULT_TRANSFER_CANCELLED = 12,
+  MissionRawServerResult_Result_RESULT_NO_SYSTEM = 13,
+  MissionRawServerResult_Result_RESULT_NEXT = 14,
+  MissionRawServerResult_Result_MissionRawServerResult_Result_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::min(),
+  MissionRawServerResult_Result_MissionRawServerResult_Result_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::max()
 };
-bool MissionResult_Result_IsValid(int value);
-constexpr MissionResult_Result MissionResult_Result_Result_MIN = MissionResult_Result_RESULT_UNKNOWN;
-constexpr MissionResult_Result MissionResult_Result_Result_MAX = MissionResult_Result_RESULT_NO_SYSTEM;
-constexpr int MissionResult_Result_Result_ARRAYSIZE = MissionResult_Result_Result_MAX + 1;
+bool MissionRawServerResult_Result_IsValid(int value);
+constexpr MissionRawServerResult_Result MissionRawServerResult_Result_Result_MIN = MissionRawServerResult_Result_RESULT_UNKNOWN;
+constexpr MissionRawServerResult_Result MissionRawServerResult_Result_Result_MAX = MissionRawServerResult_Result_RESULT_NEXT;
+constexpr int MissionRawServerResult_Result_Result_ARRAYSIZE = MissionRawServerResult_Result_Result_MAX + 1;
 
-const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* MissionResult_Result_descriptor();
+const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* MissionRawServerResult_Result_descriptor();
 template<typename T>
-inline const std::string& MissionResult_Result_Name(T enum_t_value) {
-  static_assert(::std::is_same<T, MissionResult_Result>::value ||
+inline const std::string& MissionRawServerResult_Result_Name(T enum_t_value) {
+  static_assert(::std::is_same<T, MissionRawServerResult_Result>::value ||
     ::std::is_integral<T>::value,
-    "Incorrect type passed to function MissionResult_Result_Name.");
+    "Incorrect type passed to function MissionRawServerResult_Result_Name.");
   return ::PROTOBUF_NAMESPACE_ID::internal::NameOfEnum(
-    MissionResult_Result_descriptor(), enum_t_value);
+    MissionRawServerResult_Result_descriptor(), enum_t_value);
 }
-inline bool MissionResult_Result_Parse(
-    ::PROTOBUF_NAMESPACE_ID::ConstStringParam name, MissionResult_Result* value) {
-  return ::PROTOBUF_NAMESPACE_ID::internal::ParseNamedEnum<MissionResult_Result>(
-    MissionResult_Result_descriptor(), name, value);
+inline bool MissionRawServerResult_Result_Parse(
+    ::PROTOBUF_NAMESPACE_ID::ConstStringParam name, MissionRawServerResult_Result* value) {
+  return ::PROTOBUF_NAMESPACE_ID::internal::ParseNamedEnum<MissionRawServerResult_Result>(
+    MissionRawServerResult_Result_descriptor(), name, value);
 }
 // ===================================================================
 
@@ -393,26 +394,26 @@ class IncomingMissionResponse final :
   // accessors -------------------------------------------------------
 
   enum : int {
-    kMissionResultFieldNumber = 1,
+    kMissionRawServerResultFieldNumber = 1,
     kMissionPlanFieldNumber = 2,
   };
-  // .mavsdk.rpc.mission_raw_server.MissionResult mission_result = 1;
-  bool has_mission_result() const;
+  // .mavsdk.rpc.mission_raw_server.MissionRawServerResult mission_raw_server_result = 1;
+  bool has_mission_raw_server_result() const;
   private:
-  bool _internal_has_mission_result() const;
+  bool _internal_has_mission_raw_server_result() const;
   public:
-  void clear_mission_result();
-  const ::mavsdk::rpc::mission_raw_server::MissionResult& mission_result() const;
-  PROTOBUF_MUST_USE_RESULT ::mavsdk::rpc::mission_raw_server::MissionResult* release_mission_result();
-  ::mavsdk::rpc::mission_raw_server::MissionResult* mutable_mission_result();
-  void set_allocated_mission_result(::mavsdk::rpc::mission_raw_server::MissionResult* mission_result);
+  void clear_mission_raw_server_result();
+  const ::mavsdk::rpc::mission_raw_server::MissionRawServerResult& mission_raw_server_result() const;
+  PROTOBUF_MUST_USE_RESULT ::mavsdk::rpc::mission_raw_server::MissionRawServerResult* release_mission_raw_server_result();
+  ::mavsdk::rpc::mission_raw_server::MissionRawServerResult* mutable_mission_raw_server_result();
+  void set_allocated_mission_raw_server_result(::mavsdk::rpc::mission_raw_server::MissionRawServerResult* mission_raw_server_result);
   private:
-  const ::mavsdk::rpc::mission_raw_server::MissionResult& _internal_mission_result() const;
-  ::mavsdk::rpc::mission_raw_server::MissionResult* _internal_mutable_mission_result();
+  const ::mavsdk::rpc::mission_raw_server::MissionRawServerResult& _internal_mission_raw_server_result() const;
+  ::mavsdk::rpc::mission_raw_server::MissionRawServerResult* _internal_mutable_mission_raw_server_result();
   public:
-  void unsafe_arena_set_allocated_mission_result(
-      ::mavsdk::rpc::mission_raw_server::MissionResult* mission_result);
-  ::mavsdk::rpc::mission_raw_server::MissionResult* unsafe_arena_release_mission_result();
+  void unsafe_arena_set_allocated_mission_raw_server_result(
+      ::mavsdk::rpc::mission_raw_server::MissionRawServerResult* mission_raw_server_result);
+  ::mavsdk::rpc::mission_raw_server::MissionRawServerResult* unsafe_arena_release_mission_raw_server_result();
 
   // .mavsdk.rpc.mission_raw_server.MissionPlan mission_plan = 2;
   bool has_mission_plan() const;
@@ -439,7 +440,7 @@ class IncomingMissionResponse final :
   template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
-  ::mavsdk::rpc::mission_raw_server::MissionResult* mission_result_;
+  ::mavsdk::rpc::mission_raw_server::MissionRawServerResult* mission_raw_server_result_;
   ::mavsdk::rpc::mission_raw_server::MissionPlan* mission_plan_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto;
@@ -1806,24 +1807,24 @@ class MissionProgress final :
 };
 // -------------------------------------------------------------------
 
-class MissionResult final :
-    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.mission_raw_server.MissionResult) */ {
+class MissionRawServerResult final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.mission_raw_server.MissionRawServerResult) */ {
  public:
-  inline MissionResult() : MissionResult(nullptr) {}
-  ~MissionResult() override;
-  explicit constexpr MissionResult(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+  inline MissionRawServerResult() : MissionRawServerResult(nullptr) {}
+  ~MissionRawServerResult() override;
+  explicit constexpr MissionRawServerResult(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
 
-  MissionResult(const MissionResult& from);
-  MissionResult(MissionResult&& from) noexcept
-    : MissionResult() {
+  MissionRawServerResult(const MissionRawServerResult& from);
+  MissionRawServerResult(MissionRawServerResult&& from) noexcept
+    : MissionRawServerResult() {
     *this = ::std::move(from);
   }
 
-  inline MissionResult& operator=(const MissionResult& from) {
+  inline MissionRawServerResult& operator=(const MissionRawServerResult& from) {
     CopyFrom(from);
     return *this;
   }
-  inline MissionResult& operator=(MissionResult&& from) noexcept {
+  inline MissionRawServerResult& operator=(MissionRawServerResult&& from) noexcept {
     if (this == &from) return *this;
     if (GetOwningArena() == from.GetOwningArena()) {
       InternalSwap(&from);
@@ -1842,20 +1843,20 @@ class MissionResult final :
   static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
     return default_instance().GetMetadata().reflection;
   }
-  static const MissionResult& default_instance() {
+  static const MissionRawServerResult& default_instance() {
     return *internal_default_instance();
   }
-  static inline const MissionResult* internal_default_instance() {
-    return reinterpret_cast<const MissionResult*>(
-               &_MissionResult_default_instance_);
+  static inline const MissionRawServerResult* internal_default_instance() {
+    return reinterpret_cast<const MissionRawServerResult*>(
+               &_MissionRawServerResult_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
     11;
 
-  friend void swap(MissionResult& a, MissionResult& b) {
+  friend void swap(MissionRawServerResult& a, MissionRawServerResult& b) {
     a.Swap(&b);
   }
-  inline void Swap(MissionResult* other) {
+  inline void Swap(MissionRawServerResult* other) {
     if (other == this) return;
     if (GetOwningArena() == other->GetOwningArena()) {
       InternalSwap(other);
@@ -1863,7 +1864,7 @@ class MissionResult final :
       ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
     }
   }
-  void UnsafeArenaSwap(MissionResult* other) {
+  void UnsafeArenaSwap(MissionRawServerResult* other) {
     if (other == this) return;
     GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
     InternalSwap(other);
@@ -1871,17 +1872,17 @@ class MissionResult final :
 
   // implements Message ----------------------------------------------
 
-  inline MissionResult* New() const final {
-    return new MissionResult();
+  inline MissionRawServerResult* New() const final {
+    return new MissionRawServerResult();
   }
 
-  MissionResult* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
-    return CreateMaybeMessage<MissionResult>(arena);
+  MissionRawServerResult* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<MissionRawServerResult>(arena);
   }
   using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
-  void CopyFrom(const MissionResult& from);
+  void CopyFrom(const MissionRawServerResult& from);
   using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
-  void MergeFrom(const MissionResult& from);
+  void MergeFrom(const MissionRawServerResult& from);
   private:
   static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to, const ::PROTOBUF_NAMESPACE_ID::Message&from);
   public:
@@ -1898,13 +1899,13 @@ class MissionResult final :
   void SharedCtor();
   void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(MissionResult* other);
+  void InternalSwap(MissionRawServerResult* other);
   friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
   static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
-    return "mavsdk.rpc.mission_raw_server.MissionResult";
+    return "mavsdk.rpc.mission_raw_server.MissionRawServerResult";
   }
   protected:
-  explicit MissionResult(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+  explicit MissionRawServerResult(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                        bool is_message_owned = false);
   private:
   static void ArenaDtor(void* object);
@@ -1918,54 +1919,56 @@ class MissionResult final :
 
   // nested types ----------------------------------------------------
 
-  typedef MissionResult_Result Result;
+  typedef MissionRawServerResult_Result Result;
   static constexpr Result RESULT_UNKNOWN =
-    MissionResult_Result_RESULT_UNKNOWN;
+    MissionRawServerResult_Result_RESULT_UNKNOWN;
   static constexpr Result RESULT_SUCCESS =
-    MissionResult_Result_RESULT_SUCCESS;
+    MissionRawServerResult_Result_RESULT_SUCCESS;
   static constexpr Result RESULT_ERROR =
-    MissionResult_Result_RESULT_ERROR;
+    MissionRawServerResult_Result_RESULT_ERROR;
   static constexpr Result RESULT_TOO_MANY_MISSION_ITEMS =
-    MissionResult_Result_RESULT_TOO_MANY_MISSION_ITEMS;
+    MissionRawServerResult_Result_RESULT_TOO_MANY_MISSION_ITEMS;
   static constexpr Result RESULT_BUSY =
-    MissionResult_Result_RESULT_BUSY;
+    MissionRawServerResult_Result_RESULT_BUSY;
   static constexpr Result RESULT_TIMEOUT =
-    MissionResult_Result_RESULT_TIMEOUT;
+    MissionRawServerResult_Result_RESULT_TIMEOUT;
   static constexpr Result RESULT_INVALID_ARGUMENT =
-    MissionResult_Result_RESULT_INVALID_ARGUMENT;
+    MissionRawServerResult_Result_RESULT_INVALID_ARGUMENT;
   static constexpr Result RESULT_UNSUPPORTED =
-    MissionResult_Result_RESULT_UNSUPPORTED;
+    MissionRawServerResult_Result_RESULT_UNSUPPORTED;
   static constexpr Result RESULT_NO_MISSION_AVAILABLE =
-    MissionResult_Result_RESULT_NO_MISSION_AVAILABLE;
+    MissionRawServerResult_Result_RESULT_NO_MISSION_AVAILABLE;
   static constexpr Result RESULT_UNSUPPORTED_MISSION_CMD =
-    MissionResult_Result_RESULT_UNSUPPORTED_MISSION_CMD;
+    MissionRawServerResult_Result_RESULT_UNSUPPORTED_MISSION_CMD;
   static constexpr Result RESULT_TRANSFER_CANCELLED =
-    MissionResult_Result_RESULT_TRANSFER_CANCELLED;
+    MissionRawServerResult_Result_RESULT_TRANSFER_CANCELLED;
   static constexpr Result RESULT_NO_SYSTEM =
-    MissionResult_Result_RESULT_NO_SYSTEM;
+    MissionRawServerResult_Result_RESULT_NO_SYSTEM;
+  static constexpr Result RESULT_NEXT =
+    MissionRawServerResult_Result_RESULT_NEXT;
   static inline bool Result_IsValid(int value) {
-    return MissionResult_Result_IsValid(value);
+    return MissionRawServerResult_Result_IsValid(value);
   }
   static constexpr Result Result_MIN =
-    MissionResult_Result_Result_MIN;
+    MissionRawServerResult_Result_Result_MIN;
   static constexpr Result Result_MAX =
-    MissionResult_Result_Result_MAX;
+    MissionRawServerResult_Result_Result_MAX;
   static constexpr int Result_ARRAYSIZE =
-    MissionResult_Result_Result_ARRAYSIZE;
+    MissionRawServerResult_Result_Result_ARRAYSIZE;
   static inline const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor*
   Result_descriptor() {
-    return MissionResult_Result_descriptor();
+    return MissionRawServerResult_Result_descriptor();
   }
   template<typename T>
   static inline const std::string& Result_Name(T enum_t_value) {
     static_assert(::std::is_same<T, Result>::value ||
       ::std::is_integral<T>::value,
       "Incorrect type passed to function Result_Name.");
-    return MissionResult_Result_Name(enum_t_value);
+    return MissionRawServerResult_Result_Name(enum_t_value);
   }
   static inline bool Result_Parse(::PROTOBUF_NAMESPACE_ID::ConstStringParam name,
       Result* value) {
-    return MissionResult_Result_Parse(name, value);
+    return MissionRawServerResult_Result_Parse(name, value);
   }
 
   // accessors -------------------------------------------------------
@@ -1988,16 +1991,16 @@ class MissionResult final :
   std::string* _internal_mutable_result_str();
   public:
 
-  // .mavsdk.rpc.mission_raw_server.MissionResult.Result result = 1;
+  // .mavsdk.rpc.mission_raw_server.MissionRawServerResult.Result result = 1;
   void clear_result();
-  ::mavsdk::rpc::mission_raw_server::MissionResult_Result result() const;
-  void set_result(::mavsdk::rpc::mission_raw_server::MissionResult_Result value);
+  ::mavsdk::rpc::mission_raw_server::MissionRawServerResult_Result result() const;
+  void set_result(::mavsdk::rpc::mission_raw_server::MissionRawServerResult_Result value);
   private:
-  ::mavsdk::rpc::mission_raw_server::MissionResult_Result _internal_result() const;
-  void _internal_set_result(::mavsdk::rpc::mission_raw_server::MissionResult_Result value);
+  ::mavsdk::rpc::mission_raw_server::MissionRawServerResult_Result _internal_result() const;
+  void _internal_set_result(::mavsdk::rpc::mission_raw_server::MissionRawServerResult_Result value);
   public:
 
-  // @@protoc_insertion_point(class_scope:mavsdk.rpc.mission_raw_server.MissionResult)
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.mission_raw_server.MissionRawServerResult)
  private:
   class _Internal;
 
@@ -2024,45 +2027,45 @@ class MissionResult final :
 
 // IncomingMissionResponse
 
-// .mavsdk.rpc.mission_raw_server.MissionResult mission_result = 1;
-inline bool IncomingMissionResponse::_internal_has_mission_result() const {
-  return this != internal_default_instance() && mission_result_ != nullptr;
+// .mavsdk.rpc.mission_raw_server.MissionRawServerResult mission_raw_server_result = 1;
+inline bool IncomingMissionResponse::_internal_has_mission_raw_server_result() const {
+  return this != internal_default_instance() && mission_raw_server_result_ != nullptr;
 }
-inline bool IncomingMissionResponse::has_mission_result() const {
-  return _internal_has_mission_result();
+inline bool IncomingMissionResponse::has_mission_raw_server_result() const {
+  return _internal_has_mission_raw_server_result();
 }
-inline void IncomingMissionResponse::clear_mission_result() {
-  if (GetArenaForAllocation() == nullptr && mission_result_ != nullptr) {
-    delete mission_result_;
+inline void IncomingMissionResponse::clear_mission_raw_server_result() {
+  if (GetArenaForAllocation() == nullptr && mission_raw_server_result_ != nullptr) {
+    delete mission_raw_server_result_;
   }
-  mission_result_ = nullptr;
+  mission_raw_server_result_ = nullptr;
 }
-inline const ::mavsdk::rpc::mission_raw_server::MissionResult& IncomingMissionResponse::_internal_mission_result() const {
-  const ::mavsdk::rpc::mission_raw_server::MissionResult* p = mission_result_;
-  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::mission_raw_server::MissionResult&>(
-      ::mavsdk::rpc::mission_raw_server::_MissionResult_default_instance_);
+inline const ::mavsdk::rpc::mission_raw_server::MissionRawServerResult& IncomingMissionResponse::_internal_mission_raw_server_result() const {
+  const ::mavsdk::rpc::mission_raw_server::MissionRawServerResult* p = mission_raw_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::mission_raw_server::MissionRawServerResult&>(
+      ::mavsdk::rpc::mission_raw_server::_MissionRawServerResult_default_instance_);
 }
-inline const ::mavsdk::rpc::mission_raw_server::MissionResult& IncomingMissionResponse::mission_result() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.mission_raw_server.IncomingMissionResponse.mission_result)
-  return _internal_mission_result();
+inline const ::mavsdk::rpc::mission_raw_server::MissionRawServerResult& IncomingMissionResponse::mission_raw_server_result() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.mission_raw_server.IncomingMissionResponse.mission_raw_server_result)
+  return _internal_mission_raw_server_result();
 }
-inline void IncomingMissionResponse::unsafe_arena_set_allocated_mission_result(
-    ::mavsdk::rpc::mission_raw_server::MissionResult* mission_result) {
+inline void IncomingMissionResponse::unsafe_arena_set_allocated_mission_raw_server_result(
+    ::mavsdk::rpc::mission_raw_server::MissionRawServerResult* mission_raw_server_result) {
   if (GetArenaForAllocation() == nullptr) {
-    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(mission_result_);
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(mission_raw_server_result_);
   }
-  mission_result_ = mission_result;
-  if (mission_result) {
+  mission_raw_server_result_ = mission_raw_server_result;
+  if (mission_raw_server_result) {
     
   } else {
     
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.mission_raw_server.IncomingMissionResponse.mission_result)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.mission_raw_server.IncomingMissionResponse.mission_raw_server_result)
 }
-inline ::mavsdk::rpc::mission_raw_server::MissionResult* IncomingMissionResponse::release_mission_result() {
+inline ::mavsdk::rpc::mission_raw_server::MissionRawServerResult* IncomingMissionResponse::release_mission_raw_server_result() {
   
-  ::mavsdk::rpc::mission_raw_server::MissionResult* temp = mission_result_;
-  mission_result_ = nullptr;
+  ::mavsdk::rpc::mission_raw_server::MissionRawServerResult* temp = mission_raw_server_result_;
+  mission_raw_server_result_ = nullptr;
 #ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
   auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
   temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
@@ -2074,44 +2077,44 @@ inline ::mavsdk::rpc::mission_raw_server::MissionResult* IncomingMissionResponse
 #endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
   return temp;
 }
-inline ::mavsdk::rpc::mission_raw_server::MissionResult* IncomingMissionResponse::unsafe_arena_release_mission_result() {
-  // @@protoc_insertion_point(field_release:mavsdk.rpc.mission_raw_server.IncomingMissionResponse.mission_result)
+inline ::mavsdk::rpc::mission_raw_server::MissionRawServerResult* IncomingMissionResponse::unsafe_arena_release_mission_raw_server_result() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.mission_raw_server.IncomingMissionResponse.mission_raw_server_result)
   
-  ::mavsdk::rpc::mission_raw_server::MissionResult* temp = mission_result_;
-  mission_result_ = nullptr;
+  ::mavsdk::rpc::mission_raw_server::MissionRawServerResult* temp = mission_raw_server_result_;
+  mission_raw_server_result_ = nullptr;
   return temp;
 }
-inline ::mavsdk::rpc::mission_raw_server::MissionResult* IncomingMissionResponse::_internal_mutable_mission_result() {
+inline ::mavsdk::rpc::mission_raw_server::MissionRawServerResult* IncomingMissionResponse::_internal_mutable_mission_raw_server_result() {
   
-  if (mission_result_ == nullptr) {
-    auto* p = CreateMaybeMessage<::mavsdk::rpc::mission_raw_server::MissionResult>(GetArenaForAllocation());
-    mission_result_ = p;
+  if (mission_raw_server_result_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::mission_raw_server::MissionRawServerResult>(GetArenaForAllocation());
+    mission_raw_server_result_ = p;
   }
-  return mission_result_;
+  return mission_raw_server_result_;
 }
-inline ::mavsdk::rpc::mission_raw_server::MissionResult* IncomingMissionResponse::mutable_mission_result() {
-  ::mavsdk::rpc::mission_raw_server::MissionResult* _msg = _internal_mutable_mission_result();
-  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.mission_raw_server.IncomingMissionResponse.mission_result)
+inline ::mavsdk::rpc::mission_raw_server::MissionRawServerResult* IncomingMissionResponse::mutable_mission_raw_server_result() {
+  ::mavsdk::rpc::mission_raw_server::MissionRawServerResult* _msg = _internal_mutable_mission_raw_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.mission_raw_server.IncomingMissionResponse.mission_raw_server_result)
   return _msg;
 }
-inline void IncomingMissionResponse::set_allocated_mission_result(::mavsdk::rpc::mission_raw_server::MissionResult* mission_result) {
+inline void IncomingMissionResponse::set_allocated_mission_raw_server_result(::mavsdk::rpc::mission_raw_server::MissionRawServerResult* mission_raw_server_result) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
   if (message_arena == nullptr) {
-    delete mission_result_;
+    delete mission_raw_server_result_;
   }
-  if (mission_result) {
+  if (mission_raw_server_result) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
-        ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper<::mavsdk::rpc::mission_raw_server::MissionResult>::GetOwningArena(mission_result);
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper<::mavsdk::rpc::mission_raw_server::MissionRawServerResult>::GetOwningArena(mission_raw_server_result);
     if (message_arena != submessage_arena) {
-      mission_result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
-          message_arena, mission_result, submessage_arena);
+      mission_raw_server_result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, mission_raw_server_result, submessage_arena);
     }
     
   } else {
     
   }
-  mission_result_ = mission_result;
-  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.mission_raw_server.IncomingMissionResponse.mission_result)
+  mission_raw_server_result_ = mission_raw_server_result;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.mission_raw_server.IncomingMissionResponse.mission_raw_server_result)
 }
 
 // .mavsdk.rpc.mission_raw_server.MissionPlan mission_plan = 2;
@@ -2692,64 +2695,64 @@ inline void MissionProgress::set_total(::PROTOBUF_NAMESPACE_ID::int32 value) {
 
 // -------------------------------------------------------------------
 
-// MissionResult
+// MissionRawServerResult
 
-// .mavsdk.rpc.mission_raw_server.MissionResult.Result result = 1;
-inline void MissionResult::clear_result() {
+// .mavsdk.rpc.mission_raw_server.MissionRawServerResult.Result result = 1;
+inline void MissionRawServerResult::clear_result() {
   result_ = 0;
 }
-inline ::mavsdk::rpc::mission_raw_server::MissionResult_Result MissionResult::_internal_result() const {
-  return static_cast< ::mavsdk::rpc::mission_raw_server::MissionResult_Result >(result_);
+inline ::mavsdk::rpc::mission_raw_server::MissionRawServerResult_Result MissionRawServerResult::_internal_result() const {
+  return static_cast< ::mavsdk::rpc::mission_raw_server::MissionRawServerResult_Result >(result_);
 }
-inline ::mavsdk::rpc::mission_raw_server::MissionResult_Result MissionResult::result() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.mission_raw_server.MissionResult.result)
+inline ::mavsdk::rpc::mission_raw_server::MissionRawServerResult_Result MissionRawServerResult::result() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.mission_raw_server.MissionRawServerResult.result)
   return _internal_result();
 }
-inline void MissionResult::_internal_set_result(::mavsdk::rpc::mission_raw_server::MissionResult_Result value) {
+inline void MissionRawServerResult::_internal_set_result(::mavsdk::rpc::mission_raw_server::MissionRawServerResult_Result value) {
   
   result_ = value;
 }
-inline void MissionResult::set_result(::mavsdk::rpc::mission_raw_server::MissionResult_Result value) {
+inline void MissionRawServerResult::set_result(::mavsdk::rpc::mission_raw_server::MissionRawServerResult_Result value) {
   _internal_set_result(value);
-  // @@protoc_insertion_point(field_set:mavsdk.rpc.mission_raw_server.MissionResult.result)
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.mission_raw_server.MissionRawServerResult.result)
 }
 
 // string result_str = 2;
-inline void MissionResult::clear_result_str() {
+inline void MissionRawServerResult::clear_result_str() {
   result_str_.ClearToEmpty();
 }
-inline const std::string& MissionResult::result_str() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.mission_raw_server.MissionResult.result_str)
+inline const std::string& MissionRawServerResult::result_str() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.mission_raw_server.MissionRawServerResult.result_str)
   return _internal_result_str();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void MissionResult::set_result_str(ArgT0&& arg0, ArgT... args) {
+void MissionRawServerResult::set_result_str(ArgT0&& arg0, ArgT... args) {
  
  result_str_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:mavsdk.rpc.mission_raw_server.MissionResult.result_str)
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.mission_raw_server.MissionRawServerResult.result_str)
 }
-inline std::string* MissionResult::mutable_result_str() {
+inline std::string* MissionRawServerResult::mutable_result_str() {
   std::string* _s = _internal_mutable_result_str();
-  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.mission_raw_server.MissionResult.result_str)
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.mission_raw_server.MissionRawServerResult.result_str)
   return _s;
 }
-inline const std::string& MissionResult::_internal_result_str() const {
+inline const std::string& MissionRawServerResult::_internal_result_str() const {
   return result_str_.Get();
 }
-inline void MissionResult::_internal_set_result_str(const std::string& value) {
+inline void MissionRawServerResult::_internal_set_result_str(const std::string& value) {
   
   result_str_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArenaForAllocation());
 }
-inline std::string* MissionResult::_internal_mutable_result_str() {
+inline std::string* MissionRawServerResult::_internal_mutable_result_str() {
   
   return result_str_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArenaForAllocation());
 }
-inline std::string* MissionResult::release_result_str() {
-  // @@protoc_insertion_point(field_release:mavsdk.rpc.mission_raw_server.MissionResult.result_str)
+inline std::string* MissionRawServerResult::release_result_str() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.mission_raw_server.MissionRawServerResult.result_str)
   return result_str_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArenaForAllocation());
 }
-inline void MissionResult::set_allocated_result_str(std::string* result_str) {
+inline void MissionRawServerResult::set_allocated_result_str(std::string* result_str) {
   if (result_str != nullptr) {
     
   } else {
@@ -2757,7 +2760,7 @@ inline void MissionResult::set_allocated_result_str(std::string* result_str) {
   }
   result_str_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), result_str,
       GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.mission_raw_server.MissionResult.result_str)
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.mission_raw_server.MissionRawServerResult.result_str)
 }
 
 #ifdef __GNUC__
@@ -2794,10 +2797,10 @@ inline void MissionResult::set_allocated_result_str(std::string* result_str) {
 
 PROTOBUF_NAMESPACE_OPEN
 
-template <> struct is_proto_enum< ::mavsdk::rpc::mission_raw_server::MissionResult_Result> : ::std::true_type {};
+template <> struct is_proto_enum< ::mavsdk::rpc::mission_raw_server::MissionRawServerResult_Result> : ::std::true_type {};
 template <>
-inline const EnumDescriptor* GetEnumDescriptor< ::mavsdk::rpc::mission_raw_server::MissionResult_Result>() {
-  return ::mavsdk::rpc::mission_raw_server::MissionResult_Result_descriptor();
+inline const EnumDescriptor* GetEnumDescriptor< ::mavsdk::rpc::mission_raw_server::MissionRawServerResult_Result>() {
+  return ::mavsdk::rpc::mission_raw_server::MissionRawServerResult_Result_descriptor();
 }
 
 PROTOBUF_NAMESPACE_CLOSE

--- a/src/mavsdk_server/src/generated/param_server/param_server.pb.cc
+++ b/src/mavsdk_server/src/generated/param_server/param_server.pb.cc
@@ -33,7 +33,7 @@ struct RetrieveParamIntRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT RetrieveParamIntRequestDefaultTypeInternal _RetrieveParamIntRequest_default_instance_;
 constexpr RetrieveParamIntResponse::RetrieveParamIntResponse(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
-  : param_result_(nullptr)
+  : param_server_result_(nullptr)
   , value_(0){}
 struct RetrieveParamIntResponseDefaultTypeInternal {
   constexpr RetrieveParamIntResponseDefaultTypeInternal()
@@ -59,7 +59,7 @@ struct ProvideParamIntRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT ProvideParamIntRequestDefaultTypeInternal _ProvideParamIntRequest_default_instance_;
 constexpr ProvideParamIntResponse::ProvideParamIntResponse(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
-  : param_result_(nullptr){}
+  : param_server_result_(nullptr){}
 struct ProvideParamIntResponseDefaultTypeInternal {
   constexpr ProvideParamIntResponseDefaultTypeInternal()
     : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
@@ -83,7 +83,7 @@ struct RetrieveParamFloatRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT RetrieveParamFloatRequestDefaultTypeInternal _RetrieveParamFloatRequest_default_instance_;
 constexpr RetrieveParamFloatResponse::RetrieveParamFloatResponse(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
-  : param_result_(nullptr)
+  : param_server_result_(nullptr)
   , value_(0){}
 struct RetrieveParamFloatResponseDefaultTypeInternal {
   constexpr RetrieveParamFloatResponseDefaultTypeInternal()
@@ -109,7 +109,7 @@ struct ProvideParamFloatRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT ProvideParamFloatRequestDefaultTypeInternal _ProvideParamFloatRequest_default_instance_;
 constexpr ProvideParamFloatResponse::ProvideParamFloatResponse(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
-  : param_result_(nullptr){}
+  : param_server_result_(nullptr){}
 struct ProvideParamFloatResponseDefaultTypeInternal {
   constexpr ProvideParamFloatResponseDefaultTypeInternal()
     : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
@@ -214,7 +214,7 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_param_5fserver_2fparam_5fserve
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::param_server::RetrieveParamIntResponse, param_result_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::param_server::RetrieveParamIntResponse, param_server_result_),
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::param_server::RetrieveParamIntResponse, value_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::param_server::ProvideParamIntRequest, _internal_metadata_),
@@ -228,7 +228,7 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_param_5fserver_2fparam_5fserve
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::param_server::ProvideParamIntResponse, param_result_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::param_server::ProvideParamIntResponse, param_server_result_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::param_server::RetrieveParamFloatRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -240,7 +240,7 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_param_5fserver_2fparam_5fserve
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::param_server::RetrieveParamFloatResponse, param_result_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::param_server::RetrieveParamFloatResponse, param_server_result_),
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::param_server::RetrieveParamFloatResponse, value_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::param_server::ProvideParamFloatRequest, _internal_metadata_),
@@ -254,7 +254,7 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_param_5fserver_2fparam_5fserve
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::param_server::ProvideParamFloatResponse, param_result_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::param_server::ProvideParamFloatResponse, param_server_result_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::param_server::RetrieveAllParamsRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -333,60 +333,60 @@ const char descriptor_table_protodef_param_5fserver_2fparam_5fserver_2eproto[] P
   "\n\037param_server/param_server.proto\022\027mavsd"
   "k.rpc.param_server\032\024mavsdk_options.proto"
   "\"\'\n\027RetrieveParamIntRequest\022\014\n\004name\030\001 \001("
-  "\t\"k\n\030RetrieveParamIntResponse\022@\n\014param_r"
-  "esult\030\001 \001(\0132*.mavsdk.rpc.param_server.Pa"
-  "ramServerResult\022\r\n\005value\030\002 \001(\005\"5\n\026Provid"
-  "eParamIntRequest\022\014\n\004name\030\001 \001(\t\022\r\n\005value\030"
-  "\002 \001(\005\"[\n\027ProvideParamIntResponse\022@\n\014para"
-  "m_result\030\001 \001(\0132*.mavsdk.rpc.param_server"
-  ".ParamServerResult\")\n\031RetrieveParamFloat"
-  "Request\022\014\n\004name\030\001 \001(\t\"m\n\032RetrieveParamFl"
-  "oatResponse\022@\n\014param_result\030\001 \001(\0132*.mavs"
-  "dk.rpc.param_server.ParamServerResult\022\r\n"
-  "\005value\030\002 \001(\002\"7\n\030ProvideParamFloatRequest"
-  "\022\014\n\004name\030\001 \001(\t\022\r\n\005value\030\002 \001(\002\"]\n\031Provide"
-  "ParamFloatResponse\022@\n\014param_result\030\001 \001(\013"
-  "2*.mavsdk.rpc.param_server.ParamServerRe"
-  "sult\"\032\n\030RetrieveAllParamsRequest\"O\n\031Retr"
-  "ieveAllParamsResponse\0222\n\006params\030\001 \001(\0132\"."
-  "mavsdk.rpc.param_server.AllParams\"\'\n\010Int"
-  "Param\022\014\n\004name\030\001 \001(\t\022\r\n\005value\030\002 \001(\005\")\n\nFl"
-  "oatParam\022\014\n\004name\030\001 \001(\t\022\r\n\005value\030\002 \001(\002\"}\n"
-  "\tAllParams\0225\n\nint_params\030\001 \003(\0132!.mavsdk."
-  "rpc.param_server.IntParam\0229\n\014float_param"
-  "s\030\002 \003(\0132#.mavsdk.rpc.param_server.FloatP"
-  "aram\"\351\001\n\021ParamServerResult\022A\n\006result\030\001 \001"
-  "(\01621.mavsdk.rpc.param_server.ParamServer"
-  "Result.Result\022\022\n\nresult_str\030\002 \001(\t\"}\n\006Res"
-  "ult\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCCES"
-  "S\020\001\022\024\n\020RESULT_NOT_FOUND\020\002\022\025\n\021RESULT_WRON"
-  "G_TYPE\020\003\022\036\n\032RESULT_PARAM_NAME_TOO_LONG\020\004"
-  "2\233\005\n\022ParamServerService\022}\n\020RetrieveParam"
-  "Int\0220.mavsdk.rpc.param_server.RetrievePa"
-  "ramIntRequest\0321.mavsdk.rpc.param_server."
-  "RetrieveParamIntResponse\"\004\200\265\030\001\022z\n\017Provid"
-  "eParamInt\022/.mavsdk.rpc.param_server.Prov"
-  "ideParamIntRequest\0320.mavsdk.rpc.param_se"
-  "rver.ProvideParamIntResponse\"\004\200\265\030\001\022\203\001\n\022R"
-  "etrieveParamFloat\0222.mavsdk.rpc.param_ser"
-  "ver.RetrieveParamFloatRequest\0323.mavsdk.r"
-  "pc.param_server.RetrieveParamFloatRespon"
-  "se\"\004\200\265\030\001\022\200\001\n\021ProvideParamFloat\0221.mavsdk."
-  "rpc.param_server.ProvideParamFloatReques"
-  "t\0322.mavsdk.rpc.param_server.ProvideParam"
-  "FloatResponse\"\004\200\265\030\001\022\200\001\n\021RetrieveAllParam"
-  "s\0221.mavsdk.rpc.param_server.RetrieveAllP"
-  "aramsRequest\0322.mavsdk.rpc.param_server.R"
-  "etrieveAllParamsResponse\"\004\200\265\030\001B*\n\026io.mav"
-  "sdk.param_serverB\020ParamServerProtob\006prot"
-  "o3"
+  "\t\"r\n\030RetrieveParamIntResponse\022G\n\023param_s"
+  "erver_result\030\001 \001(\0132*.mavsdk.rpc.param_se"
+  "rver.ParamServerResult\022\r\n\005value\030\002 \001(\005\"5\n"
+  "\026ProvideParamIntRequest\022\014\n\004name\030\001 \001(\t\022\r\n"
+  "\005value\030\002 \001(\005\"b\n\027ProvideParamIntResponse\022"
+  "G\n\023param_server_result\030\001 \001(\0132*.mavsdk.rp"
+  "c.param_server.ParamServerResult\")\n\031Retr"
+  "ieveParamFloatRequest\022\014\n\004name\030\001 \001(\t\"t\n\032R"
+  "etrieveParamFloatResponse\022G\n\023param_serve"
+  "r_result\030\001 \001(\0132*.mavsdk.rpc.param_server"
+  ".ParamServerResult\022\r\n\005value\030\002 \001(\002\"7\n\030Pro"
+  "videParamFloatRequest\022\014\n\004name\030\001 \001(\t\022\r\n\005v"
+  "alue\030\002 \001(\002\"d\n\031ProvideParamFloatResponse\022"
+  "G\n\023param_server_result\030\001 \001(\0132*.mavsdk.rp"
+  "c.param_server.ParamServerResult\"\032\n\030Retr"
+  "ieveAllParamsRequest\"O\n\031RetrieveAllParam"
+  "sResponse\0222\n\006params\030\001 \001(\0132\".mavsdk.rpc.p"
+  "aram_server.AllParams\"\'\n\010IntParam\022\014\n\004nam"
+  "e\030\001 \001(\t\022\r\n\005value\030\002 \001(\005\")\n\nFloatParam\022\014\n\004"
+  "name\030\001 \001(\t\022\r\n\005value\030\002 \001(\002\"}\n\tAllParams\0225"
+  "\n\nint_params\030\001 \003(\0132!.mavsdk.rpc.param_se"
+  "rver.IntParam\0229\n\014float_params\030\002 \003(\0132#.ma"
+  "vsdk.rpc.param_server.FloatParam\"\351\001\n\021Par"
+  "amServerResult\022A\n\006result\030\001 \001(\01621.mavsdk."
+  "rpc.param_server.ParamServerResult.Resul"
+  "t\022\022\n\nresult_str\030\002 \001(\t\"}\n\006Result\022\022\n\016RESUL"
+  "T_UNKNOWN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\024\n\020RESUL"
+  "T_NOT_FOUND\020\002\022\025\n\021RESULT_WRONG_TYPE\020\003\022\036\n\032"
+  "RESULT_PARAM_NAME_TOO_LONG\020\0042\233\005\n\022ParamSe"
+  "rverService\022}\n\020RetrieveParamInt\0220.mavsdk"
+  ".rpc.param_server.RetrieveParamIntReques"
+  "t\0321.mavsdk.rpc.param_server.RetrievePara"
+  "mIntResponse\"\004\200\265\030\001\022z\n\017ProvideParamInt\022/."
+  "mavsdk.rpc.param_server.ProvideParamIntR"
+  "equest\0320.mavsdk.rpc.param_server.Provide"
+  "ParamIntResponse\"\004\200\265\030\001\022\203\001\n\022RetrieveParam"
+  "Float\0222.mavsdk.rpc.param_server.Retrieve"
+  "ParamFloatRequest\0323.mavsdk.rpc.param_ser"
+  "ver.RetrieveParamFloatResponse\"\004\200\265\030\001\022\200\001\n"
+  "\021ProvideParamFloat\0221.mavsdk.rpc.param_se"
+  "rver.ProvideParamFloatRequest\0322.mavsdk.r"
+  "pc.param_server.ProvideParamFloatRespons"
+  "e\"\004\200\265\030\001\022\200\001\n\021RetrieveAllParams\0221.mavsdk.r"
+  "pc.param_server.RetrieveAllParamsRequest"
+  "\0322.mavsdk.rpc.param_server.RetrieveAllPa"
+  "ramsResponse\"\004\200\265\030\001B*\n\026io.mavsdk.param_se"
+  "rverB\020ParamServerProtob\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_param_5fserver_2fparam_5fserver_2eproto_deps[1] = {
   &::descriptor_table_mavsdk_5foptions_2eproto,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_param_5fserver_2fparam_5fserver_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_param_5fserver_2fparam_5fserver_2eproto = {
-  false, false, 1962, descriptor_table_protodef_param_5fserver_2fparam_5fserver_2eproto, "param_server/param_server.proto", 
+  false, false, 1990, descriptor_table_protodef_param_5fserver_2fparam_5fserver_2eproto, "param_server/param_server.proto", 
   &descriptor_table_param_5fserver_2fparam_5fserver_2eproto_once, descriptor_table_param_5fserver_2fparam_5fserver_2eproto_deps, 1, 14,
   schemas, file_default_instances, TableStruct_param_5fserver_2fparam_5fserver_2eproto::offsets,
   file_level_metadata_param_5fserver_2fparam_5fserver_2eproto, file_level_enum_descriptors_param_5fserver_2fparam_5fserver_2eproto, file_level_service_descriptors_param_5fserver_2fparam_5fserver_2eproto,
@@ -632,12 +632,12 @@ void RetrieveParamIntRequest::InternalSwap(RetrieveParamIntRequest* other) {
 
 class RetrieveParamIntResponse::_Internal {
  public:
-  static const ::mavsdk::rpc::param_server::ParamServerResult& param_result(const RetrieveParamIntResponse* msg);
+  static const ::mavsdk::rpc::param_server::ParamServerResult& param_server_result(const RetrieveParamIntResponse* msg);
 };
 
 const ::mavsdk::rpc::param_server::ParamServerResult&
-RetrieveParamIntResponse::_Internal::param_result(const RetrieveParamIntResponse* msg) {
-  return *msg->param_result_;
+RetrieveParamIntResponse::_Internal::param_server_result(const RetrieveParamIntResponse* msg) {
+  return *msg->param_server_result_;
 }
 RetrieveParamIntResponse::RetrieveParamIntResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
@@ -651,10 +651,10 @@ RetrieveParamIntResponse::RetrieveParamIntResponse(::PROTOBUF_NAMESPACE_ID::Aren
 RetrieveParamIntResponse::RetrieveParamIntResponse(const RetrieveParamIntResponse& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
-  if (from._internal_has_param_result()) {
-    param_result_ = new ::mavsdk::rpc::param_server::ParamServerResult(*from.param_result_);
+  if (from._internal_has_param_server_result()) {
+    param_server_result_ = new ::mavsdk::rpc::param_server::ParamServerResult(*from.param_server_result_);
   } else {
-    param_result_ = nullptr;
+    param_server_result_ = nullptr;
   }
   value_ = from.value_;
   // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.param_server.RetrieveParamIntResponse)
@@ -662,9 +662,9 @@ RetrieveParamIntResponse::RetrieveParamIntResponse(const RetrieveParamIntRespons
 
 inline void RetrieveParamIntResponse::SharedCtor() {
 ::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
-    reinterpret_cast<char*>(&param_result_) - reinterpret_cast<char*>(this)),
+    reinterpret_cast<char*>(&param_server_result_) - reinterpret_cast<char*>(this)),
     0, static_cast<size_t>(reinterpret_cast<char*>(&value_) -
-    reinterpret_cast<char*>(&param_result_)) + sizeof(value_));
+    reinterpret_cast<char*>(&param_server_result_)) + sizeof(value_));
 }
 
 RetrieveParamIntResponse::~RetrieveParamIntResponse() {
@@ -676,7 +676,7 @@ RetrieveParamIntResponse::~RetrieveParamIntResponse() {
 
 inline void RetrieveParamIntResponse::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
-  if (this != internal_default_instance()) delete param_result_;
+  if (this != internal_default_instance()) delete param_server_result_;
 }
 
 void RetrieveParamIntResponse::ArenaDtor(void* object) {
@@ -695,10 +695,10 @@ void RetrieveParamIntResponse::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  if (GetArenaForAllocation() == nullptr && param_result_ != nullptr) {
-    delete param_result_;
+  if (GetArenaForAllocation() == nullptr && param_server_result_ != nullptr) {
+    delete param_server_result_;
   }
-  param_result_ = nullptr;
+  param_server_result_ = nullptr;
   value_ = 0;
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
@@ -709,10 +709,10 @@ const char* RetrieveParamIntResponse::_InternalParse(const char* ptr, ::PROTOBUF
     ::PROTOBUF_NAMESPACE_ID::uint32 tag;
     ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
     switch (tag >> 3) {
-      // .mavsdk.rpc.param_server.ParamServerResult param_result = 1;
+      // .mavsdk.rpc.param_server.ParamServerResult param_server_result = 1;
       case 1:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
-          ptr = ctx->ParseMessage(_internal_mutable_param_result(), ptr);
+          ptr = ctx->ParseMessage(_internal_mutable_param_server_result(), ptr);
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
@@ -752,12 +752,12 @@ failure:
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // .mavsdk.rpc.param_server.ParamServerResult param_result = 1;
-  if (this->_internal_has_param_result()) {
+  // .mavsdk.rpc.param_server.ParamServerResult param_server_result = 1;
+  if (this->_internal_has_param_server_result()) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
       InternalWriteMessage(
-        1, _Internal::param_result(this), target, stream);
+        1, _Internal::param_server_result(this), target, stream);
   }
 
   // int32 value = 2;
@@ -782,11 +782,11 @@ size_t RetrieveParamIntResponse::ByteSizeLong() const {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  // .mavsdk.rpc.param_server.ParamServerResult param_result = 1;
-  if (this->_internal_has_param_result()) {
+  // .mavsdk.rpc.param_server.ParamServerResult param_server_result = 1;
+  if (this->_internal_has_param_server_result()) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-        *param_result_);
+        *param_server_result_);
   }
 
   // int32 value = 2;
@@ -824,8 +824,8 @@ void RetrieveParamIntResponse::MergeFrom(const RetrieveParamIntResponse& from) {
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  if (from._internal_has_param_result()) {
-    _internal_mutable_param_result()->::mavsdk::rpc::param_server::ParamServerResult::MergeFrom(from._internal_param_result());
+  if (from._internal_has_param_server_result()) {
+    _internal_mutable_param_server_result()->::mavsdk::rpc::param_server::ParamServerResult::MergeFrom(from._internal_param_server_result());
   }
   if (from._internal_value() != 0) {
     _internal_set_value(from._internal_value());
@@ -850,9 +850,9 @@ void RetrieveParamIntResponse::InternalSwap(RetrieveParamIntResponse* other) {
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
       PROTOBUF_FIELD_OFFSET(RetrieveParamIntResponse, value_)
       + sizeof(RetrieveParamIntResponse::value_)
-      - PROTOBUF_FIELD_OFFSET(RetrieveParamIntResponse, param_result_)>(
-          reinterpret_cast<char*>(&param_result_),
-          reinterpret_cast<char*>(&other->param_result_));
+      - PROTOBUF_FIELD_OFFSET(RetrieveParamIntResponse, param_server_result_)>(
+          reinterpret_cast<char*>(&param_server_result_),
+          reinterpret_cast<char*>(&other->param_server_result_));
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata RetrieveParamIntResponse::GetMetadata() const {
@@ -1092,12 +1092,12 @@ void ProvideParamIntRequest::InternalSwap(ProvideParamIntRequest* other) {
 
 class ProvideParamIntResponse::_Internal {
  public:
-  static const ::mavsdk::rpc::param_server::ParamServerResult& param_result(const ProvideParamIntResponse* msg);
+  static const ::mavsdk::rpc::param_server::ParamServerResult& param_server_result(const ProvideParamIntResponse* msg);
 };
 
 const ::mavsdk::rpc::param_server::ParamServerResult&
-ProvideParamIntResponse::_Internal::param_result(const ProvideParamIntResponse* msg) {
-  return *msg->param_result_;
+ProvideParamIntResponse::_Internal::param_server_result(const ProvideParamIntResponse* msg) {
+  return *msg->param_server_result_;
 }
 ProvideParamIntResponse::ProvideParamIntResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
@@ -1111,16 +1111,16 @@ ProvideParamIntResponse::ProvideParamIntResponse(::PROTOBUF_NAMESPACE_ID::Arena*
 ProvideParamIntResponse::ProvideParamIntResponse(const ProvideParamIntResponse& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
-  if (from._internal_has_param_result()) {
-    param_result_ = new ::mavsdk::rpc::param_server::ParamServerResult(*from.param_result_);
+  if (from._internal_has_param_server_result()) {
+    param_server_result_ = new ::mavsdk::rpc::param_server::ParamServerResult(*from.param_server_result_);
   } else {
-    param_result_ = nullptr;
+    param_server_result_ = nullptr;
   }
   // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.param_server.ProvideParamIntResponse)
 }
 
 inline void ProvideParamIntResponse::SharedCtor() {
-param_result_ = nullptr;
+param_server_result_ = nullptr;
 }
 
 ProvideParamIntResponse::~ProvideParamIntResponse() {
@@ -1132,7 +1132,7 @@ ProvideParamIntResponse::~ProvideParamIntResponse() {
 
 inline void ProvideParamIntResponse::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
-  if (this != internal_default_instance()) delete param_result_;
+  if (this != internal_default_instance()) delete param_server_result_;
 }
 
 void ProvideParamIntResponse::ArenaDtor(void* object) {
@@ -1151,10 +1151,10 @@ void ProvideParamIntResponse::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  if (GetArenaForAllocation() == nullptr && param_result_ != nullptr) {
-    delete param_result_;
+  if (GetArenaForAllocation() == nullptr && param_server_result_ != nullptr) {
+    delete param_server_result_;
   }
-  param_result_ = nullptr;
+  param_server_result_ = nullptr;
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -1164,10 +1164,10 @@ const char* ProvideParamIntResponse::_InternalParse(const char* ptr, ::PROTOBUF_
     ::PROTOBUF_NAMESPACE_ID::uint32 tag;
     ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
     switch (tag >> 3) {
-      // .mavsdk.rpc.param_server.ParamServerResult param_result = 1;
+      // .mavsdk.rpc.param_server.ParamServerResult param_server_result = 1;
       case 1:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
-          ptr = ctx->ParseMessage(_internal_mutable_param_result(), ptr);
+          ptr = ctx->ParseMessage(_internal_mutable_param_server_result(), ptr);
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
@@ -1200,12 +1200,12 @@ failure:
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // .mavsdk.rpc.param_server.ParamServerResult param_result = 1;
-  if (this->_internal_has_param_result()) {
+  // .mavsdk.rpc.param_server.ParamServerResult param_server_result = 1;
+  if (this->_internal_has_param_server_result()) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
       InternalWriteMessage(
-        1, _Internal::param_result(this), target, stream);
+        1, _Internal::param_server_result(this), target, stream);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -1224,11 +1224,11 @@ size_t ProvideParamIntResponse::ByteSizeLong() const {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  // .mavsdk.rpc.param_server.ParamServerResult param_result = 1;
-  if (this->_internal_has_param_result()) {
+  // .mavsdk.rpc.param_server.ParamServerResult param_server_result = 1;
+  if (this->_internal_has_param_server_result()) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-        *param_result_);
+        *param_server_result_);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -1259,8 +1259,8 @@ void ProvideParamIntResponse::MergeFrom(const ProvideParamIntResponse& from) {
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  if (from._internal_has_param_result()) {
-    _internal_mutable_param_result()->::mavsdk::rpc::param_server::ParamServerResult::MergeFrom(from._internal_param_result());
+  if (from._internal_has_param_server_result()) {
+    _internal_mutable_param_server_result()->::mavsdk::rpc::param_server::ParamServerResult::MergeFrom(from._internal_param_server_result());
   }
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
@@ -1279,7 +1279,7 @@ bool ProvideParamIntResponse::IsInitialized() const {
 void ProvideParamIntResponse::InternalSwap(ProvideParamIntResponse* other) {
   using std::swap;
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
-  swap(param_result_, other->param_result_);
+  swap(param_server_result_, other->param_server_result_);
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata ProvideParamIntResponse::GetMetadata() const {
@@ -1492,12 +1492,12 @@ void RetrieveParamFloatRequest::InternalSwap(RetrieveParamFloatRequest* other) {
 
 class RetrieveParamFloatResponse::_Internal {
  public:
-  static const ::mavsdk::rpc::param_server::ParamServerResult& param_result(const RetrieveParamFloatResponse* msg);
+  static const ::mavsdk::rpc::param_server::ParamServerResult& param_server_result(const RetrieveParamFloatResponse* msg);
 };
 
 const ::mavsdk::rpc::param_server::ParamServerResult&
-RetrieveParamFloatResponse::_Internal::param_result(const RetrieveParamFloatResponse* msg) {
-  return *msg->param_result_;
+RetrieveParamFloatResponse::_Internal::param_server_result(const RetrieveParamFloatResponse* msg) {
+  return *msg->param_server_result_;
 }
 RetrieveParamFloatResponse::RetrieveParamFloatResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
@@ -1511,10 +1511,10 @@ RetrieveParamFloatResponse::RetrieveParamFloatResponse(::PROTOBUF_NAMESPACE_ID::
 RetrieveParamFloatResponse::RetrieveParamFloatResponse(const RetrieveParamFloatResponse& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
-  if (from._internal_has_param_result()) {
-    param_result_ = new ::mavsdk::rpc::param_server::ParamServerResult(*from.param_result_);
+  if (from._internal_has_param_server_result()) {
+    param_server_result_ = new ::mavsdk::rpc::param_server::ParamServerResult(*from.param_server_result_);
   } else {
-    param_result_ = nullptr;
+    param_server_result_ = nullptr;
   }
   value_ = from.value_;
   // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.param_server.RetrieveParamFloatResponse)
@@ -1522,9 +1522,9 @@ RetrieveParamFloatResponse::RetrieveParamFloatResponse(const RetrieveParamFloatR
 
 inline void RetrieveParamFloatResponse::SharedCtor() {
 ::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
-    reinterpret_cast<char*>(&param_result_) - reinterpret_cast<char*>(this)),
+    reinterpret_cast<char*>(&param_server_result_) - reinterpret_cast<char*>(this)),
     0, static_cast<size_t>(reinterpret_cast<char*>(&value_) -
-    reinterpret_cast<char*>(&param_result_)) + sizeof(value_));
+    reinterpret_cast<char*>(&param_server_result_)) + sizeof(value_));
 }
 
 RetrieveParamFloatResponse::~RetrieveParamFloatResponse() {
@@ -1536,7 +1536,7 @@ RetrieveParamFloatResponse::~RetrieveParamFloatResponse() {
 
 inline void RetrieveParamFloatResponse::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
-  if (this != internal_default_instance()) delete param_result_;
+  if (this != internal_default_instance()) delete param_server_result_;
 }
 
 void RetrieveParamFloatResponse::ArenaDtor(void* object) {
@@ -1555,10 +1555,10 @@ void RetrieveParamFloatResponse::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  if (GetArenaForAllocation() == nullptr && param_result_ != nullptr) {
-    delete param_result_;
+  if (GetArenaForAllocation() == nullptr && param_server_result_ != nullptr) {
+    delete param_server_result_;
   }
-  param_result_ = nullptr;
+  param_server_result_ = nullptr;
   value_ = 0;
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
@@ -1569,10 +1569,10 @@ const char* RetrieveParamFloatResponse::_InternalParse(const char* ptr, ::PROTOB
     ::PROTOBUF_NAMESPACE_ID::uint32 tag;
     ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
     switch (tag >> 3) {
-      // .mavsdk.rpc.param_server.ParamServerResult param_result = 1;
+      // .mavsdk.rpc.param_server.ParamServerResult param_server_result = 1;
       case 1:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
-          ptr = ctx->ParseMessage(_internal_mutable_param_result(), ptr);
+          ptr = ctx->ParseMessage(_internal_mutable_param_server_result(), ptr);
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
@@ -1612,12 +1612,12 @@ failure:
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // .mavsdk.rpc.param_server.ParamServerResult param_result = 1;
-  if (this->_internal_has_param_result()) {
+  // .mavsdk.rpc.param_server.ParamServerResult param_server_result = 1;
+  if (this->_internal_has_param_server_result()) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
       InternalWriteMessage(
-        1, _Internal::param_result(this), target, stream);
+        1, _Internal::param_server_result(this), target, stream);
   }
 
   // float value = 2;
@@ -1642,11 +1642,11 @@ size_t RetrieveParamFloatResponse::ByteSizeLong() const {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  // .mavsdk.rpc.param_server.ParamServerResult param_result = 1;
-  if (this->_internal_has_param_result()) {
+  // .mavsdk.rpc.param_server.ParamServerResult param_server_result = 1;
+  if (this->_internal_has_param_server_result()) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-        *param_result_);
+        *param_server_result_);
   }
 
   // float value = 2;
@@ -1682,8 +1682,8 @@ void RetrieveParamFloatResponse::MergeFrom(const RetrieveParamFloatResponse& fro
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  if (from._internal_has_param_result()) {
-    _internal_mutable_param_result()->::mavsdk::rpc::param_server::ParamServerResult::MergeFrom(from._internal_param_result());
+  if (from._internal_has_param_server_result()) {
+    _internal_mutable_param_server_result()->::mavsdk::rpc::param_server::ParamServerResult::MergeFrom(from._internal_param_server_result());
   }
   if (!(from._internal_value() <= 0 && from._internal_value() >= 0)) {
     _internal_set_value(from._internal_value());
@@ -1708,9 +1708,9 @@ void RetrieveParamFloatResponse::InternalSwap(RetrieveParamFloatResponse* other)
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
       PROTOBUF_FIELD_OFFSET(RetrieveParamFloatResponse, value_)
       + sizeof(RetrieveParamFloatResponse::value_)
-      - PROTOBUF_FIELD_OFFSET(RetrieveParamFloatResponse, param_result_)>(
-          reinterpret_cast<char*>(&param_result_),
-          reinterpret_cast<char*>(&other->param_result_));
+      - PROTOBUF_FIELD_OFFSET(RetrieveParamFloatResponse, param_server_result_)>(
+          reinterpret_cast<char*>(&param_server_result_),
+          reinterpret_cast<char*>(&other->param_server_result_));
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata RetrieveParamFloatResponse::GetMetadata() const {
@@ -1948,12 +1948,12 @@ void ProvideParamFloatRequest::InternalSwap(ProvideParamFloatRequest* other) {
 
 class ProvideParamFloatResponse::_Internal {
  public:
-  static const ::mavsdk::rpc::param_server::ParamServerResult& param_result(const ProvideParamFloatResponse* msg);
+  static const ::mavsdk::rpc::param_server::ParamServerResult& param_server_result(const ProvideParamFloatResponse* msg);
 };
 
 const ::mavsdk::rpc::param_server::ParamServerResult&
-ProvideParamFloatResponse::_Internal::param_result(const ProvideParamFloatResponse* msg) {
-  return *msg->param_result_;
+ProvideParamFloatResponse::_Internal::param_server_result(const ProvideParamFloatResponse* msg) {
+  return *msg->param_server_result_;
 }
 ProvideParamFloatResponse::ProvideParamFloatResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
@@ -1967,16 +1967,16 @@ ProvideParamFloatResponse::ProvideParamFloatResponse(::PROTOBUF_NAMESPACE_ID::Ar
 ProvideParamFloatResponse::ProvideParamFloatResponse(const ProvideParamFloatResponse& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
-  if (from._internal_has_param_result()) {
-    param_result_ = new ::mavsdk::rpc::param_server::ParamServerResult(*from.param_result_);
+  if (from._internal_has_param_server_result()) {
+    param_server_result_ = new ::mavsdk::rpc::param_server::ParamServerResult(*from.param_server_result_);
   } else {
-    param_result_ = nullptr;
+    param_server_result_ = nullptr;
   }
   // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.param_server.ProvideParamFloatResponse)
 }
 
 inline void ProvideParamFloatResponse::SharedCtor() {
-param_result_ = nullptr;
+param_server_result_ = nullptr;
 }
 
 ProvideParamFloatResponse::~ProvideParamFloatResponse() {
@@ -1988,7 +1988,7 @@ ProvideParamFloatResponse::~ProvideParamFloatResponse() {
 
 inline void ProvideParamFloatResponse::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
-  if (this != internal_default_instance()) delete param_result_;
+  if (this != internal_default_instance()) delete param_server_result_;
 }
 
 void ProvideParamFloatResponse::ArenaDtor(void* object) {
@@ -2007,10 +2007,10 @@ void ProvideParamFloatResponse::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  if (GetArenaForAllocation() == nullptr && param_result_ != nullptr) {
-    delete param_result_;
+  if (GetArenaForAllocation() == nullptr && param_server_result_ != nullptr) {
+    delete param_server_result_;
   }
-  param_result_ = nullptr;
+  param_server_result_ = nullptr;
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -2020,10 +2020,10 @@ const char* ProvideParamFloatResponse::_InternalParse(const char* ptr, ::PROTOBU
     ::PROTOBUF_NAMESPACE_ID::uint32 tag;
     ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
     switch (tag >> 3) {
-      // .mavsdk.rpc.param_server.ParamServerResult param_result = 1;
+      // .mavsdk.rpc.param_server.ParamServerResult param_server_result = 1;
       case 1:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
-          ptr = ctx->ParseMessage(_internal_mutable_param_result(), ptr);
+          ptr = ctx->ParseMessage(_internal_mutable_param_server_result(), ptr);
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
@@ -2056,12 +2056,12 @@ failure:
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // .mavsdk.rpc.param_server.ParamServerResult param_result = 1;
-  if (this->_internal_has_param_result()) {
+  // .mavsdk.rpc.param_server.ParamServerResult param_server_result = 1;
+  if (this->_internal_has_param_server_result()) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
       InternalWriteMessage(
-        1, _Internal::param_result(this), target, stream);
+        1, _Internal::param_server_result(this), target, stream);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -2080,11 +2080,11 @@ size_t ProvideParamFloatResponse::ByteSizeLong() const {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  // .mavsdk.rpc.param_server.ParamServerResult param_result = 1;
-  if (this->_internal_has_param_result()) {
+  // .mavsdk.rpc.param_server.ParamServerResult param_server_result = 1;
+  if (this->_internal_has_param_server_result()) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-        *param_result_);
+        *param_server_result_);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -2115,8 +2115,8 @@ void ProvideParamFloatResponse::MergeFrom(const ProvideParamFloatResponse& from)
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  if (from._internal_has_param_result()) {
-    _internal_mutable_param_result()->::mavsdk::rpc::param_server::ParamServerResult::MergeFrom(from._internal_param_result());
+  if (from._internal_has_param_server_result()) {
+    _internal_mutable_param_server_result()->::mavsdk::rpc::param_server::ParamServerResult::MergeFrom(from._internal_param_server_result());
   }
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
@@ -2135,7 +2135,7 @@ bool ProvideParamFloatResponse::IsInitialized() const {
 void ProvideParamFloatResponse::InternalSwap(ProvideParamFloatResponse* other) {
   using std::swap;
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
-  swap(param_result_, other->param_result_);
+  swap(param_server_result_, other->param_server_result_);
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata ProvideParamFloatResponse::GetMetadata() const {

--- a/src/mavsdk_server/src/generated/param_server/param_server.pb.h
+++ b/src/mavsdk_server/src/generated/param_server/param_server.pb.h
@@ -412,26 +412,26 @@ class RetrieveParamIntResponse final :
   // accessors -------------------------------------------------------
 
   enum : int {
-    kParamResultFieldNumber = 1,
+    kParamServerResultFieldNumber = 1,
     kValueFieldNumber = 2,
   };
-  // .mavsdk.rpc.param_server.ParamServerResult param_result = 1;
-  bool has_param_result() const;
+  // .mavsdk.rpc.param_server.ParamServerResult param_server_result = 1;
+  bool has_param_server_result() const;
   private:
-  bool _internal_has_param_result() const;
+  bool _internal_has_param_server_result() const;
   public:
-  void clear_param_result();
-  const ::mavsdk::rpc::param_server::ParamServerResult& param_result() const;
-  PROTOBUF_MUST_USE_RESULT ::mavsdk::rpc::param_server::ParamServerResult* release_param_result();
-  ::mavsdk::rpc::param_server::ParamServerResult* mutable_param_result();
-  void set_allocated_param_result(::mavsdk::rpc::param_server::ParamServerResult* param_result);
+  void clear_param_server_result();
+  const ::mavsdk::rpc::param_server::ParamServerResult& param_server_result() const;
+  PROTOBUF_MUST_USE_RESULT ::mavsdk::rpc::param_server::ParamServerResult* release_param_server_result();
+  ::mavsdk::rpc::param_server::ParamServerResult* mutable_param_server_result();
+  void set_allocated_param_server_result(::mavsdk::rpc::param_server::ParamServerResult* param_server_result);
   private:
-  const ::mavsdk::rpc::param_server::ParamServerResult& _internal_param_result() const;
-  ::mavsdk::rpc::param_server::ParamServerResult* _internal_mutable_param_result();
+  const ::mavsdk::rpc::param_server::ParamServerResult& _internal_param_server_result() const;
+  ::mavsdk::rpc::param_server::ParamServerResult* _internal_mutable_param_server_result();
   public:
-  void unsafe_arena_set_allocated_param_result(
-      ::mavsdk::rpc::param_server::ParamServerResult* param_result);
-  ::mavsdk::rpc::param_server::ParamServerResult* unsafe_arena_release_param_result();
+  void unsafe_arena_set_allocated_param_server_result(
+      ::mavsdk::rpc::param_server::ParamServerResult* param_server_result);
+  ::mavsdk::rpc::param_server::ParamServerResult* unsafe_arena_release_param_server_result();
 
   // int32 value = 2;
   void clear_value();
@@ -449,7 +449,7 @@ class RetrieveParamIntResponse final :
   template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
-  ::mavsdk::rpc::param_server::ParamServerResult* param_result_;
+  ::mavsdk::rpc::param_server::ParamServerResult* param_server_result_;
   ::PROTOBUF_NAMESPACE_ID::int32 value_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_param_5fserver_2fparam_5fserver_2eproto;
@@ -726,25 +726,25 @@ class ProvideParamIntResponse final :
   // accessors -------------------------------------------------------
 
   enum : int {
-    kParamResultFieldNumber = 1,
+    kParamServerResultFieldNumber = 1,
   };
-  // .mavsdk.rpc.param_server.ParamServerResult param_result = 1;
-  bool has_param_result() const;
+  // .mavsdk.rpc.param_server.ParamServerResult param_server_result = 1;
+  bool has_param_server_result() const;
   private:
-  bool _internal_has_param_result() const;
+  bool _internal_has_param_server_result() const;
   public:
-  void clear_param_result();
-  const ::mavsdk::rpc::param_server::ParamServerResult& param_result() const;
-  PROTOBUF_MUST_USE_RESULT ::mavsdk::rpc::param_server::ParamServerResult* release_param_result();
-  ::mavsdk::rpc::param_server::ParamServerResult* mutable_param_result();
-  void set_allocated_param_result(::mavsdk::rpc::param_server::ParamServerResult* param_result);
+  void clear_param_server_result();
+  const ::mavsdk::rpc::param_server::ParamServerResult& param_server_result() const;
+  PROTOBUF_MUST_USE_RESULT ::mavsdk::rpc::param_server::ParamServerResult* release_param_server_result();
+  ::mavsdk::rpc::param_server::ParamServerResult* mutable_param_server_result();
+  void set_allocated_param_server_result(::mavsdk::rpc::param_server::ParamServerResult* param_server_result);
   private:
-  const ::mavsdk::rpc::param_server::ParamServerResult& _internal_param_result() const;
-  ::mavsdk::rpc::param_server::ParamServerResult* _internal_mutable_param_result();
+  const ::mavsdk::rpc::param_server::ParamServerResult& _internal_param_server_result() const;
+  ::mavsdk::rpc::param_server::ParamServerResult* _internal_mutable_param_server_result();
   public:
-  void unsafe_arena_set_allocated_param_result(
-      ::mavsdk::rpc::param_server::ParamServerResult* param_result);
-  ::mavsdk::rpc::param_server::ParamServerResult* unsafe_arena_release_param_result();
+  void unsafe_arena_set_allocated_param_server_result(
+      ::mavsdk::rpc::param_server::ParamServerResult* param_server_result);
+  ::mavsdk::rpc::param_server::ParamServerResult* unsafe_arena_release_param_server_result();
 
   // @@protoc_insertion_point(class_scope:mavsdk.rpc.param_server.ProvideParamIntResponse)
  private:
@@ -753,7 +753,7 @@ class ProvideParamIntResponse final :
   template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
-  ::mavsdk::rpc::param_server::ParamServerResult* param_result_;
+  ::mavsdk::rpc::param_server::ParamServerResult* param_server_result_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_param_5fserver_2fparam_5fserver_2eproto;
 };
@@ -1018,26 +1018,26 @@ class RetrieveParamFloatResponse final :
   // accessors -------------------------------------------------------
 
   enum : int {
-    kParamResultFieldNumber = 1,
+    kParamServerResultFieldNumber = 1,
     kValueFieldNumber = 2,
   };
-  // .mavsdk.rpc.param_server.ParamServerResult param_result = 1;
-  bool has_param_result() const;
+  // .mavsdk.rpc.param_server.ParamServerResult param_server_result = 1;
+  bool has_param_server_result() const;
   private:
-  bool _internal_has_param_result() const;
+  bool _internal_has_param_server_result() const;
   public:
-  void clear_param_result();
-  const ::mavsdk::rpc::param_server::ParamServerResult& param_result() const;
-  PROTOBUF_MUST_USE_RESULT ::mavsdk::rpc::param_server::ParamServerResult* release_param_result();
-  ::mavsdk::rpc::param_server::ParamServerResult* mutable_param_result();
-  void set_allocated_param_result(::mavsdk::rpc::param_server::ParamServerResult* param_result);
+  void clear_param_server_result();
+  const ::mavsdk::rpc::param_server::ParamServerResult& param_server_result() const;
+  PROTOBUF_MUST_USE_RESULT ::mavsdk::rpc::param_server::ParamServerResult* release_param_server_result();
+  ::mavsdk::rpc::param_server::ParamServerResult* mutable_param_server_result();
+  void set_allocated_param_server_result(::mavsdk::rpc::param_server::ParamServerResult* param_server_result);
   private:
-  const ::mavsdk::rpc::param_server::ParamServerResult& _internal_param_result() const;
-  ::mavsdk::rpc::param_server::ParamServerResult* _internal_mutable_param_result();
+  const ::mavsdk::rpc::param_server::ParamServerResult& _internal_param_server_result() const;
+  ::mavsdk::rpc::param_server::ParamServerResult* _internal_mutable_param_server_result();
   public:
-  void unsafe_arena_set_allocated_param_result(
-      ::mavsdk::rpc::param_server::ParamServerResult* param_result);
-  ::mavsdk::rpc::param_server::ParamServerResult* unsafe_arena_release_param_result();
+  void unsafe_arena_set_allocated_param_server_result(
+      ::mavsdk::rpc::param_server::ParamServerResult* param_server_result);
+  ::mavsdk::rpc::param_server::ParamServerResult* unsafe_arena_release_param_server_result();
 
   // float value = 2;
   void clear_value();
@@ -1055,7 +1055,7 @@ class RetrieveParamFloatResponse final :
   template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
-  ::mavsdk::rpc::param_server::ParamServerResult* param_result_;
+  ::mavsdk::rpc::param_server::ParamServerResult* param_server_result_;
   float value_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_param_5fserver_2fparam_5fserver_2eproto;
@@ -1332,25 +1332,25 @@ class ProvideParamFloatResponse final :
   // accessors -------------------------------------------------------
 
   enum : int {
-    kParamResultFieldNumber = 1,
+    kParamServerResultFieldNumber = 1,
   };
-  // .mavsdk.rpc.param_server.ParamServerResult param_result = 1;
-  bool has_param_result() const;
+  // .mavsdk.rpc.param_server.ParamServerResult param_server_result = 1;
+  bool has_param_server_result() const;
   private:
-  bool _internal_has_param_result() const;
+  bool _internal_has_param_server_result() const;
   public:
-  void clear_param_result();
-  const ::mavsdk::rpc::param_server::ParamServerResult& param_result() const;
-  PROTOBUF_MUST_USE_RESULT ::mavsdk::rpc::param_server::ParamServerResult* release_param_result();
-  ::mavsdk::rpc::param_server::ParamServerResult* mutable_param_result();
-  void set_allocated_param_result(::mavsdk::rpc::param_server::ParamServerResult* param_result);
+  void clear_param_server_result();
+  const ::mavsdk::rpc::param_server::ParamServerResult& param_server_result() const;
+  PROTOBUF_MUST_USE_RESULT ::mavsdk::rpc::param_server::ParamServerResult* release_param_server_result();
+  ::mavsdk::rpc::param_server::ParamServerResult* mutable_param_server_result();
+  void set_allocated_param_server_result(::mavsdk::rpc::param_server::ParamServerResult* param_server_result);
   private:
-  const ::mavsdk::rpc::param_server::ParamServerResult& _internal_param_result() const;
-  ::mavsdk::rpc::param_server::ParamServerResult* _internal_mutable_param_result();
+  const ::mavsdk::rpc::param_server::ParamServerResult& _internal_param_server_result() const;
+  ::mavsdk::rpc::param_server::ParamServerResult* _internal_mutable_param_server_result();
   public:
-  void unsafe_arena_set_allocated_param_result(
-      ::mavsdk::rpc::param_server::ParamServerResult* param_result);
-  ::mavsdk::rpc::param_server::ParamServerResult* unsafe_arena_release_param_result();
+  void unsafe_arena_set_allocated_param_server_result(
+      ::mavsdk::rpc::param_server::ParamServerResult* param_server_result);
+  ::mavsdk::rpc::param_server::ParamServerResult* unsafe_arena_release_param_server_result();
 
   // @@protoc_insertion_point(class_scope:mavsdk.rpc.param_server.ProvideParamFloatResponse)
  private:
@@ -1359,7 +1359,7 @@ class ProvideParamFloatResponse final :
   template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
-  ::mavsdk::rpc::param_server::ParamServerResult* param_result_;
+  ::mavsdk::rpc::param_server::ParamServerResult* param_server_result_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_param_5fserver_2fparam_5fserver_2eproto;
 };
@@ -2367,45 +2367,45 @@ inline void RetrieveParamIntRequest::set_allocated_name(std::string* name) {
 
 // RetrieveParamIntResponse
 
-// .mavsdk.rpc.param_server.ParamServerResult param_result = 1;
-inline bool RetrieveParamIntResponse::_internal_has_param_result() const {
-  return this != internal_default_instance() && param_result_ != nullptr;
+// .mavsdk.rpc.param_server.ParamServerResult param_server_result = 1;
+inline bool RetrieveParamIntResponse::_internal_has_param_server_result() const {
+  return this != internal_default_instance() && param_server_result_ != nullptr;
 }
-inline bool RetrieveParamIntResponse::has_param_result() const {
-  return _internal_has_param_result();
+inline bool RetrieveParamIntResponse::has_param_server_result() const {
+  return _internal_has_param_server_result();
 }
-inline void RetrieveParamIntResponse::clear_param_result() {
-  if (GetArenaForAllocation() == nullptr && param_result_ != nullptr) {
-    delete param_result_;
+inline void RetrieveParamIntResponse::clear_param_server_result() {
+  if (GetArenaForAllocation() == nullptr && param_server_result_ != nullptr) {
+    delete param_server_result_;
   }
-  param_result_ = nullptr;
+  param_server_result_ = nullptr;
 }
-inline const ::mavsdk::rpc::param_server::ParamServerResult& RetrieveParamIntResponse::_internal_param_result() const {
-  const ::mavsdk::rpc::param_server::ParamServerResult* p = param_result_;
+inline const ::mavsdk::rpc::param_server::ParamServerResult& RetrieveParamIntResponse::_internal_param_server_result() const {
+  const ::mavsdk::rpc::param_server::ParamServerResult* p = param_server_result_;
   return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::param_server::ParamServerResult&>(
       ::mavsdk::rpc::param_server::_ParamServerResult_default_instance_);
 }
-inline const ::mavsdk::rpc::param_server::ParamServerResult& RetrieveParamIntResponse::param_result() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.param_server.RetrieveParamIntResponse.param_result)
-  return _internal_param_result();
+inline const ::mavsdk::rpc::param_server::ParamServerResult& RetrieveParamIntResponse::param_server_result() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.param_server.RetrieveParamIntResponse.param_server_result)
+  return _internal_param_server_result();
 }
-inline void RetrieveParamIntResponse::unsafe_arena_set_allocated_param_result(
-    ::mavsdk::rpc::param_server::ParamServerResult* param_result) {
+inline void RetrieveParamIntResponse::unsafe_arena_set_allocated_param_server_result(
+    ::mavsdk::rpc::param_server::ParamServerResult* param_server_result) {
   if (GetArenaForAllocation() == nullptr) {
-    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(param_result_);
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(param_server_result_);
   }
-  param_result_ = param_result;
-  if (param_result) {
+  param_server_result_ = param_server_result;
+  if (param_server_result) {
     
   } else {
     
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.param_server.RetrieveParamIntResponse.param_result)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.param_server.RetrieveParamIntResponse.param_server_result)
 }
-inline ::mavsdk::rpc::param_server::ParamServerResult* RetrieveParamIntResponse::release_param_result() {
+inline ::mavsdk::rpc::param_server::ParamServerResult* RetrieveParamIntResponse::release_param_server_result() {
   
-  ::mavsdk::rpc::param_server::ParamServerResult* temp = param_result_;
-  param_result_ = nullptr;
+  ::mavsdk::rpc::param_server::ParamServerResult* temp = param_server_result_;
+  param_server_result_ = nullptr;
 #ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
   auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
   temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
@@ -2417,44 +2417,44 @@ inline ::mavsdk::rpc::param_server::ParamServerResult* RetrieveParamIntResponse:
 #endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
   return temp;
 }
-inline ::mavsdk::rpc::param_server::ParamServerResult* RetrieveParamIntResponse::unsafe_arena_release_param_result() {
-  // @@protoc_insertion_point(field_release:mavsdk.rpc.param_server.RetrieveParamIntResponse.param_result)
+inline ::mavsdk::rpc::param_server::ParamServerResult* RetrieveParamIntResponse::unsafe_arena_release_param_server_result() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.param_server.RetrieveParamIntResponse.param_server_result)
   
-  ::mavsdk::rpc::param_server::ParamServerResult* temp = param_result_;
-  param_result_ = nullptr;
+  ::mavsdk::rpc::param_server::ParamServerResult* temp = param_server_result_;
+  param_server_result_ = nullptr;
   return temp;
 }
-inline ::mavsdk::rpc::param_server::ParamServerResult* RetrieveParamIntResponse::_internal_mutable_param_result() {
+inline ::mavsdk::rpc::param_server::ParamServerResult* RetrieveParamIntResponse::_internal_mutable_param_server_result() {
   
-  if (param_result_ == nullptr) {
+  if (param_server_result_ == nullptr) {
     auto* p = CreateMaybeMessage<::mavsdk::rpc::param_server::ParamServerResult>(GetArenaForAllocation());
-    param_result_ = p;
+    param_server_result_ = p;
   }
-  return param_result_;
+  return param_server_result_;
 }
-inline ::mavsdk::rpc::param_server::ParamServerResult* RetrieveParamIntResponse::mutable_param_result() {
-  ::mavsdk::rpc::param_server::ParamServerResult* _msg = _internal_mutable_param_result();
-  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.param_server.RetrieveParamIntResponse.param_result)
+inline ::mavsdk::rpc::param_server::ParamServerResult* RetrieveParamIntResponse::mutable_param_server_result() {
+  ::mavsdk::rpc::param_server::ParamServerResult* _msg = _internal_mutable_param_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.param_server.RetrieveParamIntResponse.param_server_result)
   return _msg;
 }
-inline void RetrieveParamIntResponse::set_allocated_param_result(::mavsdk::rpc::param_server::ParamServerResult* param_result) {
+inline void RetrieveParamIntResponse::set_allocated_param_server_result(::mavsdk::rpc::param_server::ParamServerResult* param_server_result) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
   if (message_arena == nullptr) {
-    delete param_result_;
+    delete param_server_result_;
   }
-  if (param_result) {
+  if (param_server_result) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
-        ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper<::mavsdk::rpc::param_server::ParamServerResult>::GetOwningArena(param_result);
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper<::mavsdk::rpc::param_server::ParamServerResult>::GetOwningArena(param_server_result);
     if (message_arena != submessage_arena) {
-      param_result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
-          message_arena, param_result, submessage_arena);
+      param_server_result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, param_server_result, submessage_arena);
     }
     
   } else {
     
   }
-  param_result_ = param_result;
-  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.param_server.RetrieveParamIntResponse.param_result)
+  param_server_result_ = param_server_result;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.param_server.RetrieveParamIntResponse.param_server_result)
 }
 
 // int32 value = 2;
@@ -2551,45 +2551,45 @@ inline void ProvideParamIntRequest::set_value(::PROTOBUF_NAMESPACE_ID::int32 val
 
 // ProvideParamIntResponse
 
-// .mavsdk.rpc.param_server.ParamServerResult param_result = 1;
-inline bool ProvideParamIntResponse::_internal_has_param_result() const {
-  return this != internal_default_instance() && param_result_ != nullptr;
+// .mavsdk.rpc.param_server.ParamServerResult param_server_result = 1;
+inline bool ProvideParamIntResponse::_internal_has_param_server_result() const {
+  return this != internal_default_instance() && param_server_result_ != nullptr;
 }
-inline bool ProvideParamIntResponse::has_param_result() const {
-  return _internal_has_param_result();
+inline bool ProvideParamIntResponse::has_param_server_result() const {
+  return _internal_has_param_server_result();
 }
-inline void ProvideParamIntResponse::clear_param_result() {
-  if (GetArenaForAllocation() == nullptr && param_result_ != nullptr) {
-    delete param_result_;
+inline void ProvideParamIntResponse::clear_param_server_result() {
+  if (GetArenaForAllocation() == nullptr && param_server_result_ != nullptr) {
+    delete param_server_result_;
   }
-  param_result_ = nullptr;
+  param_server_result_ = nullptr;
 }
-inline const ::mavsdk::rpc::param_server::ParamServerResult& ProvideParamIntResponse::_internal_param_result() const {
-  const ::mavsdk::rpc::param_server::ParamServerResult* p = param_result_;
+inline const ::mavsdk::rpc::param_server::ParamServerResult& ProvideParamIntResponse::_internal_param_server_result() const {
+  const ::mavsdk::rpc::param_server::ParamServerResult* p = param_server_result_;
   return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::param_server::ParamServerResult&>(
       ::mavsdk::rpc::param_server::_ParamServerResult_default_instance_);
 }
-inline const ::mavsdk::rpc::param_server::ParamServerResult& ProvideParamIntResponse::param_result() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.param_server.ProvideParamIntResponse.param_result)
-  return _internal_param_result();
+inline const ::mavsdk::rpc::param_server::ParamServerResult& ProvideParamIntResponse::param_server_result() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.param_server.ProvideParamIntResponse.param_server_result)
+  return _internal_param_server_result();
 }
-inline void ProvideParamIntResponse::unsafe_arena_set_allocated_param_result(
-    ::mavsdk::rpc::param_server::ParamServerResult* param_result) {
+inline void ProvideParamIntResponse::unsafe_arena_set_allocated_param_server_result(
+    ::mavsdk::rpc::param_server::ParamServerResult* param_server_result) {
   if (GetArenaForAllocation() == nullptr) {
-    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(param_result_);
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(param_server_result_);
   }
-  param_result_ = param_result;
-  if (param_result) {
+  param_server_result_ = param_server_result;
+  if (param_server_result) {
     
   } else {
     
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.param_server.ProvideParamIntResponse.param_result)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.param_server.ProvideParamIntResponse.param_server_result)
 }
-inline ::mavsdk::rpc::param_server::ParamServerResult* ProvideParamIntResponse::release_param_result() {
+inline ::mavsdk::rpc::param_server::ParamServerResult* ProvideParamIntResponse::release_param_server_result() {
   
-  ::mavsdk::rpc::param_server::ParamServerResult* temp = param_result_;
-  param_result_ = nullptr;
+  ::mavsdk::rpc::param_server::ParamServerResult* temp = param_server_result_;
+  param_server_result_ = nullptr;
 #ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
   auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
   temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
@@ -2601,44 +2601,44 @@ inline ::mavsdk::rpc::param_server::ParamServerResult* ProvideParamIntResponse::
 #endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
   return temp;
 }
-inline ::mavsdk::rpc::param_server::ParamServerResult* ProvideParamIntResponse::unsafe_arena_release_param_result() {
-  // @@protoc_insertion_point(field_release:mavsdk.rpc.param_server.ProvideParamIntResponse.param_result)
+inline ::mavsdk::rpc::param_server::ParamServerResult* ProvideParamIntResponse::unsafe_arena_release_param_server_result() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.param_server.ProvideParamIntResponse.param_server_result)
   
-  ::mavsdk::rpc::param_server::ParamServerResult* temp = param_result_;
-  param_result_ = nullptr;
+  ::mavsdk::rpc::param_server::ParamServerResult* temp = param_server_result_;
+  param_server_result_ = nullptr;
   return temp;
 }
-inline ::mavsdk::rpc::param_server::ParamServerResult* ProvideParamIntResponse::_internal_mutable_param_result() {
+inline ::mavsdk::rpc::param_server::ParamServerResult* ProvideParamIntResponse::_internal_mutable_param_server_result() {
   
-  if (param_result_ == nullptr) {
+  if (param_server_result_ == nullptr) {
     auto* p = CreateMaybeMessage<::mavsdk::rpc::param_server::ParamServerResult>(GetArenaForAllocation());
-    param_result_ = p;
+    param_server_result_ = p;
   }
-  return param_result_;
+  return param_server_result_;
 }
-inline ::mavsdk::rpc::param_server::ParamServerResult* ProvideParamIntResponse::mutable_param_result() {
-  ::mavsdk::rpc::param_server::ParamServerResult* _msg = _internal_mutable_param_result();
-  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.param_server.ProvideParamIntResponse.param_result)
+inline ::mavsdk::rpc::param_server::ParamServerResult* ProvideParamIntResponse::mutable_param_server_result() {
+  ::mavsdk::rpc::param_server::ParamServerResult* _msg = _internal_mutable_param_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.param_server.ProvideParamIntResponse.param_server_result)
   return _msg;
 }
-inline void ProvideParamIntResponse::set_allocated_param_result(::mavsdk::rpc::param_server::ParamServerResult* param_result) {
+inline void ProvideParamIntResponse::set_allocated_param_server_result(::mavsdk::rpc::param_server::ParamServerResult* param_server_result) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
   if (message_arena == nullptr) {
-    delete param_result_;
+    delete param_server_result_;
   }
-  if (param_result) {
+  if (param_server_result) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
-        ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper<::mavsdk::rpc::param_server::ParamServerResult>::GetOwningArena(param_result);
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper<::mavsdk::rpc::param_server::ParamServerResult>::GetOwningArena(param_server_result);
     if (message_arena != submessage_arena) {
-      param_result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
-          message_arena, param_result, submessage_arena);
+      param_server_result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, param_server_result, submessage_arena);
     }
     
   } else {
     
   }
-  param_result_ = param_result;
-  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.param_server.ProvideParamIntResponse.param_result)
+  param_server_result_ = param_server_result;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.param_server.ProvideParamIntResponse.param_server_result)
 }
 
 // -------------------------------------------------------------------
@@ -2695,45 +2695,45 @@ inline void RetrieveParamFloatRequest::set_allocated_name(std::string* name) {
 
 // RetrieveParamFloatResponse
 
-// .mavsdk.rpc.param_server.ParamServerResult param_result = 1;
-inline bool RetrieveParamFloatResponse::_internal_has_param_result() const {
-  return this != internal_default_instance() && param_result_ != nullptr;
+// .mavsdk.rpc.param_server.ParamServerResult param_server_result = 1;
+inline bool RetrieveParamFloatResponse::_internal_has_param_server_result() const {
+  return this != internal_default_instance() && param_server_result_ != nullptr;
 }
-inline bool RetrieveParamFloatResponse::has_param_result() const {
-  return _internal_has_param_result();
+inline bool RetrieveParamFloatResponse::has_param_server_result() const {
+  return _internal_has_param_server_result();
 }
-inline void RetrieveParamFloatResponse::clear_param_result() {
-  if (GetArenaForAllocation() == nullptr && param_result_ != nullptr) {
-    delete param_result_;
+inline void RetrieveParamFloatResponse::clear_param_server_result() {
+  if (GetArenaForAllocation() == nullptr && param_server_result_ != nullptr) {
+    delete param_server_result_;
   }
-  param_result_ = nullptr;
+  param_server_result_ = nullptr;
 }
-inline const ::mavsdk::rpc::param_server::ParamServerResult& RetrieveParamFloatResponse::_internal_param_result() const {
-  const ::mavsdk::rpc::param_server::ParamServerResult* p = param_result_;
+inline const ::mavsdk::rpc::param_server::ParamServerResult& RetrieveParamFloatResponse::_internal_param_server_result() const {
+  const ::mavsdk::rpc::param_server::ParamServerResult* p = param_server_result_;
   return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::param_server::ParamServerResult&>(
       ::mavsdk::rpc::param_server::_ParamServerResult_default_instance_);
 }
-inline const ::mavsdk::rpc::param_server::ParamServerResult& RetrieveParamFloatResponse::param_result() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.param_server.RetrieveParamFloatResponse.param_result)
-  return _internal_param_result();
+inline const ::mavsdk::rpc::param_server::ParamServerResult& RetrieveParamFloatResponse::param_server_result() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.param_server.RetrieveParamFloatResponse.param_server_result)
+  return _internal_param_server_result();
 }
-inline void RetrieveParamFloatResponse::unsafe_arena_set_allocated_param_result(
-    ::mavsdk::rpc::param_server::ParamServerResult* param_result) {
+inline void RetrieveParamFloatResponse::unsafe_arena_set_allocated_param_server_result(
+    ::mavsdk::rpc::param_server::ParamServerResult* param_server_result) {
   if (GetArenaForAllocation() == nullptr) {
-    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(param_result_);
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(param_server_result_);
   }
-  param_result_ = param_result;
-  if (param_result) {
+  param_server_result_ = param_server_result;
+  if (param_server_result) {
     
   } else {
     
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.param_server.RetrieveParamFloatResponse.param_result)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.param_server.RetrieveParamFloatResponse.param_server_result)
 }
-inline ::mavsdk::rpc::param_server::ParamServerResult* RetrieveParamFloatResponse::release_param_result() {
+inline ::mavsdk::rpc::param_server::ParamServerResult* RetrieveParamFloatResponse::release_param_server_result() {
   
-  ::mavsdk::rpc::param_server::ParamServerResult* temp = param_result_;
-  param_result_ = nullptr;
+  ::mavsdk::rpc::param_server::ParamServerResult* temp = param_server_result_;
+  param_server_result_ = nullptr;
 #ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
   auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
   temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
@@ -2745,44 +2745,44 @@ inline ::mavsdk::rpc::param_server::ParamServerResult* RetrieveParamFloatRespons
 #endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
   return temp;
 }
-inline ::mavsdk::rpc::param_server::ParamServerResult* RetrieveParamFloatResponse::unsafe_arena_release_param_result() {
-  // @@protoc_insertion_point(field_release:mavsdk.rpc.param_server.RetrieveParamFloatResponse.param_result)
+inline ::mavsdk::rpc::param_server::ParamServerResult* RetrieveParamFloatResponse::unsafe_arena_release_param_server_result() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.param_server.RetrieveParamFloatResponse.param_server_result)
   
-  ::mavsdk::rpc::param_server::ParamServerResult* temp = param_result_;
-  param_result_ = nullptr;
+  ::mavsdk::rpc::param_server::ParamServerResult* temp = param_server_result_;
+  param_server_result_ = nullptr;
   return temp;
 }
-inline ::mavsdk::rpc::param_server::ParamServerResult* RetrieveParamFloatResponse::_internal_mutable_param_result() {
+inline ::mavsdk::rpc::param_server::ParamServerResult* RetrieveParamFloatResponse::_internal_mutable_param_server_result() {
   
-  if (param_result_ == nullptr) {
+  if (param_server_result_ == nullptr) {
     auto* p = CreateMaybeMessage<::mavsdk::rpc::param_server::ParamServerResult>(GetArenaForAllocation());
-    param_result_ = p;
+    param_server_result_ = p;
   }
-  return param_result_;
+  return param_server_result_;
 }
-inline ::mavsdk::rpc::param_server::ParamServerResult* RetrieveParamFloatResponse::mutable_param_result() {
-  ::mavsdk::rpc::param_server::ParamServerResult* _msg = _internal_mutable_param_result();
-  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.param_server.RetrieveParamFloatResponse.param_result)
+inline ::mavsdk::rpc::param_server::ParamServerResult* RetrieveParamFloatResponse::mutable_param_server_result() {
+  ::mavsdk::rpc::param_server::ParamServerResult* _msg = _internal_mutable_param_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.param_server.RetrieveParamFloatResponse.param_server_result)
   return _msg;
 }
-inline void RetrieveParamFloatResponse::set_allocated_param_result(::mavsdk::rpc::param_server::ParamServerResult* param_result) {
+inline void RetrieveParamFloatResponse::set_allocated_param_server_result(::mavsdk::rpc::param_server::ParamServerResult* param_server_result) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
   if (message_arena == nullptr) {
-    delete param_result_;
+    delete param_server_result_;
   }
-  if (param_result) {
+  if (param_server_result) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
-        ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper<::mavsdk::rpc::param_server::ParamServerResult>::GetOwningArena(param_result);
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper<::mavsdk::rpc::param_server::ParamServerResult>::GetOwningArena(param_server_result);
     if (message_arena != submessage_arena) {
-      param_result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
-          message_arena, param_result, submessage_arena);
+      param_server_result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, param_server_result, submessage_arena);
     }
     
   } else {
     
   }
-  param_result_ = param_result;
-  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.param_server.RetrieveParamFloatResponse.param_result)
+  param_server_result_ = param_server_result;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.param_server.RetrieveParamFloatResponse.param_server_result)
 }
 
 // float value = 2;
@@ -2879,45 +2879,45 @@ inline void ProvideParamFloatRequest::set_value(float value) {
 
 // ProvideParamFloatResponse
 
-// .mavsdk.rpc.param_server.ParamServerResult param_result = 1;
-inline bool ProvideParamFloatResponse::_internal_has_param_result() const {
-  return this != internal_default_instance() && param_result_ != nullptr;
+// .mavsdk.rpc.param_server.ParamServerResult param_server_result = 1;
+inline bool ProvideParamFloatResponse::_internal_has_param_server_result() const {
+  return this != internal_default_instance() && param_server_result_ != nullptr;
 }
-inline bool ProvideParamFloatResponse::has_param_result() const {
-  return _internal_has_param_result();
+inline bool ProvideParamFloatResponse::has_param_server_result() const {
+  return _internal_has_param_server_result();
 }
-inline void ProvideParamFloatResponse::clear_param_result() {
-  if (GetArenaForAllocation() == nullptr && param_result_ != nullptr) {
-    delete param_result_;
+inline void ProvideParamFloatResponse::clear_param_server_result() {
+  if (GetArenaForAllocation() == nullptr && param_server_result_ != nullptr) {
+    delete param_server_result_;
   }
-  param_result_ = nullptr;
+  param_server_result_ = nullptr;
 }
-inline const ::mavsdk::rpc::param_server::ParamServerResult& ProvideParamFloatResponse::_internal_param_result() const {
-  const ::mavsdk::rpc::param_server::ParamServerResult* p = param_result_;
+inline const ::mavsdk::rpc::param_server::ParamServerResult& ProvideParamFloatResponse::_internal_param_server_result() const {
+  const ::mavsdk::rpc::param_server::ParamServerResult* p = param_server_result_;
   return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::param_server::ParamServerResult&>(
       ::mavsdk::rpc::param_server::_ParamServerResult_default_instance_);
 }
-inline const ::mavsdk::rpc::param_server::ParamServerResult& ProvideParamFloatResponse::param_result() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.param_server.ProvideParamFloatResponse.param_result)
-  return _internal_param_result();
+inline const ::mavsdk::rpc::param_server::ParamServerResult& ProvideParamFloatResponse::param_server_result() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.param_server.ProvideParamFloatResponse.param_server_result)
+  return _internal_param_server_result();
 }
-inline void ProvideParamFloatResponse::unsafe_arena_set_allocated_param_result(
-    ::mavsdk::rpc::param_server::ParamServerResult* param_result) {
+inline void ProvideParamFloatResponse::unsafe_arena_set_allocated_param_server_result(
+    ::mavsdk::rpc::param_server::ParamServerResult* param_server_result) {
   if (GetArenaForAllocation() == nullptr) {
-    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(param_result_);
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(param_server_result_);
   }
-  param_result_ = param_result;
-  if (param_result) {
+  param_server_result_ = param_server_result;
+  if (param_server_result) {
     
   } else {
     
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.param_server.ProvideParamFloatResponse.param_result)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.param_server.ProvideParamFloatResponse.param_server_result)
 }
-inline ::mavsdk::rpc::param_server::ParamServerResult* ProvideParamFloatResponse::release_param_result() {
+inline ::mavsdk::rpc::param_server::ParamServerResult* ProvideParamFloatResponse::release_param_server_result() {
   
-  ::mavsdk::rpc::param_server::ParamServerResult* temp = param_result_;
-  param_result_ = nullptr;
+  ::mavsdk::rpc::param_server::ParamServerResult* temp = param_server_result_;
+  param_server_result_ = nullptr;
 #ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
   auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
   temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
@@ -2929,44 +2929,44 @@ inline ::mavsdk::rpc::param_server::ParamServerResult* ProvideParamFloatResponse
 #endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
   return temp;
 }
-inline ::mavsdk::rpc::param_server::ParamServerResult* ProvideParamFloatResponse::unsafe_arena_release_param_result() {
-  // @@protoc_insertion_point(field_release:mavsdk.rpc.param_server.ProvideParamFloatResponse.param_result)
+inline ::mavsdk::rpc::param_server::ParamServerResult* ProvideParamFloatResponse::unsafe_arena_release_param_server_result() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.param_server.ProvideParamFloatResponse.param_server_result)
   
-  ::mavsdk::rpc::param_server::ParamServerResult* temp = param_result_;
-  param_result_ = nullptr;
+  ::mavsdk::rpc::param_server::ParamServerResult* temp = param_server_result_;
+  param_server_result_ = nullptr;
   return temp;
 }
-inline ::mavsdk::rpc::param_server::ParamServerResult* ProvideParamFloatResponse::_internal_mutable_param_result() {
+inline ::mavsdk::rpc::param_server::ParamServerResult* ProvideParamFloatResponse::_internal_mutable_param_server_result() {
   
-  if (param_result_ == nullptr) {
+  if (param_server_result_ == nullptr) {
     auto* p = CreateMaybeMessage<::mavsdk::rpc::param_server::ParamServerResult>(GetArenaForAllocation());
-    param_result_ = p;
+    param_server_result_ = p;
   }
-  return param_result_;
+  return param_server_result_;
 }
-inline ::mavsdk::rpc::param_server::ParamServerResult* ProvideParamFloatResponse::mutable_param_result() {
-  ::mavsdk::rpc::param_server::ParamServerResult* _msg = _internal_mutable_param_result();
-  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.param_server.ProvideParamFloatResponse.param_result)
+inline ::mavsdk::rpc::param_server::ParamServerResult* ProvideParamFloatResponse::mutable_param_server_result() {
+  ::mavsdk::rpc::param_server::ParamServerResult* _msg = _internal_mutable_param_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.param_server.ProvideParamFloatResponse.param_server_result)
   return _msg;
 }
-inline void ProvideParamFloatResponse::set_allocated_param_result(::mavsdk::rpc::param_server::ParamServerResult* param_result) {
+inline void ProvideParamFloatResponse::set_allocated_param_server_result(::mavsdk::rpc::param_server::ParamServerResult* param_server_result) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
   if (message_arena == nullptr) {
-    delete param_result_;
+    delete param_server_result_;
   }
-  if (param_result) {
+  if (param_server_result) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
-        ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper<::mavsdk::rpc::param_server::ParamServerResult>::GetOwningArena(param_result);
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper<::mavsdk::rpc::param_server::ParamServerResult>::GetOwningArena(param_server_result);
     if (message_arena != submessage_arena) {
-      param_result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
-          message_arena, param_result, submessage_arena);
+      param_server_result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, param_server_result, submessage_arena);
     }
     
   } else {
     
   }
-  param_result_ = param_result;
-  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.param_server.ProvideParamFloatResponse.param_result)
+  param_server_result_ = param_server_result;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.param_server.ProvideParamFloatResponse.param_server_result)
 }
 
 // -------------------------------------------------------------------

--- a/src/mavsdk_server/src/plugins/action_server/action_server_service_impl.h
+++ b/src/mavsdk_server/src/plugins/action_server/action_server_service_impl.h
@@ -203,6 +203,8 @@ public:
                     ActionServerResult_Result_RESULT_NO_VTOL_TRANSITION_SUPPORT;
             case mavsdk::ActionServer::Result::ParameterError:
                 return rpc::action_server::ActionServerResult_Result_RESULT_PARAMETER_ERROR;
+            case mavsdk::ActionServer::Result::Next:
+                return rpc::action_server::ActionServerResult_Result_RESULT_NEXT;
         }
     }
 
@@ -239,6 +241,8 @@ public:
                 return mavsdk::ActionServer::Result::NoVtolTransitionSupport;
             case rpc::action_server::ActionServerResult_Result_RESULT_PARAMETER_ERROR:
                 return mavsdk::ActionServer::Result::ParameterError;
+            case rpc::action_server::ActionServerResult_Result_RESULT_NEXT:
+                return mavsdk::ActionServer::Result::Next;
         }
     }
 

--- a/src/mavsdk_server/src/plugins/mission_raw_server/mission_raw_server_service_impl.h
+++ b/src/mavsdk_server/src/plugins/mission_raw_server/mission_raw_server_service_impl.h
@@ -161,7 +161,7 @@ public:
         return obj;
     }
 
-    static rpc::mission_raw_server::MissionResult::Result
+    static rpc::mission_raw_server::MissionRawServerResult::Result
     translateToRpcResult(const mavsdk::MissionRawServer::Result& result)
     {
         switch (result) {
@@ -169,63 +169,74 @@ public:
                 LogErr() << "Unknown result enum value: " << static_cast<int>(result);
             // FALLTHROUGH
             case mavsdk::MissionRawServer::Result::Unknown:
-                return rpc::mission_raw_server::MissionResult_Result_RESULT_UNKNOWN;
+                return rpc::mission_raw_server::MissionRawServerResult_Result_RESULT_UNKNOWN;
             case mavsdk::MissionRawServer::Result::Success:
-                return rpc::mission_raw_server::MissionResult_Result_RESULT_SUCCESS;
+                return rpc::mission_raw_server::MissionRawServerResult_Result_RESULT_SUCCESS;
             case mavsdk::MissionRawServer::Result::Error:
-                return rpc::mission_raw_server::MissionResult_Result_RESULT_ERROR;
+                return rpc::mission_raw_server::MissionRawServerResult_Result_RESULT_ERROR;
             case mavsdk::MissionRawServer::Result::TooManyMissionItems:
-                return rpc::mission_raw_server::MissionResult_Result_RESULT_TOO_MANY_MISSION_ITEMS;
+                return rpc::mission_raw_server::
+                    MissionRawServerResult_Result_RESULT_TOO_MANY_MISSION_ITEMS;
             case mavsdk::MissionRawServer::Result::Busy:
-                return rpc::mission_raw_server::MissionResult_Result_RESULT_BUSY;
+                return rpc::mission_raw_server::MissionRawServerResult_Result_RESULT_BUSY;
             case mavsdk::MissionRawServer::Result::Timeout:
-                return rpc::mission_raw_server::MissionResult_Result_RESULT_TIMEOUT;
+                return rpc::mission_raw_server::MissionRawServerResult_Result_RESULT_TIMEOUT;
             case mavsdk::MissionRawServer::Result::InvalidArgument:
-                return rpc::mission_raw_server::MissionResult_Result_RESULT_INVALID_ARGUMENT;
+                return rpc::mission_raw_server::
+                    MissionRawServerResult_Result_RESULT_INVALID_ARGUMENT;
             case mavsdk::MissionRawServer::Result::Unsupported:
-                return rpc::mission_raw_server::MissionResult_Result_RESULT_UNSUPPORTED;
+                return rpc::mission_raw_server::MissionRawServerResult_Result_RESULT_UNSUPPORTED;
             case mavsdk::MissionRawServer::Result::NoMissionAvailable:
-                return rpc::mission_raw_server::MissionResult_Result_RESULT_NO_MISSION_AVAILABLE;
+                return rpc::mission_raw_server::
+                    MissionRawServerResult_Result_RESULT_NO_MISSION_AVAILABLE;
             case mavsdk::MissionRawServer::Result::UnsupportedMissionCmd:
-                return rpc::mission_raw_server::MissionResult_Result_RESULT_UNSUPPORTED_MISSION_CMD;
+                return rpc::mission_raw_server::
+                    MissionRawServerResult_Result_RESULT_UNSUPPORTED_MISSION_CMD;
             case mavsdk::MissionRawServer::Result::TransferCancelled:
-                return rpc::mission_raw_server::MissionResult_Result_RESULT_TRANSFER_CANCELLED;
+                return rpc::mission_raw_server::
+                    MissionRawServerResult_Result_RESULT_TRANSFER_CANCELLED;
             case mavsdk::MissionRawServer::Result::NoSystem:
-                return rpc::mission_raw_server::MissionResult_Result_RESULT_NO_SYSTEM;
+                return rpc::mission_raw_server::MissionRawServerResult_Result_RESULT_NO_SYSTEM;
+            case mavsdk::MissionRawServer::Result::Next:
+                return rpc::mission_raw_server::MissionRawServerResult_Result_RESULT_NEXT;
         }
     }
 
     static mavsdk::MissionRawServer::Result
-    translateFromRpcResult(const rpc::mission_raw_server::MissionResult::Result result)
+    translateFromRpcResult(const rpc::mission_raw_server::MissionRawServerResult::Result result)
     {
         switch (result) {
             default:
                 LogErr() << "Unknown result enum value: " << static_cast<int>(result);
             // FALLTHROUGH
-            case rpc::mission_raw_server::MissionResult_Result_RESULT_UNKNOWN:
+            case rpc::mission_raw_server::MissionRawServerResult_Result_RESULT_UNKNOWN:
                 return mavsdk::MissionRawServer::Result::Unknown;
-            case rpc::mission_raw_server::MissionResult_Result_RESULT_SUCCESS:
+            case rpc::mission_raw_server::MissionRawServerResult_Result_RESULT_SUCCESS:
                 return mavsdk::MissionRawServer::Result::Success;
-            case rpc::mission_raw_server::MissionResult_Result_RESULT_ERROR:
+            case rpc::mission_raw_server::MissionRawServerResult_Result_RESULT_ERROR:
                 return mavsdk::MissionRawServer::Result::Error;
-            case rpc::mission_raw_server::MissionResult_Result_RESULT_TOO_MANY_MISSION_ITEMS:
+            case rpc::mission_raw_server::
+                MissionRawServerResult_Result_RESULT_TOO_MANY_MISSION_ITEMS:
                 return mavsdk::MissionRawServer::Result::TooManyMissionItems;
-            case rpc::mission_raw_server::MissionResult_Result_RESULT_BUSY:
+            case rpc::mission_raw_server::MissionRawServerResult_Result_RESULT_BUSY:
                 return mavsdk::MissionRawServer::Result::Busy;
-            case rpc::mission_raw_server::MissionResult_Result_RESULT_TIMEOUT:
+            case rpc::mission_raw_server::MissionRawServerResult_Result_RESULT_TIMEOUT:
                 return mavsdk::MissionRawServer::Result::Timeout;
-            case rpc::mission_raw_server::MissionResult_Result_RESULT_INVALID_ARGUMENT:
+            case rpc::mission_raw_server::MissionRawServerResult_Result_RESULT_INVALID_ARGUMENT:
                 return mavsdk::MissionRawServer::Result::InvalidArgument;
-            case rpc::mission_raw_server::MissionResult_Result_RESULT_UNSUPPORTED:
+            case rpc::mission_raw_server::MissionRawServerResult_Result_RESULT_UNSUPPORTED:
                 return mavsdk::MissionRawServer::Result::Unsupported;
-            case rpc::mission_raw_server::MissionResult_Result_RESULT_NO_MISSION_AVAILABLE:
+            case rpc::mission_raw_server::MissionRawServerResult_Result_RESULT_NO_MISSION_AVAILABLE:
                 return mavsdk::MissionRawServer::Result::NoMissionAvailable;
-            case rpc::mission_raw_server::MissionResult_Result_RESULT_UNSUPPORTED_MISSION_CMD:
+            case rpc::mission_raw_server::
+                MissionRawServerResult_Result_RESULT_UNSUPPORTED_MISSION_CMD:
                 return mavsdk::MissionRawServer::Result::UnsupportedMissionCmd;
-            case rpc::mission_raw_server::MissionResult_Result_RESULT_TRANSFER_CANCELLED:
+            case rpc::mission_raw_server::MissionRawServerResult_Result_RESULT_TRANSFER_CANCELLED:
                 return mavsdk::MissionRawServer::Result::TransferCancelled;
-            case rpc::mission_raw_server::MissionResult_Result_RESULT_NO_SYSTEM:
+            case rpc::mission_raw_server::MissionRawServerResult_Result_RESULT_NO_SYSTEM:
                 return mavsdk::MissionRawServer::Result::NoSystem;
+            case rpc::mission_raw_server::MissionRawServerResult_Result_RESULT_NEXT:
+                return mavsdk::MissionRawServer::Result::Next;
         }
     }
 

--- a/src/plugins/action_server/action_server.cpp
+++ b/src/plugins/action_server/action_server.cpp
@@ -148,6 +148,8 @@ std::ostream& operator<<(std::ostream& str, ActionServer::Result const& result)
             return str << "No Vtol Transition Support";
         case ActionServer::Result::ParameterError:
             return str << "Parameter Error";
+        case ActionServer::Result::Next:
+            return str << "Next";
         default:
             return str << "Unknown";
     }

--- a/src/plugins/action_server/include/plugins/action_server/action_server.h
+++ b/src/plugins/action_server/include/plugins/action_server/action_server.h
@@ -152,6 +152,8 @@ public:
         VtolTransitionSupportUnknown, /**< @brief Hybrid/VTOL transition support is unknown. */
         NoVtolTransitionSupport, /**< @brief Vehicle does not support hybrid/VTOL transitions. */
         ParameterError, /**< @brief Error getting or setting parameter. */
+        Next, /**< @brief Intermediate message showing progress or instructions on the next steps.
+               */
     };
 
     /**

--- a/src/plugins/mission_raw_server/include/plugins/mission_raw_server/mission_raw_server.h
+++ b/src/plugins/mission_raw_server/include/plugins/mission_raw_server/mission_raw_server.h
@@ -160,6 +160,8 @@ public:
         UnsupportedMissionCmd, /**< @brief Unsupported mission command. */
         TransferCancelled, /**< @brief Mission transfer (upload or download) has been cancelled. */
         NoSystem, /**< @brief No system connected. */
+        Next, /**< @brief Intermediate message showing progress or instructions on the next steps.
+               */
     };
 
     /**

--- a/src/plugins/mission_raw_server/mission_raw_server.cpp
+++ b/src/plugins/mission_raw_server/mission_raw_server.cpp
@@ -158,6 +158,8 @@ std::ostream& operator<<(std::ostream& str, MissionRawServer::Result const& resu
             return str << "Transfer Cancelled";
         case MissionRawServer::Result::NoSystem:
             return str << "No System";
+        case MissionRawServer::Result::Next:
+            return str << "Next";
         default:
             return str << "Unknown";
     }


### PR DESCRIPTION
Goes with https://github.com/mavlink/MAVSDK-Proto/pull/254

As can be seen, it does not modify anything regarding MAVSDK's API. It just renames some implementation details (which is needed for MAVSDK-Java).