### PR TITLE
fixed mavsdk_server library versioning

### DIFF
--- a/src/mavsdk_server/src/CMakeLists.txt
+++ b/src/mavsdk_server/src/CMakeLists.txt
@@ -73,6 +73,8 @@ target_link_libraries(mavsdk_server
 
 set_target_properties(mavsdk_server
     PROPERTIES COMPILE_FLAGS ${warnings}
+    VERSION ${MAVSDK_VERSION_STRING}
+    SOVERSION ${MAVSDK_SOVERSION_STRING}
     )
 
 if(BUILD_STATIC_MAVSDK_SERVER AND ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU"))


### PR DESCRIPTION
my yocto build environment raised an QA error on the mavsdk_server library naming. This patch fixed it. if you find this useful, too feel free to accept this PR.