### PR TITLE
Fix to allow non-flight controller heartbeats to be processed

### DIFF
--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -216,15 +216,15 @@ void SystemImpl::process_heartbeat(const mavlink_message_t& message)
     // Only set the vehicle type if the heartbeat is from an autopilot component
     // This check only works if the MAV_TYPE::MAV_TYPE_ENUM_END is actually the
     // last enumerator.
-    if (heartbeat.autopilot != MAV_AUTOPILOT_INVALID &&
-        MAV_TYPE::MAV_TYPE_ENUM_END > heartbeat.type) {
+    if (MAV_TYPE::MAV_TYPE_ENUM_END < heartbeat.type) {
+        LogErr() << "type received in HEARTBEAT was not recognized";
+    } else {
         auto new_vehicle_type = static_cast<MAV_TYPE>(heartbeat.type);
-        if (_vehicle_type != new_vehicle_type)
+        if (heartbeat.autopilot != MAV_AUTOPILOT_INVALID && _vehicle_type != new_vehicle_type) {
             LogWarn() << "Vehicle type changed! New type: " << heartbeat.type
                       << " Old type: " << static_cast<uint8_t>(_vehicle_type);
+        }
         _vehicle_type = new_vehicle_type;
-    } else {
-        LogErr() << "type received in HEARTBEAT was not recognized";
     }
 
     if (message.compid == MavlinkCommandSender::DEFAULT_COMPONENT_ID_AUTOPILOT) {

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -219,12 +219,12 @@ void SystemImpl::process_heartbeat(const mavlink_message_t& message)
     if (MAV_TYPE::MAV_TYPE_ENUM_END < heartbeat.type) {
         LogErr() << "type received in HEARTBEAT was not recognized";
     } else {
-        auto new_vehicle_type = static_cast<MAV_TYPE>(heartbeat.type);
+        const auto new_vehicle_type = static_cast<MAV_TYPE>(heartbeat.type);
         if (heartbeat.autopilot != MAV_AUTOPILOT_INVALID && _vehicle_type != new_vehicle_type) {
             LogWarn() << "Vehicle type changed! New type: " << heartbeat.type
                       << " Old type: " << static_cast<uint8_t>(_vehicle_type);
+            _vehicle_type = new_vehicle_type;
         }
-        _vehicle_type = new_vehicle_type;
     }
 
     if (message.compid == MavlinkCommandSender::DEFAULT_COMPONENT_ID_AUTOPILOT) {

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -220,7 +220,8 @@ void SystemImpl::process_heartbeat(const mavlink_message_t& message)
         LogErr() << "type received in HEARTBEAT was not recognized";
     } else {
         const auto new_vehicle_type = static_cast<MAV_TYPE>(heartbeat.type);
-        if (heartbeat.autopilot != MAV_AUTOPILOT_INVALID && _vehicle_type != new_vehicle_type) {
+        if (heartbeat.autopilot != MAV_AUTOPILOT_INVALID && _vehicle_type != new_vehicle_type &&
+            _vehicle_type != MAV_TYPE_GENERIC) {
             LogWarn() << "Vehicle type changed (new type: " << static_cast<unsigned>(heartbeat.type)
                       << ", old type: " << static_cast<unsigned>(_vehicle_type) << ")";
             _vehicle_type = new_vehicle_type;

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -221,8 +221,8 @@ void SystemImpl::process_heartbeat(const mavlink_message_t& message)
     } else {
         const auto new_vehicle_type = static_cast<MAV_TYPE>(heartbeat.type);
         if (heartbeat.autopilot != MAV_AUTOPILOT_INVALID && _vehicle_type != new_vehicle_type) {
-            LogWarn() << "Vehicle type changed! New type: " << heartbeat.type
-                      << " Old type: " << static_cast<uint8_t>(_vehicle_type);
+            LogWarn() << "Vehicle type changed (new type: " << static_cast<unsigned>(heartbeat.type)
+                      << ", old type: " << static_cast<unsigned>(_vehicle_type) << ")";
             _vehicle_type = new_vehicle_type;
         }
     }


### PR DESCRIPTION
The change from https://github.com/mavlink/MAVSDK/pull/1752 inadvertantly threw a warning for all heartbeats that came from an "INVALID" autopilot. However, this is acceptable according to the [Heartbeat protocol.](https://mavlink.io/en/messages/common.html#HEARTBEAT) This small commit fixes that issue.