### PR TITLE
param: changes for making param set/get work with ArduPilot

### DIFF
--- a/src/integration_tests/param.cpp
+++ b/src/integration_tests/param.cpp
@@ -163,3 +163,29 @@ TEST_F(SitlTest, GetAllParams)
         std::cout << mixed_param.first << " : " << mixed_param.second << '\n';
     }
 }
+
+TEST_F(SitlTest, APParam)
+{
+    Mavsdk mavsdk;
+
+    ConnectionResult ret = mavsdk.add_udp_connection();
+    ASSERT_EQ(ret, ConnectionResult::Success);
+
+    // Wait for system to connect via heartbeat.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    auto system = mavsdk.systems().at(0);
+    ASSERT_TRUE(system->has_autopilot());
+
+    auto param = std::make_shared<Param>(system);
+
+    Param::Result set_result1 = param->set_param_int("TERRAIN_ENABLE", 1);
+
+    ASSERT_EQ(set_result1, Param::Result::Success);
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    const std::pair<Param::Result, int> get_result2 = param->get_param_int("TERRAIN_ENABLE");
+    EXPECT_EQ(get_result2.first, Param::Result::Success);
+    EXPECT_EQ(get_result2.second, 1);
+}

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -937,13 +937,28 @@ bool MAVLinkParameters::ParamValue::set_from_mavlink_param_value(
     const mavlink_param_value_t& mavlink_value)
 {
     switch (mavlink_value.param_type) {
+        case MAV_PARAM_TYPE_UINT8: {
+            uint8_t temp = mavlink_value.param_value;
+            _value = temp;
+        } break;
+
         case MAV_PARAM_TYPE_INT8: {
             int8_t temp = mavlink_value.param_value;
             _value = temp;
         } break;
 
+        case MAV_PARAM_TYPE_UINT16: {
+            uint16_t temp = mavlink_value.param_value;
+            _value = temp;
+        } break;
+
         case MAV_PARAM_TYPE_INT16: {
             int16_t temp = mavlink_value.param_value;
+            _value = temp;
+        } break;
+
+        case MAV_PARAM_TYPE_UINT32: {
+            uint32_t temp = mavlink_value.param_value;
             _value = temp;
         } break;
 
@@ -959,7 +974,8 @@ bool MAVLinkParameters::ParamValue::set_from_mavlink_param_value(
 
         default:
             // This would be worrying
-            LogErr() << "Error: unknown mavlink param type: ";
+            LogErr() << "Error: unknown mavlink param type: "
+                     << std::to_string(mavlink_value.param_type);
             return false;
     }
     return true;
@@ -1279,12 +1295,18 @@ bool MAVLinkParameters::ParamValue::set_as_same_type(const std::string& value_st
 {
     if (std::get_if<float>(&_value)) {
         return std::get<float>(_value);
+    } else if (std::get_if<uint32_t>(&_value)) {
+        return static_cast<float>(std::get<uint32_t>(_value));
     } else if (std::get_if<int32_t>(&_value)) {
-        return static_cast<int32_t>(std::get<float>(_value));
+        return static_cast<float>(std::get<int32_t>(_value));
+    } else if (std::get_if<uint16_t>(&_value)) {
+        return static_cast<float>(std::get<uint16_t>(_value));
     } else if (std::get_if<int16_t>(&_value)) {
-        return static_cast<int16_t>(std::get<float>(_value));
+        return static_cast<float>(std::get<int16_t>(_value));
+    } else if (std::get_if<uint8_t>(&_value)) {
+        return static_cast<float>(std::get<uint8_t>(_value));
     } else if (std::get_if<int8_t>(&_value)) {
-        return static_cast<int8_t>(std::get<float>(_value));
+        return static_cast<float>(std::get<int8_t>(_value));
     } else {
         LogErr() << "Unknown type";
         assert(false);

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -342,7 +342,7 @@ MAVLinkParameters::get_param_float(const std::string& name, bool extended)
     auto prom = std::promise<std::pair<Result, float>>();
     auto res = prom.get_future();
 
-    get_param_int_async(
+    get_param_float_async(
         name,
         [&prom](Result result, float value) { prom.set_value(std::make_pair<>(result, value)); },
         this,

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -941,28 +941,24 @@ bool MAVLinkParameters::ParamValue::set_from_mavlink_param_value(
 {
     switch (mavlink_value.param_type) {
         case MAV_PARAM_TYPE_INT8: {
-            int8_t temp = mavlink_value.param_value;  
-            _value = temp; 
-            }
-            break;
+            int8_t temp = mavlink_value.param_value;
+            _value = temp;
+        } break;
 
         case MAV_PARAM_TYPE_INT16: {
-            int16_t temp = mavlink_value.param_value;  
+            int16_t temp = mavlink_value.param_value;
             _value = temp;
-            }
-            break;
-    
+        } break;
+
         case MAV_PARAM_TYPE_INT32: {
-            int32_t temp = mavlink_value.param_value;  
-            _value = temp; 
-            }
-            break;
+            int32_t temp = mavlink_value.param_value;
+            _value = temp;
+        } break;
 
         case MAV_PARAM_TYPE_REAL32: {
             float temp = mavlink_value.param_value;
-            _value = temp; 
-            }
-            break;
+            _value = temp;
+        } break;
 
         default:
             // This would be worrying
@@ -1284,18 +1280,15 @@ bool MAVLinkParameters::ParamValue::set_as_same_type(const std::string& value_st
 
 [[nodiscard]] float MAVLinkParameters::ParamValue::get_4_float_bytes_apm() const
 {
-    
     if (std::get_if<float>(&_value)) {
         return std::get<float>(_value);
     } else if (std::get_if<int32_t>(&_value)) {
         return std::stof(get_string());
     } else if (std::get_if<int16_t>(&_value)) {
         return std::stof(get_string());
-    }
-    else if (std::get_if<int8_t>(&_value)) {
-        return std::stof(get_string()); 
-    }
-    else {
+    } else if (std::get_if<int8_t>(&_value)) {
+        return std::stof(get_string());
+    } else {
         LogErr() << "Unknown type";
         assert(false);
         return NAN;

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -310,17 +310,16 @@ void MAVLinkParameters::do_work()
                     param_value_buf,
                     work->param_value.get_mav_param_ext_type());
             } else {
-                // Param set is intended for Autopilot only.
                 float value_set = (_parent.autopilot() == SystemImpl::Autopilot::ArduPilot) ?
-                                      work->param_value.get_4_float_bytes_apm() :
-                                      work->param_value.get_4_float_bytes();
+                                      work->param_value.get_4_float_bytes_cast() :
+                                      work->param_value.get_4_float_bytes_bytewise();
 
                 mavlink_msg_param_set_pack(
                     _parent.get_own_system_id(),
                     _parent.get_own_component_id(),
                     &work->mavlink_message,
                     _parent.get_system_id(),
-                    _parent.get_autopilot_id(),
+                    _parent.get_autopilot_id(), // Param set is intended for Autopilot only.
                     param_id,
                     value_set,
                     work->param_value.get_mav_param_type());
@@ -409,18 +408,18 @@ void MAVLinkParameters::do_work()
                     work->param_count,
                     work->param_index);
             } else {
-                float _param_value;
+                float param_value;
                 if (_parent.autopilot() == SystemImpl::Autopilot::ArduPilot) {
-                    _param_value = work->param_value.get_4_float_bytes_apm();
+                    param_value = work->param_value.get_4_float_bytes_cast();
                 } else {
-                    _param_value = work->param_value.get_4_float_bytes();
+                    param_value = work->param_value.get_4_float_bytes_bytewise();
                 }
                 mavlink_msg_param_value_pack(
                     _parent.get_own_system_id(),
                     _parent.get_own_component_id(),
                     &work->mavlink_message,
                     param_id,
-                    _param_value,
+                    param_value,
                     work->param_value.get_mav_param_type(),
                     work->param_count,
                     work->param_index);
@@ -1263,7 +1262,7 @@ bool MAVLinkParameters::ParamValue::set_as_same_type(const std::string& value_st
     return true;
 }
 
-[[nodiscard]] float MAVLinkParameters::ParamValue::get_4_float_bytes() const
+[[nodiscard]] float MAVLinkParameters::ParamValue::get_4_float_bytes_bytewise() const
 {
     if (std::get_if<float>(&_value)) {
         return std::get<float>(_value);
@@ -1276,7 +1275,7 @@ bool MAVLinkParameters::ParamValue::set_as_same_type(const std::string& value_st
     }
 }
 
-[[nodiscard]] float MAVLinkParameters::ParamValue::get_4_float_bytes_apm() const
+[[nodiscard]] float MAVLinkParameters::ParamValue::get_4_float_bytes_cast() const
 {
     if (std::get_if<float>(&_value)) {
         return std::get<float>(_value);

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -311,28 +311,21 @@ void MAVLinkParameters::do_work()
                     work->param_value.get_mav_param_ext_type());
             } else {
                 // Param set is intended for Autopilot only.
+                float _value_set;
                 if (_parent.autopilot() == SystemImpl::Autopilot::ArduPilot) {
-                    mavlink_msg_param_set_pack(
+                    _value_set = work->param_value.get_4_float_bytes_apm();
+                } else {
+                    _value_set = work->param_value.get_4_float_bytes();
+                }
+                mavlink_msg_param_set_pack(
                     _parent.get_own_system_id(),
                     _parent.get_own_component_id(),
                     &work->mavlink_message,
                     _parent.get_system_id(),
                     _parent.get_autopilot_id(),
                     param_id,
-                    work->param_value.get_4_float_bytes_apm(),
+                    _value_set,
                     work->param_value.get_mav_param_type());
-                }
-                else {
-                    mavlink_msg_param_set_pack(
-                    _parent.get_own_system_id(),
-                    _parent.get_own_component_id(),
-                    &work->mavlink_message,
-                    _parent.get_system_id(),
-                    _parent.get_autopilot_id(),
-                    param_id,
-                    work->param_value.get_4_float_bytes(),
-                    work->param_value.get_mav_param_type());
-                }
             }
 
             if (!_parent.send_message(work->mavlink_message)) {
@@ -418,28 +411,21 @@ void MAVLinkParameters::do_work()
                     work->param_count,
                     work->param_index);
             } else {
+                float _param_value;
                 if (_parent.autopilot() == SystemImpl::Autopilot::ArduPilot) {
-                    mavlink_msg_param_value_pack(
+                    _param_value = work->param_value.get_4_float_bytes_apm();
+                } else {
+                    _param_value = work->param_value.get_4_float_bytes();
+                }
+                mavlink_msg_param_value_pack(
                     _parent.get_own_system_id(),
                     _parent.get_own_component_id(),
                     &work->mavlink_message,
                     param_id,
-                    work->param_value.get_4_float_bytes(),
+                    _param_value,
                     work->param_value.get_mav_param_type(),
                     work->param_count,
                     work->param_index);
-                }
-                else {
-                    mavlink_msg_param_value_pack(
-                    _parent.get_own_system_id(),
-                    _parent.get_own_component_id(),
-                    &work->mavlink_message,
-                    param_id,
-                    work->param_value.get_4_float_bytes(),
-                    work->param_value.get_mav_param_type(),
-                    work->param_count,
-                    work->param_index);
-                }
             }
 
             if (!_parent.send_message(work->mavlink_message)) {

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -1281,11 +1281,11 @@ bool MAVLinkParameters::ParamValue::set_as_same_type(const std::string& value_st
     if (std::get_if<float>(&_value)) {
         return std::get<float>(_value);
     } else if (std::get_if<int32_t>(&_value)) {
-        return std::stof(get_string());
+        return static_cast<int32_t>(std::get<float>(_value));
     } else if (std::get_if<int16_t>(&_value)) {
-        return std::stof(get_string());
+        return static_cast<int16_t>(std::get<float>(_value));
     } else if (std::get_if<int8_t>(&_value)) {
-        return std::stof(get_string());
+        return static_cast<int8_t>(std::get<float>(_value));
     } else {
         LogErr() << "Unknown type";
         assert(false);

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -311,12 +311,10 @@ void MAVLinkParameters::do_work()
                     work->param_value.get_mav_param_ext_type());
             } else {
                 // Param set is intended for Autopilot only.
-                float _value_set;
-                if (_parent.autopilot() == SystemImpl::Autopilot::ArduPilot) {
-                    _value_set = work->param_value.get_4_float_bytes_apm();
-                } else {
-                    _value_set = work->param_value.get_4_float_bytes();
-                }
+                float value_set = (_parent.autopilot() == SystemImpl::Autopilot::ArduPilot) ?
+                                      work->param_value.get_4_float_bytes_apm() :
+                                      work->param_value.get_4_float_bytes();
+
                 mavlink_msg_param_set_pack(
                     _parent.get_own_system_id(),
                     _parent.get_own_component_id(),
@@ -324,7 +322,7 @@ void MAVLinkParameters::do_work()
                     _parent.get_system_id(),
                     _parent.get_autopilot_id(),
                     param_id,
-                    _value_set,
+                    value_set,
                     work->param_value.get_mav_param_type());
             }
 

--- a/src/mavsdk/core/mavlink_parameters.h
+++ b/src/mavsdk/core/mavlink_parameters.h
@@ -10,6 +10,7 @@
 #include <cassert>
 #include <vector>
 #include <map>
+#include <optional>
 #include <variant>
 
 namespace mavsdk {

--- a/src/mavsdk/core/mavlink_parameters.h
+++ b/src/mavsdk/core/mavlink_parameters.h
@@ -35,8 +35,8 @@ public:
 
         bool set_as_same_type(const std::string& value_str);
 
-        [[nodiscard]] float get_4_float_bytes() const;
-        [[nodiscard]] float get_4_float_bytes_apm() const;
+        [[nodiscard]] float get_4_float_bytes_bytewise() const;
+        [[nodiscard]] float get_4_float_bytes_cast() const;
 
         void get_128_bytes(char* bytes) const;
 

--- a/src/mavsdk/core/mavlink_parameters.h
+++ b/src/mavsdk/core/mavlink_parameters.h
@@ -36,6 +36,7 @@ public:
         bool set_as_same_type(const std::string& value_str);
 
         [[nodiscard]] float get_4_float_bytes() const;
+        [[nodiscard]] float get_4_float_bytes_apm() const;
 
         void get_128_bytes(char* bytes) const;
 

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -27,7 +27,6 @@ SystemImpl::SystemImpl(MavsdkImpl& parent) :
     _mavlink_ftp(*this)
 {
     _system_thread = new std::thread(&SystemImpl::system_thread, this);
-
 }
 
 SystemImpl::~SystemImpl()
@@ -686,17 +685,21 @@ MAVLinkParameters::Result SystemImpl::set_param_float(const std::string& name, f
 MAVLinkParameters::Result SystemImpl::set_param_int(const std::string& name, int32_t value)
 {
     MAVLinkParameters::ParamValue param_value;
-    //param_value.set<int32_t>(value);
-    if ( _param_map.find(name) != _param_map.end() ) {
+    // param_value.set<int32_t>(value);
+    if (_param_map.find(name) != _param_map.end()) {
         param_value = _param_map.at(name);
     } else {
         // not found in the param map, let downstream functions handle the exception.
         // FIXME: Need a better way to handle this.
         param_value.set<int32_t>(value);
     }
-    if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_INT8) {param_value.set<int8_t>(value);}
-    else if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_INT16) {param_value.set<int16_t>(value);}
-    else if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_INT32) {param_value.set<int32_t>(value);}
+    if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_INT8) {
+        param_value.set<int8_t>(value);
+    } else if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_INT16) {
+        param_value.set<int16_t>(value);
+    } else if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_INT32) {
+        param_value.set<int32_t>(value);
+    }
 
     return _params.set_param(name, param_value, false);
 }
@@ -821,15 +824,15 @@ std::pair<MAVLinkParameters::Result, int> SystemImpl::get_param_int(const std::s
     auto res = prom.get_future();
 
     MAVLinkParameters::ParamValue value_type;
-    //value_type.set<int32_t>(0);
-    if ( _param_map.find(name) != _param_map.end() ) {
+    // value_type.set<int32_t>(0);
+    if (_param_map.find(name) != _param_map.end()) {
         value_type = _param_map.at(name);
     } else {
         // not found in the param map, let downstream functions handle the exception.
         // FIXME: Need a better way to handle this.
         value_type.set<int32_t>(0);
     }
-    
+
     _params.get_param_async(
         name,
         value_type,

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -674,69 +674,41 @@ uint8_t SystemImpl::get_own_mav_type() const
     return _parent.get_mav_type();
 }
 
-MAVLinkParameters::Result SystemImpl::set_param_float(const std::string& name, float value)
+MAVLinkParameters::Result
+SystemImpl::set_param_float(const std::string& name, float value, bool extended)
 {
-    MAVLinkParameters::ParamValue param_value;
-    param_value.set<float>(value);
-
-    return _params.set_param(name, param_value, false);
+    return _params.set_param_float(name, value, extended);
 }
 
-MAVLinkParameters::Result SystemImpl::set_param_int(const std::string& name, int32_t value)
+MAVLinkParameters::Result
+SystemImpl::set_param_int(const std::string& name, int32_t value, bool extended)
 {
-    MAVLinkParameters::ParamValue param_value;
-    if (_param_map.find(name) != _param_map.end()) {
-        param_value = _param_map.at(name);
-    } else {
-        // not found in the param map, let downstream functions handle the exception.
-        // FIXME: Need a better way to handle this.
-        param_value.set<int32_t>(value);
-    }
-    if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_UINT8) {
-        param_value.set<uint8_t>(value);
-    } else if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_INT8) {
-        param_value.set<int8_t>(value);
-    } else if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_UINT16) {
-        param_value.set<uint16_t>(value);
-    } else if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_INT16) {
-        param_value.set<int16_t>(value);
-    } else if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_UINT32) {
-        param_value.set<uint32_t>(value);
-    } else if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_INT32) {
-        param_value.set<int32_t>(value);
-    }
-
-    return _params.set_param(name, param_value, false);
+    return _params.set_param_int(name, value, extended);
 }
 
 std::map<std::string, MAVLinkParameters::ParamValue> SystemImpl::get_all_params()
 {
-    _param_map = _params.get_all_params();
-    return _param_map;
+    return _params.get_all_params();
 }
 
-MAVLinkParameters::Result SystemImpl::set_param_ext_float(const std::string& name, float value)
+void SystemImpl::set_param_async(
+    const std::string& name,
+    MAVLinkParameters::ParamValue value,
+    const SetParamCallback& callback,
+    const void* cookie,
+    bool extended)
 {
-    MAVLinkParameters::ParamValue param_value;
-    param_value.set<float>(value);
-
-    return _params.set_param(name, param_value, true);
-}
-
-MAVLinkParameters::Result SystemImpl::set_param_ext_int(const std::string& name, int32_t value)
-{
-    MAVLinkParameters::ParamValue param_value;
-    param_value.set<int32_t>(value);
-
-    return _params.set_param(name, param_value, true);
+    _params.set_param_async(name, value, callback, cookie, extended);
 }
 
 void SystemImpl::set_param_float_async(
-    const std::string& name, float value, const success_t& callback, const void* cookie)
+    const std::string& name,
+    float value,
+    const SetParamCallback& callback,
+    const void* cookie,
+    bool extended)
 {
-    MAVLinkParameters::ParamValue param_value;
-    param_value.set<float>(value);
-    _params.set_param_async(name, param_value, callback, cookie);
+    _params.set_param_float_async(name, value, callback, cookie, extended);
 }
 
 void SystemImpl::provide_server_param_int(const std::string& name, int32_t value)
