### PR TITLE
camera: request dropped IMAGE_CAPTURED messages

### DIFF
--- a/src/integration_tests/CMakeLists.txt
+++ b/src/integration_tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(integration_tests_runner
     action_goto.cpp
     action_hold.cpp
     calibration.cpp
+    camera_capture_info.cpp
     camera_mode.cpp
     camera_settings.cpp
     camera_status.cpp

--- a/src/integration_tests/camera_capture_info.cpp
+++ b/src/integration_tests/camera_capture_info.cpp
@@ -1,0 +1,37 @@
+#include "integration_test_helper.h"
+#include "mavsdk.h"
+#include <iostream>
+#include <functional>
+#include <atomic>
+#include "plugins/camera/camera.h"
+
+using namespace mavsdk;
+
+TEST(CameraTest, CaptureInfo)
+{
+    Mavsdk mavsdk;
+
+    ConnectionResult ret = mavsdk.add_udp_connection();
+    ASSERT_EQ(ret, ConnectionResult::Success);
+
+    // Wait for system to connect via heartbeat.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    ASSERT_EQ(mavsdk.systems().size(), 1);
+
+    auto system = mavsdk.systems().at(0);
+    auto camera = Camera{system};
+
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    EXPECT_EQ(camera.take_photo(), Camera::Result::Success);
+
+    bool received_capture_info = false;
+    camera.subscribe_capture_info([&received_capture_info](Camera::CaptureInfo capture_info) {
+        received_capture_info = true;
+        LogInfo() << capture_info;
+    });
+
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+    EXPECT_TRUE(received_capture_info);
+}

--- a/src/plugins/camera/camera_impl.h
+++ b/src/plugins/camera/camera_impl.h
@@ -158,6 +158,7 @@ private:
     void* _camera_information_call_every_cookie{nullptr};
     void* _flight_information_call_every_cookie{nullptr};
     void* _check_connection_status_call_every_cookie{nullptr};
+    void* _request_missing_capture_info_cookie{nullptr};
 
     void request_camera_settings();
     void request_camera_information();
@@ -185,6 +186,8 @@ private:
 
     MavlinkCommandSender::CommandLong make_command_request_video_stream_info();
     MavlinkCommandSender::CommandLong make_command_request_video_stream_status();
+
+    void request_missing_capture_info();
 
     std::unique_ptr<CameraDefinition> _camera_definition{};
     bool _is_fetching_camera_definition{false};
@@ -228,6 +231,7 @@ private:
         std::mutex mutex{};
         Camera::CaptureInfoCallback callback{nullptr};
         int last_advertised_image_index{-1};
+        std::map<int, int> missing_image_retries{};
     } _capture_info{};
 
     struct {


### PR DESCRIPTION
This should fix holes when displaying all images that have been captured in a mission.