### PR TITLE
core: add API to get MAVLink component IDs

### DIFF
--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -54,6 +54,11 @@ uint8_t System::get_system_id() const
     return _system_impl->get_system_id();
 }
 
+std::vector<uint8_t> System::component_ids() const
+{
+    return _system_impl->component_ids();
+}
+
 void System::subscribe_is_connected(IsConnectedCallback callback)
 {
     return _system_impl->subscribe_is_connected(callback);

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <array>
 #include <functional>
+#include <vector>
 
 #include "deprecated.h"
 
@@ -116,6 +117,15 @@ public:
      * @return the system ID.
      */
     uint8_t get_system_id() const;
+
+    /**
+     * @brief MAVLink component IDs of connected system.
+     *
+     * @note: all components that have been seen at least once will be listed.
+     *
+     * @return a list of all component ids
+     */
+    std::vector<uint8_t> component_ids() const;
 
     /**
      * @brief type for is connected callback.

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -585,6 +585,11 @@ uint8_t SystemImpl::get_system_id() const
     return _target_address.system_id;
 }
 
+std::vector<uint8_t> SystemImpl::component_ids() const
+{
+    return std::vector<uint8_t>{_components.begin(), _components.end()};
+}
+
 void SystemImpl::set_system_id(uint8_t system_id)
 {
     _target_address.system_id = system_id;

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -124,6 +124,7 @@ public:
     bool has_gimbal() const;
 
     uint8_t get_system_id() const override;
+    std::vector<uint8_t> component_ids() const;
 
     void set_system_id(uint8_t system_id);
 


### PR DESCRIPTION
I think this might be handy to debug https://github.com/mavlink/MAVSDK/issues/1507.