@@ -754,27 +726,13 @@ void SystemImpl::provide_server_param_float(const std::string& name, float value
 }
 
 void SystemImpl::set_param_int_async(
-    const std::string& name, int32_t value, const success_t& callback, const void* cookie)
+    const std::string& name,
+    int32_t value,
+    const SetParamCallback& callback,
+    const void* cookie,
+    bool extended)
 {
-    MAVLinkParameters::ParamValue param_value;
-    param_value.set<int32_t>(value);
-    _params.set_param_async(name, param_value, callback, cookie);
-}
-
-void SystemImpl::set_param_ext_float_async(
-    const std::string& name, float value, const success_t& callback, const void* cookie)
-{
-    MAVLinkParameters::ParamValue param_value;
-    param_value.set<float>(value);
-    _params.set_param_async(name, param_value, callback, cookie, true);
-}
-
-void SystemImpl::set_param_ext_int_async(
-    const std::string& name, int32_t value, const success_t& callback, const void* cookie)
-{
-    MAVLinkParameters::ParamValue param_value;
-    param_value.set<int32_t>(value);
-    _params.set_param_async(name, param_value, callback, cookie, true);
+    _params.set_param_int_async(name, value, callback, cookie, extended);
 }
 
 std::pair<MAVLinkParameters::Result, int>
