### PR TITLE
Fix stop in mavsdk_server

### DIFF
--- a/src/mavsdk_server/src/mavsdk_server.cpp
+++ b/src/mavsdk_server/src/mavsdk_server.cpp
@@ -13,10 +13,10 @@ public:
     Impl() {}
     ~Impl() {}
 
-    void connect(const std::string& connection_url)
+    bool connect(const std::string& connection_url)
     {
         _connection_initiator.start(_mavsdk, connection_url);
-        _connection_initiator.wait();
+        return _connection_initiator.wait();
     }
 
     int startGrpcServer(const int port)
@@ -29,7 +29,14 @@ public:
 
     void wait() { _server->wait(); }
 
-    void stop() { _server->stop(); }
+    void stop()
+    {
+        _connection_initiator.cancel();
+
+        if (_server != nullptr) {
+            _server->stop();
+        }
+    }
 
     int getPort() { return _grpc_port; }
 
@@ -47,14 +54,17 @@ int MavsdkServer::startGrpcServer(const int port)
 {
     return _impl->startGrpcServer(port);
 }
-void MavsdkServer::connect(const std::string& connection_url)
+
+bool MavsdkServer::connect(const std::string& connection_url)
 {
     return _impl->connect(connection_url);
 }
+
 void MavsdkServer::wait()
 {
     _impl->wait();
 }
+
 void MavsdkServer::stop()
 {
     _impl->stop();

--- a/src/mavsdk_server/src/mavsdk_server.h
+++ b/src/mavsdk_server/src/mavsdk_server.h
@@ -12,7 +12,7 @@ public:
     MavsdkServer& operator=(MavsdkServer&&) = delete;
 
     int startGrpcServer(int port);
-    void connect(const std::string& connection_url = "udp://:14540");
+    bool connect(const std::string& connection_url = "udp://:14540");
     void wait();
     void stop();
     int getPort();

--- a/src/mavsdk_server/src/mavsdk_server_api.cpp
+++ b/src/mavsdk_server/src/mavsdk_server_api.cpp
@@ -2,19 +2,26 @@
 #include "mavsdk_server.h"
 #include <string>
 
-MavsdkServer* mavsdk_server_run(const char* system_address, const int mavsdk_server_port)
+void mavsdk_server_init(MavsdkServer** mavsdk_server)
 {
-    auto mavsdk_server = new MavsdkServer();
+    *mavsdk_server = new MavsdkServer();
+}
 
-    mavsdk_server->connect(std::string(system_address));
+int mavsdk_server_run(
+    MavsdkServer* mavsdk_server, const char* system_address, const int mavsdk_server_port)
+{
+    if (!mavsdk_server->connect(std::string(system_address))) {
+        // Connection was cancelled
+        return false;
+    }
 
     auto grpc_port = mavsdk_server->startGrpcServer(mavsdk_server_port);
     if (grpc_port == 0) {
         // Server failed to start
-        return nullptr;
+        return false;
     }
 
-    return mavsdk_server;
+    return true;
 }
 
 int mavsdk_server_get_port(MavsdkServer* mavsdk_server)
@@ -30,5 +37,9 @@ void mavsdk_server_attach(MavsdkServer* mavsdk_server)
 void mavsdk_server_stop(MavsdkServer* mavsdk_server)
 {
     mavsdk_server->stop();
+}
+
+void mavsdk_server_destroy(MavsdkServer* mavsdk_server)
+{
     delete mavsdk_server;
 }

--- a/src/mavsdk_server/src/mavsdk_server_api.h
+++ b/src/mavsdk_server/src/mavsdk_server_api.h
@@ -10,14 +10,18 @@ extern "C" {
 #define DLLExport __attribute__((visibility("default")))
 #endif
 
-DLLExport struct MavsdkServer*
-mavsdk_server_run(const char* system_address, const int mavsdk_server_port);
+DLLExport void mavsdk_server_init(struct MavsdkServer** mavsdk_server);
+
+DLLExport int mavsdk_server_run(
+    struct MavsdkServer* mavsdk_server, const char* system_address, const int mavsdk_server_port);
 
 DLLExport int mavsdk_server_get_port(struct MavsdkServer* mavsdk_server);
 
 DLLExport void mavsdk_server_attach(struct MavsdkServer* mavsdk_server);
 
 DLLExport void mavsdk_server_stop(struct MavsdkServer* mavsdk_server);
+
+DLLExport void mavsdk_server_destroy(struct MavsdkServer* mavsdk_server);
 
 #ifdef __cplusplus
 }

--- a/src/mavsdk_server/src/mavsdk_server_bin.cpp
+++ b/src/mavsdk_server/src/mavsdk_server_bin.cpp
@@ -41,8 +41,20 @@ int main(int argc, char** argv)
         }
     }
 
-    auto mavsdk_server = mavsdk_server_run(connection_url.c_str(), mavsdk_server_port);
+    MavsdkServer* mavsdk_server;
+    mavsdk_server_init(&mavsdk_server);
+    auto is_started = mavsdk_server_run(mavsdk_server, connection_url.c_str(), mavsdk_server_port);
+
+    if (!is_started) {
+        std::cout << "Failed to start, exiting...\n";
+        mavsdk_server_destroy(mavsdk_server);
+        return 1;
+    }
+
     mavsdk_server_attach(mavsdk_server);
+
+    mavsdk_server_destroy(mavsdk_server);
+    return 0;
 }
 
 void usage(const char* bin_name)


### PR DESCRIPTION
Now that mavsdk_server.run() blocks until a system is discovered, mavsdk_server.stop() must cancel it.