### PR TITLE
docker: use arm lts images

### DIFF
--- a/docker/Dockerfile.dockcross-linux-arm64-custom
+++ b/docker/Dockerfile.dockcross-linux-arm64-custom
@@ -1,4 +1,4 @@
-FROM dockcross/linux-arm64
+FROM dockcross/linux-arm64-lts
 
 ENV DEFAULT_DOCKCROSS_IMAGE mavsdk/mavsdk-dockcross-arm64-custom
 

--- a/docker/Dockerfile.dockcross-linux-armv6-custom
+++ b/docker/Dockerfile.dockcross-linux-armv6-custom
@@ -1,4 +1,4 @@
-FROM dockcross/linux-armv6
+FROM dockcross/linux-armv6-lts
 
 ENV DEFAULT_DOCKCROSS_IMAGE mavsdk/mavsdk-dockcross-armv6-custom
 

--- a/docker/Dockerfile.dockcross-linux-armv7-custom
+++ b/docker/Dockerfile.dockcross-linux-armv7-custom
@@ -1,4 +1,4 @@
-FROM dockcross/linux-armv7
+FROM dockcross/linux-armv7-lts
 
 ENV DEFAULT_DOCKCROSS_IMAGE mavsdk/mavsdk-dockcross-armv7-custom
 


### PR DESCRIPTION
This means we depend on older glibc v2.27 rather than v2.34 which should work on Debian Buster and Ubuntu 20.04.