### PR TITLE
tools/workflows: fix packages for arm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -187,7 +187,7 @@ jobs:
         run: cmake --build build/release --target install -- -j2
       - name: Package
         if: startsWith(github.ref, 'refs/tags/v')
-        run: tools/create_packages.sh ./install .
+        run: tools/create_packages.sh ./install . amd64
       - name: Publish artefacts
         if: startsWith(github.ref, 'refs/tags/v')
         uses: svenstaro/upload-release-action@v1-release
@@ -230,7 +230,7 @@ jobs:
         run: cmake --build build/release --target install -- -j2
       - name: Package
         if: startsWith(github.ref, 'refs/tags/v')
-        run: tools/create_packages.sh ./install .
+        run: tools/create_packages.sh ./install . x86_64
       - name: Publish artefacts
         if: startsWith(github.ref, 'refs/tags/v')
         uses: svenstaro/upload-release-action@v1-release
@@ -266,12 +266,7 @@ jobs:
       - name: build
         run: ./dockcross-linux-${{ matrix.arch_name }}-custom cmake --build build/linux-${{ matrix.arch_name }} -j2 --target install
       - name: create deb packages
-        run: ./dockcross-linux-${{ matrix.arch_name }}-custom tools/create_packages.sh ./build/linux-${{ matrix.arch_name }}/install .
-      - name: fix file name
-        run: |
-          src=$(ls *.deb)
-          dst=$(echo $src | sed 's/amd64/${{ matrix.arch_name }}/g')
-          mv $src $dst
+        run: ./dockcross-linux-${{ matrix.arch_name }}-custom tools/create_packages.sh ./build/linux-${{ matrix.arch_name }}/install . ${{ matrix.arch_name }}
       - name: Publish artefacts
         if: startsWith(github.ref, 'refs/tags/v')
         uses: svenstaro/upload-release-action@v1-release


### PR DESCRIPTION
Without the arch argument, fpm seems to use amd64 instead which is wrong for the arch packages.

Hopefully resolves #1673.