### PR TITLE
mission: add transfer progress

### DIFF
--- a/src/mavsdk/core/mavlink_mission_transfer.cpp
+++ b/src/mavsdk/core/mavlink_mission_transfer.cpp
@@ -16,7 +16,10 @@ MAVLinkMissionTransfer::MAVLinkMissionTransfer(
 {}
 
 std::weak_ptr<MAVLinkMissionTransfer::WorkItem> MAVLinkMissionTransfer::upload_items_async(
-    uint8_t type, const std::vector<ItemInt>& items, ResultCallback callback)
+    uint8_t type,
+    const std::vector<ItemInt>& items,
+    ResultCallback callback,
+    ProgressCallback progress_callback)
 {
     if (!_int_messages_supported) {
         if (callback) {
@@ -27,15 +30,22 @@ std::weak_ptr<MAVLinkMissionTransfer::WorkItem> MAVLinkMissionTransfer::upload_i
     }
 
     auto ptr = std::make_shared<UploadWorkItem>(
-        _sender, _message_handler, _timeout_handler, type, items, _timeout_s_callback(), callback);
+        _sender,
+        _message_handler,
+        _timeout_handler,
+        type,
+        items,
+        _timeout_s_callback(),
+        callback,
+        progress_callback);
 
     _work_queue.push_back(ptr);
 
     return std::weak_ptr<WorkItem>(ptr);
 }
 
