### PR TITLE
mavsdk_server_bin: parse sysid and compid from CLI

### DIFF
--- a/src/mavsdk_server/src/mavsdk_server_bin.cpp
+++ b/src/mavsdk_server/src/mavsdk_server_bin.cpp
@@ -2,10 +2,13 @@
 
 #include <cctype>
 #include <iostream>
+#include <limits>
 #include <string>
 
 static auto constexpr default_connection = "udp://:14540";
 static auto constexpr default_mavsdk_server_port = 50051;
+static auto constexpr default_sysid = 245;
+static auto constexpr default_compid = 190;
 
 static void usage(const char* bin_name);
 static bool is_integer(const std::string& tested_integer);
@@ -14,6 +17,8 @@ int main(int argc, char** argv)
 {
     std::string connection_url = default_connection;
     int mavsdk_server_port = default_mavsdk_server_port;
+    int mavsdk_sysid = default_sysid;
+    int mavsdk_compid = default_compid;
 
     for (int i = 1; i < argc; i++) {
         const std::string current_arg = argv[i];
@@ -36,6 +41,46 @@ int main(int argc, char** argv)
             }
 
             mavsdk_server_port = std::stoi(port);
+        } else if (current_arg == "--sysid") {
+            if (argc <= i + 1) {
+                usage(argv[0]);
+                return 1;
+            }
+
+            const std::string sysid(argv[i + 1]);
+            i++;
+
+            if (!is_integer(sysid)) {
+                usage(argv[0]);
+                return 1;
+            }
+
+            mavsdk_sysid = std::stoi(sysid);
+
+            if (mavsdk_sysid > std::numeric_limits<uint8_t>::max() || mavsdk_sysid < 1) {
+                usage(argv[0]);
+                return 1;
+            }
+        } else if (current_arg == "--compid") {
+            if (argc <= i + 1) {
+                usage(argv[0]);
+                return 1;
+            }
+
+            const std::string compid(argv[i + 1]);
+            i++;
+
+            if (!is_integer(compid)) {
+                usage(argv[0]);
+                return 1;
+            }
+
+            mavsdk_compid = std::stoi(compid);
+
+            if (mavsdk_compid > std::numeric_limits<uint8_t>::max() || mavsdk_compid < 1) {
+                usage(argv[0]);
+                return 1;
+            }
         } else {
             connection_url = current_arg;
         }
@@ -43,7 +88,12 @@ int main(int argc, char** argv)
 
     MavsdkServer* mavsdk_server;
     mavsdk_server_init(&mavsdk_server);
-    auto is_started = mavsdk_server_run(mavsdk_server, connection_url.c_str(), mavsdk_server_port);
+    const auto is_started = mavsdk_server_run_with_mavlink_ids(
+        mavsdk_server,
+        connection_url.c_str(),
+        mavsdk_server_port,
+        static_cast<uint8_t>(mavsdk_sysid),
+        static_cast<uint8_t>(mavsdk_compid));
 
     if (!is_started) {
         std::cout << "Failed to start, exiting...\n";
@@ -59,8 +109,7 @@ int main(int argc, char** argv)
 
 void usage(const char* bin_name)
 {
-    std::cout << "Usage: " << bin_name << " [-h | --help]" << '\n'
-              << "       " << bin_name << " [-p mavsdk_server_port] [Connection URL]" << '\n'
+    std::cout << "Usage: " << bin_name << " [Options] [Connection URL]" << '\n'
               << '\n'
               << "Connection URL format should be:" << '\n'
               << "  Serial: serial:///path/to/serial/dev[:baudrate]" << '\n'
@@ -73,7 +122,11 @@ void usage(const char* bin_name)
               << "  -h | --help : show this help" << '\n'
               << "  -p          : set the port on which to run the gRPC server,\n"
               << "                set to 0 to choose a free port automatically\n"
-              << "                (default is " << default_mavsdk_server_port << ")\n";
+              << "                (default is " << default_mavsdk_server_port << ")\n"
+              << "  --sysid     : set the MAVLink system ID of the MAVSDK server itself,\n"
+              << "                (default is " << default_sysid << ", range 1..255)\n"
+              << "  --compid    : set the MAVLink component ID of the MAVSDK server itself,\n"
+              << "                (default is " << default_compid << ", range 1..255)\n";
 }
 
 bool is_integer(const std::string& tested_integer)


### PR DESCRIPTION
This allows to start the mavsdk_server using arguments for sysid and compid.