@@ -802,197 +760,37 @@ std::map<std::string, MAVLinkParameters::ParamValue> SystemImpl::retrieve_all_se
 
 std::pair<MAVLinkParameters::Result, float> SystemImpl::get_param_float(const std::string& name)
 {
-    auto prom = std::promise<std::pair<MAVLinkParameters::Result, float>>();
-    auto res = prom.get_future();
-
-    MAVLinkParameters::ParamValue value_type;
-    value_type.set<float>(0.0f);
-
-    _params.get_param_async(
-        name,
-        value_type,
-        [&prom](MAVLinkParameters::Result result, MAVLinkParameters::ParamValue param) {
-            float value = NAN;
-            if (result == MAVLinkParameters::Result::Success) {
-                value = param.get<float>();
-            }
-            prom.set_value(std::make_pair<>(result, value));
-        },
-        this);
-
-    return res.get();
+    return _params.get_param_float(name, false);
 }
 
 std::pair<MAVLinkParameters::Result, int> SystemImpl::get_param_int(const std::string& name)
 {
-    auto prom = std::promise<std::pair<MAVLinkParameters::Result, int>>();
-    auto res = prom.get_future();
-
-    MAVLinkParameters::ParamValue value_type;
-    if (_param_map.find(name) != _param_map.end()) {
-        value_type = _param_map.at(name);
-    } else {
-        // not found in the param map, let downstream functions handle the exception.
-        // FIXME: Need a better way to handle this.
-        value_type.set<int32_t>(0);
-    }
-
-    _params.get_param_async(
-        name,
-        value_type,
-        [&prom](MAVLinkParameters::Result result, MAVLinkParameters::ParamValue param) {
-            int value = 0;
-            if (result == MAVLinkParameters::Result::Success) {
-                auto type_string = param.typestr();
-                if (type_string == "int8_t") {
-                    value = param.get<int8_t>();
-                } else if (type_string == "int16_t") {
-                    value = param.get<int16_t>();
-                } else if (type_string == "int32_t") {
-                    value = param.get<int32_t>();
-                }
-            }
-            prom.set_value(std::make_pair<>(result, value));
-        },
-        this);
-
-    return res.get();
-}
-
-std::pair<MAVLinkParameters::Result, float> SystemImpl::get_param_ext_float(const std::string& name)
-{
-    auto prom = std::promise<std::pair<MAVLinkParameters::Result, float>>();
-    auto res = prom.get_future();
-
-    MAVLinkParameters::ParamValue value_type;
-    value_type.set<float>(0.0f);
-
-    _params.get_param_async(
-        name,
-        value_type,
-        [&prom](MAVLinkParameters::Result result, MAVLinkParameters::ParamValue param) {
-            float value = NAN;
-            if (result == MAVLinkParameters::Result::Success) {
-                value = param.get<float>();
-            }
-            prom.set_value(std::make_pair<>(result, value));
-        },
-        this,
-        true);
-
-    return res.get();
-}
-
-std::pair<MAVLinkParameters::Result, int> SystemImpl::get_param_ext_int(const std::string& name)
-{
-    auto prom = std::promise<std::pair<MAVLinkParameters::Result, int>>();
-    auto res = prom.get_future();
-
-    MAVLinkParameters::ParamValue value_type;
-    value_type.set<int32_t>(0);
-
-    _params.get_param_async(
-        name,
-        value_type,
-        [&prom](MAVLinkParameters::Result result, MAVLinkParameters::ParamValue param) {
-            int value = 0;
-            if (result == MAVLinkParameters::Result::Success) {
-                value = param.get<int32_t>();
-            }
-            prom.set_value(std::make_pair<>(result, value));
-        },
-        this,
-        true);
-
-    return res.get();
-}
-
-void SystemImpl::get_param_float_async(
-    const std::string& name, const get_param_float_callback_t& callback, const void* cookie)
-{
-    MAVLinkParameters::ParamValue value_type;
-    value_type.set<float>(0.0f);
-
-    _params.get_param_async(
-        name,
-        value_type,
-        [callback](MAVLinkParameters::Result result, MAVLinkParameters::ParamValue value) {
-            return SystemImpl::receive_float_param(result, value, callback);
-        },
-        cookie);
-}
-
-void SystemImpl::get_param_int_async(
-    const std::string& name, const get_param_int_callback_t& callback, const void* cookie)
-{
-    MAVLinkParameters::ParamValue value_type;
-    value_type.set<int32_t>(0);
-
-    _params.get_param_async(
-        name,
-        value_type,
-        [callback](MAVLinkParameters::Result result, MAVLinkParameters::ParamValue value) {
-            return SystemImpl::receive_int_param(result, value, callback);
-        },
-        cookie);
-}
-
-void SystemImpl::get_param_ext_float_async(
-    const std::string& name, const get_param_float_callback_t& callback, const void* cookie)
-{
-    MAVLinkParameters::ParamValue value_type;
-    value_type.set<float>(0.0f);
-
-    _params.get_param_async(
-        name,
-        value_type,
-        [callback](MAVLinkParameters::Result result, MAVLinkParameters::ParamValue value) {
-            return SystemImpl::receive_float_param(result, value, callback);
-        },
-        cookie,
-        true);
-}
-
-void SystemImpl::get_param_ext_int_async(
-    const std::string& name, const get_param_int_callback_t& callback, const void* cookie)
-{
-    MAVLinkParameters::ParamValue value_type;
-    value_type.set<int32_t>(0);
-
-    _params.get_param_async(
-        name,
-        value_type,
-        [callback](MAVLinkParameters::Result result, MAVLinkParameters::ParamValue value) {
-            return SystemImpl::receive_int_param(result, value, callback);
-        },
-        cookie,
-        true);
-}
-
-void SystemImpl::set_param_async(
-    const std::string& name,
-    MAVLinkParameters::ParamValue value,
-    const success_t& callback,
-    const void* cookie,
-    bool extended)
-{
-    _params.set_param_async(name, value, callback, cookie, extended);
-}
-
-MAVLinkParameters::Result
-SystemImpl::set_param(const std::string& name, MAVLinkParameters::ParamValue value, bool extended)
-{
-    return _params.set_param(name, value, extended);
+    return _params.get_param_int(name, false);
 }
 
 void SystemImpl::get_param_async(
     const std::string& name,
-    MAVLinkParameters::ParamValue value_type,
-    const get_param_callback_t& callback,
+    MAVLinkParameters::ParamValue value,
+    const GetParamAnyCallback& callback,
     const void* cookie,
     bool extended)
 {
-    _params.get_param_async(name, value_type, callback, cookie, extended);
+    _params.get_param_async(name, value, callback, cookie, extended);
+}
+
+void SystemImpl::get_param_float_async(
+    const std::string& name,
+    const GetParamFloatCallback& callback,
+    const void* cookie,
+    bool extended)
+{
+    _params.get_param_float_async(name, callback, cookie, extended);
+}
+
+void SystemImpl::get_param_int_async(
+    const std::string& name, const GetParamIntCallback& callback, const void* cookie, bool extended)
+{
+    _params.get_param_int_async(name, callback, cookie, extended);
 }
 
 void SystemImpl::cancel_all_param(const void* cookie)
