### PR TITLE
Ardupilot mission handling and vehicle type checking

### DIFF
--- a/src/core/ardupilot_custom_mode.h
+++ b/src/core/ardupilot_custom_mode.h
@@ -1,0 +1,52 @@
+#pragma once
+
+namespace ardupilot {
+
+// Enumeration representing the available modes for the Arudpilot rover autopilot.
+enum class RoverMode {
+    Manual = 0,
+    Acro = 1,
+    Steering = 3,
+    Hold = 4,
+    Loiter = 5,
+    Follow = 6,
+    Simple = 7,
+    Auto = 10,
+    RTL = 11,
+    Smart_RTL = 12,
+    Guided = 15,
+    Initializing = 16,
+    Unknown = 100
+};
+
+// Enumeration representing the available modes for the Arudpilot copter autopilot.
+enum class CopterMode {
+    Stabilize = 0,
+    Acro = 1,
+    Alt_Hold = 2,
+    Auto = 3,
+    Guided = 4,
+    Loiter = 5,
+    RTL = 6,
+    Circle = 7,
+    Land = 9,
+    Drift = 11,
+    Sport = 13,
+    Flip = 14,
+    Auto_Tune = 15,
+    POS_HOLD = 16,
+    Break = 17,
+    Throw = 18,
+    Avoid_ADBS = 19,
+    Guided_No_GPS = 20,
+    Smart_RTL = 21,
+    Flow_Hold = 22,
+    Follow = 23,
+    Zigzag = 24,
+    System_ID = 25,
+    Auto_Rotate = 26,
+    Auto_RTL = 27,
+    Turtle = 28,
+    Unknown = 100
+};
+} // namespace ardupilot

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -224,7 +224,7 @@ void SystemImpl::process_heartbeat(const mavlink_message_t& message)
         _hitl_enabled = ((heartbeat.base_mode & MAV_MODE_FLAG_HIL_ENABLED) ? true : false);
     }
     if (heartbeat.base_mode & MAV_MODE_FLAG_CUSTOM_MODE_ENABLED) {
-            _flight_mode = to_flight_mode_from_custom_mode(heartbeat.custom_mode);
+        _flight_mode = to_flight_mode_from_custom_mode(heartbeat.custom_mode);
     }
 
     set_connected();
@@ -927,16 +927,12 @@ void SystemImpl::subscribe_param_float(
         cookie);
 }
 
