### PR TITLE
Fix battery voltage

### DIFF
--- a/src/plugins/telemetry/telemetry_impl.cpp
+++ b/src/plugins/telemetry/telemetry_impl.cpp
@@ -1076,7 +1076,13 @@ void TelemetryImpl::process_battery_status(const mavlink_message_t& message)
 
     Telemetry::Battery new_battery;
     new_battery.id = bat_status.id;
-    new_battery.voltage_v = bat_status.voltages[0] * 1e-3f;
+    new_battery.voltage_v = 0.0f;
+    for (int i = 0; i < 10; i++)
+    {
+        if (bat_status.voltages[i] == UINT16_MAX)
+            break;
+        new_battery.voltage_v += static_cast<float>(bat_status.voltages[i]) * 1e-3f;
+    }
     // FIXME: it is strange calling it percent when the range goes from 0 to 1.
     new_battery.remaining_percent = bat_status.battery_remaining * 1e-2f;
 

--- a/src/plugins/telemetry/telemetry_impl.cpp
+++ b/src/plugins/telemetry/telemetry_impl.cpp
@@ -1077,8 +1077,7 @@ void TelemetryImpl::process_battery_status(const mavlink_message_t& message)
     Telemetry::Battery new_battery;
     new_battery.id = bat_status.id;
     new_battery.voltage_v = 0.0f;
-    for (int i = 0; i < 10; i++)
-    {
+    for (int i = 0; i < 255; i++) {
         if (bat_status.voltages[i] == UINT16_MAX)
             break;
         new_battery.voltage_v += static_cast<float>(bat_status.voltages[i]) * 1e-3f;


### PR DESCRIPTION
Battery voltage is reported as 3.x volt on a 4S battery. This is typically one cell only.  Sum the voltage of all cells to obtain the total battery voltage.