### PR TITLE
gitignore: ignore CLion cmake build folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ CMakeLists.txt.user*
 
 tools/docs
 venv/
+
+# CLion build folder
+cmake-build-*


### PR DESCRIPTION
Turns out sometimes I'm using CLion.