### PR TITLE
mavlink_message_handler: use std::map instead of std::vector

### DIFF
--- a/src/core/mavlink_message_handler.h
+++ b/src/core/mavlink_message_handler.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <mutex>
 #include <vector>
+#include <map>
 #include "mavlink_include.h"
 
 namespace mavsdk {
@@ -13,7 +14,6 @@ public:
     using Callback = std::function<void(const mavlink_message_t&)>;
 
     struct Entry {
-        uint32_t msg_id;
         Callback callback;
         const void* cookie; // This is the identification to unregister.
     };
@@ -25,7 +25,7 @@ public:
 
 private:
     std::mutex _mutex{};
-    std::vector<Entry> _table{};
+    std::map<uint32_t, std::vector<Entry>> _map{};
 };
 
 } // namespace mavsdk


### PR DESCRIPTION
If you have a lot of plugins activated, you naturally have a lot of mavlink message handlers (potentially even multiple handlers for the same ID). With this PR, we do not iterate through all message handlers to find the one that can handle the current messsage ID. Instead we use a std::map to have a mapping message_id -> handlers in an efficient way.