### PR TITLE
Do not report -1 as a current mission item

### DIFF
--- a/src/plugins/mission/mission_impl.cpp
+++ b/src/plugins/mission/mission_impl.cpp
@@ -810,6 +810,11 @@ void MissionImpl::report_progress()
     int current = current_mission_item();
     int total = total_mission_items();
 
+    // Do not report -1 as a current mission item
+    if (current == -1) {
+        return;
+    }
+
     bool should_report = false;
     {
         std::lock_guard<std::recursive_mutex> lock(_mission_data.mutex);


### PR DESCRIPTION
-1 is used for the current item value internally, but it should not be exposed to the users because it has no meaning...