### PR TITLE
Fixed XCode warning

### DIFF
--- a/src/mavsdk_server/src/mavsdk_server_api.h
+++ b/src/mavsdk_server/src/mavsdk_server_api.h
@@ -16,7 +16,8 @@ extern "C" {
 #define DLLExport __attribute__((visibility("default")))
 #endif
 
-    struct MavsdkServer;
+struct MavsdkServer;
+
 DLLExport void mavsdk_server_init(struct MavsdkServer** mavsdk_server);
 
 DLLExport int mavsdk_server_run(

--- a/src/mavsdk_server/src/mavsdk_server_api.h
+++ b/src/mavsdk_server/src/mavsdk_server_api.h
@@ -16,6 +16,7 @@ extern "C" {
 #define DLLExport __attribute__((visibility("default")))
 #endif
 
+    struct MavsdkServer;
 DLLExport void mavsdk_server_init(struct MavsdkServer** mavsdk_server);
 
 DLLExport int mavsdk_server_run(


### PR DESCRIPTION
Fixed XCode warning: "declaration of "Struct MavsdkServer" will not be visible outside of this function"