### PR TITLE
Fix multicamera options

### DIFF
--- a/src/mavsdk/core/mavlink_parameters.h
+++ b/src/mavsdk/core/mavlink_parameters.h
@@ -122,7 +122,11 @@ public:
         UnknownError
     };
 
-    Result set_param(const std::string& name, ParamValue value, bool extended = false);
+    Result set_param(
+        const std::string& name,
+        ParamValue value,
+        std::optional<uint8_t> maybe_component_id,
+        bool extended = false);
 
     using SetParamCallback = std::function<void(Result result)>;
 
@@ -130,25 +134,36 @@ public:
         const std::string& name,
         ParamValue value,
         const SetParamCallback& callback,
-        const void* cookie = nullptr,
+        const void* cookie,
+        std::optional<uint8_t> maybe_component_id,
         bool extended = false);
 
-    Result set_param_int(const std::string& name, int32_t value, bool extended = false);
+    Result set_param_int(
+        const std::string& name,
+        int32_t value,
+        std::optional<uint8_t> maybe_component_id,
+        bool extended = false);
 
     void set_param_int_async(
         const std::string& name,
         int32_t value,
         const SetParamCallback& callback,
-        const void* cookie = nullptr,
+        const void* cookie,
+        std::optional<uint8_t> maybe_component_id,
         bool extended = false);
 
-    Result set_param_float(const std::string& name, float value, bool extended = false);
+    Result set_param_float(
+        const std::string& name,
+        float value,
+        std::optional<uint8_t> maybe_component_id,
+        bool extended = false);
 
     void set_param_float_async(
         const std::string& name,
         float value,
         const SetParamCallback& callback,
-        const void* cookie = nullptr,
+        const void* cookie,
+        std::optional<uint8_t> maybe_component_id,
         bool extended = false);
 
     void provide_server_param(const std::string& name, const ParamValue& value);
@@ -167,9 +182,11 @@ public:
         ParamValue value,
         const GetParamAnyCallback& callback,
         const void* cookie,
+        std::optional<uint8_t> maybe_component_id,
         bool extended = false);
 
-    std::pair<Result, float> get_param_float(const std::string& name, bool extended);
+    std::pair<Result, float> get_param_float(
+        const std::string& name, std::optional<uint8_t> maybe_component_id, bool extended);
 
     using GetParamFloatCallback = std::function<void(Result, float)>;
 
@@ -177,9 +194,11 @@ public:
         const std::string& name,
         const GetParamFloatCallback& callback,
         const void* cookie,
-        bool extended = false);
+        std::optional<uint8_t> maybe_component_id,
+        bool extended);
 
-    std::pair<Result, int32_t> get_param_int(const std::string& name, bool extended);
+    std::pair<Result, int32_t> get_param_int(
+        const std::string& name, std::optional<uint8_t> maybe_component_id, bool extended);
 
     using GetParamIntCallback = std::function<void(Result, int32_t)>;
 
@@ -187,7 +206,8 @@ public:
         const std::string& name,
         const GetParamIntCallback& callback,
         const void* cookie,
-        bool extended = false);
+        std::optional<uint8_t> maybe_component_id,
+        bool extended);
 
     std::map<std::string, MAVLinkParameters::ParamValue> get_all_params();
     using GetAllParamsCallback =
@@ -243,6 +263,7 @@ private:
             callback{};
         std::string param_name{};
         ParamValue param_value{};
+        std::optional<uint8_t> maybe_component_id{};
         bool extended{false};
         bool already_requested{false};
         bool exact_type_known{false};

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -674,16 +674,28 @@ uint8_t SystemImpl::get_own_mav_type() const
     return _parent.get_mav_type();
 }
 
-MAVLinkParameters::Result
-SystemImpl::set_param_float(const std::string& name, float value, bool extended)
+MAVLinkParameters::Result SystemImpl::set_param(
+    const std::string& name,
+    MAVLinkParameters::ParamValue value,
+    std::optional<uint8_t> maybe_component_id,
+    bool extended)
 {
-    return _params.set_param_float(name, value, extended);
+    return _params.set_param(name, value, maybe_component_id, extended);
 }
 
