### PR TITLE
Remove uint castings from position packings

### DIFF
--- a/src/plugins/telemetry_server/telemetry_server_impl.cpp
+++ b/src/plugins/telemetry_server/telemetry_server_impl.cpp
@@ -164,7 +164,7 @@ TelemetryServer::Result TelemetryServerImpl::publish_raw_gps(
         static_cast<int32_t>(static_cast<double>(raw_gps.altitude_ellipsoid_m) * 1E3),
         static_cast<uint32_t>(static_cast<double>(raw_gps.horizontal_uncertainty_m) * 1E3),
         static_cast<uint32_t>(static_cast<double>(raw_gps.vertical_uncertainty_m) * 1E3),
-        static_cast<uint32_t>(static_cast<double>(raw_gps.velocity_uncertainty_m_s)  * 1E3),
+        static_cast<uint32_t>(static_cast<double>(raw_gps.velocity_uncertainty_m_s) * 1E3),
         static_cast<uint32_t>(static_cast<double>(raw_gps.heading_uncertainty_deg) * 1E5),
         static_cast<uint16_t>(static_cast<double>(raw_gps.yaw_deg) * 1E2));
 


### PR DESCRIPTION
I did not notice I have been casting positional data to `uint32_t` in the `telemetry_server`, as expected this has disastrous results when doing anything in negative lat, long or altitudes.

I have changed the castings to match the mavlink library packing function.