### PR TITLE
Offboard pos global

### DIFF
--- a/examples/offboard/offboard.cpp
+++ b/examples/offboard/offboard.cpp
@@ -154,7 +154,8 @@ bool offb_ctrl_pos_global(mavsdk::Offboard& offboard, mavsdk::Telemetry& telemet
 
     // Send it once before starting offboard, otherwise it will be rejected.
     // this is a step north about 10m, this uses altitude relative from home
-    const Offboard::PositionGlobalYaw north{origin.latitude_deg+0.0001, origin.longitude_deg, 20.0f,0.0f};
+    const Offboard::PositionGlobalYaw north{
+        origin.latitude_deg + 0.0001, origin.longitude_deg, 20.0f, 0.0f};
     offboard.set_position_global(north);
 
     Offboard::Result offboard_result = offboard.start();
@@ -167,12 +168,14 @@ bool offb_ctrl_pos_global(mavsdk::Offboard& offboard, mavsdk::Telemetry& telemet
     std::cout << "Going North\n";
     sleep_for(seconds(10));
 
-    const Offboard::PositionGlobalYaw east{origin.latitude_deg+0.0001, origin.longitude_deg+0.0001, 15.0f,90.0f};
+    const Offboard::PositionGlobalYaw east{
+        origin.latitude_deg + 0.0001, origin.longitude_deg + 0.0001, 15.0f, 90.0f};
     offboard.set_position_global(east);
     std::cout << "Going East\n";
     sleep_for(seconds(10));
 
-    const Offboard::PositionGlobalYaw home{origin.latitude_deg, origin.longitude_deg, 10.0f,180.0f};
+    const Offboard::PositionGlobalYaw home{
+        origin.latitude_deg, origin.longitude_deg, 10.0f, 180.0f};
     offboard.set_position_global(home);
     std::cout << "Going Home facing south\n";
     sleep_for(seconds(10));
@@ -369,8 +372,8 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    // using global position 
-    if (!offb_ctrl_pos_global(offboard,telemetry)) {
+    // using global position
+    if (!offb_ctrl_pos_global(offboard, telemetry)) {
         return 1;
     }
 

--- a/src/mavsdk_server/src/generated/offboard/offboard.grpc.pb.cc
+++ b/src/mavsdk_server/src/generated/offboard/offboard.grpc.pb.cc
@@ -31,6 +31,7 @@ static const char* OffboardService_method_names[] = {
   "/mavsdk.rpc.offboard.OffboardService/SetActuatorControl",
   "/mavsdk.rpc.offboard.OffboardService/SetAttitudeRate",
   "/mavsdk.rpc.offboard.OffboardService/SetPositionNed",
+  "/mavsdk.rpc.offboard.OffboardService/SetPositionGlobal",
   "/mavsdk.rpc.offboard.OffboardService/SetVelocityBody",
   "/mavsdk.rpc.offboard.OffboardService/SetVelocityNed",
   "/mavsdk.rpc.offboard.OffboardService/SetPositionVelocityNed",
@@ -51,10 +52,11 @@ OffboardService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& ch
   , rpcmethod_SetActuatorControl_(OffboardService_method_names[4], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_SetAttitudeRate_(OffboardService_method_names[5], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_SetPositionNed_(OffboardService_method_names[6], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetVelocityBody_(OffboardService_method_names[7], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetVelocityNed_(OffboardService_method_names[8], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetPositionVelocityNed_(OffboardService_method_names[9], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetAccelerationNed_(OffboardService_method_names[10], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetPositionGlobal_(OffboardService_method_names[7], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetVelocityBody_(OffboardService_method_names[8], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetVelocityNed_(OffboardService_method_names[9], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetPositionVelocityNed_(OffboardService_method_names[10], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetAccelerationNed_(OffboardService_method_names[11], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status OffboardService::Stub::Start(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::StartRequest& request, ::mavsdk::rpc::offboard::StartResponse* response) {
@@ -214,6 +216,29 @@ void OffboardService::Stub::async::SetPositionNed(::grpc::ClientContext* context
 ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::offboard::SetPositionNedResponse>* OffboardService::Stub::AsyncSetPositionNedRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionNedRequest& request, ::grpc::CompletionQueue* cq) {
   auto* result =
     this->PrepareAsyncSetPositionNedRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::Status OffboardService::Stub::SetPositionGlobal(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest& request, ::mavsdk::rpc::offboard::SetPositionGlobalResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::offboard::SetPositionGlobalRequest, ::mavsdk::rpc::offboard::SetPositionGlobalResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_SetPositionGlobal_, context, request, response);
+}
+
+void OffboardService::Stub::async::SetPositionGlobal(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest* request, ::mavsdk::rpc::offboard::SetPositionGlobalResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::offboard::SetPositionGlobalRequest, ::mavsdk::rpc::offboard::SetPositionGlobalResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetPositionGlobal_, context, request, response, std::move(f));
+}
+
+void OffboardService::Stub::async::SetPositionGlobal(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest* request, ::mavsdk::rpc::offboard::SetPositionGlobalResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetPositionGlobal_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::offboard::SetPositionGlobalResponse>* OffboardService::Stub::PrepareAsyncSetPositionGlobalRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::offboard::SetPositionGlobalResponse, ::mavsdk::rpc::offboard::SetPositionGlobalRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_SetPositionGlobal_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::offboard::SetPositionGlobalResponse>* OffboardService::Stub::AsyncSetPositionGlobalRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncSetPositionGlobalRaw(context, request, cq);
   result->StartCall();
   return result;
 }
@@ -384,6 +409,16 @@ OffboardService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       OffboardService_method_names[7],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< OffboardService::Service, ::mavsdk::rpc::offboard::SetPositionGlobalRequest, ::mavsdk::rpc::offboard::SetPositionGlobalResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](OffboardService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::offboard::SetPositionGlobalRequest* req,
+             ::mavsdk::rpc::offboard::SetPositionGlobalResponse* resp) {
+               return service->SetPositionGlobal(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      OffboardService_method_names[8],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< OffboardService::Service, ::mavsdk::rpc::offboard::SetVelocityBodyRequest, ::mavsdk::rpc::offboard::SetVelocityBodyResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](OffboardService::Service* service,
              ::grpc::ServerContext* ctx,
@@ -392,7 +427,7 @@ OffboardService::Service::Service() {
                return service->SetVelocityBody(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      OffboardService_method_names[8],
+      OffboardService_method_names[9],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< OffboardService::Service, ::mavsdk::rpc::offboard::SetVelocityNedRequest, ::mavsdk::rpc::offboard::SetVelocityNedResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](OffboardService::Service* service,
@@ -402,7 +437,7 @@ OffboardService::Service::Service() {
                return service->SetVelocityNed(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      OffboardService_method_names[9],
+      OffboardService_method_names[10],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< OffboardService::Service, ::mavsdk::rpc::offboard::SetPositionVelocityNedRequest, ::mavsdk::rpc::offboard::SetPositionVelocityNedResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](OffboardService::Service* service,
@@ -412,7 +447,7 @@ OffboardService::Service::Service() {
                return service->SetPositionVelocityNed(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      OffboardService_method_names[10],
+      OffboardService_method_names[11],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< OffboardService::Service, ::mavsdk::rpc::offboard::SetAccelerationNedRequest, ::mavsdk::rpc::offboard::SetAccelerationNedResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](OffboardService::Service* service,
@@ -469,6 +504,13 @@ OffboardService::Service::~Service() {
 }
 
 ::grpc::Status OffboardService::Service::SetPositionNed(::grpc::ServerContext* context, const ::mavsdk::rpc::offboard::SetPositionNedRequest* request, ::mavsdk::rpc::offboard::SetPositionNedResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status OffboardService::Service::SetPositionGlobal(::grpc::ServerContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest* request, ::mavsdk::rpc::offboard::SetPositionGlobalResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/src/mavsdk_server/src/generated/offboard/offboard.grpc.pb.h
+++ b/src/mavsdk_server/src/generated/offboard/offboard.grpc.pb.h
@@ -118,6 +118,15 @@ class OffboardService final {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::offboard::SetPositionNedResponse>>(PrepareAsyncSetPositionNedRaw(context, request, cq));
     }
     //
+    // Set the position in Global coordinates and yaw.
+    virtual ::grpc::Status SetPositionGlobal(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest& request, ::mavsdk::rpc::offboard::SetPositionGlobalResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::offboard::SetPositionGlobalResponse>> AsyncSetPositionGlobal(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::offboard::SetPositionGlobalResponse>>(AsyncSetPositionGlobalRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::offboard::SetPositionGlobalResponse>> PrepareAsyncSetPositionGlobal(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::offboard::SetPositionGlobalResponse>>(PrepareAsyncSetPositionGlobalRaw(context, request, cq));
+    }
+    //
     // Set the velocity in body coordinates and yaw angular rate. Not available for fixed-wing aircraft.
     virtual ::grpc::Status SetVelocityBody(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetVelocityBodyRequest& request, ::mavsdk::rpc::offboard::SetVelocityBodyResponse* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::offboard::SetVelocityBodyResponse>> AsyncSetVelocityBody(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetVelocityBodyRequest& request, ::grpc::CompletionQueue* cq) {
@@ -193,6 +202,10 @@ class OffboardService final {
       virtual void SetPositionNed(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionNedRequest* request, ::mavsdk::rpc::offboard::SetPositionNedResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void SetPositionNed(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionNedRequest* request, ::mavsdk::rpc::offboard::SetPositionNedResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       //
+      // Set the position in Global coordinates and yaw.
+      virtual void SetPositionGlobal(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest* request, ::mavsdk::rpc::offboard::SetPositionGlobalResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void SetPositionGlobal(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest* request, ::mavsdk::rpc::offboard::SetPositionGlobalResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      //
       // Set the velocity in body coordinates and yaw angular rate. Not available for fixed-wing aircraft.
       virtual void SetVelocityBody(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetVelocityBodyRequest* request, ::mavsdk::rpc::offboard::SetVelocityBodyResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void SetVelocityBody(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetVelocityBodyRequest* request, ::mavsdk::rpc::offboard::SetVelocityBodyResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
@@ -227,6 +240,8 @@ class OffboardService final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::offboard::SetAttitudeRateResponse>* PrepareAsyncSetAttitudeRateRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetAttitudeRateRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::offboard::SetPositionNedResponse>* AsyncSetPositionNedRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionNedRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::offboard::SetPositionNedResponse>* PrepareAsyncSetPositionNedRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionNedRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::offboard::SetPositionGlobalResponse>* AsyncSetPositionGlobalRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::offboard::SetPositionGlobalResponse>* PrepareAsyncSetPositionGlobalRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::offboard::SetVelocityBodyResponse>* AsyncSetVelocityBodyRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetVelocityBodyRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::offboard::SetVelocityBodyResponse>* PrepareAsyncSetVelocityBodyRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetVelocityBodyRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::offboard::SetVelocityNedResponse>* AsyncSetVelocityNedRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetVelocityNedRequest& request, ::grpc::CompletionQueue* cq) = 0;
@@ -288,6 +303,13 @@ class OffboardService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::offboard::SetPositionNedResponse>> PrepareAsyncSetPositionNed(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionNedRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::offboard::SetPositionNedResponse>>(PrepareAsyncSetPositionNedRaw(context, request, cq));
     }
+    ::grpc::Status SetPositionGlobal(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest& request, ::mavsdk::rpc::offboard::SetPositionGlobalResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::offboard::SetPositionGlobalResponse>> AsyncSetPositionGlobal(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::offboard::SetPositionGlobalResponse>>(AsyncSetPositionGlobalRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::offboard::SetPositionGlobalResponse>> PrepareAsyncSetPositionGlobal(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::offboard::SetPositionGlobalResponse>>(PrepareAsyncSetPositionGlobalRaw(context, request, cq));
+    }
     ::grpc::Status SetVelocityBody(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetVelocityBodyRequest& request, ::mavsdk::rpc::offboard::SetVelocityBodyResponse* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::offboard::SetVelocityBodyResponse>> AsyncSetVelocityBody(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetVelocityBodyRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::offboard::SetVelocityBodyResponse>>(AsyncSetVelocityBodyRaw(context, request, cq));
@@ -333,6 +355,8 @@ class OffboardService final {
       void SetAttitudeRate(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetAttitudeRateRequest* request, ::mavsdk::rpc::offboard::SetAttitudeRateResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void SetPositionNed(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionNedRequest* request, ::mavsdk::rpc::offboard::SetPositionNedResponse* response, std::function<void(::grpc::Status)>) override;
       void SetPositionNed(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionNedRequest* request, ::mavsdk::rpc::offboard::SetPositionNedResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SetPositionGlobal(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest* request, ::mavsdk::rpc::offboard::SetPositionGlobalResponse* response, std::function<void(::grpc::Status)>) override;
+      void SetPositionGlobal(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest* request, ::mavsdk::rpc::offboard::SetPositionGlobalResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void SetVelocityBody(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetVelocityBodyRequest* request, ::mavsdk::rpc::offboard::SetVelocityBodyResponse* response, std::function<void(::grpc::Status)>) override;
       void SetVelocityBody(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetVelocityBodyRequest* request, ::mavsdk::rpc::offboard::SetVelocityBodyResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void SetVelocityNed(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetVelocityNedRequest* request, ::mavsdk::rpc::offboard::SetVelocityNedResponse* response, std::function<void(::grpc::Status)>) override;
@@ -366,6 +390,8 @@ class OffboardService final {
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::offboard::SetAttitudeRateResponse>* PrepareAsyncSetAttitudeRateRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetAttitudeRateRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::offboard::SetPositionNedResponse>* AsyncSetPositionNedRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionNedRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::offboard::SetPositionNedResponse>* PrepareAsyncSetPositionNedRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionNedRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::offboard::SetPositionGlobalResponse>* AsyncSetPositionGlobalRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::offboard::SetPositionGlobalResponse>* PrepareAsyncSetPositionGlobalRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::offboard::SetVelocityBodyResponse>* AsyncSetVelocityBodyRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetVelocityBodyRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::offboard::SetVelocityBodyResponse>* PrepareAsyncSetVelocityBodyRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetVelocityBodyRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::offboard::SetVelocityNedResponse>* AsyncSetVelocityNedRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::offboard::SetVelocityNedRequest& request, ::grpc::CompletionQueue* cq) override;
@@ -381,6 +407,7 @@ class OffboardService final {
     const ::grpc::internal::RpcMethod rpcmethod_SetActuatorControl_;
     const ::grpc::internal::RpcMethod rpcmethod_SetAttitudeRate_;
     const ::grpc::internal::RpcMethod rpcmethod_SetPositionNed_;
+    const ::grpc::internal::RpcMethod rpcmethod_SetPositionGlobal_;
     const ::grpc::internal::RpcMethod rpcmethod_SetVelocityBody_;
     const ::grpc::internal::RpcMethod rpcmethod_SetVelocityNed_;
     const ::grpc::internal::RpcMethod rpcmethod_SetPositionVelocityNed_;
@@ -421,6 +448,9 @@ class OffboardService final {
     //
     // Set the position in NED coordinates and yaw.
     virtual ::grpc::Status SetPositionNed(::grpc::ServerContext* context, const ::mavsdk::rpc::offboard::SetPositionNedRequest* request, ::mavsdk::rpc::offboard::SetPositionNedResponse* response);
+    //
+    // Set the position in Global coordinates and yaw.
+    virtual ::grpc::Status SetPositionGlobal(::grpc::ServerContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest* request, ::mavsdk::rpc::offboard::SetPositionGlobalResponse* response);
     //
     // Set the velocity in body coordinates and yaw angular rate. Not available for fixed-wing aircraft.
     virtual ::grpc::Status SetVelocityBody(::grpc::ServerContext* context, const ::mavsdk::rpc::offboard::SetVelocityBodyRequest* request, ::mavsdk::rpc::offboard::SetVelocityBodyResponse* response);
@@ -575,12 +605,32 @@ class OffboardService final {
     }
   };
   template <class BaseClass>
+  class WithAsyncMethod_SetPositionGlobal : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SetPositionGlobal() {
+      ::grpc::Service::MarkMethodAsync(7);
+    }
+    ~WithAsyncMethod_SetPositionGlobal() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetPositionGlobal(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest* /*request*/, ::mavsdk::rpc::offboard::SetPositionGlobalResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetPositionGlobal(::grpc::ServerContext* context, ::mavsdk::rpc::offboard::SetPositionGlobalRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::offboard::SetPositionGlobalResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithAsyncMethod_SetVelocityBody : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetVelocityBody() {
-      ::grpc::Service::MarkMethodAsync(7);
+      ::grpc::Service::MarkMethodAsync(8);
     }
     ~WithAsyncMethod_SetVelocityBody() override {
       BaseClassMustBeDerivedFromService(this);
@@ -591,7 +641,7 @@ class OffboardService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetVelocityBody(::grpc::ServerContext* context, ::mavsdk::rpc::offboard::SetVelocityBodyRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::offboard::SetVelocityBodyResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -600,7 +650,7 @@ class OffboardService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetVelocityNed() {
-      ::grpc::Service::MarkMethodAsync(8);
+      ::grpc::Service::MarkMethodAsync(9);
     }
     ~WithAsyncMethod_SetVelocityNed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -611,7 +661,7 @@ class OffboardService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetVelocityNed(::grpc::ServerContext* context, ::mavsdk::rpc::offboard::SetVelocityNedRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::offboard::SetVelocityNedResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -620,7 +670,7 @@ class OffboardService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetPositionVelocityNed() {
-      ::grpc::Service::MarkMethodAsync(9);
+      ::grpc::Service::MarkMethodAsync(10);
     }
     ~WithAsyncMethod_SetPositionVelocityNed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -631,7 +681,7 @@ class OffboardService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetPositionVelocityNed(::grpc::ServerContext* context, ::mavsdk::rpc::offboard::SetPositionVelocityNedRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::offboard::SetPositionVelocityNedResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -640,7 +690,7 @@ class OffboardService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetAccelerationNed() {
-      ::grpc::Service::MarkMethodAsync(10);
+      ::grpc::Service::MarkMethodAsync(11);
     }
     ~WithAsyncMethod_SetAccelerationNed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -651,10 +701,10 @@ class OffboardService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetAccelerationNed(::grpc::ServerContext* context, ::mavsdk::rpc::offboard::SetAccelerationNedRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::offboard::SetAccelerationNedResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_Start<WithAsyncMethod_Stop<WithAsyncMethod_IsActive<WithAsyncMethod_SetAttitude<WithAsyncMethod_SetActuatorControl<WithAsyncMethod_SetAttitudeRate<WithAsyncMethod_SetPositionNed<WithAsyncMethod_SetVelocityBody<WithAsyncMethod_SetVelocityNed<WithAsyncMethod_SetPositionVelocityNed<WithAsyncMethod_SetAccelerationNed<Service > > > > > > > > > > > AsyncService;
+  typedef WithAsyncMethod_Start<WithAsyncMethod_Stop<WithAsyncMethod_IsActive<WithAsyncMethod_SetAttitude<WithAsyncMethod_SetActuatorControl<WithAsyncMethod_SetAttitudeRate<WithAsyncMethod_SetPositionNed<WithAsyncMethod_SetPositionGlobal<WithAsyncMethod_SetVelocityBody<WithAsyncMethod_SetVelocityNed<WithAsyncMethod_SetPositionVelocityNed<WithAsyncMethod_SetAccelerationNed<Service > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_Start : public BaseClass {
    private:
@@ -845,18 +895,45 @@ class OffboardService final {
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::offboard::SetPositionNedRequest* /*request*/, ::mavsdk::rpc::offboard::SetPositionNedResponse* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithCallbackMethod_SetPositionGlobal : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SetPositionGlobal() {
+      ::grpc::Service::MarkMethodCallback(7,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::offboard::SetPositionGlobalRequest, ::mavsdk::rpc::offboard::SetPositionGlobalResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest* request, ::mavsdk::rpc::offboard::SetPositionGlobalResponse* response) { return this->SetPositionGlobal(context, request, response); }));}
+    void SetMessageAllocatorFor_SetPositionGlobal(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::offboard::SetPositionGlobalRequest, ::mavsdk::rpc::offboard::SetPositionGlobalResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(7);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::offboard::SetPositionGlobalRequest, ::mavsdk::rpc::offboard::SetPositionGlobalResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_SetPositionGlobal() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetPositionGlobal(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest* /*request*/, ::mavsdk::rpc::offboard::SetPositionGlobalResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* SetPositionGlobal(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest* /*request*/, ::mavsdk::rpc::offboard::SetPositionGlobalResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithCallbackMethod_SetVelocityBody : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetVelocityBody() {
-      ::grpc::Service::MarkMethodCallback(7,
+      ::grpc::Service::MarkMethodCallback(8,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::offboard::SetVelocityBodyRequest, ::mavsdk::rpc::offboard::SetVelocityBodyResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::offboard::SetVelocityBodyRequest* request, ::mavsdk::rpc::offboard::SetVelocityBodyResponse* response) { return this->SetVelocityBody(context, request, response); }));}
     void SetMessageAllocatorFor_SetVelocityBody(
         ::grpc::MessageAllocator< ::mavsdk::rpc::offboard::SetVelocityBodyRequest, ::mavsdk::rpc::offboard::SetVelocityBodyResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(7);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(8);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::offboard::SetVelocityBodyRequest, ::mavsdk::rpc::offboard::SetVelocityBodyResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -877,13 +954,13 @@ class OffboardService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetVelocityNed() {
-      ::grpc::Service::MarkMethodCallback(8,
+      ::grpc::Service::MarkMethodCallback(9,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::offboard::SetVelocityNedRequest, ::mavsdk::rpc::offboard::SetVelocityNedResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::offboard::SetVelocityNedRequest* request, ::mavsdk::rpc::offboard::SetVelocityNedResponse* response) { return this->SetVelocityNed(context, request, response); }));}
     void SetMessageAllocatorFor_SetVelocityNed(
         ::grpc::MessageAllocator< ::mavsdk::rpc::offboard::SetVelocityNedRequest, ::mavsdk::rpc::offboard::SetVelocityNedResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(8);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(9);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::offboard::SetVelocityNedRequest, ::mavsdk::rpc::offboard::SetVelocityNedResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -904,13 +981,13 @@ class OffboardService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetPositionVelocityNed() {
-      ::grpc::Service::MarkMethodCallback(9,
+      ::grpc::Service::MarkMethodCallback(10,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::offboard::SetPositionVelocityNedRequest, ::mavsdk::rpc::offboard::SetPositionVelocityNedResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::offboard::SetPositionVelocityNedRequest* request, ::mavsdk::rpc::offboard::SetPositionVelocityNedResponse* response) { return this->SetPositionVelocityNed(context, request, response); }));}
     void SetMessageAllocatorFor_SetPositionVelocityNed(
         ::grpc::MessageAllocator< ::mavsdk::rpc::offboard::SetPositionVelocityNedRequest, ::mavsdk::rpc::offboard::SetPositionVelocityNedResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(9);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(10);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::offboard::SetPositionVelocityNedRequest, ::mavsdk::rpc::offboard::SetPositionVelocityNedResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -931,13 +1008,13 @@ class OffboardService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetAccelerationNed() {
-      ::grpc::Service::MarkMethodCallback(10,
+      ::grpc::Service::MarkMethodCallback(11,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::offboard::SetAccelerationNedRequest, ::mavsdk::rpc::offboard::SetAccelerationNedResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::offboard::SetAccelerationNedRequest* request, ::mavsdk::rpc::offboard::SetAccelerationNedResponse* response) { return this->SetAccelerationNed(context, request, response); }));}
     void SetMessageAllocatorFor_SetAccelerationNed(
         ::grpc::MessageAllocator< ::mavsdk::rpc::offboard::SetAccelerationNedRequest, ::mavsdk::rpc::offboard::SetAccelerationNedResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(10);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(11);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::offboard::SetAccelerationNedRequest, ::mavsdk::rpc::offboard::SetAccelerationNedResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -952,7 +1029,7 @@ class OffboardService final {
     virtual ::grpc::ServerUnaryReactor* SetAccelerationNed(
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::offboard::SetAccelerationNedRequest* /*request*/, ::mavsdk::rpc::offboard::SetAccelerationNedResponse* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_Start<WithCallbackMethod_Stop<WithCallbackMethod_IsActive<WithCallbackMethod_SetAttitude<WithCallbackMethod_SetActuatorControl<WithCallbackMethod_SetAttitudeRate<WithCallbackMethod_SetPositionNed<WithCallbackMethod_SetVelocityBody<WithCallbackMethod_SetVelocityNed<WithCallbackMethod_SetPositionVelocityNed<WithCallbackMethod_SetAccelerationNed<Service > > > > > > > > > > > CallbackService;
+  typedef WithCallbackMethod_Start<WithCallbackMethod_Stop<WithCallbackMethod_IsActive<WithCallbackMethod_SetAttitude<WithCallbackMethod_SetActuatorControl<WithCallbackMethod_SetAttitudeRate<WithCallbackMethod_SetPositionNed<WithCallbackMethod_SetPositionGlobal<WithCallbackMethod_SetVelocityBody<WithCallbackMethod_SetVelocityNed<WithCallbackMethod_SetPositionVelocityNed<WithCallbackMethod_SetAccelerationNed<Service > > > > > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_Start : public BaseClass {
@@ -1074,12 +1151,29 @@ class OffboardService final {
     }
   };
   template <class BaseClass>
+  class WithGenericMethod_SetPositionGlobal : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SetPositionGlobal() {
+      ::grpc::Service::MarkMethodGeneric(7);
+    }
+    ~WithGenericMethod_SetPositionGlobal() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetPositionGlobal(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest* /*request*/, ::mavsdk::rpc::offboard::SetPositionGlobalResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
   class WithGenericMethod_SetVelocityBody : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetVelocityBody() {
-      ::grpc::Service::MarkMethodGeneric(7);
+      ::grpc::Service::MarkMethodGeneric(8);
     }
     ~WithGenericMethod_SetVelocityBody() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1096,7 +1190,7 @@ class OffboardService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetVelocityNed() {
-      ::grpc::Service::MarkMethodGeneric(8);
+      ::grpc::Service::MarkMethodGeneric(9);
     }
     ~WithGenericMethod_SetVelocityNed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1113,7 +1207,7 @@ class OffboardService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetPositionVelocityNed() {
-      ::grpc::Service::MarkMethodGeneric(9);
+      ::grpc::Service::MarkMethodGeneric(10);
     }
     ~WithGenericMethod_SetPositionVelocityNed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1130,7 +1224,7 @@ class OffboardService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetAccelerationNed() {
-      ::grpc::Service::MarkMethodGeneric(10);
+      ::grpc::Service::MarkMethodGeneric(11);
     }
     ~WithGenericMethod_SetAccelerationNed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1282,12 +1376,32 @@ class OffboardService final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_SetPositionGlobal : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SetPositionGlobal() {
+      ::grpc::Service::MarkMethodRaw(7);
+    }
+    ~WithRawMethod_SetPositionGlobal() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetPositionGlobal(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest* /*request*/, ::mavsdk::rpc::offboard::SetPositionGlobalResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetPositionGlobal(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithRawMethod_SetVelocityBody : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetVelocityBody() {
-      ::grpc::Service::MarkMethodRaw(7);
+      ::grpc::Service::MarkMethodRaw(8);
     }
     ~WithRawMethod_SetVelocityBody() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1298,7 +1412,7 @@ class OffboardService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetVelocityBody(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1307,7 +1421,7 @@ class OffboardService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetVelocityNed() {
-      ::grpc::Service::MarkMethodRaw(8);
+      ::grpc::Service::MarkMethodRaw(9);
     }
     ~WithRawMethod_SetVelocityNed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1318,7 +1432,7 @@ class OffboardService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetVelocityNed(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1327,7 +1441,7 @@ class OffboardService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetPositionVelocityNed() {
-      ::grpc::Service::MarkMethodRaw(9);
+      ::grpc::Service::MarkMethodRaw(10);
     }
     ~WithRawMethod_SetPositionVelocityNed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1338,7 +1452,7 @@ class OffboardService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetPositionVelocityNed(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1347,7 +1461,7 @@ class OffboardService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetAccelerationNed() {
-      ::grpc::Service::MarkMethodRaw(10);
+      ::grpc::Service::MarkMethodRaw(11);
     }
     ~WithRawMethod_SetAccelerationNed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1358,7 +1472,7 @@ class OffboardService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetAccelerationNed(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1516,12 +1630,34 @@ class OffboardService final {
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithRawCallbackMethod_SetPositionGlobal : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SetPositionGlobal() {
+      ::grpc::Service::MarkMethodRawCallback(7,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetPositionGlobal(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_SetPositionGlobal() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetPositionGlobal(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest* /*request*/, ::mavsdk::rpc::offboard::SetPositionGlobalResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* SetPositionGlobal(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithRawCallbackMethod_SetVelocityBody : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetVelocityBody() {
-      ::grpc::Service::MarkMethodRawCallback(7,
+      ::grpc::Service::MarkMethodRawCallback(8,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetVelocityBody(context, request, response); }));
@@ -1543,7 +1679,7 @@ class OffboardService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetVelocityNed() {
-      ::grpc::Service::MarkMethodRawCallback(8,
+      ::grpc::Service::MarkMethodRawCallback(9,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetVelocityNed(context, request, response); }));
@@ -1565,7 +1701,7 @@ class OffboardService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetPositionVelocityNed() {
-      ::grpc::Service::MarkMethodRawCallback(9,
+      ::grpc::Service::MarkMethodRawCallback(10,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetPositionVelocityNed(context, request, response); }));
@@ -1587,7 +1723,7 @@ class OffboardService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetAccelerationNed() {
-      ::grpc::Service::MarkMethodRawCallback(10,
+      ::grpc::Service::MarkMethodRawCallback(11,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetAccelerationNed(context, request, response); }));
@@ -1793,12 +1929,39 @@ class OffboardService final {
     virtual ::grpc::Status StreamedSetPositionNed(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::offboard::SetPositionNedRequest,::mavsdk::rpc::offboard::SetPositionNedResponse>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
+  class WithStreamedUnaryMethod_SetPositionGlobal : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_SetPositionGlobal() {
+      ::grpc::Service::MarkMethodStreamed(7,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::offboard::SetPositionGlobalRequest, ::mavsdk::rpc::offboard::SetPositionGlobalResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::offboard::SetPositionGlobalRequest, ::mavsdk::rpc::offboard::SetPositionGlobalResponse>* streamer) {
+                       return this->StreamedSetPositionGlobal(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_SetPositionGlobal() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SetPositionGlobal(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::offboard::SetPositionGlobalRequest* /*request*/, ::mavsdk::rpc::offboard::SetPositionGlobalResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedSetPositionGlobal(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::offboard::SetPositionGlobalRequest,::mavsdk::rpc::offboard::SetPositionGlobalResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_SetVelocityBody : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetVelocityBody() {
-      ::grpc::Service::MarkMethodStreamed(7,
+      ::grpc::Service::MarkMethodStreamed(8,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::offboard::SetVelocityBodyRequest, ::mavsdk::rpc::offboard::SetVelocityBodyResponse>(
             [this](::grpc::ServerContext* context,
@@ -1825,7 +1988,7 @@ class OffboardService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetVelocityNed() {
-      ::grpc::Service::MarkMethodStreamed(8,
+      ::grpc::Service::MarkMethodStreamed(9,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::offboard::SetVelocityNedRequest, ::mavsdk::rpc::offboard::SetVelocityNedResponse>(
             [this](::grpc::ServerContext* context,
@@ -1852,7 +2015,7 @@ class OffboardService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetPositionVelocityNed() {
-      ::grpc::Service::MarkMethodStreamed(9,
+      ::grpc::Service::MarkMethodStreamed(10,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::offboard::SetPositionVelocityNedRequest, ::mavsdk::rpc::offboard::SetPositionVelocityNedResponse>(
             [this](::grpc::ServerContext* context,
@@ -1879,7 +2042,7 @@ class OffboardService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetAccelerationNed() {
-      ::grpc::Service::MarkMethodStreamed(10,
+      ::grpc::Service::MarkMethodStreamed(11,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::offboard::SetAccelerationNedRequest, ::mavsdk::rpc::offboard::SetAccelerationNedResponse>(
             [this](::grpc::ServerContext* context,
@@ -1900,9 +2063,9 @@ class OffboardService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedSetAccelerationNed(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::offboard::SetAccelerationNedRequest,::mavsdk::rpc::offboard::SetAccelerationNedResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_Start<WithStreamedUnaryMethod_Stop<WithStreamedUnaryMethod_IsActive<WithStreamedUnaryMethod_SetAttitude<WithStreamedUnaryMethod_SetActuatorControl<WithStreamedUnaryMethod_SetAttitudeRate<WithStreamedUnaryMethod_SetPositionNed<WithStreamedUnaryMethod_SetVelocityBody<WithStreamedUnaryMethod_SetVelocityNed<WithStreamedUnaryMethod_SetPositionVelocityNed<WithStreamedUnaryMethod_SetAccelerationNed<Service > > > > > > > > > > > StreamedUnaryService;
+  typedef WithStreamedUnaryMethod_Start<WithStreamedUnaryMethod_Stop<WithStreamedUnaryMethod_IsActive<WithStreamedUnaryMethod_SetAttitude<WithStreamedUnaryMethod_SetActuatorControl<WithStreamedUnaryMethod_SetAttitudeRate<WithStreamedUnaryMethod_SetPositionNed<WithStreamedUnaryMethod_SetPositionGlobal<WithStreamedUnaryMethod_SetVelocityBody<WithStreamedUnaryMethod_SetVelocityNed<WithStreamedUnaryMethod_SetPositionVelocityNed<WithStreamedUnaryMethod_SetAccelerationNed<Service > > > > > > > > > > > > StreamedUnaryService;
   typedef Service SplitStreamedService;
-  typedef WithStreamedUnaryMethod_Start<WithStreamedUnaryMethod_Stop<WithStreamedUnaryMethod_IsActive<WithStreamedUnaryMethod_SetAttitude<WithStreamedUnaryMethod_SetActuatorControl<WithStreamedUnaryMethod_SetAttitudeRate<WithStreamedUnaryMethod_SetPositionNed<WithStreamedUnaryMethod_SetVelocityBody<WithStreamedUnaryMethod_SetVelocityNed<WithStreamedUnaryMethod_SetPositionVelocityNed<WithStreamedUnaryMethod_SetAccelerationNed<Service > > > > > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_Start<WithStreamedUnaryMethod_Stop<WithStreamedUnaryMethod_IsActive<WithStreamedUnaryMethod_SetAttitude<WithStreamedUnaryMethod_SetActuatorControl<WithStreamedUnaryMethod_SetAttitudeRate<WithStreamedUnaryMethod_SetPositionNed<WithStreamedUnaryMethod_SetPositionGlobal<WithStreamedUnaryMethod_SetVelocityBody<WithStreamedUnaryMethod_SetVelocityNed<WithStreamedUnaryMethod_SetPositionVelocityNed<WithStreamedUnaryMethod_SetAccelerationNed<Service > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace offboard

--- a/src/mavsdk_server/src/generated/offboard/offboard.pb.cc
+++ b/src/mavsdk_server/src/generated/offboard/offboard.pb.cc
@@ -184,6 +184,30 @@ struct SetPositionNedResponseDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SetPositionNedResponseDefaultTypeInternal _SetPositionNedResponse_default_instance_;
+constexpr SetPositionGlobalRequest::SetPositionGlobalRequest(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : position_global_yaw_(nullptr){}
+struct SetPositionGlobalRequestDefaultTypeInternal {
+  constexpr SetPositionGlobalRequestDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~SetPositionGlobalRequestDefaultTypeInternal() {}
+  union {
+    SetPositionGlobalRequest _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SetPositionGlobalRequestDefaultTypeInternal _SetPositionGlobalRequest_default_instance_;
+constexpr SetPositionGlobalResponse::SetPositionGlobalResponse(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : offboard_result_(nullptr){}
+struct SetPositionGlobalResponseDefaultTypeInternal {
+  constexpr SetPositionGlobalResponseDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~SetPositionGlobalResponseDefaultTypeInternal() {}
+  union {
+    SetPositionGlobalResponse _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SetPositionGlobalResponseDefaultTypeInternal _SetPositionGlobalResponse_default_instance_;
 constexpr SetVelocityBodyRequest::SetVelocityBodyRequest(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
   : velocity_body_yawspeed_(nullptr){}
@@ -350,6 +374,21 @@ struct PositionNedYawDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PositionNedYawDefaultTypeInternal _PositionNedYaw_default_instance_;
+constexpr PositionGlobalYaw::PositionGlobalYaw(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : lat_deg_(0)
+  , lon_deg_(0)
+  , alt_m_(0)
+  , yaw_deg_(0){}
+struct PositionGlobalYawDefaultTypeInternal {
+  constexpr PositionGlobalYawDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~PositionGlobalYawDefaultTypeInternal() {}
+  union {
+    PositionGlobalYaw _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PositionGlobalYawDefaultTypeInternal _PositionGlobalYaw_default_instance_;
 constexpr VelocityBodyYawspeed::VelocityBodyYawspeed(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
   : forward_m_s_(0)
@@ -411,7 +450,7 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT OffboardResultDefaultTypeIntern
 }  // namespace offboard
 }  // namespace rpc
 }  // namespace mavsdk
-static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_offboard_2foffboard_2eproto[31];
+static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_offboard_2foffboard_2eproto[34];
 static const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* file_level_enum_descriptors_offboard_2foffboard_2eproto[1];
 static constexpr ::PROTOBUF_NAMESPACE_ID::ServiceDescriptor const** file_level_service_descriptors_offboard_2foffboard_2eproto = nullptr;
 
@@ -497,6 +536,18 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_offboard_2foffboard_2eproto::o
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::offboard::SetPositionNedResponse, offboard_result_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::offboard::SetPositionGlobalRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::offboard::SetPositionGlobalRequest, position_global_yaw_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::offboard::SetPositionGlobalResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::offboard::SetPositionGlobalResponse, offboard_result_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::offboard::SetVelocityBodyRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -586,6 +637,15 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_offboard_2foffboard_2eproto::o
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::offboard::PositionNedYaw, down_m_),
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::offboard::PositionNedYaw, yaw_deg_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::offboard::PositionGlobalYaw, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::offboard::PositionGlobalYaw, lat_deg_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::offboard::PositionGlobalYaw, lon_deg_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::offboard::PositionGlobalYaw, alt_m_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::offboard::PositionGlobalYaw, yaw_deg_),
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::offboard::VelocityBodyYawspeed, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -634,23 +694,26 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 63, -1, sizeof(::mavsdk::rpc::offboard::SetAttitudeRateResponse)},
   { 69, -1, sizeof(::mavsdk::rpc::offboard::SetPositionNedRequest)},
   { 75, -1, sizeof(::mavsdk::rpc::offboard::SetPositionNedResponse)},
-  { 81, -1, sizeof(::mavsdk::rpc::offboard::SetVelocityBodyRequest)},
-  { 87, -1, sizeof(::mavsdk::rpc::offboard::SetVelocityBodyResponse)},
-  { 93, -1, sizeof(::mavsdk::rpc::offboard::SetVelocityNedRequest)},
-  { 99, -1, sizeof(::mavsdk::rpc::offboard::SetVelocityNedResponse)},
-  { 105, -1, sizeof(::mavsdk::rpc::offboard::SetPositionVelocityNedRequest)},
-  { 112, -1, sizeof(::mavsdk::rpc::offboard::SetPositionVelocityNedResponse)},
-  { 118, -1, sizeof(::mavsdk::rpc::offboard::SetAccelerationNedRequest)},
-  { 124, -1, sizeof(::mavsdk::rpc::offboard::SetAccelerationNedResponse)},
-  { 130, -1, sizeof(::mavsdk::rpc::offboard::Attitude)},
-  { 139, -1, sizeof(::mavsdk::rpc::offboard::ActuatorControlGroup)},
-  { 145, -1, sizeof(::mavsdk::rpc::offboard::ActuatorControl)},
-  { 151, -1, sizeof(::mavsdk::rpc::offboard::AttitudeRate)},
-  { 160, -1, sizeof(::mavsdk::rpc::offboard::PositionNedYaw)},
-  { 169, -1, sizeof(::mavsdk::rpc::offboard::VelocityBodyYawspeed)},
-  { 178, -1, sizeof(::mavsdk::rpc::offboard::VelocityNedYaw)},
-  { 187, -1, sizeof(::mavsdk::rpc::offboard::AccelerationNed)},
-  { 195, -1, sizeof(::mavsdk::rpc::offboard::OffboardResult)},
+  { 81, -1, sizeof(::mavsdk::rpc::offboard::SetPositionGlobalRequest)},
+  { 87, -1, sizeof(::mavsdk::rpc::offboard::SetPositionGlobalResponse)},
+  { 93, -1, sizeof(::mavsdk::rpc::offboard::SetVelocityBodyRequest)},
+  { 99, -1, sizeof(::mavsdk::rpc::offboard::SetVelocityBodyResponse)},
+  { 105, -1, sizeof(::mavsdk::rpc::offboard::SetVelocityNedRequest)},
+  { 111, -1, sizeof(::mavsdk::rpc::offboard::SetVelocityNedResponse)},
+  { 117, -1, sizeof(::mavsdk::rpc::offboard::SetPositionVelocityNedRequest)},
+  { 124, -1, sizeof(::mavsdk::rpc::offboard::SetPositionVelocityNedResponse)},
+  { 130, -1, sizeof(::mavsdk::rpc::offboard::SetAccelerationNedRequest)},
+  { 136, -1, sizeof(::mavsdk::rpc::offboard::SetAccelerationNedResponse)},
+  { 142, -1, sizeof(::mavsdk::rpc::offboard::Attitude)},
+  { 151, -1, sizeof(::mavsdk::rpc::offboard::ActuatorControlGroup)},
+  { 157, -1, sizeof(::mavsdk::rpc::offboard::ActuatorControl)},
+  { 163, -1, sizeof(::mavsdk::rpc::offboard::AttitudeRate)},
+  { 172, -1, sizeof(::mavsdk::rpc::offboard::PositionNedYaw)},
+  { 181, -1, sizeof(::mavsdk::rpc::offboard::PositionGlobalYaw)},
+  { 190, -1, sizeof(::mavsdk::rpc::offboard::VelocityBodyYawspeed)},
+  { 199, -1, sizeof(::mavsdk::rpc::offboard::VelocityNedYaw)},
+  { 208, -1, sizeof(::mavsdk::rpc::offboard::AccelerationNed)},
+  { 216, -1, sizeof(::mavsdk::rpc::offboard::OffboardResult)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -668,6 +731,8 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::offboard::_SetAttitudeRateResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::offboard::_SetPositionNedRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::offboard::_SetPositionNedResponse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::offboard::_SetPositionGlobalRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::offboard::_SetPositionGlobalResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::offboard::_SetVelocityBodyRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::offboard::_SetVelocityBodyResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::offboard::_SetVelocityNedRequest_default_instance_),
@@ -681,6 +746,7 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::offboard::_ActuatorControl_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::offboard::_AttitudeRate_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::offboard::_PositionNedYaw_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::offboard::_PositionGlobalYaw_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::offboard::_VelocityBodyYawspeed_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::offboard::_VelocityNedYaw_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::offboard::_AccelerationNed_default_instance_),
@@ -713,90 +779,100 @@ const char descriptor_table_protodef_offboard_2foffboard_2eproto[] PROTOBUF_SECT
   "#.mavsdk.rpc.offboard.PositionNedYaw\"V\n\026"
   "SetPositionNedResponse\022<\n\017offboard_resul"
   "t\030\001 \001(\0132#.mavsdk.rpc.offboard.OffboardRe"
-  "sult\"c\n\026SetVelocityBodyRequest\022I\n\026veloci"
-  "ty_body_yawspeed\030\001 \001(\0132).mavsdk.rpc.offb"
-  "oard.VelocityBodyYawspeed\"W\n\027SetVelocity"
-  "BodyResponse\022<\n\017offboard_result\030\001 \001(\0132#."
-  "mavsdk.rpc.offboard.OffboardResult\"V\n\025Se"
-  "tVelocityNedRequest\022=\n\020velocity_ned_yaw\030"
-  "\001 \001(\0132#.mavsdk.rpc.offboard.VelocityNedY"
-  "aw\"V\n\026SetVelocityNedResponse\022<\n\017offboard"
-  "_result\030\001 \001(\0132#.mavsdk.rpc.offboard.Offb"
-  "oardResult\"\235\001\n\035SetPositionVelocityNedReq"
-  "uest\022=\n\020position_ned_yaw\030\001 \001(\0132#.mavsdk."
-  "rpc.offboard.PositionNedYaw\022=\n\020velocity_"
-  "ned_yaw\030\002 \001(\0132#.mavsdk.rpc.offboard.Velo"
-  "cityNedYaw\"^\n\036SetPositionVelocityNedResp"
-  "onse\022<\n\017offboard_result\030\001 \001(\0132#.mavsdk.r"
-  "pc.offboard.OffboardResult\"[\n\031SetAcceler"
-  "ationNedRequest\022>\n\020acceleration_ned\030\001 \001("
-  "\0132$.mavsdk.rpc.offboard.AccelerationNed\""
-  "Z\n\032SetAccelerationNedResponse\022<\n\017offboar"
-  "d_result\030\001 \001(\0132#.mavsdk.rpc.offboard.Off"
-  "boardResult\"V\n\010Attitude\022\020\n\010roll_deg\030\001 \001("
-  "\002\022\021\n\tpitch_deg\030\002 \001(\002\022\017\n\007yaw_deg\030\003 \001(\002\022\024\n"
-  "\014thrust_value\030\004 \001(\002\"(\n\024ActuatorControlGr"
-  "oup\022\020\n\010controls\030\001 \003(\002\"L\n\017ActuatorControl"
-  "\0229\n\006groups\030\001 \003(\0132).mavsdk.rpc.offboard.A"
-  "ctuatorControlGroup\"`\n\014AttitudeRate\022\022\n\nr"
-  "oll_deg_s\030\001 \001(\002\022\023\n\013pitch_deg_s\030\002 \001(\002\022\021\n\t"
-  "yaw_deg_s\030\003 \001(\002\022\024\n\014thrust_value\030\004 \001(\002\"R\n"
-  "\016PositionNedYaw\022\017\n\007north_m\030\001 \001(\002\022\016\n\006east"
-  "_m\030\002 \001(\002\022\016\n\006down_m\030\003 \001(\002\022\017\n\007yaw_deg\030\004 \001("
-  "\002\"h\n\024VelocityBodyYawspeed\022\023\n\013forward_m_s"
-  "\030\001 \001(\002\022\021\n\tright_m_s\030\002 \001(\002\022\020\n\010down_m_s\030\003 "
-  "\001(\002\022\026\n\016yawspeed_deg_s\030\004 \001(\002\"X\n\016VelocityN"
-  "edYaw\022\021\n\tnorth_m_s\030\001 \001(\002\022\020\n\010east_m_s\030\002 \001"
-  "(\002\022\020\n\010down_m_s\030\003 \001(\002\022\017\n\007yaw_deg\030\004 \001(\002\"K\n"
-  "\017AccelerationNed\022\022\n\nnorth_m_s2\030\001 \001(\002\022\021\n\t"
-  "east_m_s2\030\002 \001(\002\022\021\n\tdown_m_s2\030\003 \001(\002\"\242\002\n\016O"
-  "ffboardResult\022:\n\006result\030\001 \001(\0162*.mavsdk.r"
-  "pc.offboard.OffboardResult.Result\022\022\n\nres"
-  "ult_str\030\002 \001(\t\"\277\001\n\006Result\022\022\n\016RESULT_UNKNO"
-  "WN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\024\n\020RESULT_NO_SY"
-  "STEM\020\002\022\033\n\027RESULT_CONNECTION_ERROR\020\003\022\017\n\013R"
-  "ESULT_BUSY\020\004\022\031\n\025RESULT_COMMAND_DENIED\020\005\022"
-  "\022\n\016RESULT_TIMEOUT\020\006\022\032\n\026RESULT_NO_SETPOIN"
-  "T_SET\020\0072\307\t\n\017OffboardService\022P\n\005Start\022!.m"
-  "avsdk.rpc.offboard.StartRequest\032\".mavsdk"
-  ".rpc.offboard.StartResponse\"\000\022M\n\004Stop\022 ."
-  "mavsdk.rpc.offboard.StopRequest\032!.mavsdk"
-  ".rpc.offboard.StopResponse\"\000\022]\n\010IsActive"
-  "\022$.mavsdk.rpc.offboard.IsActiveRequest\032%"
-  ".mavsdk.rpc.offboard.IsActiveResponse\"\004\200"
-  "\265\030\001\022f\n\013SetAttitude\022\'.mavsdk.rpc.offboard"
-  ".SetAttitudeRequest\032(.mavsdk.rpc.offboar"
-  "d.SetAttitudeResponse\"\004\200\265\030\001\022{\n\022SetActuat"
-  "orControl\022..mavsdk.rpc.offboard.SetActua"
-  "torControlRequest\032/.mavsdk.rpc.offboard."
-  "SetActuatorControlResponse\"\004\200\265\030\001\022r\n\017SetA"
-  "ttitudeRate\022+.mavsdk.rpc.offboard.SetAtt"
-  "itudeRateRequest\032,.mavsdk.rpc.offboard.S"
-  "etAttitudeRateResponse\"\004\200\265\030\001\022o\n\016SetPosit"
-  "ionNed\022*.mavsdk.rpc.offboard.SetPosition"
-  "NedRequest\032+.mavsdk.rpc.offboard.SetPosi"
-  "tionNedResponse\"\004\200\265\030\001\022r\n\017SetVelocityBody"
-  "\022+.mavsdk.rpc.offboard.SetVelocityBodyRe"
-  "quest\032,.mavsdk.rpc.offboard.SetVelocityB"
-  "odyResponse\"\004\200\265\030\001\022o\n\016SetVelocityNed\022*.ma"
-  "vsdk.rpc.offboard.SetVelocityNedRequest\032"
-  "+.mavsdk.rpc.offboard.SetVelocityNedResp"
-  "onse\"\004\200\265\030\001\022\207\001\n\026SetPositionVelocityNed\0222."
-  "mavsdk.rpc.offboard.SetPositionVelocityN"
-  "edRequest\0323.mavsdk.rpc.offboard.SetPosit"
-  "ionVelocityNedResponse\"\004\200\265\030\001\022{\n\022SetAccel"
-  "erationNed\022..mavsdk.rpc.offboard.SetAcce"
-  "lerationNedRequest\032/.mavsdk.rpc.offboard"
-  ".SetAccelerationNedResponse\"\004\200\265\030\001B#\n\022io."
-  "mavsdk.offboardB\rOffboardProtob\006proto3"
+  "sult\"_\n\030SetPositionGlobalRequest\022C\n\023posi"
+  "tion_global_yaw\030\001 \001(\0132&.mavsdk.rpc.offbo"
+  "ard.PositionGlobalYaw\"Y\n\031SetPositionGlob"
+  "alResponse\022<\n\017offboard_result\030\001 \001(\0132#.ma"
+  "vsdk.rpc.offboard.OffboardResult\"c\n\026SetV"
+  "elocityBodyRequest\022I\n\026velocity_body_yaws"
+  "peed\030\001 \001(\0132).mavsdk.rpc.offboard.Velocit"
+  "yBodyYawspeed\"W\n\027SetVelocityBodyResponse"
+  "\022<\n\017offboard_result\030\001 \001(\0132#.mavsdk.rpc.o"
+  "ffboard.OffboardResult\"V\n\025SetVelocityNed"
+  "Request\022=\n\020velocity_ned_yaw\030\001 \001(\0132#.mavs"
+  "dk.rpc.offboard.VelocityNedYaw\"V\n\026SetVel"
+  "ocityNedResponse\022<\n\017offboard_result\030\001 \001("
+  "\0132#.mavsdk.rpc.offboard.OffboardResult\"\235"
+  "\001\n\035SetPositionVelocityNedRequest\022=\n\020posi"
+  "tion_ned_yaw\030\001 \001(\0132#.mavsdk.rpc.offboard"
+  ".PositionNedYaw\022=\n\020velocity_ned_yaw\030\002 \001("
+  "\0132#.mavsdk.rpc.offboard.VelocityNedYaw\"^"
+  "\n\036SetPositionVelocityNedResponse\022<\n\017offb"
+  "oard_result\030\001 \001(\0132#.mavsdk.rpc.offboard."
+  "OffboardResult\"[\n\031SetAccelerationNedRequ"
+  "est\022>\n\020acceleration_ned\030\001 \001(\0132$.mavsdk.r"
+  "pc.offboard.AccelerationNed\"Z\n\032SetAccele"
+  "rationNedResponse\022<\n\017offboard_result\030\001 \001"
+  "(\0132#.mavsdk.rpc.offboard.OffboardResult\""
+  "V\n\010Attitude\022\020\n\010roll_deg\030\001 \001(\002\022\021\n\tpitch_d"
+  "eg\030\002 \001(\002\022\017\n\007yaw_deg\030\003 \001(\002\022\024\n\014thrust_valu"
+  "e\030\004 \001(\002\"(\n\024ActuatorControlGroup\022\020\n\010contr"
+  "ols\030\001 \003(\002\"L\n\017ActuatorControl\0229\n\006groups\030\001"
+  " \003(\0132).mavsdk.rpc.offboard.ActuatorContr"
+  "olGroup\"`\n\014AttitudeRate\022\022\n\nroll_deg_s\030\001 "
+  "\001(\002\022\023\n\013pitch_deg_s\030\002 \001(\002\022\021\n\tyaw_deg_s\030\003 "
+  "\001(\002\022\024\n\014thrust_value\030\004 \001(\002\"R\n\016PositionNed"
+  "Yaw\022\017\n\007north_m\030\001 \001(\002\022\016\n\006east_m\030\002 \001(\002\022\016\n\006"
+  "down_m\030\003 \001(\002\022\017\n\007yaw_deg\030\004 \001(\002\"U\n\021Positio"
+  "nGlobalYaw\022\017\n\007lat_deg\030\001 \001(\001\022\017\n\007lon_deg\030\002"
+  " \001(\001\022\r\n\005alt_m\030\003 \001(\002\022\017\n\007yaw_deg\030\004 \001(\002\"h\n\024"
+  "VelocityBodyYawspeed\022\023\n\013forward_m_s\030\001 \001("
+  "\002\022\021\n\tright_m_s\030\002 \001(\002\022\020\n\010down_m_s\030\003 \001(\002\022\026"
+  "\n\016yawspeed_deg_s\030\004 \001(\002\"X\n\016VelocityNedYaw"
+  "\022\021\n\tnorth_m_s\030\001 \001(\002\022\020\n\010east_m_s\030\002 \001(\002\022\020\n"
+  "\010down_m_s\030\003 \001(\002\022\017\n\007yaw_deg\030\004 \001(\002\"K\n\017Acce"
+  "lerationNed\022\022\n\nnorth_m_s2\030\001 \001(\002\022\021\n\teast_"
+  "m_s2\030\002 \001(\002\022\021\n\tdown_m_s2\030\003 \001(\002\"\242\002\n\016Offboa"
+  "rdResult\022:\n\006result\030\001 \001(\0162*.mavsdk.rpc.of"
+  "fboard.OffboardResult.Result\022\022\n\nresult_s"
+  "tr\030\002 \001(\t\"\277\001\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022"
+  "\022\n\016RESULT_SUCCESS\020\001\022\024\n\020RESULT_NO_SYSTEM\020"
+  "\002\022\033\n\027RESULT_CONNECTION_ERROR\020\003\022\017\n\013RESULT"
+  "_BUSY\020\004\022\031\n\025RESULT_COMMAND_DENIED\020\005\022\022\n\016RE"
+  "SULT_TIMEOUT\020\006\022\032\n\026RESULT_NO_SETPOINT_SET"
+  "\020\0072\301\n\n\017OffboardService\022P\n\005Start\022!.mavsdk"
+  ".rpc.offboard.StartRequest\032\".mavsdk.rpc."
+  "offboard.StartResponse\"\000\022M\n\004Stop\022 .mavsd"
+  "k.rpc.offboard.StopRequest\032!.mavsdk.rpc."
+  "offboard.StopResponse\"\000\022]\n\010IsActive\022$.ma"
+  "vsdk.rpc.offboard.IsActiveRequest\032%.mavs"
+  "dk.rpc.offboard.IsActiveResponse\"\004\200\265\030\001\022f"
+  "\n\013SetAttitude\022\'.mavsdk.rpc.offboard.SetA"
+  "ttitudeRequest\032(.mavsdk.rpc.offboard.Set"
+  "AttitudeResponse\"\004\200\265\030\001\022{\n\022SetActuatorCon"
+  "trol\022..mavsdk.rpc.offboard.SetActuatorCo"
+  "ntrolRequest\032/.mavsdk.rpc.offboard.SetAc"
+  "tuatorControlResponse\"\004\200\265\030\001\022r\n\017SetAttitu"
+  "deRate\022+.mavsdk.rpc.offboard.SetAttitude"
+  "RateRequest\032,.mavsdk.rpc.offboard.SetAtt"
+  "itudeRateResponse\"\004\200\265\030\001\022o\n\016SetPositionNe"
+  "d\022*.mavsdk.rpc.offboard.SetPositionNedRe"
+  "quest\032+.mavsdk.rpc.offboard.SetPositionN"
+  "edResponse\"\004\200\265\030\001\022x\n\021SetPositionGlobal\022-."
+  "mavsdk.rpc.offboard.SetPositionGlobalReq"
+  "uest\032..mavsdk.rpc.offboard.SetPositionGl"
+  "obalResponse\"\004\200\265\030\001\022r\n\017SetVelocityBody\022+."
+  "mavsdk.rpc.offboard.SetVelocityBodyReque"
+  "st\032,.mavsdk.rpc.offboard.SetVelocityBody"
+  "Response\"\004\200\265\030\001\022o\n\016SetVelocityNed\022*.mavsd"
+  "k.rpc.offboard.SetVelocityNedRequest\032+.m"
+  "avsdk.rpc.offboard.SetVelocityNedRespons"
+  "e\"\004\200\265\030\001\022\207\001\n\026SetPositionVelocityNed\0222.mav"
+  "sdk.rpc.offboard.SetPositionVelocityNedR"
+  "equest\0323.mavsdk.rpc.offboard.SetPosition"
+  "VelocityNedResponse\"\004\200\265\030\001\022{\n\022SetAccelera"
+  "tionNed\022..mavsdk.rpc.offboard.SetAcceler"
+  "ationNedRequest\032/.mavsdk.rpc.offboard.Se"
+  "tAccelerationNedResponse\"\004\200\265\030\001B#\n\022io.mav"
+  "sdk.offboardB\rOffboardProtob\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_offboard_2foffboard_2eproto_deps[1] = {
   &::descriptor_table_mavsdk_5foptions_2eproto,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_offboard_2foffboard_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_offboard_2foffboard_2eproto = {
-  false, false, 4038, descriptor_table_protodef_offboard_2foffboard_2eproto, "offboard/offboard.proto", 
-  &descriptor_table_offboard_2foffboard_2eproto_once, descriptor_table_offboard_2foffboard_2eproto_deps, 1, 31,
+  false, false, 4435, descriptor_table_protodef_offboard_2foffboard_2eproto, "offboard/offboard.proto", 
+  &descriptor_table_offboard_2foffboard_2eproto_once, descriptor_table_offboard_2foffboard_2eproto_deps, 1, 34,
   schemas, file_default_instances, TableStruct_offboard_2foffboard_2eproto::offsets,
   file_level_metadata_offboard_2foffboard_2eproto, file_level_enum_descriptors_offboard_2foffboard_2eproto, file_level_service_descriptors_offboard_2foffboard_2eproto,
 };
@@ -3487,6 +3563,406 @@ void SetPositionNedResponse::InternalSwap(SetPositionNedResponse* other) {
 
 // ===================================================================
 
+class SetPositionGlobalRequest::_Internal {
+ public:
+  static const ::mavsdk::rpc::offboard::PositionGlobalYaw& position_global_yaw(const SetPositionGlobalRequest* msg);
+};
+
+const ::mavsdk::rpc::offboard::PositionGlobalYaw&
+SetPositionGlobalRequest::_Internal::position_global_yaw(const SetPositionGlobalRequest* msg) {
+  return *msg->position_global_yaw_;
+}
+SetPositionGlobalRequest::SetPositionGlobalRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor();
+  if (!is_message_owned) {
+    RegisterArenaDtor(arena);
+  }
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.offboard.SetPositionGlobalRequest)
+}
+SetPositionGlobalRequest::SetPositionGlobalRequest(const SetPositionGlobalRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_position_global_yaw()) {
+    position_global_yaw_ = new ::mavsdk::rpc::offboard::PositionGlobalYaw(*from.position_global_yaw_);
+  } else {
+    position_global_yaw_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.offboard.SetPositionGlobalRequest)
+}
+
+inline void SetPositionGlobalRequest::SharedCtor() {
+position_global_yaw_ = nullptr;
+}
+
+SetPositionGlobalRequest::~SetPositionGlobalRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.offboard.SetPositionGlobalRequest)
+  if (GetArenaForAllocation() != nullptr) return;
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+inline void SetPositionGlobalRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  if (this != internal_default_instance()) delete position_global_yaw_;
+}
+
+void SetPositionGlobalRequest::ArenaDtor(void* object) {
+  SetPositionGlobalRequest* _this = reinterpret_cast< SetPositionGlobalRequest* >(object);
+  (void)_this;
+}
+void SetPositionGlobalRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void SetPositionGlobalRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void SetPositionGlobalRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.offboard.SetPositionGlobalRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArenaForAllocation() == nullptr && position_global_yaw_ != nullptr) {
+    delete position_global_yaw_;
+  }
+  position_global_yaw_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* SetPositionGlobalRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // .mavsdk.rpc.offboard.PositionGlobalYaw position_global_yaw = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_position_global_yaw(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag == 0) || ((tag & 7) == 4)) {
+          CHK_(ptr);
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* SetPositionGlobalRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.offboard.SetPositionGlobalRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.offboard.PositionGlobalYaw position_global_yaw = 1;
+  if (this->_internal_has_position_global_yaw()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::position_global_yaw(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.offboard.SetPositionGlobalRequest)
+  return target;
+}
+
+size_t SetPositionGlobalRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.offboard.SetPositionGlobalRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.offboard.PositionGlobalYaw position_global_yaw = 1;
+  if (this->_internal_has_position_global_yaw()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *position_global_yaw_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData SetPositionGlobalRequest::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSizeCheck,
+    SetPositionGlobalRequest::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*SetPositionGlobalRequest::GetClassData() const { return &_class_data_; }
+
+void SetPositionGlobalRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
+                      const ::PROTOBUF_NAMESPACE_ID::Message&from) {
+  static_cast<SetPositionGlobalRequest *>(to)->MergeFrom(
+      static_cast<const SetPositionGlobalRequest &>(from));
+}
+
+
+void SetPositionGlobalRequest::MergeFrom(const SetPositionGlobalRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.offboard.SetPositionGlobalRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_has_position_global_yaw()) {
+    _internal_mutable_position_global_yaw()->::mavsdk::rpc::offboard::PositionGlobalYaw::MergeFrom(from._internal_position_global_yaw());
+  }
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SetPositionGlobalRequest::CopyFrom(const SetPositionGlobalRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.offboard.SetPositionGlobalRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SetPositionGlobalRequest::IsInitialized() const {
+  return true;
+}
+
+void SetPositionGlobalRequest::InternalSwap(SetPositionGlobalRequest* other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(position_global_yaw_, other->position_global_yaw_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata SetPositionGlobalRequest::GetMetadata() const {
+  return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
+      &descriptor_table_offboard_2foffboard_2eproto_getter, &descriptor_table_offboard_2foffboard_2eproto_once,
+      file_level_metadata_offboard_2foffboard_2eproto[14]);
+}
+
+// ===================================================================
+
+class SetPositionGlobalResponse::_Internal {
+ public:
+  static const ::mavsdk::rpc::offboard::OffboardResult& offboard_result(const SetPositionGlobalResponse* msg);
+};
+
+const ::mavsdk::rpc::offboard::OffboardResult&
+SetPositionGlobalResponse::_Internal::offboard_result(const SetPositionGlobalResponse* msg) {
+  return *msg->offboard_result_;
+}
+SetPositionGlobalResponse::SetPositionGlobalResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor();
+  if (!is_message_owned) {
+    RegisterArenaDtor(arena);
+  }
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.offboard.SetPositionGlobalResponse)
+}
+SetPositionGlobalResponse::SetPositionGlobalResponse(const SetPositionGlobalResponse& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_offboard_result()) {
+    offboard_result_ = new ::mavsdk::rpc::offboard::OffboardResult(*from.offboard_result_);
+  } else {
+    offboard_result_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.offboard.SetPositionGlobalResponse)
+}
+
+inline void SetPositionGlobalResponse::SharedCtor() {
+offboard_result_ = nullptr;
+}
+
+SetPositionGlobalResponse::~SetPositionGlobalResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.offboard.SetPositionGlobalResponse)
+  if (GetArenaForAllocation() != nullptr) return;
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+inline void SetPositionGlobalResponse::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  if (this != internal_default_instance()) delete offboard_result_;
+}
+
+void SetPositionGlobalResponse::ArenaDtor(void* object) {
+  SetPositionGlobalResponse* _this = reinterpret_cast< SetPositionGlobalResponse* >(object);
+  (void)_this;
+}
+void SetPositionGlobalResponse::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void SetPositionGlobalResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void SetPositionGlobalResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.offboard.SetPositionGlobalResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArenaForAllocation() == nullptr && offboard_result_ != nullptr) {
+    delete offboard_result_;
+  }
+  offboard_result_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* SetPositionGlobalResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // .mavsdk.rpc.offboard.OffboardResult offboard_result = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_offboard_result(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag == 0) || ((tag & 7) == 4)) {
+          CHK_(ptr);
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* SetPositionGlobalResponse::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.offboard.SetPositionGlobalResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.offboard.OffboardResult offboard_result = 1;
+  if (this->_internal_has_offboard_result()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::offboard_result(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.offboard.SetPositionGlobalResponse)
+  return target;
+}
+
+size_t SetPositionGlobalResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.offboard.SetPositionGlobalResponse)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.offboard.OffboardResult offboard_result = 1;
+  if (this->_internal_has_offboard_result()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *offboard_result_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData SetPositionGlobalResponse::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSizeCheck,
+    SetPositionGlobalResponse::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*SetPositionGlobalResponse::GetClassData() const { return &_class_data_; }
+
+void SetPositionGlobalResponse::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
+                      const ::PROTOBUF_NAMESPACE_ID::Message&from) {
+  static_cast<SetPositionGlobalResponse *>(to)->MergeFrom(
+      static_cast<const SetPositionGlobalResponse &>(from));
+}
+
+
+void SetPositionGlobalResponse::MergeFrom(const SetPositionGlobalResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.offboard.SetPositionGlobalResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_has_offboard_result()) {
+    _internal_mutable_offboard_result()->::mavsdk::rpc::offboard::OffboardResult::MergeFrom(from._internal_offboard_result());
+  }
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SetPositionGlobalResponse::CopyFrom(const SetPositionGlobalResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.offboard.SetPositionGlobalResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SetPositionGlobalResponse::IsInitialized() const {
+  return true;
+}
+
+void SetPositionGlobalResponse::InternalSwap(SetPositionGlobalResponse* other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(offboard_result_, other->offboard_result_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata SetPositionGlobalResponse::GetMetadata() const {
+  return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
+      &descriptor_table_offboard_2foffboard_2eproto_getter, &descriptor_table_offboard_2foffboard_2eproto_once,
+      file_level_metadata_offboard_2foffboard_2eproto[15]);
+}
+
+// ===================================================================
+
 class SetVelocityBodyRequest::_Internal {
  public:
   static const ::mavsdk::rpc::offboard::VelocityBodyYawspeed& velocity_body_yawspeed(const SetVelocityBodyRequest* msg);
@@ -3682,7 +4158,7 @@ void SetVelocityBodyRequest::InternalSwap(SetVelocityBodyRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata SetVelocityBodyRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_offboard_2foffboard_2eproto_getter, &descriptor_table_offboard_2foffboard_2eproto_once,
-      file_level_metadata_offboard_2foffboard_2eproto[14]);
+      file_level_metadata_offboard_2foffboard_2eproto[16]);
 }
 
 // ===================================================================
@@ -3882,7 +4358,7 @@ void SetVelocityBodyResponse::InternalSwap(SetVelocityBodyResponse* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata SetVelocityBodyResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_offboard_2foffboard_2eproto_getter, &descriptor_table_offboard_2foffboard_2eproto_once,
-      file_level_metadata_offboard_2foffboard_2eproto[15]);
+      file_level_metadata_offboard_2foffboard_2eproto[17]);
 }
 
 // ===================================================================
@@ -4082,7 +4558,7 @@ void SetVelocityNedRequest::InternalSwap(SetVelocityNedRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata SetVelocityNedRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_offboard_2foffboard_2eproto_getter, &descriptor_table_offboard_2foffboard_2eproto_once,
-      file_level_metadata_offboard_2foffboard_2eproto[16]);
+      file_level_metadata_offboard_2foffboard_2eproto[18]);
 }
 
 // ===================================================================
@@ -4282,7 +4758,7 @@ void SetVelocityNedResponse::InternalSwap(SetVelocityNedResponse* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata SetVelocityNedResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_offboard_2foffboard_2eproto_getter, &descriptor_table_offboard_2foffboard_2eproto_once,
-      file_level_metadata_offboard_2foffboard_2eproto[17]);
+      file_level_metadata_offboard_2foffboard_2eproto[19]);
 }
 
 // ===================================================================
@@ -4530,7 +5006,7 @@ void SetPositionVelocityNedRequest::InternalSwap(SetPositionVelocityNedRequest* 
 ::PROTOBUF_NAMESPACE_ID::Metadata SetPositionVelocityNedRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_offboard_2foffboard_2eproto_getter, &descriptor_table_offboard_2foffboard_2eproto_once,
-      file_level_metadata_offboard_2foffboard_2eproto[18]);
+      file_level_metadata_offboard_2foffboard_2eproto[20]);
 }
 
 // ===================================================================
@@ -4730,7 +5206,7 @@ void SetPositionVelocityNedResponse::InternalSwap(SetPositionVelocityNedResponse
 ::PROTOBUF_NAMESPACE_ID::Metadata SetPositionVelocityNedResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_offboard_2foffboard_2eproto_getter, &descriptor_table_offboard_2foffboard_2eproto_once,
-      file_level_metadata_offboard_2foffboard_2eproto[19]);
+      file_level_metadata_offboard_2foffboard_2eproto[21]);
 }
 
 // ===================================================================
@@ -4930,7 +5406,7 @@ void SetAccelerationNedRequest::InternalSwap(SetAccelerationNedRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata SetAccelerationNedRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_offboard_2foffboard_2eproto_getter, &descriptor_table_offboard_2foffboard_2eproto_once,
-      file_level_metadata_offboard_2foffboard_2eproto[20]);
+      file_level_metadata_offboard_2foffboard_2eproto[22]);
 }
 
 // ===================================================================
@@ -5130,7 +5606,7 @@ void SetAccelerationNedResponse::InternalSwap(SetAccelerationNedResponse* other)
 ::PROTOBUF_NAMESPACE_ID::Metadata SetAccelerationNedResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_offboard_2foffboard_2eproto_getter, &descriptor_table_offboard_2foffboard_2eproto_once,
-      file_level_metadata_offboard_2foffboard_2eproto[21]);
+      file_level_metadata_offboard_2foffboard_2eproto[23]);
 }
 
 // ===================================================================
@@ -5388,7 +5864,7 @@ void Attitude::InternalSwap(Attitude* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata Attitude::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_offboard_2foffboard_2eproto_getter, &descriptor_table_offboard_2foffboard_2eproto_once,
-      file_level_metadata_offboard_2foffboard_2eproto[22]);
+      file_level_metadata_offboard_2foffboard_2eproto[24]);
 }
 
 // ===================================================================
@@ -5578,7 +6054,7 @@ void ActuatorControlGroup::InternalSwap(ActuatorControlGroup* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata ActuatorControlGroup::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_offboard_2foffboard_2eproto_getter, &descriptor_table_offboard_2foffboard_2eproto_once,
-      file_level_metadata_offboard_2foffboard_2eproto[23]);
+      file_level_metadata_offboard_2foffboard_2eproto[25]);
 }
 
 // ===================================================================
@@ -5768,7 +6244,7 @@ void ActuatorControl::InternalSwap(ActuatorControl* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata ActuatorControl::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_offboard_2foffboard_2eproto_getter, &descriptor_table_offboard_2foffboard_2eproto_once,
-      file_level_metadata_offboard_2foffboard_2eproto[24]);
+      file_level_metadata_offboard_2foffboard_2eproto[26]);
 }
 
 // ===================================================================
@@ -6026,7 +6502,7 @@ void AttitudeRate::InternalSwap(AttitudeRate* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata AttitudeRate::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_offboard_2foffboard_2eproto_getter, &descriptor_table_offboard_2foffboard_2eproto_once,
-      file_level_metadata_offboard_2foffboard_2eproto[25]);
+      file_level_metadata_offboard_2foffboard_2eproto[27]);
 }
 
 // ===================================================================
@@ -6284,7 +6760,265 @@ void PositionNedYaw::InternalSwap(PositionNedYaw* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata PositionNedYaw::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_offboard_2foffboard_2eproto_getter, &descriptor_table_offboard_2foffboard_2eproto_once,
-      file_level_metadata_offboard_2foffboard_2eproto[26]);
+      file_level_metadata_offboard_2foffboard_2eproto[28]);
+}
+
+// ===================================================================
+
+class PositionGlobalYaw::_Internal {
+ public:
+};
+
+PositionGlobalYaw::PositionGlobalYaw(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor();
+  if (!is_message_owned) {
+    RegisterArenaDtor(arena);
+  }
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.offboard.PositionGlobalYaw)
+}
+PositionGlobalYaw::PositionGlobalYaw(const PositionGlobalYaw& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::memcpy(&lat_deg_, &from.lat_deg_,
+    static_cast<size_t>(reinterpret_cast<char*>(&yaw_deg_) -
+    reinterpret_cast<char*>(&lat_deg_)) + sizeof(yaw_deg_));
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.offboard.PositionGlobalYaw)
+}
+
+inline void PositionGlobalYaw::SharedCtor() {
+::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
+    reinterpret_cast<char*>(&lat_deg_) - reinterpret_cast<char*>(this)),
+    0, static_cast<size_t>(reinterpret_cast<char*>(&yaw_deg_) -
+    reinterpret_cast<char*>(&lat_deg_)) + sizeof(yaw_deg_));
+}
+
+PositionGlobalYaw::~PositionGlobalYaw() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.offboard.PositionGlobalYaw)
+  if (GetArenaForAllocation() != nullptr) return;
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+inline void PositionGlobalYaw::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+}
+
+void PositionGlobalYaw::ArenaDtor(void* object) {
+  PositionGlobalYaw* _this = reinterpret_cast< PositionGlobalYaw* >(object);
+  (void)_this;
+}
+void PositionGlobalYaw::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void PositionGlobalYaw::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void PositionGlobalYaw::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.offboard.PositionGlobalYaw)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  ::memset(&lat_deg_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&yaw_deg_) -
+      reinterpret_cast<char*>(&lat_deg_)) + sizeof(yaw_deg_));
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* PositionGlobalYaw::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // double lat_deg = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 9)) {
+          lat_deg_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<double>(ptr);
+          ptr += sizeof(double);
+        } else goto handle_unusual;
+        continue;
+      // double lon_deg = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 17)) {
+          lon_deg_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<double>(ptr);
+          ptr += sizeof(double);
+        } else goto handle_unusual;
+        continue;
+      // float alt_m = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 29)) {
+          alt_m_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<float>(ptr);
+          ptr += sizeof(float);
+        } else goto handle_unusual;
+        continue;
+      // float yaw_deg = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 37)) {
+          yaw_deg_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<float>(ptr);
+          ptr += sizeof(float);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag == 0) || ((tag & 7) == 4)) {
+          CHK_(ptr);
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* PositionGlobalYaw::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.offboard.PositionGlobalYaw)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // double lat_deg = 1;
+  if (!(this->_internal_lat_deg() <= 0 && this->_internal_lat_deg() >= 0)) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteDoubleToArray(1, this->_internal_lat_deg(), target);
+  }
+
+  // double lon_deg = 2;
+  if (!(this->_internal_lon_deg() <= 0 && this->_internal_lon_deg() >= 0)) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteDoubleToArray(2, this->_internal_lon_deg(), target);
+  }
+
+  // float alt_m = 3;
+  if (!(this->_internal_alt_m() <= 0 && this->_internal_alt_m() >= 0)) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteFloatToArray(3, this->_internal_alt_m(), target);
+  }
+
+  // float yaw_deg = 4;
+  if (!(this->_internal_yaw_deg() <= 0 && this->_internal_yaw_deg() >= 0)) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteFloatToArray(4, this->_internal_yaw_deg(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.offboard.PositionGlobalYaw)
+  return target;
+}
+
+size_t PositionGlobalYaw::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.offboard.PositionGlobalYaw)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // double lat_deg = 1;
+  if (!(this->_internal_lat_deg() <= 0 && this->_internal_lat_deg() >= 0)) {
+    total_size += 1 + 8;
+  }
+
+  // double lon_deg = 2;
+  if (!(this->_internal_lon_deg() <= 0 && this->_internal_lon_deg() >= 0)) {
+    total_size += 1 + 8;
+  }
+
+  // float alt_m = 3;
+  if (!(this->_internal_alt_m() <= 0 && this->_internal_alt_m() >= 0)) {
+    total_size += 1 + 4;
+  }
+
+  // float yaw_deg = 4;
+  if (!(this->_internal_yaw_deg() <= 0 && this->_internal_yaw_deg() >= 0)) {
+    total_size += 1 + 4;
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData PositionGlobalYaw::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSizeCheck,
+    PositionGlobalYaw::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*PositionGlobalYaw::GetClassData() const { return &_class_data_; }
+
+void PositionGlobalYaw::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
+                      const ::PROTOBUF_NAMESPACE_ID::Message&from) {
+  static_cast<PositionGlobalYaw *>(to)->MergeFrom(
+      static_cast<const PositionGlobalYaw &>(from));
+}
+
+
+void PositionGlobalYaw::MergeFrom(const PositionGlobalYaw& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.offboard.PositionGlobalYaw)
+  GOOGLE_DCHECK_NE(&from, this);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!(from._internal_lat_deg() <= 0 && from._internal_lat_deg() >= 0)) {
+    _internal_set_lat_deg(from._internal_lat_deg());
+  }
+  if (!(from._internal_lon_deg() <= 0 && from._internal_lon_deg() >= 0)) {
+    _internal_set_lon_deg(from._internal_lon_deg());
+  }
+  if (!(from._internal_alt_m() <= 0 && from._internal_alt_m() >= 0)) {
+    _internal_set_alt_m(from._internal_alt_m());
+  }
+  if (!(from._internal_yaw_deg() <= 0 && from._internal_yaw_deg() >= 0)) {
+    _internal_set_yaw_deg(from._internal_yaw_deg());
+  }
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void PositionGlobalYaw::CopyFrom(const PositionGlobalYaw& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.offboard.PositionGlobalYaw)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool PositionGlobalYaw::IsInitialized() const {
+  return true;
+}
+
+void PositionGlobalYaw::InternalSwap(PositionGlobalYaw* other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(PositionGlobalYaw, yaw_deg_)
+      + sizeof(PositionGlobalYaw::yaw_deg_)
+      - PROTOBUF_FIELD_OFFSET(PositionGlobalYaw, lat_deg_)>(
+          reinterpret_cast<char*>(&lat_deg_),
+          reinterpret_cast<char*>(&other->lat_deg_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata PositionGlobalYaw::GetMetadata() const {
+  return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
+      &descriptor_table_offboard_2foffboard_2eproto_getter, &descriptor_table_offboard_2foffboard_2eproto_once,
+      file_level_metadata_offboard_2foffboard_2eproto[29]);
 }
 
 // ===================================================================
@@ -6542,7 +7276,7 @@ void VelocityBodyYawspeed::InternalSwap(VelocityBodyYawspeed* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata VelocityBodyYawspeed::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_offboard_2foffboard_2eproto_getter, &descriptor_table_offboard_2foffboard_2eproto_once,
-      file_level_metadata_offboard_2foffboard_2eproto[27]);
+      file_level_metadata_offboard_2foffboard_2eproto[30]);
 }
 
 // ===================================================================
@@ -6800,7 +7534,7 @@ void VelocityNedYaw::InternalSwap(VelocityNedYaw* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata VelocityNedYaw::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_offboard_2foffboard_2eproto_getter, &descriptor_table_offboard_2foffboard_2eproto_once,
-      file_level_metadata_offboard_2foffboard_2eproto[28]);
+      file_level_metadata_offboard_2foffboard_2eproto[31]);
 }
 
 // ===================================================================
@@ -7037,7 +7771,7 @@ void AccelerationNed::InternalSwap(AccelerationNed* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata AccelerationNed::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_offboard_2foffboard_2eproto_getter, &descriptor_table_offboard_2foffboard_2eproto_once,
-      file_level_metadata_offboard_2foffboard_2eproto[29]);
+      file_level_metadata_offboard_2foffboard_2eproto[32]);
 }
 
 // ===================================================================
@@ -7265,7 +7999,7 @@ void OffboardResult::InternalSwap(OffboardResult* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata OffboardResult::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_offboard_2foffboard_2eproto_getter, &descriptor_table_offboard_2foffboard_2eproto_once,
-      file_level_metadata_offboard_2foffboard_2eproto[30]);
+      file_level_metadata_offboard_2foffboard_2eproto[33]);
 }
 
 // @@protoc_insertion_point(namespace_scope)
@@ -7315,6 +8049,12 @@ template<> PROTOBUF_NOINLINE ::mavsdk::rpc::offboard::SetPositionNedRequest* Are
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::offboard::SetPositionNedResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::offboard::SetPositionNedResponse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::offboard::SetPositionNedResponse >(arena);
 }
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::offboard::SetPositionGlobalRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::offboard::SetPositionGlobalRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::offboard::SetPositionGlobalRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::offboard::SetPositionGlobalResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::offboard::SetPositionGlobalResponse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::offboard::SetPositionGlobalResponse >(arena);
+}
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::offboard::SetVelocityBodyRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::offboard::SetVelocityBodyRequest >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::offboard::SetVelocityBodyRequest >(arena);
 }
@@ -7353,6 +8093,9 @@ template<> PROTOBUF_NOINLINE ::mavsdk::rpc::offboard::AttitudeRate* Arena::Creat
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::offboard::PositionNedYaw* Arena::CreateMaybeMessage< ::mavsdk::rpc::offboard::PositionNedYaw >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::offboard::PositionNedYaw >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::offboard::PositionGlobalYaw* Arena::CreateMaybeMessage< ::mavsdk::rpc::offboard::PositionGlobalYaw >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::offboard::PositionGlobalYaw >(arena);
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::offboard::VelocityBodyYawspeed* Arena::CreateMaybeMessage< ::mavsdk::rpc::offboard::VelocityBodyYawspeed >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::offboard::VelocityBodyYawspeed >(arena);

--- a/src/mavsdk_server/src/generated/offboard/offboard.pb.h
+++ b/src/mavsdk_server/src/generated/offboard/offboard.pb.h
@@ -48,7 +48,7 @@ struct TableStruct_offboard_2foffboard_2eproto {
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::AuxiliaryParseTableField aux[]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
-  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[31]
+  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[34]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::FieldMetadata field_metadata[];
   static const ::PROTOBUF_NAMESPACE_ID::internal::SerializationTable serialization_table[];
@@ -82,6 +82,9 @@ extern IsActiveResponseDefaultTypeInternal _IsActiveResponse_default_instance_;
 class OffboardResult;
 struct OffboardResultDefaultTypeInternal;
 extern OffboardResultDefaultTypeInternal _OffboardResult_default_instance_;
+class PositionGlobalYaw;
+struct PositionGlobalYawDefaultTypeInternal;
+extern PositionGlobalYawDefaultTypeInternal _PositionGlobalYaw_default_instance_;
 class PositionNedYaw;
 struct PositionNedYawDefaultTypeInternal;
 extern PositionNedYawDefaultTypeInternal _PositionNedYaw_default_instance_;
@@ -109,6 +112,12 @@ extern SetAttitudeRequestDefaultTypeInternal _SetAttitudeRequest_default_instanc
 class SetAttitudeResponse;
 struct SetAttitudeResponseDefaultTypeInternal;
 extern SetAttitudeResponseDefaultTypeInternal _SetAttitudeResponse_default_instance_;
+class SetPositionGlobalRequest;
+struct SetPositionGlobalRequestDefaultTypeInternal;
+extern SetPositionGlobalRequestDefaultTypeInternal _SetPositionGlobalRequest_default_instance_;
+class SetPositionGlobalResponse;
+struct SetPositionGlobalResponseDefaultTypeInternal;
+extern SetPositionGlobalResponseDefaultTypeInternal _SetPositionGlobalResponse_default_instance_;
 class SetPositionNedRequest;
 struct SetPositionNedRequestDefaultTypeInternal;
 extern SetPositionNedRequestDefaultTypeInternal _SetPositionNedRequest_default_instance_;
@@ -163,6 +172,7 @@ template<> ::mavsdk::rpc::offboard::AttitudeRate* Arena::CreateMaybeMessage<::ma
 template<> ::mavsdk::rpc::offboard::IsActiveRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::offboard::IsActiveRequest>(Arena*);
 template<> ::mavsdk::rpc::offboard::IsActiveResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::offboard::IsActiveResponse>(Arena*);
 template<> ::mavsdk::rpc::offboard::OffboardResult* Arena::CreateMaybeMessage<::mavsdk::rpc::offboard::OffboardResult>(Arena*);
+template<> ::mavsdk::rpc::offboard::PositionGlobalYaw* Arena::CreateMaybeMessage<::mavsdk::rpc::offboard::PositionGlobalYaw>(Arena*);
 template<> ::mavsdk::rpc::offboard::PositionNedYaw* Arena::CreateMaybeMessage<::mavsdk::rpc::offboard::PositionNedYaw>(Arena*);
 template<> ::mavsdk::rpc::offboard::SetAccelerationNedRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::offboard::SetAccelerationNedRequest>(Arena*);
 template<> ::mavsdk::rpc::offboard::SetAccelerationNedResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::offboard::SetAccelerationNedResponse>(Arena*);
@@ -172,6 +182,8 @@ template<> ::mavsdk::rpc::offboard::SetAttitudeRateRequest* Arena::CreateMaybeMe
 template<> ::mavsdk::rpc::offboard::SetAttitudeRateResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::offboard::SetAttitudeRateResponse>(Arena*);
 template<> ::mavsdk::rpc::offboard::SetAttitudeRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::offboard::SetAttitudeRequest>(Arena*);
 template<> ::mavsdk::rpc::offboard::SetAttitudeResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::offboard::SetAttitudeResponse>(Arena*);
+template<> ::mavsdk::rpc::offboard::SetPositionGlobalRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::offboard::SetPositionGlobalRequest>(Arena*);
+template<> ::mavsdk::rpc::offboard::SetPositionGlobalResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::offboard::SetPositionGlobalResponse>(Arena*);
 template<> ::mavsdk::rpc::offboard::SetPositionNedRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::offboard::SetPositionNedRequest>(Arena*);
 template<> ::mavsdk::rpc::offboard::SetPositionNedResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::offboard::SetPositionNedResponse>(Arena*);
 template<> ::mavsdk::rpc::offboard::SetPositionVelocityNedRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::offboard::SetPositionVelocityNedRequest>(Arena*);
@@ -2221,6 +2233,302 @@ class SetPositionNedResponse final :
 };
 // -------------------------------------------------------------------
 
+class SetPositionGlobalRequest final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.offboard.SetPositionGlobalRequest) */ {
+ public:
+  inline SetPositionGlobalRequest() : SetPositionGlobalRequest(nullptr) {}
+  ~SetPositionGlobalRequest() override;
+  explicit constexpr SetPositionGlobalRequest(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  SetPositionGlobalRequest(const SetPositionGlobalRequest& from);
+  SetPositionGlobalRequest(SetPositionGlobalRequest&& from) noexcept
+    : SetPositionGlobalRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline SetPositionGlobalRequest& operator=(const SetPositionGlobalRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetPositionGlobalRequest& operator=(SetPositionGlobalRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SetPositionGlobalRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SetPositionGlobalRequest* internal_default_instance() {
+    return reinterpret_cast<const SetPositionGlobalRequest*>(
+               &_SetPositionGlobalRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    14;
+
+  friend void swap(SetPositionGlobalRequest& a, SetPositionGlobalRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(SetPositionGlobalRequest* other) {
+    if (other == this) return;
+    if (GetOwningArena() == other->GetOwningArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetPositionGlobalRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline SetPositionGlobalRequest* New() const final {
+    return new SetPositionGlobalRequest();
+  }
+
+  SetPositionGlobalRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<SetPositionGlobalRequest>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const SetPositionGlobalRequest& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom(const SetPositionGlobalRequest& from);
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to, const ::PROTOBUF_NAMESPACE_ID::Message&from);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(SetPositionGlobalRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.offboard.SetPositionGlobalRequest";
+  }
+  protected:
+  explicit SetPositionGlobalRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kPositionGlobalYawFieldNumber = 1,
+  };
+  // .mavsdk.rpc.offboard.PositionGlobalYaw position_global_yaw = 1;
+  bool has_position_global_yaw() const;
+  private:
+  bool _internal_has_position_global_yaw() const;
+  public:
+  void clear_position_global_yaw();
+  const ::mavsdk::rpc::offboard::PositionGlobalYaw& position_global_yaw() const;
+  PROTOBUF_MUST_USE_RESULT ::mavsdk::rpc::offboard::PositionGlobalYaw* release_position_global_yaw();
+  ::mavsdk::rpc::offboard::PositionGlobalYaw* mutable_position_global_yaw();
+  void set_allocated_position_global_yaw(::mavsdk::rpc::offboard::PositionGlobalYaw* position_global_yaw);
+  private:
+  const ::mavsdk::rpc::offboard::PositionGlobalYaw& _internal_position_global_yaw() const;
+  ::mavsdk::rpc::offboard::PositionGlobalYaw* _internal_mutable_position_global_yaw();
+  public:
+  void unsafe_arena_set_allocated_position_global_yaw(
+      ::mavsdk::rpc::offboard::PositionGlobalYaw* position_global_yaw);
+  ::mavsdk::rpc::offboard::PositionGlobalYaw* unsafe_arena_release_position_global_yaw();
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.offboard.SetPositionGlobalRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::mavsdk::rpc::offboard::PositionGlobalYaw* position_global_yaw_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_offboard_2foffboard_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SetPositionGlobalResponse final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.offboard.SetPositionGlobalResponse) */ {
+ public:
+  inline SetPositionGlobalResponse() : SetPositionGlobalResponse(nullptr) {}
+  ~SetPositionGlobalResponse() override;
+  explicit constexpr SetPositionGlobalResponse(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  SetPositionGlobalResponse(const SetPositionGlobalResponse& from);
+  SetPositionGlobalResponse(SetPositionGlobalResponse&& from) noexcept
+    : SetPositionGlobalResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline SetPositionGlobalResponse& operator=(const SetPositionGlobalResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetPositionGlobalResponse& operator=(SetPositionGlobalResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SetPositionGlobalResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SetPositionGlobalResponse* internal_default_instance() {
+    return reinterpret_cast<const SetPositionGlobalResponse*>(
+               &_SetPositionGlobalResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    15;
+
+  friend void swap(SetPositionGlobalResponse& a, SetPositionGlobalResponse& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(SetPositionGlobalResponse* other) {
+    if (other == this) return;
+    if (GetOwningArena() == other->GetOwningArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetPositionGlobalResponse* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline SetPositionGlobalResponse* New() const final {
+    return new SetPositionGlobalResponse();
+  }
+
+  SetPositionGlobalResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<SetPositionGlobalResponse>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const SetPositionGlobalResponse& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom(const SetPositionGlobalResponse& from);
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to, const ::PROTOBUF_NAMESPACE_ID::Message&from);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(SetPositionGlobalResponse* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.offboard.SetPositionGlobalResponse";
+  }
+  protected:
+  explicit SetPositionGlobalResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kOffboardResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.offboard.OffboardResult offboard_result = 1;
+  bool has_offboard_result() const;
+  private:
+  bool _internal_has_offboard_result() const;
+  public:
+  void clear_offboard_result();
+  const ::mavsdk::rpc::offboard::OffboardResult& offboard_result() const;
+  PROTOBUF_MUST_USE_RESULT ::mavsdk::rpc::offboard::OffboardResult* release_offboard_result();
+  ::mavsdk::rpc::offboard::OffboardResult* mutable_offboard_result();
+  void set_allocated_offboard_result(::mavsdk::rpc::offboard::OffboardResult* offboard_result);
+  private:
+  const ::mavsdk::rpc::offboard::OffboardResult& _internal_offboard_result() const;
+  ::mavsdk::rpc::offboard::OffboardResult* _internal_mutable_offboard_result();
+  public:
+  void unsafe_arena_set_allocated_offboard_result(
+      ::mavsdk::rpc::offboard::OffboardResult* offboard_result);
+  ::mavsdk::rpc::offboard::OffboardResult* unsafe_arena_release_offboard_result();
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.offboard.SetPositionGlobalResponse)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::mavsdk::rpc::offboard::OffboardResult* offboard_result_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_offboard_2foffboard_2eproto;
+};
+// -------------------------------------------------------------------
+
 class SetVelocityBodyRequest final :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.offboard.SetVelocityBodyRequest) */ {
  public:
@@ -2265,7 +2573,7 @@ class SetVelocityBodyRequest final :
                &_SetVelocityBodyRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    14;
+    16;
 
   friend void swap(SetVelocityBodyRequest& a, SetVelocityBodyRequest& b) {
     a.Swap(&b);
@@ -2413,7 +2721,7 @@ class SetVelocityBodyResponse final :
                &_SetVelocityBodyResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    15;
+    17;
 
   friend void swap(SetVelocityBodyResponse& a, SetVelocityBodyResponse& b) {
     a.Swap(&b);
@@ -2561,7 +2869,7 @@ class SetVelocityNedRequest final :
                &_SetVelocityNedRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    16;
+    18;
 
   friend void swap(SetVelocityNedRequest& a, SetVelocityNedRequest& b) {
     a.Swap(&b);
@@ -2709,7 +3017,7 @@ class SetVelocityNedResponse final :
                &_SetVelocityNedResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    17;
+    19;
 
   friend void swap(SetVelocityNedResponse& a, SetVelocityNedResponse& b) {
     a.Swap(&b);
@@ -2857,7 +3165,7 @@ class SetPositionVelocityNedRequest final :
                &_SetPositionVelocityNedRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    18;
+    20;
 
   friend void swap(SetPositionVelocityNedRequest& a, SetPositionVelocityNedRequest& b) {
     a.Swap(&b);
@@ -3025,7 +3333,7 @@ class SetPositionVelocityNedResponse final :
                &_SetPositionVelocityNedResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    19;
+    21;
 
   friend void swap(SetPositionVelocityNedResponse& a, SetPositionVelocityNedResponse& b) {
     a.Swap(&b);
@@ -3173,7 +3481,7 @@ class SetAccelerationNedRequest final :
                &_SetAccelerationNedRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    20;
+    22;
 
   friend void swap(SetAccelerationNedRequest& a, SetAccelerationNedRequest& b) {
     a.Swap(&b);
@@ -3321,7 +3629,7 @@ class SetAccelerationNedResponse final :
                &_SetAccelerationNedResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    21;
+    23;
 
   friend void swap(SetAccelerationNedResponse& a, SetAccelerationNedResponse& b) {
     a.Swap(&b);
@@ -3469,7 +3777,7 @@ class Attitude final :
                &_Attitude_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    22;
+    24;
 
   friend void swap(Attitude& a, Attitude& b) {
     a.Swap(&b);
@@ -3641,7 +3949,7 @@ class ActuatorControlGroup final :
                &_ActuatorControlGroup_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    23;
+    25;
 
   friend void swap(ActuatorControlGroup& a, ActuatorControlGroup& b) {
     a.Swap(&b);
@@ -3793,7 +4101,7 @@ class ActuatorControl final :
                &_ActuatorControl_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    24;
+    26;
 
   friend void swap(ActuatorControl& a, ActuatorControl& b) {
     a.Swap(&b);
@@ -3941,7 +4249,7 @@ class AttitudeRate final :
                &_AttitudeRate_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    25;
+    27;
 
   friend void swap(AttitudeRate& a, AttitudeRate& b) {
     a.Swap(&b);
@@ -4113,7 +4421,7 @@ class PositionNedYaw final :
                &_PositionNedYaw_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    26;
+    28;
 
   friend void swap(PositionNedYaw& a, PositionNedYaw& b) {
     a.Swap(&b);
@@ -4241,6 +4549,178 @@ class PositionNedYaw final :
 };
 // -------------------------------------------------------------------
 
+class PositionGlobalYaw final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.offboard.PositionGlobalYaw) */ {
+ public:
+  inline PositionGlobalYaw() : PositionGlobalYaw(nullptr) {}
+  ~PositionGlobalYaw() override;
+  explicit constexpr PositionGlobalYaw(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  PositionGlobalYaw(const PositionGlobalYaw& from);
+  PositionGlobalYaw(PositionGlobalYaw&& from) noexcept
+    : PositionGlobalYaw() {
+    *this = ::std::move(from);
+  }
+
+  inline PositionGlobalYaw& operator=(const PositionGlobalYaw& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline PositionGlobalYaw& operator=(PositionGlobalYaw&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const PositionGlobalYaw& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const PositionGlobalYaw* internal_default_instance() {
+    return reinterpret_cast<const PositionGlobalYaw*>(
+               &_PositionGlobalYaw_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    29;
+
+  friend void swap(PositionGlobalYaw& a, PositionGlobalYaw& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(PositionGlobalYaw* other) {
+    if (other == this) return;
+    if (GetOwningArena() == other->GetOwningArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(PositionGlobalYaw* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline PositionGlobalYaw* New() const final {
+    return new PositionGlobalYaw();
+  }
+
+  PositionGlobalYaw* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<PositionGlobalYaw>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const PositionGlobalYaw& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom(const PositionGlobalYaw& from);
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to, const ::PROTOBUF_NAMESPACE_ID::Message&from);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(PositionGlobalYaw* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.offboard.PositionGlobalYaw";
+  }
+  protected:
+  explicit PositionGlobalYaw(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kLatDegFieldNumber = 1,
+    kLonDegFieldNumber = 2,
+    kAltMFieldNumber = 3,
+    kYawDegFieldNumber = 4,
+  };
+  // double lat_deg = 1;
+  void clear_lat_deg();
+  double lat_deg() const;
+  void set_lat_deg(double value);
+  private:
+  double _internal_lat_deg() const;
+  void _internal_set_lat_deg(double value);
+  public:
+
+  // double lon_deg = 2;
+  void clear_lon_deg();
+  double lon_deg() const;
+  void set_lon_deg(double value);
+  private:
+  double _internal_lon_deg() const;
+  void _internal_set_lon_deg(double value);
+  public:
+
+  // float alt_m = 3;
+  void clear_alt_m();
+  float alt_m() const;
+  void set_alt_m(float value);
+  private:
+  float _internal_alt_m() const;
+  void _internal_set_alt_m(float value);
+  public:
+
+  // float yaw_deg = 4;
+  void clear_yaw_deg();
+  float yaw_deg() const;
+  void set_yaw_deg(float value);
+  private:
+  float _internal_yaw_deg() const;
+  void _internal_set_yaw_deg(float value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.offboard.PositionGlobalYaw)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  double lat_deg_;
+  double lon_deg_;
+  float alt_m_;
+  float yaw_deg_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_offboard_2foffboard_2eproto;
+};
+// -------------------------------------------------------------------
+
 class VelocityBodyYawspeed final :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.offboard.VelocityBodyYawspeed) */ {
  public:
@@ -4285,7 +4765,7 @@ class VelocityBodyYawspeed final :
                &_VelocityBodyYawspeed_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    27;
+    30;
 
   friend void swap(VelocityBodyYawspeed& a, VelocityBodyYawspeed& b) {
     a.Swap(&b);
@@ -4457,7 +4937,7 @@ class VelocityNedYaw final :
                &_VelocityNedYaw_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    28;
+    31;
 
   friend void swap(VelocityNedYaw& a, VelocityNedYaw& b) {
     a.Swap(&b);
@@ -4629,7 +5109,7 @@ class AccelerationNed final :
                &_AccelerationNed_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    29;
+    32;
 
   friend void swap(AccelerationNed& a, AccelerationNed& b) {
     a.Swap(&b);
@@ -4790,7 +5270,7 @@ class OffboardResult final :
                &_OffboardResult_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    30;
+    33;
 
   friend void swap(OffboardResult& a, OffboardResult& b) {
     a.Swap(&b);
@@ -5922,6 +6402,194 @@ inline void SetPositionNedResponse::set_allocated_offboard_result(::mavsdk::rpc:
   }
   offboard_result_ = offboard_result;
   // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.offboard.SetPositionNedResponse.offboard_result)
+}
+
+// -------------------------------------------------------------------
+
+// SetPositionGlobalRequest
+
+// .mavsdk.rpc.offboard.PositionGlobalYaw position_global_yaw = 1;
+inline bool SetPositionGlobalRequest::_internal_has_position_global_yaw() const {
+  return this != internal_default_instance() && position_global_yaw_ != nullptr;
+}
+inline bool SetPositionGlobalRequest::has_position_global_yaw() const {
+  return _internal_has_position_global_yaw();
+}
+inline void SetPositionGlobalRequest::clear_position_global_yaw() {
+  if (GetArenaForAllocation() == nullptr && position_global_yaw_ != nullptr) {
+    delete position_global_yaw_;
+  }
+  position_global_yaw_ = nullptr;
+}
+inline const ::mavsdk::rpc::offboard::PositionGlobalYaw& SetPositionGlobalRequest::_internal_position_global_yaw() const {
+  const ::mavsdk::rpc::offboard::PositionGlobalYaw* p = position_global_yaw_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::offboard::PositionGlobalYaw&>(
+      ::mavsdk::rpc::offboard::_PositionGlobalYaw_default_instance_);
+}
+inline const ::mavsdk::rpc::offboard::PositionGlobalYaw& SetPositionGlobalRequest::position_global_yaw() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.offboard.SetPositionGlobalRequest.position_global_yaw)
+  return _internal_position_global_yaw();
+}
+inline void SetPositionGlobalRequest::unsafe_arena_set_allocated_position_global_yaw(
+    ::mavsdk::rpc::offboard::PositionGlobalYaw* position_global_yaw) {
+  if (GetArenaForAllocation() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(position_global_yaw_);
+  }
+  position_global_yaw_ = position_global_yaw;
+  if (position_global_yaw) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.offboard.SetPositionGlobalRequest.position_global_yaw)
+}
+inline ::mavsdk::rpc::offboard::PositionGlobalYaw* SetPositionGlobalRequest::release_position_global_yaw() {
+  
+  ::mavsdk::rpc::offboard::PositionGlobalYaw* temp = position_global_yaw_;
+  position_global_yaw_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
+  temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  if (GetArenaForAllocation() == nullptr) { delete old; }
+#else  // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArenaForAllocation() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return temp;
+}
+inline ::mavsdk::rpc::offboard::PositionGlobalYaw* SetPositionGlobalRequest::unsafe_arena_release_position_global_yaw() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.offboard.SetPositionGlobalRequest.position_global_yaw)
+  
+  ::mavsdk::rpc::offboard::PositionGlobalYaw* temp = position_global_yaw_;
+  position_global_yaw_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::offboard::PositionGlobalYaw* SetPositionGlobalRequest::_internal_mutable_position_global_yaw() {
+  
+  if (position_global_yaw_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::offboard::PositionGlobalYaw>(GetArenaForAllocation());
+    position_global_yaw_ = p;
+  }
+  return position_global_yaw_;
+}
+inline ::mavsdk::rpc::offboard::PositionGlobalYaw* SetPositionGlobalRequest::mutable_position_global_yaw() {
+  ::mavsdk::rpc::offboard::PositionGlobalYaw* _msg = _internal_mutable_position_global_yaw();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.offboard.SetPositionGlobalRequest.position_global_yaw)
+  return _msg;
+}
+inline void SetPositionGlobalRequest::set_allocated_position_global_yaw(::mavsdk::rpc::offboard::PositionGlobalYaw* position_global_yaw) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
+  if (message_arena == nullptr) {
+    delete position_global_yaw_;
+  }
+  if (position_global_yaw) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper<::mavsdk::rpc::offboard::PositionGlobalYaw>::GetOwningArena(position_global_yaw);
+    if (message_arena != submessage_arena) {
+      position_global_yaw = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, position_global_yaw, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  position_global_yaw_ = position_global_yaw;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.offboard.SetPositionGlobalRequest.position_global_yaw)
+}
+
+// -------------------------------------------------------------------
+
+// SetPositionGlobalResponse
+
+// .mavsdk.rpc.offboard.OffboardResult offboard_result = 1;
+inline bool SetPositionGlobalResponse::_internal_has_offboard_result() const {
+  return this != internal_default_instance() && offboard_result_ != nullptr;
+}
+inline bool SetPositionGlobalResponse::has_offboard_result() const {
+  return _internal_has_offboard_result();
+}
+inline void SetPositionGlobalResponse::clear_offboard_result() {
+  if (GetArenaForAllocation() == nullptr && offboard_result_ != nullptr) {
+    delete offboard_result_;
+  }
+  offboard_result_ = nullptr;
+}
+inline const ::mavsdk::rpc::offboard::OffboardResult& SetPositionGlobalResponse::_internal_offboard_result() const {
+  const ::mavsdk::rpc::offboard::OffboardResult* p = offboard_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::offboard::OffboardResult&>(
+      ::mavsdk::rpc::offboard::_OffboardResult_default_instance_);
+}
+inline const ::mavsdk::rpc::offboard::OffboardResult& SetPositionGlobalResponse::offboard_result() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.offboard.SetPositionGlobalResponse.offboard_result)
+  return _internal_offboard_result();
+}
+inline void SetPositionGlobalResponse::unsafe_arena_set_allocated_offboard_result(
+    ::mavsdk::rpc::offboard::OffboardResult* offboard_result) {
+  if (GetArenaForAllocation() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(offboard_result_);
+  }
+  offboard_result_ = offboard_result;
+  if (offboard_result) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.offboard.SetPositionGlobalResponse.offboard_result)
+}
+inline ::mavsdk::rpc::offboard::OffboardResult* SetPositionGlobalResponse::release_offboard_result() {
+  
+  ::mavsdk::rpc::offboard::OffboardResult* temp = offboard_result_;
+  offboard_result_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
+  temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  if (GetArenaForAllocation() == nullptr) { delete old; }
+#else  // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArenaForAllocation() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return temp;
+}
+inline ::mavsdk::rpc::offboard::OffboardResult* SetPositionGlobalResponse::unsafe_arena_release_offboard_result() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.offboard.SetPositionGlobalResponse.offboard_result)
+  
+  ::mavsdk::rpc::offboard::OffboardResult* temp = offboard_result_;
+  offboard_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::offboard::OffboardResult* SetPositionGlobalResponse::_internal_mutable_offboard_result() {
+  
+  if (offboard_result_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::offboard::OffboardResult>(GetArenaForAllocation());
+    offboard_result_ = p;
+  }
+  return offboard_result_;
+}
+inline ::mavsdk::rpc::offboard::OffboardResult* SetPositionGlobalResponse::mutable_offboard_result() {
+  ::mavsdk::rpc::offboard::OffboardResult* _msg = _internal_mutable_offboard_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.offboard.SetPositionGlobalResponse.offboard_result)
+  return _msg;
+}
+inline void SetPositionGlobalResponse::set_allocated_offboard_result(::mavsdk::rpc::offboard::OffboardResult* offboard_result) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
+  if (message_arena == nullptr) {
+    delete offboard_result_;
+  }
+  if (offboard_result) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper<::mavsdk::rpc::offboard::OffboardResult>::GetOwningArena(offboard_result);
+    if (message_arena != submessage_arena) {
+      offboard_result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, offboard_result, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  offboard_result_ = offboard_result;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.offboard.SetPositionGlobalResponse.offboard_result)
 }
 
 // -------------------------------------------------------------------
@@ -7115,6 +7783,90 @@ inline void PositionNedYaw::set_yaw_deg(float value) {
 
 // -------------------------------------------------------------------
 
+// PositionGlobalYaw
+
+// double lat_deg = 1;
+inline void PositionGlobalYaw::clear_lat_deg() {
+  lat_deg_ = 0;
+}
+inline double PositionGlobalYaw::_internal_lat_deg() const {
+  return lat_deg_;
+}
+inline double PositionGlobalYaw::lat_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.offboard.PositionGlobalYaw.lat_deg)
+  return _internal_lat_deg();
+}
+inline void PositionGlobalYaw::_internal_set_lat_deg(double value) {
+  
+  lat_deg_ = value;
+}
+inline void PositionGlobalYaw::set_lat_deg(double value) {
+  _internal_set_lat_deg(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.offboard.PositionGlobalYaw.lat_deg)
+}
+
+// double lon_deg = 2;
+inline void PositionGlobalYaw::clear_lon_deg() {
+  lon_deg_ = 0;
+}
+inline double PositionGlobalYaw::_internal_lon_deg() const {
+  return lon_deg_;
+}
+inline double PositionGlobalYaw::lon_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.offboard.PositionGlobalYaw.lon_deg)
+  return _internal_lon_deg();
+}
+inline void PositionGlobalYaw::_internal_set_lon_deg(double value) {
+  
+  lon_deg_ = value;
+}
+inline void PositionGlobalYaw::set_lon_deg(double value) {
+  _internal_set_lon_deg(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.offboard.PositionGlobalYaw.lon_deg)
+}
+
+// float alt_m = 3;
+inline void PositionGlobalYaw::clear_alt_m() {
+  alt_m_ = 0;
+}
+inline float PositionGlobalYaw::_internal_alt_m() const {
+  return alt_m_;
+}
+inline float PositionGlobalYaw::alt_m() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.offboard.PositionGlobalYaw.alt_m)
+  return _internal_alt_m();
+}
+inline void PositionGlobalYaw::_internal_set_alt_m(float value) {
+  
+  alt_m_ = value;
+}
+inline void PositionGlobalYaw::set_alt_m(float value) {
+  _internal_set_alt_m(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.offboard.PositionGlobalYaw.alt_m)
+}
+
+// float yaw_deg = 4;
+inline void PositionGlobalYaw::clear_yaw_deg() {
+  yaw_deg_ = 0;
+}
+inline float PositionGlobalYaw::_internal_yaw_deg() const {
+  return yaw_deg_;
+}
+inline float PositionGlobalYaw::yaw_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.offboard.PositionGlobalYaw.yaw_deg)
+  return _internal_yaw_deg();
+}
+inline void PositionGlobalYaw::_internal_set_yaw_deg(float value) {
+  
+  yaw_deg_ = value;
+}
+inline void PositionGlobalYaw::set_yaw_deg(float value) {
+  _internal_set_yaw_deg(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.offboard.PositionGlobalYaw.yaw_deg)
+}
+
+// -------------------------------------------------------------------
+
 // VelocityBodyYawspeed
 
 // float forward_m_s = 1;
@@ -7418,6 +8170,12 @@ inline void OffboardResult::set_allocated_result_str(std::string* result_str) {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/src/plugins/offboard/include/plugins/offboard/offboard.h
+++ b/src/plugins/offboard/include/plugins/offboard/offboard.h
@@ -205,6 +205,34 @@ public:
     operator<<(std::ostream& str, Offboard::PositionNedYaw const& position_ned_yaw);
 
     /**
+     * @brief Type for position commands in Global (Latitude, Longitude, Altitude) coordinates and
+     * yaw.
+     */
+    struct PositionGlobalYaw {
+        double lat_deg{}; /**< @brief Latitude (in degrees) */
+        double lon_deg{}; /**< @brief Longitude (in degrees) */
+        float alt_m{}; /**< @brief altitude (in metres) */
+        float yaw_deg{}; /**< @brief Yaw in degrees (0 North, positive is clock-wise looking from
+                            above) */
+    };
+
+    /**
+     * @brief Equal operator to compare two `Offboard::PositionGlobalYaw` objects.
+     *
+     * @return `true` if items are equal.
+     */
+    friend bool
+    operator==(const Offboard::PositionGlobalYaw& lhs, const Offboard::PositionGlobalYaw& rhs);
+
+    /**
+     * @brief Stream operator to print information about a `Offboard::PositionGlobalYaw`.
+     *
+     * @return A reference to the stream.
+     */
+    friend std::ostream&
+    operator<<(std::ostream& str, Offboard::PositionGlobalYaw const& position_global_yaw);
+
+    /**
      * @brief Type for velocity commands in body coordinates.
      */
     struct VelocityBodyYawspeed {
@@ -395,6 +423,15 @@ public:
      * @return Result of request.
      */
     Result set_position_ned(PositionNedYaw position_ned_yaw) const;
+
+    /**
+     * @brief Set the position in Global coordinates and yaw.
+     *
+     * This function is blocking.
+     *
+     * @return Result of request.
+     */
+    Result set_position_global(PositionGlobalYaw position_global_yaw) const;
 
     /**
      * @brief Set the velocity in body coordinates and yaw angular rate. Not available for

--- a/src/plugins/offboard/mocks/offboard_mock.h
+++ b/src/plugins/offboard/mocks/offboard_mock.h
@@ -13,6 +13,7 @@ public:
     MOCK_CONST_METHOD1(set_attitude, Offboard::Result(Offboard::Attitude)){};
     MOCK_CONST_METHOD1(set_attitude_rate, Offboard::Result(Offboard::AttitudeRate)){};
     MOCK_CONST_METHOD1(set_position_ned, Offboard::Result(Offboard::PositionNedYaw)){};
+    MOCK_CONST_METHOD1(set_position_global, Offboard::Result(Offboard::PositionGlobalYaw)){};
     MOCK_CONST_METHOD1(set_velocity_body, Offboard::Result(Offboard::VelocityBodyYawspeed)){};
     MOCK_CONST_METHOD1(set_velocity_ned, Offboard::Result(Offboard::VelocityNedYaw)){};
     MOCK_CONST_METHOD2(

--- a/src/plugins/offboard/offboard.cpp
+++ b/src/plugins/offboard/offboard.cpp
@@ -14,6 +14,7 @@ using ActuatorControlGroup = Offboard::ActuatorControlGroup;
 using ActuatorControl = Offboard::ActuatorControl;
 using AttitudeRate = Offboard::AttitudeRate;
 using PositionNedYaw = Offboard::PositionNedYaw;
+using PositionGlobalYaw = Offboard::PositionGlobalYaw;
 using VelocityBodyYawspeed = Offboard::VelocityBodyYawspeed;
 using VelocityNedYaw = Offboard::VelocityNedYaw;
 using AccelerationNed = Offboard::AccelerationNed;
@@ -70,6 +71,11 @@ Offboard::Result Offboard::set_attitude_rate(AttitudeRate attitude_rate) const
 Offboard::Result Offboard::set_position_ned(PositionNedYaw position_ned_yaw) const
 {
     return _impl->set_position_ned(position_ned_yaw);
+}
+
+Offboard::Result Offboard::set_position_global(PositionGlobalYaw position_global_yaw) const
+{
+    return _impl->set_position_global(position_global_yaw);
 }
 
 Offboard::Result Offboard::set_velocity_body(VelocityBodyYawspeed velocity_body_yawspeed) const
@@ -196,6 +202,26 @@ std::ostream& operator<<(std::ostream& str, Offboard::PositionNedYaw const& posi
     str << "    east_m: " << position_ned_yaw.east_m << '\n';
     str << "    down_m: " << position_ned_yaw.down_m << '\n';
     str << "    yaw_deg: " << position_ned_yaw.yaw_deg << '\n';
+    str << '}';
+    return str;
+}
+
+bool operator==(const Offboard::PositionGlobalYaw& lhs, const Offboard::PositionGlobalYaw& rhs)
+{
+    return ((std::isnan(rhs.lat_deg) && std::isnan(lhs.lat_deg)) || rhs.lat_deg == lhs.lat_deg) &&
+           ((std::isnan(rhs.lon_deg) && std::isnan(lhs.lon_deg)) || rhs.lon_deg == lhs.lon_deg) &&
+           ((std::isnan(rhs.alt_m) && std::isnan(lhs.alt_m)) || rhs.alt_m == lhs.alt_m) &&
+           ((std::isnan(rhs.yaw_deg) && std::isnan(lhs.yaw_deg)) || rhs.yaw_deg == lhs.yaw_deg);
+}
+
+std::ostream& operator<<(std::ostream& str, Offboard::PositionGlobalYaw const& position_global_yaw)
+{
+    str << std::setprecision(15);
+    str << "position_global_yaw:" << '\n' << "{\n";
+    str << "    lat_deg: " << position_global_yaw.lat_deg << '\n';
+    str << "    lon_deg: " << position_global_yaw.lon_deg << '\n';
+    str << "    alt_m: " << position_global_yaw.alt_m << '\n';
+    str << "    yaw_deg: " << position_global_yaw.yaw_deg << '\n';
     str << '}';
     return str;
 }

--- a/src/plugins/offboard/offboard_impl.h
+++ b/src/plugins/offboard/offboard_impl.h
@@ -30,6 +30,7 @@ public:
     bool is_active();
 
     Offboard::Result set_position_ned(Offboard::PositionNedYaw position_ned_yaw);
+    Offboard::Result set_position_global(Offboard::PositionGlobalYaw position_global_yaw);
     Offboard::Result set_velocity_ned(Offboard::VelocityNedYaw velocity_ned_yaw);
     Offboard::Result set_position_velocity_ned(
         Offboard::PositionNedYaw position_ned_yaw, Offboard::VelocityNedYaw velocity_ned_yaw);
@@ -44,6 +45,7 @@ public:
 
 private:
     Offboard::Result send_position_ned();
+    Offboard::Result send_position_global();
     Offboard::Result send_velocity_ned();
     Offboard::Result send_position_velocity_ned();
     Offboard::Result send_acceleration_ned();
@@ -68,6 +70,8 @@ private:
     enum class Mode {
         NotActive,
         PositionNed,
+        // PositionGlobalAMSL,
+        PositionGlobalAltRel,
         VelocityNed,
         PositionVelocityNed,
         AccelerationNed,
@@ -77,6 +81,7 @@ private:
         ActuatorControl
     } _mode = Mode::NotActive;
     Offboard::PositionNedYaw _position_ned_yaw{};
+    Offboard::PositionGlobalYaw _position_global_yaw{};
     Offboard::VelocityNedYaw _velocity_ned_yaw{};
     Offboard::AccelerationNed _acceleration_ned{};
     Offboard::VelocityBodyYawspeed _velocity_body_yawspeed{};


### PR DESCRIPTION
Offboard global position control using [SET_POSITION_TARGET_GLOBAL_INT](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_GLOBAL_INT), (latitude, longitude, altitude relative from home, and yaw).

Tested successfully in [sih](https://docs.px4.io/v1.12/en/simulation/simulation-in-hardware.html) simulator with a quad and a fw.

Proto is in [PR-264](https://github.com/mavlink/MAVSDK-Proto/pull/264)

Resolves #939 