### PR TITLE
Fix CI permissions when generating xcframework

### DIFF
--- a/src/mavsdk_server/tools/package_mavsdk_server_framework.bash
+++ b/src/mavsdk_server/tools/package_mavsdk_server_framework.bash
@@ -19,6 +19,10 @@ ln -sf Versions/Current/Modules ${MACOS_BACKEND_DIR}/mavsdk_server.framework
 echo "Creating xcframework..."
 xcodebuild -create-xcframework -framework ${IOS_BACKEND_DIR}/mavsdk_server.framework -framework ${IOS_SIM_BACKEND_DIR}/mavsdk_server.framework -framework ${MACOS_BACKEND_DIR}/mavsdk_server.framework -output ${BUILD_DIR}/mavsdk_server.xcframework
 
+chmod 755 ${BUILD_DIR}/mavsdk_server.xcframework/ios-arm64/mavsdk_server.framework/mavsdk_server
+chmod 755 ${BUILD_DIR}/mavsdk_server.xcframework/ios-x86_64-simulator/mavsdk_server.framework/mavsdk_server
+chmod 755 ${BUILD_DIR}/mavsdk_server.xcframework/macos-x86_64/mavsdk_server.framework/mavsdk_server
+
 cd ${BUILD_DIR}
 zip -9 -r mavsdk_server.xcframework.zip mavsdk_server.xcframework
 


### PR DESCRIPTION
No idea why, but the `.xcframework` generated in the CI  has permission issues (missing execution permissions) while the one I build locally is fine.

This is an attempt at fixing it.