-
 std::pair<MavlinkCommandSender::Result, MavlinkCommandSender::CommandLong>
 SystemImpl::make_command_flight_mode(FlightMode flight_mode, uint8_t component_id)
 {
-    if(_autopilot == Autopilot::ArduPilot)
-    {
+    if (_autopilot == Autopilot::ArduPilot) {
         return make_command_ardupilot_mode(flight_mode, component_id);
-    }
-    else
-    {
+    } else {
         return make_command_px4_mode(flight_mode, component_id);
     }
 }
@@ -951,32 +947,26 @@ SystemImpl::make_command_ardupilot_mode(FlightMode flight_mode, uint8_t componen
 
     MavlinkCommandSender::CommandLong command{*this};
 
-
     command.command = MAV_CMD_DO_SET_MODE;
     command.params.param1 = float(mode_type);
 
-    switch(_vehicle_type){
+    switch (_vehicle_type) {
         case MAV_TYPE::MAV_TYPE_GROUND_ROVER:
-            if(flight_mode_to_ardupilot_rover_mode(flight_mode) == ardupilot::RoverMode::Unknown)
-            {
+            if (flight_mode_to_ardupilot_rover_mode(flight_mode) == ardupilot::RoverMode::Unknown) {
                 LogErr() << "Cannot translate flight mode to ardupilot rover mode.";
                 MavlinkCommandSender::CommandLong empty_command{*this};
                 return std::make_pair<>(MavlinkCommandSender::Result::UnknownError, empty_command);
-            }
-            else
-            {
+            } else {
                 command.params.param2 = float(flight_mode_to_ardupilot_rover_mode(flight_mode));
             }
             break;
         default:
-            if(flight_mode_to_ardupilot_copter_mode(flight_mode) == ardupilot::CopterMode::Unknown)
-            {
+            if (flight_mode_to_ardupilot_copter_mode(flight_mode) ==
+                ardupilot::CopterMode::Unknown) {
                 LogErr() << "Cannot translate flight mode to ardupilot copter mode.";
                 MavlinkCommandSender::CommandLong empty_command{*this};
                 return std::make_pair<>(MavlinkCommandSender::Result::UnknownError, empty_command);
-            }
-            else
-            {
+            } else {
                 command.params.param2 = float(flight_mode_to_ardupilot_copter_mode(flight_mode));
             }
             break;
@@ -987,8 +977,7 @@ SystemImpl::make_command_ardupilot_mode(FlightMode flight_mode, uint8_t componen
 }
 ardupilot::RoverMode SystemImpl::flight_mode_to_ardupilot_rover_mode(FlightMode flight_mode)
 {
-    switch(flight_mode)
-    {
+    switch (flight_mode) {
         case FlightMode::Mission:
             return ardupilot::RoverMode::Auto;
         case FlightMode::Acro:
@@ -1013,13 +1002,10 @@ ardupilot::RoverMode SystemImpl::flight_mode_to_ardupilot_rover_mode(FlightMode 
         default:
             return ardupilot::RoverMode::Unknown;
     }
-
-
 }
 ardupilot::CopterMode SystemImpl::flight_mode_to_ardupilot_copter_mode(FlightMode flight_mode)
 {
-    switch(flight_mode)
-    {
+    switch (flight_mode) {
         case FlightMode::Mission:
             return ardupilot::CopterMode::Auto;
         case FlightMode::Acro:
@@ -1044,7 +1030,6 @@ ardupilot::CopterMode SystemImpl::flight_mode_to_ardupilot_copter_mode(FlightMod
             return ardupilot::CopterMode::Unknown;
     }
 }
-
 
 std::pair<MavlinkCommandSender::Result, MavlinkCommandSender::CommandLong>
 SystemImpl::make_command_px4_mode(FlightMode flight_mode, uint8_t component_id)
@@ -1122,27 +1107,21 @@ SystemImpl::FlightMode SystemImpl::get_flight_mode() const
 }
 SystemImpl::FlightMode SystemImpl::to_flight_mode_from_custom_mode(uint32_t custom_mode)
 {
-    if(_autopilot == Autopilot::ArduPilot)
-    {
-        switch(_vehicle_type)
-        {
+    if (_autopilot == Autopilot::ArduPilot) {
+        switch (_vehicle_type) {
             case MAV_TYPE::MAV_TYPE_GROUND_ROVER:
                 return to_flight_mode_from_ardupilot_rover_mode(custom_mode);
             default:
                 return to_flight_mode_from_ardupilot_copter_mode(custom_mode);
         }
+    } else {
+        return to_flight_mode_from_px4_mode(custom_mode);
     }
-    else
-    {
-       return  to_flight_mode_from_px4_mode(custom_mode);
-    }
-
 }
 
 SystemImpl::FlightMode SystemImpl::to_flight_mode_from_ardupilot_rover_mode(uint32_t custom_mode)
 {
-    switch(static_cast<ardupilot::RoverMode>(custom_mode))
-    {
+    switch (static_cast<ardupilot::RoverMode>(custom_mode)) {
         case ardupilot::RoverMode::Auto:
             return FlightMode::Mission;
         case ardupilot::RoverMode::Acro:
@@ -1161,8 +1140,7 @@ SystemImpl::FlightMode SystemImpl::to_flight_mode_from_ardupilot_rover_mode(uint
 }
 SystemImpl::FlightMode SystemImpl::to_flight_mode_from_ardupilot_copter_mode(uint32_t custom_mode)
 {
-    switch(static_cast<ardupilot::CopterMode>(custom_mode))
-    {
+    switch (static_cast<ardupilot::CopterMode>(custom_mode)) {
         case ardupilot::CopterMode::Auto:
             return FlightMode::Mission;
         case ardupilot::CopterMode::Acro:

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -212,12 +212,9 @@ void SystemImpl::process_heartbeat(const mavlink_message_t& message)
     }
     // This check only works if the MAV_TYPE::MAV_TYPE_ENUM_END is actually the
     // last enumerator.
-    if(MAV_TYPE::MAV_TYPE_ENUM_END > heartbeat.type)
-    {
+    if (MAV_TYPE::MAV_TYPE_ENUM_END > heartbeat.type) {
         _vehicle_type = static_cast<MAV_TYPE>(heartbeat.type);
-    }
-    else
-    {
+    } else {
         LogErr() << "type received in HEARTBEAT was not recognized";
     }
 
@@ -226,20 +223,16 @@ void SystemImpl::process_heartbeat(const mavlink_message_t& message)
         _hitl_enabled = ((heartbeat.base_mode & MAV_MODE_FLAG_HIL_ENABLED) ? true : false);
     }
     if (heartbeat.base_mode & MAV_MODE_FLAG_CUSTOM_MODE_ENABLED) {
-        if (_autopilot == Autopilot::ArduPilot)
-        {
+        if (_autopilot == Autopilot::ArduPilot) {
             // Currently, just ground rover and default (copter).
-            switch(_vehicle_type)
-            {
-                case MAV_TYPE::MAV_TYPE_GROUND_ROVER :
+            switch (_vehicle_type) {
+                case MAV_TYPE::MAV_TYPE_GROUND_ROVER:
                     _ap_mode = to_ap_mode_from_custom_mode<APRoverMode>(heartbeat.custom_mode);
                     break;
                 default:
                     _ap_mode = to_ap_mode_from_custom_mode<APCopterMode>(heartbeat.custom_mode);
             }
-        }
-        else
-        {
+        } else {
             _flight_mode = to_flight_mode_from_custom_mode(heartbeat.custom_mode);
         }
     }
@@ -945,22 +938,23 @@ void SystemImpl::subscribe_param_float(
 }
 
 std::pair<MavlinkCommandSender::Result, MavlinkCommandSender::CommandLong>
-SystemImpl::make_command_ap_mode(std::variant<APCopterMode,APRoverMode> mode, uint8_t component_id)
+SystemImpl::make_command_ap_mode(std::variant<APCopterMode, APRoverMode> mode, uint8_t component_id)
 {
     const uint8_t flag_safety_armed = is_armed() ? MAV_MODE_FLAG_SAFETY_ARMED : 0;
     const uint8_t flag_hitl_enabled = _hitl_enabled ? MAV_MODE_FLAG_HIL_ENABLED : 0;
-    const uint8_t mode_type = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED | flag_safety_armed | flag_hitl_enabled;
+    const uint8_t mode_type =
+        MAV_MODE_FLAG_CUSTOM_MODE_ENABLED | flag_safety_armed | flag_hitl_enabled;
 
     MavlinkCommandSender::CommandLong command{*this};
 
     command.command = MAV_CMD_DO_SET_MODE;
     command.params.param1 = float(mode_type);
-    command.params.param2 = std::visit([](auto&& x) -> float {return static_cast<float>(x);}, mode);
+    command.params.param2 =
+        std::visit([](auto&& x) -> float { return static_cast<float>(x); }, mode);
     command.params.param3 = 0.0;
     command.target_component_id = component_id;
 
     return std::make_pair<>(MavlinkCommandSender::Result::Success, command);
-
 }
 
 std::pair<MavlinkCommandSender::Result, MavlinkCommandSender::CommandLong>
@@ -1038,8 +1032,7 @@ SystemImpl::FlightMode SystemImpl::get_flight_mode() const
     return _flight_mode;
 }
 
-std::variant<SystemImpl::APRoverMode, SystemImpl::APCopterMode>
-SystemImpl::get_ap_mode() const
+std::variant<SystemImpl::APRoverMode, SystemImpl::APCopterMode> SystemImpl::get_ap_mode() const
 {
     return _ap_mode;
 }
@@ -1088,7 +1081,7 @@ SystemImpl::FlightMode SystemImpl::to_flight_mode_from_custom_mode(uint32_t cust
     }
 }
 MavlinkCommandSender::Result
-    SystemImpl::set_ap_mode(std::variant<APCopterMode, APRoverMode> mode, uint8_t component_id)
+SystemImpl::set_ap_mode(std::variant<APCopterMode, APRoverMode> mode, uint8_t component_id)
 {
     std::pair<MavlinkCommandSender::Result, MavlinkCommandSender::CommandLong> result =
         make_command_ap_mode(std::move(mode), component_id);
@@ -1100,7 +1093,10 @@ MavlinkCommandSender::Result
     return send_command(result.second);
 }
 
-void SystemImpl::set_ap_mode_async(std::variant<APCopterMode, APRoverMode> mode, CommandResultCallback callback, uint8_t component_id)
+void SystemImpl::set_ap_mode_async(
+    std::variant<APCopterMode, APRoverMode> mode,
+    CommandResultCallback callback,
+    uint8_t component_id)
 {
     std::pair<MavlinkCommandSender::Result, MavlinkCommandSender::CommandLong> result =
         make_command_ap_mode(std::move(mode), component_id);
@@ -1114,7 +1110,6 @@ void SystemImpl::set_ap_mode_async(std::variant<APCopterMode, APRoverMode> mode,
 
     send_command_async(result.second, callback);
 }
-
 
 MavlinkCommandSender::Result
 SystemImpl::set_flight_mode(FlightMode system_mode, uint8_t component_id)

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -88,7 +88,6 @@ public:
 
     Autopilot autopilot() const override { return _autopilot; };
 
-
     FlightMode to_flight_mode_from_custom_mode(uint32_t custom_mode);
     static FlightMode to_flight_mode_from_px4_mode(uint32_t custom_mode);
     static FlightMode to_flight_mode_from_ardupilot_rover_mode(uint32_t custom_mode);

--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -51,7 +51,7 @@ public:
     };
 
     // Enumeration representing the available modes for the Arudpilot rover autopilot.
-    enum class APRoverMode{
+    enum class APRoverMode {
         Manual = 0,
         Acro = 1,
         Steering = 3,
@@ -67,7 +67,7 @@ public:
     };
 
     // Enumeration representing the available modes for the Arudpilot copter autopilot.
-    enum class APCopterMode{
+    enum class APCopterMode {
         Stabilize = 0,
         Acro = 1,
         Alt_Hold = 2,
@@ -135,8 +135,10 @@ public:
 
     static FlightMode to_flight_mode_from_custom_mode(uint32_t custom_mode);
 
-    template<typename ap_mode>
-    static ap_mode to_ap_mode_from_custom_mode(uint32_t custom_mode) { return static_cast<ap_mode>(custom_mode); }
+    template<typename ap_mode> static ap_mode to_ap_mode_from_custom_mode(uint32_t custom_mode)
+    {
+        return static_cast<ap_mode>(custom_mode);
+    }
 
     using CommandResultCallback = MavlinkCommandSender::CommandResultCallback;
 
@@ -182,7 +184,6 @@ public:
     uint8_t get_own_mav_type() const;
     MAV_TYPE get_vehicle_type() const;
 
-
     bool is_armed() const { return _armed; }
 
     MAVLinkParameters::Result set_param_float(const std::string& name, float value);
@@ -222,11 +223,13 @@ public:
         CommandResultCallback callback,
         uint8_t component_id = MAV_COMP_ID_AUTOPILOT1);
 
-    MavlinkCommandSender::Result
-    set_ap_mode(std::variant<APCopterMode, APRoverMode> mode, uint8_t component_id = MAV_COMP_ID_AUTOPILOT1);
-    void set_ap_mode_async(std::variant<APCopterMode, APRoverMode> mode,
-                           CommandResultCallback callback,
-                           uint8_t component_id = MAV_COMP_ID_AUTOPILOT1);
+    MavlinkCommandSender::Result set_ap_mode(
+        std::variant<APCopterMode, APRoverMode> mode,
+        uint8_t component_id = MAV_COMP_ID_AUTOPILOT1);
+    void set_ap_mode_async(
+        std::variant<APCopterMode, APRoverMode> mode,
+        CommandResultCallback callback,
+        uint8_t component_id = MAV_COMP_ID_AUTOPILOT1);
 
     typedef std::function<void(MAVLinkParameters::Result result, float value)>
         get_param_float_callback_t;
@@ -365,7 +368,7 @@ private:
     make_command_flight_mode(FlightMode mode, uint8_t component_id);
 
     std::pair<MavlinkCommandSender::Result, MavlinkCommandSender::CommandLong>
-    make_command_ap_mode(std::variant<APCopterMode,APRoverMode> mode, uint8_t component_id);
+    make_command_ap_mode(std::variant<APCopterMode, APRoverMode> mode, uint8_t component_id);
 
     MavlinkCommandSender::CommandLong
     make_command_msg_rate(uint16_t message_id, double rate_hz, uint8_t component_id);
@@ -449,7 +452,7 @@ private:
 
     std::atomic<FlightMode> _flight_mode{FlightMode::Unknown};
 
-    std::variant<APRoverMode,APCopterMode> _ap_mode;
+    std::variant<APRoverMode, APCopterMode> _ap_mode;
 
     std::mutex _autopilot_version_mutex{};
     System::AutopilotVersion _autopilot_version{

--- a/src/plugins/mission_raw/mission_raw_impl.cpp
+++ b/src/plugins/mission_raw/mission_raw_impl.cpp
@@ -307,30 +307,11 @@ MissionRaw::Result MissionRawImpl::start_mission()
 
 void MissionRawImpl::start_mission_async(const MissionRaw::ResultCallback& callback)
 {
-    if (_parent->autopilot() == Sender::Autopilot::ArduPilot) {
-        switch (_parent->get_vehicle_type()) {
-            case MAV_TYPE::MAV_TYPE_GROUND_ROVER:
-                _parent->set_ap_mode_async(
-                    SystemImpl::APRoverMode::Auto,
-                    [this, callback](MavlinkCommandSender::Result result, float) {
-                        report_flight_mode_change(callback, result);
-                    });
-                break;
-
-            default:
-                _parent->set_ap_mode_async(
-                    SystemImpl::APCopterMode::Auto,
-                    [this, callback](MavlinkCommandSender::Result result, float) {
-                        report_flight_mode_change(callback, result);
-                    });
-        }
-    } else {
-        _parent->set_flight_mode_async(
-            SystemImpl::FlightMode::Mission,
-            [this, callback](MavlinkCommandSender::Result result, float) {
-                report_flight_mode_change(callback, result);
-            });
-    }
+    _parent->set_flight_mode_async(
+        SystemImpl::FlightMode::Mission,
+        [this, callback](MavlinkCommandSender::Result result, float) {
+            report_flight_mode_change(callback, result);
+        });
 }
 
 MissionRaw::Result MissionRawImpl::pause_mission()
@@ -402,9 +383,7 @@ void MissionRawImpl::clear_mission_async(const MissionRaw::ResultCallback& callb
     // For ArduPilot to clear a mission we need to upload an empty mission.
     if (_parent->autopilot() == SystemImpl::Autopilot::ArduPilot) {
         std::vector<MissionRaw::MissionItem> mission_items{empty_item};
-        if (upload_mission(mission_items) != MissionRaw::Result::Success) {
-            LogErr() << "Clearing the ArduPilot mission by uploading an empty mission failed";
-        }
+        upload_mission_async(mission_items, callback);
     } else {
         _parent->mission_transfer().clear_items_async(
             MAV_MISSION_TYPE_MISSION, [this, callback](MAVLinkMissionTransfer::Result result) {

--- a/src/plugins/mission_raw/mission_raw_impl.cpp
+++ b/src/plugins/mission_raw/mission_raw_impl.cpp
@@ -8,8 +8,8 @@
 
 namespace mavsdk {
 
-//This is an empty item that can be sent to ArduPilot to mimic clearing of mission.
-constexpr MissionRaw::MissionItem empty_item{0,3,16,1};
+// This is an empty item that can be sent to ArduPilot to mimic clearing of mission.
+constexpr MissionRaw::MissionItem empty_item{0, 3, 16, 1};
 
 using namespace std::placeholders; // for `_1`
 
@@ -307,15 +307,13 @@ MissionRaw::Result MissionRawImpl::start_mission()
 
 void MissionRawImpl::start_mission_async(const MissionRaw::ResultCallback& callback)
 {
-    if(_parent->autopilot() == Sender::Autopilot::ArduPilot)
-    {
-        switch(_parent->get_vehicle_type())
-        {
+    if (_parent->autopilot() == Sender::Autopilot::ArduPilot) {
+        switch (_parent->get_vehicle_type()) {
             case MAV_TYPE::MAV_TYPE_GROUND_ROVER:
                 _parent->set_ap_mode_async(
                     SystemImpl::APRoverMode::Auto,
                     [this, callback](MavlinkCommandSender::Result result, float) {
-                      report_flight_mode_change(callback, result);
+                        report_flight_mode_change(callback, result);
                     });
                 break;
 
@@ -323,12 +321,10 @@ void MissionRawImpl::start_mission_async(const MissionRaw::ResultCallback& callb
                 _parent->set_ap_mode_async(
                     SystemImpl::APCopterMode::Auto,
                     [this, callback](MavlinkCommandSender::Result result, float) {
-                      report_flight_mode_change(callback, result);
+                        report_flight_mode_change(callback, result);
                     });
         }
-    }
-    else
-    {
+    } else {
         _parent->set_flight_mode_async(
             SystemImpl::FlightMode::Mission,
             [this, callback](MavlinkCommandSender::Result result, float) {
@@ -404,15 +400,12 @@ void MissionRawImpl::clear_mission_async(const MissionRaw::ResultCallback& callb
     reset_mission_progress();
 
     // For ArduPilot to clear a mission we need to upload an empty mission.
-    if(_parent->autopilot() == SystemImpl::Autopilot::ArduPilot)
-    {
+    if (_parent->autopilot() == SystemImpl::Autopilot::ArduPilot) {
         std::vector<MissionRaw::MissionItem> mission_items{empty_item};
-        if(upload_mission(mission_items) != MissionRaw::Result::Success)
-        {
+        if (upload_mission(mission_items) != MissionRaw::Result::Success) {
             LogErr() << "Clearing the ArduPilot mission by uploading an empty mission failed";
         }
-    }
-    else {
+    } else {
         _parent->mission_transfer().clear_items_async(
             MAV_MISSION_TYPE_MISSION, [this, callback](MAVLinkMissionTransfer::Result result) {
                 auto converted_result = convert_result(result);

--- a/src/plugins/mission_raw/mission_raw_impl.h
+++ b/src/plugins/mission_raw/mission_raw_impl.h
@@ -64,8 +64,6 @@ public:
     const MissionRawImpl& operator=(const MissionRawImpl&) = delete;
 
 private:
-
-
     void reset_mission_progress();
 
     void process_mission_ack(const mavlink_message_t& message);

--- a/src/plugins/mission_raw/mission_raw_impl.h
+++ b/src/plugins/mission_raw/mission_raw_impl.h
@@ -64,6 +64,8 @@ public:
     const MissionRawImpl& operator=(const MissionRawImpl&) = delete;
 
 private:
+
+
     void reset_mission_progress();
 
     void process_mission_ack(const mavlink_message_t& message);


### PR DESCRIPTION
Adds support to mission_raw to upload, start missions and clear missions when the autopilot is ArduPilot.

Further adds support to grab the vehicle type from the HEARTBEAT message, and to use this to determine what the correct mode command is for a ArduPilot vehicle, since this depends on the type.