### PR TITLE
Fix vehicle_type detection for systems

### DIFF
--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -212,10 +212,17 @@ void SystemImpl::process_heartbeat(const mavlink_message_t& message)
     } else if (heartbeat.autopilot == MAV_AUTOPILOT_ARDUPILOTMEGA) {
         _autopilot = Autopilot::ArduPilot;
     }
+
+    // Only set the vehicle type if the heartbeat is from an autopilot component
     // This check only works if the MAV_TYPE::MAV_TYPE_ENUM_END is actually the
     // last enumerator.
-    if (MAV_TYPE::MAV_TYPE_ENUM_END > heartbeat.type) {
-        _vehicle_type = static_cast<MAV_TYPE>(heartbeat.type);
+    if (heartbeat.autopilot != MAV_AUTOPILOT_INVALID &&
+        MAV_TYPE::MAV_TYPE_ENUM_END > heartbeat.type) {
+        auto new_vehicle_type = static_cast<MAV_TYPE>(heartbeat.type);
+        if (_vehicle_type != new_vehicle_type)
+            LogWarn() << "Vehicle type changed! New type: " << heartbeat.type
+                      << " Old type: " << static_cast<uint8_t>(_vehicle_type);
+        _vehicle_type = new_vehicle_type;
     } else {
         LogErr() << "type received in HEARTBEAT was not recognized";
     }


### PR DESCRIPTION
It seems like `vehicle_type` can jump around a lot if multiple systems are reporting vehicle_types differently. This allows only autopilots the ability to set vehicle types for system.