### PR TITLE
Set RUNTIME DESTINATION to fix Windows install

### DIFF
--- a/src/mavsdk/core/CMakeLists.txt
+++ b/src/mavsdk/core/CMakeLists.txt
@@ -91,6 +91,7 @@ target_include_directories(mavsdk
 
 install(TARGETS mavsdk
     EXPORT mavsdk-targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )


### PR DESCRIPTION
Trying a fix for https://github.com/mavlink/MAVSDK/issues/1688

Resolves #1688