### PR TITLE
Add health support for ardupilot

### DIFF
--- a/src/plugins/telemetry/telemetry_impl.h
+++ b/src/plugins/telemetry/telemetry_impl.h
@@ -74,7 +74,6 @@ public:
     void set_rate_unix_epoch_time_async(double rate_hz, Telemetry::ResultCallback callback);
 
     void get_gps_global_origin_async(const Telemetry::GetGpsGlobalOriginCallback callback);
-    void request_home_position_async();
     std::pair<Telemetry::Result, Telemetry::GpsGlobalOrigin> get_gps_global_origin();
 
     Telemetry::PositionVelocityNed position_velocity_ned() const;
@@ -234,6 +233,7 @@ private:
 
     void receive_statustext(const MavlinkStatustextHandler::Statustext&);
 
+    void request_home_position_async();
     void check_calibration();
 
     static Telemetry::Result

--- a/src/plugins/telemetry/telemetry_impl.h
+++ b/src/plugins/telemetry/telemetry_impl.h
@@ -74,6 +74,7 @@ public:
     void set_rate_unix_epoch_time_async(double rate_hz, Telemetry::ResultCallback callback);
 
     void get_gps_global_origin_async(const Telemetry::GetGpsGlobalOriginCallback callback);
+    void request_home_position_async();
     std::pair<Telemetry::Result, Telemetry::GpsGlobalOrigin> get_gps_global_origin();
 
     Telemetry::PositionVelocityNed position_velocity_ned() const;
@@ -212,6 +213,17 @@ private:
     void receive_param_cal_gyro(MAVLinkParameters::Result result, int value);
     void receive_param_cal_accel(MAVLinkParameters::Result result, int value);
     void receive_param_cal_mag(MAVLinkParameters::Result result, int value);
+
+    // Ardupilot sensor offset callbacks.
+    void receive_param_cal_gyro_offset_x(MAVLinkParameters::Result result, float value);
+    void receive_param_cal_gyro_offset_y(MAVLinkParameters::Result result, float value);
+    void receive_param_cal_gyro_offset_z(MAVLinkParameters::Result result, float value);
+    void receive_param_cal_accel_offset_x(MAVLinkParameters::Result result, float value);
+    void receive_param_cal_accel_offset_y(MAVLinkParameters::Result result, float value);
+    void receive_param_cal_accel_offset_z(MAVLinkParameters::Result result, float value);
+    void receive_param_cal_mag_offset_x(MAVLinkParameters::Result result, float value);
+    void receive_param_cal_mag_offset_y(MAVLinkParameters::Result result, float value);
+    void receive_param_cal_mag_offset_z(MAVLinkParameters::Result result, float value);
 
     void process_parameter_update(const std::string& name);
     void receive_param_hitl(MAVLinkParameters::Result result, int value);
@@ -381,5 +393,24 @@ private:
     bool _has_received_gyro_calibration{false};
     bool _has_received_accel_calibration{false};
     bool _has_received_mag_calibration{false};
+
+    // Ardupilot calibration status values
+
+    struct ap_calibration_offset {
+        float x{0};
+        float y{0};
+        float z{0};
+
+        [[nodiscard]] bool calibrated() const { return ((x != 0) && (y != 0) && (z != 0)); }
+    };
+
+    mutable std::mutex _ap_mag_offset_mutex{};
+    ap_calibration_offset _ap_mag_offset;
+
+    mutable std::mutex _ap_accel_offset_mutex{};
+    ap_calibration_offset _ap_accel_offset;
+
+    mutable std::mutex _ap_gyro_offset_mutex{};
+    ap_calibration_offset _ap_gyro_offset;
 };
 } // namespace mavsdk


### PR DESCRIPTION
For the Ardupilot branch the following is done to set health:

1) Checks calibration of the magnetometer, gyro and accelerometer by checking the corresponding offset values. If any offset is zero then the calibration is not complete.

2) Requests the home position. The currently home position is sent only on startup for Ardupilot so we need to ask for it here in case we have missed it.