### PR TITLE
camera: handle empty camera definition URI

### DIFF
--- a/src/plugins/camera/camera_impl.cpp
+++ b/src/plugins/camera/camera_impl.cpp
@@ -1054,7 +1054,7 @@ void CameraImpl::process_camera_information(const mavlink_message_t& message)
             [temp_callback, temp_information]() { temp_callback(temp_information); });
     }
 
-    if (should_fetch_camera_definition()) {
+    if (should_fetch_camera_definition(camera_information.cam_definition_uri)) {
         _is_fetching_camera_definition = true;
 
         std::thread([this, camera_information]() {
@@ -1093,9 +1093,9 @@ void CameraImpl::process_camera_information(const mavlink_message_t& message)
     }
 }
 
-bool CameraImpl::should_fetch_camera_definition() const
+bool CameraImpl::should_fetch_camera_definition(const std::string& uri) const
 {
-    return !_camera_definition && !_is_fetching_camera_definition &&
+    return !uri.empty() && !_camera_definition && !_is_fetching_camera_definition &&
            !_has_camera_definition_timed_out;
 }
 

--- a/src/plugins/camera/camera_impl.h
+++ b/src/plugins/camera/camera_impl.h
@@ -141,7 +141,7 @@ private:
 
     void check_status();
 
-    bool should_fetch_camera_definition() const;
+    bool should_fetch_camera_definition(const std::string& uri) const;
     bool fetch_camera_definition(
         const mavlink_camera_information_t& camera_information, std::string& camera_definition_out);
     bool download_definition_file(const std::string& uri, std::string& camera_definition_out);


### PR DESCRIPTION
Currently, MAVSDK expects all cameras to have a camera definition URI and the Prepare method of the camera plugin will fail after 3 tries to fetch the file.

However the spec says this is optional, so an empty string should be allowed and should avoid the error.

This adds a check for the empty string to `should_fetch_camera_definition()` to handle this case.

Fixes #1603