### PR TITLE
Fix FTP test segfault

### DIFF
--- a/src/mavsdk/core/mavsdk_impl.cpp
+++ b/src/mavsdk/core/mavsdk_impl.cpp
@@ -307,6 +307,10 @@ void MavsdkImpl::receive_message(mavlink_message_t& message, Connection* connect
                    << " Comp ID: " << static_cast<int>(message.compid);
         _systems[0].first = message.sysid;
         _systems[0].second->system_impl()->set_system_id(message.sysid);
+
+        // Even though the fake system was already discovered, we can now
+        // send a notification, now that it seems to really actually exist.
+        notify_on_discover();
     }
 
     bool found_system = false;

--- a/src/mavsdk/core/mavsdk_impl.cpp
+++ b/src/mavsdk/core/mavsdk_impl.cpp
@@ -300,10 +300,13 @@ void MavsdkImpl::receive_message(mavlink_message_t& message, Connection* connect
 
     std::lock_guard<std::recursive_mutex> lock(_systems_mutex);
 
-    // If we have a system with sysid 0, it is the "fake" system we built to initialize the
-    // connection to the remote. We can remove it now that a remote system is discovered.
+    // The only situation where we create a system with sysid 0 is when we initialize the connection
+    // to the remote.
     if (_systems.size() == 1 && _systems[0].first == 0) {
-        _systems.clear();
+        LogDebug() << "New: System ID: " << static_cast<int>(message.sysid)
+                   << " Comp ID: " << static_cast<int>(message.compid);
+        _systems[0].first = message.sysid;
+        _systems[0].second->system_impl()->set_system_id(message.sysid);
     }
 
     bool found_system = false;


### PR DESCRIPTION
@JonasVautherin I think the fix you suggested in #1774 does not work in general.

Removing a system is not really supported, so in the case of the FTP test, the ftp plugin is already created from the fake plugin and removing it has bad effects, in this case a segfault.

This PR reverts your commit and adds a commit which instead triggers a discovery notification when a fake system changes to a real system.

However, in the future, given the server components - I think - we can remove the fake system completely. However, this requires us to split the FTP plugin into client and server. That's something I wanted to do but haven't gotten to yet.