### PR TITLE
core: use separate mavlink_status_t again

### DIFF
--- a/src/mavsdk/core/mavlink_include.h
+++ b/src/mavsdk/core/mavlink_include.h
@@ -4,10 +4,4 @@
 #pragma GCC system_header
 #endif
 
-#define MAVLINK_GET_CHANNEL_STATUS
-
-#include "mavlink/v2.0/mavlink_types.h"
-
-extern mavlink_status_t* mavlink_get_channel_status(uint8_t chan);
-
 #include "mavlink/v2.0/common/mavlink.h"

--- a/src/mavsdk/core/mavsdk_impl.cpp
+++ b/src/mavsdk/core/mavsdk_impl.cpp
@@ -13,14 +13,6 @@
 #include "version.h"
 #include "unused.h"
 
-static mavlink_status_t status_;
-
-mavlink_status_t* mavlink_get_channel_status(uint8_t chan)
-{
-    UNUSED(chan);
-    return &status_;
-}
-
 namespace mavsdk {
 
 MavsdkImpl::MavsdkImpl() : timeout_handler(_time), call_every_handler(_time)


### PR DESCRIPTION
Previously, we made an attempt to fix the outgoing sequence numbers. Therefore, we would ignore the chan number for the mavlink_status_t, however, this lead to serious problems when doing system tests with multiple mavsdk instances sending messages to each other as they would sometimes both use the mavlink_status_t data and mess up each others parsing.

Therefore, we remove the previous hack, and go back to separate mavlink_status_t. This will probably mess up outgoing sequence numbers but given they can't reliably be used to assess drop rate anyway it's an ok pill to swallow, for now. And this enables more consistent system tests, and in general applications with more than one Mavsdk instance.