-std::weak_ptr<MAVLinkMissionTransfer::WorkItem>
-MAVLinkMissionTransfer::download_items_async(uint8_t type, ResultAndItemsCallback callback)
+std::weak_ptr<MAVLinkMissionTransfer::WorkItem> MAVLinkMissionTransfer::download_items_async(
+    uint8_t type, ResultAndItemsCallback callback, ProgressCallback progress_callback)
 {
     if (!_int_messages_supported) {
         if (callback) {
@@ -46,7 +56,13 @@ MAVLinkMissionTransfer::download_items_async(uint8_t type, ResultAndItemsCallbac
     }
 
     auto ptr = std::make_shared<DownloadWorkItem>(
-        _sender, _message_handler, _timeout_handler, type, _timeout_s_callback(), callback);
+        _sender,
+        _message_handler,
+        _timeout_handler,
+        type,
+        _timeout_s_callback(),
+        callback,
+        progress_callback);
 
     _work_queue.push_back(ptr);
 
@@ -153,10 +169,12 @@ MAVLinkMissionTransfer::UploadWorkItem::UploadWorkItem(
     uint8_t type,
     const std::vector<ItemInt>& items,
     double timeout_s,
-    ResultCallback callback) :
+    ResultCallback callback,
+    ProgressCallback progress_callback) :
     WorkItem(sender, message_handler, timeout_handler, type, timeout_s),
     _items(items),
-    _callback(callback)
+    _callback(callback),
+    _progress_callback(progress_callback)
 {
     std::lock_guard<std::mutex> lock(_mutex);
 
@@ -216,6 +234,8 @@ void MAVLinkMissionTransfer::UploadWorkItem::start()
         callback_and_reset(Result::MissionTypeNotConsistent);
         return;
     }
+
+    update_progress(0.0f);
 
     _retries_done = 0;
     _step = Step::SendCount;
@@ -360,6 +380,10 @@ void MAVLinkMissionTransfer::UploadWorkItem::process_mission_request_int(
     _timeout_handler.refresh(_cookie);
 
     _next_sequence = request_int.seq;
+
+    // We add in a step for the final ack, so plus one.
+    update_progress(static_cast<float>(_next_sequence + 1) / static_cast<float>(_items.size() + 1));
+
     send_mission_item();
 }
 
@@ -458,6 +482,7 @@ void MAVLinkMissionTransfer::UploadWorkItem::process_mission_ack(const mavlink_m
     }
 
     if (_next_sequence == _items.size()) {
+        update_progress(1.0f);
         callback_and_reset(Result::Success);
     } else {
         callback_and_reset(Result::ProtocolError);
@@ -506,9 +531,11 @@ MAVLinkMissionTransfer::DownloadWorkItem::DownloadWorkItem(
     TimeoutHandler& timeout_handler,
     uint8_t type,
     double timeout_s,
-    ResultAndItemsCallback callback) :
+    ResultAndItemsCallback callback,
+    ProgressCallback progress_callback) :
     WorkItem(sender, message_handler, timeout_handler, type, timeout_s),
-    _callback(callback)
+    _callback(callback),
+    _progress_callback(progress_callback)
 {
     std::lock_guard<std::mutex> lock(_mutex);
 
@@ -523,6 +550,13 @@ MAVLinkMissionTransfer::DownloadWorkItem::DownloadWorkItem(
         this);
 }
 
+void MAVLinkMissionTransfer::UploadWorkItem::update_progress(float progress)
+{
+    if (_progress_callback != nullptr) {
+        _progress_callback(progress);
+    }
+}
+
 MAVLinkMissionTransfer::DownloadWorkItem::~DownloadWorkItem()
 {
     std::lock_guard<std::mutex> lock(_mutex);
@@ -533,6 +567,8 @@ MAVLinkMissionTransfer::DownloadWorkItem::~DownloadWorkItem()
 
 void MAVLinkMissionTransfer::DownloadWorkItem::start()
 {
+    update_progress(0.0f);
+
     std::lock_guard<std::mutex> lock(_mutex);
 
     _items.clear();
@@ -682,11 +718,13 @@ void MAVLinkMissionTransfer::DownloadWorkItem::process_mission_item_int(
 
     if (_next_sequence + 1 == _expected_count) {
         _timeout_handler.remove(_cookie);
+        update_progress(1.0f);
         send_ack_and_finish();
 
     } else {
         _next_sequence = item_int.seq + 1;
         _retries_done = 0;
+        update_progress(static_cast<float>(_next_sequence) / static_cast<float>(_expected_count));
         request_item();
     }
 }
@@ -720,6 +758,13 @@ void MAVLinkMissionTransfer::DownloadWorkItem::callback_and_reset(Result result)
     }
     _callback = nullptr;
     _done = true;
+}
+
+void MAVLinkMissionTransfer::DownloadWorkItem::update_progress(float progress)
+{
+    if (_progress_callback != nullptr) {
+        _progress_callback(progress);
+    }
 }
 
 MAVLinkMissionTransfer::ReceiveIncomingMission::ReceiveIncomingMission(

--- a/src/mavsdk/plugins/mission/include/plugins/mission/mission.h
+++ b/src/mavsdk/plugins/mission/include/plugins/mission/mission.h
@@ -145,6 +145,51 @@ public:
     friend std::ostream& operator<<(std::ostream& str, Mission::MissionPlan const& mission_plan);
 
     /**
+     * @brief Mission upload progress type.
+     */
+    struct UploadProgress {
+        float progress{}; /**< @brief Upload progress from 0.0 to 1.0 */
+    };
+
+    /**
+     * @brief Equal operator to compare two `Mission::UploadProgress` objects.
+     *
+     * @return `true` if items are equal.
+     */
+    friend bool operator==(const Mission::UploadProgress& lhs, const Mission::UploadProgress& rhs);
+
+    /**
+     * @brief Stream operator to print information about a `Mission::UploadProgress`.
+     *
+     * @return A reference to the stream.
+     */
+    friend std::ostream&
+    operator<<(std::ostream& str, Mission::UploadProgress const& upload_progress);
+
+    /**
+     * @brief Mission download progress type.
+     */
+    struct DownloadProgress {
+        float progress{}; /**< @brief Download progress from 0.0 to 1.0 */
+    };
+
+    /**
+     * @brief Equal operator to compare two `Mission::DownloadProgress` objects.
+     *
+     * @return `true` if items are equal.
+     */
+    friend bool
+    operator==(const Mission::DownloadProgress& lhs, const Mission::DownloadProgress& rhs);
+
+    /**
+     * @brief Stream operator to print information about a `Mission::DownloadProgress`.
+     *
+     * @return A reference to the stream.
+     */
+    friend std::ostream&
+    operator<<(std::ostream& str, Mission::DownloadProgress const& download_progress);
+
+    /**
      * @brief Mission progress type.
      */
     struct MissionProgress {
@@ -231,6 +276,17 @@ public:
     Result cancel_mission_upload() const;
 
     /**
+     * @brief Callback type for subscribe_upload_progress.
+     */
+
+    using UploadProgressCallback = std::function<void(UploadProgress)>;
+
+    /**
+     * @brief Subscribe to mission upload progress.
+     */
+    void subscribe_upload_progress(UploadProgressCallback callback);
+
+    /**
      * @brief Callback type for download_mission_async.
      */
     using DownloadMissionCallback = std::function<void(Result, MissionPlan)>;
@@ -265,6 +321,17 @@ public:
      * @return Result of request.
      */
     Result cancel_mission_download() const;
+
+    /**
+     * @brief Callback type for subscribe_download_progress.
+     */
+
+    using DownloadProgressCallback = std::function<void(DownloadProgress)>;
+
+    /**
+     * @brief Subscribe to mission download progress.
+     */
+    void subscribe_download_progress(DownloadProgressCallback callback);
 
     /**
      * @brief Start the mission.

--- a/src/mavsdk/plugins/mission/mission.cpp
+++ b/src/mavsdk/plugins/mission/mission.cpp
@@ -11,6 +11,8 @@ namespace mavsdk {
 
 using MissionItem = Mission::MissionItem;
 using MissionPlan = Mission::MissionPlan;
+using UploadProgress = Mission::UploadProgress;
+using DownloadProgress = Mission::DownloadProgress;
 using MissionProgress = Mission::MissionProgress;
 
 Mission::Mission(System& system) : PluginBase(), _impl{std::make_unique<MissionImpl>(system)} {}
@@ -37,6 +39,11 @@ Mission::Result Mission::cancel_mission_upload() const
     return _impl->cancel_mission_upload();
 }
 
+void Mission::subscribe_upload_progress(UploadProgressCallback callback)
+{
+    _impl->subscribe_upload_progress(callback);
+}
+
 void Mission::download_mission_async(const DownloadMissionCallback callback)
 {
     _impl->download_mission_async(callback);
@@ -50,6 +57,11 @@ std::pair<Mission::Result, Mission::MissionPlan> Mission::download_mission() con
 Mission::Result Mission::cancel_mission_download() const
 {
     return _impl->cancel_mission_download();
+}
+
+void Mission::subscribe_download_progress(DownloadProgressCallback callback)
+{
+    _impl->subscribe_download_progress(callback);
 }
 
 void Mission::start_mission_async(const ResultCallback callback)
@@ -203,6 +215,34 @@ std::ostream& operator<<(std::ostream& str, Mission::MissionPlan const& mission_
         str << *it;
         str << (it + 1 != mission_plan.mission_items.end() ? ", " : "]\n");
     }
+    str << '}';
+    return str;
+}
+
+bool operator==(const Mission::UploadProgress& lhs, const Mission::UploadProgress& rhs)
+{
+    return ((std::isnan(rhs.progress) && std::isnan(lhs.progress)) || rhs.progress == lhs.progress);
+}
+
+std::ostream& operator<<(std::ostream& str, Mission::UploadProgress const& upload_progress)
+{
+    str << std::setprecision(15);
+    str << "upload_progress:" << '\n' << "{\n";
+    str << "    progress: " << upload_progress.progress << '\n';
+    str << '}';
+    return str;
+}
+
+bool operator==(const Mission::DownloadProgress& lhs, const Mission::DownloadProgress& rhs)
+{
+    return ((std::isnan(rhs.progress) && std::isnan(lhs.progress)) || rhs.progress == lhs.progress);
+}
+
+std::ostream& operator<<(std::ostream& str, Mission::DownloadProgress const& download_progress)
+{
+    str << std::setprecision(15);
+    str << "download_progress:" << '\n' << "{\n";
+    str << "    progress: " << download_progress.progress << '\n';
     str << '}';
     return str;
 }

--- a/src/mavsdk/plugins/mission/mission_impl.cpp
+++ b/src/mavsdk/plugins/mission/mission_impl.cpp
@@ -457,7 +457,7 @@ MissionImpl::convert_to_int_items(const std::vector<MissionItem>& mission_items)
                     break;
                 case CameraAction::StartPhotoDistance:
                     command = MAV_CMD_DO_SET_CAM_TRIGG_DIST;
-                    if (std::isfinite(item.camera_photo_distance_m)) {
+                    if (!std::isfinite(item.camera_photo_distance_m)) {
                         LogErr() << "No photo distance specified";
                     }
                     param1 = item.camera_photo_distance_m; // enable with distance

--- a/src/mavsdk/plugins/mission/mission_impl.h
+++ b/src/mavsdk/plugins/mission/mission_impl.h
@@ -63,6 +63,9 @@ public:
     Mission::MissionProgress mission_progress();
     void subscribe_mission_progress(Mission::MissionProgressCallback callback);
 
+    void subscribe_upload_progress(Mission::UploadProgressCallback callback);
+    void subscribe_download_progress(Mission::DownloadProgressCallback callback);
+
     // Non-copyable
     MissionImpl(const MissionImpl&) = delete;
     const MissionImpl& operator=(const MissionImpl&) = delete;
@@ -125,6 +128,8 @@ private:
         Mission::ResultCallback result_callback{nullptr};
         Mission::DownloadMissionCallback download_mission_callback{nullptr};
         Mission::MissionProgressCallback mission_progress_callback{nullptr};
+        Mission::DownloadProgressCallback download_progress_callback{nullptr};
+        Mission::UploadProgressCallback upload_progress_callback{nullptr};
         int last_current_reported_mission_item{-1};
         int last_total_reported_mission_item{-1};
         std::weak_ptr<MAVLinkMissionTransfer::WorkItem> last_upload{};

--- a/src/mavsdk/plugins/mission/mocks/mission_mock.h
+++ b/src/mavsdk/plugins/mission/mocks/mission_mock.h
@@ -29,6 +29,8 @@ public:
     MOCK_CONST_METHOD0(total_mission_items, int()){};
     MOCK_CONST_METHOD0(is_mission_finished, std::pair<Mission::Result, bool>()){};
     MOCK_CONST_METHOD1(subscribe_mission_progress, void(Mission::MissionProgressCallback)){};
+    MOCK_CONST_METHOD1(subscribe_upload_progress, void(Mission::UploadProgressCallback)){};
+    MOCK_CONST_METHOD1(subscribe_download_progress, void(Mission::DownloadProgressCallback)){};
     MOCK_CONST_METHOD0(get_return_to_launch_after_mission, std::pair<Mission::Result, bool>()){};
     MOCK_CONST_METHOD1(set_return_to_launch_after_mission, Mission::Result(bool)){};
 

--- a/src/mavsdk_server/src/generated/mission/mission.grpc.pb.cc
+++ b/src/mavsdk_server/src/generated/mission/mission.grpc.pb.cc
@@ -26,8 +26,10 @@ namespace mission {
 static const char* MissionService_method_names[] = {
   "/mavsdk.rpc.mission.MissionService/UploadMission",
   "/mavsdk.rpc.mission.MissionService/CancelMissionUpload",
+  "/mavsdk.rpc.mission.MissionService/SubscribeUploadProgress",
   "/mavsdk.rpc.mission.MissionService/DownloadMission",
   "/mavsdk.rpc.mission.MissionService/CancelMissionDownload",
+  "/mavsdk.rpc.mission.MissionService/SubscribeDownloadProgress",
   "/mavsdk.rpc.mission.MissionService/StartMission",
   "/mavsdk.rpc.mission.MissionService/PauseMission",
   "/mavsdk.rpc.mission.MissionService/ClearMission",
@@ -47,16 +49,18 @@ std::unique_ptr< MissionService::Stub> MissionService::NewStub(const std::shared
 MissionService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options)
   : channel_(channel), rpcmethod_UploadMission_(MissionService_method_names[0], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_CancelMissionUpload_(MissionService_method_names[1], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_DownloadMission_(MissionService_method_names[2], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_CancelMissionDownload_(MissionService_method_names[3], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_StartMission_(MissionService_method_names[4], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_PauseMission_(MissionService_method_names[5], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ClearMission_(MissionService_method_names[6], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetCurrentMissionItem_(MissionService_method_names[7], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_IsMissionFinished_(MissionService_method_names[8], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SubscribeMissionProgress_(MissionService_method_names[9], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
-  , rpcmethod_GetReturnToLaunchAfterMission_(MissionService_method_names[10], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetReturnToLaunchAfterMission_(MissionService_method_names[11], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubscribeUploadProgress_(MissionService_method_names[2], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_DownloadMission_(MissionService_method_names[3], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_CancelMissionDownload_(MissionService_method_names[4], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubscribeDownloadProgress_(MissionService_method_names[5], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_StartMission_(MissionService_method_names[6], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_PauseMission_(MissionService_method_names[7], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ClearMission_(MissionService_method_names[8], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetCurrentMissionItem_(MissionService_method_names[9], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_IsMissionFinished_(MissionService_method_names[10], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubscribeMissionProgress_(MissionService_method_names[11], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_GetReturnToLaunchAfterMission_(MissionService_method_names[12], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetReturnToLaunchAfterMission_(MissionService_method_names[13], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status MissionService::Stub::UploadMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::UploadMissionRequest& request, ::mavsdk::rpc::mission::UploadMissionResponse* response) {
@@ -105,6 +109,22 @@ void MissionService::Stub::async::CancelMissionUpload(::grpc::ClientContext* con
   return result;
 }
 
+::grpc::ClientReader< ::mavsdk::rpc::mission::UploadProgressResponse>* MissionService::Stub::SubscribeUploadProgressRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest& request) {
+  return ::grpc::internal::ClientReaderFactory< ::mavsdk::rpc::mission::UploadProgressResponse>::Create(channel_.get(), rpcmethod_SubscribeUploadProgress_, context, request);
+}
+
+void MissionService::Stub::async::SubscribeUploadProgress(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::mission::UploadProgressResponse>* reactor) {
+  ::grpc::internal::ClientCallbackReaderFactory< ::mavsdk::rpc::mission::UploadProgressResponse>::Create(stub_->channel_.get(), stub_->rpcmethod_SubscribeUploadProgress_, context, request, reactor);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::mission::UploadProgressResponse>* MissionService::Stub::AsyncSubscribeUploadProgressRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::mission::UploadProgressResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeUploadProgress_, context, request, true, tag);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::mission::UploadProgressResponse>* MissionService::Stub::PrepareAsyncSubscribeUploadProgressRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::mission::UploadProgressResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeUploadProgress_, context, request, false, nullptr);
+}
+
 ::grpc::Status MissionService::Stub::DownloadMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::DownloadMissionRequest& request, ::mavsdk::rpc::mission::DownloadMissionResponse* response) {
   return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::mission::DownloadMissionRequest, ::mavsdk::rpc::mission::DownloadMissionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_DownloadMission_, context, request, response);
 }
@@ -149,6 +169,22 @@ void MissionService::Stub::async::CancelMissionDownload(::grpc::ClientContext* c
     this->PrepareAsyncCancelMissionDownloadRaw(context, request, cq);
   result->StartCall();
   return result;
+}
+
+::grpc::ClientReader< ::mavsdk::rpc::mission::DownloadProgressResponse>* MissionService::Stub::SubscribeDownloadProgressRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest& request) {
+  return ::grpc::internal::ClientReaderFactory< ::mavsdk::rpc::mission::DownloadProgressResponse>::Create(channel_.get(), rpcmethod_SubscribeDownloadProgress_, context, request);
+}
+
+void MissionService::Stub::async::SubscribeDownloadProgress(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::mission::DownloadProgressResponse>* reactor) {
+  ::grpc::internal::ClientCallbackReaderFactory< ::mavsdk::rpc::mission::DownloadProgressResponse>::Create(stub_->channel_.get(), stub_->rpcmethod_SubscribeDownloadProgress_, context, request, reactor);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::mission::DownloadProgressResponse>* MissionService::Stub::AsyncSubscribeDownloadProgressRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::mission::DownloadProgressResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeDownloadProgress_, context, request, true, tag);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::mission::DownloadProgressResponse>* MissionService::Stub::PrepareAsyncSubscribeDownloadProgressRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::mission::DownloadProgressResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeDownloadProgress_, context, request, false, nullptr);
 }
 
 ::grpc::Status MissionService::Stub::StartMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::StartMissionRequest& request, ::mavsdk::rpc::mission::StartMissionResponse* response) {
@@ -351,6 +387,16 @@ MissionService::Service::Service() {
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       MissionService_method_names[2],
+      ::grpc::internal::RpcMethod::SERVER_STREAMING,
+      new ::grpc::internal::ServerStreamingHandler< MissionService::Service, ::mavsdk::rpc::mission::SubscribeUploadProgressRequest, ::mavsdk::rpc::mission::UploadProgressResponse>(
+          [](MissionService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest* req,
+             ::grpc::ServerWriter<::mavsdk::rpc::mission::UploadProgressResponse>* writer) {
+               return service->SubscribeUploadProgress(ctx, req, writer);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      MissionService_method_names[3],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< MissionService::Service, ::mavsdk::rpc::mission::DownloadMissionRequest, ::mavsdk::rpc::mission::DownloadMissionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](MissionService::Service* service,
@@ -360,7 +406,7 @@ MissionService::Service::Service() {
                return service->DownloadMission(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      MissionService_method_names[3],
+      MissionService_method_names[4],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< MissionService::Service, ::mavsdk::rpc::mission::CancelMissionDownloadRequest, ::mavsdk::rpc::mission::CancelMissionDownloadResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](MissionService::Service* service,
@@ -370,7 +416,17 @@ MissionService::Service::Service() {
                return service->CancelMissionDownload(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      MissionService_method_names[4],
+      MissionService_method_names[5],
+      ::grpc::internal::RpcMethod::SERVER_STREAMING,
+      new ::grpc::internal::ServerStreamingHandler< MissionService::Service, ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest, ::mavsdk::rpc::mission::DownloadProgressResponse>(
+          [](MissionService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest* req,
+             ::grpc::ServerWriter<::mavsdk::rpc::mission::DownloadProgressResponse>* writer) {
+               return service->SubscribeDownloadProgress(ctx, req, writer);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      MissionService_method_names[6],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< MissionService::Service, ::mavsdk::rpc::mission::StartMissionRequest, ::mavsdk::rpc::mission::StartMissionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](MissionService::Service* service,
@@ -380,7 +436,7 @@ MissionService::Service::Service() {
                return service->StartMission(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      MissionService_method_names[5],
+      MissionService_method_names[7],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< MissionService::Service, ::mavsdk::rpc::mission::PauseMissionRequest, ::mavsdk::rpc::mission::PauseMissionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](MissionService::Service* service,
@@ -390,7 +446,7 @@ MissionService::Service::Service() {
                return service->PauseMission(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      MissionService_method_names[6],
+      MissionService_method_names[8],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< MissionService::Service, ::mavsdk::rpc::mission::ClearMissionRequest, ::mavsdk::rpc::mission::ClearMissionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](MissionService::Service* service,
@@ -400,7 +456,7 @@ MissionService::Service::Service() {
                return service->ClearMission(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      MissionService_method_names[7],
+      MissionService_method_names[9],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< MissionService::Service, ::mavsdk::rpc::mission::SetCurrentMissionItemRequest, ::mavsdk::rpc::mission::SetCurrentMissionItemResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](MissionService::Service* service,
@@ -410,7 +466,7 @@ MissionService::Service::Service() {
                return service->SetCurrentMissionItem(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      MissionService_method_names[8],
+      MissionService_method_names[10],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< MissionService::Service, ::mavsdk::rpc::mission::IsMissionFinishedRequest, ::mavsdk::rpc::mission::IsMissionFinishedResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](MissionService::Service* service,
@@ -420,7 +476,7 @@ MissionService::Service::Service() {
                return service->IsMissionFinished(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      MissionService_method_names[9],
+      MissionService_method_names[11],
       ::grpc::internal::RpcMethod::SERVER_STREAMING,
       new ::grpc::internal::ServerStreamingHandler< MissionService::Service, ::mavsdk::rpc::mission::SubscribeMissionProgressRequest, ::mavsdk::rpc::mission::MissionProgressResponse>(
           [](MissionService::Service* service,
@@ -430,7 +486,7 @@ MissionService::Service::Service() {
                return service->SubscribeMissionProgress(ctx, req, writer);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      MissionService_method_names[10],
+      MissionService_method_names[12],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< MissionService::Service, ::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionRequest, ::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](MissionService::Service* service,
@@ -440,7 +496,7 @@ MissionService::Service::Service() {
                return service->GetReturnToLaunchAfterMission(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      MissionService_method_names[11],
+      MissionService_method_names[13],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< MissionService::Service, ::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionRequest, ::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](MissionService::Service* service,
@@ -468,6 +524,13 @@ MissionService::Service::~Service() {
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
+::grpc::Status MissionService::Service::SubscribeUploadProgress(::grpc::ServerContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::mission::UploadProgressResponse>* writer) {
+  (void) context;
+  (void) request;
+  (void) writer;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
 ::grpc::Status MissionService::Service::DownloadMission(::grpc::ServerContext* context, const ::mavsdk::rpc::mission::DownloadMissionRequest* request, ::mavsdk::rpc::mission::DownloadMissionResponse* response) {
   (void) context;
   (void) request;
@@ -479,6 +542,13 @@ MissionService::Service::~Service() {
   (void) context;
   (void) request;
   (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status MissionService::Service::SubscribeDownloadProgress(::grpc::ServerContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::mission::DownloadProgressResponse>* writer) {
+  (void) context;
+  (void) request;
+  (void) writer;
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 

--- a/src/mavsdk_server/src/generated/mission/mission.grpc.pb.h
+++ b/src/mavsdk_server/src/generated/mission/mission.grpc.pb.h
@@ -60,6 +60,17 @@ class MissionService final {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission::CancelMissionUploadResponse>>(PrepareAsyncCancelMissionUploadRaw(context, request, cq));
     }
     //
+    // Subscribe to mission upload progress.
+    std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::mission::UploadProgressResponse>> SubscribeUploadProgress(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::mission::UploadProgressResponse>>(SubscribeUploadProgressRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::mission::UploadProgressResponse>> AsyncSubscribeUploadProgress(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::mission::UploadProgressResponse>>(AsyncSubscribeUploadProgressRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::mission::UploadProgressResponse>> PrepareAsyncSubscribeUploadProgress(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::mission::UploadProgressResponse>>(PrepareAsyncSubscribeUploadProgressRaw(context, request, cq));
+    }
+    //
     // Download a list of mission items from the system (asynchronous).
     //
     // Will fail if any of the downloaded mission items are not supported
@@ -79,6 +90,17 @@ class MissionService final {
     }
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission::CancelMissionDownloadResponse>> PrepareAsyncCancelMissionDownload(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::CancelMissionDownloadRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission::CancelMissionDownloadResponse>>(PrepareAsyncCancelMissionDownloadRaw(context, request, cq));
+    }
+    //
+    // Subscribe to mission download progress.
+    std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::mission::DownloadProgressResponse>> SubscribeDownloadProgress(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::mission::DownloadProgressResponse>>(SubscribeDownloadProgressRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::mission::DownloadProgressResponse>> AsyncSubscribeDownloadProgress(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::mission::DownloadProgressResponse>>(AsyncSubscribeDownloadProgressRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::mission::DownloadProgressResponse>> PrepareAsyncSubscribeDownloadProgress(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::mission::DownloadProgressResponse>>(PrepareAsyncSubscribeDownloadProgressRaw(context, request, cq));
     }
     //
     // Start the mission.
@@ -188,6 +210,9 @@ class MissionService final {
       virtual void CancelMissionUpload(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::CancelMissionUploadRequest* request, ::mavsdk::rpc::mission::CancelMissionUploadResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void CancelMissionUpload(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::CancelMissionUploadRequest* request, ::mavsdk::rpc::mission::CancelMissionUploadResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       //
+      // Subscribe to mission upload progress.
+      virtual void SubscribeUploadProgress(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::mission::UploadProgressResponse>* reactor) = 0;
+      //
       // Download a list of mission items from the system (asynchronous).
       //
       // Will fail if any of the downloaded mission items are not supported
@@ -198,6 +223,9 @@ class MissionService final {
       // Cancel an ongoing mission download.
       virtual void CancelMissionDownload(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::CancelMissionDownloadRequest* request, ::mavsdk::rpc::mission::CancelMissionDownloadResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void CancelMissionDownload(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::CancelMissionDownloadRequest* request, ::mavsdk::rpc::mission::CancelMissionDownloadResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      //
+      // Subscribe to mission download progress.
+      virtual void SubscribeDownloadProgress(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::mission::DownloadProgressResponse>* reactor) = 0;
       //
       // Start the mission.
       //
@@ -257,10 +285,16 @@ class MissionService final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission::UploadMissionResponse>* PrepareAsyncUploadMissionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::UploadMissionRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission::CancelMissionUploadResponse>* AsyncCancelMissionUploadRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::CancelMissionUploadRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission::CancelMissionUploadResponse>* PrepareAsyncCancelMissionUploadRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::CancelMissionUploadRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientReaderInterface< ::mavsdk::rpc::mission::UploadProgressResponse>* SubscribeUploadProgressRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest& request) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::mission::UploadProgressResponse>* AsyncSubscribeUploadProgressRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::mission::UploadProgressResponse>* PrepareAsyncSubscribeUploadProgressRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission::DownloadMissionResponse>* AsyncDownloadMissionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::DownloadMissionRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission::DownloadMissionResponse>* PrepareAsyncDownloadMissionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::DownloadMissionRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission::CancelMissionDownloadResponse>* AsyncCancelMissionDownloadRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::CancelMissionDownloadRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission::CancelMissionDownloadResponse>* PrepareAsyncCancelMissionDownloadRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::CancelMissionDownloadRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientReaderInterface< ::mavsdk::rpc::mission::DownloadProgressResponse>* SubscribeDownloadProgressRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest& request) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::mission::DownloadProgressResponse>* AsyncSubscribeDownloadProgressRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::mission::DownloadProgressResponse>* PrepareAsyncSubscribeDownloadProgressRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission::StartMissionResponse>* AsyncStartMissionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::StartMissionRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission::StartMissionResponse>* PrepareAsyncStartMissionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::StartMissionRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission::PauseMissionResponse>* AsyncPauseMissionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::PauseMissionRequest& request, ::grpc::CompletionQueue* cq) = 0;
@@ -296,6 +330,15 @@ class MissionService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission::CancelMissionUploadResponse>> PrepareAsyncCancelMissionUpload(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::CancelMissionUploadRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission::CancelMissionUploadResponse>>(PrepareAsyncCancelMissionUploadRaw(context, request, cq));
     }
+    std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::mission::UploadProgressResponse>> SubscribeUploadProgress(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::mission::UploadProgressResponse>>(SubscribeUploadProgressRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::mission::UploadProgressResponse>> AsyncSubscribeUploadProgress(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::mission::UploadProgressResponse>>(AsyncSubscribeUploadProgressRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::mission::UploadProgressResponse>> PrepareAsyncSubscribeUploadProgress(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::mission::UploadProgressResponse>>(PrepareAsyncSubscribeUploadProgressRaw(context, request, cq));
+    }
     ::grpc::Status DownloadMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::DownloadMissionRequest& request, ::mavsdk::rpc::mission::DownloadMissionResponse* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission::DownloadMissionResponse>> AsyncDownloadMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::DownloadMissionRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission::DownloadMissionResponse>>(AsyncDownloadMissionRaw(context, request, cq));
@@ -309,6 +352,15 @@ class MissionService final {
     }
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission::CancelMissionDownloadResponse>> PrepareAsyncCancelMissionDownload(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::CancelMissionDownloadRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission::CancelMissionDownloadResponse>>(PrepareAsyncCancelMissionDownloadRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::mission::DownloadProgressResponse>> SubscribeDownloadProgress(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::mission::DownloadProgressResponse>>(SubscribeDownloadProgressRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::mission::DownloadProgressResponse>> AsyncSubscribeDownloadProgress(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::mission::DownloadProgressResponse>>(AsyncSubscribeDownloadProgressRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::mission::DownloadProgressResponse>> PrepareAsyncSubscribeDownloadProgress(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::mission::DownloadProgressResponse>>(PrepareAsyncSubscribeDownloadProgressRaw(context, request, cq));
     }
     ::grpc::Status StartMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::StartMissionRequest& request, ::mavsdk::rpc::mission::StartMissionResponse* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission::StartMissionResponse>> AsyncStartMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::StartMissionRequest& request, ::grpc::CompletionQueue* cq) {
@@ -375,10 +427,12 @@ class MissionService final {
       void UploadMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::UploadMissionRequest* request, ::mavsdk::rpc::mission::UploadMissionResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void CancelMissionUpload(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::CancelMissionUploadRequest* request, ::mavsdk::rpc::mission::CancelMissionUploadResponse* response, std::function<void(::grpc::Status)>) override;
       void CancelMissionUpload(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::CancelMissionUploadRequest* request, ::mavsdk::rpc::mission::CancelMissionUploadResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SubscribeUploadProgress(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::mission::UploadProgressResponse>* reactor) override;
       void DownloadMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::DownloadMissionRequest* request, ::mavsdk::rpc::mission::DownloadMissionResponse* response, std::function<void(::grpc::Status)>) override;
       void DownloadMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::DownloadMissionRequest* request, ::mavsdk::rpc::mission::DownloadMissionResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void CancelMissionDownload(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::CancelMissionDownloadRequest* request, ::mavsdk::rpc::mission::CancelMissionDownloadResponse* response, std::function<void(::grpc::Status)>) override;
       void CancelMissionDownload(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::CancelMissionDownloadRequest* request, ::mavsdk::rpc::mission::CancelMissionDownloadResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SubscribeDownloadProgress(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::mission::DownloadProgressResponse>* reactor) override;
       void StartMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::StartMissionRequest* request, ::mavsdk::rpc::mission::StartMissionResponse* response, std::function<void(::grpc::Status)>) override;
       void StartMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::StartMissionRequest* request, ::mavsdk::rpc::mission::StartMissionResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void PauseMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::PauseMissionRequest* request, ::mavsdk::rpc::mission::PauseMissionResponse* response, std::function<void(::grpc::Status)>) override;
@@ -409,10 +463,16 @@ class MissionService final {
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission::UploadMissionResponse>* PrepareAsyncUploadMissionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::UploadMissionRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission::CancelMissionUploadResponse>* AsyncCancelMissionUploadRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::CancelMissionUploadRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission::CancelMissionUploadResponse>* PrepareAsyncCancelMissionUploadRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::CancelMissionUploadRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientReader< ::mavsdk::rpc::mission::UploadProgressResponse>* SubscribeUploadProgressRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest& request) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::mission::UploadProgressResponse>* AsyncSubscribeUploadProgressRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::mission::UploadProgressResponse>* PrepareAsyncSubscribeUploadProgressRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission::DownloadMissionResponse>* AsyncDownloadMissionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::DownloadMissionRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission::DownloadMissionResponse>* PrepareAsyncDownloadMissionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::DownloadMissionRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission::CancelMissionDownloadResponse>* AsyncCancelMissionDownloadRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::CancelMissionDownloadRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission::CancelMissionDownloadResponse>* PrepareAsyncCancelMissionDownloadRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::CancelMissionDownloadRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientReader< ::mavsdk::rpc::mission::DownloadProgressResponse>* SubscribeDownloadProgressRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest& request) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::mission::DownloadProgressResponse>* AsyncSubscribeDownloadProgressRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::mission::DownloadProgressResponse>* PrepareAsyncSubscribeDownloadProgressRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission::StartMissionResponse>* AsyncStartMissionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::StartMissionRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission::StartMissionResponse>* PrepareAsyncStartMissionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::StartMissionRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission::PauseMissionResponse>* AsyncPauseMissionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::PauseMissionRequest& request, ::grpc::CompletionQueue* cq) override;
@@ -432,8 +492,10 @@ class MissionService final {
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionResponse>* PrepareAsyncSetReturnToLaunchAfterMissionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionRequest& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_UploadMission_;
     const ::grpc::internal::RpcMethod rpcmethod_CancelMissionUpload_;
+    const ::grpc::internal::RpcMethod rpcmethod_SubscribeUploadProgress_;
     const ::grpc::internal::RpcMethod rpcmethod_DownloadMission_;
     const ::grpc::internal::RpcMethod rpcmethod_CancelMissionDownload_;
+    const ::grpc::internal::RpcMethod rpcmethod_SubscribeDownloadProgress_;
     const ::grpc::internal::RpcMethod rpcmethod_StartMission_;
     const ::grpc::internal::RpcMethod rpcmethod_PauseMission_;
     const ::grpc::internal::RpcMethod rpcmethod_ClearMission_;
@@ -459,6 +521,9 @@ class MissionService final {
     // Cancel an ongoing mission upload.
     virtual ::grpc::Status CancelMissionUpload(::grpc::ServerContext* context, const ::mavsdk::rpc::mission::CancelMissionUploadRequest* request, ::mavsdk::rpc::mission::CancelMissionUploadResponse* response);
     //
+    // Subscribe to mission upload progress.
+    virtual ::grpc::Status SubscribeUploadProgress(::grpc::ServerContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::mission::UploadProgressResponse>* writer);
+    //
     // Download a list of mission items from the system (asynchronous).
     //
     // Will fail if any of the downloaded mission items are not supported
@@ -467,6 +532,9 @@ class MissionService final {
     //
     // Cancel an ongoing mission download.
     virtual ::grpc::Status CancelMissionDownload(::grpc::ServerContext* context, const ::mavsdk::rpc::mission::CancelMissionDownloadRequest* request, ::mavsdk::rpc::mission::CancelMissionDownloadResponse* response);
+    //
+    // Subscribe to mission download progress.
+    virtual ::grpc::Status SubscribeDownloadProgress(::grpc::ServerContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::mission::DownloadProgressResponse>* writer);
     //
     // Start the mission.
     //
@@ -552,12 +620,32 @@ class MissionService final {
     }
   };
   template <class BaseClass>
+  class WithAsyncMethod_SubscribeUploadProgress : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SubscribeUploadProgress() {
+      ::grpc::Service::MarkMethodAsync(2);
+    }
+    ~WithAsyncMethod_SubscribeUploadProgress() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeUploadProgress(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::mission::UploadProgressResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeUploadProgress(::grpc::ServerContext* context, ::mavsdk::rpc::mission::SubscribeUploadProgressRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::mission::UploadProgressResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(2, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithAsyncMethod_DownloadMission : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_DownloadMission() {
-      ::grpc::Service::MarkMethodAsync(2);
+      ::grpc::Service::MarkMethodAsync(3);
     }
     ~WithAsyncMethod_DownloadMission() override {
       BaseClassMustBeDerivedFromService(this);
@@ -568,7 +656,7 @@ class MissionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestDownloadMission(::grpc::ServerContext* context, ::mavsdk::rpc::mission::DownloadMissionRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::mission::DownloadMissionResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -577,7 +665,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_CancelMissionDownload() {
-      ::grpc::Service::MarkMethodAsync(3);
+      ::grpc::Service::MarkMethodAsync(4);
     }
     ~WithAsyncMethod_CancelMissionDownload() override {
       BaseClassMustBeDerivedFromService(this);
@@ -588,7 +676,27 @@ class MissionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestCancelMissionDownload(::grpc::ServerContext* context, ::mavsdk::rpc::mission::CancelMissionDownloadRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::mission::CancelMissionDownloadResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_SubscribeDownloadProgress : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SubscribeDownloadProgress() {
+      ::grpc::Service::MarkMethodAsync(5);
+    }
+    ~WithAsyncMethod_SubscribeDownloadProgress() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeDownloadProgress(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::mission::DownloadProgressResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeDownloadProgress(::grpc::ServerContext* context, ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::mission::DownloadProgressResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(5, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -597,7 +705,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_StartMission() {
-      ::grpc::Service::MarkMethodAsync(4);
+      ::grpc::Service::MarkMethodAsync(6);
     }
     ~WithAsyncMethod_StartMission() override {
       BaseClassMustBeDerivedFromService(this);
@@ -608,7 +716,7 @@ class MissionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestStartMission(::grpc::ServerContext* context, ::mavsdk::rpc::mission::StartMissionRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::mission::StartMissionResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -617,7 +725,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_PauseMission() {
-      ::grpc::Service::MarkMethodAsync(5);
+      ::grpc::Service::MarkMethodAsync(7);
     }
     ~WithAsyncMethod_PauseMission() override {
       BaseClassMustBeDerivedFromService(this);
@@ -628,7 +736,7 @@ class MissionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestPauseMission(::grpc::ServerContext* context, ::mavsdk::rpc::mission::PauseMissionRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::mission::PauseMissionResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -637,7 +745,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_ClearMission() {
-      ::grpc::Service::MarkMethodAsync(6);
+      ::grpc::Service::MarkMethodAsync(8);
     }
     ~WithAsyncMethod_ClearMission() override {
       BaseClassMustBeDerivedFromService(this);
@@ -648,7 +756,7 @@ class MissionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestClearMission(::grpc::ServerContext* context, ::mavsdk::rpc::mission::ClearMissionRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::mission::ClearMissionResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -657,7 +765,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetCurrentMissionItem() {
-      ::grpc::Service::MarkMethodAsync(7);
+      ::grpc::Service::MarkMethodAsync(9);
     }
     ~WithAsyncMethod_SetCurrentMissionItem() override {
       BaseClassMustBeDerivedFromService(this);
@@ -668,7 +776,7 @@ class MissionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetCurrentMissionItem(::grpc::ServerContext* context, ::mavsdk::rpc::mission::SetCurrentMissionItemRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::mission::SetCurrentMissionItemResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -677,7 +785,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_IsMissionFinished() {
-      ::grpc::Service::MarkMethodAsync(8);
+      ::grpc::Service::MarkMethodAsync(10);
     }
     ~WithAsyncMethod_IsMissionFinished() override {
       BaseClassMustBeDerivedFromService(this);
@@ -688,7 +796,7 @@ class MissionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestIsMissionFinished(::grpc::ServerContext* context, ::mavsdk::rpc::mission::IsMissionFinishedRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::mission::IsMissionFinishedResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -697,7 +805,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SubscribeMissionProgress() {
-      ::grpc::Service::MarkMethodAsync(9);
+      ::grpc::Service::MarkMethodAsync(11);
     }
     ~WithAsyncMethod_SubscribeMissionProgress() override {
       BaseClassMustBeDerivedFromService(this);
@@ -708,7 +816,7 @@ class MissionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeMissionProgress(::grpc::ServerContext* context, ::mavsdk::rpc::mission::SubscribeMissionProgressRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::mission::MissionProgressResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(9, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(11, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -717,7 +825,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_GetReturnToLaunchAfterMission() {
-      ::grpc::Service::MarkMethodAsync(10);
+      ::grpc::Service::MarkMethodAsync(12);
     }
     ~WithAsyncMethod_GetReturnToLaunchAfterMission() override {
       BaseClassMustBeDerivedFromService(this);
@@ -728,7 +836,7 @@ class MissionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetReturnToLaunchAfterMission(::grpc::ServerContext* context, ::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -737,7 +845,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetReturnToLaunchAfterMission() {
-      ::grpc::Service::MarkMethodAsync(11);
+      ::grpc::Service::MarkMethodAsync(13);
     }
     ~WithAsyncMethod_SetReturnToLaunchAfterMission() override {
       BaseClassMustBeDerivedFromService(this);
@@ -748,10 +856,10 @@ class MissionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetReturnToLaunchAfterMission(::grpc::ServerContext* context, ::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_UploadMission<WithAsyncMethod_CancelMissionUpload<WithAsyncMethod_DownloadMission<WithAsyncMethod_CancelMissionDownload<WithAsyncMethod_StartMission<WithAsyncMethod_PauseMission<WithAsyncMethod_ClearMission<WithAsyncMethod_SetCurrentMissionItem<WithAsyncMethod_IsMissionFinished<WithAsyncMethod_SubscribeMissionProgress<WithAsyncMethod_GetReturnToLaunchAfterMission<WithAsyncMethod_SetReturnToLaunchAfterMission<Service > > > > > > > > > > > > AsyncService;
+  typedef WithAsyncMethod_UploadMission<WithAsyncMethod_CancelMissionUpload<WithAsyncMethod_SubscribeUploadProgress<WithAsyncMethod_DownloadMission<WithAsyncMethod_CancelMissionDownload<WithAsyncMethod_SubscribeDownloadProgress<WithAsyncMethod_StartMission<WithAsyncMethod_PauseMission<WithAsyncMethod_ClearMission<WithAsyncMethod_SetCurrentMissionItem<WithAsyncMethod_IsMissionFinished<WithAsyncMethod_SubscribeMissionProgress<WithAsyncMethod_GetReturnToLaunchAfterMission<WithAsyncMethod_SetReturnToLaunchAfterMission<Service > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_UploadMission : public BaseClass {
    private:
@@ -807,18 +915,40 @@ class MissionService final {
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::mission::CancelMissionUploadRequest* /*request*/, ::mavsdk::rpc::mission::CancelMissionUploadResponse* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithCallbackMethod_SubscribeUploadProgress : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SubscribeUploadProgress() {
+      ::grpc::Service::MarkMethodCallback(2,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::mission::SubscribeUploadProgressRequest, ::mavsdk::rpc::mission::UploadProgressResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest* request) { return this->SubscribeUploadProgress(context, request); }));
+    }
+    ~WithCallbackMethod_SubscribeUploadProgress() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeUploadProgress(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::mission::UploadProgressResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::mavsdk::rpc::mission::UploadProgressResponse>* SubscribeUploadProgress(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithCallbackMethod_DownloadMission : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_DownloadMission() {
-      ::grpc::Service::MarkMethodCallback(2,
+      ::grpc::Service::MarkMethodCallback(3,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission::DownloadMissionRequest, ::mavsdk::rpc::mission::DownloadMissionResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::mission::DownloadMissionRequest* request, ::mavsdk::rpc::mission::DownloadMissionResponse* response) { return this->DownloadMission(context, request, response); }));}
     void SetMessageAllocatorFor_DownloadMission(
         ::grpc::MessageAllocator< ::mavsdk::rpc::mission::DownloadMissionRequest, ::mavsdk::rpc::mission::DownloadMissionResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(2);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(3);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission::DownloadMissionRequest, ::mavsdk::rpc::mission::DownloadMissionResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -839,13 +969,13 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_CancelMissionDownload() {
-      ::grpc::Service::MarkMethodCallback(3,
+      ::grpc::Service::MarkMethodCallback(4,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission::CancelMissionDownloadRequest, ::mavsdk::rpc::mission::CancelMissionDownloadResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::mission::CancelMissionDownloadRequest* request, ::mavsdk::rpc::mission::CancelMissionDownloadResponse* response) { return this->CancelMissionDownload(context, request, response); }));}
     void SetMessageAllocatorFor_CancelMissionDownload(
         ::grpc::MessageAllocator< ::mavsdk::rpc::mission::CancelMissionDownloadRequest, ::mavsdk::rpc::mission::CancelMissionDownloadResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(3);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(4);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission::CancelMissionDownloadRequest, ::mavsdk::rpc::mission::CancelMissionDownloadResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -861,18 +991,40 @@ class MissionService final {
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::mission::CancelMissionDownloadRequest* /*request*/, ::mavsdk::rpc::mission::CancelMissionDownloadResponse* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithCallbackMethod_SubscribeDownloadProgress : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SubscribeDownloadProgress() {
+      ::grpc::Service::MarkMethodCallback(5,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest, ::mavsdk::rpc::mission::DownloadProgressResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest* request) { return this->SubscribeDownloadProgress(context, request); }));
+    }
+    ~WithCallbackMethod_SubscribeDownloadProgress() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeDownloadProgress(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::mission::DownloadProgressResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::mavsdk::rpc::mission::DownloadProgressResponse>* SubscribeDownloadProgress(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithCallbackMethod_StartMission : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_StartMission() {
-      ::grpc::Service::MarkMethodCallback(4,
+      ::grpc::Service::MarkMethodCallback(6,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission::StartMissionRequest, ::mavsdk::rpc::mission::StartMissionResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::mission::StartMissionRequest* request, ::mavsdk::rpc::mission::StartMissionResponse* response) { return this->StartMission(context, request, response); }));}
     void SetMessageAllocatorFor_StartMission(
         ::grpc::MessageAllocator< ::mavsdk::rpc::mission::StartMissionRequest, ::mavsdk::rpc::mission::StartMissionResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(4);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(6);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission::StartMissionRequest, ::mavsdk::rpc::mission::StartMissionResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -893,13 +1045,13 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_PauseMission() {
-      ::grpc::Service::MarkMethodCallback(5,
+      ::grpc::Service::MarkMethodCallback(7,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission::PauseMissionRequest, ::mavsdk::rpc::mission::PauseMissionResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::mission::PauseMissionRequest* request, ::mavsdk::rpc::mission::PauseMissionResponse* response) { return this->PauseMission(context, request, response); }));}
     void SetMessageAllocatorFor_PauseMission(
         ::grpc::MessageAllocator< ::mavsdk::rpc::mission::PauseMissionRequest, ::mavsdk::rpc::mission::PauseMissionResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(5);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(7);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission::PauseMissionRequest, ::mavsdk::rpc::mission::PauseMissionResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -920,13 +1072,13 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_ClearMission() {
-      ::grpc::Service::MarkMethodCallback(6,
+      ::grpc::Service::MarkMethodCallback(8,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission::ClearMissionRequest, ::mavsdk::rpc::mission::ClearMissionResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::mission::ClearMissionRequest* request, ::mavsdk::rpc::mission::ClearMissionResponse* response) { return this->ClearMission(context, request, response); }));}
     void SetMessageAllocatorFor_ClearMission(
         ::grpc::MessageAllocator< ::mavsdk::rpc::mission::ClearMissionRequest, ::mavsdk::rpc::mission::ClearMissionResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(6);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(8);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission::ClearMissionRequest, ::mavsdk::rpc::mission::ClearMissionResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -947,13 +1099,13 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetCurrentMissionItem() {
-      ::grpc::Service::MarkMethodCallback(7,
+      ::grpc::Service::MarkMethodCallback(9,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission::SetCurrentMissionItemRequest, ::mavsdk::rpc::mission::SetCurrentMissionItemResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::mission::SetCurrentMissionItemRequest* request, ::mavsdk::rpc::mission::SetCurrentMissionItemResponse* response) { return this->SetCurrentMissionItem(context, request, response); }));}
     void SetMessageAllocatorFor_SetCurrentMissionItem(
         ::grpc::MessageAllocator< ::mavsdk::rpc::mission::SetCurrentMissionItemRequest, ::mavsdk::rpc::mission::SetCurrentMissionItemResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(7);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(9);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission::SetCurrentMissionItemRequest, ::mavsdk::rpc::mission::SetCurrentMissionItemResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -974,13 +1126,13 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_IsMissionFinished() {
-      ::grpc::Service::MarkMethodCallback(8,
+      ::grpc::Service::MarkMethodCallback(10,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission::IsMissionFinishedRequest, ::mavsdk::rpc::mission::IsMissionFinishedResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::mission::IsMissionFinishedRequest* request, ::mavsdk::rpc::mission::IsMissionFinishedResponse* response) { return this->IsMissionFinished(context, request, response); }));}
     void SetMessageAllocatorFor_IsMissionFinished(
         ::grpc::MessageAllocator< ::mavsdk::rpc::mission::IsMissionFinishedRequest, ::mavsdk::rpc::mission::IsMissionFinishedResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(8);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(10);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission::IsMissionFinishedRequest, ::mavsdk::rpc::mission::IsMissionFinishedResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -1001,7 +1153,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SubscribeMissionProgress() {
-      ::grpc::Service::MarkMethodCallback(9,
+      ::grpc::Service::MarkMethodCallback(11,
           new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::mission::SubscribeMissionProgressRequest, ::mavsdk::rpc::mission::MissionProgressResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::mission::SubscribeMissionProgressRequest* request) { return this->SubscribeMissionProgress(context, request); }));
@@ -1023,13 +1175,13 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_GetReturnToLaunchAfterMission() {
-      ::grpc::Service::MarkMethodCallback(10,
+      ::grpc::Service::MarkMethodCallback(12,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionRequest, ::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionRequest* request, ::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionResponse* response) { return this->GetReturnToLaunchAfterMission(context, request, response); }));}
     void SetMessageAllocatorFor_GetReturnToLaunchAfterMission(
         ::grpc::MessageAllocator< ::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionRequest, ::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(10);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(12);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionRequest, ::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -1050,13 +1202,13 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetReturnToLaunchAfterMission() {
-      ::grpc::Service::MarkMethodCallback(11,
+      ::grpc::Service::MarkMethodCallback(13,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionRequest, ::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionRequest* request, ::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionResponse* response) { return this->SetReturnToLaunchAfterMission(context, request, response); }));}
     void SetMessageAllocatorFor_SetReturnToLaunchAfterMission(
         ::grpc::MessageAllocator< ::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionRequest, ::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(11);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(13);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionRequest, ::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -1071,7 +1223,7 @@ class MissionService final {
     virtual ::grpc::ServerUnaryReactor* SetReturnToLaunchAfterMission(
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionRequest* /*request*/, ::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionResponse* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_UploadMission<WithCallbackMethod_CancelMissionUpload<WithCallbackMethod_DownloadMission<WithCallbackMethod_CancelMissionDownload<WithCallbackMethod_StartMission<WithCallbackMethod_PauseMission<WithCallbackMethod_ClearMission<WithCallbackMethod_SetCurrentMissionItem<WithCallbackMethod_IsMissionFinished<WithCallbackMethod_SubscribeMissionProgress<WithCallbackMethod_GetReturnToLaunchAfterMission<WithCallbackMethod_SetReturnToLaunchAfterMission<Service > > > > > > > > > > > > CallbackService;
+  typedef WithCallbackMethod_UploadMission<WithCallbackMethod_CancelMissionUpload<WithCallbackMethod_SubscribeUploadProgress<WithCallbackMethod_DownloadMission<WithCallbackMethod_CancelMissionDownload<WithCallbackMethod_SubscribeDownloadProgress<WithCallbackMethod_StartMission<WithCallbackMethod_PauseMission<WithCallbackMethod_ClearMission<WithCallbackMethod_SetCurrentMissionItem<WithCallbackMethod_IsMissionFinished<WithCallbackMethod_SubscribeMissionProgress<WithCallbackMethod_GetReturnToLaunchAfterMission<WithCallbackMethod_SetReturnToLaunchAfterMission<Service > > > > > > > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_UploadMission : public BaseClass {
@@ -1108,12 +1260,29 @@ class MissionService final {
     }
   };
   template <class BaseClass>
+  class WithGenericMethod_SubscribeUploadProgress : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SubscribeUploadProgress() {
+      ::grpc::Service::MarkMethodGeneric(2);
+    }
+    ~WithGenericMethod_SubscribeUploadProgress() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeUploadProgress(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::mission::UploadProgressResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
   class WithGenericMethod_DownloadMission : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_DownloadMission() {
-      ::grpc::Service::MarkMethodGeneric(2);
+      ::grpc::Service::MarkMethodGeneric(3);
     }
     ~WithGenericMethod_DownloadMission() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1130,7 +1299,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_CancelMissionDownload() {
-      ::grpc::Service::MarkMethodGeneric(3);
+      ::grpc::Service::MarkMethodGeneric(4);
     }
     ~WithGenericMethod_CancelMissionDownload() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1142,12 +1311,29 @@ class MissionService final {
     }
   };
   template <class BaseClass>
+  class WithGenericMethod_SubscribeDownloadProgress : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SubscribeDownloadProgress() {
+      ::grpc::Service::MarkMethodGeneric(5);
+    }
+    ~WithGenericMethod_SubscribeDownloadProgress() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeDownloadProgress(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::mission::DownloadProgressResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
   class WithGenericMethod_StartMission : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_StartMission() {
-      ::grpc::Service::MarkMethodGeneric(4);
+      ::grpc::Service::MarkMethodGeneric(6);
     }
     ~WithGenericMethod_StartMission() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1164,7 +1350,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_PauseMission() {
-      ::grpc::Service::MarkMethodGeneric(5);
+      ::grpc::Service::MarkMethodGeneric(7);
     }
     ~WithGenericMethod_PauseMission() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1181,7 +1367,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_ClearMission() {
-      ::grpc::Service::MarkMethodGeneric(6);
+      ::grpc::Service::MarkMethodGeneric(8);
     }
     ~WithGenericMethod_ClearMission() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1198,7 +1384,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetCurrentMissionItem() {
-      ::grpc::Service::MarkMethodGeneric(7);
+      ::grpc::Service::MarkMethodGeneric(9);
     }
     ~WithGenericMethod_SetCurrentMissionItem() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1215,7 +1401,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_IsMissionFinished() {
-      ::grpc::Service::MarkMethodGeneric(8);
+      ::grpc::Service::MarkMethodGeneric(10);
     }
     ~WithGenericMethod_IsMissionFinished() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1232,7 +1418,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SubscribeMissionProgress() {
-      ::grpc::Service::MarkMethodGeneric(9);
+      ::grpc::Service::MarkMethodGeneric(11);
     }
     ~WithGenericMethod_SubscribeMissionProgress() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1249,7 +1435,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_GetReturnToLaunchAfterMission() {
-      ::grpc::Service::MarkMethodGeneric(10);
+      ::grpc::Service::MarkMethodGeneric(12);
     }
     ~WithGenericMethod_GetReturnToLaunchAfterMission() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1266,7 +1452,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetReturnToLaunchAfterMission() {
-      ::grpc::Service::MarkMethodGeneric(11);
+      ::grpc::Service::MarkMethodGeneric(13);
     }
     ~WithGenericMethod_SetReturnToLaunchAfterMission() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1318,12 +1504,32 @@ class MissionService final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_SubscribeUploadProgress : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SubscribeUploadProgress() {
+      ::grpc::Service::MarkMethodRaw(2);
+    }
+    ~WithRawMethod_SubscribeUploadProgress() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeUploadProgress(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::mission::UploadProgressResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeUploadProgress(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(2, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithRawMethod_DownloadMission : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_DownloadMission() {
-      ::grpc::Service::MarkMethodRaw(2);
+      ::grpc::Service::MarkMethodRaw(3);
     }
     ~WithRawMethod_DownloadMission() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1334,7 +1540,7 @@ class MissionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestDownloadMission(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1343,7 +1549,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_CancelMissionDownload() {
-      ::grpc::Service::MarkMethodRaw(3);
+      ::grpc::Service::MarkMethodRaw(4);
     }
     ~WithRawMethod_CancelMissionDownload() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1354,7 +1560,27 @@ class MissionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestCancelMissionDownload(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_SubscribeDownloadProgress : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SubscribeDownloadProgress() {
+      ::grpc::Service::MarkMethodRaw(5);
+    }
+    ~WithRawMethod_SubscribeDownloadProgress() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeDownloadProgress(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::mission::DownloadProgressResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeDownloadProgress(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(5, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1363,7 +1589,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_StartMission() {
-      ::grpc::Service::MarkMethodRaw(4);
+      ::grpc::Service::MarkMethodRaw(6);
     }
     ~WithRawMethod_StartMission() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1374,7 +1600,7 @@ class MissionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestStartMission(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1383,7 +1609,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_PauseMission() {
-      ::grpc::Service::MarkMethodRaw(5);
+      ::grpc::Service::MarkMethodRaw(7);
     }
     ~WithRawMethod_PauseMission() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1394,7 +1620,7 @@ class MissionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestPauseMission(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1403,7 +1629,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_ClearMission() {
-      ::grpc::Service::MarkMethodRaw(6);
+      ::grpc::Service::MarkMethodRaw(8);
     }
     ~WithRawMethod_ClearMission() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1414,7 +1640,7 @@ class MissionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestClearMission(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1423,7 +1649,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetCurrentMissionItem() {
-      ::grpc::Service::MarkMethodRaw(7);
+      ::grpc::Service::MarkMethodRaw(9);
     }
     ~WithRawMethod_SetCurrentMissionItem() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1434,7 +1660,7 @@ class MissionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetCurrentMissionItem(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1443,7 +1669,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_IsMissionFinished() {
-      ::grpc::Service::MarkMethodRaw(8);
+      ::grpc::Service::MarkMethodRaw(10);
     }
     ~WithRawMethod_IsMissionFinished() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1454,7 +1680,7 @@ class MissionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestIsMissionFinished(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1463,7 +1689,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SubscribeMissionProgress() {
-      ::grpc::Service::MarkMethodRaw(9);
+      ::grpc::Service::MarkMethodRaw(11);
     }
     ~WithRawMethod_SubscribeMissionProgress() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1474,7 +1700,7 @@ class MissionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeMissionProgress(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(9, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(11, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1483,7 +1709,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_GetReturnToLaunchAfterMission() {
-      ::grpc::Service::MarkMethodRaw(10);
+      ::grpc::Service::MarkMethodRaw(12);
     }
     ~WithRawMethod_GetReturnToLaunchAfterMission() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1494,7 +1720,7 @@ class MissionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetReturnToLaunchAfterMission(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1503,7 +1729,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetReturnToLaunchAfterMission() {
-      ::grpc::Service::MarkMethodRaw(11);
+      ::grpc::Service::MarkMethodRaw(13);
     }
     ~WithRawMethod_SetReturnToLaunchAfterMission() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1514,7 +1740,7 @@ class MissionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetReturnToLaunchAfterMission(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1562,12 +1788,34 @@ class MissionService final {
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithRawCallbackMethod_SubscribeUploadProgress : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SubscribeUploadProgress() {
+      ::grpc::Service::MarkMethodRawCallback(2,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeUploadProgress(context, request); }));
+    }
+    ~WithRawCallbackMethod_SubscribeUploadProgress() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeUploadProgress(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::mission::UploadProgressResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::grpc::ByteBuffer>* SubscribeUploadProgress(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithRawCallbackMethod_DownloadMission : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_DownloadMission() {
-      ::grpc::Service::MarkMethodRawCallback(2,
+      ::grpc::Service::MarkMethodRawCallback(3,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->DownloadMission(context, request, response); }));
@@ -1589,7 +1837,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_CancelMissionDownload() {
-      ::grpc::Service::MarkMethodRawCallback(3,
+      ::grpc::Service::MarkMethodRawCallback(4,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->CancelMissionDownload(context, request, response); }));
@@ -1606,12 +1854,34 @@ class MissionService final {
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithRawCallbackMethod_SubscribeDownloadProgress : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SubscribeDownloadProgress() {
+      ::grpc::Service::MarkMethodRawCallback(5,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeDownloadProgress(context, request); }));
+    }
+    ~WithRawCallbackMethod_SubscribeDownloadProgress() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeDownloadProgress(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::mission::DownloadProgressResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::grpc::ByteBuffer>* SubscribeDownloadProgress(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithRawCallbackMethod_StartMission : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_StartMission() {
-      ::grpc::Service::MarkMethodRawCallback(4,
+      ::grpc::Service::MarkMethodRawCallback(6,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->StartMission(context, request, response); }));
@@ -1633,7 +1903,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_PauseMission() {
-      ::grpc::Service::MarkMethodRawCallback(5,
+      ::grpc::Service::MarkMethodRawCallback(7,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->PauseMission(context, request, response); }));
@@ -1655,7 +1925,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_ClearMission() {
-      ::grpc::Service::MarkMethodRawCallback(6,
+      ::grpc::Service::MarkMethodRawCallback(8,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->ClearMission(context, request, response); }));
@@ -1677,7 +1947,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetCurrentMissionItem() {
-      ::grpc::Service::MarkMethodRawCallback(7,
+      ::grpc::Service::MarkMethodRawCallback(9,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetCurrentMissionItem(context, request, response); }));
@@ -1699,7 +1969,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_IsMissionFinished() {
-      ::grpc::Service::MarkMethodRawCallback(8,
+      ::grpc::Service::MarkMethodRawCallback(10,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->IsMissionFinished(context, request, response); }));
@@ -1721,7 +1991,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SubscribeMissionProgress() {
-      ::grpc::Service::MarkMethodRawCallback(9,
+      ::grpc::Service::MarkMethodRawCallback(11,
           new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeMissionProgress(context, request); }));
@@ -1743,7 +2013,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_GetReturnToLaunchAfterMission() {
-      ::grpc::Service::MarkMethodRawCallback(10,
+      ::grpc::Service::MarkMethodRawCallback(12,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->GetReturnToLaunchAfterMission(context, request, response); }));
@@ -1765,7 +2035,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetReturnToLaunchAfterMission() {
-      ::grpc::Service::MarkMethodRawCallback(11,
+      ::grpc::Service::MarkMethodRawCallback(13,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetReturnToLaunchAfterMission(context, request, response); }));
@@ -1841,7 +2111,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_DownloadMission() {
-      ::grpc::Service::MarkMethodStreamed(2,
+      ::grpc::Service::MarkMethodStreamed(3,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::mission::DownloadMissionRequest, ::mavsdk::rpc::mission::DownloadMissionResponse>(
             [this](::grpc::ServerContext* context,
@@ -1868,7 +2138,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_CancelMissionDownload() {
-      ::grpc::Service::MarkMethodStreamed(3,
+      ::grpc::Service::MarkMethodStreamed(4,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::mission::CancelMissionDownloadRequest, ::mavsdk::rpc::mission::CancelMissionDownloadResponse>(
             [this](::grpc::ServerContext* context,
@@ -1895,7 +2165,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_StartMission() {
-      ::grpc::Service::MarkMethodStreamed(4,
+      ::grpc::Service::MarkMethodStreamed(6,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::mission::StartMissionRequest, ::mavsdk::rpc::mission::StartMissionResponse>(
             [this](::grpc::ServerContext* context,
@@ -1922,7 +2192,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_PauseMission() {
-      ::grpc::Service::MarkMethodStreamed(5,
+      ::grpc::Service::MarkMethodStreamed(7,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::mission::PauseMissionRequest, ::mavsdk::rpc::mission::PauseMissionResponse>(
             [this](::grpc::ServerContext* context,
@@ -1949,7 +2219,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_ClearMission() {
-      ::grpc::Service::MarkMethodStreamed(6,
+      ::grpc::Service::MarkMethodStreamed(8,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::mission::ClearMissionRequest, ::mavsdk::rpc::mission::ClearMissionResponse>(
             [this](::grpc::ServerContext* context,
@@ -1976,7 +2246,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetCurrentMissionItem() {
-      ::grpc::Service::MarkMethodStreamed(7,
+      ::grpc::Service::MarkMethodStreamed(9,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::mission::SetCurrentMissionItemRequest, ::mavsdk::rpc::mission::SetCurrentMissionItemResponse>(
             [this](::grpc::ServerContext* context,
@@ -2003,7 +2273,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_IsMissionFinished() {
-      ::grpc::Service::MarkMethodStreamed(8,
+      ::grpc::Service::MarkMethodStreamed(10,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::mission::IsMissionFinishedRequest, ::mavsdk::rpc::mission::IsMissionFinishedResponse>(
             [this](::grpc::ServerContext* context,
@@ -2030,7 +2300,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_GetReturnToLaunchAfterMission() {
-      ::grpc::Service::MarkMethodStreamed(10,
+      ::grpc::Service::MarkMethodStreamed(12,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionRequest, ::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionResponse>(
             [this](::grpc::ServerContext* context,
@@ -2057,7 +2327,7 @@ class MissionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetReturnToLaunchAfterMission() {
-      ::grpc::Service::MarkMethodStreamed(11,
+      ::grpc::Service::MarkMethodStreamed(13,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionRequest, ::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionResponse>(
             [this](::grpc::ServerContext* context,
@@ -2080,12 +2350,66 @@ class MissionService final {
   };
   typedef WithStreamedUnaryMethod_UploadMission<WithStreamedUnaryMethod_CancelMissionUpload<WithStreamedUnaryMethod_DownloadMission<WithStreamedUnaryMethod_CancelMissionDownload<WithStreamedUnaryMethod_StartMission<WithStreamedUnaryMethod_PauseMission<WithStreamedUnaryMethod_ClearMission<WithStreamedUnaryMethod_SetCurrentMissionItem<WithStreamedUnaryMethod_IsMissionFinished<WithStreamedUnaryMethod_GetReturnToLaunchAfterMission<WithStreamedUnaryMethod_SetReturnToLaunchAfterMission<Service > > > > > > > > > > > StreamedUnaryService;
   template <class BaseClass>
+  class WithSplitStreamingMethod_SubscribeUploadProgress : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithSplitStreamingMethod_SubscribeUploadProgress() {
+      ::grpc::Service::MarkMethodStreamed(2,
+        new ::grpc::internal::SplitServerStreamingHandler<
+          ::mavsdk::rpc::mission::SubscribeUploadProgressRequest, ::mavsdk::rpc::mission::UploadProgressResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerSplitStreamer<
+                     ::mavsdk::rpc::mission::SubscribeUploadProgressRequest, ::mavsdk::rpc::mission::UploadProgressResponse>* streamer) {
+                       return this->StreamedSubscribeUploadProgress(context,
+                         streamer);
+                  }));
+    }
+    ~WithSplitStreamingMethod_SubscribeUploadProgress() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SubscribeUploadProgress(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission::SubscribeUploadProgressRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::mission::UploadProgressResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with split streamed
+    virtual ::grpc::Status StreamedSubscribeUploadProgress(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::mission::SubscribeUploadProgressRequest,::mavsdk::rpc::mission::UploadProgressResponse>* server_split_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithSplitStreamingMethod_SubscribeDownloadProgress : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithSplitStreamingMethod_SubscribeDownloadProgress() {
+      ::grpc::Service::MarkMethodStreamed(5,
+        new ::grpc::internal::SplitServerStreamingHandler<
+          ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest, ::mavsdk::rpc::mission::DownloadProgressResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerSplitStreamer<
+                     ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest, ::mavsdk::rpc::mission::DownloadProgressResponse>* streamer) {
+                       return this->StreamedSubscribeDownloadProgress(context,
+                         streamer);
+                  }));
+    }
+    ~WithSplitStreamingMethod_SubscribeDownloadProgress() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SubscribeDownloadProgress(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::mission::DownloadProgressResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with split streamed
+    virtual ::grpc::Status StreamedSubscribeDownloadProgress(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest,::mavsdk::rpc::mission::DownloadProgressResponse>* server_split_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithSplitStreamingMethod_SubscribeMissionProgress : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithSplitStreamingMethod_SubscribeMissionProgress() {
-      ::grpc::Service::MarkMethodStreamed(9,
+      ::grpc::Service::MarkMethodStreamed(11,
         new ::grpc::internal::SplitServerStreamingHandler<
           ::mavsdk::rpc::mission::SubscribeMissionProgressRequest, ::mavsdk::rpc::mission::MissionProgressResponse>(
             [this](::grpc::ServerContext* context,
@@ -2106,8 +2430,8 @@ class MissionService final {
     // replace default version of method with split streamed
     virtual ::grpc::Status StreamedSubscribeMissionProgress(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::mission::SubscribeMissionProgressRequest,::mavsdk::rpc::mission::MissionProgressResponse>* server_split_streamer) = 0;
   };
-  typedef WithSplitStreamingMethod_SubscribeMissionProgress<Service > SplitStreamedService;
-  typedef WithStreamedUnaryMethod_UploadMission<WithStreamedUnaryMethod_CancelMissionUpload<WithStreamedUnaryMethod_DownloadMission<WithStreamedUnaryMethod_CancelMissionDownload<WithStreamedUnaryMethod_StartMission<WithStreamedUnaryMethod_PauseMission<WithStreamedUnaryMethod_ClearMission<WithStreamedUnaryMethod_SetCurrentMissionItem<WithStreamedUnaryMethod_IsMissionFinished<WithSplitStreamingMethod_SubscribeMissionProgress<WithStreamedUnaryMethod_GetReturnToLaunchAfterMission<WithStreamedUnaryMethod_SetReturnToLaunchAfterMission<Service > > > > > > > > > > > > StreamedService;
+  typedef WithSplitStreamingMethod_SubscribeUploadProgress<WithSplitStreamingMethod_SubscribeDownloadProgress<WithSplitStreamingMethod_SubscribeMissionProgress<Service > > > SplitStreamedService;
+  typedef WithStreamedUnaryMethod_UploadMission<WithStreamedUnaryMethod_CancelMissionUpload<WithSplitStreamingMethod_SubscribeUploadProgress<WithStreamedUnaryMethod_DownloadMission<WithStreamedUnaryMethod_CancelMissionDownload<WithSplitStreamingMethod_SubscribeDownloadProgress<WithStreamedUnaryMethod_StartMission<WithStreamedUnaryMethod_PauseMission<WithStreamedUnaryMethod_ClearMission<WithStreamedUnaryMethod_SetCurrentMissionItem<WithStreamedUnaryMethod_IsMissionFinished<WithSplitStreamingMethod_SubscribeMissionProgress<WithStreamedUnaryMethod_GetReturnToLaunchAfterMission<WithStreamedUnaryMethod_SetReturnToLaunchAfterMission<Service > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace mission

--- a/src/mavsdk_server/src/generated/mission/mission.pb.cc
+++ b/src/mavsdk_server/src/generated/mission/mission.pb.cc
@@ -66,6 +66,29 @@ struct CancelMissionUploadResponseDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT CancelMissionUploadResponseDefaultTypeInternal _CancelMissionUploadResponse_default_instance_;
+constexpr SubscribeUploadProgressRequest::SubscribeUploadProgressRequest(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized){}
+struct SubscribeUploadProgressRequestDefaultTypeInternal {
+  constexpr SubscribeUploadProgressRequestDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~SubscribeUploadProgressRequestDefaultTypeInternal() {}
+  union {
+    SubscribeUploadProgressRequest _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SubscribeUploadProgressRequestDefaultTypeInternal _SubscribeUploadProgressRequest_default_instance_;
+constexpr UploadProgressResponse::UploadProgressResponse(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : upload_progress_(nullptr){}
+struct UploadProgressResponseDefaultTypeInternal {
+  constexpr UploadProgressResponseDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~UploadProgressResponseDefaultTypeInternal() {}
+  union {
+    UploadProgressResponse _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT UploadProgressResponseDefaultTypeInternal _UploadProgressResponse_default_instance_;
 constexpr DownloadMissionRequest::DownloadMissionRequest(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized){}
 struct DownloadMissionRequestDefaultTypeInternal {
@@ -113,6 +136,29 @@ struct CancelMissionDownloadResponseDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT CancelMissionDownloadResponseDefaultTypeInternal _CancelMissionDownloadResponse_default_instance_;
+constexpr SubscribeDownloadProgressRequest::SubscribeDownloadProgressRequest(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized){}
+struct SubscribeDownloadProgressRequestDefaultTypeInternal {
+  constexpr SubscribeDownloadProgressRequestDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~SubscribeDownloadProgressRequestDefaultTypeInternal() {}
+  union {
+    SubscribeDownloadProgressRequest _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SubscribeDownloadProgressRequestDefaultTypeInternal _SubscribeDownloadProgressRequest_default_instance_;
+constexpr DownloadProgressResponse::DownloadProgressResponse(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : download_progress_(nullptr){}
+struct DownloadProgressResponseDefaultTypeInternal {
+  constexpr DownloadProgressResponseDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~DownloadProgressResponseDefaultTypeInternal() {}
+  union {
+    DownloadProgressResponse _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT DownloadProgressResponseDefaultTypeInternal _DownloadProgressResponse_default_instance_;
 constexpr StartMissionRequest::StartMissionRequest(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized){}
 struct StartMissionRequestDefaultTypeInternal {
@@ -338,6 +384,30 @@ struct MissionPlanDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT MissionPlanDefaultTypeInternal _MissionPlan_default_instance_;
+constexpr UploadProgress::UploadProgress(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : progress_(0){}
+struct UploadProgressDefaultTypeInternal {
+  constexpr UploadProgressDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~UploadProgressDefaultTypeInternal() {}
+  union {
+    UploadProgress _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT UploadProgressDefaultTypeInternal _UploadProgress_default_instance_;
+constexpr DownloadProgress::DownloadProgress(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : progress_(0){}
+struct DownloadProgressDefaultTypeInternal {
+  constexpr DownloadProgressDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~DownloadProgressDefaultTypeInternal() {}
+  union {
+    DownloadProgress _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT DownloadProgressDefaultTypeInternal _DownloadProgress_default_instance_;
 constexpr MissionProgress::MissionProgress(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
   : current_(0)
@@ -368,7 +438,7 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT MissionResultDefaultTypeInterna
 }  // namespace mission
 }  // namespace rpc
 }  // namespace mavsdk
-static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_mission_2fmission_2eproto[28];
+static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_mission_2fmission_2eproto[34];
 static const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* file_level_enum_descriptors_mission_2fmission_2eproto[2];
 static constexpr ::PROTOBUF_NAMESPACE_ID::ServiceDescriptor const** file_level_service_descriptors_mission_2fmission_2eproto = nullptr;
 
@@ -397,6 +467,17 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_mission_2fmission_2eproto::off
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::CancelMissionUploadResponse, mission_result_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::SubscribeUploadProgressRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::UploadProgressResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::UploadProgressResponse, upload_progress_),
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::DownloadMissionRequest, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -419,6 +500,17 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_mission_2fmission_2eproto::off
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::CancelMissionDownloadResponse, mission_result_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::SubscribeDownloadProgressRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::DownloadProgressResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::DownloadProgressResponse, download_progress_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::StartMissionRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -536,6 +628,18 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_mission_2fmission_2eproto::off
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::MissionPlan, mission_items_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::UploadProgress, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::UploadProgress, progress_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::DownloadProgress, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::DownloadProgress, progress_),
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission::MissionProgress, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -555,30 +659,36 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 6, -1, sizeof(::mavsdk::rpc::mission::UploadMissionResponse)},
   { 12, -1, sizeof(::mavsdk::rpc::mission::CancelMissionUploadRequest)},
   { 17, -1, sizeof(::mavsdk::rpc::mission::CancelMissionUploadResponse)},
-  { 23, -1, sizeof(::mavsdk::rpc::mission::DownloadMissionRequest)},
-  { 28, -1, sizeof(::mavsdk::rpc::mission::DownloadMissionResponse)},
-  { 35, -1, sizeof(::mavsdk::rpc::mission::CancelMissionDownloadRequest)},
-  { 40, -1, sizeof(::mavsdk::rpc::mission::CancelMissionDownloadResponse)},
-  { 46, -1, sizeof(::mavsdk::rpc::mission::StartMissionRequest)},
-  { 51, -1, sizeof(::mavsdk::rpc::mission::StartMissionResponse)},
-  { 57, -1, sizeof(::mavsdk::rpc::mission::PauseMissionRequest)},
-  { 62, -1, sizeof(::mavsdk::rpc::mission::PauseMissionResponse)},
-  { 68, -1, sizeof(::mavsdk::rpc::mission::ClearMissionRequest)},
-  { 73, -1, sizeof(::mavsdk::rpc::mission::ClearMissionResponse)},
-  { 79, -1, sizeof(::mavsdk::rpc::mission::SetCurrentMissionItemRequest)},
-  { 85, -1, sizeof(::mavsdk::rpc::mission::SetCurrentMissionItemResponse)},
-  { 91, -1, sizeof(::mavsdk::rpc::mission::IsMissionFinishedRequest)},
-  { 96, -1, sizeof(::mavsdk::rpc::mission::IsMissionFinishedResponse)},
-  { 103, -1, sizeof(::mavsdk::rpc::mission::SubscribeMissionProgressRequest)},
-  { 108, -1, sizeof(::mavsdk::rpc::mission::MissionProgressResponse)},
-  { 114, -1, sizeof(::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionRequest)},
-  { 119, -1, sizeof(::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionResponse)},
-  { 126, -1, sizeof(::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionRequest)},
-  { 132, -1, sizeof(::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionResponse)},
-  { 138, -1, sizeof(::mavsdk::rpc::mission::MissionItem)},
-  { 156, -1, sizeof(::mavsdk::rpc::mission::MissionPlan)},
-  { 162, -1, sizeof(::mavsdk::rpc::mission::MissionProgress)},
-  { 169, -1, sizeof(::mavsdk::rpc::mission::MissionResult)},
+  { 23, -1, sizeof(::mavsdk::rpc::mission::SubscribeUploadProgressRequest)},
+  { 28, -1, sizeof(::mavsdk::rpc::mission::UploadProgressResponse)},
+  { 34, -1, sizeof(::mavsdk::rpc::mission::DownloadMissionRequest)},
+  { 39, -1, sizeof(::mavsdk::rpc::mission::DownloadMissionResponse)},
+  { 46, -1, sizeof(::mavsdk::rpc::mission::CancelMissionDownloadRequest)},
+  { 51, -1, sizeof(::mavsdk::rpc::mission::CancelMissionDownloadResponse)},
+  { 57, -1, sizeof(::mavsdk::rpc::mission::SubscribeDownloadProgressRequest)},
+  { 62, -1, sizeof(::mavsdk::rpc::mission::DownloadProgressResponse)},
+  { 68, -1, sizeof(::mavsdk::rpc::mission::StartMissionRequest)},
+  { 73, -1, sizeof(::mavsdk::rpc::mission::StartMissionResponse)},
+  { 79, -1, sizeof(::mavsdk::rpc::mission::PauseMissionRequest)},
+  { 84, -1, sizeof(::mavsdk::rpc::mission::PauseMissionResponse)},
+  { 90, -1, sizeof(::mavsdk::rpc::mission::ClearMissionRequest)},
+  { 95, -1, sizeof(::mavsdk::rpc::mission::ClearMissionResponse)},
+  { 101, -1, sizeof(::mavsdk::rpc::mission::SetCurrentMissionItemRequest)},
+  { 107, -1, sizeof(::mavsdk::rpc::mission::SetCurrentMissionItemResponse)},
+  { 113, -1, sizeof(::mavsdk::rpc::mission::IsMissionFinishedRequest)},
+  { 118, -1, sizeof(::mavsdk::rpc::mission::IsMissionFinishedResponse)},
+  { 125, -1, sizeof(::mavsdk::rpc::mission::SubscribeMissionProgressRequest)},
+  { 130, -1, sizeof(::mavsdk::rpc::mission::MissionProgressResponse)},
+  { 136, -1, sizeof(::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionRequest)},
+  { 141, -1, sizeof(::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionResponse)},
+  { 148, -1, sizeof(::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionRequest)},
+  { 154, -1, sizeof(::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionResponse)},
+  { 160, -1, sizeof(::mavsdk::rpc::mission::MissionItem)},
+  { 178, -1, sizeof(::mavsdk::rpc::mission::MissionPlan)},
+  { 184, -1, sizeof(::mavsdk::rpc::mission::UploadProgress)},
+  { 190, -1, sizeof(::mavsdk::rpc::mission::DownloadProgress)},
+  { 196, -1, sizeof(::mavsdk::rpc::mission::MissionProgress)},
+  { 203, -1, sizeof(::mavsdk::rpc::mission::MissionResult)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -586,10 +696,14 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_UploadMissionResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_CancelMissionUploadRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_CancelMissionUploadResponse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_SubscribeUploadProgressRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_UploadProgressResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_DownloadMissionRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_DownloadMissionResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_CancelMissionDownloadRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_CancelMissionDownloadResponse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_SubscribeDownloadProgressRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_DownloadProgressResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_StartMissionRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_StartMissionResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_PauseMissionRequest_default_instance_),
@@ -608,6 +722,8 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_SetReturnToLaunchAfterMissionResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_MissionItem_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_MissionPlan_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_UploadProgress_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_DownloadProgress_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_MissionProgress_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::mavsdk::rpc::mission::_MissionResult_default_instance_),
 };
@@ -621,121 +737,136 @@ const char descriptor_table_protodef_mission_2fmission_2eproto[] PROTOBUF_SECTIO
   "dk.rpc.mission.MissionResult\"\034\n\032CancelMi"
   "ssionUploadRequest\"X\n\033CancelMissionUploa"
   "dResponse\0229\n\016mission_result\030\001 \001(\0132!.mavs"
-  "dk.rpc.mission.MissionResult\"\030\n\026Download"
-  "MissionRequest\"\213\001\n\027DownloadMissionRespon"
-  "se\0229\n\016mission_result\030\001 \001(\0132!.mavsdk.rpc."
-  "mission.MissionResult\0225\n\014mission_plan\030\002 "
-  "\001(\0132\037.mavsdk.rpc.mission.MissionPlan\"\036\n\034"
-  "CancelMissionDownloadRequest\"Z\n\035CancelMi"
-  "ssionDownloadResponse\0229\n\016mission_result\030"
-  "\001 \001(\0132!.mavsdk.rpc.mission.MissionResult"
-  "\"\025\n\023StartMissionRequest\"Q\n\024StartMissionR"
-  "esponse\0229\n\016mission_result\030\001 \001(\0132!.mavsdk"
-  ".rpc.mission.MissionResult\"\025\n\023PauseMissi"
-  "onRequest\"Q\n\024PauseMissionResponse\0229\n\016mis"
-  "sion_result\030\001 \001(\0132!.mavsdk.rpc.mission.M"
-  "issionResult\"\025\n\023ClearMissionRequest\"Q\n\024C"
-  "learMissionResponse\0229\n\016mission_result\030\001 "
-  "\001(\0132!.mavsdk.rpc.mission.MissionResult\"-"
-  "\n\034SetCurrentMissionItemRequest\022\r\n\005index\030"
-  "\001 \001(\005\"Z\n\035SetCurrentMissionItemResponse\0229"
-  "\n\016mission_result\030\001 \001(\0132!.mavsdk.rpc.miss"
-  "ion.MissionResult\"\032\n\030IsMissionFinishedRe"
-  "quest\"k\n\031IsMissionFinishedResponse\0229\n\016mi"
-  "ssion_result\030\001 \001(\0132!.mavsdk.rpc.mission."
-  "MissionResult\022\023\n\013is_finished\030\002 \001(\010\"!\n\037Su"
-  "bscribeMissionProgressRequest\"X\n\027Mission"
-  "ProgressResponse\022=\n\020mission_progress\030\001 \001"
-  "(\0132#.mavsdk.rpc.mission.MissionProgress\""
-  "&\n$GetReturnToLaunchAfterMissionRequest\""
-  "r\n%GetReturnToLaunchAfterMissionResponse"
-  "\0229\n\016mission_result\030\001 \001(\0132!.mavsdk.rpc.mi"
-  "ssion.MissionResult\022\016\n\006enable\030\002 \001(\010\"6\n$S"
-  "etReturnToLaunchAfterMissionRequest\022\016\n\006e"
-  "nable\030\001 \001(\010\"b\n%SetReturnToLaunchAfterMis"
-  "sionResponse\0229\n\016mission_result\030\001 \001(\0132!.m"
-  "avsdk.rpc.mission.MissionResult\"\274\006\n\013Miss"
-  "ionItem\022(\n\014latitude_deg\030\001 \001(\001B\022\202\265\030\003NaN\211\265"
-  "\030H\257\274\232\362\327z>\022)\n\rlongitude_deg\030\002 \001(\001B\022\202\265\030\003Na"
-  "N\211\265\030H\257\274\232\362\327z>\022$\n\023relative_altitude_m\030\003 \001("
-  "\002B\007\202\265\030\003NaN\022\032\n\tspeed_m_s\030\004 \001(\002B\007\202\265\030\003NaN\022!"
-  "\n\016is_fly_through\030\005 \001(\010B\t\202\265\030\005false\022,\n\020gim"
-  "bal_pitch_deg\030\006 \001(\002B\022\202\265\030\003NaN\211\265\030-C\034\353\3426\032\?\022"
-  "*\n\016gimbal_yaw_deg\030\007 \001(\002B\022\202\265\030\003NaN\211\265\030-C\034\353\342"
-  "6\032\?\022C\n\rcamera_action\030\010 \001(\0162,.mavsdk.rpc."
-  "mission.MissionItem.CameraAction\022\036\n\rloit"
-  "er_time_s\030\t \001(\002B\007\202\265\030\003NaN\022(\n\027camera_photo"
-  "_interval_s\030\n \001(\001B\007\202\265\030\0031.0\022$\n\023acceptance"
-  "_radius_m\030\013 \001(\002B\007\202\265\030\003NaN\022\030\n\007yaw_deg\030\014 \001("
-  "\002B\007\202\265\030\003NaN\022(\n\027camera_photo_distance_m\030\r "
-  "\001(\002B\007\202\265\030\003NAN\"\237\002\n\014CameraAction\022\026\n\022CAMERA_"
-  "ACTION_NONE\020\000\022\034\n\030CAMERA_ACTION_TAKE_PHOT"
-  "O\020\001\022&\n\"CAMERA_ACTION_START_PHOTO_INTERVA"
-  "L\020\002\022%\n!CAMERA_ACTION_STOP_PHOTO_INTERVAL"
-  "\020\003\022\035\n\031CAMERA_ACTION_START_VIDEO\020\004\022\034\n\030CAM"
-  "ERA_ACTION_STOP_VIDEO\020\005\022&\n\"CAMERA_ACTION"
-  "_START_PHOTO_DISTANCE\020\006\022%\n!CAMERA_ACTION"
-  "_STOP_PHOTO_DISTANCE\020\007\"E\n\013MissionPlan\0226\n"
-  "\rmission_items\030\001 \003(\0132\037.mavsdk.rpc.missio"
-  "n.MissionItem\"1\n\017MissionProgress\022\017\n\007curr"
-  "ent\030\001 \001(\005\022\r\n\005total\030\002 \001(\005\"\231\003\n\rMissionResu"
-  "lt\0228\n\006result\030\001 \001(\0162(.mavsdk.rpc.mission."
-  "MissionResult.Result\022\022\n\nresult_str\030\002 \001(\t"
-  "\"\271\002\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESUL"
-  "T_SUCCESS\020\001\022\020\n\014RESULT_ERROR\020\002\022!\n\035RESULT_"
-  "TOO_MANY_MISSION_ITEMS\020\003\022\017\n\013RESULT_BUSY\020"
-  "\004\022\022\n\016RESULT_TIMEOUT\020\005\022\033\n\027RESULT_INVALID_"
-  "ARGUMENT\020\006\022\026\n\022RESULT_UNSUPPORTED\020\007\022\037\n\033RE"
-  "SULT_NO_MISSION_AVAILABLE\020\010\022\"\n\036RESULT_UN"
-  "SUPPORTED_MISSION_CMD\020\013\022\035\n\031RESULT_TRANSF"
-  "ER_CANCELLED\020\014\022\024\n\020RESULT_NO_SYSTEM\020\r2\315\013\n"
-  "\016MissionService\022f\n\rUploadMission\022(.mavsd"
-  "k.rpc.mission.UploadMissionRequest\032).mav"
-  "sdk.rpc.mission.UploadMissionResponse\"\000\022"
-  "|\n\023CancelMissionUpload\022..mavsdk.rpc.miss"
-  "ion.CancelMissionUploadRequest\032/.mavsdk."
-  "rpc.mission.CancelMissionUploadResponse\""
-  "\004\200\265\030\001\022l\n\017DownloadMission\022*.mavsdk.rpc.mi"
-  "ssion.DownloadMissionRequest\032+.mavsdk.rp"
-  "c.mission.DownloadMissionResponse\"\000\022\202\001\n\025"
-  "CancelMissionDownload\0220.mavsdk.rpc.missi"
-  "on.CancelMissionDownloadRequest\0321.mavsdk"
-  ".rpc.mission.CancelMissionDownloadRespon"
-  "se\"\004\200\265\030\001\022c\n\014StartMission\022\'.mavsdk.rpc.mi"
-  "ssion.StartMissionRequest\032(.mavsdk.rpc.m"
-  "ission.StartMissionResponse\"\000\022c\n\014PauseMi"
-  "ssion\022\'.mavsdk.rpc.mission.PauseMissionR"
-  "equest\032(.mavsdk.rpc.mission.PauseMission"
-  "Response\"\000\022c\n\014ClearMission\022\'.mavsdk.rpc."
-  "mission.ClearMissionRequest\032(.mavsdk.rpc"
-  ".mission.ClearMissionResponse\"\000\022~\n\025SetCu"
-  "rrentMissionItem\0220.mavsdk.rpc.mission.Se"
-  "tCurrentMissionItemRequest\0321.mavsdk.rpc."
-  "mission.SetCurrentMissionItemResponse\"\000\022"
-  "v\n\021IsMissionFinished\022,.mavsdk.rpc.missio"
-  "n.IsMissionFinishedRequest\032-.mavsdk.rpc."
-  "mission.IsMissionFinishedResponse\"\004\200\265\030\001\022"
-  "\200\001\n\030SubscribeMissionProgress\0223.mavsdk.rp"
-  "c.mission.SubscribeMissionProgressReques"
-  "t\032+.mavsdk.rpc.mission.MissionProgressRe"
-  "sponse\"\0000\001\022\232\001\n\035GetReturnToLaunchAfterMis"
-  "sion\0228.mavsdk.rpc.mission.GetReturnToLau"
-  "nchAfterMissionRequest\0329.mavsdk.rpc.miss"
-  "ion.GetReturnToLaunchAfterMissionRespons"
-  "e\"\004\200\265\030\001\022\232\001\n\035SetReturnToLaunchAfterMissio"
-  "n\0228.mavsdk.rpc.mission.SetReturnToLaunch"
-  "AfterMissionRequest\0329.mavsdk.rpc.mission"
-  ".SetReturnToLaunchAfterMissionResponse\"\004"
-  "\200\265\030\001B!\n\021io.mavsdk.missionB\014MissionProtob"
-  "\006proto3"
+  "dk.rpc.mission.MissionResult\" \n\036Subscrib"
+  "eUploadProgressRequest\"U\n\026UploadProgress"
+  "Response\022;\n\017upload_progress\030\001 \001(\0132\".mavs"
+  "dk.rpc.mission.UploadProgress\"\030\n\026Downloa"
+  "dMissionRequest\"\213\001\n\027DownloadMissionRespo"
+  "nse\0229\n\016mission_result\030\001 \001(\0132!.mavsdk.rpc"
+  ".mission.MissionResult\0225\n\014mission_plan\030\002"
+  " \001(\0132\037.mavsdk.rpc.mission.MissionPlan\"\036\n"
+  "\034CancelMissionDownloadRequest\"Z\n\035CancelM"
+  "issionDownloadResponse\0229\n\016mission_result"
+  "\030\001 \001(\0132!.mavsdk.rpc.mission.MissionResul"
+  "t\"\"\n SubscribeDownloadProgressRequest\"[\n"
+  "\030DownloadProgressResponse\022\?\n\021download_pr"
+  "ogress\030\001 \001(\0132$.mavsdk.rpc.mission.Downlo"
+  "adProgress\"\025\n\023StartMissionRequest\"Q\n\024Sta"
+  "rtMissionResponse\0229\n\016mission_result\030\001 \001("
+  "\0132!.mavsdk.rpc.mission.MissionResult\"\025\n\023"
+  "PauseMissionRequest\"Q\n\024PauseMissionRespo"
+  "nse\0229\n\016mission_result\030\001 \001(\0132!.mavsdk.rpc"
+  ".mission.MissionResult\"\025\n\023ClearMissionRe"
+  "quest\"Q\n\024ClearMissionResponse\0229\n\016mission"
+  "_result\030\001 \001(\0132!.mavsdk.rpc.mission.Missi"
+  "onResult\"-\n\034SetCurrentMissionItemRequest"
+  "\022\r\n\005index\030\001 \001(\005\"Z\n\035SetCurrentMissionItem"
+  "Response\0229\n\016mission_result\030\001 \001(\0132!.mavsd"
+  "k.rpc.mission.MissionResult\"\032\n\030IsMission"
+  "FinishedRequest\"k\n\031IsMissionFinishedResp"
+  "onse\0229\n\016mission_result\030\001 \001(\0132!.mavsdk.rp"
+  "c.mission.MissionResult\022\023\n\013is_finished\030\002"
+  " \001(\010\"!\n\037SubscribeMissionProgressRequest\""
+  "X\n\027MissionProgressResponse\022=\n\020mission_pr"
+  "ogress\030\001 \001(\0132#.mavsdk.rpc.mission.Missio"
+  "nProgress\"&\n$GetReturnToLaunchAfterMissi"
+  "onRequest\"r\n%GetReturnToLaunchAfterMissi"
+  "onResponse\0229\n\016mission_result\030\001 \001(\0132!.mav"
+  "sdk.rpc.mission.MissionResult\022\016\n\006enable\030"
+  "\002 \001(\010\"6\n$SetReturnToLaunchAfterMissionRe"
+  "quest\022\016\n\006enable\030\001 \001(\010\"b\n%SetReturnToLaun"
+  "chAfterMissionResponse\0229\n\016mission_result"
+  "\030\001 \001(\0132!.mavsdk.rpc.mission.MissionResul"
+  "t\"\274\006\n\013MissionItem\022(\n\014latitude_deg\030\001 \001(\001B"
+  "\022\202\265\030\003NaN\211\265\030H\257\274\232\362\327z>\022)\n\rlongitude_deg\030\002 \001"
+  "(\001B\022\202\265\030\003NaN\211\265\030H\257\274\232\362\327z>\022$\n\023relative_altit"
+  "ude_m\030\003 \001(\002B\007\202\265\030\003NaN\022\032\n\tspeed_m_s\030\004 \001(\002B"
+  "\007\202\265\030\003NaN\022!\n\016is_fly_through\030\005 \001(\010B\t\202\265\030\005fa"
+  "lse\022,\n\020gimbal_pitch_deg\030\006 \001(\002B\022\202\265\030\003NaN\211\265"
+  "\030-C\034\353\3426\032\?\022*\n\016gimbal_yaw_deg\030\007 \001(\002B\022\202\265\030\003N"
+  "aN\211\265\030-C\034\353\3426\032\?\022C\n\rcamera_action\030\010 \001(\0162,.m"
+  "avsdk.rpc.mission.MissionItem.CameraActi"
+  "on\022\036\n\rloiter_time_s\030\t \001(\002B\007\202\265\030\003NaN\022(\n\027ca"
+  "mera_photo_interval_s\030\n \001(\001B\007\202\265\030\0031.0\022$\n\023"
+  "acceptance_radius_m\030\013 \001(\002B\007\202\265\030\003NaN\022\030\n\007ya"
+  "w_deg\030\014 \001(\002B\007\202\265\030\003NaN\022(\n\027camera_photo_dis"
+  "tance_m\030\r \001(\002B\007\202\265\030\003NAN\"\237\002\n\014CameraAction\022"
+  "\026\n\022CAMERA_ACTION_NONE\020\000\022\034\n\030CAMERA_ACTION"
+  "_TAKE_PHOTO\020\001\022&\n\"CAMERA_ACTION_START_PHO"
+  "TO_INTERVAL\020\002\022%\n!CAMERA_ACTION_STOP_PHOT"
+  "O_INTERVAL\020\003\022\035\n\031CAMERA_ACTION_START_VIDE"
+  "O\020\004\022\034\n\030CAMERA_ACTION_STOP_VIDEO\020\005\022&\n\"CAM"
+  "ERA_ACTION_START_PHOTO_DISTANCE\020\006\022%\n!CAM"
+  "ERA_ACTION_STOP_PHOTO_DISTANCE\020\007\"E\n\013Miss"
+  "ionPlan\0226\n\rmission_items\030\001 \003(\0132\037.mavsdk."
+  "rpc.mission.MissionItem\"\"\n\016UploadProgres"
+  "s\022\020\n\010progress\030\001 \001(\002\"$\n\020DownloadProgress\022"
+  "\020\n\010progress\030\001 \001(\002\"1\n\017MissionProgress\022\017\n\007"
+  "current\030\001 \001(\005\022\r\n\005total\030\002 \001(\005\"\231\003\n\rMission"
+  "Result\0228\n\006result\030\001 \001(\0162(.mavsdk.rpc.miss"
+  "ion.MissionResult.Result\022\022\n\nresult_str\030\002"
+  " \001(\t\"\271\002\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016R"
+  "ESULT_SUCCESS\020\001\022\020\n\014RESULT_ERROR\020\002\022!\n\035RES"
+  "ULT_TOO_MANY_MISSION_ITEMS\020\003\022\017\n\013RESULT_B"
+  "USY\020\004\022\022\n\016RESULT_TIMEOUT\020\005\022\033\n\027RESULT_INVA"
+  "LID_ARGUMENT\020\006\022\026\n\022RESULT_UNSUPPORTED\020\007\022\037"
+  "\n\033RESULT_NO_MISSION_AVAILABLE\020\010\022\"\n\036RESUL"
+  "T_UNSUPPORTED_MISSION_CMD\020\013\022\035\n\031RESULT_TR"
+  "ANSFER_CANCELLED\020\014\022\024\n\020RESULT_NO_SYSTEM\020\r"
+  "2\333\r\n\016MissionService\022f\n\rUploadMission\022(.m"
+  "avsdk.rpc.mission.UploadMissionRequest\032)"
+  ".mavsdk.rpc.mission.UploadMissionRespons"
+  "e\"\000\022|\n\023CancelMissionUpload\022..mavsdk.rpc."
+  "mission.CancelMissionUploadRequest\032/.mav"
+  "sdk.rpc.mission.CancelMissionUploadRespo"
+  "nse\"\004\200\265\030\001\022\201\001\n\027SubscribeUploadProgress\0222."
+  "mavsdk.rpc.mission.SubscribeUploadProgre"
+  "ssRequest\032*.mavsdk.rpc.mission.UploadPro"
+  "gressResponse\"\004\200\265\030\0000\001\022l\n\017DownloadMission"
+  "\022*.mavsdk.rpc.mission.DownloadMissionReq"
+  "uest\032+.mavsdk.rpc.mission.DownloadMissio"
+  "nResponse\"\000\022\202\001\n\025CancelMissionDownload\0220."
+  "mavsdk.rpc.mission.CancelMissionDownload"
+  "Request\0321.mavsdk.rpc.mission.CancelMissi"
+  "onDownloadResponse\"\004\200\265\030\001\022\207\001\n\031SubscribeDo"
+  "wnloadProgress\0224.mavsdk.rpc.mission.Subs"
+  "cribeDownloadProgressRequest\032,.mavsdk.rp"
+  "c.mission.DownloadProgressResponse\"\004\200\265\030\000"
+  "0\001\022c\n\014StartMission\022\'.mavsdk.rpc.mission."
+  "StartMissionRequest\032(.mavsdk.rpc.mission"
+  ".StartMissionResponse\"\000\022c\n\014PauseMission\022"
+  "\'.mavsdk.rpc.mission.PauseMissionRequest"
+  "\032(.mavsdk.rpc.mission.PauseMissionRespon"
+  "se\"\000\022c\n\014ClearMission\022\'.mavsdk.rpc.missio"
+  "n.ClearMissionRequest\032(.mavsdk.rpc.missi"
+  "on.ClearMissionResponse\"\000\022~\n\025SetCurrentM"
+  "issionItem\0220.mavsdk.rpc.mission.SetCurre"
+  "ntMissionItemRequest\0321.mavsdk.rpc.missio"
+  "n.SetCurrentMissionItemResponse\"\000\022v\n\021IsM"
+  "issionFinished\022,.mavsdk.rpc.mission.IsMi"
+  "ssionFinishedRequest\032-.mavsdk.rpc.missio"
+  "n.IsMissionFinishedResponse\"\004\200\265\030\001\022\200\001\n\030Su"
+  "bscribeMissionProgress\0223.mavsdk.rpc.miss"
+  "ion.SubscribeMissionProgressRequest\032+.ma"
+  "vsdk.rpc.mission.MissionProgressResponse"
+  "\"\0000\001\022\232\001\n\035GetReturnToLaunchAfterMission\0228"
+  ".mavsdk.rpc.mission.GetReturnToLaunchAft"
+  "erMissionRequest\0329.mavsdk.rpc.mission.Ge"
+  "tReturnToLaunchAfterMissionResponse\"\004\200\265\030"
+  "\001\022\232\001\n\035SetReturnToLaunchAfterMission\0228.ma"
+  "vsdk.rpc.mission.SetReturnToLaunchAfterM"
+  "issionRequest\0329.mavsdk.rpc.mission.SetRe"
+  "turnToLaunchAfterMissionResponse\"\004\200\265\030\001B!"
+  "\n\021io.mavsdk.missionB\014MissionProtob\006proto"
+  "3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_mission_2fmission_2eproto_deps[1] = {
   &::descriptor_table_mavsdk_5foptions_2eproto,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_mission_2fmission_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_mission_2fmission_2eproto = {
-  false, false, 4567, descriptor_table_protodef_mission_2fmission_2eproto, "mission/mission.proto", 
-  &descriptor_table_mission_2fmission_2eproto_once, descriptor_table_mission_2fmission_2eproto_deps, 1, 28,
+  false, false, 5161, descriptor_table_protodef_mission_2fmission_2eproto, "mission/mission.proto", 
+  &descriptor_table_mission_2fmission_2eproto_once, descriptor_table_mission_2fmission_2eproto_deps, 1, 34,
   schemas, file_default_instances, TableStruct_mission_2fmission_2eproto::offsets,
   file_level_metadata_mission_2fmission_2eproto, file_level_enum_descriptors_mission_2fmission_2eproto, file_level_service_descriptors_mission_2fmission_2eproto,
 };
@@ -1578,6 +1709,359 @@ void CancelMissionUploadResponse::InternalSwap(CancelMissionUploadResponse* othe
 
 // ===================================================================
 
+class SubscribeUploadProgressRequest::_Internal {
+ public:
+};
+
+SubscribeUploadProgressRequest::SubscribeUploadProgressRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor();
+  if (!is_message_owned) {
+    RegisterArenaDtor(arena);
+  }
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.mission.SubscribeUploadProgressRequest)
+}
+SubscribeUploadProgressRequest::SubscribeUploadProgressRequest(const SubscribeUploadProgressRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.mission.SubscribeUploadProgressRequest)
+}
+
+inline void SubscribeUploadProgressRequest::SharedCtor() {
+}
+
+SubscribeUploadProgressRequest::~SubscribeUploadProgressRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.mission.SubscribeUploadProgressRequest)
+  if (GetArenaForAllocation() != nullptr) return;
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+inline void SubscribeUploadProgressRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+}
+
+void SubscribeUploadProgressRequest::ArenaDtor(void* object) {
+  SubscribeUploadProgressRequest* _this = reinterpret_cast< SubscribeUploadProgressRequest* >(object);
+  (void)_this;
+}
+void SubscribeUploadProgressRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void SubscribeUploadProgressRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void SubscribeUploadProgressRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.mission.SubscribeUploadProgressRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* SubscribeUploadProgressRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+        if ((tag == 0) || ((tag & 7) == 4)) {
+          CHK_(ptr);
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* SubscribeUploadProgressRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.mission.SubscribeUploadProgressRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.mission.SubscribeUploadProgressRequest)
+  return target;
+}
+
+size_t SubscribeUploadProgressRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.mission.SubscribeUploadProgressRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData SubscribeUploadProgressRequest::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSizeCheck,
+    SubscribeUploadProgressRequest::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*SubscribeUploadProgressRequest::GetClassData() const { return &_class_data_; }
+
+void SubscribeUploadProgressRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
+                      const ::PROTOBUF_NAMESPACE_ID::Message&from) {
+  static_cast<SubscribeUploadProgressRequest *>(to)->MergeFrom(
+      static_cast<const SubscribeUploadProgressRequest &>(from));
+}
+
+
+void SubscribeUploadProgressRequest::MergeFrom(const SubscribeUploadProgressRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.mission.SubscribeUploadProgressRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SubscribeUploadProgressRequest::CopyFrom(const SubscribeUploadProgressRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.mission.SubscribeUploadProgressRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SubscribeUploadProgressRequest::IsInitialized() const {
+  return true;
+}
+
+void SubscribeUploadProgressRequest::InternalSwap(SubscribeUploadProgressRequest* other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata SubscribeUploadProgressRequest::GetMetadata() const {
+  return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
+      &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
+      file_level_metadata_mission_2fmission_2eproto[4]);
+}
+
+// ===================================================================
+
+class UploadProgressResponse::_Internal {
+ public:
+  static const ::mavsdk::rpc::mission::UploadProgress& upload_progress(const UploadProgressResponse* msg);
+};
+
+const ::mavsdk::rpc::mission::UploadProgress&
+UploadProgressResponse::_Internal::upload_progress(const UploadProgressResponse* msg) {
+  return *msg->upload_progress_;
+}
+UploadProgressResponse::UploadProgressResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor();
+  if (!is_message_owned) {
+    RegisterArenaDtor(arena);
+  }
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.mission.UploadProgressResponse)
+}
+UploadProgressResponse::UploadProgressResponse(const UploadProgressResponse& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_upload_progress()) {
+    upload_progress_ = new ::mavsdk::rpc::mission::UploadProgress(*from.upload_progress_);
+  } else {
+    upload_progress_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.mission.UploadProgressResponse)
+}
+
+inline void UploadProgressResponse::SharedCtor() {
+upload_progress_ = nullptr;
+}
+
+UploadProgressResponse::~UploadProgressResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.mission.UploadProgressResponse)
+  if (GetArenaForAllocation() != nullptr) return;
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+inline void UploadProgressResponse::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  if (this != internal_default_instance()) delete upload_progress_;
+}
+
+void UploadProgressResponse::ArenaDtor(void* object) {
+  UploadProgressResponse* _this = reinterpret_cast< UploadProgressResponse* >(object);
+  (void)_this;
+}
+void UploadProgressResponse::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void UploadProgressResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void UploadProgressResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.mission.UploadProgressResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArenaForAllocation() == nullptr && upload_progress_ != nullptr) {
+    delete upload_progress_;
+  }
+  upload_progress_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* UploadProgressResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // .mavsdk.rpc.mission.UploadProgress upload_progress = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_upload_progress(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag == 0) || ((tag & 7) == 4)) {
+          CHK_(ptr);
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* UploadProgressResponse::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.mission.UploadProgressResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.mission.UploadProgress upload_progress = 1;
+  if (this->_internal_has_upload_progress()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::upload_progress(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.mission.UploadProgressResponse)
+  return target;
+}
+
+size_t UploadProgressResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.mission.UploadProgressResponse)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.mission.UploadProgress upload_progress = 1;
+  if (this->_internal_has_upload_progress()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *upload_progress_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData UploadProgressResponse::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSizeCheck,
+    UploadProgressResponse::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*UploadProgressResponse::GetClassData() const { return &_class_data_; }
+
+void UploadProgressResponse::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
+                      const ::PROTOBUF_NAMESPACE_ID::Message&from) {
+  static_cast<UploadProgressResponse *>(to)->MergeFrom(
+      static_cast<const UploadProgressResponse &>(from));
+}
+
+
+void UploadProgressResponse::MergeFrom(const UploadProgressResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.mission.UploadProgressResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_has_upload_progress()) {
+    _internal_mutable_upload_progress()->::mavsdk::rpc::mission::UploadProgress::MergeFrom(from._internal_upload_progress());
+  }
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void UploadProgressResponse::CopyFrom(const UploadProgressResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.mission.UploadProgressResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool UploadProgressResponse::IsInitialized() const {
+  return true;
+}
+
+void UploadProgressResponse::InternalSwap(UploadProgressResponse* other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(upload_progress_, other->upload_progress_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata UploadProgressResponse::GetMetadata() const {
+  return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
+      &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
+      file_level_metadata_mission_2fmission_2eproto[5]);
+}
+
+// ===================================================================
+
 class DownloadMissionRequest::_Internal {
  public:
 };
@@ -1726,7 +2210,7 @@ void DownloadMissionRequest::InternalSwap(DownloadMissionRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata DownloadMissionRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[4]);
+      file_level_metadata_mission_2fmission_2eproto[6]);
 }
 
 // ===================================================================
@@ -1974,7 +2458,7 @@ void DownloadMissionResponse::InternalSwap(DownloadMissionResponse* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata DownloadMissionResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[5]);
+      file_level_metadata_mission_2fmission_2eproto[7]);
 }
 
 // ===================================================================
@@ -2127,7 +2611,7 @@ void CancelMissionDownloadRequest::InternalSwap(CancelMissionDownloadRequest* ot
 ::PROTOBUF_NAMESPACE_ID::Metadata CancelMissionDownloadRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[6]);
+      file_level_metadata_mission_2fmission_2eproto[8]);
 }
 
 // ===================================================================
@@ -2327,7 +2811,360 @@ void CancelMissionDownloadResponse::InternalSwap(CancelMissionDownloadResponse* 
 ::PROTOBUF_NAMESPACE_ID::Metadata CancelMissionDownloadResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[7]);
+      file_level_metadata_mission_2fmission_2eproto[9]);
+}
+
+// ===================================================================
+
+class SubscribeDownloadProgressRequest::_Internal {
+ public:
+};
+
+SubscribeDownloadProgressRequest::SubscribeDownloadProgressRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor();
+  if (!is_message_owned) {
+    RegisterArenaDtor(arena);
+  }
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.mission.SubscribeDownloadProgressRequest)
+}
+SubscribeDownloadProgressRequest::SubscribeDownloadProgressRequest(const SubscribeDownloadProgressRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.mission.SubscribeDownloadProgressRequest)
+}
+
+inline void SubscribeDownloadProgressRequest::SharedCtor() {
+}
+
+SubscribeDownloadProgressRequest::~SubscribeDownloadProgressRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.mission.SubscribeDownloadProgressRequest)
+  if (GetArenaForAllocation() != nullptr) return;
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+inline void SubscribeDownloadProgressRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+}
+
+void SubscribeDownloadProgressRequest::ArenaDtor(void* object) {
+  SubscribeDownloadProgressRequest* _this = reinterpret_cast< SubscribeDownloadProgressRequest* >(object);
+  (void)_this;
+}
+void SubscribeDownloadProgressRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void SubscribeDownloadProgressRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void SubscribeDownloadProgressRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.mission.SubscribeDownloadProgressRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* SubscribeDownloadProgressRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+        if ((tag == 0) || ((tag & 7) == 4)) {
+          CHK_(ptr);
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* SubscribeDownloadProgressRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.mission.SubscribeDownloadProgressRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.mission.SubscribeDownloadProgressRequest)
+  return target;
+}
+
+size_t SubscribeDownloadProgressRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.mission.SubscribeDownloadProgressRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData SubscribeDownloadProgressRequest::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSizeCheck,
+    SubscribeDownloadProgressRequest::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*SubscribeDownloadProgressRequest::GetClassData() const { return &_class_data_; }
+
+void SubscribeDownloadProgressRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
+                      const ::PROTOBUF_NAMESPACE_ID::Message&from) {
+  static_cast<SubscribeDownloadProgressRequest *>(to)->MergeFrom(
+      static_cast<const SubscribeDownloadProgressRequest &>(from));
+}
+
+
+void SubscribeDownloadProgressRequest::MergeFrom(const SubscribeDownloadProgressRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.mission.SubscribeDownloadProgressRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SubscribeDownloadProgressRequest::CopyFrom(const SubscribeDownloadProgressRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.mission.SubscribeDownloadProgressRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SubscribeDownloadProgressRequest::IsInitialized() const {
+  return true;
+}
+
+void SubscribeDownloadProgressRequest::InternalSwap(SubscribeDownloadProgressRequest* other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata SubscribeDownloadProgressRequest::GetMetadata() const {
+  return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
+      &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
+      file_level_metadata_mission_2fmission_2eproto[10]);
+}
+
+// ===================================================================
+
+class DownloadProgressResponse::_Internal {
+ public:
+  static const ::mavsdk::rpc::mission::DownloadProgress& download_progress(const DownloadProgressResponse* msg);
+};
+
+const ::mavsdk::rpc::mission::DownloadProgress&
+DownloadProgressResponse::_Internal::download_progress(const DownloadProgressResponse* msg) {
+  return *msg->download_progress_;
+}
+DownloadProgressResponse::DownloadProgressResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor();
+  if (!is_message_owned) {
+    RegisterArenaDtor(arena);
+  }
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.mission.DownloadProgressResponse)
+}
+DownloadProgressResponse::DownloadProgressResponse(const DownloadProgressResponse& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_download_progress()) {
+    download_progress_ = new ::mavsdk::rpc::mission::DownloadProgress(*from.download_progress_);
+  } else {
+    download_progress_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.mission.DownloadProgressResponse)
+}
+
+inline void DownloadProgressResponse::SharedCtor() {
+download_progress_ = nullptr;
+}
+
+DownloadProgressResponse::~DownloadProgressResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.mission.DownloadProgressResponse)
+  if (GetArenaForAllocation() != nullptr) return;
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+inline void DownloadProgressResponse::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  if (this != internal_default_instance()) delete download_progress_;
+}
+
+void DownloadProgressResponse::ArenaDtor(void* object) {
+  DownloadProgressResponse* _this = reinterpret_cast< DownloadProgressResponse* >(object);
+  (void)_this;
+}
+void DownloadProgressResponse::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void DownloadProgressResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void DownloadProgressResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.mission.DownloadProgressResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArenaForAllocation() == nullptr && download_progress_ != nullptr) {
+    delete download_progress_;
+  }
+  download_progress_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* DownloadProgressResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // .mavsdk.rpc.mission.DownloadProgress download_progress = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_download_progress(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag == 0) || ((tag & 7) == 4)) {
+          CHK_(ptr);
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* DownloadProgressResponse::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.mission.DownloadProgressResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.mission.DownloadProgress download_progress = 1;
+  if (this->_internal_has_download_progress()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::download_progress(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.mission.DownloadProgressResponse)
+  return target;
+}
+
+size_t DownloadProgressResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.mission.DownloadProgressResponse)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.mission.DownloadProgress download_progress = 1;
+  if (this->_internal_has_download_progress()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *download_progress_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData DownloadProgressResponse::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSizeCheck,
+    DownloadProgressResponse::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*DownloadProgressResponse::GetClassData() const { return &_class_data_; }
+
+void DownloadProgressResponse::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
+                      const ::PROTOBUF_NAMESPACE_ID::Message&from) {
+  static_cast<DownloadProgressResponse *>(to)->MergeFrom(
+      static_cast<const DownloadProgressResponse &>(from));
+}
+
+
+void DownloadProgressResponse::MergeFrom(const DownloadProgressResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.mission.DownloadProgressResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_has_download_progress()) {
+    _internal_mutable_download_progress()->::mavsdk::rpc::mission::DownloadProgress::MergeFrom(from._internal_download_progress());
+  }
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void DownloadProgressResponse::CopyFrom(const DownloadProgressResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.mission.DownloadProgressResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool DownloadProgressResponse::IsInitialized() const {
+  return true;
+}
+
+void DownloadProgressResponse::InternalSwap(DownloadProgressResponse* other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(download_progress_, other->download_progress_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata DownloadProgressResponse::GetMetadata() const {
+  return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
+      &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
+      file_level_metadata_mission_2fmission_2eproto[11]);
 }
 
 // ===================================================================
@@ -2480,7 +3317,7 @@ void StartMissionRequest::InternalSwap(StartMissionRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata StartMissionRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[8]);
+      file_level_metadata_mission_2fmission_2eproto[12]);
 }
 
 // ===================================================================
@@ -2680,7 +3517,7 @@ void StartMissionResponse::InternalSwap(StartMissionResponse* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata StartMissionResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[9]);
+      file_level_metadata_mission_2fmission_2eproto[13]);
 }
 
 // ===================================================================
@@ -2833,7 +3670,7 @@ void PauseMissionRequest::InternalSwap(PauseMissionRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata PauseMissionRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[10]);
+      file_level_metadata_mission_2fmission_2eproto[14]);
 }
 
 // ===================================================================
@@ -3033,7 +3870,7 @@ void PauseMissionResponse::InternalSwap(PauseMissionResponse* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata PauseMissionResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[11]);
+      file_level_metadata_mission_2fmission_2eproto[15]);
 }
 
 // ===================================================================
@@ -3186,7 +4023,7 @@ void ClearMissionRequest::InternalSwap(ClearMissionRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata ClearMissionRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[12]);
+      file_level_metadata_mission_2fmission_2eproto[16]);
 }
 
 // ===================================================================
@@ -3386,7 +4223,7 @@ void ClearMissionResponse::InternalSwap(ClearMissionResponse* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata ClearMissionResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[13]);
+      file_level_metadata_mission_2fmission_2eproto[17]);
 }
 
 // ===================================================================
@@ -3571,7 +4408,7 @@ void SetCurrentMissionItemRequest::InternalSwap(SetCurrentMissionItemRequest* ot
 ::PROTOBUF_NAMESPACE_ID::Metadata SetCurrentMissionItemRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[14]);
+      file_level_metadata_mission_2fmission_2eproto[18]);
 }
 
 // ===================================================================
@@ -3771,7 +4608,7 @@ void SetCurrentMissionItemResponse::InternalSwap(SetCurrentMissionItemResponse* 
 ::PROTOBUF_NAMESPACE_ID::Metadata SetCurrentMissionItemResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[15]);
+      file_level_metadata_mission_2fmission_2eproto[19]);
 }
 
 // ===================================================================
@@ -3924,7 +4761,7 @@ void IsMissionFinishedRequest::InternalSwap(IsMissionFinishedRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata IsMissionFinishedRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[16]);
+      file_level_metadata_mission_2fmission_2eproto[20]);
 }
 
 // ===================================================================
@@ -4155,7 +4992,7 @@ void IsMissionFinishedResponse::InternalSwap(IsMissionFinishedResponse* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata IsMissionFinishedResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[17]);
+      file_level_metadata_mission_2fmission_2eproto[21]);
 }
 
 // ===================================================================
@@ -4308,7 +5145,7 @@ void SubscribeMissionProgressRequest::InternalSwap(SubscribeMissionProgressReque
 ::PROTOBUF_NAMESPACE_ID::Metadata SubscribeMissionProgressRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[18]);
+      file_level_metadata_mission_2fmission_2eproto[22]);
 }
 
 // ===================================================================
@@ -4508,7 +5345,7 @@ void MissionProgressResponse::InternalSwap(MissionProgressResponse* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata MissionProgressResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[19]);
+      file_level_metadata_mission_2fmission_2eproto[23]);
 }
 
 // ===================================================================
@@ -4661,7 +5498,7 @@ void GetReturnToLaunchAfterMissionRequest::InternalSwap(GetReturnToLaunchAfterMi
 ::PROTOBUF_NAMESPACE_ID::Metadata GetReturnToLaunchAfterMissionRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[20]);
+      file_level_metadata_mission_2fmission_2eproto[24]);
 }
 
 // ===================================================================
@@ -4892,7 +5729,7 @@ void GetReturnToLaunchAfterMissionResponse::InternalSwap(GetReturnToLaunchAfterM
 ::PROTOBUF_NAMESPACE_ID::Metadata GetReturnToLaunchAfterMissionResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[21]);
+      file_level_metadata_mission_2fmission_2eproto[25]);
 }
 
 // ===================================================================
@@ -5075,7 +5912,7 @@ void SetReturnToLaunchAfterMissionRequest::InternalSwap(SetReturnToLaunchAfterMi
 ::PROTOBUF_NAMESPACE_ID::Metadata SetReturnToLaunchAfterMissionRequest::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[22]);
+      file_level_metadata_mission_2fmission_2eproto[26]);
 }
 
 // ===================================================================
@@ -5275,7 +6112,7 @@ void SetReturnToLaunchAfterMissionResponse::InternalSwap(SetReturnToLaunchAfterM
 ::PROTOBUF_NAMESPACE_ID::Metadata SetReturnToLaunchAfterMissionResponse::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[23]);
+      file_level_metadata_mission_2fmission_2eproto[27]);
 }
 
 // ===================================================================
@@ -5725,7 +6562,7 @@ void MissionItem::InternalSwap(MissionItem* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata MissionItem::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[24]);
+      file_level_metadata_mission_2fmission_2eproto[28]);
 }
 
 // ===================================================================
@@ -5915,7 +6752,373 @@ void MissionPlan::InternalSwap(MissionPlan* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata MissionPlan::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[25]);
+      file_level_metadata_mission_2fmission_2eproto[29]);
+}
+
+// ===================================================================
+
+class UploadProgress::_Internal {
+ public:
+};
+
+UploadProgress::UploadProgress(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor();
+  if (!is_message_owned) {
+    RegisterArenaDtor(arena);
+  }
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.mission.UploadProgress)
+}
+UploadProgress::UploadProgress(const UploadProgress& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  progress_ = from.progress_;
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.mission.UploadProgress)
+}
+
+inline void UploadProgress::SharedCtor() {
+progress_ = 0;
+}
+
+UploadProgress::~UploadProgress() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.mission.UploadProgress)
+  if (GetArenaForAllocation() != nullptr) return;
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+inline void UploadProgress::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+}
+
+void UploadProgress::ArenaDtor(void* object) {
+  UploadProgress* _this = reinterpret_cast< UploadProgress* >(object);
+  (void)_this;
+}
+void UploadProgress::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void UploadProgress::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void UploadProgress::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.mission.UploadProgress)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  progress_ = 0;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* UploadProgress::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // float progress = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 13)) {
+          progress_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<float>(ptr);
+          ptr += sizeof(float);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag == 0) || ((tag & 7) == 4)) {
+          CHK_(ptr);
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* UploadProgress::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.mission.UploadProgress)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // float progress = 1;
+  if (!(this->_internal_progress() <= 0 && this->_internal_progress() >= 0)) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteFloatToArray(1, this->_internal_progress(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.mission.UploadProgress)
+  return target;
+}
+
+size_t UploadProgress::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.mission.UploadProgress)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // float progress = 1;
+  if (!(this->_internal_progress() <= 0 && this->_internal_progress() >= 0)) {
+    total_size += 1 + 4;
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData UploadProgress::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSizeCheck,
+    UploadProgress::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*UploadProgress::GetClassData() const { return &_class_data_; }
+
+void UploadProgress::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
+                      const ::PROTOBUF_NAMESPACE_ID::Message&from) {
+  static_cast<UploadProgress *>(to)->MergeFrom(
+      static_cast<const UploadProgress &>(from));
+}
+
+
+void UploadProgress::MergeFrom(const UploadProgress& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.mission.UploadProgress)
+  GOOGLE_DCHECK_NE(&from, this);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!(from._internal_progress() <= 0 && from._internal_progress() >= 0)) {
+    _internal_set_progress(from._internal_progress());
+  }
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void UploadProgress::CopyFrom(const UploadProgress& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.mission.UploadProgress)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool UploadProgress::IsInitialized() const {
+  return true;
+}
+
+void UploadProgress::InternalSwap(UploadProgress* other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(progress_, other->progress_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata UploadProgress::GetMetadata() const {
+  return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
+      &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
+      file_level_metadata_mission_2fmission_2eproto[30]);
+}
+
+// ===================================================================
+
+class DownloadProgress::_Internal {
+ public:
+};
+
+DownloadProgress::DownloadProgress(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor();
+  if (!is_message_owned) {
+    RegisterArenaDtor(arena);
+  }
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.mission.DownloadProgress)
+}
+DownloadProgress::DownloadProgress(const DownloadProgress& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  progress_ = from.progress_;
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.mission.DownloadProgress)
+}
+
+inline void DownloadProgress::SharedCtor() {
+progress_ = 0;
+}
+
+DownloadProgress::~DownloadProgress() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.mission.DownloadProgress)
+  if (GetArenaForAllocation() != nullptr) return;
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+inline void DownloadProgress::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+}
+
+void DownloadProgress::ArenaDtor(void* object) {
+  DownloadProgress* _this = reinterpret_cast< DownloadProgress* >(object);
+  (void)_this;
+}
+void DownloadProgress::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void DownloadProgress::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void DownloadProgress::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.mission.DownloadProgress)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  progress_ = 0;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* DownloadProgress::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // float progress = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 13)) {
+          progress_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<float>(ptr);
+          ptr += sizeof(float);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag == 0) || ((tag & 7) == 4)) {
+          CHK_(ptr);
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* DownloadProgress::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.mission.DownloadProgress)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // float progress = 1;
+  if (!(this->_internal_progress() <= 0 && this->_internal_progress() >= 0)) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteFloatToArray(1, this->_internal_progress(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.mission.DownloadProgress)
+  return target;
+}
+
+size_t DownloadProgress::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.mission.DownloadProgress)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // float progress = 1;
+  if (!(this->_internal_progress() <= 0 && this->_internal_progress() >= 0)) {
+    total_size += 1 + 4;
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData DownloadProgress::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSizeCheck,
+    DownloadProgress::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*DownloadProgress::GetClassData() const { return &_class_data_; }
+
+void DownloadProgress::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to,
+                      const ::PROTOBUF_NAMESPACE_ID::Message&from) {
+  static_cast<DownloadProgress *>(to)->MergeFrom(
+      static_cast<const DownloadProgress &>(from));
+}
+
+
+void DownloadProgress::MergeFrom(const DownloadProgress& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.mission.DownloadProgress)
+  GOOGLE_DCHECK_NE(&from, this);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!(from._internal_progress() <= 0 && from._internal_progress() >= 0)) {
+    _internal_set_progress(from._internal_progress());
+  }
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void DownloadProgress::CopyFrom(const DownloadProgress& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.mission.DownloadProgress)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool DownloadProgress::IsInitialized() const {
+  return true;
+}
+
+void DownloadProgress::InternalSwap(DownloadProgress* other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(progress_, other->progress_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata DownloadProgress::GetMetadata() const {
+  return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
+      &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
+      file_level_metadata_mission_2fmission_2eproto[31]);
 }
 
 // ===================================================================
@@ -6135,7 +7338,7 @@ void MissionProgress::InternalSwap(MissionProgress* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata MissionProgress::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[26]);
+      file_level_metadata_mission_2fmission_2eproto[32]);
 }
 
 // ===================================================================
@@ -6363,7 +7566,7 @@ void MissionResult::InternalSwap(MissionResult* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata MissionResult::GetMetadata() const {
   return ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(
       &descriptor_table_mission_2fmission_2eproto_getter, &descriptor_table_mission_2fmission_2eproto_once,
-      file_level_metadata_mission_2fmission_2eproto[27]);
+      file_level_metadata_mission_2fmission_2eproto[33]);
 }
 
 // @@protoc_insertion_point(namespace_scope)
@@ -6383,6 +7586,12 @@ template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission::CancelMissionUploadRequest*
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission::CancelMissionUploadResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::mission::CancelMissionUploadResponse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::mission::CancelMissionUploadResponse >(arena);
 }
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission::SubscribeUploadProgressRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::mission::SubscribeUploadProgressRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::mission::SubscribeUploadProgressRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission::UploadProgressResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::mission::UploadProgressResponse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::mission::UploadProgressResponse >(arena);
+}
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission::DownloadMissionRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::mission::DownloadMissionRequest >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::mission::DownloadMissionRequest >(arena);
 }
@@ -6394,6 +7603,12 @@ template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission::CancelMissionDownloadReques
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission::CancelMissionDownloadResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::mission::CancelMissionDownloadResponse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::mission::CancelMissionDownloadResponse >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission::DownloadProgressResponse* Arena::CreateMaybeMessage< ::mavsdk::rpc::mission::DownloadProgressResponse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::mission::DownloadProgressResponse >(arena);
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission::StartMissionRequest* Arena::CreateMaybeMessage< ::mavsdk::rpc::mission::StartMissionRequest >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::mission::StartMissionRequest >(arena);
@@ -6448,6 +7663,12 @@ template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission::MissionItem* Arena::CreateM
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission::MissionPlan* Arena::CreateMaybeMessage< ::mavsdk::rpc::mission::MissionPlan >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::mission::MissionPlan >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission::UploadProgress* Arena::CreateMaybeMessage< ::mavsdk::rpc::mission::UploadProgress >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::mission::UploadProgress >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission::DownloadProgress* Arena::CreateMaybeMessage< ::mavsdk::rpc::mission::DownloadProgress >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::mission::DownloadProgress >(arena);
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission::MissionProgress* Arena::CreateMaybeMessage< ::mavsdk::rpc::mission::MissionProgress >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::mission::MissionProgress >(arena);

--- a/src/mavsdk_server/src/generated/mission/mission.pb.h
+++ b/src/mavsdk_server/src/generated/mission/mission.pb.h
@@ -48,7 +48,7 @@ struct TableStruct_mission_2fmission_2eproto {
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::AuxiliaryParseTableField aux[]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
-  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[28]
+  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[34]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::FieldMetadata field_metadata[];
   static const ::PROTOBUF_NAMESPACE_ID::internal::SerializationTable serialization_table[];
@@ -82,6 +82,12 @@ extern DownloadMissionRequestDefaultTypeInternal _DownloadMissionRequest_default
 class DownloadMissionResponse;
 struct DownloadMissionResponseDefaultTypeInternal;
 extern DownloadMissionResponseDefaultTypeInternal _DownloadMissionResponse_default_instance_;
+class DownloadProgress;
+struct DownloadProgressDefaultTypeInternal;
+extern DownloadProgressDefaultTypeInternal _DownloadProgress_default_instance_;
+class DownloadProgressResponse;
+struct DownloadProgressResponseDefaultTypeInternal;
+extern DownloadProgressResponseDefaultTypeInternal _DownloadProgressResponse_default_instance_;
 class GetReturnToLaunchAfterMissionRequest;
 struct GetReturnToLaunchAfterMissionRequestDefaultTypeInternal;
 extern GetReturnToLaunchAfterMissionRequestDefaultTypeInternal _GetReturnToLaunchAfterMissionRequest_default_instance_;
@@ -133,15 +139,27 @@ extern StartMissionRequestDefaultTypeInternal _StartMissionRequest_default_insta
 class StartMissionResponse;
 struct StartMissionResponseDefaultTypeInternal;
 extern StartMissionResponseDefaultTypeInternal _StartMissionResponse_default_instance_;
+class SubscribeDownloadProgressRequest;
+struct SubscribeDownloadProgressRequestDefaultTypeInternal;
+extern SubscribeDownloadProgressRequestDefaultTypeInternal _SubscribeDownloadProgressRequest_default_instance_;
 class SubscribeMissionProgressRequest;
 struct SubscribeMissionProgressRequestDefaultTypeInternal;
 extern SubscribeMissionProgressRequestDefaultTypeInternal _SubscribeMissionProgressRequest_default_instance_;
+class SubscribeUploadProgressRequest;
+struct SubscribeUploadProgressRequestDefaultTypeInternal;
+extern SubscribeUploadProgressRequestDefaultTypeInternal _SubscribeUploadProgressRequest_default_instance_;
 class UploadMissionRequest;
 struct UploadMissionRequestDefaultTypeInternal;
 extern UploadMissionRequestDefaultTypeInternal _UploadMissionRequest_default_instance_;
 class UploadMissionResponse;
 struct UploadMissionResponseDefaultTypeInternal;
 extern UploadMissionResponseDefaultTypeInternal _UploadMissionResponse_default_instance_;
+class UploadProgress;
+struct UploadProgressDefaultTypeInternal;
+extern UploadProgressDefaultTypeInternal _UploadProgress_default_instance_;
+class UploadProgressResponse;
+struct UploadProgressResponseDefaultTypeInternal;
+extern UploadProgressResponseDefaultTypeInternal _UploadProgressResponse_default_instance_;
 }  // namespace mission
 }  // namespace rpc
 }  // namespace mavsdk
@@ -154,6 +172,8 @@ template<> ::mavsdk::rpc::mission::ClearMissionRequest* Arena::CreateMaybeMessag
 template<> ::mavsdk::rpc::mission::ClearMissionResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::mission::ClearMissionResponse>(Arena*);
 template<> ::mavsdk::rpc::mission::DownloadMissionRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::mission::DownloadMissionRequest>(Arena*);
 template<> ::mavsdk::rpc::mission::DownloadMissionResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::mission::DownloadMissionResponse>(Arena*);
+template<> ::mavsdk::rpc::mission::DownloadProgress* Arena::CreateMaybeMessage<::mavsdk::rpc::mission::DownloadProgress>(Arena*);
+template<> ::mavsdk::rpc::mission::DownloadProgressResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::mission::DownloadProgressResponse>(Arena*);
 template<> ::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionRequest>(Arena*);
 template<> ::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::mission::GetReturnToLaunchAfterMissionResponse>(Arena*);
 template<> ::mavsdk::rpc::mission::IsMissionFinishedRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::mission::IsMissionFinishedRequest>(Arena*);
@@ -171,9 +191,13 @@ template<> ::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionRequest* Arena::
 template<> ::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::mission::SetReturnToLaunchAfterMissionResponse>(Arena*);
 template<> ::mavsdk::rpc::mission::StartMissionRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::mission::StartMissionRequest>(Arena*);
 template<> ::mavsdk::rpc::mission::StartMissionResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::mission::StartMissionResponse>(Arena*);
+template<> ::mavsdk::rpc::mission::SubscribeDownloadProgressRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::mission::SubscribeDownloadProgressRequest>(Arena*);
 template<> ::mavsdk::rpc::mission::SubscribeMissionProgressRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::mission::SubscribeMissionProgressRequest>(Arena*);
+template<> ::mavsdk::rpc::mission::SubscribeUploadProgressRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::mission::SubscribeUploadProgressRequest>(Arena*);
 template<> ::mavsdk::rpc::mission::UploadMissionRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::mission::UploadMissionRequest>(Arena*);
 template<> ::mavsdk::rpc::mission::UploadMissionResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::mission::UploadMissionResponse>(Arena*);
+template<> ::mavsdk::rpc::mission::UploadProgress* Arena::CreateMaybeMessage<::mavsdk::rpc::mission::UploadProgress>(Arena*);
+template<> ::mavsdk::rpc::mission::UploadProgressResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::mission::UploadProgressResponse>(Arena*);
 PROTOBUF_NAMESPACE_CLOSE
 namespace mavsdk {
 namespace rpc {
@@ -817,6 +841,280 @@ class CancelMissionUploadResponse final :
 };
 // -------------------------------------------------------------------
 
+class SubscribeUploadProgressRequest final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.mission.SubscribeUploadProgressRequest) */ {
+ public:
+  inline SubscribeUploadProgressRequest() : SubscribeUploadProgressRequest(nullptr) {}
+  ~SubscribeUploadProgressRequest() override;
+  explicit constexpr SubscribeUploadProgressRequest(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  SubscribeUploadProgressRequest(const SubscribeUploadProgressRequest& from);
+  SubscribeUploadProgressRequest(SubscribeUploadProgressRequest&& from) noexcept
+    : SubscribeUploadProgressRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline SubscribeUploadProgressRequest& operator=(const SubscribeUploadProgressRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SubscribeUploadProgressRequest& operator=(SubscribeUploadProgressRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SubscribeUploadProgressRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SubscribeUploadProgressRequest* internal_default_instance() {
+    return reinterpret_cast<const SubscribeUploadProgressRequest*>(
+               &_SubscribeUploadProgressRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    4;
+
+  friend void swap(SubscribeUploadProgressRequest& a, SubscribeUploadProgressRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(SubscribeUploadProgressRequest* other) {
+    if (other == this) return;
+    if (GetOwningArena() == other->GetOwningArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SubscribeUploadProgressRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline SubscribeUploadProgressRequest* New() const final {
+    return new SubscribeUploadProgressRequest();
+  }
+
+  SubscribeUploadProgressRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<SubscribeUploadProgressRequest>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const SubscribeUploadProgressRequest& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom(const SubscribeUploadProgressRequest& from);
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to, const ::PROTOBUF_NAMESPACE_ID::Message&from);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(SubscribeUploadProgressRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.mission.SubscribeUploadProgressRequest";
+  }
+  protected:
+  explicit SubscribeUploadProgressRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.mission.SubscribeUploadProgressRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_mission_2fmission_2eproto;
+};
+// -------------------------------------------------------------------
+
+class UploadProgressResponse final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.mission.UploadProgressResponse) */ {
+ public:
+  inline UploadProgressResponse() : UploadProgressResponse(nullptr) {}
+  ~UploadProgressResponse() override;
+  explicit constexpr UploadProgressResponse(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  UploadProgressResponse(const UploadProgressResponse& from);
+  UploadProgressResponse(UploadProgressResponse&& from) noexcept
+    : UploadProgressResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline UploadProgressResponse& operator=(const UploadProgressResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline UploadProgressResponse& operator=(UploadProgressResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const UploadProgressResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const UploadProgressResponse* internal_default_instance() {
+    return reinterpret_cast<const UploadProgressResponse*>(
+               &_UploadProgressResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    5;
+
+  friend void swap(UploadProgressResponse& a, UploadProgressResponse& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(UploadProgressResponse* other) {
+    if (other == this) return;
+    if (GetOwningArena() == other->GetOwningArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(UploadProgressResponse* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline UploadProgressResponse* New() const final {
+    return new UploadProgressResponse();
+  }
+
+  UploadProgressResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<UploadProgressResponse>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const UploadProgressResponse& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom(const UploadProgressResponse& from);
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to, const ::PROTOBUF_NAMESPACE_ID::Message&from);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(UploadProgressResponse* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.mission.UploadProgressResponse";
+  }
+  protected:
+  explicit UploadProgressResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kUploadProgressFieldNumber = 1,
+  };
+  // .mavsdk.rpc.mission.UploadProgress upload_progress = 1;
+  bool has_upload_progress() const;
+  private:
+  bool _internal_has_upload_progress() const;
+  public:
+  void clear_upload_progress();
+  const ::mavsdk::rpc::mission::UploadProgress& upload_progress() const;
+  PROTOBUF_MUST_USE_RESULT ::mavsdk::rpc::mission::UploadProgress* release_upload_progress();
+  ::mavsdk::rpc::mission::UploadProgress* mutable_upload_progress();
+  void set_allocated_upload_progress(::mavsdk::rpc::mission::UploadProgress* upload_progress);
+  private:
+  const ::mavsdk::rpc::mission::UploadProgress& _internal_upload_progress() const;
+  ::mavsdk::rpc::mission::UploadProgress* _internal_mutable_upload_progress();
+  public:
+  void unsafe_arena_set_allocated_upload_progress(
+      ::mavsdk::rpc::mission::UploadProgress* upload_progress);
+  ::mavsdk::rpc::mission::UploadProgress* unsafe_arena_release_upload_progress();
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.mission.UploadProgressResponse)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::mavsdk::rpc::mission::UploadProgress* upload_progress_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_mission_2fmission_2eproto;
+};
+// -------------------------------------------------------------------
+
 class DownloadMissionRequest final :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.mission.DownloadMissionRequest) */ {
  public:
@@ -861,7 +1159,7 @@ class DownloadMissionRequest final :
                &_DownloadMissionRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    4;
+    6;
 
   friend void swap(DownloadMissionRequest& a, DownloadMissionRequest& b) {
     a.Swap(&b);
@@ -987,7 +1285,7 @@ class DownloadMissionResponse final :
                &_DownloadMissionResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    5;
+    7;
 
   friend void swap(DownloadMissionResponse& a, DownloadMissionResponse& b) {
     a.Swap(&b);
@@ -1155,7 +1453,7 @@ class CancelMissionDownloadRequest final :
                &_CancelMissionDownloadRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    6;
+    8;
 
   friend void swap(CancelMissionDownloadRequest& a, CancelMissionDownloadRequest& b) {
     a.Swap(&b);
@@ -1281,7 +1579,7 @@ class CancelMissionDownloadResponse final :
                &_CancelMissionDownloadResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    7;
+    9;
 
   friend void swap(CancelMissionDownloadResponse& a, CancelMissionDownloadResponse& b) {
     a.Swap(&b);
@@ -1385,6 +1683,280 @@ class CancelMissionDownloadResponse final :
 };
 // -------------------------------------------------------------------
 
+class SubscribeDownloadProgressRequest final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.mission.SubscribeDownloadProgressRequest) */ {
+ public:
+  inline SubscribeDownloadProgressRequest() : SubscribeDownloadProgressRequest(nullptr) {}
+  ~SubscribeDownloadProgressRequest() override;
+  explicit constexpr SubscribeDownloadProgressRequest(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  SubscribeDownloadProgressRequest(const SubscribeDownloadProgressRequest& from);
+  SubscribeDownloadProgressRequest(SubscribeDownloadProgressRequest&& from) noexcept
+    : SubscribeDownloadProgressRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline SubscribeDownloadProgressRequest& operator=(const SubscribeDownloadProgressRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SubscribeDownloadProgressRequest& operator=(SubscribeDownloadProgressRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SubscribeDownloadProgressRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SubscribeDownloadProgressRequest* internal_default_instance() {
+    return reinterpret_cast<const SubscribeDownloadProgressRequest*>(
+               &_SubscribeDownloadProgressRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    10;
+
+  friend void swap(SubscribeDownloadProgressRequest& a, SubscribeDownloadProgressRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(SubscribeDownloadProgressRequest* other) {
+    if (other == this) return;
+    if (GetOwningArena() == other->GetOwningArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SubscribeDownloadProgressRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline SubscribeDownloadProgressRequest* New() const final {
+    return new SubscribeDownloadProgressRequest();
+  }
+
+  SubscribeDownloadProgressRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<SubscribeDownloadProgressRequest>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const SubscribeDownloadProgressRequest& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom(const SubscribeDownloadProgressRequest& from);
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to, const ::PROTOBUF_NAMESPACE_ID::Message&from);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(SubscribeDownloadProgressRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.mission.SubscribeDownloadProgressRequest";
+  }
+  protected:
+  explicit SubscribeDownloadProgressRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.mission.SubscribeDownloadProgressRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_mission_2fmission_2eproto;
+};
+// -------------------------------------------------------------------
+
+class DownloadProgressResponse final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.mission.DownloadProgressResponse) */ {
+ public:
+  inline DownloadProgressResponse() : DownloadProgressResponse(nullptr) {}
+  ~DownloadProgressResponse() override;
+  explicit constexpr DownloadProgressResponse(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  DownloadProgressResponse(const DownloadProgressResponse& from);
+  DownloadProgressResponse(DownloadProgressResponse&& from) noexcept
+    : DownloadProgressResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline DownloadProgressResponse& operator=(const DownloadProgressResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline DownloadProgressResponse& operator=(DownloadProgressResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const DownloadProgressResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const DownloadProgressResponse* internal_default_instance() {
+    return reinterpret_cast<const DownloadProgressResponse*>(
+               &_DownloadProgressResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    11;
+
+  friend void swap(DownloadProgressResponse& a, DownloadProgressResponse& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(DownloadProgressResponse* other) {
+    if (other == this) return;
+    if (GetOwningArena() == other->GetOwningArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(DownloadProgressResponse* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline DownloadProgressResponse* New() const final {
+    return new DownloadProgressResponse();
+  }
+
+  DownloadProgressResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<DownloadProgressResponse>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const DownloadProgressResponse& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom(const DownloadProgressResponse& from);
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to, const ::PROTOBUF_NAMESPACE_ID::Message&from);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(DownloadProgressResponse* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.mission.DownloadProgressResponse";
+  }
+  protected:
+  explicit DownloadProgressResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kDownloadProgressFieldNumber = 1,
+  };
+  // .mavsdk.rpc.mission.DownloadProgress download_progress = 1;
+  bool has_download_progress() const;
+  private:
+  bool _internal_has_download_progress() const;
+  public:
+  void clear_download_progress();
+  const ::mavsdk::rpc::mission::DownloadProgress& download_progress() const;
+  PROTOBUF_MUST_USE_RESULT ::mavsdk::rpc::mission::DownloadProgress* release_download_progress();
+  ::mavsdk::rpc::mission::DownloadProgress* mutable_download_progress();
+  void set_allocated_download_progress(::mavsdk::rpc::mission::DownloadProgress* download_progress);
+  private:
+  const ::mavsdk::rpc::mission::DownloadProgress& _internal_download_progress() const;
+  ::mavsdk::rpc::mission::DownloadProgress* _internal_mutable_download_progress();
+  public:
+  void unsafe_arena_set_allocated_download_progress(
+      ::mavsdk::rpc::mission::DownloadProgress* download_progress);
+  ::mavsdk::rpc::mission::DownloadProgress* unsafe_arena_release_download_progress();
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.mission.DownloadProgressResponse)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::mavsdk::rpc::mission::DownloadProgress* download_progress_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_mission_2fmission_2eproto;
+};
+// -------------------------------------------------------------------
+
 class StartMissionRequest final :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.mission.StartMissionRequest) */ {
  public:
@@ -1429,7 +2001,7 @@ class StartMissionRequest final :
                &_StartMissionRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    8;
+    12;
 
   friend void swap(StartMissionRequest& a, StartMissionRequest& b) {
     a.Swap(&b);
@@ -1555,7 +2127,7 @@ class StartMissionResponse final :
                &_StartMissionResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    9;
+    13;
 
   friend void swap(StartMissionResponse& a, StartMissionResponse& b) {
     a.Swap(&b);
@@ -1703,7 +2275,7 @@ class PauseMissionRequest final :
                &_PauseMissionRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    10;
+    14;
 
   friend void swap(PauseMissionRequest& a, PauseMissionRequest& b) {
     a.Swap(&b);
@@ -1829,7 +2401,7 @@ class PauseMissionResponse final :
                &_PauseMissionResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    11;
+    15;
 
   friend void swap(PauseMissionResponse& a, PauseMissionResponse& b) {
     a.Swap(&b);
@@ -1977,7 +2549,7 @@ class ClearMissionRequest final :
                &_ClearMissionRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    12;
+    16;
 
   friend void swap(ClearMissionRequest& a, ClearMissionRequest& b) {
     a.Swap(&b);
@@ -2103,7 +2675,7 @@ class ClearMissionResponse final :
                &_ClearMissionResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    13;
+    17;
 
   friend void swap(ClearMissionResponse& a, ClearMissionResponse& b) {
     a.Swap(&b);
@@ -2251,7 +2823,7 @@ class SetCurrentMissionItemRequest final :
                &_SetCurrentMissionItemRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    14;
+    18;
 
   friend void swap(SetCurrentMissionItemRequest& a, SetCurrentMissionItemRequest& b) {
     a.Swap(&b);
@@ -2390,7 +2962,7 @@ class SetCurrentMissionItemResponse final :
                &_SetCurrentMissionItemResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    15;
+    19;
 
   friend void swap(SetCurrentMissionItemResponse& a, SetCurrentMissionItemResponse& b) {
     a.Swap(&b);
@@ -2538,7 +3110,7 @@ class IsMissionFinishedRequest final :
                &_IsMissionFinishedRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    16;
+    20;
 
   friend void swap(IsMissionFinishedRequest& a, IsMissionFinishedRequest& b) {
     a.Swap(&b);
@@ -2664,7 +3236,7 @@ class IsMissionFinishedResponse final :
                &_IsMissionFinishedResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    17;
+    21;
 
   friend void swap(IsMissionFinishedResponse& a, IsMissionFinishedResponse& b) {
     a.Swap(&b);
@@ -2823,7 +3395,7 @@ class SubscribeMissionProgressRequest final :
                &_SubscribeMissionProgressRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    18;
+    22;
 
   friend void swap(SubscribeMissionProgressRequest& a, SubscribeMissionProgressRequest& b) {
     a.Swap(&b);
@@ -2949,7 +3521,7 @@ class MissionProgressResponse final :
                &_MissionProgressResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    19;
+    23;
 
   friend void swap(MissionProgressResponse& a, MissionProgressResponse& b) {
     a.Swap(&b);
@@ -3097,7 +3669,7 @@ class GetReturnToLaunchAfterMissionRequest final :
                &_GetReturnToLaunchAfterMissionRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    20;
+    24;
 
   friend void swap(GetReturnToLaunchAfterMissionRequest& a, GetReturnToLaunchAfterMissionRequest& b) {
     a.Swap(&b);
@@ -3223,7 +3795,7 @@ class GetReturnToLaunchAfterMissionResponse final :
                &_GetReturnToLaunchAfterMissionResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    21;
+    25;
 
   friend void swap(GetReturnToLaunchAfterMissionResponse& a, GetReturnToLaunchAfterMissionResponse& b) {
     a.Swap(&b);
@@ -3382,7 +3954,7 @@ class SetReturnToLaunchAfterMissionRequest final :
                &_SetReturnToLaunchAfterMissionRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    22;
+    26;
 
   friend void swap(SetReturnToLaunchAfterMissionRequest& a, SetReturnToLaunchAfterMissionRequest& b) {
     a.Swap(&b);
@@ -3521,7 +4093,7 @@ class SetReturnToLaunchAfterMissionResponse final :
                &_SetReturnToLaunchAfterMissionResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    23;
+    27;
 
   friend void swap(SetReturnToLaunchAfterMissionResponse& a, SetReturnToLaunchAfterMissionResponse& b) {
     a.Swap(&b);
@@ -3669,7 +4241,7 @@ class MissionItem final :
                &_MissionItem_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    24;
+    28;
 
   friend void swap(MissionItem& a, MissionItem& b) {
     a.Swap(&b);
@@ -3982,7 +4554,7 @@ class MissionPlan final :
                &_MissionPlan_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    25;
+    29;
 
   friend void swap(MissionPlan& a, MissionPlan& b) {
     a.Swap(&b);
@@ -4086,6 +4658,284 @@ class MissionPlan final :
 };
 // -------------------------------------------------------------------
 
+class UploadProgress final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.mission.UploadProgress) */ {
+ public:
+  inline UploadProgress() : UploadProgress(nullptr) {}
+  ~UploadProgress() override;
+  explicit constexpr UploadProgress(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  UploadProgress(const UploadProgress& from);
+  UploadProgress(UploadProgress&& from) noexcept
+    : UploadProgress() {
+    *this = ::std::move(from);
+  }
+
+  inline UploadProgress& operator=(const UploadProgress& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline UploadProgress& operator=(UploadProgress&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const UploadProgress& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const UploadProgress* internal_default_instance() {
+    return reinterpret_cast<const UploadProgress*>(
+               &_UploadProgress_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    30;
+
+  friend void swap(UploadProgress& a, UploadProgress& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(UploadProgress* other) {
+    if (other == this) return;
+    if (GetOwningArena() == other->GetOwningArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(UploadProgress* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline UploadProgress* New() const final {
+    return new UploadProgress();
+  }
+
+  UploadProgress* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<UploadProgress>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const UploadProgress& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom(const UploadProgress& from);
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to, const ::PROTOBUF_NAMESPACE_ID::Message&from);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(UploadProgress* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.mission.UploadProgress";
+  }
+  protected:
+  explicit UploadProgress(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kProgressFieldNumber = 1,
+  };
+  // float progress = 1;
+  void clear_progress();
+  float progress() const;
+  void set_progress(float value);
+  private:
+  float _internal_progress() const;
+  void _internal_set_progress(float value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.mission.UploadProgress)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  float progress_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_mission_2fmission_2eproto;
+};
+// -------------------------------------------------------------------
+
+class DownloadProgress final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.mission.DownloadProgress) */ {
+ public:
+  inline DownloadProgress() : DownloadProgress(nullptr) {}
+  ~DownloadProgress() override;
+  explicit constexpr DownloadProgress(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  DownloadProgress(const DownloadProgress& from);
+  DownloadProgress(DownloadProgress&& from) noexcept
+    : DownloadProgress() {
+    *this = ::std::move(from);
+  }
+
+  inline DownloadProgress& operator=(const DownloadProgress& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline DownloadProgress& operator=(DownloadProgress&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const DownloadProgress& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const DownloadProgress* internal_default_instance() {
+    return reinterpret_cast<const DownloadProgress*>(
+               &_DownloadProgress_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    31;
+
+  friend void swap(DownloadProgress& a, DownloadProgress& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(DownloadProgress* other) {
+    if (other == this) return;
+    if (GetOwningArena() == other->GetOwningArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(DownloadProgress* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline DownloadProgress* New() const final {
+    return new DownloadProgress();
+  }
+
+  DownloadProgress* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<DownloadProgress>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const DownloadProgress& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom(const DownloadProgress& from);
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message*to, const ::PROTOBUF_NAMESPACE_ID::Message&from);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(DownloadProgress* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.mission.DownloadProgress";
+  }
+  protected:
+  explicit DownloadProgress(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kProgressFieldNumber = 1,
+  };
+  // float progress = 1;
+  void clear_progress();
+  float progress() const;
+  void set_progress(float value);
+  private:
+  float _internal_progress() const;
+  void _internal_set_progress(float value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.mission.DownloadProgress)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  float progress_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_mission_2fmission_2eproto;
+};
+// -------------------------------------------------------------------
+
 class MissionProgress final :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.mission.MissionProgress) */ {
  public:
@@ -4130,7 +4980,7 @@ class MissionProgress final :
                &_MissionProgress_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    26;
+    32;
 
   friend void swap(MissionProgress& a, MissionProgress& b) {
     a.Swap(&b);
@@ -4280,7 +5130,7 @@ class MissionResult final :
                &_MissionResult_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    27;
+    33;
 
   friend void swap(MissionResult& a, MissionResult& b) {
     a.Swap(&b);
@@ -4734,6 +5584,104 @@ inline void CancelMissionUploadResponse::set_allocated_mission_result(::mavsdk::
 
 // -------------------------------------------------------------------
 
+// SubscribeUploadProgressRequest
+
+// -------------------------------------------------------------------
+
+// UploadProgressResponse
+
+// .mavsdk.rpc.mission.UploadProgress upload_progress = 1;
+inline bool UploadProgressResponse::_internal_has_upload_progress() const {
+  return this != internal_default_instance() && upload_progress_ != nullptr;
+}
+inline bool UploadProgressResponse::has_upload_progress() const {
+  return _internal_has_upload_progress();
+}
+inline void UploadProgressResponse::clear_upload_progress() {
+  if (GetArenaForAllocation() == nullptr && upload_progress_ != nullptr) {
+    delete upload_progress_;
+  }
+  upload_progress_ = nullptr;
+}
+inline const ::mavsdk::rpc::mission::UploadProgress& UploadProgressResponse::_internal_upload_progress() const {
+  const ::mavsdk::rpc::mission::UploadProgress* p = upload_progress_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::mission::UploadProgress&>(
+      ::mavsdk::rpc::mission::_UploadProgress_default_instance_);
+}
+inline const ::mavsdk::rpc::mission::UploadProgress& UploadProgressResponse::upload_progress() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.mission.UploadProgressResponse.upload_progress)
+  return _internal_upload_progress();
+}
+inline void UploadProgressResponse::unsafe_arena_set_allocated_upload_progress(
+    ::mavsdk::rpc::mission::UploadProgress* upload_progress) {
+  if (GetArenaForAllocation() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(upload_progress_);
+  }
+  upload_progress_ = upload_progress;
+  if (upload_progress) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.mission.UploadProgressResponse.upload_progress)
+}
+inline ::mavsdk::rpc::mission::UploadProgress* UploadProgressResponse::release_upload_progress() {
+  
+  ::mavsdk::rpc::mission::UploadProgress* temp = upload_progress_;
+  upload_progress_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
+  temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  if (GetArenaForAllocation() == nullptr) { delete old; }
+#else  // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArenaForAllocation() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return temp;
+}
+inline ::mavsdk::rpc::mission::UploadProgress* UploadProgressResponse::unsafe_arena_release_upload_progress() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.mission.UploadProgressResponse.upload_progress)
+  
+  ::mavsdk::rpc::mission::UploadProgress* temp = upload_progress_;
+  upload_progress_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::mission::UploadProgress* UploadProgressResponse::_internal_mutable_upload_progress() {
+  
+  if (upload_progress_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::mission::UploadProgress>(GetArenaForAllocation());
+    upload_progress_ = p;
+  }
+  return upload_progress_;
+}
+inline ::mavsdk::rpc::mission::UploadProgress* UploadProgressResponse::mutable_upload_progress() {
+  ::mavsdk::rpc::mission::UploadProgress* _msg = _internal_mutable_upload_progress();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.mission.UploadProgressResponse.upload_progress)
+  return _msg;
+}
+inline void UploadProgressResponse::set_allocated_upload_progress(::mavsdk::rpc::mission::UploadProgress* upload_progress) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
+  if (message_arena == nullptr) {
+    delete upload_progress_;
+  }
+  if (upload_progress) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper<::mavsdk::rpc::mission::UploadProgress>::GetOwningArena(upload_progress);
+    if (message_arena != submessage_arena) {
+      upload_progress = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, upload_progress, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  upload_progress_ = upload_progress;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.mission.UploadProgressResponse.upload_progress)
+}
+
+// -------------------------------------------------------------------
+
 // DownloadMissionRequest
 
 // -------------------------------------------------------------------
@@ -5016,6 +5964,104 @@ inline void CancelMissionDownloadResponse::set_allocated_mission_result(::mavsdk
   }
   mission_result_ = mission_result;
   // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.mission.CancelMissionDownloadResponse.mission_result)
+}
+
+// -------------------------------------------------------------------
+
+// SubscribeDownloadProgressRequest
+
+// -------------------------------------------------------------------
+
+// DownloadProgressResponse
+
+// .mavsdk.rpc.mission.DownloadProgress download_progress = 1;
+inline bool DownloadProgressResponse::_internal_has_download_progress() const {
+  return this != internal_default_instance() && download_progress_ != nullptr;
+}
+inline bool DownloadProgressResponse::has_download_progress() const {
+  return _internal_has_download_progress();
+}
+inline void DownloadProgressResponse::clear_download_progress() {
+  if (GetArenaForAllocation() == nullptr && download_progress_ != nullptr) {
+    delete download_progress_;
+  }
+  download_progress_ = nullptr;
+}
+inline const ::mavsdk::rpc::mission::DownloadProgress& DownloadProgressResponse::_internal_download_progress() const {
+  const ::mavsdk::rpc::mission::DownloadProgress* p = download_progress_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::mission::DownloadProgress&>(
+      ::mavsdk::rpc::mission::_DownloadProgress_default_instance_);
+}
+inline const ::mavsdk::rpc::mission::DownloadProgress& DownloadProgressResponse::download_progress() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.mission.DownloadProgressResponse.download_progress)
+  return _internal_download_progress();
+}
+inline void DownloadProgressResponse::unsafe_arena_set_allocated_download_progress(
+    ::mavsdk::rpc::mission::DownloadProgress* download_progress) {
+  if (GetArenaForAllocation() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(download_progress_);
+  }
+  download_progress_ = download_progress;
+  if (download_progress) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.mission.DownloadProgressResponse.download_progress)
+}
+inline ::mavsdk::rpc::mission::DownloadProgress* DownloadProgressResponse::release_download_progress() {
+  
+  ::mavsdk::rpc::mission::DownloadProgress* temp = download_progress_;
+  download_progress_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
+  temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  if (GetArenaForAllocation() == nullptr) { delete old; }
+#else  // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArenaForAllocation() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return temp;
+}
+inline ::mavsdk::rpc::mission::DownloadProgress* DownloadProgressResponse::unsafe_arena_release_download_progress() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.mission.DownloadProgressResponse.download_progress)
+  
+  ::mavsdk::rpc::mission::DownloadProgress* temp = download_progress_;
+  download_progress_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::mission::DownloadProgress* DownloadProgressResponse::_internal_mutable_download_progress() {
+  
+  if (download_progress_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::mission::DownloadProgress>(GetArenaForAllocation());
+    download_progress_ = p;
+  }
+  return download_progress_;
+}
+inline ::mavsdk::rpc::mission::DownloadProgress* DownloadProgressResponse::mutable_download_progress() {
+  ::mavsdk::rpc::mission::DownloadProgress* _msg = _internal_mutable_download_progress();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.mission.DownloadProgressResponse.download_progress)
+  return _msg;
+}
+inline void DownloadProgressResponse::set_allocated_download_progress(::mavsdk::rpc::mission::DownloadProgress* download_progress) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
+  if (message_arena == nullptr) {
+    delete download_progress_;
+  }
+  if (download_progress) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper<::mavsdk::rpc::mission::DownloadProgress>::GetOwningArena(download_progress);
+    if (message_arena != submessage_arena) {
+      download_progress = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, download_progress, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  download_progress_ = download_progress;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.mission.DownloadProgressResponse.download_progress)
 }
 
 // -------------------------------------------------------------------
@@ -6192,6 +7238,54 @@ MissionPlan::mission_items() const {
 
 // -------------------------------------------------------------------
 
+// UploadProgress
+
+// float progress = 1;
+inline void UploadProgress::clear_progress() {
+  progress_ = 0;
+}
+inline float UploadProgress::_internal_progress() const {
+  return progress_;
+}
+inline float UploadProgress::progress() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.mission.UploadProgress.progress)
+  return _internal_progress();
+}
+inline void UploadProgress::_internal_set_progress(float value) {
+  
+  progress_ = value;
+}
+inline void UploadProgress::set_progress(float value) {
+  _internal_set_progress(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.mission.UploadProgress.progress)
+}
+
+// -------------------------------------------------------------------
+
+// DownloadProgress
+
+// float progress = 1;
+inline void DownloadProgress::clear_progress() {
+  progress_ = 0;
+}
+inline float DownloadProgress::_internal_progress() const {
+  return progress_;
+}
+inline float DownloadProgress::progress() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.mission.DownloadProgress.progress)
+  return _internal_progress();
+}
+inline void DownloadProgress::_internal_set_progress(float value) {
+  
+  progress_ = value;
+}
+inline void DownloadProgress::set_progress(float value) {
+  _internal_set_progress(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.mission.DownloadProgress.progress)
+}
+
+// -------------------------------------------------------------------
+
 // MissionProgress
 
 // int32 current = 1;
@@ -6307,6 +7401,18 @@ inline void MissionResult::set_allocated_result_str(std::string* result_str) {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------


### PR DESCRIPTION
This adds separate callbacks to get progress updates during the mission upload and download transfer.

https://github.com/mavlink/MAVSDK-Proto/pull/269 needs to be merged first.

Closes #1272.