### PR TITLE
Update CMakeList to avoid "plugin_base.h" error

### DIFF
--- a/examples/takeoff_and_land/CMakeLists.txt
+++ b/examples/takeoff_and_land/CMakeLists.txt
@@ -12,7 +12,9 @@ add_executable(takeoff_and_land
 find_package(MAVSDK REQUIRED)
 
 target_link_libraries(takeoff_and_land
-    MAVSDK::mavsdk
+        MAVSDK::mavsdk
+        MAVSDK::mavsdk_action
+        MAVSDK::mavsdk_telemetry
 )
 
 if(NOT MSVC)


### PR DESCRIPTION
Hello,

The CMakeList does not including correct target link libraries:
https://github.com/mavlink/MAVSDK/issues/992

The "MAVSDK::mavsdk_action" and "MAVSDK::mavsdk_telemetry" should be added to compile correctly.