### PR TITLE
gitmodule: remove mavlink repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "mavsdk-proto"]
 	path = proto
 	url = https://github.com/mavlink/MAVSDK-Proto.git
-[submodule "src/third_party/mavlink"]
-	path = src/third_party/mavlink
-	url = https://github.com/mavlink/mavlink.git


### PR DESCRIPTION
This is now fetched from cmake or manually.

Leftover from #1741.