### PR TITLE
Fix list_photos

### DIFF
--- a/src/plugins/camera/camera_impl.cpp
+++ b/src/plugins/camera/camera_impl.cpp
@@ -1734,6 +1734,7 @@ void CameraImpl::format_storage_async(Camera::ResultCallback callback)
     cmd_format.command = MAV_CMD_STORAGE_FORMAT;
     cmd_format.params.param1 = 1.0f; // storage ID
     cmd_format.params.param2 = 1.0f; // format
+    cmd_format.params.param3 = 1.0f; // clear
     cmd_format.target_component_id = _camera_id + MAV_COMP_ID_CAMERA;
 
     _parent->send_command_async(
@@ -1840,7 +1841,7 @@ void CameraImpl::list_photos_async(
                     _parent->send_command_async(
                         make_command_request_camera_image_captured(i), nullptr);
                     cv_status = _captured_request_cv.wait_for(
-                        capture_request_lock, std::chrono::duration<double>(1));
+                        capture_request_lock, std::chrono::seconds(1));
                 }
             }
 

--- a/src/plugins/camera/camera_impl.cpp
+++ b/src/plugins/camera/camera_impl.cpp
@@ -1742,7 +1742,10 @@ void CameraImpl::format_storage_async(Camera::ResultCallback callback)
 
             receive_command_result(result, [this, callback](Camera::Result camera_result) {
                 if (camera_result == Camera::Result::Success) {
+                    std::lock_guard<std::mutex> status_lock(_status.mutex);
                     _status.photo_list.clear();
+                    _status.image_count = 0;
+                    _status.image_count_at_connection = 0;
                 }
 
                 callback(camera_result);


### PR DESCRIPTION
* Don't get stuck in busy mode: when returning an error, set `is_fetching_photos` back to `false`
* Don't notify for old photos: if `last_advertised_image_index == -1` (i.e. the camera plugin is not fully initialized), don't notify for `CAMERA_IMAGE_CAPTURED` message because it may come from QGC listing old photos.
* Clear image storage when formatting, otherwise the image metadata stay for the deleted images and we end up requesting them for nothing