### PR TITLE
Do not cancel SITL jobs in CI, even if another one failed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -548,6 +548,7 @@ jobs:
     strategy:
       matrix:
         px4_version: [v1.9, v1.10]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2
         with:
@@ -562,6 +563,7 @@ jobs:
     strategy:
       matrix:
         px4_version: [v1.11, v1.12]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Most of the time SITL failures are independent from the PR, so it seems interesting to always run all of them (instead of cancelling all the matrix when one job fails).