### PR TITLE
Fix system discovery

### DIFF
--- a/src/mavsdk/core/mavsdk_impl.cpp
+++ b/src/mavsdk/core/mavsdk_impl.cpp
@@ -300,13 +300,10 @@ void MavsdkImpl::receive_message(mavlink_message_t& message, Connection* connect
 
     std::lock_guard<std::recursive_mutex> lock(_systems_mutex);
 
-    // The only situation where we create a system with sysid 0 is when we initialize the connection
-    // to the remote.
+    // If we have a system with sysid 0, it is the "fake" system we built to initialize the
+    // connection to the remote. We can remove it now that a remote system is discovered.
     if (_systems.size() == 1 && _systems[0].first == 0) {
-        LogDebug() << "New: System ID: " << static_cast<int>(message.sysid)
-                   << " Comp ID: " << static_cast<int>(message.compid);
-        _systems[0].first = message.sysid;
-        _systems[0].second->system_impl()->set_system_id(message.sysid);
+        _systems.clear();
     }
 
     bool found_system = false;


### PR DESCRIPTION
Without this fix, MAVSDK has issues detecting more than one system (it seems like one `notify_on_discover` is lost, because one of the systems was `always_connected` and is renamed when a new one is detected).

This fix just clears the "fake system" when a new one is discovered, so that the new one triggers the discovery callback.