### PR TITLE
ftp: remove mavlink header install

### DIFF
--- a/src/plugins/ftp/CMakeLists.txt
+++ b/src/plugins/ftp/CMakeLists.txt
@@ -30,8 +30,3 @@ install(FILES
     include/plugins/ftp/ftp.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mavsdk/plugins/ftp
 )
-
-install(DIRECTORY
-    ../../third_party/mavlink/include/mavlink
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mavsdk/plugins/ftp
-)


### PR DESCRIPTION
This is not required, at least not anymore.

Fixes #1561.