### PR TITLE
MAVLink param improvements

### DIFF
--- a/src/core/mavlink_parameters.cpp
+++ b/src/core/mavlink_parameters.cpp
@@ -186,7 +186,7 @@ void MAVLinkParameters::get_all_params_async(const get_all_params_callback_t& ca
     }
 
     _parent.register_timeout_handler(
-        [this] { receive_timeout(); }, 1.0, &_all_param_store->timeout_cookie);
+        [this] { receive_timeout(); }, _parent.timeout_s(), &_all_param_store->timeout_cookie);
 }
 
 std::map<std::string, MAVLinkParameters::ParamValue> MAVLinkParameters::get_all_params()
@@ -418,7 +418,9 @@ void MAVLinkParameters::process_param_value(const mavlink_message_t& message)
             _parent.unregister_timeout_handler(_all_param_store->timeout_cookie);
 
             _parent.register_timeout_handler(
-                [this] { receive_timeout(); }, 1.0, &_all_param_store->timeout_cookie);
+                [this] { receive_timeout(); },
+                _parent.timeout_s(),
+                &_all_param_store->timeout_cookie);
         }
 
         return;

--- a/src/core/mavlink_parameters.cpp
+++ b/src/core/mavlink_parameters.cpp
@@ -602,7 +602,17 @@ void MAVLinkParameters::process_param_ext_ack(const mavlink_message_t& message)
                          << int(param_ext_ack.param_result);
 
                 if (work->set_param_callback) {
-                    work->set_param_callback(MAVLinkParameters::Result::Timeout);
+                    auto result = [&]() {
+                        switch (param_ext_ack.param_result) {
+                            case PARAM_ACK_FAILED:
+                                return MAVLinkParameters::Result::Failed;
+                            case PARAM_ACK_VALUE_UNSUPPORTED:
+                                return MAVLinkParameters::Result::ValueUnsupported;
+                            default:
+                                return MAVLinkParameters::Result::UnknownError;
+                        }
+                    }();
+                    work->set_param_callback(result);
                 }
 
                 _parent.unregister_timeout_handler(_timeout_cookie);

--- a/src/core/mavlink_parameters.h
+++ b/src/core/mavlink_parameters.h
@@ -459,7 +459,17 @@ public:
             _value{};
     };
 
-    enum class Result { Success, Timeout, ConnectionError, WrongType, ParamNameTooLong, NotFound };
+    enum class Result {
+        Success,
+        Timeout,
+        ConnectionError,
+        WrongType,
+        ParamNameTooLong,
+        NotFound,
+        ValueUnsupported,
+        Failed,
+        UnknownError
+    };
 
     typedef std::function<void(Result result)> set_param_callback_t;
 

--- a/src/plugins/camera/camera_impl.cpp
+++ b/src/plugins/camera/camera_impl.cpp
@@ -650,6 +650,12 @@ CameraImpl::camera_result_from_parameter_result(const MAVLinkParameters::Result 
             return Camera::Result::WrongArgument;
         case MAVLinkParameters::Result::NotFound:
             return Camera::Result::WrongArgument;
+        case MAVLinkParameters::Result::ValueUnsupported:
+            return Camera::Result::WrongArgument;
+        case MAVLinkParameters::Result::Failed:
+            return Camera::Result::Error;
+        case MAVLinkParameters::Result::UnknownError:
+            return Camera::Result::Error;
         default:
             return Camera::Result::Unknown;
     }


### PR DESCRIPTION
This fixes two timeouts and fixes some results where we displayed "Timeout" when it was not actually a timeout.