### PR TITLE
info: updated the message to obtain flight and autopilot info as per …

### DIFF
--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -469,7 +469,7 @@ void SystemImpl::send_autopilot_version_request()
     MavlinkCommandSender::CommandLong command{};
 
     command.command = MAV_CMD_REQUEST_MESSAGE; // MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES;
-    command.params.maybe_param1 = MAVLINK_MSG_ID_AUTOPILOT_VERSION;
+    command.params.maybe_param1 = {static_cast<float>(MAVLINK_MSG_ID_AUTOPILOT_VERSION)};
     command.target_component_id = get_autopilot_id();
 
     send_command_async(command, nullptr);
@@ -481,7 +481,7 @@ void SystemImpl::send_flight_information_request()
     MavlinkCommandSender::CommandLong command{};
 
     command.command = MAV_CMD_REQUEST_MESSAGE; // MAV_CMD_REQUEST_FLIGHT_INFORMATION;
-    command.params.maybe_param1 = MAVLINK_MSG_ID_FLIGHT_INFORMATION;
+    command.params.maybe_param1 = {static_cast<float>(MAVLINK_MSG_ID_FLIGHT_INFORMATION)};
     command.target_component_id = get_autopilot_id();
 
     send_command_async(command, nullptr);

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -468,7 +468,7 @@ void SystemImpl::send_autopilot_version_request()
     // We don't care about an answer, we mostly care about receiving AUTOPILOT_VERSION.
     MavlinkCommandSender::CommandLong command{};
 
-    command.command = MAV_CMD_REQUEST_MESSAGE; //MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES;
+    command.command = MAV_CMD_REQUEST_MESSAGE; // MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES;
     command.params.maybe_param1 = MAVLINK_MSG_ID_AUTOPILOT_VERSION;
     command.target_component_id = get_autopilot_id();
 

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -487,6 +487,7 @@ void SystemImpl::send_autopilot_version_request()
     if (fut.get() == MavlinkCommandSender::Result::Unsupported) {
         _old_message_520_supported = false;
         LogWarn() << "Trying alternative command (512).";
+        send_autopilot_version_request();
     }
 }
 
@@ -514,6 +515,7 @@ void SystemImpl::send_flight_information_request()
     if (fut.get() == MavlinkCommandSender::Result::Unsupported) {
         _old_message_528_supported = false;
         LogWarn() << "Trying alternative command (512)..";
+        send_flight_information_request();
     }
 }
 

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -465,26 +465,56 @@ bool SystemImpl::send_message(mavlink_message_t& message)
 
 void SystemImpl::send_autopilot_version_request()
 {
-    // We don't care about an answer, we mostly care about receiving AUTOPILOT_VERSION.
-    MavlinkCommandSender::CommandLong command{};
+    auto prom = std::promise<MavlinkCommandSender::Result>();
+    auto fut = prom.get_future();
 
-    command.command = MAV_CMD_REQUEST_MESSAGE; // MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES;
-    command.params.maybe_param1 = {static_cast<float>(MAVLINK_MSG_ID_AUTOPILOT_VERSION)};
+    MavlinkCommandSender::CommandLong command{};
     command.target_component_id = get_autopilot_id();
 
-    send_command_async(command, nullptr);
+    if (_old_message_520_supported) {
+        // Note: This MAVLINK message is deprecated and would be removed from MAVSDK in a future
+        // release.
+        command.command = MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES;
+        command.params.maybe_param1 = 1.0f;
+    } else {
+        command.command = MAV_CMD_REQUEST_MESSAGE;
+        command.params.maybe_param1 = {static_cast<float>(MAVLINK_MSG_ID_AUTOPILOT_VERSION)};
+    }
+
+    send_command_async(command, [&prom](MavlinkCommandSender::Result result, float _val) {
+        prom.set_value(result);
+    });
+    if (fut.get() == MavlinkCommandSender::Result::Unsupported) {
+        _old_message_520_supported = false;
+        LogWarn() << "Trying alternative command (512).";
+    }
 }
 
 void SystemImpl::send_flight_information_request()
 {
-    // We don't care about an answer, we mostly care about receiving FLIGHT_INFORMATION.
-    MavlinkCommandSender::CommandLong command{};
+    auto prom = std::promise<MavlinkCommandSender::Result>();
+    auto fut = prom.get_future();
 
-    command.command = MAV_CMD_REQUEST_MESSAGE; // MAV_CMD_REQUEST_FLIGHT_INFORMATION;
-    command.params.maybe_param1 = {static_cast<float>(MAVLINK_MSG_ID_FLIGHT_INFORMATION)};
+    MavlinkCommandSender::CommandLong command{};
     command.target_component_id = get_autopilot_id();
 
-    send_command_async(command, nullptr);
+    if (_old_message_528_supported) {
+        // Note: This MAVLINK message is deprecated and would be removed from MAVSDK in a future
+        // release.
+        command.command = MAV_CMD_REQUEST_FLIGHT_INFORMATION;
+        command.params.maybe_param1 = 1.0f;
+    } else {
+        command.command = MAV_CMD_REQUEST_MESSAGE;
+        command.params.maybe_param1 = {static_cast<float>(MAVLINK_MSG_ID_FLIGHT_INFORMATION)};
+    }
+
+    send_command_async(command, [&prom](MavlinkCommandSender::Result result, float _val) {
+        prom.set_value(result);
+    });
+    if (fut.get() == MavlinkCommandSender::Result::Unsupported) {
+        _old_message_528_supported = false;
+        LogWarn() << "Trying alternative command (512)..";
+    }
 }
 
 void SystemImpl::set_connected()
