### PR TITLE
Make LazyPlugin thread-safe

### DIFF
--- a/src/mavsdk/core/lazy_plugin.h
+++ b/src/mavsdk/core/lazy_plugin.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 
 #include <mavsdk.h>
 
@@ -12,6 +13,7 @@ public:
 
     Plugin* maybe_plugin()
     {
+        std::lock_guard<std::mutex> lock(_mutex);
         if (_plugin == nullptr) {
             if (_mavsdk.systems().empty()) {
                 return nullptr;
@@ -24,6 +26,7 @@ public:
 private:
     Mavsdk& _mavsdk;
     std::unique_ptr<Plugin> _plugin{};
+    std::mutex _mutex{};
 };
 
 } // namespace mavsdk::mavsdk_server

--- a/src/mavsdk/core/lazy_plugin.h
+++ b/src/mavsdk/core/lazy_plugin.h
@@ -12,18 +12,18 @@ public:
 
     Plugin* maybe_plugin()
     {
-        if (_action == nullptr) {
+        if (_plugin == nullptr) {
             if (_mavsdk.systems().empty()) {
                 return nullptr;
             }
-            _action = std::make_unique<Plugin>(_mavsdk.systems()[0]);
+            _plugin = std::make_unique<Plugin>(_mavsdk.systems()[0]);
         }
-        return _action.get();
+        return _plugin.get();
     }
 
 private:
     Mavsdk& _mavsdk;
-    std::unique_ptr<Plugin> _action{};
+    std::unique_ptr<Plugin> _plugin{};
 };
 
 } // namespace mavsdk::mavsdk_server


### PR DESCRIPTION
I think this should fix https://github.com/mavlink/MAVSDK-Python/issues/460.