### PR TITLE
mavsdk_server: add API to set sysid/compid

### DIFF
--- a/src/mavsdk_server/src/mavsdk_server.cpp
+++ b/src/mavsdk_server/src/mavsdk_server.cpp
@@ -40,6 +40,11 @@ public:
 
     int getPort() { return _grpc_port; }
 
+    void setMavlinkIds(uint8_t system_id, uint8_t component_id)
+    {
+        _mavsdk.set_configuration(mavsdk::Mavsdk::Configuration{system_id, component_id, false});
+    }
+
 private:
     mavsdk::Mavsdk _mavsdk;
     ConnectionInitiator<mavsdk::Mavsdk> _connection_initiator;
@@ -73,4 +78,9 @@ void MavsdkServer::stop()
 int MavsdkServer::getPort()
 {
     return _impl->getPort();
+}
+
+void MavsdkServer::setMavlinkIds(uint8_t system_id, uint8_t component_id)
+{
+    _impl->setMavlinkIds(system_id, component_id);
 }

--- a/src/mavsdk_server/src/mavsdk_server.h
+++ b/src/mavsdk_server/src/mavsdk_server.h
@@ -16,6 +16,7 @@ public:
     void wait();
     void stop();
     int getPort();
+    void setMavlinkIds(uint8_t system_id, uint8_t component_id);
 
 private:
     class Impl;

--- a/src/mavsdk_server/src/mavsdk_server_api.cpp
+++ b/src/mavsdk_server/src/mavsdk_server_api.cpp
@@ -24,6 +24,17 @@ int mavsdk_server_run(
     return true;
 }
 
+int mavsdk_server_run_with_mavlink_ids(
+    MavsdkServer* mavsdk_server,
+    const char* system_address,
+    const int mavsdk_server_port,
+    const uint8_t system_id,
+    const uint8_t component_id)
+{
+    mavsdk_server->setMavlinkIds(system_id, component_id);
+    return mavsdk_server_run(mavsdk_server, system_address, mavsdk_server_port);
+}
+
 int mavsdk_server_get_port(MavsdkServer* mavsdk_server)
 {
     return mavsdk_server->getPort();

--- a/src/mavsdk_server/src/mavsdk_server_api.h
+++ b/src/mavsdk_server/src/mavsdk_server_api.h
@@ -4,6 +4,12 @@
 extern "C" {
 #endif
 
+#ifdef __cplusplus
+#include <cstdint>
+#else
+#include <stdint.h>
+#endif
+
 #ifdef WINDOWS
 #define DLLExport __declspec(dllexport)
 #else
@@ -14,6 +20,13 @@ DLLExport void mavsdk_server_init(struct MavsdkServer** mavsdk_server);
 
 DLLExport int mavsdk_server_run(
     struct MavsdkServer* mavsdk_server, const char* system_address, const int mavsdk_server_port);
+
+DLLExport int mavsdk_server_run_with_mavlink_ids(
+    struct MavsdkServer* mavsdk_server,
+    const char* system_address,
+    const int mavsdk_server_port,
+    const uint8_t system_id,
+    const uint8_t component_id);
 
 DLLExport int mavsdk_server_get_port(struct MavsdkServer* mavsdk_server);
 


### PR DESCRIPTION
What about something along these lines?

Instead of https://github.com/mavlink/MAVSDK-Proto/pull/256.