### PR TITLE
core: Add callback list

### DIFF
--- a/src/mavsdk/core/CMakeLists.txt
+++ b/src/mavsdk/core/CMakeLists.txt
@@ -120,6 +120,7 @@ install(FILES
 )
 
 list(APPEND UNIT_TEST_SOURCES
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/callback_list_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/mavsdk_time_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/mavsdk_math_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/mavlink_channels_test.cpp

--- a/src/mavsdk/core/callback_list.h
+++ b/src/mavsdk/core/callback_list.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+namespace mavsdk {
+
+template<typename... Args> class CallbackList;
+
+template<typename... Args> class Handle {
+public:
+    explicit Handle(uint64_t id) : _id(id) {}
+
+private:
+    uint64_t _id;
+
+    friend CallbackList<Args...>;
+};
+
+template<typename... Args> class CallbackList {
+public:
+    Handle<Args...> subscribe(const std::function<void(Args...)>&& callback)
+    {
+        check_removals();
+
+        std::lock_guard<std::mutex> lock(_mutex);
+        auto handle = Handle<Args...>(_last_id++);
+        _list.emplace_back(handle, callback);
+        return handle;
+    }
+
+    void unsubscribe(Handle<Args...> handle)
+    {
+        // We want to allow unsubscribing while in a callback. This would
+        // normally lead to a deadlock. Therefore, we just try to grab the
+        // lock here, and if it's already taken, we schedule the removal
+        // for later.
+        std::unique_lock<std::mutex> lock(_mutex, std::try_to_lock);
+        if (lock.owns_lock()) {
+            _list.erase(
+                std::remove_if(
+                    _list.begin(),
+                    _list.end(),
+                    [&](auto& pair) { return pair.first._id == handle._id; }),
+                _list.end());
+        } else {
+            std::lock_guard<std::mutex> remove_later_lock(_remove_later_mutex);
+            _remove_later.push_back(handle._id);
+        }
+    }
+
+    void operator()(Args... args)
+    {
+        check_removals();
+
+        std::lock_guard<std::mutex> lock(_mutex);
+        for (const auto& pair : _list) {
+            pair.second(args...);
+        }
+    }
+
+private:
+    void check_removals()
+    {
+        std::lock_guard<std::mutex> remove_later_lock(_remove_later_mutex);
+
+        // We could probably just grab the lock here but it's safer not to
+        // acquire both locks to avoid deadlocks.
+        if (_mutex.try_lock()) {
+            for (auto& id : _remove_later) {
+                _list.erase(
+                    std::remove_if(
+                        _list.begin(),
+                        _list.end(),
+                        [&](auto& pair) { return pair.first._id == id; }),
+                    _list.end());
+            }
+            _mutex.unlock();
+        }
+    }
+
+    mutable std::mutex _mutex{};
+    uint64_t _last_id{0};
+    std::vector<std::pair<Handle<Args...>, std::function<void(Args...)>>> _list{};
+
+    mutable std::mutex _remove_later_mutex{};
+    std::vector<uint64_t> _remove_later{};
+};
+
+} // namespace mavsdk

--- a/src/mavsdk/core/callback_list_test.cpp
+++ b/src/mavsdk/core/callback_list_test.cpp
@@ -1,0 +1,71 @@
+#include "callback_list.h"
+#include "log.h"
+#include <gtest/gtest.h>
+
+using namespace mavsdk;
+
+TEST(CallbackList, SubscribeCallUnsubscribe)
+{
+    unsigned first_called = 0;
+    unsigned second_called = 0;
+
+    CallbackList<int, double> cl;
+    auto first_handle = cl.subscribe([&](int i, double d) {
+        ++first_called;
+        EXPECT_GE(i, 42);
+        EXPECT_LE(i, 44);
+        EXPECT_GT(d, 77.0);
+        EXPECT_LT(d, 112.0);
+    });
+
+    auto second_handle = cl.subscribe([&](int i, double d) {
+        ++second_called;
+        EXPECT_GE(i, 42);
+        EXPECT_LE(i, 44);
+        EXPECT_GT(d, 77.0);
+        EXPECT_LT(d, 112.0);
+    });
+
+    // Call both a first time.
+    cl(42, 77.7);
+    EXPECT_EQ(first_called, 1);
+    EXPECT_EQ(second_called, 1);
+
+    // Call both a second time.
+    cl(43, 88.8);
+    EXPECT_EQ(first_called, 2);
+    EXPECT_EQ(second_called, 2);
+
+    // Now we unsubscribe the first one.
+    cl.unsubscribe(first_handle);
+
+    cl(43, 99.9);
+    EXPECT_EQ(first_called, 2);
+    EXPECT_EQ(second_called, 3);
+
+    // Unsubscribing the first once should be ignored.
+    cl.unsubscribe(first_handle);
+
+    // Now we unsubscribe the second one as well, no more calling.
+    cl.unsubscribe(second_handle);
+
+    cl(44, 111.1);
+    EXPECT_EQ(first_called, 2);
+    EXPECT_EQ(second_called, 3);
+}
+
+TEST(CallbackList, UnsubscribeFromCallback)
+{
+    unsigned called = 0;
+
+    CallbackList<> cl;
+    Handle<> handle = cl.subscribe([&]() {
+        cl.unsubscribe(handle);
+        ++called;
+    });
+
+    // We call it twice but only expect it to be called once.
+    cl();
+    cl();
+    EXPECT_EQ(called, 1);
+}


### PR DESCRIPTION
This allows to replace callback subscriptions with lists, so that multiple callbacks can be registered.

FYI @devbharat: I think this might be the minimal implementation of what we need for multiple subscriptions.