### PR TITLE
Set CFBundleShortVersionString correctly

### DIFF
--- a/src/mavsdk_server/cmake/MacOSXFrameworkInfo.plist.in
+++ b/src/mavsdk_server/cmake/MacOSXFrameworkInfo.plist.in
@@ -17,7 +17,7 @@
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>CFBundleShortVersionString</key>
-    <string>${VERSION_STR}</string>
+    <string>${MAVSDK_VERSION_STRING}</string>
     <key>DTSDKName</key>
     <string>iphoneos10.0</string>
     <key>MinimumOSVersion</key>


### PR DESCRIPTION
We keep getting these errors (inconsistently) in the CI:

```
2021-11-17T22:59:29.0090500Z Copying OS X content src/mavsdk_server/src/mavsdk_server.framework/Versions/903813c0.903813c0.903813c0/Headers/mavsdk_server_api.h
2021-11-17T22:59:29.0307080Z Copying OS X content src/mavsdk_server/src/mavsdk_server.framework/Versions/903813c0.903813c0.903813c0/Modules/module.modulemap
2021-11-17T22:59:41.4030010Z [ 97%] Linking CXX shared library mavsdk_server.framework/mavsdk_server
2021-11-17T22:59:41.4355590Z ld: malformed 32-bit x.y.z version number: 903813.0.0
```

903813 is the beginning of the hash of that commit. Purely guessing, but I'm hoping that this has to do with the plist file.