### PR TITLE
camera: filter by compid at init time

### DIFF
--- a/src/mavsdk/plugins/camera/camera_impl.cpp
+++ b/src/mavsdk/plugins/camera/camera_impl.cpp
@@ -30,36 +30,43 @@ void CameraImpl::init()
 {
     _parent->register_mavlink_message_handler(
         MAVLINK_MSG_ID_CAMERA_CAPTURE_STATUS,
+        _camera_id + MAV_COMP_ID_CAMERA,
         [this](const mavlink_message_t& message) { process_camera_capture_status(message); },
         this);
 
     _parent->register_mavlink_message_handler(
         MAVLINK_MSG_ID_STORAGE_INFORMATION,
+        _camera_id + MAV_COMP_ID_CAMERA,
         [this](const mavlink_message_t& message) { process_storage_information(message); },
         this);
 
     _parent->register_mavlink_message_handler(
         MAVLINK_MSG_ID_CAMERA_IMAGE_CAPTURED,
+        _camera_id + MAV_COMP_ID_CAMERA,
         [this](const mavlink_message_t& message) { process_camera_image_captured(message); },
         this);
 
     _parent->register_mavlink_message_handler(
         MAVLINK_MSG_ID_CAMERA_SETTINGS,
+        _camera_id + MAV_COMP_ID_CAMERA,
         [this](const mavlink_message_t& message) { process_camera_settings(message); },
         this);
 
     _parent->register_mavlink_message_handler(
         MAVLINK_MSG_ID_CAMERA_INFORMATION,
+        _camera_id + MAV_COMP_ID_CAMERA,
         [this](const mavlink_message_t& message) { process_camera_information(message); },
         this);
 
     _parent->register_mavlink_message_handler(
         MAVLINK_MSG_ID_VIDEO_STREAM_INFORMATION,
+        _camera_id + MAV_COMP_ID_CAMERA,
         [this](const mavlink_message_t& message) { process_video_information(message); },
         this);
 
     _parent->register_mavlink_message_handler(
         MAVLINK_MSG_ID_VIDEO_STREAM_STATUS,
+        _camera_id + MAV_COMP_ID_CAMERA,
         [this](const mavlink_message_t& message) { process_video_stream_status(message); },
         this);
 


### PR DESCRIPTION
I just realized that [select_camera()](https://github.com/mavlink/MAVSDK/blob/10181c60148ace1229565cbb2e04531122d529d0/src/mavsdk/plugins/camera/camera_impl.cpp#L263) will [update the component id for the camera message handlers](https://github.com/mavlink/MAVSDK/blob/10181c60148ace1229565cbb2e04531122d529d0/src/mavsdk/plugins/camera/camera_impl.cpp#L229-L248), but if `select_camera()` is never called (the default), then that filtering is not set (and hence I believe that the camera instance will receive those messages even if they come from a different component id).

This just sets the compid at `init()` time, to be consistent.