@@ -1338,7 +1136,7 @@ void SystemImpl::set_flight_mode_async(
 void SystemImpl::receive_float_param(
     MAVLinkParameters::Result result,
     MAVLinkParameters::ParamValue value,
-    const get_param_float_callback_t& callback)
+    const GetParamFloatCallback& callback)
 {
     if (callback) {
         if (result == MAVLinkParameters::Result::Success) {
@@ -1352,7 +1150,7 @@ void SystemImpl::receive_float_param(
 void SystemImpl::receive_int_param(
     MAVLinkParameters::Result result,
     MAVLinkParameters::ParamValue value,
-    const get_param_int_callback_t& callback)
+    const GetParamIntCallback& callback)
 {
     if (callback) {
         if (result == MAVLinkParameters::Result::Success) {

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -28,8 +28,6 @@ SystemImpl::SystemImpl(MavsdkImpl& parent) :
 {
     _system_thread = new std::thread(&SystemImpl::system_thread, this);
 
-    // Cache the param store
-    _param_map = _params.get_all_params();
 }
 
 SystemImpl::~SystemImpl()
@@ -699,7 +697,6 @@ MAVLinkParameters::Result SystemImpl::set_param_int(const std::string& name, int
     if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_INT8) {param_value.set<int8_t>(value);}
     else if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_INT16) {param_value.set<int16_t>(value);}
     else if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_INT32) {param_value.set<int32_t>(value);}
-    else {std::cout << " Invalid Type "<< "\n";}
 
     return _params.set_param(name, param_value, false);
 }
@@ -707,15 +704,6 @@ MAVLinkParameters::Result SystemImpl::set_param_int(const std::string& name, int
 std::map<std::string, MAVLinkParameters::ParamValue> SystemImpl::get_all_params()
 {
     _param_map = _params.get_all_params();
-    // for (auto const& x : _param_map)
-    // {
-    //     std::cout << x.first  // ParamValue ID
-    //             << ':' 
-    //             << x.second // ParamValue Value 
-    //             << ':' 
-    //             << x.second.get_mav_param_type() // ParamValue Type
-    //             << std::endl;
-    // }
     return _param_map;
 }
 

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -692,10 +692,16 @@ MAVLinkParameters::Result SystemImpl::set_param_int(const std::string& name, int
         // FIXME: Need a better way to handle this.
         param_value.set<int32_t>(value);
     }
-    if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_INT8) {
+    if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_UINT8) {
+        param_value.set<uint8_t>(value);
+    } else if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_INT8) {
         param_value.set<int8_t>(value);
+    } else if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_UINT16) {
+        param_value.set<uint16_t>(value);
     } else if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_INT16) {
         param_value.set<int16_t>(value);
+    } else if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_UINT32) {
+        param_value.set<uint32_t>(value);
     } else if (param_value.get_mav_param_type() == MAV_PARAM_TYPE_INT32) {
         param_value.set<int32_t>(value);
     }

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -685,7 +685,6 @@ MAVLinkParameters::Result SystemImpl::set_param_float(const std::string& name, f
 MAVLinkParameters::Result SystemImpl::set_param_int(const std::string& name, int32_t value)
 {
     MAVLinkParameters::ParamValue param_value;
-    // param_value.set<int32_t>(value);
     if (_param_map.find(name) != _param_map.end()) {
         param_value = _param_map.at(name);
     } else {
@@ -824,7 +823,6 @@ std::pair<MAVLinkParameters::Result, int> SystemImpl::get_param_int(const std::s
     auto res = prom.get_future();
 
     MAVLinkParameters::ParamValue value_type;
-    // value_type.set<int32_t>(0);
     if (_param_map.find(name) != _param_map.end()) {
         value_type = _param_map.at(name);
     } else {

--- a/src/mavsdk/core/system_impl.h
+++ b/src/mavsdk/core/system_impl.h
@@ -155,21 +155,27 @@ public:
 
     bool is_armed() const { return _armed; }
 
-    MAVLinkParameters::Result set_param_float(const std::string& name, float value);
-    MAVLinkParameters::Result set_param_int(const std::string& name, int32_t value);
-    MAVLinkParameters::Result set_param_ext_float(const std::string& name, float value);
-    MAVLinkParameters::Result set_param_ext_int(const std::string& name, int32_t value);
+    MAVLinkParameters::Result
+    set_param(const std::string& name, MAVLinkParameters::ParamValue value, bool extended = false);
+    MAVLinkParameters::Result
+    set_param_float(const std::string& name, float value, bool extended = false);
+    MAVLinkParameters::Result
+    set_param_int(const std::string& name, int32_t value, bool extended = false);
     std::map<std::string, MAVLinkParameters::ParamValue> get_all_params();
 
-    typedef std::function<void(MAVLinkParameters::Result result)> success_t;
+    using SetParamCallback = std::function<void(MAVLinkParameters::Result result)>;
     void set_param_float_async(
-        const std::string& name, float value, const success_t& callback, const void* cookie);
+        const std::string& name,
+        float value,
+        const SetParamCallback& callback,
+        const void* cookie,
+        bool extended = false);
     void set_param_int_async(
-        const std::string& name, int32_t value, const success_t& callback, const void* cookie);
-    void set_param_ext_float_async(
-        const std::string& name, float value, const success_t& callback, const void* cookie);
-    void set_param_ext_int_async(
-        const std::string& name, int32_t value, const success_t& callback, const void* cookie);
+        const std::string& name,
+        int32_t value,
+        const SetParamCallback& callback,
+        const void* cookie,
+        bool extended = false);
 
     void provide_server_param_float(const std::string& name, float value);
     void provide_server_param_int(const std::string& name, int32_t value);
@@ -217,10 +223,12 @@ public:
         const CommandResultCallback& callback,
         uint8_t component_id = MAV_COMP_ID_AUTOPILOT1);
 
-    typedef std::function<void(MAVLinkParameters::Result result, float value)>
-        get_param_float_callback_t;
-    typedef std::function<void(MAVLinkParameters::Result result, int32_t value)>
-        get_param_int_callback_t;
+    using GetParamAnyCallback =
+        std::function<void(MAVLinkParameters::Result result, MAVLinkParameters::ParamValue value)>;
+    using GetParamFloatCallback =
+        std::function<void(MAVLinkParameters::Result result, float value)>;
+    using GetParamIntCallback =
+        std::function<void(MAVLinkParameters::Result result, int32_t value)>;
 
     std::pair<MAVLinkParameters::Result, float>
     retrieve_server_param_float(const std::string& name);
@@ -233,35 +241,29 @@ public:
 
     // These methods can be used to cache a parameter when a system connects. For that
     // the callback can just be set to nullptr.
+    void get_param_async(
+        const std::string& name,
+        MAVLinkParameters::ParamValue value,
+        const GetParamAnyCallback& callback,
+        const void* cookie,
+        bool extended = false);
     void get_param_float_async(
-        const std::string& name, const get_param_float_callback_t& callback, const void* cookie);
+        const std::string& name,
+        const GetParamFloatCallback& callback,
+        const void* cookie,
+        bool extended = false);
     void get_param_int_async(
-        const std::string& name, const get_param_int_callback_t& callback, const void* cookie);
-    void get_param_ext_float_async(
-        const std::string& name, const get_param_float_callback_t& callback, const void* cookie);
-    void get_param_ext_int_async(
-        const std::string& name, const get_param_int_callback_t& callback, const void* cookie);
-
-    typedef std::function<void(
-        MAVLinkParameters::Result result, MAVLinkParameters::ParamValue value)>
-        get_param_callback_t;
+        const std::string& name,
+        const GetParamIntCallback& callback,
+        const void* cookie,
+        bool extended = false);
 
     void set_param_async(
         const std::string& name,
         MAVLinkParameters::ParamValue value,
-        const success_t& callback,
+        const SetParamCallback& callback,
         const void* cookie,
         bool extended = false);
