### PR TITLE
added mavsdk_connection

### DIFF
--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -25,6 +25,7 @@ public:
     bool has_system_id(uint8_t system_id);
     bool should_forward_messages() const;
     static unsigned forwarding_connections_count();
+    void register_callback(receiver_callback_t receiver_callback);
 
     // Non-copyable
     Connection(const Connection&) = delete;
@@ -35,7 +36,7 @@ protected:
     void stop_mavlink_receiver();
     void receive_message(mavlink_message_t& message, Connection* connection);
 
-    receiver_callback_t _receiver_callback{};
+    std::vector<receiver_callback_t> _receiver_callback{0};
     std::unique_ptr<MAVLinkReceiver> _mavlink_receiver;
     ForwardingOption _forwarding_option;
     std::unordered_set<uint8_t> _system_ids;

--- a/src/core/mavsdk.cpp
+++ b/src/core/mavsdk.cpp
@@ -55,6 +55,10 @@ ConnectionResult Mavsdk::add_serial_connection(
     return _impl->add_serial_connection(dev_path, baudrate, flow_control, forwarding_option);
 }
 
+ConnectionResult Mavsdk::add_mavsdk_connection(Mavsdk *mavsdk) {
+    return _impl->add_mavsdk_connection(mavsdk->_impl.get());
+}
+
 std::vector<std::shared_ptr<System>> Mavsdk::systems() const
 {
     return _impl->systems();

--- a/src/core/mavsdk.h
+++ b/src/core/mavsdk.h
@@ -162,6 +162,16 @@ public:
         ForwardingOption forwarding_option = ForwardingOption::ForwardingOff);
 
     /**
+     * @brief Adds the first connection of antoher Mavsdk instance to this Mavsdk instance. Used to share
+     * the same connection between two or more components.
+     *
+     *
+     * @param mavsdk other mavsdk instance.
+     * @return The result of adding the connection.
+     */
+    ConnectionResult add_mavsdk_connection(Mavsdk *mavsdk);
+
+    /**
      * @brief Get a vector of systems which have been discovered or set-up.
      *
      * @return The vector of systems which are available.

--- a/src/core/mavsdk_impl.cpp
+++ b/src/core/mavsdk_impl.cpp
@@ -415,6 +415,18 @@ ConnectionResult MavsdkImpl::add_serial_connection(
     return ret;
 }
 
+ConnectionResult MavsdkImpl::add_mavsdk_connection(MavsdkImpl *mavsdk) {
+    if(mavsdk->_connections.size() == 0) {
+        return ConnectionResult::ConnectionError;
+    }
+    auto shared_conn = mavsdk->_connections.front();
+    shared_conn->register_callback([this](mavlink_message_t& message, Connection* connection) {
+        receive_message(message, connection);
+    });
+    add_connection(shared_conn);
+    return ConnectionResult::Success;
+}
+
 void MavsdkImpl::add_connection(const std::shared_ptr<Connection>& new_connection)
 {
     std::lock_guard<std::mutex> lock(_connections_mutex);

--- a/src/core/mavsdk_impl.h
+++ b/src/core/mavsdk_impl.h
@@ -57,6 +57,7 @@ public:
         int baudrate,
         bool flow_control,
         ForwardingOption forwarding_option);
+    ConnectionResult add_mavsdk_connection(MavsdkImpl *mavsdk);
     ConnectionResult setup_udp_remote(
         const std::string& remote_ip, int remote_port, ForwardingOption forwarding_option);
 

--- a/src/core/serial_connection.cpp
+++ b/src/core/serial_connection.cpp
@@ -266,6 +266,8 @@ bool SerialConnection::send_message(const mavlink_message_t& message)
     uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
     uint16_t buffer_len = mavlink_msg_to_send_buffer(buffer, &message);
 
+    std::lock_guard<std::mutex> lock(_send_mutex);
+
     int send_len;
 #if defined(LINUX) || defined(APPLE)
     send_len = static_cast<int>(write(_fd, buffer, buffer_len));

--- a/src/core/serial_connection.h
+++ b/src/core/serial_connection.h
@@ -48,6 +48,7 @@ private:
     HANDLE _handle;
 #endif
 
+    std::mutex _send_mutex{};
     std::thread* _recv_thread = nullptr;
     std::atomic_bool _should_exit{false};
 };

--- a/src/core/tcp_connection.cpp
+++ b/src/core/tcp_connection.cpp
@@ -165,6 +165,8 @@ bool TcpConnection::send_message(const mavlink_message_t& message)
     auto flags = MSG_NOSIGNAL;
 #endif
 
+    std::lock_guard<std::mutex> lock(_send_mutex);
+
     const auto send_len = sendto(
         _socket_fd,
         reinterpret_cast<char*>(buffer),

--- a/src/core/tcp_connection.h
+++ b/src/core/tcp_connection.h
@@ -43,6 +43,7 @@ private:
     std::mutex _mutex = {};
     int _socket_fd = -1;
 
+    std::mutex _send_mutex{};
     std::thread* _recv_thread = nullptr;
     std::atomic_bool _should_exit;
     std::atomic_bool _is_ok{false};


### PR DESCRIPTION
This pull request adds Mavsdk::add_mavsdk_connection function. That function permit to share the connection of another mavsdk instance. This function is useful if you want to impersonate different devices on the same connection.

For example if you want to make a single application that act as a camera, a gimbal and a client companion computer sharing that same autopilot serial connection.

