### PR TITLE
PR for BATTERY_STATUS_V2

### DIFF
--- a/src/mavsdk/plugins/telemetry/telemetry_impl.h
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.h
@@ -201,6 +201,7 @@ private:
     void process_fixedwing_metrics(const mavlink_message_t& message);
     void process_sys_status(const mavlink_message_t& message);
     void process_battery_status(const mavlink_message_t& message);
+    void process_battery_status_v2(const mavlink_message_t& message);
     void process_heartbeat(const mavlink_message_t& message);
     void process_rc_channels(const mavlink_message_t& message);
     void process_unix_epoch_time(const mavlink_message_t& message);

--- a/third_party/mavlink/CMakeLists.txt
+++ b/third_party/mavlink/CMakeLists.txt
@@ -18,7 +18,9 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 ExternalProject_add(
     mavlink
     GIT_REPOSITORY https://github.com/mavlink/mavlink
-    GIT_TAG 3b52eac09c2e37325e4bc49cd2667ea37bf1d7d2
+    GIT_TAG a5556816af29e348875cbcc26a1d36b42dc5e921
+    # This GIT_TAG will need to update as it is for a temporary branch containing the new battery
+    # https://github.com/mavlink/mavlink/commit/a5556816af29e348875cbcc26a1d36b42dc5e921
     PREFIX mavlink
     CONFIGURE_COMMAND Python3::Interpreter
         -m pymavlink.tools.mavgen


### PR DESCRIPTION
This is  PR for a new battery status message `BATTERY_STATUS_V2` that is being added in (under discussion) RFC: https://github.com/mavlink/rfcs/pull/19

This message has been added in https://github.com/mavlink/mavlink/pull/1846 into development.xml

Note, first version just allows easy testing. 
- It pulls in the mavlink git_tag in a commit that can later be removed.
- adds handler for new message. Does not update proto with new fields.