-
-    MAVLinkParameters::Result
-    set_param(const std::string& name, MAVLinkParameters::ParamValue value, bool extended = false);
-
-    void get_param_async(
-        const std::string& name,
-        MAVLinkParameters::ParamValue value_type,
-        const get_param_callback_t& callback,
-        const void* cookie,
-        bool extended);
 
     void cancel_all_param(const void* cookie);
 
@@ -379,11 +381,11 @@ private:
     static void receive_float_param(
         MAVLinkParameters::Result result,
         MAVLinkParameters::ParamValue value,
-        const get_param_float_callback_t& callback);
+        const GetParamFloatCallback& callback);
     static void receive_int_param(
         MAVLinkParameters::Result result,
         MAVLinkParameters::ParamValue value,
-        const get_param_int_callback_t& callback);
+        const GetParamIntCallback& callback);
 
     std::mutex _component_discovered_callback_mutex{};
     System::DiscoverCallback _component_discovered_callback{nullptr};
@@ -464,8 +466,6 @@ private:
 
     std::mutex _mavlink_ftp_files_mutex{};
     std::unordered_map<std::string, std::string> _mavlink_ftp_files{};
-
-    std::map<std::string, MAVLinkParameters::ParamValue> _param_map{};
 };
 
 } // namespace mavsdk

