### PR TITLE
camera: fix non-successful set_param result

### DIFF
--- a/src/plugins/camera/camera_impl.h
+++ b/src/plugins/camera/camera_impl.h
@@ -115,6 +115,8 @@ private:
 
     static Camera::Result
     camera_result_from_command_result(const MavlinkCommandSender::Result command_result);
+    static Camera::Result
+    camera_result_from_parameter_result(const MAVLinkParameters::Result parameter_result);
 
     void receive_command_result(
         MavlinkCommandSender::Result command_result, const Camera::ResultCallback& callback);


### PR DESCRIPTION
The non-success cases were not covered and lead to a timeout.
Found with @byuarus.