### PR TITLE
Improve connection and corresponding logging

### DIFF
--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -514,7 +514,12 @@ void SystemImpl::set_connected()
             }
 
             _connected = true;
-            _parent.notify_on_discover();
+
+            // System with sysid 0 is a bit special: it is a placeholder for a connection initiated
+            // by MAVSDK. As such, it should not be advertised as a newly discovered system.
+            if (static_cast<int>(get_system_id()) != 0) {
+                _parent.notify_on_discover();
+            }
 
             // Send a heartbeat back immediately.
             _parent.start_sending_heartbeats();

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -509,7 +509,9 @@ void SystemImpl::set_connected()
         std::lock_guard<std::mutex> lock(_connection_mutex);
 
         if (!_connected) {
-            LogDebug() << "Discovered " << _components.size() << " component(s)";
+            if (_components.size() > 0) {
+                LogDebug() << "Discovered " << _components.size() << " component(s)";
+            }
 
             _connected = true;
             _parent.notify_on_discover();

--- a/src/core/udp_connection.cpp
+++ b/src/core/udp_connection.cpp
@@ -188,8 +188,12 @@ void UdpConnection::add_remote_with_remote_sysid(
         });
 
     if (existing_remote == _remotes.end()) {
-        LogInfo() << "New system on: " << new_remote.ip << ":" << new_remote.port_number
-                  << " (with sysid: " << (int)remote_sysid << ")";
+        // System with sysid 0 is a bit special: it is a placeholder for a connection initiated
+        // by MAVSDK. As such, it should not be advertised as a newly discovered system.
+        if (static_cast<int>(remote_sysid) != 0) {
+            LogInfo() << "New system on: " << new_remote.ip << ":" << new_remote.port_number
+                      << " (with sysid: " << static_cast<int>(remote_sysid) << ")";
+        }
         _remotes.push_back(new_remote);
     }
 }

--- a/src/mavsdk_server/src/mavsdk_server.cpp
+++ b/src/mavsdk_server/src/mavsdk_server.cpp
@@ -16,6 +16,7 @@ public:
     void connect(const std::string& connection_url)
     {
         _connection_initiator.start(_mavsdk, connection_url);
+        _connection_initiator.wait();
     }
 
     int startGrpcServer(const int port)

--- a/src/mavsdk_server/src/mavsdk_server.h
+++ b/src/mavsdk_server/src/mavsdk_server.h
@@ -12,7 +12,7 @@ public:
     MavsdkServer& operator=(MavsdkServer&&) = delete;
 
     int startGrpcServer(int port);
-    void connect(const std::string& connection_url = "udp://");
+    void connect(const std::string& connection_url = "udp://:14540");
     void wait();
     void stop();
     int getPort();

--- a/src/mavsdk_server/src/mavsdk_server_api.cpp
+++ b/src/mavsdk_server/src/mavsdk_server_api.cpp
@@ -6,13 +6,13 @@ MavsdkServer* mavsdk_server_run(const char* system_address, const int mavsdk_ser
 {
     auto mavsdk_server = new MavsdkServer();
 
+    mavsdk_server->connect(std::string(system_address));
+
     auto grpc_port = mavsdk_server->startGrpcServer(mavsdk_server_port);
     if (grpc_port == 0) {
         // Server failed to start
         return nullptr;
     }
-
-    mavsdk_server->connect(std::string(system_address));
 
     return mavsdk_server;
 }


### PR DESCRIPTION
* Discover the remote system before starting the grpc server
* Do not call notify_on_discover when the sysid is 0 (which means that MAVSDK is connecting to a remote, and therefore a system has not actually been discovered)
* Improve connection logging (stuff like "discovered 0 components" is a bit confusing IMO)