@@ -532,7 +562,7 @@ void SystemImpl::set_connected()
     }
     if (enable_needed) {
         if (has_autopilot()) {
-            send_autopilot_version_request();
+            // send_autopilot_version_request();
         }
 
         std::lock_guard<std::mutex> lock(_plugin_impls_mutex);

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -468,8 +468,8 @@ void SystemImpl::send_autopilot_version_request()
     // We don't care about an answer, we mostly care about receiving AUTOPILOT_VERSION.
     MavlinkCommandSender::CommandLong command{};
 
-    command.command = MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES;
-    command.params.maybe_param1 = 1.0f;
+    command.command = MAV_CMD_REQUEST_MESSAGE; //MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES;
+    command.params.maybe_param1 = MAVLINK_MSG_ID_AUTOPILOT_VERSION;
     command.target_component_id = get_autopilot_id();
 
     send_command_async(command, nullptr);
@@ -480,8 +480,8 @@ void SystemImpl::send_flight_information_request()
     // We don't care about an answer, we mostly care about receiving FLIGHT_INFORMATION.
     MavlinkCommandSender::CommandLong command{};
 
-    command.command = MAV_CMD_REQUEST_FLIGHT_INFORMATION;
-    command.params.maybe_param1 = 1.0f;
+    command.command = MAV_CMD_REQUEST_MESSAGE; // MAV_CMD_REQUEST_FLIGHT_INFORMATION;
+    command.params.maybe_param1 = MAVLINK_MSG_ID_FLIGHT_INFORMATION;
     command.target_component_id = get_autopilot_id();
 
     send_command_async(command, nullptr);

--- a/src/mavsdk/core/system_impl.h
+++ b/src/mavsdk/core/system_impl.h
@@ -383,6 +383,9 @@ private:
 
     std::mutex _mavlink_ftp_files_mutex{};
     std::unordered_map<std::string, std::string> _mavlink_ftp_files{};
+
+    bool _old_message_520_supported{true};
+    bool _old_message_528_supported{true};
 };
 
 } // namespace mavsdk

--- a/src/mavsdk/core/system_impl.h
+++ b/src/mavsdk/core/system_impl.h
@@ -258,6 +258,8 @@ public:
         const std::string& filename, int linenumber, const std::function<void()>& func);
 
     void send_autopilot_version_request();
+    void send_autopilot_version_request_async(
+        const MavlinkCommandSender::CommandResultCallback& callback);
     void send_flight_information_request();
 
     MavlinkMissionTransfer& mission_transfer() { return _mission_transfer; };


### PR DESCRIPTION
…the mavlink spec.
The following messages are deprecated in the MAVLINK protocol

[MAV_CMD_REQUEST_FLIGHT_INFORMATION](https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_FLIGHT_INFORMATION)
[MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES](https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES)

The suggested way to get the same information is using the following command message:
[MAV_CMD_REQUEST_MESSAGE](https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_MESSAGE)

with appropriate message ID for requested message which would be for flight information the following message: 
[MAVLINK_MSG_ID_FLIGHT_INFORMATION](https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_MESSAGE) 

_Note APM does not implement this yet. See Issue      https://github.com/ArduPilot/ardupilot/issues/15217_

and for autopilot version: 
[MAVLINK_MSG_ID_AUTOPILOT_VERSION 148](https://mavlink.io/en/messages/common.html#AUTOPILOT_VERSION)

This PR resolves this incompatibility with the MAVLINK protocol.

Happy to hear your thoughts :)