### PR TITLE
params: fix double promise call

### DIFF
--- a/src/integration_tests/param.cpp
+++ b/src/integration_tests/param.cpp
@@ -162,6 +162,8 @@ TEST_F(SitlTest, GetAllParams)
     for (const auto& mixed_param : all_mixed) {
         std::cout << mixed_param.first << " : " << mixed_param.second << '\n';
     }
+
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 }
 
 TEST_F(SitlTest, APParam)

--- a/src/mavsdk/core/mavlink_command_sender.cpp
+++ b/src/mavsdk/core/mavlink_command_sender.cpp
@@ -293,6 +293,10 @@ void MavlinkCommandSender::receive_timeout(const CommandIdentification& identifi
                       << " s, retries to do: " << work->retries_to_do << "  ("
                       << work->identification.command << ").";
 
+            if (work->identification.command == MAV_CMD_REQUEST_MESSAGE) {
+                LogWarn() << "Request was for msg ID: " << work->identification.maybe_param1;
+            }
+
             mavlink_message_t message = create_mavlink_message(work->command);
             if (!_parent.send_message(message)) {
                 LogErr() << "connection send error in retransmit (" << work->identification.command

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -992,6 +992,7 @@ void MAVLinkParameters::process_param_value(const mavlink_message_t& message)
         // check if we are looking for param list
         if (_all_params_callback) {
             if (param_value.param_index + 1 == param_value.param_count) {
+                _timeout_handler.remove(_all_params_timeout_cookie);
                 lock.unlock();
                 _all_params_callback(_all_params);
             } else {

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -992,6 +992,7 @@ void MAVLinkParameters::process_param_value(const mavlink_message_t& message)
             if (param_value.param_index + 1 == param_value.param_count) {
                 _timeout_handler.remove(_all_params_timeout_cookie);
                 _all_params_callback(_all_params);
+                _all_params_callback = nullptr;
             } else {
                 _timeout_handler.remove(_all_params_timeout_cookie);
 

--- a/src/mavsdk/core/server_component_impl.h
+++ b/src/mavsdk/core/server_component_impl.h
@@ -21,7 +21,7 @@ class ServerPluginImplBase;
 class ServerComponentImpl {
 public:
     ServerComponentImpl(MavsdkImpl& mavsdk_impl, uint8_t component_id);
-    ~ServerComponentImpl() = default;
+    ~ServerComponentImpl();
 
     void register_plugin(ServerPluginImplBase* server_plugin_impl);
     void unregister_plugin(ServerPluginImplBase* server_plugin_impl);

--- a/src/system_tests/CMakeLists.txt
+++ b/src/system_tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(system_tests_runner
     action_arm_disarm.cpp
     system_tests_helper.cpp
     param_set_and_get.cpp
+    param_get_all.cpp
     param_custom_set_and_get.cpp
     mission_raw_upload.cpp
 )

--- a/src/system_tests/param_get_all.cpp
+++ b/src/system_tests/param_get_all.cpp
@@ -1,0 +1,75 @@
+#include "log.h"
+#include "mavsdk.h"
+#include "system_tests_helper.h"
+#include "plugins/param/param.h"
+#include "plugins/param_server/param_server.h"
+
+using namespace mavsdk;
+
+static constexpr unsigned num_params_per_type = 100;
+
+std::vector<std::pair<std::string, float>> generate_float_params()
+{
+    std::vector<std::pair<std::string, float>> params;
+
+    for (unsigned i = 0; i < num_params_per_type; ++i) {
+        params.emplace_back(std::string("TEST_BLA") + std::to_string(i), 42.0f + i);
+    }
+
+    return params;
+}
+
+std::vector<std::pair<std::string, int>> generate_int_params()
+{
+    std::vector<std::pair<std::string, int>> params;
+
+    for (unsigned i = 0; i < num_params_per_type; ++i) {
+        params.emplace_back(std::string("TEST_FOO") + std::to_string(i), 42.0f + i);
+    }
+
+    return params;
+}
+
+TEST(SystemTest, ParamGetAll)
+{
+    Mavsdk mavsdk_groundstation;
+    mavsdk_groundstation.set_configuration(
+        Mavsdk::Configuration{Mavsdk::Configuration::UsageType::GroundStation});
+
+    Mavsdk mavsdk_autopilot;
+    mavsdk_autopilot.set_configuration(
+        Mavsdk::Configuration{Mavsdk::Configuration::UsageType::Autopilot});
+
+    ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
+    ASSERT_EQ(
+        mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
+
+    auto param_server = ParamServer{
+        mavsdk_autopilot.server_component_by_type(Mavsdk::ServerComponentType::Autopilot)};
+
+    auto fut = wait_for_first_system_detected(mavsdk_groundstation);
+    ASSERT_EQ(fut.wait_for(std::chrono::seconds(10)), std::future_status::ready);
+    auto system = fut.get();
+
+    ASSERT_TRUE(system->has_autopilot());
+
+    auto param = Param{system};
+
+    // Add many params
+    for (const auto& float_param : generate_float_params()) {
+        EXPECT_EQ(
+            param_server.provide_param_float(float_param.first, float_param.second),
+            ParamServer::Result::Success);
+    }
+    for (const auto& int_param : generate_int_params()) {
+        EXPECT_EQ(
+            param_server.provide_param_int(int_param.first, int_param.second),
+            ParamServer::Result::Success);
+    }
+
+    auto all_params = param.get_all_params();
+
+    EXPECT_EQ(all_params.float_params.size(), generate_float_params().size());
+    EXPECT_EQ(all_params.int_params.size(), generate_int_params().size());
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+}

--- a/src/system_tests/param_get_all.cpp
+++ b/src/system_tests/param_get_all.cpp
@@ -3,6 +3,10 @@
 #include "system_tests_helper.h"
 #include "plugins/param/param.h"
 #include "plugins/param_server/param_server.h"
+#include <chrono>
+#include <utility>
+#include <vector>
+#include <thread>
 
 using namespace mavsdk;
 


### PR DESCRIPTION
This fixes a segfault/abort when using get_all_params(). The issue was that the timeout handler was not removed as it should have been, and so after a successful completion, we got another call from the timeout handler which then satisfies the promise a second time which is not possible.

This did not show up in the integration test (or at least not often) because the test was already destructed by the time the timeout would trigger.

Fixes #1785.