--- a/src/mavsdk/core/system_impl.h
+++ b/src/mavsdk/core/system_impl.h
@@ -465,7 +465,7 @@ private:
     std::mutex _mavlink_ftp_files_mutex{};
     std::unordered_map<std::string, std::string> _mavlink_ftp_files{};
 
-    std::map<std::string, MAVLinkParameters::ParamValue> _param_map {};
+    std::map<std::string, MAVLinkParameters::ParamValue> _param_map{};
 };
 
 } // namespace mavsdk

--- a/src/mavsdk/core/system_impl.h
+++ b/src/mavsdk/core/system_impl.h
@@ -464,6 +464,8 @@ private:
 
     std::mutex _mavlink_ftp_files_mutex{};
     std::unordered_map<std::string, std::string> _mavlink_ftp_files{};
+
+    std::map<std::string, MAVLinkParameters::ParamValue> _param_map {};
 };
 
 } // namespace mavsdk

--- a/src/mavsdk/plugins/param/param_impl.cpp
+++ b/src/mavsdk/plugins/param/param_impl.cpp
@@ -19,7 +19,10 @@ ParamImpl::~ParamImpl()
     _parent->unregister_plugin(this);
 }
 
-void ParamImpl::init() { _parent->get_all_params(); }
+void ParamImpl::init()
+{
+    _parent->get_all_params();
+}
 
 void ParamImpl::deinit() {}
 
