### PR TITLE
core: only request autopilot version if autopilot

### DIFF
--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -553,7 +553,9 @@ void SystemImpl::set_connected()
         // If not yet connected there is nothing to do/
     }
     if (enable_needed) {
-        send_autopilot_version_request();
+        if (has_autopilot()) {
+            send_autopilot_version_request();
+        }
 
         std::lock_guard<std::mutex> lock(_plugin_impls_mutex);
         for (auto plugin_impl : _plugin_impls) {


### PR DESCRIPTION
This adds a check to only request the autopilot version on connection if the connection is actually an autopilot. This message fails, e.g. when connecting to a ground control station, which causes extra noise in the logs and extra mavlink messages that are just one more thing that has to be filtered out when debugging other problems.