-MAVLinkParameters::Result
-SystemImpl::set_param_int(const std::string& name, int32_t value, bool extended)
+MAVLinkParameters::Result SystemImpl::set_param_float(
+    const std::string& name, float value, std::optional<uint8_t> maybe_component_id, bool extended)
 {
-    return _params.set_param_int(name, value, extended);
+    return _params.set_param_float(name, value, maybe_component_id, extended);
+}
+
+MAVLinkParameters::Result SystemImpl::set_param_int(
+    const std::string& name,
+    int32_t value,
+    std::optional<uint8_t> maybe_component_id,
+    bool extended)
+{
+    return _params.set_param_int(name, value, maybe_component_id, extended);
 }
 
 std::map<std::string, MAVLinkParameters::ParamValue> SystemImpl::get_all_params()
@@ -696,9 +708,10 @@ void SystemImpl::set_param_async(
     MAVLinkParameters::ParamValue value,
     const SetParamCallback& callback,
     const void* cookie,
+    std::optional<uint8_t> maybe_component_id,
     bool extended)
 {
-    _params.set_param_async(name, value, callback, cookie, extended);
+    _params.set_param_async(name, value, callback, cookie, maybe_component_id, extended);
 }
 
 void SystemImpl::set_param_float_async(
@@ -706,9 +719,10 @@ void SystemImpl::set_param_float_async(
     float value,
     const SetParamCallback& callback,
     const void* cookie,
+    std::optional<uint8_t> maybe_component_id,
     bool extended)
 {
-    _params.set_param_float_async(name, value, callback, cookie, extended);
+    _params.set_param_float_async(name, value, callback, cookie, maybe_component_id, extended);
 }
 
 void SystemImpl::provide_server_param_int(const std::string& name, int32_t value)
@@ -730,9 +744,10 @@ void SystemImpl::set_param_int_async(
     int32_t value,
     const SetParamCallback& callback,
     const void* cookie,
+    std::optional<uint8_t> maybe_component_id,
     bool extended)
 {
-    _params.set_param_int_async(name, value, callback, cookie, extended);
+    _params.set_param_int_async(name, value, callback, cookie, maybe_component_id, extended);
 }
 
 std::pair<MAVLinkParameters::Result, int>
@@ -760,12 +775,12 @@ std::map<std::string, MAVLinkParameters::ParamValue> SystemImpl::retrieve_all_se
 
 std::pair<MAVLinkParameters::Result, float> SystemImpl::get_param_float(const std::string& name)
 {
-    return _params.get_param_float(name, false);
+    return _params.get_param_float(name, {}, false);
 }
 
 std::pair<MAVLinkParameters::Result, int> SystemImpl::get_param_int(const std::string& name)
 {
-    return _params.get_param_int(name, false);
+    return _params.get_param_int(name, {}, false);
 }
 
 void SystemImpl::get_param_async(
@@ -773,24 +788,30 @@ void SystemImpl::get_param_async(
     MAVLinkParameters::ParamValue value,
     const GetParamAnyCallback& callback,
     const void* cookie,
+    std::optional<uint8_t> maybe_component_id,
     bool extended)
 {
-    _params.get_param_async(name, value, callback, cookie, extended);
+    _params.get_param_async(name, value, callback, cookie, maybe_component_id, extended);
 }
 
 void SystemImpl::get_param_float_async(
     const std::string& name,
     const GetParamFloatCallback& callback,
     const void* cookie,
+    std::optional<uint8_t> maybe_component_id,
     bool extended)
 {
-    _params.get_param_float_async(name, callback, cookie, extended);
+    _params.get_param_float_async(name, callback, cookie, maybe_component_id, extended);
 }
 
 void SystemImpl::get_param_int_async(
-    const std::string& name, const GetParamIntCallback& callback, const void* cookie, bool extended)
+    const std::string& name,
+    const GetParamIntCallback& callback,
+    const void* cookie,
+    std::optional<uint8_t> maybe_component_id,
+    bool extended)
 {
-    _params.get_param_int_async(name, callback, cookie, extended);
+    _params.get_param_int_async(name, callback, cookie, maybe_component_id, extended);
 }
 
 void SystemImpl::cancel_all_param(const void* cookie)

--- a/src/mavsdk/core/system_impl.h
+++ b/src/mavsdk/core/system_impl.h
@@ -119,13 +119,13 @@ public:
         MavlinkCommandSender::CommandInt command, const CommandResultCallback& callback);
 
     MavlinkCommandSender::Result set_msg_rate(
-        uint16_t message_id, double rate_hz, uint8_t component_id = MAV_COMP_ID_AUTOPILOT1);
+        uint16_t message_id, double rate_hz, uint8_t maybe_component_id = MAV_COMP_ID_AUTOPILOT1);
 
     void set_msg_rate_async(
         uint16_t message_id,
         double rate_hz,
         const CommandResultCallback& callback,
-        uint8_t component_id = MAV_COMP_ID_AUTOPILOT1);
+        uint8_t maybe_component_id = MAV_COMP_ID_AUTOPILOT1);
 
     // Adds unique component ids
     void add_new_component(uint8_t component_id);
