### PR TITLE
core: refactor MAVLink command queue

### DIFF
--- a/src/core/mavlink_commands.h
+++ b/src/core/mavlink_commands.h
@@ -3,6 +3,7 @@
 #include "mavlink_include.h"
 #include "locked_queue.h"
 #include "global_include.h"
+#include <cmath>
 #include <cstdint>
 #include <string>
 #include <functional>
@@ -118,7 +119,7 @@ private:
     using Command = std::variant<std::monostate, CommandLong, CommandInt>;
 
     struct CommandIdentification {
-        float maybe_param1{0}; // only for commands where this matters
+        uint32_t maybe_param1{0}; // only for commands where this matters
         uint16_t command{0};
         uint8_t target_system_id{0};
         uint8_t target_component_id{0};
@@ -152,7 +153,7 @@ private:
         identification.command = command.command;
         if (command.command == MAV_CMD_REQUEST_MESSAGE ||
             command.command == MAV_CMD_SET_MESSAGE_INTERVAL) {
-            identification.maybe_param1 = command.params.param1;
+            identification.maybe_param1 = static_cast<uint32_t>(std::lround(command.params.param1));
         }
         identification.target_system_id = command.target_system_id;
         identification.target_component_id = command.target_component_id;

--- a/src/core/mavlink_commands.h
+++ b/src/core/mavlink_commands.h
@@ -118,7 +118,7 @@ private:
     using Command = std::variant<std::monostate, CommandLong, CommandInt>;
 
     struct CommandIdentification {
-        uint32_t maybe_param1{0}; // only for commands where this matters
+        float maybe_param1{0}; // only for commands where this matters
         uint16_t command{0};
         uint8_t target_system_id{0};
         uint8_t target_component_id{0};


### PR DESCRIPTION
This changes the command queue, so that:
- Only one queue is required instead of a queue and a sent map
- SET_MESSAGE_INTERVAL (511) and REQUEST_MESSAGE (512) commands are only denied if also param1 (msgid) match, otherwise they are kept in the queue until later. This should help with initial requests of messages.