### PR TITLE
core: fix MAV_TYPE of mavsdk_server

### DIFF
--- a/src/mavsdk/core/include/mavsdk/mavsdk.h
+++ b/src/mavsdk/core/include/mavsdk/mavsdk.h
@@ -249,6 +249,8 @@ public:
         uint8_t _component_id;
         bool _always_send_heartbeats;
         UsageType _usage_type;
+
+        static Mavsdk::Configuration::UsageType usage_type_for_component(uint8_t component_id);
     };
 
     /**

--- a/src/mavsdk/core/mavsdk.cpp
+++ b/src/mavsdk/core/mavsdk.cpp
@@ -79,8 +79,25 @@ Mavsdk::Configuration::Configuration(
     _system_id(system_id),
     _component_id(component_id),
     _always_send_heartbeats(always_send_heartbeats),
-    _usage_type(Mavsdk::Configuration::UsageType::Custom)
+    _usage_type(usage_type_for_component(component_id))
 {}
+
+Mavsdk::Configuration::UsageType
+Mavsdk::Configuration::usage_type_for_component(uint8_t component_id)
+{
+    switch (component_id) {
+        case MavsdkImpl::DEFAULT_COMPONENT_ID_GCS:
+            return UsageType::GroundStation;
+        case MavsdkImpl::DEFAULT_COMPONENT_ID_CC:
+            return UsageType::CompanionComputer;
+        case MavsdkImpl::DEFAULT_COMPONENT_ID_AUTOPILOT:
+            return UsageType::Autopilot;
+        case MavsdkImpl::DEFAULT_COMPONENT_ID_CAMERA:
+            return UsageType::Camera;
+        default:
+            return UsageType::Custom;
+    }
+}
 
 Mavsdk::Configuration::Configuration(UsageType usage_type) :
     _system_id(MavsdkImpl::DEFAULT_SYSTEM_ID_GCS),


### PR DESCRIPTION
It turns out that we sent out MAV_TYPE_GENERIC for UsageType::Custom if we manually set sysid and compid. However, when we use the usual ground station compid, we would probably expect that the normal MAV_TYPE_GCS.

This fixes mavsdk_server were sysid and compid is set manually and therefore the MAV_TYPE was suddenly wrong.

Fixes https://github.com/mavlink/MAVSDK-Python/issues/448.