### PR TITLE
cmake: fix installed include path

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,9 +54,6 @@ else()
     set(lib_path "lib")
 endif()
 
-set(mavsdk_install_include_dir "include/mavsdk")
-set(mavsdk_install_lib_dir ${lib_path})
-
 add_subdirectory(mavsdk)
 
 include(cmake/static_analyzers.cmake)

--- a/src/mavsdk/core/CMakeLists.txt
+++ b/src/mavsdk/core/CMakeLists.txt
@@ -82,7 +82,8 @@ set_target_properties(mavsdk
 target_include_directories(mavsdk
     PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/mavsdk>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
     PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/src/mavsdk/plugins/action/CMakeLists.txt
+++ b/src/mavsdk/plugins/action/CMakeLists.txt
@@ -6,7 +6,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/action/include/plugins/action/action.h
+++ b/src/mavsdk/plugins/action/include/plugins/action/action.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/action_server/CMakeLists.txt
+++ b/src/mavsdk/plugins/action_server/CMakeLists.txt
@@ -6,7 +6,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/action_server/include/plugins/action_server/action_server.h
+++ b/src/mavsdk/plugins/action_server/include/plugins/action_server/action_server.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/calibration/CMakeLists.txt
+++ b/src/mavsdk/plugins/calibration/CMakeLists.txt
@@ -7,7 +7,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/calibration/include/plugins/calibration/calibration.h
+++ b/src/mavsdk/plugins/calibration/include/plugins/calibration/calibration.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/camera/CMakeLists.txt
+++ b/src/mavsdk/plugins/camera/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(mavsdk
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/camera_definition_files/generated>
     PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/camera/include/plugins/camera/camera.h
+++ b/src/mavsdk/plugins/camera/include/plugins/camera/camera.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/failure/CMakeLists.txt
+++ b/src/mavsdk/plugins/failure/CMakeLists.txt
@@ -6,7 +6,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/failure/include/plugins/failure/failure.h
+++ b/src/mavsdk/plugins/failure/include/plugins/failure/failure.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/follow_me/CMakeLists.txt
+++ b/src/mavsdk/plugins/follow_me/CMakeLists.txt
@@ -6,7 +6,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/follow_me/include/plugins/follow_me/follow_me.h
+++ b/src/mavsdk/plugins/follow_me/include/plugins/follow_me/follow_me.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/ftp/CMakeLists.txt
+++ b/src/mavsdk/plugins/ftp/CMakeLists.txt
@@ -8,7 +8,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/ftp/include/plugins/ftp/ftp.h
+++ b/src/mavsdk/plugins/ftp/include/plugins/ftp/ftp.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/geofence/CMakeLists.txt
+++ b/src/mavsdk/plugins/geofence/CMakeLists.txt
@@ -6,7 +6,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/geofence/include/plugins/geofence/geofence.h
+++ b/src/mavsdk/plugins/geofence/include/plugins/geofence/geofence.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/gimbal/CMakeLists.txt
+++ b/src/mavsdk/plugins/gimbal/CMakeLists.txt
@@ -8,7 +8,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/gimbal/include/plugins/gimbal/gimbal.h
+++ b/src/mavsdk/plugins/gimbal/include/plugins/gimbal/gimbal.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/info/CMakeLists.txt
+++ b/src/mavsdk/plugins/info/CMakeLists.txt
@@ -6,7 +6,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/info/include/plugins/info/info.h
+++ b/src/mavsdk/plugins/info/include/plugins/info/info.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/log_files/CMakeLists.txt
+++ b/src/mavsdk/plugins/log_files/CMakeLists.txt
@@ -6,7 +6,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/log_files/include/plugins/log_files/log_files.h
+++ b/src/mavsdk/plugins/log_files/include/plugins/log_files/log_files.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/manual_control/CMakeLists.txt
+++ b/src/mavsdk/plugins/manual_control/CMakeLists.txt
@@ -6,7 +6,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/manual_control/include/plugins/manual_control/manual_control.h
+++ b/src/mavsdk/plugins/manual_control/include/plugins/manual_control/manual_control.h
@@ -14,7 +14,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/mavlink_passthrough/CMakeLists.txt
+++ b/src/mavsdk/plugins/mavlink_passthrough/CMakeLists.txt
@@ -6,7 +6,8 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../core/>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.h
+++ b/src/mavsdk/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.h
@@ -6,7 +6,7 @@
 
 // This plugin provides/includes the mavlink 2.0 header files.
 #include "mavlink_include.h"
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/mission/CMakeLists.txt
+++ b/src/mavsdk/plugins/mission/CMakeLists.txt
@@ -6,7 +6,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/mission/include/plugins/mission/mission.h
+++ b/src/mavsdk/plugins/mission/include/plugins/mission/mission.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/mission_raw/CMakeLists.txt
+++ b/src/mavsdk/plugins/mission_raw/CMakeLists.txt
@@ -7,7 +7,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/mission_raw/include/plugins/mission_raw/mission_raw.h
+++ b/src/mavsdk/plugins/mission_raw/include/plugins/mission_raw/mission_raw.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/mission_raw_server/CMakeLists.txt
+++ b/src/mavsdk/plugins/mission_raw_server/CMakeLists.txt
@@ -5,7 +5,7 @@ target_sources(mavsdk
 )
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/mission_raw_server/include/plugins/mission_raw_server/mission_raw_server.h
+++ b/src/mavsdk/plugins/mission_raw_server/include/plugins/mission_raw_server/mission_raw_server.h
@@ -14,7 +14,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/mocap/CMakeLists.txt
+++ b/src/mavsdk/plugins/mocap/CMakeLists.txt
@@ -6,7 +6,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/mocap/include/plugins/mocap/mocap.h
+++ b/src/mavsdk/plugins/mocap/include/plugins/mocap/mocap.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/offboard/CMakeLists.txt
+++ b/src/mavsdk/plugins/offboard/CMakeLists.txt
@@ -6,7 +6,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/offboard/include/plugins/offboard/offboard.h
+++ b/src/mavsdk/plugins/offboard/include/plugins/offboard/offboard.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/param/CMakeLists.txt
+++ b/src/mavsdk/plugins/param/CMakeLists.txt
@@ -6,7 +6,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/param/include/plugins/param/param.h
+++ b/src/mavsdk/plugins/param/include/plugins/param/param.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/param_server/CMakeLists.txt
+++ b/src/mavsdk/plugins/param_server/CMakeLists.txt
@@ -6,7 +6,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/param_server/include/plugins/param_server/param_server.h
+++ b/src/mavsdk/plugins/param_server/include/plugins/param_server/param_server.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/server_utility/CMakeLists.txt
+++ b/src/mavsdk/plugins/server_utility/CMakeLists.txt
@@ -6,7 +6,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/server_utility/include/plugins/server_utility/server_utility.h
+++ b/src/mavsdk/plugins/server_utility/include/plugins/server_utility/server_utility.h
@@ -14,7 +14,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/shell/CMakeLists.txt
+++ b/src/mavsdk/plugins/shell/CMakeLists.txt
@@ -6,7 +6,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/shell/include/plugins/shell/shell.h
+++ b/src/mavsdk/plugins/shell/include/plugins/shell/shell.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/telemetry/CMakeLists.txt
+++ b/src/mavsdk/plugins/telemetry/CMakeLists.txt
@@ -7,7 +7,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/telemetry_server/CMakeLists.txt
+++ b/src/mavsdk/plugins/telemetry_server/CMakeLists.txt
@@ -6,7 +6,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/telemetry_server/include/plugins/telemetry_server/telemetry_server.h
+++ b/src/mavsdk/plugins/telemetry_server/include/plugins/telemetry_server/telemetry_server.h
@@ -14,7 +14,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/tracking_server/CMakeLists.txt
+++ b/src/mavsdk/plugins/tracking_server/CMakeLists.txt
@@ -6,7 +6,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/tracking_server/include/plugins/tracking_server/tracking_server.h
+++ b/src/mavsdk/plugins/tracking_server/include/plugins/tracking_server/tracking_server.h
@@ -14,7 +14,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/transponder/CMakeLists.txt
+++ b/src/mavsdk/plugins/transponder/CMakeLists.txt
@@ -6,7 +6,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/transponder/include/plugins/transponder/transponder.h
+++ b/src/mavsdk/plugins/transponder/include/plugins/transponder/transponder.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/src/mavsdk/plugins/tune/CMakeLists.txt
+++ b/src/mavsdk/plugins/tune/CMakeLists.txt
@@ -6,7 +6,7 @@ target_sources(mavsdk
 
 target_include_directories(mavsdk PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/mavsdk>
+    $<INSTALL_INTERFACE:include>
     )
 
 install(FILES

--- a/src/mavsdk/plugins/tune/include/plugins/tune/tune.h
+++ b/src/mavsdk/plugins/tune/include/plugins/tune/tune.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 

--- a/templates/plugin_h/file.j2
+++ b/templates/plugin_h/file.j2
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "plugin_base.h"
+#include "mavsdk/plugin_base.h"
 
 namespace mavsdk {
 


### PR DESCRIPTION
This only mattered if you installed the library without the mavsdk_server since the mavsdk_server had the correct include path.