### PR TITLE
Do not shallow-clone and use a specific commit

### DIFF
--- a/third_party/mavlink/CMakeLists.txt
+++ b/third_party/mavlink/CMakeLists.txt
@@ -19,7 +19,6 @@ ExternalProject_add(
     mavlink
     GIT_REPOSITORY https://github.com/mavlink/mavlink
     GIT_TAG 3b52eac09c2e37325e4bc49cd2667ea37bf1d7d2
-    GIT_SHALLOW TRUE
     PREFIX mavlink
     CONFIGURE_COMMAND Python3::Interpreter
         -m pymavlink.tools.mavgen
@@ -27,7 +26,7 @@ ExternalProject_add(
         --wire-protocol=2.0
         --output=<BINARY_DIR>/include/mavlink/v2.0/
         message_definitions/v1.0/${MAVLINK_DIALECT}.xml
-    BUILD_COMMAND "" 
+    BUILD_COMMAND ""
     INSTALL_COMMAND ""
     BUILD_IN_SOURCE TRUE
 )


### PR DESCRIPTION
Otherwise we end up with errors like this:

```
[ 12%] Performing download step (git clone) for 'mavlink'
Cloning into 'mavlink'...
fatal: reference is not a tree: 3b52eac09c2e37325e4bc49cd2667ea37bf1d7d2
CMake Error at /home/dronedojo/github_repos/MAVSDK/build/default/third_party/mavlink/mavlink/tmp/mavlink-gitclone.cmake:49 (message):
  Failed to checkout tag: '3b52eac09c2e37325e4bc49cd2667ea37bf1d7d2'
```

Resolves #1755.