### PR TITLE
Soft remove gimbal v1 and always use v2

### DIFF
--- a/src/core/request_message.cpp
+++ b/src/core/request_message.cpp
@@ -61,7 +61,8 @@ void RequestMessage::send_request(uint32_t message_id, uint8_t target_component_
     command_request_message.target_component_id = target_component_id;
     command_request_message.params.maybe_param1 = {static_cast<float>(message_id)};
     _command_sender.queue_command_async(
-        command_request_message, [this, message_id](MavlinkCommandSender::Result result, float) {
+        command_request_message,
+        [this, message_id, target_component_id](MavlinkCommandSender::Result result, float) {
             if (result != MavlinkCommandSender::Result::InProgress) {
                 handle_command_result(message_id, target_component_id, result);
             }
@@ -112,7 +113,9 @@ void RequestMessage::handle_command_result(
                 // This is promising, let's hope the message will actually arrive.
                 // We'll set a timeout in case we need to retry.
                 _timeout_handler.add(
-                    [this, message_id]() { handle_timeout(message_id, target_component_id); },
+                    [this, message_id, target_component_id]() {
+                        handle_timeout(message_id, target_component_id);
+                    },
                     1.0,
                     &it->timeout_cookie);
                 return;

--- a/src/core/request_message.h
+++ b/src/core/request_message.h
@@ -40,8 +40,9 @@ private:
 
     void send_request(uint32_t message_id, uint8_t target_component_id = MAV_COMP_ID_AUTOPILOT1);
     void handle_any_message(const mavlink_message_t& message);
-    void handle_command_result(uint32_t message_id, MavlinkCommandSender::Result result);
-    void handle_timeout(uint32_t message_id);
+    void handle_command_result(
+        uint32_t message_id, uint8_t target_component_id, MavlinkCommandSender::Result result);
+    void handle_timeout(uint32_t message_id, uint8_t target_component_id);
 
     MavlinkCommandSender& _command_sender;
     MAVLinkMessageHandler& _message_handler;

--- a/src/core/request_message.h
+++ b/src/core/request_message.h
@@ -22,7 +22,11 @@ public:
     using RequestMessageCallback =
         std::function<void(MavlinkCommandSender::Result, const mavlink_message_t&)>;
 
-    void request(uint32_t message_id, RequestMessageCallback callback, uint32_t param2 = 0);
+    void request(
+        uint32_t message_id,
+        RequestMessageCallback callback,
+        uint8_t target_component_id = MAV_COMP_ID_AUTOPILOT1,
+        uint32_t param2 = 0);
 
 private:
     struct WorkItem {
@@ -34,7 +38,7 @@ private:
         std::optional<MavlinkCommandSender::Result> maybe_result{};
     };
 
-    void send_request(uint32_t message_id);
+    void send_request(uint32_t message_id, uint8_t target_component_id = MAV_COMP_ID_AUTOPILOT1);
     void handle_any_message(const mavlink_message_t& message);
     void handle_command_result(uint32_t message_id, MavlinkCommandSender::Result result);
     void handle_timeout(uint32_t message_id);

--- a/src/mavsdk_server/src/generated/gimbal/gimbal.grpc.pb.cc
+++ b/src/mavsdk_server/src/generated/gimbal/gimbal.grpc.pb.cc
@@ -24,6 +24,7 @@ namespace rpc {
 namespace gimbal {
 
 static const char* GimbalService_method_names[] = {
+  "/mavsdk.rpc.gimbal.GimbalService/Prepare",
   "/mavsdk.rpc.gimbal.GimbalService/SetPitchAndYaw",
   "/mavsdk.rpc.gimbal.GimbalService/SetPitchRateAndYawRate",
   "/mavsdk.rpc.gimbal.GimbalService/SetMode",
@@ -40,14 +41,38 @@ std::unique_ptr< GimbalService::Stub> GimbalService::NewStub(const std::shared_p
 }
 
 GimbalService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options)
-  : channel_(channel), rpcmethod_SetPitchAndYaw_(GimbalService_method_names[0], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetPitchRateAndYawRate_(GimbalService_method_names[1], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetMode_(GimbalService_method_names[2], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRoiLocation_(GimbalService_method_names[3], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_TakeControl_(GimbalService_method_names[4], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ReleaseControl_(GimbalService_method_names[5], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SubscribeControl_(GimbalService_method_names[6], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  : channel_(channel), rpcmethod_Prepare_(GimbalService_method_names[0], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetPitchAndYaw_(GimbalService_method_names[1], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetPitchRateAndYawRate_(GimbalService_method_names[2], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetMode_(GimbalService_method_names[3], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRoiLocation_(GimbalService_method_names[4], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_TakeControl_(GimbalService_method_names[5], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ReleaseControl_(GimbalService_method_names[6], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubscribeControl_(GimbalService_method_names[7], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
   {}
+
+::grpc::Status GimbalService::Stub::Prepare(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest& request, ::mavsdk::rpc::gimbal::PrepareResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::gimbal::PrepareRequest, ::mavsdk::rpc::gimbal::PrepareResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_Prepare_, context, request, response);
+}
+
+void GimbalService::Stub::async::Prepare(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest* request, ::mavsdk::rpc::gimbal::PrepareResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::gimbal::PrepareRequest, ::mavsdk::rpc::gimbal::PrepareResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_Prepare_, context, request, response, std::move(f));
+}
+
+void GimbalService::Stub::async::Prepare(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest* request, ::mavsdk::rpc::gimbal::PrepareResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_Prepare_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::PrepareResponse>* GimbalService::Stub::PrepareAsyncPrepareRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::gimbal::PrepareResponse, ::mavsdk::rpc::gimbal::PrepareRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_Prepare_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::PrepareResponse>* GimbalService::Stub::AsyncPrepareRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncPrepareRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
 
 ::grpc::Status GimbalService::Stub::SetPitchAndYaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest& request, ::mavsdk::rpc::gimbal::SetPitchAndYawResponse* response) {
   return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::gimbal::SetPitchAndYawRequest, ::mavsdk::rpc::gimbal::SetPitchAndYawResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_SetPitchAndYaw_, context, request, response);
@@ -207,6 +232,16 @@ GimbalService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       GimbalService_method_names[0],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< GimbalService::Service, ::mavsdk::rpc::gimbal::PrepareRequest, ::mavsdk::rpc::gimbal::PrepareResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](GimbalService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::gimbal::PrepareRequest* req,
+             ::mavsdk::rpc::gimbal::PrepareResponse* resp) {
+               return service->Prepare(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      GimbalService_method_names[1],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< GimbalService::Service, ::mavsdk::rpc::gimbal::SetPitchAndYawRequest, ::mavsdk::rpc::gimbal::SetPitchAndYawResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](GimbalService::Service* service,
              ::grpc::ServerContext* ctx,
@@ -215,7 +250,7 @@ GimbalService::Service::Service() {
                return service->SetPitchAndYaw(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      GimbalService_method_names[1],
+      GimbalService_method_names[2],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< GimbalService::Service, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](GimbalService::Service* service,
@@ -225,7 +260,7 @@ GimbalService::Service::Service() {
                return service->SetPitchRateAndYawRate(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      GimbalService_method_names[2],
+      GimbalService_method_names[3],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< GimbalService::Service, ::mavsdk::rpc::gimbal::SetModeRequest, ::mavsdk::rpc::gimbal::SetModeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](GimbalService::Service* service,
@@ -235,7 +270,7 @@ GimbalService::Service::Service() {
                return service->SetMode(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      GimbalService_method_names[3],
+      GimbalService_method_names[4],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< GimbalService::Service, ::mavsdk::rpc::gimbal::SetRoiLocationRequest, ::mavsdk::rpc::gimbal::SetRoiLocationResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](GimbalService::Service* service,
@@ -245,7 +280,7 @@ GimbalService::Service::Service() {
                return service->SetRoiLocation(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      GimbalService_method_names[4],
+      GimbalService_method_names[5],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< GimbalService::Service, ::mavsdk::rpc::gimbal::TakeControlRequest, ::mavsdk::rpc::gimbal::TakeControlResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](GimbalService::Service* service,
@@ -255,7 +290,7 @@ GimbalService::Service::Service() {
                return service->TakeControl(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      GimbalService_method_names[5],
+      GimbalService_method_names[6],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< GimbalService::Service, ::mavsdk::rpc::gimbal::ReleaseControlRequest, ::mavsdk::rpc::gimbal::ReleaseControlResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](GimbalService::Service* service,
@@ -265,7 +300,7 @@ GimbalService::Service::Service() {
                return service->ReleaseControl(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      GimbalService_method_names[6],
+      GimbalService_method_names[7],
       ::grpc::internal::RpcMethod::SERVER_STREAMING,
       new ::grpc::internal::ServerStreamingHandler< GimbalService::Service, ::mavsdk::rpc::gimbal::SubscribeControlRequest, ::mavsdk::rpc::gimbal::ControlResponse>(
           [](GimbalService::Service* service,
@@ -277,6 +312,13 @@ GimbalService::Service::Service() {
 }
 
 GimbalService::Service::~Service() {
+}
+
+::grpc::Status GimbalService::Service::Prepare(::grpc::ServerContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest* request, ::mavsdk::rpc::gimbal::PrepareResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
 ::grpc::Status GimbalService::Service::SetPitchAndYaw(::grpc::ServerContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest* request, ::mavsdk::rpc::gimbal::SetPitchAndYawResponse* response) {

--- a/src/mavsdk_server/src/generated/gimbal/gimbal.grpc.pb.h
+++ b/src/mavsdk_server/src/generated/gimbal/gimbal.grpc.pb.h
@@ -39,6 +39,15 @@ class GimbalService final {
    public:
     virtual ~StubInterface() {}
     //
+    // Prepare the gimbal plugin. Must be called before the plugin can be used.
+    virtual ::grpc::Status Prepare(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest& request, ::mavsdk::rpc::gimbal::PrepareResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::PrepareResponse>> AsyncPrepare(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::PrepareResponse>>(AsyncPrepareRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::PrepareResponse>> PrepareAsyncPrepare(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::PrepareResponse>>(PrepareAsyncPrepareRaw(context, request, cq));
+    }
+    //
     //
     // Set gimbal pitch and yaw angles.
     //
@@ -141,6 +150,10 @@ class GimbalService final {
      public:
       virtual ~async_interface() {}
       //
+      // Prepare the gimbal plugin. Must be called before the plugin can be used.
+      virtual void Prepare(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest* request, ::mavsdk::rpc::gimbal::PrepareResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void Prepare(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest* request, ::mavsdk::rpc::gimbal::PrepareResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      //
       //
       // Set gimbal pitch and yaw angles.
       //
@@ -206,6 +219,8 @@ class GimbalService final {
     virtual class async_interface* async() { return nullptr; }
     class async_interface* experimental_async() { return async(); }
   private:
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::PrepareResponse>* AsyncPrepareRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::PrepareResponse>* PrepareAsyncPrepareRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::SetPitchAndYawResponse>* AsyncSetPitchAndYawRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::SetPitchAndYawResponse>* PrepareAsyncSetPitchAndYawRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>* AsyncSetPitchRateAndYawRateRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest& request, ::grpc::CompletionQueue* cq) = 0;
@@ -225,6 +240,13 @@ class GimbalService final {
   class Stub final : public StubInterface {
    public:
     Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
+    ::grpc::Status Prepare(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest& request, ::mavsdk::rpc::gimbal::PrepareResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::PrepareResponse>> AsyncPrepare(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::PrepareResponse>>(AsyncPrepareRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::PrepareResponse>> PrepareAsyncPrepare(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::PrepareResponse>>(PrepareAsyncPrepareRaw(context, request, cq));
+    }
     ::grpc::Status SetPitchAndYaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest& request, ::mavsdk::rpc::gimbal::SetPitchAndYawResponse* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetPitchAndYawResponse>> AsyncSetPitchAndYaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetPitchAndYawResponse>>(AsyncSetPitchAndYawRaw(context, request, cq));
@@ -279,6 +301,8 @@ class GimbalService final {
     class async final :
       public StubInterface::async_interface {
      public:
+      void Prepare(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest* request, ::mavsdk::rpc::gimbal::PrepareResponse* response, std::function<void(::grpc::Status)>) override;
+      void Prepare(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest* request, ::mavsdk::rpc::gimbal::PrepareResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void SetPitchAndYaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest* request, ::mavsdk::rpc::gimbal::SetPitchAndYawResponse* response, std::function<void(::grpc::Status)>) override;
       void SetPitchAndYaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest* request, ::mavsdk::rpc::gimbal::SetPitchAndYawResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void SetPitchRateAndYawRate(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* request, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* response, std::function<void(::grpc::Status)>) override;
@@ -303,6 +327,8 @@ class GimbalService final {
    private:
     std::shared_ptr< ::grpc::ChannelInterface> channel_;
     class async async_stub_{this};
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::PrepareResponse>* AsyncPrepareRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::PrepareResponse>* PrepareAsyncPrepareRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetPitchAndYawResponse>* AsyncSetPitchAndYawRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetPitchAndYawResponse>* PrepareAsyncSetPitchAndYawRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>* AsyncSetPitchRateAndYawRateRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest& request, ::grpc::CompletionQueue* cq) override;
@@ -318,6 +344,7 @@ class GimbalService final {
     ::grpc::ClientReader< ::mavsdk::rpc::gimbal::ControlResponse>* SubscribeControlRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SubscribeControlRequest& request) override;
     ::grpc::ClientAsyncReader< ::mavsdk::rpc::gimbal::ControlResponse>* AsyncSubscribeControlRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SubscribeControlRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
     ::grpc::ClientAsyncReader< ::mavsdk::rpc::gimbal::ControlResponse>* PrepareAsyncSubscribeControlRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::gimbal::SubscribeControlRequest& request, ::grpc::CompletionQueue* cq) override;
+    const ::grpc::internal::RpcMethod rpcmethod_Prepare_;
     const ::grpc::internal::RpcMethod rpcmethod_SetPitchAndYaw_;
     const ::grpc::internal::RpcMethod rpcmethod_SetPitchRateAndYawRate_;
     const ::grpc::internal::RpcMethod rpcmethod_SetMode_;
@@ -332,6 +359,9 @@ class GimbalService final {
    public:
     Service();
     virtual ~Service();
+    //
+    // Prepare the gimbal plugin. Must be called before the plugin can be used.
+    virtual ::grpc::Status Prepare(::grpc::ServerContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest* request, ::mavsdk::rpc::gimbal::PrepareResponse* response);
     //
     //
     // Set gimbal pitch and yaw angles.
@@ -389,12 +419,32 @@ class GimbalService final {
     virtual ::grpc::Status SubscribeControl(::grpc::ServerContext* context, const ::mavsdk::rpc::gimbal::SubscribeControlRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::gimbal::ControlResponse>* writer);
   };
   template <class BaseClass>
+  class WithAsyncMethod_Prepare : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_Prepare() {
+      ::grpc::Service::MarkMethodAsync(0);
+    }
+    ~WithAsyncMethod_Prepare() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Prepare(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::gimbal::PrepareRequest* /*request*/, ::mavsdk::rpc::gimbal::PrepareResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestPrepare(::grpc::ServerContext* context, ::mavsdk::rpc::gimbal::PrepareRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::gimbal::PrepareResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(0, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithAsyncMethod_SetPitchAndYaw : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetPitchAndYaw() {
-      ::grpc::Service::MarkMethodAsync(0);
+      ::grpc::Service::MarkMethodAsync(1);
     }
     ~WithAsyncMethod_SetPitchAndYaw() override {
       BaseClassMustBeDerivedFromService(this);
@@ -405,7 +455,7 @@ class GimbalService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetPitchAndYaw(::grpc::ServerContext* context, ::mavsdk::rpc::gimbal::SetPitchAndYawRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::gimbal::SetPitchAndYawResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(0, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -414,7 +464,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetPitchRateAndYawRate() {
-      ::grpc::Service::MarkMethodAsync(1);
+      ::grpc::Service::MarkMethodAsync(2);
     }
     ~WithAsyncMethod_SetPitchRateAndYawRate() override {
       BaseClassMustBeDerivedFromService(this);
@@ -425,7 +475,7 @@ class GimbalService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetPitchRateAndYawRate(::grpc::ServerContext* context, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -434,7 +484,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetMode() {
-      ::grpc::Service::MarkMethodAsync(2);
+      ::grpc::Service::MarkMethodAsync(3);
     }
     ~WithAsyncMethod_SetMode() override {
       BaseClassMustBeDerivedFromService(this);
@@ -445,7 +495,7 @@ class GimbalService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetMode(::grpc::ServerContext* context, ::mavsdk::rpc::gimbal::SetModeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::gimbal::SetModeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -454,7 +504,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRoiLocation() {
-      ::grpc::Service::MarkMethodAsync(3);
+      ::grpc::Service::MarkMethodAsync(4);
     }
     ~WithAsyncMethod_SetRoiLocation() override {
       BaseClassMustBeDerivedFromService(this);
@@ -465,7 +515,7 @@ class GimbalService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRoiLocation(::grpc::ServerContext* context, ::mavsdk::rpc::gimbal::SetRoiLocationRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::gimbal::SetRoiLocationResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -474,7 +524,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_TakeControl() {
-      ::grpc::Service::MarkMethodAsync(4);
+      ::grpc::Service::MarkMethodAsync(5);
     }
     ~WithAsyncMethod_TakeControl() override {
       BaseClassMustBeDerivedFromService(this);
@@ -485,7 +535,7 @@ class GimbalService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestTakeControl(::grpc::ServerContext* context, ::mavsdk::rpc::gimbal::TakeControlRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::gimbal::TakeControlResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -494,7 +544,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_ReleaseControl() {
-      ::grpc::Service::MarkMethodAsync(5);
+      ::grpc::Service::MarkMethodAsync(6);
     }
     ~WithAsyncMethod_ReleaseControl() override {
       BaseClassMustBeDerivedFromService(this);
@@ -505,7 +555,7 @@ class GimbalService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestReleaseControl(::grpc::ServerContext* context, ::mavsdk::rpc::gimbal::ReleaseControlRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::gimbal::ReleaseControlResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -514,7 +564,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SubscribeControl() {
-      ::grpc::Service::MarkMethodAsync(6);
+      ::grpc::Service::MarkMethodAsync(7);
     }
     ~WithAsyncMethod_SubscribeControl() override {
       BaseClassMustBeDerivedFromService(this);
@@ -525,23 +575,50 @@ class GimbalService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeControl(::grpc::ServerContext* context, ::mavsdk::rpc::gimbal::SubscribeControlRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::gimbal::ControlResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(6, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(7, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_SetPitchAndYaw<WithAsyncMethod_SetPitchRateAndYawRate<WithAsyncMethod_SetMode<WithAsyncMethod_SetRoiLocation<WithAsyncMethod_TakeControl<WithAsyncMethod_ReleaseControl<WithAsyncMethod_SubscribeControl<Service > > > > > > > AsyncService;
+  typedef WithAsyncMethod_Prepare<WithAsyncMethod_SetPitchAndYaw<WithAsyncMethod_SetPitchRateAndYawRate<WithAsyncMethod_SetMode<WithAsyncMethod_SetRoiLocation<WithAsyncMethod_TakeControl<WithAsyncMethod_ReleaseControl<WithAsyncMethod_SubscribeControl<Service > > > > > > > > AsyncService;
+  template <class BaseClass>
+  class WithCallbackMethod_Prepare : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_Prepare() {
+      ::grpc::Service::MarkMethodCallback(0,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::gimbal::PrepareRequest, ::mavsdk::rpc::gimbal::PrepareResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::gimbal::PrepareRequest* request, ::mavsdk::rpc::gimbal::PrepareResponse* response) { return this->Prepare(context, request, response); }));}
+    void SetMessageAllocatorFor_Prepare(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::gimbal::PrepareRequest, ::mavsdk::rpc::gimbal::PrepareResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(0);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::gimbal::PrepareRequest, ::mavsdk::rpc::gimbal::PrepareResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_Prepare() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Prepare(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::gimbal::PrepareRequest* /*request*/, ::mavsdk::rpc::gimbal::PrepareResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* Prepare(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::gimbal::PrepareRequest* /*request*/, ::mavsdk::rpc::gimbal::PrepareResponse* /*response*/)  { return nullptr; }
+  };
   template <class BaseClass>
   class WithCallbackMethod_SetPitchAndYaw : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetPitchAndYaw() {
-      ::grpc::Service::MarkMethodCallback(0,
+      ::grpc::Service::MarkMethodCallback(1,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::gimbal::SetPitchAndYawRequest, ::mavsdk::rpc::gimbal::SetPitchAndYawResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::gimbal::SetPitchAndYawRequest* request, ::mavsdk::rpc::gimbal::SetPitchAndYawResponse* response) { return this->SetPitchAndYaw(context, request, response); }));}
     void SetMessageAllocatorFor_SetPitchAndYaw(
         ::grpc::MessageAllocator< ::mavsdk::rpc::gimbal::SetPitchAndYawRequest, ::mavsdk::rpc::gimbal::SetPitchAndYawResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(0);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(1);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::gimbal::SetPitchAndYawRequest, ::mavsdk::rpc::gimbal::SetPitchAndYawResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -562,13 +639,13 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetPitchRateAndYawRate() {
-      ::grpc::Service::MarkMethodCallback(1,
+      ::grpc::Service::MarkMethodCallback(2,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest* request, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse* response) { return this->SetPitchRateAndYawRate(context, request, response); }));}
     void SetMessageAllocatorFor_SetPitchRateAndYawRate(
         ::grpc::MessageAllocator< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(1);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(2);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -589,13 +666,13 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetMode() {
-      ::grpc::Service::MarkMethodCallback(2,
+      ::grpc::Service::MarkMethodCallback(3,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::gimbal::SetModeRequest, ::mavsdk::rpc::gimbal::SetModeResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::gimbal::SetModeRequest* request, ::mavsdk::rpc::gimbal::SetModeResponse* response) { return this->SetMode(context, request, response); }));}
     void SetMessageAllocatorFor_SetMode(
         ::grpc::MessageAllocator< ::mavsdk::rpc::gimbal::SetModeRequest, ::mavsdk::rpc::gimbal::SetModeResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(2);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(3);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::gimbal::SetModeRequest, ::mavsdk::rpc::gimbal::SetModeResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -616,13 +693,13 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetRoiLocation() {
-      ::grpc::Service::MarkMethodCallback(3,
+      ::grpc::Service::MarkMethodCallback(4,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::gimbal::SetRoiLocationRequest, ::mavsdk::rpc::gimbal::SetRoiLocationResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::gimbal::SetRoiLocationRequest* request, ::mavsdk::rpc::gimbal::SetRoiLocationResponse* response) { return this->SetRoiLocation(context, request, response); }));}
     void SetMessageAllocatorFor_SetRoiLocation(
         ::grpc::MessageAllocator< ::mavsdk::rpc::gimbal::SetRoiLocationRequest, ::mavsdk::rpc::gimbal::SetRoiLocationResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(3);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(4);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::gimbal::SetRoiLocationRequest, ::mavsdk::rpc::gimbal::SetRoiLocationResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -643,13 +720,13 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_TakeControl() {
-      ::grpc::Service::MarkMethodCallback(4,
+      ::grpc::Service::MarkMethodCallback(5,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::gimbal::TakeControlRequest, ::mavsdk::rpc::gimbal::TakeControlResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::gimbal::TakeControlRequest* request, ::mavsdk::rpc::gimbal::TakeControlResponse* response) { return this->TakeControl(context, request, response); }));}
     void SetMessageAllocatorFor_TakeControl(
         ::grpc::MessageAllocator< ::mavsdk::rpc::gimbal::TakeControlRequest, ::mavsdk::rpc::gimbal::TakeControlResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(4);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(5);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::gimbal::TakeControlRequest, ::mavsdk::rpc::gimbal::TakeControlResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -670,13 +747,13 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_ReleaseControl() {
-      ::grpc::Service::MarkMethodCallback(5,
+      ::grpc::Service::MarkMethodCallback(6,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::gimbal::ReleaseControlRequest, ::mavsdk::rpc::gimbal::ReleaseControlResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::gimbal::ReleaseControlRequest* request, ::mavsdk::rpc::gimbal::ReleaseControlResponse* response) { return this->ReleaseControl(context, request, response); }));}
     void SetMessageAllocatorFor_ReleaseControl(
         ::grpc::MessageAllocator< ::mavsdk::rpc::gimbal::ReleaseControlRequest, ::mavsdk::rpc::gimbal::ReleaseControlResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(5);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(6);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::gimbal::ReleaseControlRequest, ::mavsdk::rpc::gimbal::ReleaseControlResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -697,7 +774,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SubscribeControl() {
-      ::grpc::Service::MarkMethodCallback(6,
+      ::grpc::Service::MarkMethodCallback(7,
           new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::gimbal::SubscribeControlRequest, ::mavsdk::rpc::gimbal::ControlResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::gimbal::SubscribeControlRequest* request) { return this->SubscribeControl(context, request); }));
@@ -713,15 +790,32 @@ class GimbalService final {
     virtual ::grpc::ServerWriteReactor< ::mavsdk::rpc::gimbal::ControlResponse>* SubscribeControl(
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::gimbal::SubscribeControlRequest* /*request*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_SetPitchAndYaw<WithCallbackMethod_SetPitchRateAndYawRate<WithCallbackMethod_SetMode<WithCallbackMethod_SetRoiLocation<WithCallbackMethod_TakeControl<WithCallbackMethod_ReleaseControl<WithCallbackMethod_SubscribeControl<Service > > > > > > > CallbackService;
+  typedef WithCallbackMethod_Prepare<WithCallbackMethod_SetPitchAndYaw<WithCallbackMethod_SetPitchRateAndYawRate<WithCallbackMethod_SetMode<WithCallbackMethod_SetRoiLocation<WithCallbackMethod_TakeControl<WithCallbackMethod_ReleaseControl<WithCallbackMethod_SubscribeControl<Service > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
+  template <class BaseClass>
+  class WithGenericMethod_Prepare : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_Prepare() {
+      ::grpc::Service::MarkMethodGeneric(0);
+    }
+    ~WithGenericMethod_Prepare() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Prepare(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::gimbal::PrepareRequest* /*request*/, ::mavsdk::rpc::gimbal::PrepareResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
   template <class BaseClass>
   class WithGenericMethod_SetPitchAndYaw : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetPitchAndYaw() {
-      ::grpc::Service::MarkMethodGeneric(0);
+      ::grpc::Service::MarkMethodGeneric(1);
     }
     ~WithGenericMethod_SetPitchAndYaw() override {
       BaseClassMustBeDerivedFromService(this);
@@ -738,7 +832,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetPitchRateAndYawRate() {
-      ::grpc::Service::MarkMethodGeneric(1);
+      ::grpc::Service::MarkMethodGeneric(2);
     }
     ~WithGenericMethod_SetPitchRateAndYawRate() override {
       BaseClassMustBeDerivedFromService(this);
@@ -755,7 +849,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetMode() {
-      ::grpc::Service::MarkMethodGeneric(2);
+      ::grpc::Service::MarkMethodGeneric(3);
     }
     ~WithGenericMethod_SetMode() override {
       BaseClassMustBeDerivedFromService(this);
@@ -772,7 +866,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRoiLocation() {
-      ::grpc::Service::MarkMethodGeneric(3);
+      ::grpc::Service::MarkMethodGeneric(4);
     }
     ~WithGenericMethod_SetRoiLocation() override {
       BaseClassMustBeDerivedFromService(this);
@@ -789,7 +883,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_TakeControl() {
-      ::grpc::Service::MarkMethodGeneric(4);
+      ::grpc::Service::MarkMethodGeneric(5);
     }
     ~WithGenericMethod_TakeControl() override {
       BaseClassMustBeDerivedFromService(this);
@@ -806,7 +900,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_ReleaseControl() {
-      ::grpc::Service::MarkMethodGeneric(5);
+      ::grpc::Service::MarkMethodGeneric(6);
     }
     ~WithGenericMethod_ReleaseControl() override {
       BaseClassMustBeDerivedFromService(this);
@@ -823,7 +917,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SubscribeControl() {
-      ::grpc::Service::MarkMethodGeneric(6);
+      ::grpc::Service::MarkMethodGeneric(7);
     }
     ~WithGenericMethod_SubscribeControl() override {
       BaseClassMustBeDerivedFromService(this);
@@ -835,12 +929,32 @@ class GimbalService final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_Prepare : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_Prepare() {
+      ::grpc::Service::MarkMethodRaw(0);
+    }
+    ~WithRawMethod_Prepare() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Prepare(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::gimbal::PrepareRequest* /*request*/, ::mavsdk::rpc::gimbal::PrepareResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestPrepare(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(0, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithRawMethod_SetPitchAndYaw : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetPitchAndYaw() {
-      ::grpc::Service::MarkMethodRaw(0);
+      ::grpc::Service::MarkMethodRaw(1);
     }
     ~WithRawMethod_SetPitchAndYaw() override {
       BaseClassMustBeDerivedFromService(this);
@@ -851,7 +965,7 @@ class GimbalService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetPitchAndYaw(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(0, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -860,7 +974,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetPitchRateAndYawRate() {
-      ::grpc::Service::MarkMethodRaw(1);
+      ::grpc::Service::MarkMethodRaw(2);
     }
     ~WithRawMethod_SetPitchRateAndYawRate() override {
       BaseClassMustBeDerivedFromService(this);
@@ -871,7 +985,7 @@ class GimbalService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetPitchRateAndYawRate(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -880,7 +994,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetMode() {
-      ::grpc::Service::MarkMethodRaw(2);
+      ::grpc::Service::MarkMethodRaw(3);
     }
     ~WithRawMethod_SetMode() override {
       BaseClassMustBeDerivedFromService(this);
@@ -891,7 +1005,7 @@ class GimbalService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetMode(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -900,7 +1014,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRoiLocation() {
-      ::grpc::Service::MarkMethodRaw(3);
+      ::grpc::Service::MarkMethodRaw(4);
     }
     ~WithRawMethod_SetRoiLocation() override {
       BaseClassMustBeDerivedFromService(this);
@@ -911,7 +1025,7 @@ class GimbalService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRoiLocation(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -920,7 +1034,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_TakeControl() {
-      ::grpc::Service::MarkMethodRaw(4);
+      ::grpc::Service::MarkMethodRaw(5);
     }
     ~WithRawMethod_TakeControl() override {
       BaseClassMustBeDerivedFromService(this);
@@ -931,7 +1045,7 @@ class GimbalService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestTakeControl(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -940,7 +1054,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_ReleaseControl() {
-      ::grpc::Service::MarkMethodRaw(5);
+      ::grpc::Service::MarkMethodRaw(6);
     }
     ~WithRawMethod_ReleaseControl() override {
       BaseClassMustBeDerivedFromService(this);
@@ -951,7 +1065,7 @@ class GimbalService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestReleaseControl(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -960,7 +1074,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SubscribeControl() {
-      ::grpc::Service::MarkMethodRaw(6);
+      ::grpc::Service::MarkMethodRaw(7);
     }
     ~WithRawMethod_SubscribeControl() override {
       BaseClassMustBeDerivedFromService(this);
@@ -971,8 +1085,30 @@ class GimbalService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeControl(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(6, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(7, context, request, writer, new_call_cq, notification_cq, tag);
     }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_Prepare : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_Prepare() {
+      ::grpc::Service::MarkMethodRawCallback(0,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->Prepare(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_Prepare() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Prepare(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::gimbal::PrepareRequest* /*request*/, ::mavsdk::rpc::gimbal::PrepareResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* Prepare(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
   class WithRawCallbackMethod_SetPitchAndYaw : public BaseClass {
@@ -980,7 +1116,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetPitchAndYaw() {
-      ::grpc::Service::MarkMethodRawCallback(0,
+      ::grpc::Service::MarkMethodRawCallback(1,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetPitchAndYaw(context, request, response); }));
@@ -1002,7 +1138,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetPitchRateAndYawRate() {
-      ::grpc::Service::MarkMethodRawCallback(1,
+      ::grpc::Service::MarkMethodRawCallback(2,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetPitchRateAndYawRate(context, request, response); }));
@@ -1024,7 +1160,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetMode() {
-      ::grpc::Service::MarkMethodRawCallback(2,
+      ::grpc::Service::MarkMethodRawCallback(3,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetMode(context, request, response); }));
@@ -1046,7 +1182,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetRoiLocation() {
-      ::grpc::Service::MarkMethodRawCallback(3,
+      ::grpc::Service::MarkMethodRawCallback(4,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetRoiLocation(context, request, response); }));
@@ -1068,7 +1204,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_TakeControl() {
-      ::grpc::Service::MarkMethodRawCallback(4,
+      ::grpc::Service::MarkMethodRawCallback(5,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->TakeControl(context, request, response); }));
@@ -1090,7 +1226,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_ReleaseControl() {
-      ::grpc::Service::MarkMethodRawCallback(5,
+      ::grpc::Service::MarkMethodRawCallback(6,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->ReleaseControl(context, request, response); }));
@@ -1112,7 +1248,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SubscribeControl() {
-      ::grpc::Service::MarkMethodRawCallback(6,
+      ::grpc::Service::MarkMethodRawCallback(7,
           new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeControl(context, request); }));
@@ -1129,12 +1265,39 @@ class GimbalService final {
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithStreamedUnaryMethod_Prepare : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_Prepare() {
+      ::grpc::Service::MarkMethodStreamed(0,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::gimbal::PrepareRequest, ::mavsdk::rpc::gimbal::PrepareResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::gimbal::PrepareRequest, ::mavsdk::rpc::gimbal::PrepareResponse>* streamer) {
+                       return this->StreamedPrepare(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_Prepare() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status Prepare(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::gimbal::PrepareRequest* /*request*/, ::mavsdk::rpc::gimbal::PrepareResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedPrepare(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::gimbal::PrepareRequest,::mavsdk::rpc::gimbal::PrepareResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_SetPitchAndYaw : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetPitchAndYaw() {
-      ::grpc::Service::MarkMethodStreamed(0,
+      ::grpc::Service::MarkMethodStreamed(1,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::gimbal::SetPitchAndYawRequest, ::mavsdk::rpc::gimbal::SetPitchAndYawResponse>(
             [this](::grpc::ServerContext* context,
@@ -1161,7 +1324,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetPitchRateAndYawRate() {
-      ::grpc::Service::MarkMethodStreamed(1,
+      ::grpc::Service::MarkMethodStreamed(2,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest, ::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse>(
             [this](::grpc::ServerContext* context,
@@ -1188,7 +1351,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetMode() {
-      ::grpc::Service::MarkMethodStreamed(2,
+      ::grpc::Service::MarkMethodStreamed(3,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::gimbal::SetModeRequest, ::mavsdk::rpc::gimbal::SetModeResponse>(
             [this](::grpc::ServerContext* context,
@@ -1215,7 +1378,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRoiLocation() {
-      ::grpc::Service::MarkMethodStreamed(3,
+      ::grpc::Service::MarkMethodStreamed(4,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::gimbal::SetRoiLocationRequest, ::mavsdk::rpc::gimbal::SetRoiLocationResponse>(
             [this](::grpc::ServerContext* context,
@@ -1242,7 +1405,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_TakeControl() {
-      ::grpc::Service::MarkMethodStreamed(4,
+      ::grpc::Service::MarkMethodStreamed(5,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::gimbal::TakeControlRequest, ::mavsdk::rpc::gimbal::TakeControlResponse>(
             [this](::grpc::ServerContext* context,
@@ -1269,7 +1432,7 @@ class GimbalService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_ReleaseControl() {
-      ::grpc::Service::MarkMethodStreamed(5,
+      ::grpc::Service::MarkMethodStreamed(6,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::gimbal::ReleaseControlRequest, ::mavsdk::rpc::gimbal::ReleaseControlResponse>(
             [this](::grpc::ServerContext* context,
@@ -1290,14 +1453,14 @@ class GimbalService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedReleaseControl(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::gimbal::ReleaseControlRequest,::mavsdk::rpc::gimbal::ReleaseControlResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_SetPitchAndYaw<WithStreamedUnaryMethod_SetPitchRateAndYawRate<WithStreamedUnaryMethod_SetMode<WithStreamedUnaryMethod_SetRoiLocation<WithStreamedUnaryMethod_TakeControl<WithStreamedUnaryMethod_ReleaseControl<Service > > > > > > StreamedUnaryService;
+  typedef WithStreamedUnaryMethod_Prepare<WithStreamedUnaryMethod_SetPitchAndYaw<WithStreamedUnaryMethod_SetPitchRateAndYawRate<WithStreamedUnaryMethod_SetMode<WithStreamedUnaryMethod_SetRoiLocation<WithStreamedUnaryMethod_TakeControl<WithStreamedUnaryMethod_ReleaseControl<Service > > > > > > > StreamedUnaryService;
   template <class BaseClass>
   class WithSplitStreamingMethod_SubscribeControl : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithSplitStreamingMethod_SubscribeControl() {
-      ::grpc::Service::MarkMethodStreamed(6,
+      ::grpc::Service::MarkMethodStreamed(7,
         new ::grpc::internal::SplitServerStreamingHandler<
           ::mavsdk::rpc::gimbal::SubscribeControlRequest, ::mavsdk::rpc::gimbal::ControlResponse>(
             [this](::grpc::ServerContext* context,
@@ -1319,7 +1482,7 @@ class GimbalService final {
     virtual ::grpc::Status StreamedSubscribeControl(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::gimbal::SubscribeControlRequest,::mavsdk::rpc::gimbal::ControlResponse>* server_split_streamer) = 0;
   };
   typedef WithSplitStreamingMethod_SubscribeControl<Service > SplitStreamedService;
-  typedef WithStreamedUnaryMethod_SetPitchAndYaw<WithStreamedUnaryMethod_SetPitchRateAndYawRate<WithStreamedUnaryMethod_SetMode<WithStreamedUnaryMethod_SetRoiLocation<WithStreamedUnaryMethod_TakeControl<WithStreamedUnaryMethod_ReleaseControl<WithSplitStreamingMethod_SubscribeControl<Service > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_Prepare<WithStreamedUnaryMethod_SetPitchAndYaw<WithStreamedUnaryMethod_SetPitchRateAndYawRate<WithStreamedUnaryMethod_SetMode<WithStreamedUnaryMethod_SetRoiLocation<WithStreamedUnaryMethod_TakeControl<WithStreamedUnaryMethod_ReleaseControl<WithSplitStreamingMethod_SubscribeControl<Service > > > > > > > > StreamedService;
 };
 
 }  // namespace gimbal

--- a/src/mavsdk_server/src/generated/gimbal/gimbal.pb.cc
+++ b/src/mavsdk_server/src/generated/gimbal/gimbal.pb.cc
@@ -19,6 +19,29 @@ PROTOBUF_PRAGMA_INIT_SEG
 namespace mavsdk {
 namespace rpc {
 namespace gimbal {
+constexpr PrepareRequest::PrepareRequest(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized){}
+struct PrepareRequestDefaultTypeInternal {
+  constexpr PrepareRequestDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~PrepareRequestDefaultTypeInternal() {}
+  union {
+    PrepareRequest _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PrepareRequestDefaultTypeInternal _PrepareRequest_default_instance_;
+constexpr PrepareResponse::PrepareResponse(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : gimbal_result_(nullptr){}
+struct PrepareResponseDefaultTypeInternal {
+  constexpr PrepareResponseDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~PrepareResponseDefaultTypeInternal() {}
+  union {
+    PrepareResponse _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PrepareResponseDefaultTypeInternal _PrepareResponse_default_instance_;
 constexpr SetPitchAndYawRequest::SetPitchAndYawRequest(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
   : pitch_deg_(0)
@@ -225,11 +248,22 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT GimbalResultDefaultTypeInternal
 }  // namespace gimbal
 }  // namespace rpc
 }  // namespace mavsdk
-static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_gimbal_2fgimbal_2eproto[16];
+static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_gimbal_2fgimbal_2eproto[18];
 static const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* file_level_enum_descriptors_gimbal_2fgimbal_2eproto[3];
 static constexpr ::PROTOBUF_NAMESPACE_ID::ServiceDescriptor const** file_level_service_descriptors_gimbal_2fgimbal_2eproto = nullptr;
 
 const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_gimbal_2fgimbal_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::gimbal::PrepareRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::gimbal::PrepareResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::gimbal::PrepareResponse, gimbal_result_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::gimbal::SetPitchAndYawRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -335,25 +369,29 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_gimbal_2fgimbal_2eproto::offse
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::gimbal::GimbalResult, result_str_),
 };
 static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
-  { 0, -1, sizeof(::mavsdk::rpc::gimbal::SetPitchAndYawRequest)},
-  { 7, -1, sizeof(::mavsdk::rpc::gimbal::SetPitchAndYawResponse)},
-  { 13, -1, sizeof(::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest)},
-  { 20, -1, sizeof(::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse)},
-  { 26, -1, sizeof(::mavsdk::rpc::gimbal::SetModeRequest)},
-  { 32, -1, sizeof(::mavsdk::rpc::gimbal::SetModeResponse)},
-  { 38, -1, sizeof(::mavsdk::rpc::gimbal::SetRoiLocationRequest)},
-  { 46, -1, sizeof(::mavsdk::rpc::gimbal::SetRoiLocationResponse)},
-  { 52, -1, sizeof(::mavsdk::rpc::gimbal::TakeControlRequest)},
-  { 58, -1, sizeof(::mavsdk::rpc::gimbal::TakeControlResponse)},
-  { 64, -1, sizeof(::mavsdk::rpc::gimbal::ReleaseControlRequest)},
-  { 69, -1, sizeof(::mavsdk::rpc::gimbal::ReleaseControlResponse)},
-  { 75, -1, sizeof(::mavsdk::rpc::gimbal::SubscribeControlRequest)},
-  { 80, -1, sizeof(::mavsdk::rpc::gimbal::ControlResponse)},
-  { 86, -1, sizeof(::mavsdk::rpc::gimbal::ControlStatus)},
-  { 96, -1, sizeof(::mavsdk::rpc::gimbal::GimbalResult)},
+  { 0, -1, sizeof(::mavsdk::rpc::gimbal::PrepareRequest)},
+  { 5, -1, sizeof(::mavsdk::rpc::gimbal::PrepareResponse)},
+  { 11, -1, sizeof(::mavsdk::rpc::gimbal::SetPitchAndYawRequest)},
+  { 18, -1, sizeof(::mavsdk::rpc::gimbal::SetPitchAndYawResponse)},
+  { 24, -1, sizeof(::mavsdk::rpc::gimbal::SetPitchRateAndYawRateRequest)},
+  { 31, -1, sizeof(::mavsdk::rpc::gimbal::SetPitchRateAndYawRateResponse)},
+  { 37, -1, sizeof(::mavsdk::rpc::gimbal::SetModeRequest)},
+  { 43, -1, sizeof(::mavsdk::rpc::gimbal::SetModeResponse)},
+  { 49, -1, sizeof(::mavsdk::rpc::gimbal::SetRoiLocationRequest)},
+  { 57, -1, sizeof(::mavsdk::rpc::gimbal::SetRoiLocationResponse)},
+  { 63, -1, sizeof(::mavsdk::rpc::gimbal::TakeControlRequest)},
+  { 69, -1, sizeof(::mavsdk::rpc::gimbal::TakeControlResponse)},
+  { 75, -1, sizeof(::mavsdk::rpc::gimbal::ReleaseControlRequest)},
+  { 80, -1, sizeof(::mavsdk::rpc::gimbal::ReleaseControlResponse)},
+  { 86, -1, sizeof(::mavsdk::rpc::gimbal::SubscribeControlRequest)},
+  { 91, -1, sizeof(::mavsdk::rpc::gimbal::ControlResponse)},
+  { 97, -1, sizeof(::mavsdk::rpc::gimbal::ControlStatus)},
+  { 107, -1, sizeof(::mavsdk::rpc::gimbal::GimbalResult)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::gimbal::_PrepareRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::gimbal::_PrepareResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::gimbal::_SetPitchAndYawRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::gimbal::_SetPitchAndYawResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::gimbal::_SetPitchRateAndYawRateRequest_default_instance_),
@@ -374,71 +412,75 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
 
 const char descriptor_table_protodef_gimbal_2fgimbal_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) =
   "\n\023gimbal/gimbal.proto\022\021mavsdk.rpc.gimbal"
-  "\";\n\025SetPitchAndYawRequest\022\021\n\tpitch_deg\030\001"
-  " \001(\002\022\017\n\007yaw_deg\030\002 \001(\002\"P\n\026SetPitchAndYawR"
-  "esponse\0226\n\rgimbal_result\030\001 \001(\0132\037.mavsdk."
-  "rpc.gimbal.GimbalResult\"Q\n\035SetPitchRateA"
-  "ndYawRateRequest\022\030\n\020pitch_rate_deg_s\030\001 \001"
-  "(\002\022\026\n\016yaw_rate_deg_s\030\002 \001(\002\"X\n\036SetPitchRa"
-  "teAndYawRateResponse\0226\n\rgimbal_result\030\001 "
-  "\001(\0132\037.mavsdk.rpc.gimbal.GimbalResult\"D\n\016"
-  "SetModeRequest\0222\n\013gimbal_mode\030\001 \001(\0162\035.ma"
-  "vsdk.rpc.gimbal.GimbalMode\"I\n\017SetModeRes"
-  "ponse\0226\n\rgimbal_result\030\001 \001(\0132\037.mavsdk.rp"
-  "c.gimbal.GimbalResult\"X\n\025SetRoiLocationR"
-  "equest\022\024\n\014latitude_deg\030\001 \001(\001\022\025\n\rlongitud"
-  "e_deg\030\002 \001(\001\022\022\n\naltitude_m\030\003 \001(\002\"P\n\026SetRo"
-  "iLocationResponse\0226\n\rgimbal_result\030\001 \001(\013"
-  "2\037.mavsdk.rpc.gimbal.GimbalResult\"J\n\022Tak"
-  "eControlRequest\0224\n\014control_mode\030\001 \001(\0162\036."
-  "mavsdk.rpc.gimbal.ControlMode\"M\n\023TakeCon"
+  "\"\020\n\016PrepareRequest\"I\n\017PrepareResponse\0226\n"
+  "\rgimbal_result\030\001 \001(\0132\037.mavsdk.rpc.gimbal"
+  ".GimbalResult\";\n\025SetPitchAndYawRequest\022\021"
+  "\n\tpitch_deg\030\001 \001(\002\022\017\n\007yaw_deg\030\002 \001(\002\"P\n\026Se"
+  "tPitchAndYawResponse\0226\n\rgimbal_result\030\001 "
+  "\001(\0132\037.mavsdk.rpc.gimbal.GimbalResult\"Q\n\035"
+  "SetPitchRateAndYawRateRequest\022\030\n\020pitch_r"
+  "ate_deg_s\030\001 \001(\002\022\026\n\016yaw_rate_deg_s\030\002 \001(\002\""
+  "X\n\036SetPitchRateAndYawRateResponse\0226\n\rgim"
+  "bal_result\030\001 \001(\0132\037.mavsdk.rpc.gimbal.Gim"
+  "balResult\"D\n\016SetModeRequest\0222\n\013gimbal_mo"
+  "de\030\001 \001(\0162\035.mavsdk.rpc.gimbal.GimbalMode\""
+  "I\n\017SetModeResponse\0226\n\rgimbal_result\030\001 \001("
+  "\0132\037.mavsdk.rpc.gimbal.GimbalResult\"X\n\025Se"
+  "tRoiLocationRequest\022\024\n\014latitude_deg\030\001 \001("
+  "\001\022\025\n\rlongitude_deg\030\002 \001(\001\022\022\n\naltitude_m\030\003"
+  " \001(\002\"P\n\026SetRoiLocationResponse\0226\n\rgimbal"
+  "_result\030\001 \001(\0132\037.mavsdk.rpc.gimbal.Gimbal"
+  "Result\"J\n\022TakeControlRequest\0224\n\014control_"
+  "mode\030\001 \001(\0162\036.mavsdk.rpc.gimbal.ControlMo"
+  "de\"M\n\023TakeControlResponse\0226\n\rgimbal_resu"
+  "lt\030\001 \001(\0132\037.mavsdk.rpc.gimbal.GimbalResul"
+  "t\"\027\n\025ReleaseControlRequest\"P\n\026ReleaseCon"
   "trolResponse\0226\n\rgimbal_result\030\001 \001(\0132\037.ma"
-  "vsdk.rpc.gimbal.GimbalResult\"\027\n\025ReleaseC"
-  "ontrolRequest\"P\n\026ReleaseControlResponse\022"
-  "6\n\rgimbal_result\030\001 \001(\0132\037.mavsdk.rpc.gimb"
-  "al.GimbalResult\"\031\n\027SubscribeControlReque"
-  "st\"K\n\017ControlResponse\0228\n\016control_status\030"
-  "\001 \001(\0132 .mavsdk.rpc.gimbal.ControlStatus\""
-  "\307\001\n\rControlStatus\0224\n\014control_mode\030\001 \001(\0162"
-  "\036.mavsdk.rpc.gimbal.ControlMode\022\035\n\025sysid"
-  "_primary_control\030\002 \001(\005\022\036\n\026compid_primary"
-  "_control\030\003 \001(\005\022\037\n\027sysid_secondary_contro"
-  "l\030\004 \001(\005\022 \n\030compid_secondary_control\030\005 \001("
-  "\005\"\341\001\n\014GimbalResult\0226\n\006result\030\001 \001(\0162&.mav"
-  "sdk.rpc.gimbal.GimbalResult.Result\022\022\n\nre"
-  "sult_str\030\002 \001(\t\"\204\001\n\006Result\022\022\n\016RESULT_UNKN"
-  "OWN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\020\n\014RESULT_ERRO"
-  "R\020\002\022\022\n\016RESULT_TIMEOUT\020\003\022\026\n\022RESULT_UNSUPP"
-  "ORTED\020\004\022\024\n\020RESULT_NO_SYSTEM\020\005*B\n\nGimbalM"
-  "ode\022\032\n\026GIMBAL_MODE_YAW_FOLLOW\020\000\022\030\n\024GIMBA"
-  "L_MODE_YAW_LOCK\020\001*Z\n\013ControlMode\022\025\n\021CONT"
-  "ROL_MODE_NONE\020\000\022\030\n\024CONTROL_MODE_PRIMARY\020"
-  "\001\022\032\n\026CONTROL_MODE_SECONDARY\020\0022\347\005\n\rGimbal"
-  "Service\022g\n\016SetPitchAndYaw\022(.mavsdk.rpc.g"
-  "imbal.SetPitchAndYawRequest\032).mavsdk.rpc"
-  ".gimbal.SetPitchAndYawResponse\"\000\022\177\n\026SetP"
-  "itchRateAndYawRate\0220.mavsdk.rpc.gimbal.S"
-  "etPitchRateAndYawRateRequest\0321.mavsdk.rp"
-  "c.gimbal.SetPitchRateAndYawRateResponse\""
-  "\000\022R\n\007SetMode\022!.mavsdk.rpc.gimbal.SetMode"
-  "Request\032\".mavsdk.rpc.gimbal.SetModeRespo"
-  "nse\"\000\022g\n\016SetRoiLocation\022(.mavsdk.rpc.gim"
-  "bal.SetRoiLocationRequest\032).mavsdk.rpc.g"
-  "imbal.SetRoiLocationResponse\"\000\022^\n\013TakeCo"
-  "ntrol\022%.mavsdk.rpc.gimbal.TakeControlReq"
-  "uest\032&.mavsdk.rpc.gimbal.TakeControlResp"
-  "onse\"\000\022g\n\016ReleaseControl\022(.mavsdk.rpc.gi"
-  "mbal.ReleaseControlRequest\032).mavsdk.rpc."
-  "gimbal.ReleaseControlResponse\"\000\022f\n\020Subsc"
-  "ribeControl\022*.mavsdk.rpc.gimbal.Subscrib"
-  "eControlRequest\032\".mavsdk.rpc.gimbal.Cont"
-  "rolResponse\"\0000\001B\037\n\020io.mavsdk.gimbalB\013Gim"
-  "balProtob\006proto3"
+  "vsdk.rpc.gimbal.GimbalResult\"\031\n\027Subscrib"
+  "eControlRequest\"K\n\017ControlResponse\0228\n\016co"
+  "ntrol_status\030\001 \001(\0132 .mavsdk.rpc.gimbal.C"
+  "ontrolStatus\"\307\001\n\rControlStatus\0224\n\014contro"
+  "l_mode\030\001 \001(\0162\036.mavsdk.rpc.gimbal.Control"
+  "Mode\022\035\n\025sysid_primary_control\030\002 \001(\005\022\036\n\026c"
+  "ompid_primary_control\030\003 \001(\005\022\037\n\027sysid_sec"
+  "ondary_control\030\004 \001(\005\022 \n\030compid_secondary"
+  "_control\030\005 \001(\005\"\341\001\n\014GimbalResult\0226\n\006resul"
+  "t\030\001 \001(\0162&.mavsdk.rpc.gimbal.GimbalResult"
+  ".Result\022\022\n\nresult_str\030\002 \001(\t\"\204\001\n\006Result\022\022"
+  "\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\020"
+  "\n\014RESULT_ERROR\020\002\022\022\n\016RESULT_TIMEOUT\020\003\022\026\n\022"
+  "RESULT_UNSUPPORTED\020\004\022\024\n\020RESULT_NO_SYSTEM"
+  "\020\005*B\n\nGimbalMode\022\032\n\026GIMBAL_MODE_YAW_FOLL"
+  "OW\020\000\022\030\n\024GIMBAL_MODE_YAW_LOCK\020\001*Z\n\013Contro"
+  "lMode\022\025\n\021CONTROL_MODE_NONE\020\000\022\030\n\024CONTROL_"
+  "MODE_PRIMARY\020\001\022\032\n\026CONTROL_MODE_SECONDARY"
+  "\020\0022\273\006\n\rGimbalService\022R\n\007Prepare\022!.mavsdk"
+  ".rpc.gimbal.PrepareRequest\032\".mavsdk.rpc."
+  "gimbal.PrepareResponse\"\000\022g\n\016SetPitchAndY"
+  "aw\022(.mavsdk.rpc.gimbal.SetPitchAndYawReq"
+  "uest\032).mavsdk.rpc.gimbal.SetPitchAndYawR"
+  "esponse\"\000\022\177\n\026SetPitchRateAndYawRate\0220.ma"
+  "vsdk.rpc.gimbal.SetPitchRateAndYawRateRe"
+  "quest\0321.mavsdk.rpc.gimbal.SetPitchRateAn"
+  "dYawRateResponse\"\000\022R\n\007SetMode\022!.mavsdk.r"
+  "pc.gimbal.SetModeRequest\032\".mavsdk.rpc.gi"
+  "mbal.SetModeResponse\"\000\022g\n\016SetRoiLocation"
+  "\022(.mavsdk.rpc.gimbal.SetRoiLocationReque"
+  "st\032).mavsdk.rpc.gimbal.SetRoiLocationRes"
+  "ponse\"\000\022^\n\013TakeControl\022%.mavsdk.rpc.gimb"
+  "al.TakeControlRequest\032&.mavsdk.rpc.gimba"
+  "l.TakeControlResponse\"\000\022g\n\016ReleaseContro"
+  "l\022(.mavsdk.rpc.gimbal.ReleaseControlRequ"
+  "est\032).mavsdk.rpc.gimbal.ReleaseControlRe"
+  "sponse\"\000\022f\n\020SubscribeControl\022*.mavsdk.rp"
+  "c.gimbal.SubscribeControlRequest\032\".mavsd"
+  "k.rpc.gimbal.ControlResponse\"\0000\001B\037\n\020io.m"
+  "avsdk.gimbalB\013GimbalProtob\006proto3"
   ;
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_gimbal_2fgimbal_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_gimbal_2fgimbal_2eproto = {
-  false, false, 2416, descriptor_table_protodef_gimbal_2fgimbal_2eproto, "gimbal/gimbal.proto", 
-  &descriptor_table_gimbal_2fgimbal_2eproto_once, nullptr, 0, 16,
+  false, false, 2593, descriptor_table_protodef_gimbal_2fgimbal_2eproto, "gimbal/gimbal.proto", 
+  &descriptor_table_gimbal_2fgimbal_2eproto_once, nullptr, 0, 18,
   schemas, file_default_instances, TableStruct_gimbal_2fgimbal_2eproto::offsets,
   file_level_metadata_gimbal_2fgimbal_2eproto, file_level_enum_descriptors_gimbal_2fgimbal_2eproto, file_level_service_descriptors_gimbal_2fgimbal_2eproto,
 };
@@ -509,6 +551,359 @@ bool ControlMode_IsValid(int value) {
   }
 }
 
+
+// ===================================================================
+
+class PrepareRequest::_Internal {
+ public:
+};
+
+PrepareRequest::PrepareRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor();
+  if (!is_message_owned) {
+    RegisterArenaDtor(arena);
+  }
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.gimbal.PrepareRequest)
+}
+PrepareRequest::PrepareRequest(const PrepareRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.gimbal.PrepareRequest)
+}
+
+inline void PrepareRequest::SharedCtor() {
+}
+
+PrepareRequest::~PrepareRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.gimbal.PrepareRequest)
+  if (GetArenaForAllocation() != nullptr) return;
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+inline void PrepareRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+}
+
+void PrepareRequest::ArenaDtor(void* object) {
+  PrepareRequest* _this = reinterpret_cast< PrepareRequest* >(object);
+  (void)_this;
+}
+void PrepareRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void PrepareRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void PrepareRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.gimbal.PrepareRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* PrepareRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+        if ((tag == 0) || ((tag & 7) == 4)) {
+          CHK_(ptr);
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* PrepareRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.gimbal.PrepareRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.gimbal.PrepareRequest)
+  return target;
+}
+
+size_t PrepareRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.gimbal.PrepareRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData PrepareRequest::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSizeCheck,
+    PrepareRequest::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*PrepareRequest::GetClassData() const { return &_class_data_; }
+
+void PrepareRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
+                      const ::PROTOBUF_NAMESPACE_ID::Message&from) {
+  static_cast<PrepareRequest *>(to)->MergeFrom(
+      static_cast<const PrepareRequest &>(from));
+}
+
+
+void PrepareRequest::MergeFrom(const PrepareRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.gimbal.PrepareRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void PrepareRequest::CopyFrom(const PrepareRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.gimbal.PrepareRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool PrepareRequest::IsInitialized() const {
+  return true;
+}
+
+void PrepareRequest::InternalSwap(PrepareRequest* other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata PrepareRequest::GetMetadata() const {
+  return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
+      &descriptor_table_gimbal_2fgimbal_2eproto_getter, &descriptor_table_gimbal_2fgimbal_2eproto_once,
+      file_level_metadata_gimbal_2fgimbal_2eproto[0]);
+}
+
+// ===================================================================
+
+class PrepareResponse::_Internal {
+ public:
+  static const ::mavsdk::rpc::gimbal::GimbalResult& gimbal_result(const PrepareResponse* msg);
+};
+
+const ::mavsdk::rpc::gimbal::GimbalResult&
+PrepareResponse::_Internal::gimbal_result(const PrepareResponse* msg) {
+  return *msg->gimbal_result_;
+}
+PrepareResponse::PrepareResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor();
+  if (!is_message_owned) {
+    RegisterArenaDtor(arena);
+  }
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.gimbal.PrepareResponse)
+}
+PrepareResponse::PrepareResponse(const PrepareResponse& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_gimbal_result()) {
+    gimbal_result_ = new ::mavsdk::rpc::gimbal::GimbalResult(*from.gimbal_result_);
+  } else {
+    gimbal_result_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.gimbal.PrepareResponse)
+}
+
+inline void PrepareResponse::SharedCtor() {
+gimbal_result_ = nullptr;
+}
+
+PrepareResponse::~PrepareResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.gimbal.PrepareResponse)
+  if (GetArenaForAllocation() != nullptr) return;
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+inline void PrepareResponse::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  if (this != internal_default_instance()) delete gimbal_result_;
+}
+
+void PrepareResponse::ArenaDtor(void* object) {
+  PrepareResponse* _this = reinterpret_cast< PrepareResponse* >(object);
+  (void)_this;
+}
+void PrepareResponse::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void PrepareResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void PrepareResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.gimbal.PrepareResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArenaForAllocation() == nullptr && gimbal_result_ != nullptr) {
+    delete gimbal_result_;
+  }
+  gimbal_result_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* PrepareResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // .mavsdk.rpc.gimbal.GimbalResult gimbal_result = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_gimbal_result(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag == 0) || ((tag & 7) == 4)) {
+          CHK_(ptr);
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* PrepareResponse::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.gimbal.PrepareResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.gimbal.GimbalResult gimbal_result = 1;
+  if (this->_internal_has_gimbal_result()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::gimbal_result(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.gimbal.PrepareResponse)
+  return target;
+}
+
+size_t PrepareResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.gimbal.PrepareResponse)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.gimbal.GimbalResult gimbal_result = 1;
+  if (this->_internal_has_gimbal_result()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *gimbal_result_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData PrepareResponse::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSizeCheck,
+    PrepareResponse::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*PrepareResponse::GetClassData() const { return &_class_data_; }
+
+void PrepareResponse::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
+                      const ::PROTOBUF_NAMESPACE_ID::Message&from) {
+  static_cast<PrepareResponse *>(to)->MergeFrom(
+      static_cast<const PrepareResponse &>(from));
+}
+
+
+void PrepareResponse::MergeFrom(const PrepareResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.gimbal.PrepareResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_has_gimbal_result()) {
+    _internal_mutable_gimbal_result()->::mavsdk::rpc::gimbal::GimbalResult::MergeFrom(from._internal_gimbal_result());
+  }
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void PrepareResponse::CopyFrom(const PrepareResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.gimbal.PrepareResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool PrepareResponse::IsInitialized() const {
+  return true;
+}
+
+void PrepareResponse::InternalSwap(PrepareResponse* other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(gimbal_result_, other->gimbal_result_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata PrepareResponse::GetMetadata() const {
+  return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
+      &descriptor_table_gimbal_2fgimbal_2eproto_getter, &descriptor_table_gimbal_2fgimbal_2eproto_once,
+      file_level_metadata_gimbal_2fgimbal_2eproto[1]);
+}
 
 // ===================================================================
 
@@ -723,7 +1118,7 @@ void SetPitchAndYawRequest::InternalSwap(SetPitchAndYawRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata SetPitchAndYawRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_gimbal_2fgimbal_2eproto_getter, &descriptor_table_gimbal_2fgimbal_2eproto_once,
-      file_level_metadata_gimbal_2fgimbal_2eproto[0]);
+      file_level_metadata_gimbal_2fgimbal_2eproto[2]);
 }
 
 // ===================================================================
@@ -923,7 +1318,7 @@ void SetPitchAndYawResponse::InternalSwap(SetPitchAndYawResponse* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata SetPitchAndYawResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_gimbal_2fgimbal_2eproto_getter, &descriptor_table_gimbal_2fgimbal_2eproto_once,
-      file_level_metadata_gimbal_2fgimbal_2eproto[1]);
+      file_level_metadata_gimbal_2fgimbal_2eproto[3]);
 }
 
 // ===================================================================
@@ -1139,7 +1534,7 @@ void SetPitchRateAndYawRateRequest::InternalSwap(SetPitchRateAndYawRateRequest* 
 ::PROTOBUF_NAMESPACE_ID::Metadata SetPitchRateAndYawRateRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_gimbal_2fgimbal_2eproto_getter, &descriptor_table_gimbal_2fgimbal_2eproto_once,
-      file_level_metadata_gimbal_2fgimbal_2eproto[2]);
+      file_level_metadata_gimbal_2fgimbal_2eproto[4]);
 }
 
 // ===================================================================
@@ -1339,7 +1734,7 @@ void SetPitchRateAndYawRateResponse::InternalSwap(SetPitchRateAndYawRateResponse
 ::PROTOBUF_NAMESPACE_ID::Metadata SetPitchRateAndYawRateResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_gimbal_2fgimbal_2eproto_getter, &descriptor_table_gimbal_2fgimbal_2eproto_once,
-      file_level_metadata_gimbal_2fgimbal_2eproto[3]);
+      file_level_metadata_gimbal_2fgimbal_2eproto[5]);
 }
 
 // ===================================================================
@@ -1525,7 +1920,7 @@ void SetModeRequest::InternalSwap(SetModeRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata SetModeRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_gimbal_2fgimbal_2eproto_getter, &descriptor_table_gimbal_2fgimbal_2eproto_once,
-      file_level_metadata_gimbal_2fgimbal_2eproto[4]);
+      file_level_metadata_gimbal_2fgimbal_2eproto[6]);
 }
 
 // ===================================================================
@@ -1725,7 +2120,7 @@ void SetModeResponse::InternalSwap(SetModeResponse* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata SetModeResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_gimbal_2fgimbal_2eproto_getter, &descriptor_table_gimbal_2fgimbal_2eproto_once,
-      file_level_metadata_gimbal_2fgimbal_2eproto[5]);
+      file_level_metadata_gimbal_2fgimbal_2eproto[7]);
 }
 
 // ===================================================================
@@ -1962,7 +2357,7 @@ void SetRoiLocationRequest::InternalSwap(SetRoiLocationRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata SetRoiLocationRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_gimbal_2fgimbal_2eproto_getter, &descriptor_table_gimbal_2fgimbal_2eproto_once,
-      file_level_metadata_gimbal_2fgimbal_2eproto[6]);
+      file_level_metadata_gimbal_2fgimbal_2eproto[8]);
 }
 
 // ===================================================================
@@ -2162,7 +2557,7 @@ void SetRoiLocationResponse::InternalSwap(SetRoiLocationResponse* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata SetRoiLocationResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_gimbal_2fgimbal_2eproto_getter, &descriptor_table_gimbal_2fgimbal_2eproto_once,
-      file_level_metadata_gimbal_2fgimbal_2eproto[7]);
+      file_level_metadata_gimbal_2fgimbal_2eproto[9]);
 }
 
 // ===================================================================
@@ -2348,7 +2743,7 @@ void TakeControlRequest::InternalSwap(TakeControlRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata TakeControlRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_gimbal_2fgimbal_2eproto_getter, &descriptor_table_gimbal_2fgimbal_2eproto_once,
-      file_level_metadata_gimbal_2fgimbal_2eproto[8]);
+      file_level_metadata_gimbal_2fgimbal_2eproto[10]);
 }
 
 // ===================================================================
@@ -2548,7 +2943,7 @@ void TakeControlResponse::InternalSwap(TakeControlResponse* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata TakeControlResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_gimbal_2fgimbal_2eproto_getter, &descriptor_table_gimbal_2fgimbal_2eproto_once,
-      file_level_metadata_gimbal_2fgimbal_2eproto[9]);
+      file_level_metadata_gimbal_2fgimbal_2eproto[11]);
 }
 
 // ===================================================================
@@ -2701,7 +3096,7 @@ void ReleaseControlRequest::InternalSwap(ReleaseControlRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata ReleaseControlRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_gimbal_2fgimbal_2eproto_getter, &descriptor_table_gimbal_2fgimbal_2eproto_once,
-      file_level_metadata_gimbal_2fgimbal_2eproto[10]);
+      file_level_metadata_gimbal_2fgimbal_2eproto[12]);
 }
 
 // ===================================================================
@@ -2901,7 +3296,7 @@ void ReleaseControlResponse::InternalSwap(ReleaseControlResponse* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata ReleaseControlResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_gimbal_2fgimbal_2eproto_getter, &descriptor_table_gimbal_2fgimbal_2eproto_once,
-      file_level_metadata_gimbal_2fgimbal_2eproto[11]);
+      file_level_metadata_gimbal_2fgimbal_2eproto[13]);
 }
 
 // ===================================================================
@@ -3054,7 +3449,7 @@ void SubscribeControlRequest::InternalSwap(SubscribeControlRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata SubscribeControlRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_gimbal_2fgimbal_2eproto_getter, &descriptor_table_gimbal_2fgimbal_2eproto_once,
-      file_level_metadata_gimbal_2fgimbal_2eproto[12]);
+      file_level_metadata_gimbal_2fgimbal_2eproto[14]);
 }
 
 // ===================================================================
@@ -3254,7 +3649,7 @@ void ControlResponse::InternalSwap(ControlResponse* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata ControlResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_gimbal_2fgimbal_2eproto_getter, &descriptor_table_gimbal_2fgimbal_2eproto_once,
-      file_level_metadata_gimbal_2fgimbal_2eproto[13]);
+      file_level_metadata_gimbal_2fgimbal_2eproto[15]);
 }
 
 // ===================================================================
@@ -3544,7 +3939,7 @@ void ControlStatus::InternalSwap(ControlStatus* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata ControlStatus::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_gimbal_2fgimbal_2eproto_getter, &descriptor_table_gimbal_2fgimbal_2eproto_once,
-      file_level_metadata_gimbal_2fgimbal_2eproto[14]);
+      file_level_metadata_gimbal_2fgimbal_2eproto[16]);
 }
 
 // ===================================================================
@@ -3772,7 +4167,7 @@ void GimbalResult::InternalSwap(GimbalResult* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata GimbalResult::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_gimbal_2fgimbal_2eproto_getter, &descriptor_table_gimbal_2fgimbal_2eproto_once,
-      file_level_metadata_gimbal_2fgimbal_2eproto[15]);
+      file_level_metadata_gimbal_2fgimbal_2eproto[17]);
 }
 
 // @@protoc_insertion_point(namespace_scope)
@@ -3780,6 +4175,12 @@ void GimbalResult::InternalSwap(GimbalResult* other) {
 }  // namespace rpc
 }  // namespace mavsdk
 PROTOBUF_NAMESPACE_OPEN
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::gimbal::PrepareRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::gimbal::PrepareRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::gimbal::PrepareRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::gimbal::PrepareResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::gimbal::PrepareResponse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::gimbal::PrepareResponse >(arena);
+}
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::gimbal::SetPitchAndYawRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::gimbal::SetPitchAndYawRequest >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::gimbal::SetPitchAndYawRequest >(arena);
 }

--- a/src/mavsdk_server/src/generated/gimbal/gimbal.pb.h
+++ b/src/mavsdk_server/src/generated/gimbal/gimbal.pb.h
@@ -47,7 +47,7 @@ struct TableStruct_gimbal_2fgimbal_2eproto {
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::AuxiliaryParseTableField aux[]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
-  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[16]
+  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[18]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::FieldMetadata field_metadata[];
   static const ::PROTOBUF_NAMESPACE_ID::internal::SerializationTable serialization_table[];
@@ -66,6 +66,12 @@ extern ControlStatusDefaultTypeInternal _ControlStatus_default_instance_;
 class GimbalResult;
 struct GimbalResultDefaultTypeInternal;
 extern GimbalResultDefaultTypeInternal _GimbalResult_default_instance_;
+class PrepareRequest;
+struct PrepareRequestDefaultTypeInternal;
+extern PrepareRequestDefaultTypeInternal _PrepareRequest_default_instance_;
+class PrepareResponse;
+struct PrepareResponseDefaultTypeInternal;
+extern PrepareResponseDefaultTypeInternal _PrepareResponse_default_instance_;
 class ReleaseControlRequest;
 struct ReleaseControlRequestDefaultTypeInternal;
 extern ReleaseControlRequestDefaultTypeInternal _ReleaseControlRequest_default_instance_;
@@ -112,6 +118,8 @@ PROTOBUF_NAMESPACE_OPEN
 template<> ::mavsdk::rpc::gimbal::ControlResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::gimbal::ControlResponse>(Arena*);
 template<> ::mavsdk::rpc::gimbal::ControlStatus* Arena::CreateMaybeMessage<::mavsdk::rpc::gimbal::ControlStatus>(Arena*);
 template<> ::mavsdk::rpc::gimbal::GimbalResult* Arena::CreateMaybeMessage<::mavsdk::rpc::gimbal::GimbalResult>(Arena*);
+template<> ::mavsdk::rpc::gimbal::PrepareRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::gimbal::PrepareRequest>(Arena*);
+template<> ::mavsdk::rpc::gimbal::PrepareResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::gimbal::PrepareResponse>(Arena*);
 template<> ::mavsdk::rpc::gimbal::ReleaseControlRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::gimbal::ReleaseControlRequest>(Arena*);
 template<> ::mavsdk::rpc::gimbal::ReleaseControlResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::gimbal::ReleaseControlResponse>(Arena*);
 template<> ::mavsdk::rpc::gimbal::SetModeRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::gimbal::SetModeRequest>(Arena*);
@@ -212,6 +220,280 @@ inline bool ControlMode_Parse(
 }
 // ===================================================================
 
+class PrepareRequest final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.gimbal.PrepareRequest) */ {
+ public:
+  inline PrepareRequest() : PrepareRequest(nullptr) {}
+  ~PrepareRequest() override;
+  explicit constexpr PrepareRequest(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  PrepareRequest(const PrepareRequest& from);
+  PrepareRequest(PrepareRequest&& from) noexcept
+    : PrepareRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline PrepareRequest& operator=(const PrepareRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline PrepareRequest& operator=(PrepareRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const PrepareRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const PrepareRequest* internal_default_instance() {
+    return reinterpret_cast<const PrepareRequest*>(
+               &_PrepareRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    0;
+
+  friend void swap(PrepareRequest& a, PrepareRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(PrepareRequest* other) {
+    if (other == this) return;
+    if (GetOwningArena() == other->GetOwningArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(PrepareRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline PrepareRequest* New() const final {
+    return new PrepareRequest();
+  }
+
+  PrepareRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<PrepareRequest>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const PrepareRequest& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom(const PrepareRequest& from);
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to, const ::PROTOBUF_NAMESPACE_ID::Message&from);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(PrepareRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.gimbal.PrepareRequest";
+  }
+  protected:
+  explicit PrepareRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.gimbal.PrepareRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_gimbal_2fgimbal_2eproto;
+};
+// -------------------------------------------------------------------
+
+class PrepareResponse final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.gimbal.PrepareResponse) */ {
+ public:
+  inline PrepareResponse() : PrepareResponse(nullptr) {}
+  ~PrepareResponse() override;
+  explicit constexpr PrepareResponse(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  PrepareResponse(const PrepareResponse& from);
+  PrepareResponse(PrepareResponse&& from) noexcept
+    : PrepareResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline PrepareResponse& operator=(const PrepareResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline PrepareResponse& operator=(PrepareResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const PrepareResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const PrepareResponse* internal_default_instance() {
+    return reinterpret_cast<const PrepareResponse*>(
+               &_PrepareResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    1;
+
+  friend void swap(PrepareResponse& a, PrepareResponse& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(PrepareResponse* other) {
+    if (other == this) return;
+    if (GetOwningArena() == other->GetOwningArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(PrepareResponse* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline PrepareResponse* New() const final {
+    return new PrepareResponse();
+  }
+
+  PrepareResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<PrepareResponse>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const PrepareResponse& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom(const PrepareResponse& from);
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to, const ::PROTOBUF_NAMESPACE_ID::Message&from);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(PrepareResponse* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.gimbal.PrepareResponse";
+  }
+  protected:
+  explicit PrepareResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kGimbalResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.gimbal.GimbalResult gimbal_result = 1;
+  bool has_gimbal_result() const;
+  private:
+  bool _internal_has_gimbal_result() const;
+  public:
+  void clear_gimbal_result();
+  const ::mavsdk::rpc::gimbal::GimbalResult& gimbal_result() const;
+  PROTOBUF_MUST_USE_RESULT ::mavsdk::rpc::gimbal::GimbalResult* release_gimbal_result();
+  ::mavsdk::rpc::gimbal::GimbalResult* mutable_gimbal_result();
+  void set_allocated_gimbal_result(::mavsdk::rpc::gimbal::GimbalResult* gimbal_result);
+  private:
+  const ::mavsdk::rpc::gimbal::GimbalResult& _internal_gimbal_result() const;
+  ::mavsdk::rpc::gimbal::GimbalResult* _internal_mutable_gimbal_result();
+  public:
+  void unsafe_arena_set_allocated_gimbal_result(
+      ::mavsdk::rpc::gimbal::GimbalResult* gimbal_result);
+  ::mavsdk::rpc::gimbal::GimbalResult* unsafe_arena_release_gimbal_result();
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.gimbal.PrepareResponse)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::mavsdk::rpc::gimbal::GimbalResult* gimbal_result_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_gimbal_2fgimbal_2eproto;
+};
+// -------------------------------------------------------------------
+
 class SetPitchAndYawRequest final :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.gimbal.SetPitchAndYawRequest) */ {
  public:
@@ -256,7 +538,7 @@ class SetPitchAndYawRequest final :
                &_SetPitchAndYawRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    0;
+    2;
 
   friend void swap(SetPitchAndYawRequest& a, SetPitchAndYawRequest& b) {
     a.Swap(&b);
@@ -406,7 +688,7 @@ class SetPitchAndYawResponse final :
                &_SetPitchAndYawResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    1;
+    3;
 
   friend void swap(SetPitchAndYawResponse& a, SetPitchAndYawResponse& b) {
     a.Swap(&b);
@@ -554,7 +836,7 @@ class SetPitchRateAndYawRateRequest final :
                &_SetPitchRateAndYawRateRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    2;
+    4;
 
   friend void swap(SetPitchRateAndYawRateRequest& a, SetPitchRateAndYawRateRequest& b) {
     a.Swap(&b);
@@ -704,7 +986,7 @@ class SetPitchRateAndYawRateResponse final :
                &_SetPitchRateAndYawRateResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    3;
+    5;
 
   friend void swap(SetPitchRateAndYawRateResponse& a, SetPitchRateAndYawRateResponse& b) {
     a.Swap(&b);
@@ -852,7 +1134,7 @@ class SetModeRequest final :
                &_SetModeRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    4;
+    6;
 
   friend void swap(SetModeRequest& a, SetModeRequest& b) {
     a.Swap(&b);
@@ -991,7 +1273,7 @@ class SetModeResponse final :
                &_SetModeResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    5;
+    7;
 
   friend void swap(SetModeResponse& a, SetModeResponse& b) {
     a.Swap(&b);
@@ -1139,7 +1421,7 @@ class SetRoiLocationRequest final :
                &_SetRoiLocationRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    6;
+    8;
 
   friend void swap(SetRoiLocationRequest& a, SetRoiLocationRequest& b) {
     a.Swap(&b);
@@ -1300,7 +1582,7 @@ class SetRoiLocationResponse final :
                &_SetRoiLocationResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    7;
+    9;
 
   friend void swap(SetRoiLocationResponse& a, SetRoiLocationResponse& b) {
     a.Swap(&b);
@@ -1448,7 +1730,7 @@ class TakeControlRequest final :
                &_TakeControlRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    8;
+    10;
 
   friend void swap(TakeControlRequest& a, TakeControlRequest& b) {
     a.Swap(&b);
@@ -1587,7 +1869,7 @@ class TakeControlResponse final :
                &_TakeControlResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    9;
+    11;
 
   friend void swap(TakeControlResponse& a, TakeControlResponse& b) {
     a.Swap(&b);
@@ -1735,7 +2017,7 @@ class ReleaseControlRequest final :
                &_ReleaseControlRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    10;
+    12;
 
   friend void swap(ReleaseControlRequest& a, ReleaseControlRequest& b) {
     a.Swap(&b);
@@ -1861,7 +2143,7 @@ class ReleaseControlResponse final :
                &_ReleaseControlResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    11;
+    13;
 
   friend void swap(ReleaseControlResponse& a, ReleaseControlResponse& b) {
     a.Swap(&b);
@@ -2009,7 +2291,7 @@ class SubscribeControlRequest final :
                &_SubscribeControlRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    12;
+    14;
 
   friend void swap(SubscribeControlRequest& a, SubscribeControlRequest& b) {
     a.Swap(&b);
@@ -2135,7 +2417,7 @@ class ControlResponse final :
                &_ControlResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    13;
+    15;
 
   friend void swap(ControlResponse& a, ControlResponse& b) {
     a.Swap(&b);
@@ -2283,7 +2565,7 @@ class ControlStatus final :
                &_ControlStatus_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    14;
+    16;
 
   friend void swap(ControlStatus& a, ControlStatus& b) {
     a.Swap(&b);
@@ -2466,7 +2748,7 @@ class GimbalResult final :
                &_GimbalResult_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    15;
+    17;
 
   friend void swap(GimbalResult& a, GimbalResult& b) {
     a.Swap(&b);
@@ -2622,6 +2904,104 @@ class GimbalResult final :
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif  // __GNUC__
+// PrepareRequest
+
+// -------------------------------------------------------------------
+
+// PrepareResponse
+
+// .mavsdk.rpc.gimbal.GimbalResult gimbal_result = 1;
+inline bool PrepareResponse::_internal_has_gimbal_result() const {
+  return this != internal_default_instance() && gimbal_result_ != nullptr;
+}
+inline bool PrepareResponse::has_gimbal_result() const {
+  return _internal_has_gimbal_result();
+}
+inline void PrepareResponse::clear_gimbal_result() {
+  if (GetArenaForAllocation() == nullptr && gimbal_result_ != nullptr) {
+    delete gimbal_result_;
+  }
+  gimbal_result_ = nullptr;
+}
+inline const ::mavsdk::rpc::gimbal::GimbalResult& PrepareResponse::_internal_gimbal_result() const {
+  const ::mavsdk::rpc::gimbal::GimbalResult* p = gimbal_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::gimbal::GimbalResult&>(
+      ::mavsdk::rpc::gimbal::_GimbalResult_default_instance_);
+}
+inline const ::mavsdk::rpc::gimbal::GimbalResult& PrepareResponse::gimbal_result() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.gimbal.PrepareResponse.gimbal_result)
+  return _internal_gimbal_result();
+}
+inline void PrepareResponse::unsafe_arena_set_allocated_gimbal_result(
+    ::mavsdk::rpc::gimbal::GimbalResult* gimbal_result) {
+  if (GetArenaForAllocation() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(gimbal_result_);
+  }
+  gimbal_result_ = gimbal_result;
+  if (gimbal_result) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.gimbal.PrepareResponse.gimbal_result)
+}
+inline ::mavsdk::rpc::gimbal::GimbalResult* PrepareResponse::release_gimbal_result() {
+  
+  ::mavsdk::rpc::gimbal::GimbalResult* temp = gimbal_result_;
+  gimbal_result_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
+  temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  if (GetArenaForAllocation() == nullptr) { delete old; }
+#else  // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArenaForAllocation() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return temp;
+}
+inline ::mavsdk::rpc::gimbal::GimbalResult* PrepareResponse::unsafe_arena_release_gimbal_result() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.gimbal.PrepareResponse.gimbal_result)
+  
+  ::mavsdk::rpc::gimbal::GimbalResult* temp = gimbal_result_;
+  gimbal_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::gimbal::GimbalResult* PrepareResponse::_internal_mutable_gimbal_result() {
+  
+  if (gimbal_result_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::gimbal::GimbalResult>(GetArenaForAllocation());
+    gimbal_result_ = p;
+  }
+  return gimbal_result_;
+}
+inline ::mavsdk::rpc::gimbal::GimbalResult* PrepareResponse::mutable_gimbal_result() {
+  ::mavsdk::rpc::gimbal::GimbalResult* _msg = _internal_mutable_gimbal_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.gimbal.PrepareResponse.gimbal_result)
+  return _msg;
+}
+inline void PrepareResponse::set_allocated_gimbal_result(::mavsdk::rpc::gimbal::GimbalResult* gimbal_result) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
+  if (message_arena == nullptr) {
+    delete gimbal_result_;
+  }
+  if (gimbal_result) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper<::mavsdk::rpc::gimbal::GimbalResult>::GetOwningArena(gimbal_result);
+    if (message_arena != submessage_arena) {
+      gimbal_result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, gimbal_result, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  gimbal_result_ = gimbal_result;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.gimbal.PrepareResponse.gimbal_result)
+}
+
+// -------------------------------------------------------------------
+
 // SetPitchAndYawRequest
 
 // float pitch_deg = 1;
@@ -3663,6 +4043,10 @@ inline void GimbalResult::set_allocated_result_str(std::string* result_str) {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/src/mavsdk_server/src/plugins/gimbal/gimbal_service_impl.h
+++ b/src/mavsdk_server/src/plugins/gimbal/gimbal_service_impl.h
@@ -178,6 +178,29 @@ public:
         }
     }
 
+    grpc::Status Prepare(
+        grpc::ServerContext* /* context */,
+        const rpc::gimbal::PrepareRequest* /* request */,
+        rpc::gimbal::PrepareResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            if (response != nullptr) {
+                auto result = mavsdk::Gimbal::Result::NoSystem;
+                fillResponseWithResult(response, result);
+            }
+
+            return grpc::Status::OK;
+        }
+
+        auto result = _lazy_plugin.maybe_plugin()->prepare();
+
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+
+        return grpc::Status::OK;
+    }
+
     grpc::Status SetPitchAndYaw(
         grpc::ServerContext* /* context */,
         const rpc::gimbal::SetPitchAndYawRequest* request,

--- a/src/plugins/gimbal/gimbal.cpp
+++ b/src/plugins/gimbal/gimbal.cpp
@@ -20,6 +20,16 @@ Gimbal::Gimbal(std::shared_ptr<System> system) :
 
 Gimbal::~Gimbal() {}
 
+void Gimbal::prepare_async(const ResultCallback callback)
+{
+    _impl->prepare_async(callback);
+}
+
+Gimbal::Result Gimbal::prepare() const
+{
+    return _impl->prepare();
+}
+
 void Gimbal::set_pitch_and_yaw_async(float pitch_deg, float yaw_deg, const ResultCallback callback)
 {
     _impl->set_pitch_and_yaw_async(pitch_deg, yaw_deg, callback);

--- a/src/plugins/gimbal/gimbal_impl.h
+++ b/src/plugins/gimbal/gimbal_impl.h
@@ -19,6 +19,9 @@ public:
     void enable() override;
     void disable() override;
 
+    Gimbal::Result prepare();
+    void prepare_async(const Gimbal::ResultCallback& callback);
+
     Gimbal::Result set_pitch_and_yaw(float pitch_deg, float yaw_deg);
     void set_pitch_and_yaw_async(float pitch_deg, float yaw_deg, Gimbal::ResultCallback callback);
 
@@ -58,13 +61,6 @@ public:
 
 private:
     std::unique_ptr<GimbalProtocolBase> _gimbal_protocol{nullptr};
-
-    void* _protocol_cookie{nullptr};
-
-    void wait_for_protocol();
-    void wait_for_protocol_async(std::function<void()> callback);
-    void receive_protocol_timeout();
-    void process_gimbal_manager_information(const mavlink_message_t& message);
 };
 
 } // namespace mavsdk

--- a/src/plugins/gimbal/include/plugins/gimbal/gimbal.h
+++ b/src/plugins/gimbal/include/plugins/gimbal/gimbal.h
@@ -142,6 +142,22 @@ public:
     using ResultCallback = std::function<void(Result)>;
 
     /**
+     * @brief Prepare the gimbal plugin. Must be called before the plugin can be used.
+     *
+     * This function is non-blocking. See 'prepare' for the blocking counterpart.
+     */
+    void prepare_async(const ResultCallback callback);
+
+    /**
+     * @brief Prepare the gimbal plugin. Must be called before the plugin can be used.
+     *
+     * This function is blocking. See 'prepare_async' for the non-blocking counterpart.
+     *
+     * @return Result of request.
+     */
+    Result prepare() const;
+
+    /**
      * @brief Set gimbal pitch and yaw angles.
      *
      * This sets the desired pitch and yaw angles of a gimbal.

--- a/src/plugins/mission/mission_impl.h
+++ b/src/plugins/mission/mission_impl.h
@@ -72,10 +72,6 @@ private:
     void process_mission_current(const mavlink_message_t& message);
     void process_mission_item_reached(const mavlink_message_t& message);
     void process_gimbal_information(const mavlink_message_t& message);
-    void process_gimbal_manager_information(const mavlink_message_t& message);
-    void receive_protocol_timeout();
-    void wait_for_protocol();
-    void wait_for_protocol_async(std::function<void()> callback);
 
     static bool has_valid_position(const Mission::MissionItem& item);
     static float hold_time(const Mission::MissionItem& item);
@@ -167,9 +163,8 @@ private:
 
     static constexpr double RETRY_TIMEOUT_S = 0.250;
 
-    void* _gimbal_protocol_cookie{nullptr};
     enum class GimbalProtocol { Unknown, V1, V2 };
-    std::atomic<GimbalProtocol> _gimbal_protocol{GimbalProtocol::Unknown};
+    std::atomic<GimbalProtocol> _gimbal_protocol{GimbalProtocol::V2};
 };
 
 } // namespace mavsdk


### PR DESCRIPTION
* Add target_component_id to `RequestMessage`
* Default to gimbal v2 in mission plugin
* Default to gimbal v2 in gimbal plugin, requiring a newly-added `prepare()` function to detect the remote gimbal manager

Currently, both the mission plugin and the gimbal plugin detect the protocol version separately, which can end up in one going for v2 and the other going for v1. Also MAVLink cannot properly detect the protocol version and has to guess, falling back to v1 in case of timeout.

The big question here is whether or not we can drop gimbal protocol v1 in MAVSDK. This PR does not completely remove it, with the idea that we could try for a while and see if it impacts many users before completely removing the entire v1 code.

Resolves #1625 (supposedly).