### PR TITLE
Add version number fallback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,12 @@ execute_process(
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     OUTPUT_VARIABLE VERSION_STR
     OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE GITVER
 )
+if(NOT GITVER EQUAL "0")
+    message(STATUS "No git version found. Falling back to empty version no")
+    set(VERSION_STR "0.0.0")
+endif()
 
 message(STATUS "Version: ${VERSION_STR}")
 STRING(REGEX REPLACE v\([0-9]+\).[0-9]+.[0-9]+.*$ \\1 MAVSDK_VERSION_MAJOR "${VERSION_STR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,8 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
     RESULT_VARIABLE GITVER
 )
-if(NOT GITVER EQUAL "0")
+
+if (NOT GITVER EQUAL "0")
     message(STATUS "No git version found. Falling back to empty version no")
     set(VERSION_STR "0.0.0")
 endif()


### PR DESCRIPTION
It's impossible to build from source.tar.gz or .zips at current as it is dependent on the repo being a git repository. This adds a fallback to `0.0.0` in this case as version number is not known and allows dependent modules to build