### PR TITLE
Fix possible setting options list when camera uses exclusions

### DIFF
--- a/src/plugins/camera/camera_definition.cpp
+++ b/src/plugins/camera/camera_definition.cpp
@@ -113,22 +113,22 @@ bool CameraDefinition::parse_xml()
 
         const char* type_str = e_parameter->Attribute("type");
         if (!type_str) {
-            LogErr() << "type attribute missing";
+            LogErr() << "type attribute missing for " << param_name;
             return false;
         }
 
         if (strcmp(type_str, "string") == 0) {
-            LogDebug() << "Ignoring string params.";
+            LogDebug() << "Ignoring string params: " << param_name;
             continue;
         }
 
         if (strcmp(type_str, "custom") == 0) {
-            LogDebug() << "Ignoring custom params.";
+            LogDebug() << "Ignoring custom params: " << param_name;
             continue;
         }
 
         if (!new_parameter->type.set_empty_type_from_xml(type_str)) {
-            LogErr() << "unknown type attribute";
+            LogErr() << "Unknown type attribute: " << type_str;
             return false;
         }
 

--- a/src/plugins/camera/camera_definition.cpp
+++ b/src/plugins/camera/camera_definition.cpp
@@ -486,9 +486,6 @@ bool CameraDefinition::get_possible_settings(
 
     for (const auto& parameter : _parameter_map) {
         for (const auto& option : parameter.second->options) {
-            if (_current_settings[parameter.first].needs_updating) {
-                continue;
-            }
             if (_current_settings[parameter.first].value == option->value) {
                 for (const auto& exclusion : option->exclusions) {
                     // LogDebug() << "found exclusion for " << parameter.first

--- a/src/plugins/camera/camera_definition_test.cpp
+++ b/src/plugins/camera/camera_definition_test.cpp
@@ -111,7 +111,7 @@ TEST(CameraDefinition, E90ChangeSettings)
     {
         // Check default
         MAVLinkParameters::ParamValue value;
-        EXPECT_TRUE(cd.get_setting("CAM_WBMODE", value));
+        ASSERT_TRUE(cd.get_setting("CAM_WBMODE", value));
         EXPECT_EQ(value.get<uint32_t>(), 0);
     }
 
@@ -119,7 +119,7 @@ TEST(CameraDefinition, E90ChangeSettings)
         // We can only set CAM_COLORMODE in photo mode
         MAVLinkParameters::ParamValue value;
         value.set<uint32_t>(0);
-        EXPECT_TRUE(cd.set_setting("CAM_MODE", value));
+        ASSERT_TRUE(cd.set_setting("CAM_MODE", value));
     }
 
     {
@@ -132,14 +132,14 @@ TEST(CameraDefinition, E90ChangeSettings)
     {
         // Check if WBMODE was correctly set
         MAVLinkParameters::ParamValue value;
-        EXPECT_TRUE(cd.get_setting("CAM_WBMODE", value));
+        ASSERT_TRUE(cd.get_setting("CAM_WBMODE", value));
         EXPECT_EQ(value.get<uint32_t>(), 1);
     }
 
     {
         // Interleave COLORMODE, first check default
         MAVLinkParameters::ParamValue value;
-        EXPECT_TRUE(cd.get_setting("CAM_COLORMODE", value));
+        ASSERT_TRUE(cd.get_setting("CAM_COLORMODE", value));
         EXPECT_EQ(value.get<uint32_t>(), 1);
     }
 
@@ -147,20 +147,20 @@ TEST(CameraDefinition, E90ChangeSettings)
         // Then set COLORMODE to 5
         MAVLinkParameters::ParamValue value;
         value.set<uint32_t>(5);
-        EXPECT_TRUE(cd.set_setting("CAM_COLORMODE", value));
+        ASSERT_TRUE(cd.set_setting("CAM_COLORMODE", value));
     }
 
     {
         // COLORMODE should now be 5
         MAVLinkParameters::ParamValue value;
-        EXPECT_TRUE(cd.get_setting("CAM_COLORMODE", value));
+        ASSERT_TRUE(cd.get_setting("CAM_COLORMODE", value));
         EXPECT_EQ(value.get<uint32_t>(), 5);
     }
 
     {
         // WBMODE should still be 1
         MAVLinkParameters::ParamValue value;
-        EXPECT_TRUE(cd.get_setting("CAM_WBMODE", value));
+        ASSERT_TRUE(cd.get_setting("CAM_WBMODE", value));
         EXPECT_EQ(value.get<uint32_t>(), 1);
     }
 
@@ -168,13 +168,13 @@ TEST(CameraDefinition, E90ChangeSettings)
         // Change WBMODE to 7
         MAVLinkParameters::ParamValue value;
         value.set<uint32_t>(7);
-        EXPECT_TRUE(cd.set_setting("CAM_WBMODE", value));
+        ASSERT_TRUE(cd.set_setting("CAM_WBMODE", value));
     }
 
     {
         // And check WBMODE again
         MAVLinkParameters::ParamValue value;
-        EXPECT_TRUE(cd.get_setting("CAM_WBMODE", value));
+        ASSERT_TRUE(cd.get_setting("CAM_WBMODE", value));
         EXPECT_EQ(value.get<uint32_t>(), 7);
     }
 }

--- a/src/plugins/camera/camera_definition_test.cpp
+++ b/src/plugins/camera/camera_definition_test.cpp
@@ -75,7 +75,7 @@ TEST(CameraDefinition, E90CheckDefaultSettings)
     {
         std::unordered_map<std::string, MAVLinkParameters::ParamValue> settings{};
         EXPECT_TRUE(cd.get_possible_settings(settings));
-        EXPECT_EQ(settings.size(), 7);
+        EXPECT_EQ(settings.size(), 6);
         // LogDebug() << "Found settings:";
         // for (const auto &setting : settings) {
         //     LogDebug() << " - " << setting.first;

--- a/src/plugins/camera/camera_impl.cpp
+++ b/src/plugins/camera/camera_impl.cpp
@@ -1633,6 +1633,7 @@ void CameraImpl::refresh_params()
         // any other possible settings to change. However, we still would
         // like to notify the current settings with this one change.
         notify_current_settings();
+        notify_possible_setting_options();
         return;
     }
 

--- a/src/plugins/camera/camera_impl.cpp
+++ b/src/plugins/camera/camera_impl.cpp
@@ -1589,7 +1589,7 @@ void CameraImpl::notify_possible_setting_options()
 
     const auto temp_callback = _subscribe_possible_setting_options.callback;
 
-    // We create a function object in order to move be able to move the settings into it.
+    // We create a function object in order to be able to move the settings into it.
     // FIXME: Use C++14 where this is not necessary anymore.
     _parent->call_user_callback(std::bind(
         [temp_callback](const std::vector<Camera::SettingOptions>& options) {
@@ -1640,7 +1640,7 @@ void CameraImpl::refresh_params()
     for (const auto& param : params) {
         const std::string& param_name = param.first;
         const MAVLinkParameters::ParamValue& param_value_type = param.second;
-        const bool is_last = (count + 1 == params.size());
+        const bool is_last = (count == params.size() - 1);
         _parent->get_param_async(
             param_name,
             param_value_type,


### PR DESCRIPTION
Currently, parameters are refreshed when they are changed. If the camera definition defines an "update" dependency (not sure when that's done), then a parameter that is modified triggers a refresh in those update dependencies.

However, what is currently missing is a way to refresh parameters that were excluded. Let's have a look using the python [`examples/camera_params.py`](https://github.com/mavlink/MAVSDK-Python/blob/main/examples/camera_params.py) example.

Without this PR, say the camera is in VIDEO mode, with exposure set to "Aperture Priority". The output will be:

```
=== Current settings ===

* CAM_MODE: PHOTO
* CAM_FOCUSMODE: Focus Mode
    -> Infinity
* CAM_EXPMODE: Exposure Mode
    -> Aperture Priority
* CAM_WBMODE: White Balance
    -> Auto
* CAM_EV: Exposure Compensation
    -> 0
* CAM_APERTURE: Aperture
    -> f/3.5
* CAM_ISO: ISO
    -> Auto
* CAM_IMGDEST: Image store
    -> Camera
* CAM_IMGSIZE: Image Size
    -> Large

Usage:
  p    print current (changeable) camera settings
  m    change camera mode
  s    change a setting
```

Note how there is no shutter option, because it is excluded by the aperture option. Now say you move to "Manual Exposure", the shutter option will not appear. This PR aims at fixing that, such that switching between "Manual", "Program Auto", "Shutter Priority" and "Aperture Priority" update the list accordingly.

This issue was first discovered in the MAVSDK-Swift sample app. I will test it there before setting this PR as "ready".