### PR TITLE
mavsdk: add camera configuration

### DIFF
--- a/src/core/mavsdk.cpp
+++ b/src/core/mavsdk.cpp
@@ -106,6 +106,11 @@ Mavsdk::Configuration::Configuration(UsageType usage_type) :
             _component_id = MavsdkImpl::DEFAULT_COMPONENT_ID_AUTOPILOT;
             _always_send_heartbeats = true;
             break;
+        case Mavsdk::Configuration::UsageType::Camera:
+            _system_id = MavsdkImpl::DEFAULT_SYSTEM_ID_CAMERA;
+            _component_id = MavsdkImpl::DEFAULT_COMPONENT_ID_CAMERA;
+            _always_send_heartbeats = true;
+            break;
         default:
             break;
     }

--- a/src/core/mavsdk.h
+++ b/src/core/mavsdk.h
@@ -180,6 +180,7 @@ public:
             Autopilot, /**< @brief SDK is used as an autopilot. */
             GroundStation, /**< @brief SDK is used as a ground station. */
             CompanionComputer, /**< @brief SDK is used as a companion computer on board the MAV. */
+            Camera, /** < @brief SDK is used as a camera. */
             Custom /**< @brief the SDK is used in a custom configuration, no automatic ID will be
                       provided */
         };

--- a/src/core/mavsdk_impl.cpp
+++ b/src/core/mavsdk_impl.cpp
@@ -457,6 +457,9 @@ uint8_t MavsdkImpl::get_mav_type() const
         case Mavsdk::Configuration::UsageType::CompanionComputer:
             return MAV_TYPE_ONBOARD_CONTROLLER;
 
+        case Mavsdk::Configuration::UsageType::Camera:
+            return MAV_TYPE_CAMERA;
+
         case Mavsdk::Configuration::UsageType::Custom:
             return MAV_TYPE_GENERIC;
 

--- a/src/core/mavsdk_impl.h
+++ b/src/core/mavsdk_impl.h
@@ -30,6 +30,10 @@ public:
     static constexpr int DEFAULT_SYSTEM_ID_AUTOPILOT = 1;
     /** @brief Default Component ID for Autopilot configuration type. */
     static constexpr int DEFAULT_COMPONENT_ID_AUTOPILOT = MAV_COMP_ID_AUTOPILOT1;
+    /** @brief Default System ID for Camera configuration type. */
+    static constexpr int DEFAULT_SYSTEM_ID_CAMERA = 1;
+    /** @brief Default Component ID for Camera configuration type. */
+    static constexpr int DEFAULT_COMPONENT_ID_CAMERA = MAV_COMP_ID_CAMERA;
 
     MavsdkImpl();
     ~MavsdkImpl();


### PR DESCRIPTION
This adds a new default configuration to support running MAVSDK as a camera.

A CameraServer plugin will be added later to fully support this use case.