### PR TITLE
server: enabled option for default health check service for mavsdk grpc server.

### DIFF
--- a/src/mavsdk_server/src/grpc_server.cpp
+++ b/src/mavsdk_server/src/grpc_server.cpp
@@ -47,6 +47,7 @@ int GrpcServer::run()
     builder.RegisterService(&_transponder_service);
     builder.RegisterService(&_tune_service);
 
+    grpc::EnableDefaultHealthCheckService(true);
     _server = builder.BuildAndStart();
 
     if (_bound_port != 0) {


### PR DESCRIPTION
This PR enables the default grpc health check service for the mavsdk_server. Such a service is useful to check if mavsdk_server has started serving before clients would try to connect it. Documentation on this service is at [gRPC-C++ Health Check Protocol](https://grpc.github.io/grpc/cpp/md_doc_health-checking.html)

Once enabled, a CLI client like [grpc_health_probe](https://github.com/grpc-ecosystem/grpc-health-probe) can be used to check if the service is serving or not.

Example 1: MAVSDK Server is not yet connected to any autopilot so not listening on port 50051.
```bashroot@e85de2b5138f:/home/user/tools# ./grpc_health_probe -addr 127.0.0.1:50051
timeout: failed to connect service "127.0.0.1:50051" within 1s
```

Example 2: MAVSDK Server IS conencted to a autopilot and listening on port 50051
```bashroot@e85de2b5138f:/home/user/tools# ./grpc_health_probe -addr 127.0.0.1:50051
status: SERVING
```
