### PR TITLE
core: don't send AUTOPILOT_VERSION by default

### DIFF
--- a/src/core/system_impl.h
+++ b/src/core/system_impl.h
@@ -58,6 +58,7 @@ public:
     void init(uint8_t system_id, uint8_t comp_id, bool connected);
 
     void enable_timesync();
+    void enable_sending_autopilot_version();
 
     void subscribe_is_connected(System::IsConnectedCallback callback);
 
@@ -408,6 +409,8 @@ private:
     std::mutex _autopilot_version_mutex{};
     System::AutopilotVersion _autopilot_version{
         MAV_PROTOCOL_CAPABILITY_COMMAND_INT, 0, 0, 0, 0, 0, 0, {0}};
+
+    std::atomic<bool> _should_send_autopilot_version{false};
 };
 
 } // namespace mavsdk

--- a/src/plugins/action_server/action_server_impl.cpp
+++ b/src/plugins/action_server/action_server_impl.cpp
@@ -53,6 +53,8 @@ ActionServerImpl::~ActionServerImpl()
 
 void ActionServerImpl::init()
 {
+    _parent->enable_sending_autopilot_version();
+
     // Arming / Disarm / Kill
     _parent->register_mavlink_command_handler(
         MAV_CMD_COMPONENT_ARM_DISARM,


### PR DESCRIPTION
If MAVSDK is run on the companion side this will confuse the ground stations and they will say that the version of PX4 is "not supported".