### PR TITLE
mavlink: update submodule

### DIFF
--- a/src/plugins/manual_control/manual_control_impl.cpp
+++ b/src/plugins/manual_control/manual_control_impl.cpp
@@ -99,8 +99,12 @@ ManualControlImpl::set_manual_control_input(float x, float y, float z, float r)
         _input = Input::Set;
     }
 
-    // No buttons supported yet.
+    // No buttons/extensions supported yet.
     const uint16_t buttons = 0;
+    const uint16_t buttons2 = 0;
+    const uint8_t enabled_extensions = 0;
+    const int16_t pitch_only_axis = 0;
+    const int16_t roll_only_axis = 0;
 
     mavlink_message_t message;
     mavlink_msg_manual_control_pack(
@@ -112,7 +116,11 @@ ManualControlImpl::set_manual_control_input(float x, float y, float z, float r)
         static_cast<int16_t>(y * 1000),
         static_cast<int16_t>(z * 1000),
         static_cast<int16_t>(r * 1000),
-        buttons);
+        buttons,
+        buttons2,
+        enabled_extensions,
+        pitch_only_axis,
+        roll_only_axis);
     return _parent->send_message(message) ? ManualControl::Result::Success :
                                             ManualControl::Result::ConnectionError;
 }

--- a/src/plugins/shell/shell_impl.cpp
+++ b/src/plugins/shell/shell_impl.cpp
@@ -73,7 +73,9 @@ bool ShellImpl::send_command_message(std::string command)
             timeout_ms,
             0,
             static_cast<uint8_t>(MAVLINK_MSG_SERIAL_CONTROL_FIELD_DATA_LEN),
-            reinterpret_cast<const uint8_t*>(command.c_str()));
+            reinterpret_cast<const uint8_t*>(command.c_str()),
+            _parent->get_system_id(),
+            _parent->get_autopilot_id());
         command.erase(0, MAVLINK_MSG_SERIAL_CONTROL_FIELD_DATA_LEN);
         if (!_parent->send_message(message)) {
             return false;
@@ -101,7 +103,9 @@ bool ShellImpl::send_command_message(std::string command)
         timeout_ms,
         0,
         static_cast<uint8_t>(command.length()),
-        data);
+        data,
+        _parent->get_system_id(),
+        _parent->get_autopilot_id());
 
     return _parent->send_message(message);
 }


### PR DESCRIPTION
This is needed to get `MAV_CMD_SET_STORAGE_USAGE` for a complete camera server implementation.

Also fix breakage due to update.