@@ -78,7 +81,6 @@ Param::AllParams ParamImpl::get_all_params()
             tmp_param.value = parampair.second.get<int8_t>();
             res.int_params.push_back(tmp_param);
         }
-        
     }
 
     return res;

--- a/src/mavsdk/plugins/param/param_impl.cpp
+++ b/src/mavsdk/plugins/param/param_impl.cpp
@@ -59,26 +59,26 @@ Param::AllParams ParamImpl::get_all_params()
     auto tmp = _parent->get_all_params();
 
     Param::AllParams res{};
-    for (auto const& parampair : tmp) {
-        if (parampair.second.is<float>()) {
+    for (auto const& param_pair : tmp) {
+        if (param_pair.second.is<float>()) {
             Param::FloatParam tmp_param;
-            tmp_param.name = parampair.first;
-            tmp_param.value = parampair.second.get<float>();
+            tmp_param.name = param_pair.first;
+            tmp_param.value = param_pair.second.get<float>();
             res.float_params.push_back(tmp_param);
-        } else if (parampair.second.is<int32_t>()) {
+        } else if (param_pair.second.is<int32_t>()) {
             Param::IntParam tmp_param;
-            tmp_param.name = parampair.first;
-            tmp_param.value = parampair.second.get<int32_t>();
+            tmp_param.name = param_pair.first;
+            tmp_param.value = param_pair.second.get<int32_t>();
             res.int_params.push_back(tmp_param);
-        } else if (parampair.second.is<int16_t>()) {
+        } else if (param_pair.second.is<int16_t>()) {
             Param::IntParam tmp_param;
-            tmp_param.name = parampair.first;
-            tmp_param.value = parampair.second.get<int16_t>();
+            tmp_param.name = param_pair.first;
+            tmp_param.value = param_pair.second.get<int16_t>();
             res.int_params.push_back(tmp_param);
-        } else if (parampair.second.is<int8_t>()) {
+        } else if (param_pair.second.is<int8_t>()) {
             Param::IntParam tmp_param;
-            tmp_param.name = parampair.first;
-            tmp_param.value = parampair.second.get<int8_t>();
+            tmp_param.name = param_pair.first;
+            tmp_param.value = param_pair.second.get<int8_t>();
             res.int_params.push_back(tmp_param);
         }
     }

--- a/src/mavsdk/plugins/param/param_impl.cpp
+++ b/src/mavsdk/plugins/param/param_impl.cpp
@@ -19,7 +19,7 @@ ParamImpl::~ParamImpl()
     _parent->unregister_plugin(this);
 }
 
-void ParamImpl::init() { _param_map = _parent->get_all_params(); }
+void ParamImpl::init() { _parent->get_all_params(); }
 
 void ParamImpl::deinit() {}
 

--- a/src/mavsdk/plugins/param/param_impl.cpp
+++ b/src/mavsdk/plugins/param/param_impl.cpp
@@ -19,7 +19,7 @@ ParamImpl::~ParamImpl()
     _parent->unregister_plugin(this);
 }
 