@@ -155,26 +155,42 @@ public:
 
     bool is_armed() const { return _armed; }
 
-    MAVLinkParameters::Result
-    set_param(const std::string& name, MAVLinkParameters::ParamValue value, bool extended = false);
-    MAVLinkParameters::Result
-    set_param_float(const std::string& name, float value, bool extended = false);
-    MAVLinkParameters::Result
-    set_param_int(const std::string& name, int32_t value, bool extended = false);
+    MAVLinkParameters::Result set_param(
+        const std::string& name,
+        MAVLinkParameters::ParamValue value,
+        std::optional<uint8_t> maybe_component_id = {},
+        bool extended = false);
+
+    MAVLinkParameters::Result set_param_float(
+        const std::string& name,
+        float value,
+        std::optional<uint8_t> maybe_component_id = {},
+        bool extended = false);
+
+    MAVLinkParameters::Result set_param_int(
+        const std::string& name,
+        int32_t value,
+        std::optional<uint8_t> maybe_component_id = {},
+        bool extended = false);
+
     std::map<std::string, MAVLinkParameters::ParamValue> get_all_params();
 
     using SetParamCallback = std::function<void(MAVLinkParameters::Result result)>;
+
     void set_param_float_async(
         const std::string& name,
         float value,
         const SetParamCallback& callback,
         const void* cookie,
+        std::optional<uint8_t> maybe_component_id = {},
         bool extended = false);
+
     void set_param_int_async(
         const std::string& name,
         int32_t value,
         const SetParamCallback& callback,
         const void* cookie,
+        std::optional<uint8_t> maybe_component_id = {},
         bool extended = false);
 
     void provide_server_param_float(const std::string& name, float value);
@@ -236,8 +252,6 @@ public:
 
     std::pair<MAVLinkParameters::Result, float> get_param_float(const std::string& name);
     std::pair<MAVLinkParameters::Result, int> get_param_int(const std::string& name);
-    std::pair<MAVLinkParameters::Result, float> get_param_ext_float(const std::string& name);
-    std::pair<MAVLinkParameters::Result, int> get_param_ext_int(const std::string& name);
 
     // These methods can be used to cache a parameter when a system connects. For that
     // the callback can just be set to nullptr.
@@ -246,16 +260,21 @@ public:
         MAVLinkParameters::ParamValue value,
         const GetParamAnyCallback& callback,
         const void* cookie,
+        std::optional<uint8_t> maybe_component_id = {},
         bool extended = false);
+
     void get_param_float_async(
         const std::string& name,
         const GetParamFloatCallback& callback,
         const void* cookie,
+        std::optional<uint8_t> maybe_component_id = {},
         bool extended = false);
+
     void get_param_int_async(
         const std::string& name,
         const GetParamIntCallback& callback,
         const void* cookie,
+        std::optional<uint8_t> maybe_component_id = {},
         bool extended = false);
 
     void set_param_async(
@@ -263,6 +282,7 @@ public:
         MAVLinkParameters::ParamValue value,
         const SetParamCallback& callback,
         const void* cookie,
+        std::optional<uint8_t> maybe_component_id = {},
         bool extended = false);
 
     void cancel_all_param(const void* cookie);

--- a/src/mavsdk/plugins/camera/camera_impl.cpp
+++ b/src/mavsdk/plugins/camera/camera_impl.cpp
@@ -1572,6 +1572,7 @@ void CameraImpl::set_option_async(
             }
         },
         this,
+        static_cast<uint8_t>(_camera_id + MAV_COMP_ID_CAMERA),
         true);
 }
 
@@ -1819,6 +1820,7 @@ void CameraImpl::refresh_params()
                 }
             },
             this,
+            static_cast<uint8_t>(_camera_id + MAV_COMP_ID_CAMERA),
             true);
         ++count;
     }


### PR DESCRIPTION
As seen in #1728 the MAVLinkParameters is using some magic numbers to define the designated target component of the message,

This prevents the Camera plugin to read the parameters of the any camera other than the first.

This PR add some overloaded functions for the `set_param` and `get_params` actions that accept an additional target `component_id` parameter. 

The Camera plugin as been updated to make use of this new functions.

 