### PR TITLE
openssl: update to  1.1.1o

### DIFF
--- a/third_party/openssl/CMakeLists.txt
+++ b/third_party/openssl/CMakeLists.txt
@@ -5,7 +5,7 @@ include(ExternalProject)
 
 message(STATUS "Preparing external project \"openssl\"")
 
-set(OPENSSL_VERSION 1.1.1l)
+set(OPENSSL_VERSION 1.1.1o)
 
 if(ANDROID)
     if(${CMAKE_ANDROID_ARCH_ABI} STREQUAL "armeabi-v7a")


### PR DESCRIPTION
Not sure if we would be affected but let's update anyway:
https://www.openssl.org/news/secadv/20220503.txt