-void ParamImpl::init() {}
+void ParamImpl::init() { _param_map = _parent->get_all_params(); }
 
 void ParamImpl::deinit() {}
 
@@ -56,7 +56,6 @@ Param::AllParams ParamImpl::get_all_params()
     auto tmp = _parent->get_all_params();
 
     Param::AllParams res{};
-
     for (auto const& parampair : tmp) {
         if (parampair.second.is<float>()) {
             Param::FloatParam tmp_param;
@@ -68,7 +67,18 @@ Param::AllParams ParamImpl::get_all_params()
             tmp_param.name = parampair.first;
             tmp_param.value = parampair.second.get<int32_t>();
             res.int_params.push_back(tmp_param);
+        } else if (parampair.second.is<int16_t>()) {
+            Param::IntParam tmp_param;
+            tmp_param.name = parampair.first;
+            tmp_param.value = parampair.second.get<int16_t>();
+            res.int_params.push_back(tmp_param);
+        } else if (parampair.second.is<int8_t>()) {
+            Param::IntParam tmp_param;
+            tmp_param.name = parampair.first;
+            tmp_param.value = parampair.second.get<int8_t>();
+            res.int_params.push_back(tmp_param);
         }
+        
     }
 
     return res;

--- a/src/mavsdk/plugins/param/param_impl.cpp
+++ b/src/mavsdk/plugins/param/param_impl.cpp
@@ -19,10 +19,7 @@ ParamImpl::~ParamImpl()
     _parent->unregister_plugin(this);
 }
 
-void ParamImpl::init()
-{
-    _parent->get_all_params();
-}
+void ParamImpl::init() {}
 
 void ParamImpl::deinit() {}
 

--- a/src/mavsdk/plugins/param/param_impl.h
+++ b/src/mavsdk/plugins/param/param_impl.h
@@ -32,6 +32,8 @@ public:
 
 private:
     static Param::Result result_from_mavlink_parameters_result(MAVLinkParameters::Result result);
+
+    std::map<std::string, MAVLinkParameters::ParamValue> _param_map {};
 };
 
 } // namespace mavsdk

--- a/src/mavsdk/plugins/param/param_impl.h
+++ b/src/mavsdk/plugins/param/param_impl.h
@@ -32,8 +32,6 @@ public:
 
 private:
     static Param::Result result_from_mavlink_parameters_result(MAVLinkParameters::Result result);
-
-    std::map<std::string, MAVLinkParameters::ParamValue> _param_map {};
 };
 
 } // namespace mavsdk


### PR DESCRIPTION
This pull request contains the minimal necessary changes needed in the MAVSDK to make param set/get work with Ardupilot. Following the discussion from https://github.com/mavlink/MAVSDK/issues/1683, I decided to try the suggestion B from @julianoes 

> B) Always download all params on startup to then have the type cached when the function is used. This would take longer but make the API easier. What do you think?

I had to, however create a different function to deal with the param set for APM

```bash
float MAVLinkParameters::ParamValue::get_4_float_bytes() const
float MAVLinkParameters::ParamValue::get_4_float_bytes_apm() const
```
As mentioned before, Ardupilot likes to have direct cast to float instead of the re-interpret cast used in MAVSDK for PX4 param set. More details can be found in https://mavlink.io/en/services/parameter.html#ardupilot

Awaiting valued feedback on this.