### PR TITLE
Consti test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ venv/
 cmake-build-*
 
 # Build folder when using the command line (as recommended from the tutorial)
-build
+build/*
 
 # mavlink repo to generate mavlink-headers
 mavlink

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ venv/
 
 # CLion build folder
 cmake-build-*
+# Clion local files folder
+.idea/*
 
 # Build folder when using the command line (as recommended from the tutorial)
 build/*

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ venv/
 # CLion build folder
 cmake-build-*
 
+# Build folder when using the command line (as recommended from the tutorial)
+build
+
 # mavlink repo to generate mavlink-headers
 mavlink
 mavlink-headers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ set(DEPS_INSTALL_PATH "${DEPS_BUILD_PATH}/install" CACHE PATH "Install path for 
 
 include(GNUInstallDirs)
 
+set(MAVLINK_DIALECT openhd)
 if (NOT MAVLINK_DIALECT)
     set(MAVLINK_DIALECT common)
 endif()

--- a/build_install.sh
+++ b/build_install.sh
@@ -1,5 +1,5 @@
 rm -rf build
-cmake -DCMAKE_BUILD_TYPE=Debug -DMAVLINK_DIALECT=openhd -Bbuild/default -H.
+cmake -DCMAKE_BUILD_TYPE=Debug -Bbuild/default -H.
 cmake --build build/default -j8
 
 sudo cmake --build build/default --target install

--- a/build_install.sh
+++ b/build_install.sh
@@ -1,0 +1,5 @@
+rm -rf build
+cmake -DCMAKE_BUILD_TYPE=Debug -DMAVLINK_DIALECT=openhd -Bbuild/default -H.
+cmake --build build/default -j8
+
+sudo cmake --build build/default --target install

--- a/examples/autopilot_server/autopilot_server.cpp
+++ b/examples/autopilot_server/autopilot_server.cpp
@@ -84,6 +84,8 @@ int main(int argc, char** argv)
         paramServer.provide_param_int("MIS_TAKEOFF_ALT", 0);
         // Add a custom param
         paramServer.provide_param_int("my_param", 1);
+		//Consti10 show bug 1:
+	  	paramServer.provide_param_custom("OHD_UART_NAME","/dev/ttyUSB0");
 
         // Allow the vehicle to change modes, takeoff and arm
         actionServer.set_allowable_flight_modes({true, true, true});
@@ -185,6 +187,9 @@ int main(int argc, char** argv)
     auto action = mavsdk::Action{system};
     auto param = mavsdk::Param{system};
     auto telemetry = mavsdk::Telemetry{system};
+
+  	//Consti10 show bug part 2.
+  	param.get_all_params();
 
     std::this_thread::sleep_for(std::chrono::seconds(5));
     auto mission = mavsdk::Mission{system};

--- a/src/mavsdk/core/CMakeLists.txt
+++ b/src/mavsdk/core/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(mavsdk
     mavlink_ftp.cpp
     mavlink_mission_transfer.cpp
     mavlink_parameters.cpp
+    mavlink_param_value.cpp
     mavlink_receiver.cpp
     mavlink_request_message_handler.cpp
     mavlink_statustext_handler.cpp

--- a/src/mavsdk/core/mavlink_param_value.cpp
+++ b/src/mavsdk/core/mavlink_param_value.cpp
@@ -623,13 +623,5 @@ void ParamValue::log_if_type_is_different_ext(MAV_PARAM_EXT_TYPE newType)const{
   }
 }
 
-/*template<class T> bool ParamValue::is_same_type_x()const
-{
-    if (std::holds_alternative<T>(_value)) {
-        return true;
-    }
-    return false;
-}*/
-
 }
 }

--- a/src/mavsdk/core/mavlink_param_value.cpp
+++ b/src/mavsdk/core/mavlink_param_value.cpp
@@ -1,0 +1,656 @@
+//
+// Created by consti10 on 17.06.22.
+//
+
+#include "mavlink_param_value.h"
+
+#include "mavlink_message_handler.h"
+#include "timeout_handler.h"
+#include "system_impl.h"
+#include <algorithm>
+#include <cstring>
+#include <future>
+
+namespace mavsdk {
+namespace parameters {
+
+bool ParamValue::set_from_mavlink_param_value_bytewise(
+	const mavlink_param_value_t &mavlink_value) {
+  switch (mavlink_value.param_type) {
+	case MAV_PARAM_TYPE_UINT8: {
+	  uint8_t temp;
+	  memcpy(&temp, &mavlink_value.param_value, sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+
+	case MAV_PARAM_TYPE_INT8: {
+	  int8_t temp;
+	  memcpy(&temp, &mavlink_value.param_value, sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+
+	case MAV_PARAM_TYPE_UINT16: {
+	  uint16_t temp;
+	  memcpy(&temp, &mavlink_value.param_value, sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+
+	case MAV_PARAM_TYPE_INT16: {
+	  int16_t temp;
+	  memcpy(&temp, &mavlink_value.param_value, sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+
+	case MAV_PARAM_TYPE_UINT32: {
+	  uint32_t temp;
+	  memcpy(&temp, &mavlink_value.param_value, sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+
+	case MAV_PARAM_TYPE_INT32: {
+	  int32_t temp;
+	  memcpy(&temp, &mavlink_value.param_value, sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+
+	case MAV_PARAM_TYPE_REAL32: {
+	  _value = mavlink_value.param_value;
+	}
+	  break;
+
+	default:
+	  // This would be worrying
+	  LogErr() << "Error: unknown mavlink param type: "
+			   << std::to_string(mavlink_value.param_type);
+	  return false;
+  }
+  return true;
+}
+
+bool ParamValue::set_from_mavlink_param_value_cast(
+	const mavlink_param_value_t &mavlink_value) {
+  switch (mavlink_value.param_type) {
+	case MAV_PARAM_TYPE_UINT8: {
+	  _value = static_cast<uint8_t>(mavlink_value.param_value);
+	}
+	  break;
+
+	case MAV_PARAM_TYPE_INT8: {
+	  _value = static_cast<int8_t>(mavlink_value.param_value);
+	}
+	  break;
+
+	case MAV_PARAM_TYPE_UINT16: {
+	  _value = static_cast<uint16_t>(mavlink_value.param_value);
+	}
+	  break;
+
+	case MAV_PARAM_TYPE_INT16: {
+	  _value = static_cast<int16_t>(mavlink_value.param_value);
+	}
+	  break;
+
+	case MAV_PARAM_TYPE_UINT32: {
+	  _value = static_cast<uint32_t>(mavlink_value.param_value);
+	}
+	  break;
+
+	case MAV_PARAM_TYPE_INT32: {
+	  _value = static_cast<int32_t>(mavlink_value.param_value);
+	}
+	  break;
+
+	case MAV_PARAM_TYPE_REAL32: {
+	  float temp = mavlink_value.param_value;
+	  _value = temp;
+	}
+	  break;
+
+	default:
+	  // This would be worrying
+	  LogErr() << "Error: unknown mavlink param type: "
+			   << std::to_string(mavlink_value.param_type);
+	  return false;
+  }
+  return true;
+}
+
+bool ParamValue::set_from_mavlink_param_set_bytewise(
+	const mavlink_param_set_t &mavlink_set) {
+  mavlink_param_value_t mavlink_value{};
+  mavlink_value.param_value = mavlink_set.param_value;
+  mavlink_value.param_type = mavlink_set.param_type;
+
+  return set_from_mavlink_param_value_bytewise(mavlink_value);
+}
+
+bool ParamValue::set_from_mavlink_param_ext_set(
+	const mavlink_param_ext_set_t &mavlink_ext_set) {
+  switch (mavlink_ext_set.param_type) {
+	case MAV_PARAM_EXT_TYPE_UINT8: {
+	  uint8_t temp;
+	  memcpy(&temp, &mavlink_ext_set.param_value[0], sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+	case MAV_PARAM_EXT_TYPE_INT8: {
+	  int8_t temp;
+	  memcpy(&temp, &mavlink_ext_set.param_value[0], sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+	case MAV_PARAM_EXT_TYPE_UINT16: {
+	  uint16_t temp;
+	  memcpy(&temp, &mavlink_ext_set.param_value[0], sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+	case MAV_PARAM_EXT_TYPE_INT16: {
+	  int16_t temp;
+	  memcpy(&temp, &mavlink_ext_set.param_value[0], sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+	case MAV_PARAM_EXT_TYPE_UINT32: {
+	  uint32_t temp;
+	  memcpy(&temp, &mavlink_ext_set.param_value[0], sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+	case MAV_PARAM_EXT_TYPE_INT32: {
+	  int32_t temp;
+	  memcpy(&temp, &mavlink_ext_set.param_value[0], sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+	case MAV_PARAM_EXT_TYPE_UINT64: {
+	  uint64_t temp;
+	  memcpy(&temp, &mavlink_ext_set.param_value[0], sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+	case MAV_PARAM_EXT_TYPE_INT64: {
+	  int64_t temp;
+	  memcpy(&temp, &mavlink_ext_set.param_value[0], sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+	case MAV_PARAM_EXT_TYPE_REAL32: {
+	  float temp;
+	  memcpy(&temp, &mavlink_ext_set.param_value[0], sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+	case MAV_PARAM_EXT_TYPE_REAL64: {
+	  double temp;
+	  memcpy(&temp, &mavlink_ext_set.param_value[0], sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+	case MAV_PARAM_EXT_TYPE_CUSTOM: {
+	  std::size_t len = std::min(std::size_t(128), strlen(mavlink_ext_set.param_value));
+	  _value = std::string(mavlink_ext_set.param_value, mavlink_ext_set.param_value + len);
+	}
+	  break;
+	default:
+	  // This would be worrying
+	  LogErr() << "Error: unknown mavlink ext param type";
+	  assert(false);
+	  return false;
+  }
+  return true;
+}
+
+// FIXME: this function can collapse with the one above.
+bool ParamValue::set_from_mavlink_param_ext_value(
+	const mavlink_param_ext_value_t &mavlink_ext_value) {
+  switch (mavlink_ext_value.param_type) {
+	case MAV_PARAM_EXT_TYPE_UINT8: {
+	  uint8_t temp;
+	  memcpy(&temp, &mavlink_ext_value.param_value[0], sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+	case MAV_PARAM_EXT_TYPE_INT8: {
+	  int8_t temp;
+	  memcpy(&temp, &mavlink_ext_value.param_value[0], sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+	case MAV_PARAM_EXT_TYPE_UINT16: {
+	  uint16_t temp;
+	  memcpy(&temp, &mavlink_ext_value.param_value[0], sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+	case MAV_PARAM_EXT_TYPE_INT16: {
+	  int16_t temp;
+	  memcpy(&temp, &mavlink_ext_value.param_value[0], sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+	case MAV_PARAM_EXT_TYPE_UINT32: {
+	  uint32_t temp;
+	  memcpy(&temp, &mavlink_ext_value.param_value[0], sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+	case MAV_PARAM_EXT_TYPE_INT32: {
+	  int32_t temp;
+	  memcpy(&temp, &mavlink_ext_value.param_value[0], sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+	case MAV_PARAM_EXT_TYPE_UINT64: {
+	  uint64_t temp;
+	  memcpy(&temp, &mavlink_ext_value.param_value[0], sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+	case MAV_PARAM_EXT_TYPE_INT64: {
+	  int64_t temp;
+	  memcpy(&temp, &mavlink_ext_value.param_value[0], sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+	case MAV_PARAM_EXT_TYPE_REAL32: {
+	  float temp;
+	  memcpy(&temp, &mavlink_ext_value.param_value[0], sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+	case MAV_PARAM_EXT_TYPE_REAL64: {
+	  double temp;
+	  memcpy(&temp, &mavlink_ext_value.param_value[0], sizeof(temp));
+	  _value = temp;
+	}
+	  break;
+	case MAV_PARAM_EXT_TYPE_CUSTOM: {
+	  std::size_t len = std::min(std::size_t(128), strlen(mavlink_ext_value.param_value));
+	  _value =
+		  std::string(mavlink_ext_value.param_value, mavlink_ext_value.param_value + len);
+	}
+	  break;
+	default:
+	  // This would be worrying
+	  LogErr() << "Error: unknown mavlink ext param type";
+	  assert(false);
+	  return false;
+  }
+  return true;
+}
+
+bool ParamValue::set_from_xml(
+	const std::string &type_str, const std::string &value_str) {
+  if (strcmp(type_str.c_str(), "uint8") == 0) {
+	_value = static_cast<uint8_t>(std::stoi(value_str));
+  } else if (strcmp(type_str.c_str(), "int8") == 0) {
+	_value = static_cast<int8_t>(std::stoi(value_str));
+  } else if (strcmp(type_str.c_str(), "uint16") == 0) {
+	_value = static_cast<uint16_t>(std::stoi(value_str));
+  } else if (strcmp(type_str.c_str(), "int16") == 0) {
+	_value = static_cast<int16_t>(std::stoi(value_str));
+  } else if (strcmp(type_str.c_str(), "uint32") == 0) {
+	_value = static_cast<uint32_t>(std::stoi(value_str));
+  } else if (strcmp(type_str.c_str(), "int32") == 0) {
+	_value = static_cast<int32_t>(std::stoi(value_str));
+  } else if (strcmp(type_str.c_str(), "uint64") == 0) {
+	_value = static_cast<uint64_t>(std::stoll(value_str));
+  } else if (strcmp(type_str.c_str(), "int64") == 0) {
+	_value = static_cast<int64_t>(std::stoll(value_str));
+  } else if (strcmp(type_str.c_str(), "float") == 0) {
+	_value = static_cast<float>(std::stof(value_str));
+  } else if (strcmp(type_str.c_str(), "double") == 0) {
+	_value = static_cast<double>(std::stod(value_str));
+  } else {
+	LogErr() << "Unknown type: " << type_str;
+	return false;
+  }
+  return true;
+}
+
+bool ParamValue::set_empty_type_from_xml(const std::string &type_str) {
+  if (strcmp(type_str.c_str(), "uint8") == 0) {
+	_value = uint8_t(0);
+  } else if (strcmp(type_str.c_str(), "int8") == 0) {
+	_value = int8_t(0);
+  } else if (strcmp(type_str.c_str(), "uint16") == 0) {
+	_value = uint16_t(0);
+  } else if (strcmp(type_str.c_str(), "int16") == 0) {
+	_value = int16_t(0);
+  } else if (strcmp(type_str.c_str(), "uint32") == 0) {
+	_value = uint32_t(0);
+  } else if (strcmp(type_str.c_str(), "int32") == 0) {
+	_value = int32_t(0);
+  } else if (strcmp(type_str.c_str(), "uint64") == 0) {
+	_value = uint64_t(0);
+  } else if (strcmp(type_str.c_str(), "int64") == 0) {
+	_value = int64_t(0);
+  } else if (strcmp(type_str.c_str(), "float") == 0) {
+	_value = 0.0f;
+  } else if (strcmp(type_str.c_str(), "double") == 0) {
+	_value = 0.0;
+  } else {
+	LogErr() << "Unknown type: " << type_str;
+	return false;
+  }
+  return true;
+}
+
+[[nodiscard]] MAV_PARAM_TYPE ParamValue::get_mav_param_type() const {
+  if (std::get_if<uint8_t>(&_value)) {
+	return MAV_PARAM_TYPE_UINT8;
+  } else if (std::get_if<int8_t>(&_value)) {
+	return MAV_PARAM_TYPE_INT8;
+  } else if (std::get_if<uint16_t>(&_value)) {
+	return MAV_PARAM_TYPE_UINT16;
+  } else if (std::get_if<int16_t>(&_value)) {
+	return MAV_PARAM_TYPE_INT16;
+  } else if (std::get_if<uint32_t>(&_value)) {
+	return MAV_PARAM_TYPE_UINT32;
+  } else if (std::get_if<int32_t>(&_value)) {
+	return MAV_PARAM_TYPE_INT32;
+  } else if (std::get_if<uint64_t>(&_value)) {
+	return MAV_PARAM_TYPE_UINT64;
+  } else if (std::get_if<int64_t>(&_value)) {
+	return MAV_PARAM_TYPE_INT64;
+  } else if (std::get_if<float>(&_value)) {
+	return MAV_PARAM_TYPE_REAL32;
+  } else if (std::get_if<double>(&_value)) {
+	return MAV_PARAM_TYPE_REAL64;
+  } else {
+	LogErr() << "Unknown data type for param.";
+	assert(false);
+	return MAV_PARAM_TYPE_INT32;
+  }
+}
+
+[[nodiscard]] MAV_PARAM_EXT_TYPE ParamValue::get_mav_param_ext_type() const {
+  if (std::get_if<uint8_t>(&_value)) {
+	return MAV_PARAM_EXT_TYPE_UINT8;
+  } else if (std::get_if<int8_t>(&_value)) {
+	return MAV_PARAM_EXT_TYPE_INT8;
+  } else if (std::get_if<uint16_t>(&_value)) {
+	return MAV_PARAM_EXT_TYPE_UINT16;
+  } else if (std::get_if<int16_t>(&_value)) {
+	return MAV_PARAM_EXT_TYPE_INT16;
+  } else if (std::get_if<uint32_t>(&_value)) {
+	return MAV_PARAM_EXT_TYPE_UINT32;
+  } else if (std::get_if<int32_t>(&_value)) {
+	return MAV_PARAM_EXT_TYPE_INT32;
+  } else if (std::get_if<uint64_t>(&_value)) {
+	return MAV_PARAM_EXT_TYPE_UINT64;
+  } else if (std::get_if<int64_t>(&_value)) {
+	return MAV_PARAM_EXT_TYPE_INT64;
+  } else if (std::get_if<float>(&_value)) {
+	return MAV_PARAM_EXT_TYPE_REAL32;
+  } else if (std::get_if<double>(&_value)) {
+	return MAV_PARAM_EXT_TYPE_REAL64;
+  } else if (std::get_if<std::string>(&_value)) {
+	return MAV_PARAM_EXT_TYPE_CUSTOM;
+  } else {
+	LogErr() << "Unknown data type for param.";
+	assert(false);
+	return MAV_PARAM_EXT_TYPE_INT32;
+  }
+}
+
+bool ParamValue::set_as_same_type(const std::string &value_str) {
+  if (std::get_if<uint8_t>(&_value)) {
+	_value = uint8_t(std::stoi(value_str));
+  } else if (std::get_if<int8_t>(&_value)) {
+	_value = int8_t(std::stoi(value_str));
+  } else if (std::get_if<uint16_t>(&_value)) {
+	_value = uint16_t(std::stoi(value_str));
+  } else if (std::get_if<int16_t>(&_value)) {
+	_value = int16_t(std::stoi(value_str));
+  } else if (std::get_if<uint32_t>(&_value)) {
+	_value = uint32_t(std::stoi(value_str));
+  } else if (std::get_if<int32_t>(&_value)) {
+	_value = int32_t(std::stoi(value_str));
+  } else if (std::get_if<uint64_t>(&_value)) {
+	_value = uint64_t(std::stoll(value_str));
+  } else if (std::get_if<int64_t>(&_value)) {
+	_value = int64_t(std::stoll(value_str));
+  } else if (std::get_if<float>(&_value)) {
+	_value = float(std::stof(value_str));
+  } else if (std::get_if<double>(&_value)) {
+	_value = double(std::stod(value_str));
+  } else {
+	LogErr() << "Unknown type";
+	return false;
+  }
+  return true;
+}
+
+[[nodiscard]] float ParamValue::get_4_float_bytes_bytewise() const {
+  if (std::get_if<float>(&_value)) {
+	return std::get<float>(_value);
+  } else if (std::get_if<int32_t>(&_value)) {
+	return *(reinterpret_cast<const float *>(&std::get<int32_t>(_value)));
+  } else {
+	LogErr() << "Unknown type";
+	assert(false);
+	return NAN;
+  }
+}
+
+[[nodiscard]] float ParamValue::get_4_float_bytes_cast() const {
+  if (std::get_if<float>(&_value)) {
+	return std::get<float>(_value);
+  } else if (std::get_if<uint32_t>(&_value)) {
+	return static_cast<float>(std::get<uint32_t>(_value));
+  } else if (std::get_if<int32_t>(&_value)) {
+	return static_cast<float>(std::get<int32_t>(_value));
+  } else if (std::get_if<uint16_t>(&_value)) {
+	return static_cast<float>(std::get<uint16_t>(_value));
+  } else if (std::get_if<int16_t>(&_value)) {
+	return static_cast<float>(std::get<int16_t>(_value));
+  } else if (std::get_if<uint8_t>(&_value)) {
+	return static_cast<float>(std::get<uint8_t>(_value));
+  } else if (std::get_if<int8_t>(&_value)) {
+	return static_cast<float>(std::get<int8_t>(_value));
+  } else {
+	LogErr() << "Unknown type";
+	assert(false);
+	return NAN;
+  }
+}
+
+[[nodiscard]] std::optional<int> ParamValue::get_int() const {
+  if (std::get_if<uint32_t>(&_value)) {
+	return static_cast<int>(std::get<uint32_t>(_value));
+  } else if (std::get_if<int32_t>(&_value)) {
+	return static_cast<int>(std::get<int32_t>(_value));
+  } else if (std::get_if<uint16_t>(&_value)) {
+	return static_cast<int>(std::get<uint16_t>(_value));
+  } else if (std::get_if<int16_t>(&_value)) {
+	return static_cast<int>(std::get<int16_t>(_value));
+  } else if (std::get_if<uint8_t>(&_value)) {
+	return static_cast<int>(std::get<uint8_t>(_value));
+  } else if (std::get_if<int8_t>(&_value)) {
+	return static_cast<int>(std::get<int8_t>(_value));
+  } else {
+	LogErr() << "Not int type";
+	return {};
+  }
+}
+
+bool ParamValue::set_int(int new_value) {
+  if (std::get_if<uint8_t>(&_value)) {
+	_value = static_cast<uint8_t>(new_value);
+	return true;
+  } else if (std::get_if<int8_t>(&_value)) {
+	_value = static_cast<int8_t>(new_value);
+	return true;
+  } else if (std::get_if<uint16_t>(&_value)) {
+	_value = static_cast<uint16_t>(new_value);
+	return true;
+  } else if (std::get_if<int16_t>(&_value)) {
+	_value = static_cast<int16_t>(new_value);
+	return true;
+  } else if (std::get_if<uint32_t>(&_value)) {
+	_value = static_cast<uint32_t>(new_value);
+	return true;
+  } else if (std::get_if<int32_t>(&_value)) {
+	_value = static_cast<int32_t>(new_value);
+	return true;
+  } else {
+	return false;
+  }
+}
+
+void ParamValue::set_float(float new_value) {
+  _value = new_value;
+}
+
+void ParamValue::set_custom(const std::string &new_value) {
+  _value = new_value;
+}
+
+[[nodiscard]] std::optional<float> ParamValue::get_float() const {
+  if (std::get_if<float>(&_value)) {
+	return std::get<float>(_value);
+  } else {
+	LogErr() << "Not float type";
+	return {};
+  }
+}
+
+[[nodiscard]] std::optional<std::string> ParamValue::get_custom() const {
+  if (std::get_if<std::string>(&_value)) {
+	return std::get<std::string>(_value);
+  } else {
+	LogErr() << "Not custom type";
+	return {};
+  }
+}
+
+std::array<char, 128> ParamValue::get_128_bytes() const {
+  std::array<char, 128> bytes{};
+
+  if (std::get_if<uint8_t>(&_value)) {
+	memcpy(bytes.data(), &std::get<uint8_t>(_value), sizeof(uint8_t));
+  } else if (std::get_if<int8_t>(&_value)) {
+	memcpy(bytes.data(), &std::get<int8_t>(_value), sizeof(int8_t));
+  } else if (std::get_if<uint16_t>(&_value)) {
+	memcpy(bytes.data(), &std::get<uint16_t>(_value), sizeof(uint16_t));
+  } else if (std::get_if<int16_t>(&_value)) {
+	memcpy(bytes.data(), &std::get<int16_t>(_value), sizeof(int16_t));
+  } else if (std::get_if<uint32_t>(&_value)) {
+	memcpy(bytes.data(), &std::get<uint32_t>(_value), sizeof(uint32_t));
+  } else if (std::get_if<int32_t>(&_value)) {
+	memcpy(bytes.data(), &std::get<int32_t>(_value), sizeof(int32_t));
+  } else if (std::get_if<uint64_t>(&_value)) {
+	memcpy(bytes.data(), &std::get<uint64_t>(_value), sizeof(uint64_t));
+  } else if (std::get_if<int64_t>(&_value)) {
+	memcpy(bytes.data(), &std::get<int64_t>(_value), sizeof(int64_t));
+  } else if (std::get_if<float>(&_value)) {
+	memcpy(bytes.data(), &std::get<float>(_value), sizeof(float));
+  } else if (std::get_if<double>(&_value)) {
+	memcpy(bytes.data(), &std::get<double>(_value), sizeof(double));
+  } else if (std::get_if<std::string>(&_value)) {
+	auto str_ptr = &std::get<std::string>(_value);
+	// Copy all data in string, max 128 bytes
+	memcpy(bytes.data(), str_ptr->data(), std::min(bytes.size(), str_ptr->size()));
+  } else {
+	LogErr() << "Unknown type";
+	assert(false);
+  }
+
+  return bytes;
+}
+
+[[nodiscard]] std::string ParamValue::get_string() const {
+  return std::visit([](auto value) { return to_string(value); }, _value);
+}
+
+[[nodiscard]] bool ParamValue::is_same_type(const ParamValue &rhs) const {
+  if ((std::get_if<uint8_t>(&_value) && std::get_if<uint8_t>(&rhs._value)) ||
+	  (std::get_if<int8_t>(&_value) && std::get_if<int8_t>(&rhs._value)) ||
+	  (std::get_if<uint16_t>(&_value) && std::get_if<uint16_t>(&rhs._value)) ||
+	  (std::get_if<int16_t>(&_value) && std::get_if<int16_t>(&rhs._value)) ||
+	  (std::get_if<uint32_t>(&_value) && std::get_if<uint32_t>(&rhs._value)) ||
+	  (std::get_if<int32_t>(&_value) && std::get_if<int32_t>(&rhs._value)) ||
+	  (std::get_if<uint64_t>(&_value) && std::get_if<uint64_t>(&rhs._value)) ||
+	  (std::get_if<int64_t>(&_value) && std::get_if<int64_t>(&rhs._value)) ||
+	  (std::get_if<float>(&_value) && std::get_if<float>(&rhs._value)) ||
+	  (std::get_if<double>(&_value) && std::get_if<double>(&rhs._value)) ||
+	  (std::get_if<std::string>(&_value) && std::get_if<std::string>(&rhs._value))) {
+	return true;
+  } else {
+	LogWarn() << "Comparison type mismatch between " << typestr() << " and " << rhs.typestr();
+	return false;
+  }
+}
+
+bool ParamValue::operator==(const std::string &value_str) const {
+  // LogDebug() << "Compare " << value_str() << " and " << rhs.value_str();
+  if (std::get_if<uint8_t>(&_value)) {
+	return std::get<uint8_t>(_value) == std::stoi(value_str);
+  } else if (std::get_if<int8_t>(&_value)) {
+	return std::get<int8_t>(_value) == std::stoi(value_str);
+  } else if (std::get_if<uint16_t>(&_value)) {
+	return std::get<uint16_t>(_value) == std::stoi(value_str);
+  } else if (std::get_if<int16_t>(&_value)) {
+	return std::get<int16_t>(_value) == std::stoi(value_str);
+  } else if (std::get_if<uint32_t>(&_value)) {
+	return std::get<uint32_t>(_value) == std::stoul(value_str);
+  } else if (std::get_if<int32_t>(&_value)) {
+	return std::get<int32_t>(_value) == std::stol(value_str);
+  } else if (std::get_if<uint64_t>(&_value)) {
+	return std::get<uint64_t>(_value) == std::stoull(value_str);
+  } else if (std::get_if<int64_t>(&_value)) {
+	return std::get<int64_t>(_value) == std::stoll(value_str);
+  } else if (std::get_if<float>(&_value)) {
+	return std::get<float>(_value) == std::stof(value_str);
+  } else if (std::get_if<double>(&_value)) {
+	return std::get<double>(_value) == std::stod(value_str);
+  } else {
+	// This also covers custom_type_t
+	return false;
+  }
+}
+
+[[nodiscard]] std::string ParamValue::typestr() const {
+  if (std::get_if<uint8_t>(&_value)) {
+	return "uint8_t";
+  } else if (std::get_if<int8_t>(&_value)) {
+	return "int8_t";
+  } else if (std::get_if<uint16_t>(&_value)) {
+	return "uint16_t";
+  } else if (std::get_if<int16_t>(&_value)) {
+	return "int16_t";
+  } else if (std::get_if<uint32_t>(&_value)) {
+	return "uint32_t";
+  } else if (std::get_if<int32_t>(&_value)) {
+	return "int32_t";
+  } else if (std::get_if<uint64_t>(&_value)) {
+	return "uint64_t";
+  } else if (std::get_if<int64_t>(&_value)) {
+	return "int64_t";
+  } else if (std::get_if<float>(&_value)) {
+	return "float";
+  } else if (std::get_if<double>(&_value)) {
+	return "double";
+  } else if (std::get_if<std::string>(&_value)) {
+	return "custom";
+  }
+  // FIXME: Added to fix CI error (control reading end of non-void function)
+  return "unknown";
+}
+
+std::ostream& operator<<(std::ostream& strm, const parameters::ParamValue& obj)
+{
+  strm << obj.get_string();
+  return strm;
+}
+
+}
+}

--- a/src/mavsdk/core/mavlink_param_value.cpp
+++ b/src/mavsdk/core/mavlink_param_value.cpp
@@ -224,10 +224,7 @@ bool ParamValue::set_from_mavlink_param_value_cast(
 
 bool ParamValue::set_from_mavlink_param_set_bytewise(
 	const mavlink_param_set_t &mavlink_set) {
-  mavlink_param_value_t mavlink_value{};
-  mavlink_value.param_value = mavlink_set.param_value;
-  mavlink_value.param_type = mavlink_set.param_type;
-  return set_from_mavlink_param_value_bytewise(mavlink_value);
+  return set_from_mavlink_param_type_bytewise(static_cast<MAV_PARAM_TYPE>(mavlink_set.param_type),mavlink_set.param_value);
 }
 
 bool ParamValue::set_from_mavlink_param_ext_set(

--- a/src/mavsdk/core/mavlink_param_value.cpp
+++ b/src/mavsdk/core/mavlink_param_value.cpp
@@ -14,6 +14,7 @@ namespace parameters {
 
 bool ParamValue::set_from_mavlink_param_value_bytewise(
 	const mavlink_param_value_t &mavlink_value) {
+  log_if_type_is_different(static_cast<MAV_PARAM_TYPE>(mavlink_value.param_type));
   switch (mavlink_value.param_type) {
 	case MAV_PARAM_TYPE_UINT8: {
 	  uint8_t temp;
@@ -73,6 +74,7 @@ bool ParamValue::set_from_mavlink_param_value_bytewise(
 
 bool ParamValue::set_from_mavlink_param_value_cast(
 	const mavlink_param_value_t &mavlink_value) {
+  log_if_type_is_different(static_cast<MAV_PARAM_TYPE>(mavlink_value.param_type));
   switch (mavlink_value.param_type) {
 	case MAV_PARAM_TYPE_UINT8: {
 	  _value = static_cast<uint8_t>(mavlink_value.param_value);
@@ -124,12 +126,12 @@ bool ParamValue::set_from_mavlink_param_set_bytewise(
   mavlink_param_value_t mavlink_value{};
   mavlink_value.param_value = mavlink_set.param_value;
   mavlink_value.param_type = mavlink_set.param_type;
-
   return set_from_mavlink_param_value_bytewise(mavlink_value);
 }
 
 bool ParamValue::set_from_mavlink_param_ext_set(
 	const mavlink_param_ext_set_t &mavlink_ext_set) {
+  log_if_type_is_different_ext(static_cast<MAV_PARAM_EXT_TYPE>(mavlink_ext_set.param_type));
   switch (mavlink_ext_set.param_type) {
 	case MAV_PARAM_EXT_TYPE_UINT8: {
 	  uint8_t temp;
@@ -208,6 +210,7 @@ bool ParamValue::set_from_mavlink_param_ext_set(
 // FIXME: this function can collapse with the one above.
 bool ParamValue::set_from_mavlink_param_ext_value(
 	const mavlink_param_ext_value_t &mavlink_ext_value) {
+  log_if_type_is_different_ext(static_cast<MAV_PARAM_EXT_TYPE>(mavlink_ext_value.param_type));
   switch (mavlink_ext_value.param_type) {
 	case MAV_PARAM_EXT_TYPE_UINT8: {
 	  uint8_t temp;
@@ -648,6 +651,20 @@ std::ostream& operator<<(std::ostream& strm, const parameters::ParamValue& obj)
 {
   strm << obj.get_string();
   return strm;
+}
+
+void ParamValue::log_if_type_is_different(MAV_PARAM_TYPE newType)const{
+  const auto current_type=get_mav_param_type();
+  if(newType!=current_type){
+	LogDebug()<<"Changing data type from "<<current_type<<" to "<<newType;
+  }
+}
+
+void ParamValue::log_if_type_is_different_ext(MAV_PARAM_EXT_TYPE newType)const{
+  const auto current_type_ext=get_mav_param_ext_type();
+  if(newType!=current_type_ext){
+	LogDebug()<<"Changing data type (ext) from "<<current_type_ext<<" to "<<newType;
+  }
 }
 
 }

--- a/src/mavsdk/core/mavlink_param_value.cpp
+++ b/src/mavsdk/core/mavlink_param_value.cpp
@@ -4,8 +4,6 @@
 
 #include "mavlink_param_value.h"
 
-#include "mavlink_message_handler.h"
-#include "timeout_handler.h"
 #include "system_impl.h"
 #include <algorithm>
 #include <cstring>

--- a/src/mavsdk/core/mavlink_param_value.cpp
+++ b/src/mavsdk/core/mavlink_param_value.cpp
@@ -623,5 +623,13 @@ void ParamValue::log_if_type_is_different_ext(MAV_PARAM_EXT_TYPE newType)const{
   }
 }
 
+/*template<class T> bool ParamValue::is_same_type_x()const
+{
+    if (std::holds_alternative<T>(_value)) {
+        return true;
+    }
+    return false;
+}*/
+
 }
 }

--- a/src/mavsdk/core/mavlink_param_value.h
+++ b/src/mavsdk/core/mavlink_param_value.h
@@ -100,6 +100,15 @@ class ParamValue {
 
   [[nodiscard]] bool is_same_type(const ParamValue &rhs) const;
 
+  // Note: the implementation here needs to stay in the header,unfortunately.
+  template<class T>
+  [[nodiscard]] bool is_same_type_x()const{
+      if (std::holds_alternative<T>(_value)) {
+          return true;
+      }
+      return false;
+  }
+
   bool operator==(const ParamValue &rhs) const {
 	if (!is_same_type(rhs)) {
 	  LogWarn() << "Trying to compare different types.";

--- a/src/mavsdk/core/mavlink_param_value.h
+++ b/src/mavsdk/core/mavlink_param_value.h
@@ -68,7 +68,8 @@ class ParamValue {
   [[nodiscard]] MAV_PARAM_TYPE get_mav_param_type() const;
   [[nodiscard]] MAV_PARAM_EXT_TYPE get_mav_param_ext_type() const;
 
-  // WARNING, this mutates the internally stored type
+  // This parses the given value string into the type that is currently stored.
+  // It does not mutate the internal type
   bool set_as_same_type(const std::string &value_str);
 
   [[nodiscard]] float get_4_float_bytes_bytewise() const;

--- a/src/mavsdk/core/mavlink_param_value.h
+++ b/src/mavsdk/core/mavlink_param_value.h
@@ -34,6 +34,9 @@ namespace parameters {
  */
 class ParamValue {
  public:
+  // These set_xxx are convenient ways to change the value (parameter) by using the
+  // different mavlink message payload's of the extended and non-extended protocol.
+  // TODO I think r.n it is possible they mutate the type, should that be allowed ?
   bool set_from_mavlink_param_value_bytewise(const mavlink_param_value_t &mavlink_value);
   bool set_from_mavlink_param_value_cast(const mavlink_param_value_t &mavlink_value);
   bool set_from_mavlink_param_set_bytewise(const mavlink_param_set_t &mavlink_set);
@@ -42,9 +45,11 @@ class ParamValue {
   bool set_from_xml(const std::string &type_str, const std::string &value_str);
   bool set_empty_type_from_xml(const std::string &type_str);
 
+  // These return the proper mavlink parameter type for the current generic type of the stored parameter.
   [[nodiscard]] MAV_PARAM_TYPE get_mav_param_type() const;
   [[nodiscard]] MAV_PARAM_EXT_TYPE get_mav_param_ext_type() const;
 
+  // WARNING, this mutates the internally stored type
   bool set_as_same_type(const std::string &value_str);
 
   [[nodiscard]] float get_4_float_bytes_bytewise() const;
@@ -114,6 +119,9 @@ class ParamValue {
   }
   friend std::ostream& operator<<(std::ostream&, const parameters::ParamValue&);
  private:
+  // Log a warning if the internal data type is different than the new one provded.
+  void log_if_type_is_different(MAV_PARAM_TYPE newType)const;
+  void log_if_type_is_different_ext(MAV_PARAM_EXT_TYPE newType)const;
   std::variant<
 	  uint8_t,
 	  int8_t,
@@ -125,7 +133,7 @@ class ParamValue {
 	  int64_t,
 	  float,
 	  double,
-	  std::string>
+	  std::string> // Note: std::string is only supported on extended parameters protocol
 	  _value{};
 };
 

--- a/src/mavsdk/core/mavlink_param_value.h
+++ b/src/mavsdk/core/mavlink_param_value.h
@@ -5,11 +5,8 @@
 #ifndef MAVSDK_SRC_MAVSDK_CORE_MAVLINK_PARAM_VALUE_H_
 #define MAVSDK_SRC_MAVSDK_CORE_MAVLINK_PARAM_VALUE_H_
 
-#include "log.h"
 #include "mavlink_include.h"
-#include "mavlink_param_value.h"
-#include "timeout_s_callback.h"
-#include "locked_queue.h"
+#include "log.h"
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -17,7 +14,6 @@
 #include <functional>
 #include <cassert>
 #include <vector>
-#include <map>
 #include <optional>
 #include <variant>
 
@@ -110,6 +106,14 @@ class ParamValue {
 
   [[nodiscard]] std::string typestr() const;
 
+  // Consti10: hacky, returns true if this parameter needs the extended parameters' protocol
+  // (which is the case when its value is represented by a string)
+  bool needs_extended() const {
+	// true if it is a string, false otherwise.
+	return is<std::string>();
+  }
+  friend std::ostream& operator<<(std::ostream&, const parameters::ParamValue&);
+ private:
   std::variant<
 	  uint8_t,
 	  int8_t,
@@ -123,14 +127,6 @@ class ParamValue {
 	  double,
 	  std::string>
 	  _value{};
-
-  // Consti10: hacky, returns true if this parameter needs the extended parameters' protocol
-  // (which is the case when its value is represented by a string)
-  bool needs_extended() const {
-	// true if it is a string, false otherwise.
-	return is<std::string>();
-  }
-  friend std::ostream& operator<<(std::ostream&, const parameters::ParamValue&);
 };
 
 }

--- a/src/mavsdk/core/mavlink_param_value.h
+++ b/src/mavsdk/core/mavlink_param_value.h
@@ -1,0 +1,139 @@
+//
+// Created by consti10 on 17.06.22.
+//
+
+#ifndef MAVSDK_SRC_MAVSDK_CORE_MAVLINK_PARAM_VALUE_H_
+#define MAVSDK_SRC_MAVSDK_CORE_MAVLINK_PARAM_VALUE_H_
+
+#include "log.h"
+#include "mavlink_include.h"
+#include "mavlink_param_value.h"
+#include "timeout_s_callback.h"
+#include "locked_queue.h"
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <functional>
+#include <cassert>
+#include <vector>
+#include <map>
+#include <optional>
+#include <variant>
+
+namespace mavsdk {
+namespace parameters {
+
+/**
+ * This class wraps a mavlink extended or non-extended parameter value.
+ * For now, it has just been refactored out of mavlink_parameters.h for better readability.
+ * In general, I think this class should expose the following behaviour:
+ * While the parameter value can change (e.g. a set changes the internally hold value)
+ * the type of the internal value can never change.
+ *
+ * For example, it is possible to change an
+ * int=0 to int=1 but it is NOT POSSIBLE to change an int=0 to a float=1.0.
+ *
+ * Maybe we can do that compiler type safe in c++, but I am not sure.
+ */
+class ParamValue {
+ public:
+  bool set_from_mavlink_param_value_bytewise(const mavlink_param_value_t &mavlink_value);
+  bool set_from_mavlink_param_value_cast(const mavlink_param_value_t &mavlink_value);
+  bool set_from_mavlink_param_set_bytewise(const mavlink_param_set_t &mavlink_set);
+  bool set_from_mavlink_param_ext_set(const mavlink_param_ext_set_t &mavlink_ext_set);
+  bool set_from_mavlink_param_ext_value(const mavlink_param_ext_value_t &mavlink_ext_value);
+  bool set_from_xml(const std::string &type_str, const std::string &value_str);
+  bool set_empty_type_from_xml(const std::string &type_str);
+
+  [[nodiscard]] MAV_PARAM_TYPE get_mav_param_type() const;
+  [[nodiscard]] MAV_PARAM_EXT_TYPE get_mav_param_ext_type() const;
+
+  bool set_as_same_type(const std::string &value_str);
+
+  [[nodiscard]] float get_4_float_bytes_bytewise() const;
+  [[nodiscard]] float get_4_float_bytes_cast() const;
+
+  [[nodiscard]] std::optional<int> get_int() const;
+  [[nodiscard]] std::optional<float> get_float() const;
+  [[nodiscard]] std::optional<std::string> get_custom() const;
+
+  bool set_int(int new_value);
+  void set_float(float new_value);
+  void set_custom(const std::string &new_value);
+
+  std::array<char, 128> get_128_bytes() const;
+
+  [[nodiscard]] std::string get_string() const;
+
+  template<typename T>
+  [[nodiscard]] bool is() const {
+	return (std::get_if<T>(&_value) != nullptr);
+  }
+
+  template<typename T>
+  T get() const { return std::get<T>(_value); }
+
+  template<typename T>
+  void set(T new_value) { _value = new_value; }
+
+  [[nodiscard]] bool is_same_type(const ParamValue &rhs) const;
+
+  bool operator==(const ParamValue &rhs) const {
+	if (!is_same_type(rhs)) {
+	  LogWarn() << "Trying to compare different types.";
+	  return false;
+	}
+
+	return _value == rhs._value;
+  }
+
+  bool operator<(const ParamValue &rhs) const {
+	if (!is_same_type(rhs)) {
+	  LogWarn() << "Trying to compare different types.";
+	  return false;
+	}
+
+	return _value < rhs._value;
+  }
+
+  bool operator>(const ParamValue &rhs) const {
+	if (!is_same_type(rhs)) {
+	  LogWarn() << "Trying to compare different types.";
+	  return false;
+	}
+
+	return _value > rhs._value;
+  }
+
+  bool operator==(const std::string &value_str) const;
+
+  [[nodiscard]] std::string typestr() const;
+
+  std::variant<
+	  uint8_t,
+	  int8_t,
+	  uint16_t,
+	  int16_t,
+	  uint32_t,
+	  int32_t,
+	  uint64_t,
+	  int64_t,
+	  float,
+	  double,
+	  std::string>
+	  _value{};
+
+  // Consti10: hacky, returns true if this parameter needs the extended parameters' protocol
+  // (which is the case when its value is represented by a string)
+  bool needs_extended() const {
+	// true if it is a string, false otherwise.
+	return is<std::string>();
+  }
+  friend std::ostream& operator<<(std::ostream&, const parameters::ParamValue&);
+};
+
+}
+}
+
+#endif //MAVSDK_SRC_MAVSDK_CORE_MAVLINK_PARAM_VALUE_H_

--- a/src/mavsdk/core/mavlink_param_value.h
+++ b/src/mavsdk/core/mavlink_param_value.h
@@ -34,6 +34,25 @@ namespace parameters {
  */
 class ParamValue {
  public:
+  /**
+   * The mavlink parameters protocol uses a float to store the data type, but that doesn't mean the value is actually of type float
+   * (See https://mavlink.io/en/services/parameter.html#parameter-encoding).
+   * This method first logs a warning if the type of the internal value is not the expected @param mav_param_type, then updates the internal
+   * value by extracting the specified data type from @param param_value using byte-wise encoding.
+   * See https://mavlink.io/en/services/parameter.html#parameter-encoding for an explanation on byte-wise / c-style
+   */
+  bool set_from_mavlink_param_type_bytewise(MAV_PARAM_TYPE mav_param_type,float param_value);
+  /**
+   * Same as above, but uses value cast to extract the data type.
+   */
+  bool set_from_mavlink_param_type_value_cast(MAV_PARAM_TYPE mav_param_type,float param_value);
+
+  /**
+   * Same as above, but since the extended protocol only uses byte-wise encoding, we don't need
+   * two different flavours for it.
+   */
+  bool set_from_mavlink_param_type_ext(MAV_PARAM_EXT_TYPE mav_param_ext_type,const std::array<char, 128>& param_value);
+
   // These set_xxx are convenient ways to change the value (parameter) by using the
   // different mavlink message payload's of the extended and non-extended protocol.
   // TODO I think r.n it is possible they mutate the type, should that be allowed ?

--- a/src/mavsdk/core/mavlink_param_value.h
+++ b/src/mavsdk/core/mavlink_param_value.h
@@ -83,7 +83,7 @@ class ParamValue {
   void set_float(float new_value);
   void set_custom(const std::string &new_value);
 
-  std::array<char, 128> get_128_bytes() const;
+  [[nodiscard]] std::array<char, 128> get_128_bytes() const;
 
   [[nodiscard]] std::string get_string() const;
 
@@ -142,13 +142,13 @@ class ParamValue {
 
   // Consti10: hacky, returns true if this parameter needs the extended parameters' protocol
   // (which is the case when its value is represented by a string)
-  bool needs_extended() const {
+  [[nodiscard]] bool needs_extended() const {
 	// true if it is a string, false otherwise.
 	return is<std::string>();
   }
   friend std::ostream& operator<<(std::ostream&, const parameters::ParamValue&);
  private:
-  // Log a warning if the internal data type is different than the new one provded.
+  // Log a warning if the internal data type is different than the new one provided.
   void log_if_type_is_different(MAV_PARAM_TYPE newType)const;
   void log_if_type_is_different_ext(MAV_PARAM_EXT_TYPE newType)const;
   std::variant<

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -340,7 +340,7 @@ void MAVLinkParameters::get_param_async(
     std::optional<uint8_t> maybe_component_id,
     bool extended)
 {
-  	assert(!_is_server);
+    assert(!_is_server);
     if (_parameter_debugging) {
         LogDebug() << "getting param " << name << ", extended: " << (extended ? "yes" : "no");
     }

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -154,7 +154,7 @@ void MAVLinkParameters::set_param_async(
     std::optional<uint8_t> maybe_component_id,
     bool extended)
 {
-  	assert(!_is_server);
+    assert(!_is_server);
     if (name.size() > PARAM_ID_LEN) {
         LogErr() << "Error: param name too long";
         if (callback) {
@@ -162,9 +162,7 @@ void MAVLinkParameters::set_param_async(
         }
         return;
     }
-
     auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
-
     new_work->type = WorkItem::Type::Set;
     new_work->callback = callback;
     new_work->maybe_component_id = maybe_component_id;
@@ -184,7 +182,7 @@ void MAVLinkParameters::set_param_int_async(
     std::optional<uint8_t> maybe_component_id,
     bool extended)
 {
-  	assert(!_is_server);
+    assert(!_is_server);
     if (name.size() > PARAM_ID_LEN) {
         LogErr() << "Error: param name too long";
         if (callback) {
@@ -199,8 +197,7 @@ void MAVLinkParameters::set_param_int_async(
 
     const auto set_step = [=]() {
         auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
-
-	  	parameters::ParamValue value_to_set;
+        parameters::ParamValue value_to_set;
         value_to_set.set(value);
 
         new_work->type = WorkItem::Type::Set;
@@ -230,7 +227,7 @@ MAVLinkParameters::Result MAVLinkParameters::set_param_int(
     std::optional<uint8_t> maybe_component_id,
     bool extended)
 {
-  	assert(!_is_server);
+    assert(!_is_server);
     auto prom = std::promise<Result>();
     auto res = prom.get_future();
 
@@ -487,6 +484,7 @@ std::map<std::string, parameters::ParamValue> MAVLinkParameters::retrieve_all_se
 template<class T>
 std::pair<MAVLinkParameters::Result, T> MAVLinkParameters::retrieve_server_param(const std::string& name)
 {
+    std::lock_guard<std::mutex> lock(_all_params_mutex);
     if (_all_params.find(name) != _all_params.end()) {
         // This parameter exists, check its type
         const auto value = _all_params.at(name);

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -88,6 +88,7 @@ MAVLinkParameters::~MAVLinkParameters()
 MAVLinkParameters::Result
 MAVLinkParameters::provide_server_param_float(const std::string& name, float value)
 {
+  	assert(_is_server);
     if (name.size() > PARAM_ID_LEN) {
         LogErr() << "Error: param name too long";
         return Result::ParamNameTooLong;
@@ -102,6 +103,7 @@ MAVLinkParameters::provide_server_param_float(const std::string& name, float val
 MAVLinkParameters::Result
 MAVLinkParameters::provide_server_param_int(const std::string& name, int value)
 {
+  	assert(_is_server);
     if (name.size() > PARAM_ID_LEN) {
         LogErr() << "Error: param name too long";
         return Result::ParamNameTooLong;
@@ -116,6 +118,7 @@ MAVLinkParameters::provide_server_param_int(const std::string& name, int value)
 MAVLinkParameters::Result
 MAVLinkParameters::provide_server_param_custom(const std::string& name, const std::string& value)
 {
+  	assert(_is_server);
     if (name.size() > PARAM_ID_LEN) {
         LogErr() << "Error: param name too long";
         return Result::ParamNameTooLong;
@@ -135,10 +138,10 @@ MAVLinkParameters::provide_server_param_custom(const std::string& name, const st
 MAVLinkParameters::Result MAVLinkParameters::set_param(
     const std::string& name,
     ParamValue value,
-
     std::optional<uint8_t> maybe_component_id,
     bool extended)
 {
+  	assert(!_is_server);
     auto prom = std::promise<Result>();
     auto res = prom.get_future();
 
@@ -161,6 +164,7 @@ void MAVLinkParameters::set_param_async(
     std::optional<uint8_t> maybe_component_id,
     bool extended)
 {
+  	assert(!_is_server);
     if (name.size() > PARAM_ID_LEN) {
         LogErr() << "Error: param name too long";
         if (callback) {
@@ -190,6 +194,7 @@ void MAVLinkParameters::set_param_int_async(
     std::optional<uint8_t> maybe_component_id,
     bool extended)
 {
+  	assert(!_is_server);
     if (name.size() > PARAM_ID_LEN) {
         LogErr() << "Error: param name too long";
         if (callback) {
@@ -235,6 +240,7 @@ MAVLinkParameters::Result MAVLinkParameters::set_param_int(
     std::optional<uint8_t> maybe_component_id,
     bool extended)
 {
+  	assert(!_is_server);
     auto prom = std::promise<Result>();
     auto res = prom.get_future();
 
@@ -257,6 +263,7 @@ void MAVLinkParameters::set_param_float_async(
     std::optional<uint8_t> maybe_component_id,
     bool extended)
 {
+  	assert(!_is_server);
     if (name.size() > PARAM_ID_LEN) {
         LogErr() << "Error: param name too long";
         if (callback) {
@@ -284,6 +291,7 @@ void MAVLinkParameters::set_param_float_async(
 MAVLinkParameters::Result MAVLinkParameters::set_param_float(
     const std::string& name, float value, std::optional<uint8_t> maybe_component_id, bool extended)
 {
+  	assert(!_is_server);
     auto prom = std::promise<Result>();
     auto res = prom.get_future();
 
@@ -305,6 +313,7 @@ void MAVLinkParameters::get_param_float_async(
     std::optional<uint8_t> maybe_component_id,
     bool extended)
 {
+  	assert(!_is_server);
     if (_parameter_debugging) {
         LogDebug() << "getting param " << name << ", extended: " << (extended ? "yes" : "no");
     }
@@ -341,6 +350,7 @@ void MAVLinkParameters::get_param_async(
     std::optional<uint8_t> maybe_component_id,
     bool extended)
 {
+  	assert(!_is_server);
     if (_parameter_debugging) {
         LogDebug() << "getting param " << name << ", extended: " << (extended ? "yes" : "no");
     }
@@ -374,6 +384,7 @@ void MAVLinkParameters::get_param_int_async(
     std::optional<uint8_t> maybe_component_id,
     bool extended)
 {
+  	assert(!_is_server);
     if (_parameter_debugging) {
         LogDebug() << "getting param " << name << ", extended: " << (extended ? "yes" : "no");
     }
@@ -402,6 +413,7 @@ void MAVLinkParameters::get_param_int_async(
 MAVLinkParameters::Result
 MAVLinkParameters::set_param_custom(const std::string& name, const std::string& value)
 {
+  	assert(!_is_server);
     auto prom = std::promise<Result>();
     auto res = prom.get_future();
 
@@ -414,6 +426,7 @@ MAVLinkParameters::set_param_custom(const std::string& name, const std::string& 
 void MAVLinkParameters::get_param_custom_async(
     const std::string& name, const GetParamCustomCallback& callback, const void* cookie)
 {
+  	assert(!_is_server);
     if (_parameter_debugging) {
         LogDebug() << "getting param " << name;
     }

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -588,7 +588,7 @@ std::map<std::string, parameters::ParamValue> MAVLinkParameters::get_all_params(
 		// goes out of scope when the callback returns. So don't use a reference here, pass by value or refactor the code to use
 		// a std::shared_ptr.
         [&prom](std::map<std::string, parameters::ParamValue> all_params) {
-            prom.set_value(all_params);
+            prom.set_value(std::move(all_params));
         },use_extended);
     return res.get();
 }

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -170,11 +170,9 @@ void MAVLinkParameters::set_param_async(
         }
         return;
     }
-    auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
-    new_work->type = WorkItem::Type::Set;
+    auto new_work = std::make_shared<WorkItem>(WorkItem::Type::Set,name,_timeout_s_callback());
     new_work->callback = callback;
     new_work->maybe_component_id = maybe_component_id;
-    new_work->param_name = name;
     new_work->param_value = value;
     new_work->extended = extended;
     new_work->exact_type_known = true;
@@ -204,13 +202,10 @@ void MAVLinkParameters::set_param_int_async(
     const bool exact_int_type_known = (_sender.autopilot() == SystemImpl::Autopilot::Px4);
 
     const auto set_step = [=]() {
-        auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
+        auto new_work = std::make_shared<WorkItem>(WorkItem::Type::Set,name,_timeout_s_callback());
         parameters::ParamValue value_to_set;
         value_to_set.set(value);
-
-        new_work->type = WorkItem::Type::Set;
         new_work->callback = callback;
-        new_work->param_name = name;
         new_work->param_value = value_to_set;
         new_work->extended = extended;
         new_work->exact_type_known = exact_int_type_known;
@@ -267,15 +262,11 @@ void MAVLinkParameters::set_param_float_async(
         return;
     }
 
-    auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
-
-  	parameters::ParamValue value_to_set;
+    auto new_work = std::make_shared<WorkItem>(WorkItem::Type::Set,name,_timeout_s_callback());
+    parameters::ParamValue value_to_set;
     value_to_set.set_float(value);
-
-    new_work->type = WorkItem::Type::Set;
     new_work->callback = callback;
     new_work->maybe_component_id = maybe_component_id;
-    new_work->param_name = name;
     new_work->param_value = value_to_set;
     new_work->extended = extended;
     new_work->exact_type_known = true;
@@ -325,11 +316,9 @@ void MAVLinkParameters::get_param_float_async(
     value_type.set(NAN);
 
     // Otherwise, push work onto queue.
-    auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
-    new_work->type = WorkItem::Type::Get;
+    auto new_work = std::make_shared<WorkItem>(WorkItem::Type::Get,name,_timeout_s_callback());
     new_work->callback = callback;
     new_work->maybe_component_id = maybe_component_id;
-    new_work->param_name = name;
     new_work->param_value = value_type;
     new_work->extended = extended;
     new_work->cookie = cookie;
@@ -359,11 +348,9 @@ void MAVLinkParameters::get_param_async(
     }
 
     // Otherwise, push work onto queue.
-    auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
-    new_work->type = WorkItem::Type::Get;
+    auto new_work = std::make_shared<WorkItem>(WorkItem::Type::Get,name,_timeout_s_callback());
     new_work->callback = callback;
     new_work->maybe_component_id = maybe_component_id;
-    new_work->param_name = name;
     new_work->param_value = value;
     new_work->extended = extended;
     new_work->exact_type_known = true;
@@ -393,11 +380,9 @@ void MAVLinkParameters::get_param_int_async(
     }
 
     // Otherwise, push work onto queue.
-    auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
-    new_work->type = WorkItem::Type::Get;
+    auto new_work = std::make_shared<WorkItem>(WorkItem::Type::Get,name,_timeout_s_callback());
     new_work->callback = callback;
     new_work->maybe_component_id = maybe_component_id;
-    new_work->param_name = name;
     new_work->param_value = {};
     new_work->extended = extended;
     new_work->cookie = cookie;
@@ -435,10 +420,8 @@ void MAVLinkParameters::get_param_custom_async(
     }
 
     // Otherwise, push work onto queue.
-    auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
-    new_work->type = WorkItem::Type::Get;
+    auto new_work = std::make_shared<WorkItem>(WorkItem::Type::Get,name,_timeout_s_callback());
     new_work->callback = callback;
-    new_work->param_name = name;
     new_work->param_value.set_custom(std::string());
     new_work->extended = true;
     new_work->cookie = cookie;
@@ -469,14 +452,10 @@ void MAVLinkParameters::set_param_custom_async(
         return;
     }
 
-    auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
-
-  	parameters::ParamValue value_to_set;
+    auto new_work = std::make_shared<WorkItem>(WorkItem::Type::Set,name,_timeout_s_callback());
+    parameters::ParamValue value_to_set;
     value_to_set.set_custom(value);
-
-    new_work->type = WorkItem::Type::Set;
     new_work->callback = callback;
-    new_work->param_name = name;
     new_work->param_value = value_to_set;
     new_work->extended = true;
     new_work->exact_type_known = true;
@@ -1333,9 +1312,7 @@ void MAVLinkParameters::process_param_ext_set(const mavlink_message_t& message)
             _all_params[safe_param_id] = value;
         }
 
-        auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
-        new_work->type = WorkItem::Type::Ack;
-        new_work->param_name = safe_param_id;
+        auto new_work = std::make_shared<WorkItem>(WorkItem::Type::Ack,safe_param_id,_timeout_s_callback());
         new_work->param_value = _all_params[safe_param_id];
         new_work->extended = true;
         _work_queue.push_back(new_work);
@@ -1502,9 +1479,7 @@ void MAVLinkParameters::process_param_set(const mavlink_message_t& message)
             LogDebug() << "Changing param from " << _all_params[safe_param_id] << " to " << value;
             _all_params[safe_param_id] = value;
 
-            auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
-            new_work->type = WorkItem::Type::Value;
-            new_work->param_name = safe_param_id;
+            auto new_work = std::make_shared<WorkItem>(WorkItem::Type::Value,safe_param_id,_timeout_s_callback());
             new_work->param_value = _all_params.at(safe_param_id);
             new_work->extended = false;
             _work_queue.push_back(new_work);
@@ -1562,9 +1537,7 @@ void MAVLinkParameters::process_param_request_read(const mavlink_message_t& mess
 			  LogDebug()<<"Not forwarding param"<<safe_param_id<<" since it needs extended";
 			  return;
 			}
-            auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
-            new_work->type = WorkItem::Type::Value;
-            new_work->param_name = safe_param_id;
+            auto new_work = std::make_shared<WorkItem>(WorkItem::Type::Value,safe_param_id,_timeout_s_callback());
             new_work->param_value = _all_params.at(safe_param_id);
             new_work->extended = false;
             _work_queue.push_back(new_work);
@@ -1586,9 +1559,7 @@ void MAVLinkParameters::process_param_request_list(const mavlink_message_t& mess
 		  LogDebug()<<"Not forwarding param"<<pair.first<<" since it needs extended";
 		  continue;
 		}
-        auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
-        new_work->type = WorkItem::Type::Value;
-        new_work->param_name = pair.first;
+        auto new_work = std::make_shared<WorkItem>(WorkItem::Type::Value,pair.first,_timeout_s_callback());
         new_work->param_value = pair.second;
         new_work->extended = false;
 		// Consti10 - the count of parameters when queried from a non-ext perspective is different, since we need to hide the parameters
@@ -1606,9 +1577,7 @@ void MAVLinkParameters::process_param_ext_request_list(const mavlink_message_t& 
   mavlink_msg_param_ext_request_list_decode(&message, &ext_list_request);
   int idx=0;
   for (const auto& pair : _all_params) {
-	auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
-	new_work->type = WorkItem::Type::Value;
-	new_work->param_name = pair.first;
+	auto new_work = std::make_shared<WorkItem>(WorkItem::Type::Value,pair.first,_timeout_s_callback());
 	new_work->param_value = pair.second;
 	new_work->extended = true;
 	new_work->param_count = get_current_parameters_count(true);
@@ -1627,9 +1596,7 @@ void MAVLinkParameters::process_param_ext_request_read(const mavlink_message_t& 
         LogDebug() << "Request Param " << safe_param_id;
         // Use the ID
         if (_all_params.find(safe_param_id) != _all_params.end()) {
-            auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
-            new_work->type = WorkItem::Type::Value;
-            new_work->param_name = safe_param_id;
+            auto new_work = std::make_shared<WorkItem>(WorkItem::Type::Value,safe_param_id,_timeout_s_callback());
             new_work->param_value = _all_params.at(safe_param_id);
             new_work->extended = true;
             _work_queue.push_back(new_work);

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -1646,8 +1646,6 @@ void MAVLinkParameters::process_param_ext_request_read(const mavlink_message_t& 
     }
 }
 
-
-
 std::ostream& operator<<(std::ostream& str, const MAVLinkParameters::Result& result)
 {
     switch (result) {

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -353,7 +353,7 @@ void MAVLinkParameters::get_param_async(
     if (name.size() > PARAM_ID_LEN) {
         LogErr() << "Error: param name too long";
         if (callback) {
-            callback(Result::ParamNameTooLong, ParamValue{});
+            callback(Result::ParamNameTooLong, {});
         }
         return;
     }
@@ -441,18 +441,6 @@ void MAVLinkParameters::get_param_int_async(
 void MAVLinkParameters::get_param_custom_async(
     const std::string& name, const GetParamCustomCallback& callback, const void* cookie,std::optional<uint8_t> maybe_component_id)
 {
-    assert(!_is_server);
-    if (_parameter_debugging) {
-        LogDebug() << "getting param " << name;
-    }
-
-    if (name.size() > PARAM_ID_LEN) {
-        LogErr() << "Error: param name too long";
-        if (callback) {
-            callback(MAVLinkParameters::Result::ParamNameTooLong, 0);
-        }
-        return;
-    }
     get_param_async_typesafe<std::string>(name,callback,cookie,maybe_component_id,true);
 }
 

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -93,6 +93,14 @@ MAVLinkParameters::provide_server_param(const std::string& name,ParamValue param
         return Result::ParamNameTooLong;
     }
     std::lock_guard<std::mutex> lock(_all_params_mutex);
+    // TODO: should we make these undefined / error cases errors ?
+    if(_all_params.find(name) != _all_params.end()){
+        LogDebug()<<" Providing same parameter twice:"<<name;
+        const auto curr_value = _all_params.at(name);
+        if(!curr_value.is_same_type(param_value)){
+            LogDebug()<<"WARNING Changing type of parameter "<<name<<" from "<<curr_value.typestr()<<" to "<<param_value.typestr();
+        }
+    }
     _all_params.insert_or_assign(name, param_value);
     return Result::Success;
 }

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -605,14 +605,14 @@ void MAVLinkParameters::get_all_params_async(const GetAllParamsCallback& callbac
     _all_params_callback = callback;
     mavlink_message_t msg;
 	if(use_extended){
-	  mavlink_msg_param_request_list_pack(
+	  mavlink_msg_param_ext_request_list_pack(
 		  _sender.get_own_system_id(),
 		  _sender.get_own_component_id(),
 		  &msg,
 		  _sender.get_system_id(),
 		  MAV_COMP_ID_AUTOPILOT1); // FIXME: what should the component be?
 	}else{
-	  mavlink_msg_param_ext_request_list_pack(
+	  mavlink_msg_param_request_list_pack(
 		  _sender.get_own_system_id(),
 		  _sender.get_own_component_id(),
 		  &msg,

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -7,6 +7,7 @@
 #include <future>
 
 namespace mavsdk {
+using namespace parameters;
 
 MAVLinkParameters::MAVLinkParameters(
     Sender& sender,
@@ -67,6 +68,10 @@ MAVLinkParameters::MAVLinkParameters(
             MAVLINK_MSG_ID_PARAM_REQUEST_LIST,
             [this](const mavlink_message_t& message) { process_param_request_list(message); },
             this);
+		_message_handler.register_one(
+			MAVLINK_MSG_ID_PARAM_EXT_REQUEST_LIST,
+			[this](const mavlink_message_t& message) { process_param_ext_request_list(message); },
+			this);
 
         _message_handler.register_one(
             MAVLINK_MSG_ID_PARAM_EXT_REQUEST_READ,
@@ -200,7 +205,7 @@ void MAVLinkParameters::set_param_int_async(
     const auto set_step = [=]() {
         auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
 
-        MAVLinkParameters::ParamValue value_to_set;
+	  	parameters::ParamValue value_to_set;
         value_to_set.set(value);
 
         new_work->type = WorkItem::Type::Set;
@@ -262,7 +267,7 @@ void MAVLinkParameters::set_param_float_async(
 
     auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
 
-    MAVLinkParameters::ParamValue value_to_set;
+  	parameters::ParamValue value_to_set;
     value_to_set.set_float(value);
 
     new_work->type = WorkItem::Type::Set;
@@ -457,7 +462,7 @@ void MAVLinkParameters::set_param_custom_async(
 
     auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
 
-    MAVLinkParameters::ParamValue value_to_set;
+  	parameters::ParamValue value_to_set;
     value_to_set.set_custom(value);
 
     new_work->type = WorkItem::Type::Set;
@@ -470,13 +475,13 @@ void MAVLinkParameters::set_param_custom_async(
     _work_queue.push_back(new_work);
 }
 
-std::map<std::string, MAVLinkParameters::ParamValue> MAVLinkParameters::retrieve_all_server_params()
+std::map<std::string, parameters::ParamValue> MAVLinkParameters::retrieve_all_server_params()
 {
     std::lock_guard<std::mutex> lock(_all_params_mutex);
     return _all_params;
 }
 
-std::pair<MAVLinkParameters::Result, MAVLinkParameters::ParamValue>
+std::pair<MAVLinkParameters::Result, parameters::ParamValue>
 MAVLinkParameters::retrieve_server_param(const std::string& name, ParamValue value_type)
 {
     if (_all_params.find(name) != _all_params.end()) {
@@ -528,8 +533,8 @@ MAVLinkParameters::retrieve_server_param_int(const std::string& name)
     return {MAVLinkParameters::Result::NotFound, {}};
 }
 
-std::pair<MAVLinkParameters::Result, MAVLinkParameters::ParamValue> MAVLinkParameters::get_param(
-    const std::string& name, MAVLinkParameters::ParamValue value, bool extended)
+std::pair<MAVLinkParameters::Result, parameters::ParamValue> MAVLinkParameters::get_param(
+    const std::string& name, parameters::ParamValue value, bool extended)
 {
     auto prom = std::promise<std::pair<Result, ParamValue>>();
     auto res = prom.get_future();
@@ -594,31 +599,38 @@ MAVLinkParameters::get_param_custom(const std::string& name)
     return res.get();
 }
 
-void MAVLinkParameters::get_all_params_async(const GetAllParamsCallback& callback)
+void MAVLinkParameters::get_all_params_async(const GetAllParamsCallback& callback,const bool use_extended)
 {
     std::lock_guard<std::mutex> lock(_all_params_mutex);
-
     _all_params_callback = callback;
-
     mavlink_message_t msg;
-
-    mavlink_msg_param_request_list_pack(
-        _sender.get_own_system_id(),
-        _sender.get_own_component_id(),
-        &msg,
-        _sender.get_system_id(),
-        MAV_COMP_ID_AUTOPILOT1); // FIXME: what should the component be?
-
+	if(use_extended){
+	  mavlink_msg_param_request_list_pack(
+		  _sender.get_own_system_id(),
+		  _sender.get_own_component_id(),
+		  &msg,
+		  _sender.get_system_id(),
+		  MAV_COMP_ID_AUTOPILOT1); // FIXME: what should the component be?
+	}else{
+	  mavlink_msg_param_ext_request_list_pack(
+		  _sender.get_own_system_id(),
+		  _sender.get_own_component_id(),
+		  &msg,
+		  _sender.get_system_id(),
+		  MAV_COMP_ID_AUTOPILOT1); // FIXME: what should the component be?
+	}
     if (!_sender.send_message(msg)) {
         LogErr() << "Failed to send param list request!";
         callback(std::map<std::string, ParamValue>{});
     }
-
+	// There are 2 possible cases - we get all the messages in time - in this case, the
+	// _all_params_callback member is called. Otherwise, we get a timeout at some point, which then calls
+	// the _all_params_callback member with an empty result.
     _timeout_handler.add(
         [this] { receive_timeout(); }, _timeout_s_callback(), &_all_params_timeout_cookie);
 }
 
-std::map<std::string, MAVLinkParameters::ParamValue> MAVLinkParameters::get_all_params()
+std::map<std::string, parameters::ParamValue> MAVLinkParameters::get_all_params(const bool use_extended)
 {
     std::promise<std::map<std::string, ParamValue>> prom;
     auto res = prom.get_future();
@@ -628,9 +640,9 @@ std::map<std::string, MAVLinkParameters::ParamValue> MAVLinkParameters::get_all_
 		// Since for example on a receive timeout, the empty all_params result is constructed in-place and then
 		// goes out of scope when the callback returns. So don't use a reference here, pass by value or refactor the code to use
 		// a std::shared_ptr.
-        [&prom](std::map<std::string, MAVLinkParameters::ParamValue> all_params) {
+        [&prom](std::map<std::string, parameters::ParamValue> all_params) {
             prom.set_value(all_params);
-        });
+        },use_extended);
     return res.get();
 }
 
@@ -988,7 +1000,7 @@ void MAVLinkParameters::process_param_value(const mavlink_message_t& message)
         received_value.set_from_mavlink_param_value_bytewise(param_value);
     }
 
-    std::string param_id = extract_safe_param_id(param_value.param_id);
+    const std::string param_id = extract_safe_param_id(param_value.param_id);
 
     {
         std::lock_guard<std::mutex> lock(_all_params_mutex);
@@ -1318,7 +1330,7 @@ void MAVLinkParameters::process_param_ext_set(const mavlink_message_t& message)
         {
             // Use the ID
             std::lock_guard<std::mutex> lock(_all_params_mutex);
-            ParamValue value{};
+		  	parameters::ParamValue value{};
             if (!value.set_from_mavlink_param_ext_set(set_request)) {
                 LogWarn() << "Invalid Param Ext Set Request: " << safe_param_id;
                 return;
@@ -1379,7 +1391,7 @@ void MAVLinkParameters::receive_timeout()
 
     switch (work->type) {
         case WorkItem::Type::Get: {
-            ParamValue empty_value;
+		  	parameters::ParamValue empty_value;
             if (work->retries_to_do > 0) {
                 // We're not sure the command arrived, let's retransmit.
                 LogWarn() << "sending again, retries to do: " << work->retries_to_do << "  ("
@@ -1401,7 +1413,7 @@ void MAVLinkParameters::receive_timeout()
                     } else if (std::get_if<GetParamAnyCallback>(&work->callback)) {
                         const auto& callback = std::get<GetParamAnyCallback>(work->callback);
                         if (callback) {
-                            callback(Result::ConnectionError, ParamValue{});
+                            callback(Result::ConnectionError, parameters::ParamValue{});
                         }
                     }
                 } else {
@@ -1474,12 +1486,6 @@ std::string MAVLinkParameters::extract_safe_param_id(const char param_id[])
     return {param_id_long_enough};
 }
 
-std::ostream& operator<<(std::ostream& strm, const MAVLinkParameters::ParamValue& obj)
-{
-    strm << obj.get_string();
-    return strm;
-}
-
 void MAVLinkParameters::process_param_set(const mavlink_message_t& message)
 {
     mavlink_param_set_t set_request{};
@@ -1492,7 +1498,7 @@ void MAVLinkParameters::process_param_set(const mavlink_message_t& message)
 
         // Use the ID
         if (_all_params.find(safe_param_id) != _all_params.end()) {
-            ParamValue value{};
+		  	parameters::ParamValue value{};
             if (!value.set_from_mavlink_param_set_bytewise(set_request)) {
                 LogWarn() << "Invalid Param Set Request: " << safe_param_id;
                 return;
@@ -1577,8 +1583,7 @@ void MAVLinkParameters::process_param_request_list(const mavlink_message_t& mess
 {
     mavlink_param_request_list_t list_request{};
     mavlink_msg_param_request_list_decode(&message, &list_request);
-
-    auto idx = 0;
+	int idx=0;
     for (const auto& pair : _all_params) {
 	  	// make sure extended parameters never make it out via the param request list
 		// (use param extended list)
@@ -1598,6 +1603,23 @@ void MAVLinkParameters::process_param_request_list(const mavlink_message_t& mess
         new_work->param_index = idx++;
         _work_queue.push_back(new_work);
     }
+}
+
+void MAVLinkParameters::process_param_ext_request_list(const mavlink_message_t& message)
+{
+  mavlink_param_ext_request_list_t ext_list_request{};
+  mavlink_msg_param_ext_request_list_decode(&message, &ext_list_request);
+  int idx=0;
+  for (const auto& pair : _all_params) {
+	auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
+	new_work->type = WorkItem::Type::Value;
+	new_work->param_name = pair.first;
+	new_work->param_value = pair.second;
+	new_work->extended = true;
+	new_work->param_count = get_current_parameters_count(true);
+	new_work->param_index = idx++;
+	_work_queue.push_back(new_work);
+  }
 }
 
 void MAVLinkParameters::process_param_ext_request_read(const mavlink_message_t& message)
@@ -1624,624 +1646,7 @@ void MAVLinkParameters::process_param_ext_request_read(const mavlink_message_t& 
     }
 }
 
-bool MAVLinkParameters::ParamValue::set_from_mavlink_param_value_bytewise(
-    const mavlink_param_value_t& mavlink_value)
-{
-    switch (mavlink_value.param_type) {
-        case MAV_PARAM_TYPE_UINT8: {
-            uint8_t temp;
-            memcpy(&temp, &mavlink_value.param_value, sizeof(temp));
-            _value = temp;
-        } break;
 
-        case MAV_PARAM_TYPE_INT8: {
-            int8_t temp;
-            memcpy(&temp, &mavlink_value.param_value, sizeof(temp));
-            _value = temp;
-        } break;
-
-        case MAV_PARAM_TYPE_UINT16: {
-            uint16_t temp;
-            memcpy(&temp, &mavlink_value.param_value, sizeof(temp));
-            _value = temp;
-        } break;
-
-        case MAV_PARAM_TYPE_INT16: {
-            int16_t temp;
-            memcpy(&temp, &mavlink_value.param_value, sizeof(temp));
-            _value = temp;
-        } break;
-
-        case MAV_PARAM_TYPE_UINT32: {
-            uint32_t temp;
-            memcpy(&temp, &mavlink_value.param_value, sizeof(temp));
-            _value = temp;
-        } break;
-
-        case MAV_PARAM_TYPE_INT32: {
-            int32_t temp;
-            memcpy(&temp, &mavlink_value.param_value, sizeof(temp));
-            _value = temp;
-        } break;
-
-        case MAV_PARAM_TYPE_REAL32: {
-            _value = mavlink_value.param_value;
-        } break;
-
-        default:
-            // This would be worrying
-            LogErr() << "Error: unknown mavlink param type: "
-                     << std::to_string(mavlink_value.param_type);
-            return false;
-    }
-    return true;
-}
-
-bool MAVLinkParameters::ParamValue::set_from_mavlink_param_value_cast(
-    const mavlink_param_value_t& mavlink_value)
-{
-    switch (mavlink_value.param_type) {
-        case MAV_PARAM_TYPE_UINT8: {
-            _value = static_cast<uint8_t>(mavlink_value.param_value);
-        } break;
-
-        case MAV_PARAM_TYPE_INT8: {
-            _value = static_cast<int8_t>(mavlink_value.param_value);
-        } break;
-
-        case MAV_PARAM_TYPE_UINT16: {
-            _value = static_cast<uint16_t>(mavlink_value.param_value);
-        } break;
-
-        case MAV_PARAM_TYPE_INT16: {
-            _value = static_cast<int16_t>(mavlink_value.param_value);
-        } break;
-
-        case MAV_PARAM_TYPE_UINT32: {
-            _value = static_cast<uint32_t>(mavlink_value.param_value);
-        } break;
-
-        case MAV_PARAM_TYPE_INT32: {
-            _value = static_cast<int32_t>(mavlink_value.param_value);
-        } break;
-
-        case MAV_PARAM_TYPE_REAL32: {
-            float temp = mavlink_value.param_value;
-            _value = temp;
-        } break;
-
-        default:
-            // This would be worrying
-            LogErr() << "Error: unknown mavlink param type: "
-                     << std::to_string(mavlink_value.param_type);
-            return false;
-    }
-    return true;
-}
-
-bool MAVLinkParameters::ParamValue::set_from_mavlink_param_set_bytewise(
-    const mavlink_param_set_t& mavlink_set)
-{
-    mavlink_param_value_t mavlink_value{};
-    mavlink_value.param_value = mavlink_set.param_value;
-    mavlink_value.param_type = mavlink_set.param_type;
-
-    return set_from_mavlink_param_value_bytewise(mavlink_value);
-}
-
-bool MAVLinkParameters::ParamValue::set_from_mavlink_param_ext_set(
-    const mavlink_param_ext_set_t& mavlink_ext_set)
-{
-    switch (mavlink_ext_set.param_type) {
-        case MAV_PARAM_EXT_TYPE_UINT8: {
-            uint8_t temp;
-            memcpy(&temp, &mavlink_ext_set.param_value[0], sizeof(temp));
-            _value = temp;
-        } break;
-        case MAV_PARAM_EXT_TYPE_INT8: {
-            int8_t temp;
-            memcpy(&temp, &mavlink_ext_set.param_value[0], sizeof(temp));
-            _value = temp;
-        } break;
-        case MAV_PARAM_EXT_TYPE_UINT16: {
-            uint16_t temp;
-            memcpy(&temp, &mavlink_ext_set.param_value[0], sizeof(temp));
-            _value = temp;
-        } break;
-        case MAV_PARAM_EXT_TYPE_INT16: {
-            int16_t temp;
-            memcpy(&temp, &mavlink_ext_set.param_value[0], sizeof(temp));
-            _value = temp;
-        } break;
-        case MAV_PARAM_EXT_TYPE_UINT32: {
-            uint32_t temp;
-            memcpy(&temp, &mavlink_ext_set.param_value[0], sizeof(temp));
-            _value = temp;
-        } break;
-        case MAV_PARAM_EXT_TYPE_INT32: {
-            int32_t temp;
-            memcpy(&temp, &mavlink_ext_set.param_value[0], sizeof(temp));
-            _value = temp;
-        } break;
-        case MAV_PARAM_EXT_TYPE_UINT64: {
-            uint64_t temp;
-            memcpy(&temp, &mavlink_ext_set.param_value[0], sizeof(temp));
-            _value = temp;
-        } break;
-        case MAV_PARAM_EXT_TYPE_INT64: {
-            int64_t temp;
-            memcpy(&temp, &mavlink_ext_set.param_value[0], sizeof(temp));
-            _value = temp;
-        } break;
-        case MAV_PARAM_EXT_TYPE_REAL32: {
-            float temp;
-            memcpy(&temp, &mavlink_ext_set.param_value[0], sizeof(temp));
-            _value = temp;
-        } break;
-        case MAV_PARAM_EXT_TYPE_REAL64: {
-            double temp;
-            memcpy(&temp, &mavlink_ext_set.param_value[0], sizeof(temp));
-            _value = temp;
-        } break;
-        case MAV_PARAM_EXT_TYPE_CUSTOM: {
-            std::size_t len = std::min(std::size_t(128), strlen(mavlink_ext_set.param_value));
-            _value = std::string(mavlink_ext_set.param_value, mavlink_ext_set.param_value + len);
-        } break;
-        default:
-            // This would be worrying
-            LogErr() << "Error: unknown mavlink ext param type";
-            assert(false);
-            return false;
-    }
-    return true;
-}
-
-// FIXME: this function can collapse with the one above.
-bool MAVLinkParameters::ParamValue::set_from_mavlink_param_ext_value(
-    const mavlink_param_ext_value_t& mavlink_ext_value)
-{
-    switch (mavlink_ext_value.param_type) {
-        case MAV_PARAM_EXT_TYPE_UINT8: {
-            uint8_t temp;
-            memcpy(&temp, &mavlink_ext_value.param_value[0], sizeof(temp));
-            _value = temp;
-        } break;
-        case MAV_PARAM_EXT_TYPE_INT8: {
-            int8_t temp;
-            memcpy(&temp, &mavlink_ext_value.param_value[0], sizeof(temp));
-            _value = temp;
-        } break;
-        case MAV_PARAM_EXT_TYPE_UINT16: {
-            uint16_t temp;
-            memcpy(&temp, &mavlink_ext_value.param_value[0], sizeof(temp));
-            _value = temp;
-        } break;
-        case MAV_PARAM_EXT_TYPE_INT16: {
-            int16_t temp;
-            memcpy(&temp, &mavlink_ext_value.param_value[0], sizeof(temp));
-            _value = temp;
-        } break;
-        case MAV_PARAM_EXT_TYPE_UINT32: {
-            uint32_t temp;
-            memcpy(&temp, &mavlink_ext_value.param_value[0], sizeof(temp));
-            _value = temp;
-        } break;
-        case MAV_PARAM_EXT_TYPE_INT32: {
-            int32_t temp;
-            memcpy(&temp, &mavlink_ext_value.param_value[0], sizeof(temp));
-            _value = temp;
-        } break;
-        case MAV_PARAM_EXT_TYPE_UINT64: {
-            uint64_t temp;
-            memcpy(&temp, &mavlink_ext_value.param_value[0], sizeof(temp));
-            _value = temp;
-        } break;
-        case MAV_PARAM_EXT_TYPE_INT64: {
-            int64_t temp;
-            memcpy(&temp, &mavlink_ext_value.param_value[0], sizeof(temp));
-            _value = temp;
-        } break;
-        case MAV_PARAM_EXT_TYPE_REAL32: {
-            float temp;
-            memcpy(&temp, &mavlink_ext_value.param_value[0], sizeof(temp));
-            _value = temp;
-        } break;
-        case MAV_PARAM_EXT_TYPE_REAL64: {
-            double temp;
-            memcpy(&temp, &mavlink_ext_value.param_value[0], sizeof(temp));
-            _value = temp;
-        } break;
-        case MAV_PARAM_EXT_TYPE_CUSTOM: {
-            std::size_t len = std::min(std::size_t(128), strlen(mavlink_ext_value.param_value));
-            _value =
-                std::string(mavlink_ext_value.param_value, mavlink_ext_value.param_value + len);
-        } break;
-        default:
-            // This would be worrying
-            LogErr() << "Error: unknown mavlink ext param type";
-            assert(false);
-            return false;
-    }
-    return true;
-}
-
-bool MAVLinkParameters::ParamValue::set_from_xml(
-    const std::string& type_str, const std::string& value_str)
-{
-    if (strcmp(type_str.c_str(), "uint8") == 0) {
-        _value = static_cast<uint8_t>(std::stoi(value_str));
-    } else if (strcmp(type_str.c_str(), "int8") == 0) {
-        _value = static_cast<int8_t>(std::stoi(value_str));
-    } else if (strcmp(type_str.c_str(), "uint16") == 0) {
-        _value = static_cast<uint16_t>(std::stoi(value_str));
-    } else if (strcmp(type_str.c_str(), "int16") == 0) {
-        _value = static_cast<int16_t>(std::stoi(value_str));
-    } else if (strcmp(type_str.c_str(), "uint32") == 0) {
-        _value = static_cast<uint32_t>(std::stoi(value_str));
-    } else if (strcmp(type_str.c_str(), "int32") == 0) {
-        _value = static_cast<int32_t>(std::stoi(value_str));
-    } else if (strcmp(type_str.c_str(), "uint64") == 0) {
-        _value = static_cast<uint64_t>(std::stoll(value_str));
-    } else if (strcmp(type_str.c_str(), "int64") == 0) {
-        _value = static_cast<int64_t>(std::stoll(value_str));
-    } else if (strcmp(type_str.c_str(), "float") == 0) {
-        _value = static_cast<float>(std::stof(value_str));
-    } else if (strcmp(type_str.c_str(), "double") == 0) {
-        _value = static_cast<double>(std::stod(value_str));
-    } else {
-        LogErr() << "Unknown type: " << type_str;
-        return false;
-    }
-    return true;
-}
-
-bool MAVLinkParameters::ParamValue::set_empty_type_from_xml(const std::string& type_str)
-{
-    if (strcmp(type_str.c_str(), "uint8") == 0) {
-        _value = uint8_t(0);
-    } else if (strcmp(type_str.c_str(), "int8") == 0) {
-        _value = int8_t(0);
-    } else if (strcmp(type_str.c_str(), "uint16") == 0) {
-        _value = uint16_t(0);
-    } else if (strcmp(type_str.c_str(), "int16") == 0) {
-        _value = int16_t(0);
-    } else if (strcmp(type_str.c_str(), "uint32") == 0) {
-        _value = uint32_t(0);
-    } else if (strcmp(type_str.c_str(), "int32") == 0) {
-        _value = int32_t(0);
-    } else if (strcmp(type_str.c_str(), "uint64") == 0) {
-        _value = uint64_t(0);
-    } else if (strcmp(type_str.c_str(), "int64") == 0) {
-        _value = int64_t(0);
-    } else if (strcmp(type_str.c_str(), "float") == 0) {
-        _value = 0.0f;
-    } else if (strcmp(type_str.c_str(), "double") == 0) {
-        _value = 0.0;
-    } else {
-        LogErr() << "Unknown type: " << type_str;
-        return false;
-    }
-    return true;
-}
-
-[[nodiscard]] MAV_PARAM_TYPE MAVLinkParameters::ParamValue::get_mav_param_type() const
-{
-    if (std::get_if<uint8_t>(&_value)) {
-        return MAV_PARAM_TYPE_UINT8;
-    } else if (std::get_if<int8_t>(&_value)) {
-        return MAV_PARAM_TYPE_INT8;
-    } else if (std::get_if<uint16_t>(&_value)) {
-        return MAV_PARAM_TYPE_UINT16;
-    } else if (std::get_if<int16_t>(&_value)) {
-        return MAV_PARAM_TYPE_INT16;
-    } else if (std::get_if<uint32_t>(&_value)) {
-        return MAV_PARAM_TYPE_UINT32;
-    } else if (std::get_if<int32_t>(&_value)) {
-        return MAV_PARAM_TYPE_INT32;
-    } else if (std::get_if<uint64_t>(&_value)) {
-        return MAV_PARAM_TYPE_UINT64;
-    } else if (std::get_if<int64_t>(&_value)) {
-        return MAV_PARAM_TYPE_INT64;
-    } else if (std::get_if<float>(&_value)) {
-        return MAV_PARAM_TYPE_REAL32;
-    } else if (std::get_if<double>(&_value)) {
-        return MAV_PARAM_TYPE_REAL64;
-    } else {
-        LogErr() << "Unknown data type for param.";
-        assert(false);
-        return MAV_PARAM_TYPE_INT32;
-    }
-}
-
-[[nodiscard]] MAV_PARAM_EXT_TYPE MAVLinkParameters::ParamValue::get_mav_param_ext_type() const
-{
-    if (std::get_if<uint8_t>(&_value)) {
-        return MAV_PARAM_EXT_TYPE_UINT8;
-    } else if (std::get_if<int8_t>(&_value)) {
-        return MAV_PARAM_EXT_TYPE_INT8;
-    } else if (std::get_if<uint16_t>(&_value)) {
-        return MAV_PARAM_EXT_TYPE_UINT16;
-    } else if (std::get_if<int16_t>(&_value)) {
-        return MAV_PARAM_EXT_TYPE_INT16;
-    } else if (std::get_if<uint32_t>(&_value)) {
-        return MAV_PARAM_EXT_TYPE_UINT32;
-    } else if (std::get_if<int32_t>(&_value)) {
-        return MAV_PARAM_EXT_TYPE_INT32;
-    } else if (std::get_if<uint64_t>(&_value)) {
-        return MAV_PARAM_EXT_TYPE_UINT64;
-    } else if (std::get_if<int64_t>(&_value)) {
-        return MAV_PARAM_EXT_TYPE_INT64;
-    } else if (std::get_if<float>(&_value)) {
-        return MAV_PARAM_EXT_TYPE_REAL32;
-    } else if (std::get_if<double>(&_value)) {
-        return MAV_PARAM_EXT_TYPE_REAL64;
-    } else if (std::get_if<std::string>(&_value)) {
-        return MAV_PARAM_EXT_TYPE_CUSTOM;
-    } else {
-        LogErr() << "Unknown data type for param.";
-        assert(false);
-        return MAV_PARAM_EXT_TYPE_INT32;
-    }
-}
-
-bool MAVLinkParameters::ParamValue::set_as_same_type(const std::string& value_str)
-{
-    if (std::get_if<uint8_t>(&_value)) {
-        _value = uint8_t(std::stoi(value_str));
-    } else if (std::get_if<int8_t>(&_value)) {
-        _value = int8_t(std::stoi(value_str));
-    } else if (std::get_if<uint16_t>(&_value)) {
-        _value = uint16_t(std::stoi(value_str));
-    } else if (std::get_if<int16_t>(&_value)) {
-        _value = int16_t(std::stoi(value_str));
-    } else if (std::get_if<uint32_t>(&_value)) {
-        _value = uint32_t(std::stoi(value_str));
-    } else if (std::get_if<int32_t>(&_value)) {
-        _value = int32_t(std::stoi(value_str));
-    } else if (std::get_if<uint64_t>(&_value)) {
-        _value = uint64_t(std::stoll(value_str));
-    } else if (std::get_if<int64_t>(&_value)) {
-        _value = int64_t(std::stoll(value_str));
-    } else if (std::get_if<float>(&_value)) {
-        _value = float(std::stof(value_str));
-    } else if (std::get_if<double>(&_value)) {
-        _value = double(std::stod(value_str));
-    } else {
-        LogErr() << "Unknown type";
-        return false;
-    }
-    return true;
-}
-
-[[nodiscard]] float MAVLinkParameters::ParamValue::get_4_float_bytes_bytewise() const
-{
-    if (std::get_if<float>(&_value)) {
-        return std::get<float>(_value);
-    } else if (std::get_if<int32_t>(&_value)) {
-        return *(reinterpret_cast<const float*>(&std::get<int32_t>(_value)));
-    } else {
-        LogErr() << "Unknown type";
-        assert(false);
-        return NAN;
-    }
-}
-
-[[nodiscard]] float MAVLinkParameters::ParamValue::get_4_float_bytes_cast() const
-{
-    if (std::get_if<float>(&_value)) {
-        return std::get<float>(_value);
-    } else if (std::get_if<uint32_t>(&_value)) {
-        return static_cast<float>(std::get<uint32_t>(_value));
-    } else if (std::get_if<int32_t>(&_value)) {
-        return static_cast<float>(std::get<int32_t>(_value));
-    } else if (std::get_if<uint16_t>(&_value)) {
-        return static_cast<float>(std::get<uint16_t>(_value));
-    } else if (std::get_if<int16_t>(&_value)) {
-        return static_cast<float>(std::get<int16_t>(_value));
-    } else if (std::get_if<uint8_t>(&_value)) {
-        return static_cast<float>(std::get<uint8_t>(_value));
-    } else if (std::get_if<int8_t>(&_value)) {
-        return static_cast<float>(std::get<int8_t>(_value));
-    } else {
-        LogErr() << "Unknown type";
-        assert(false);
-        return NAN;
-    }
-}
-
-[[nodiscard]] std::optional<int> MAVLinkParameters::ParamValue::get_int() const
-{
-    if (std::get_if<uint32_t>(&_value)) {
-        return static_cast<int>(std::get<uint32_t>(_value));
-    } else if (std::get_if<int32_t>(&_value)) {
-        return static_cast<int>(std::get<int32_t>(_value));
-    } else if (std::get_if<uint16_t>(&_value)) {
-        return static_cast<int>(std::get<uint16_t>(_value));
-    } else if (std::get_if<int16_t>(&_value)) {
-        return static_cast<int>(std::get<int16_t>(_value));
-    } else if (std::get_if<uint8_t>(&_value)) {
-        return static_cast<int>(std::get<uint8_t>(_value));
-    } else if (std::get_if<int8_t>(&_value)) {
-        return static_cast<int>(std::get<int8_t>(_value));
-    } else {
-        LogErr() << "Not int type";
-        return {};
-    }
-}
-
-bool MAVLinkParameters::ParamValue::set_int(int new_value)
-{
-    if (std::get_if<uint8_t>(&_value)) {
-        _value = static_cast<uint8_t>(new_value);
-        return true;
-    } else if (std::get_if<int8_t>(&_value)) {
-        _value = static_cast<int8_t>(new_value);
-        return true;
-    } else if (std::get_if<uint16_t>(&_value)) {
-        _value = static_cast<uint16_t>(new_value);
-        return true;
-    } else if (std::get_if<int16_t>(&_value)) {
-        _value = static_cast<int16_t>(new_value);
-        return true;
-    } else if (std::get_if<uint32_t>(&_value)) {
-        _value = static_cast<uint32_t>(new_value);
-        return true;
-    } else if (std::get_if<int32_t>(&_value)) {
-        _value = static_cast<int32_t>(new_value);
-        return true;
-    } else {
-        return false;
-    }
-}
-
-void MAVLinkParameters::ParamValue::set_float(float new_value)
-{
-    _value = new_value;
-}
-
-void MAVLinkParameters::ParamValue::set_custom(const std::string& new_value)
-{
-    _value = new_value;
-}
-
-[[nodiscard]] std::optional<float> MAVLinkParameters::ParamValue::get_float() const
-{
-    if (std::get_if<float>(&_value)) {
-        return std::get<float>(_value);
-    } else {
-        LogErr() << "Not float type";
-        return {};
-    }
-}
-
-[[nodiscard]] std::optional<std::string> MAVLinkParameters::ParamValue::get_custom() const
-{
-    if (std::get_if<std::string>(&_value)) {
-        return std::get<std::string>(_value);
-    } else {
-        LogErr() << "Not custom type";
-        return {};
-    }
-}
-
-std::array<char, 128> MAVLinkParameters::ParamValue::get_128_bytes() const
-{
-    std::array<char, 128> bytes{};
-
-    if (std::get_if<uint8_t>(&_value)) {
-        memcpy(bytes.data(), &std::get<uint8_t>(_value), sizeof(uint8_t));
-    } else if (std::get_if<int8_t>(&_value)) {
-        memcpy(bytes.data(), &std::get<int8_t>(_value), sizeof(int8_t));
-    } else if (std::get_if<uint16_t>(&_value)) {
-        memcpy(bytes.data(), &std::get<uint16_t>(_value), sizeof(uint16_t));
-    } else if (std::get_if<int16_t>(&_value)) {
-        memcpy(bytes.data(), &std::get<int16_t>(_value), sizeof(int16_t));
-    } else if (std::get_if<uint32_t>(&_value)) {
-        memcpy(bytes.data(), &std::get<uint32_t>(_value), sizeof(uint32_t));
-    } else if (std::get_if<int32_t>(&_value)) {
-        memcpy(bytes.data(), &std::get<int32_t>(_value), sizeof(int32_t));
-    } else if (std::get_if<uint64_t>(&_value)) {
-        memcpy(bytes.data(), &std::get<uint64_t>(_value), sizeof(uint64_t));
-    } else if (std::get_if<int64_t>(&_value)) {
-        memcpy(bytes.data(), &std::get<int64_t>(_value), sizeof(int64_t));
-    } else if (std::get_if<float>(&_value)) {
-        memcpy(bytes.data(), &std::get<float>(_value), sizeof(float));
-    } else if (std::get_if<double>(&_value)) {
-        memcpy(bytes.data(), &std::get<double>(_value), sizeof(double));
-    } else if (std::get_if<std::string>(&_value)) {
-        auto str_ptr = &std::get<std::string>(_value);
-        // Copy all data in string, max 128 bytes
-        memcpy(bytes.data(), str_ptr->data(), std::min(bytes.size(), str_ptr->size()));
-    } else {
-        LogErr() << "Unknown type";
-        assert(false);
-    }
-
-    return bytes;
-}
-
-[[nodiscard]] std::string MAVLinkParameters::ParamValue::get_string() const
-{
-    return std::visit([](auto value) { return to_string(value); }, _value);
-}
-
-[[nodiscard]] bool MAVLinkParameters::ParamValue::is_same_type(const ParamValue& rhs) const
-{
-    if ((std::get_if<uint8_t>(&_value) && std::get_if<uint8_t>(&rhs._value)) ||
-        (std::get_if<int8_t>(&_value) && std::get_if<int8_t>(&rhs._value)) ||
-        (std::get_if<uint16_t>(&_value) && std::get_if<uint16_t>(&rhs._value)) ||
-        (std::get_if<int16_t>(&_value) && std::get_if<int16_t>(&rhs._value)) ||
-        (std::get_if<uint32_t>(&_value) && std::get_if<uint32_t>(&rhs._value)) ||
-        (std::get_if<int32_t>(&_value) && std::get_if<int32_t>(&rhs._value)) ||
-        (std::get_if<uint64_t>(&_value) && std::get_if<uint64_t>(&rhs._value)) ||
-        (std::get_if<int64_t>(&_value) && std::get_if<int64_t>(&rhs._value)) ||
-        (std::get_if<float>(&_value) && std::get_if<float>(&rhs._value)) ||
-        (std::get_if<double>(&_value) && std::get_if<double>(&rhs._value)) ||
-        (std::get_if<std::string>(&_value) && std::get_if<std::string>(&rhs._value))) {
-        return true;
-    } else {
-        LogWarn() << "Comparison type mismatch between " << typestr() << " and " << rhs.typestr();
-        return false;
-    }
-}
-
-bool MAVLinkParameters::ParamValue::operator==(const std::string& value_str) const
-{
-    // LogDebug() << "Compare " << value_str() << " and " << rhs.value_str();
-    if (std::get_if<uint8_t>(&_value)) {
-        return std::get<uint8_t>(_value) == std::stoi(value_str);
-    } else if (std::get_if<int8_t>(&_value)) {
-        return std::get<int8_t>(_value) == std::stoi(value_str);
-    } else if (std::get_if<uint16_t>(&_value)) {
-        return std::get<uint16_t>(_value) == std::stoi(value_str);
-    } else if (std::get_if<int16_t>(&_value)) {
-        return std::get<int16_t>(_value) == std::stoi(value_str);
-    } else if (std::get_if<uint32_t>(&_value)) {
-        return std::get<uint32_t>(_value) == std::stoul(value_str);
-    } else if (std::get_if<int32_t>(&_value)) {
-        return std::get<int32_t>(_value) == std::stol(value_str);
-    } else if (std::get_if<uint64_t>(&_value)) {
-        return std::get<uint64_t>(_value) == std::stoull(value_str);
-    } else if (std::get_if<int64_t>(&_value)) {
-        return std::get<int64_t>(_value) == std::stoll(value_str);
-    } else if (std::get_if<float>(&_value)) {
-        return std::get<float>(_value) == std::stof(value_str);
-    } else if (std::get_if<double>(&_value)) {
-        return std::get<double>(_value) == std::stod(value_str);
-    } else {
-        // This also covers custom_type_t
-        return false;
-    }
-}
-
-[[nodiscard]] std::string MAVLinkParameters::ParamValue::typestr() const
-{
-    if (std::get_if<uint8_t>(&_value)) {
-        return "uint8_t";
-    } else if (std::get_if<int8_t>(&_value)) {
-        return "int8_t";
-    } else if (std::get_if<uint16_t>(&_value)) {
-        return "uint16_t";
-    } else if (std::get_if<int16_t>(&_value)) {
-        return "int16_t";
-    } else if (std::get_if<uint32_t>(&_value)) {
-        return "uint32_t";
-    } else if (std::get_if<int32_t>(&_value)) {
-        return "int32_t";
-    } else if (std::get_if<uint64_t>(&_value)) {
-        return "uint64_t";
-    } else if (std::get_if<int64_t>(&_value)) {
-        return "int64_t";
-    } else if (std::get_if<float>(&_value)) {
-        return "float";
-    } else if (std::get_if<double>(&_value)) {
-        return "double";
-    } else if (std::get_if<std::string>(&_value)) {
-        return "custom";
-    }
-    // FIXME: Added to fix CI error (control reading end of non-void function)
-    return "unknown";
-}
 
 std::ostream& operator<<(std::ostream& str, const MAVLinkParameters::Result& result)
 {

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -484,15 +484,16 @@ std::map<std::string, parameters::ParamValue> MAVLinkParameters::retrieve_all_se
     return _all_params;
 }
 
-std::pair<MAVLinkParameters::Result, parameters::ParamValue>
-MAVLinkParameters::retrieve_server_param(const std::string& name,const parameters::ParamValue& value_type)
+template<class T>
+std::pair<MAVLinkParameters::Result, T> MAVLinkParameters::retrieve_server_param(const std::string& name)
 {
     if (_all_params.find(name) != _all_params.end()) {
-        auto value = _all_params.at(name);
-        if (value.is_same_type(value_type))
-            return {MAVLinkParameters::Result::Success, value};
-        else
-            return {MAVLinkParameters::Result::WrongType, {}};
+        // This parameter exists, check its type
+        const auto value = _all_params.at(name);
+        if(value.is_same_type_x<T>()){
+            return {MAVLinkParameters::Result::Success, value.get<T>()};
+        }
+        return {MAVLinkParameters::Result::WrongType, {}};
     }
     return {MAVLinkParameters::Result::NotFound, {}};
 }
@@ -500,40 +501,19 @@ MAVLinkParameters::retrieve_server_param(const std::string& name,const parameter
 std::pair<MAVLinkParameters::Result, float>
 MAVLinkParameters::retrieve_server_param_float(const std::string& name)
 {
-    if (_all_params.find(name) != _all_params.end()) {
-        const auto maybe_value = _all_params.at(name).get_float();
-        if (maybe_value)
-            return {MAVLinkParameters::Result::Success, maybe_value.value()};
-        else
-            return {MAVLinkParameters::Result::WrongType, {}};
-    }
-    return {MAVLinkParameters::Result::NotFound, {}};
+    return retrieve_server_param<float>(name);
 }
 
 std::pair<MAVLinkParameters::Result, std::string>
 MAVLinkParameters::retrieve_server_param_custom(const std::string& name)
 {
-    if (_all_params.find(name) != _all_params.end()) {
-        const auto maybe_value = _all_params.at(name).get_custom();
-        if (maybe_value)
-            return {MAVLinkParameters::Result::Success, maybe_value.value()};
-        else
-            return {MAVLinkParameters::Result::WrongType, {}};
-    }
-    return {MAVLinkParameters::Result::NotFound, {}};
+    return retrieve_server_param<std::string>(name);
 }
 
 std::pair<MAVLinkParameters::Result, int>
 MAVLinkParameters::retrieve_server_param_int(const std::string& name)
 {
-    if (_all_params.find(name) != _all_params.end()) {
-        const auto maybe_value = _all_params.at(name).get_int();
-        if (maybe_value)
-            return {MAVLinkParameters::Result::Success, maybe_value.value()};
-        else
-            return {MAVLinkParameters::Result::WrongType, {}};
-    }
-    return {MAVLinkParameters::Result::NotFound, {}};
+    return retrieve_server_param<int>(name);
 }
 
 std::pair<MAVLinkParameters::Result, parameters::ParamValue> MAVLinkParameters::get_param(
@@ -1686,5 +1666,6 @@ int MAVLinkParameters::get_current_parameters_count(bool extended)const{
   }
   return count;
 }
+
 
 } // namespace mavsdk

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -139,7 +139,7 @@ MAVLinkParameters::Result MAVLinkParameters::set_param(
     std::optional<uint8_t> maybe_component_id,
     bool extended)
 {
-  	assert(!_is_server);
+    assert(!_is_server);
     auto prom = std::promise<Result>();
     auto res = prom.get_future();
 
@@ -452,6 +452,7 @@ void MAVLinkParameters::set_param_custom_async(
     const SetParamCallback& callback,
     const void* cookie)
 {
+    assert(!_is_server);
     if (name.size() > PARAM_ID_LEN) {
         LogErr() << "Error: param name too long";
         if (callback) {
@@ -485,6 +486,7 @@ void MAVLinkParameters::set_param_custom_async(
 
 std::map<std::string, parameters::ParamValue> MAVLinkParameters::retrieve_all_server_params()
 {
+    assert(_is_server);
     std::lock_guard<std::mutex> lock(_all_params_mutex);
     return _all_params;
 }
@@ -492,6 +494,7 @@ std::map<std::string, parameters::ParamValue> MAVLinkParameters::retrieve_all_se
 template<class T>
 std::pair<MAVLinkParameters::Result, T> MAVLinkParameters::retrieve_server_param(const std::string& name)
 {
+    assert(_is_server);
     std::lock_guard<std::mutex> lock(_all_params_mutex);
     if (_all_params.find(name) != _all_params.end()) {
         // This parameter exists, check its type
@@ -525,6 +528,7 @@ MAVLinkParameters::retrieve_server_param_int(const std::string& name)
 std::pair<MAVLinkParameters::Result, parameters::ParamValue> MAVLinkParameters::get_param(
     const std::string& name, parameters::ParamValue value, bool extended)
 {
+    assert(!_is_server);
     auto prom = std::promise<std::pair<Result, ParamValue>>();
     auto res = prom.get_future();
 
@@ -543,6 +547,7 @@ std::pair<MAVLinkParameters::Result, parameters::ParamValue> MAVLinkParameters::
 std::pair<MAVLinkParameters::Result, int32_t> MAVLinkParameters::get_param_int(
     const std::string& name, std::optional<uint8_t> maybe_component_id, bool extended)
 {
+    assert(!_is_server);
     auto prom = std::promise<std::pair<Result, int32_t>>();
     auto res = prom.get_future();
 
@@ -559,6 +564,7 @@ std::pair<MAVLinkParameters::Result, int32_t> MAVLinkParameters::get_param_int(
 std::pair<MAVLinkParameters::Result, float> MAVLinkParameters::get_param_float(
     const std::string& name, std::optional<uint8_t> maybe_component_id, bool extended)
 {
+    assert(!_is_server);
     auto prom = std::promise<std::pair<Result, float>>();
     auto res = prom.get_future();
 
@@ -575,6 +581,7 @@ std::pair<MAVLinkParameters::Result, float> MAVLinkParameters::get_param_float(
 std::pair<MAVLinkParameters::Result, std::string>
 MAVLinkParameters::get_param_custom(const std::string& name)
 {
+    assert(!_is_server);
     auto prom = std::promise<std::pair<Result, std::string>>();
     auto res = prom.get_future();
 
@@ -590,6 +597,7 @@ MAVLinkParameters::get_param_custom(const std::string& name)
 
 void MAVLinkParameters::get_all_params_async(const GetAllParamsCallback& callback,const bool use_extended)
 {
+    assert(!_is_server);
     std::lock_guard<std::mutex> lock(_all_params_mutex);
     _all_params_callback = callback;
     mavlink_message_t msg;
@@ -623,7 +631,6 @@ std::map<std::string, parameters::ParamValue> MAVLinkParameters::get_all_params(
 {
     std::promise<std::map<std::string, ParamValue>> prom;
     auto res = prom.get_future();
-
     get_all_params_async(
 		// Consti10: all_params used to be passed in here as a reference - that is a bug.
 		// Since for example on a receive timeout, the empty all_params result is constructed in-place and then

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -949,10 +949,10 @@ void MAVLinkParameters::process_param_value(const mavlink_message_t& message)
 
         // check if we are looking for param list (get all parameters).
         if (_all_params_callback) {
-			// If we are currently waiting for all parameters, this is a hacky way to basically say
-			// "Hey, we got the last parameter, so we got all parameters, and can forward that to the user."
-			// Note that I don't think this accounts for the case where a parameter that is not the last parameter went missing.
-			// So it is better than nothing, but also not ideal. Correct me if I'm wrong.
+            // If we are currently waiting for all parameters, this is a hacky way to basically say
+            // "Hey, we got the last parameter, so we got all parameters, and can forward that to the user."
+            // Note that I don't think this accounts for the case where a parameter that is not the last parameter went missing.
+            // So it is better than nothing, but also not ideal. Correct me if I'm wrong.
             if (param_value.param_index + 1 == param_value.param_count) {
                 _timeout_handler.remove(_all_params_timeout_cookie);
                 _all_params_callback(_all_params);

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -456,13 +456,6 @@ void MAVLinkParameters::get_param_custom_async(
     get_param_async_typesafe<std::string>(name,callback,cookie,maybe_component_id,true);
 }
 
-std::map<std::string, parameters::ParamValue> MAVLinkParameters::retrieve_all_server_params()
-{
-    assert(_is_server);
-    std::lock_guard<std::mutex> lock(_all_params_mutex);
-    return _all_params;
-}
-
 template<class T>
 std::pair<MAVLinkParameters::Result, T> MAVLinkParameters::retrieve_server_param(const std::string& name)
 {
@@ -495,6 +488,13 @@ std::pair<MAVLinkParameters::Result, int>
 MAVLinkParameters::retrieve_server_param_int(const std::string& name)
 {
     return retrieve_server_param<int>(name);
+}
+
+std::map<std::string, parameters::ParamValue> MAVLinkParameters::retrieve_all_server_params()
+{
+    assert(_is_server);
+    std::lock_guard<std::mutex> lock(_all_params_mutex);
+    return _all_params;
 }
 
 std::pair<MAVLinkParameters::Result, parameters::ParamValue> MAVLinkParameters::get_param(

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -994,9 +994,12 @@ void MAVLinkParameters::process_param_value(const mavlink_message_t& message)
         std::lock_guard<std::mutex> lock(_all_params_mutex);
         _all_params[param_id] = received_value;
 
-        // check if we are looking for param list
-		// Consti10 - now this is broken since the n of parameters is different for ext and non-ext use cases.
+        // check if we are looking for param list (get all parameters).
         if (_all_params_callback) {
+			// If we are currently waiting for all parameters, this is a hacky way to basically say
+			// "Hey, we got the last parameter, so we got all parameters, and can forward that to the user."
+			// Note that I don't think this accounts for the case where a parameter that is not the last parameter went missing.
+			// So it is better than nothing, but also not ideal. Correct me if I'm wrong.
             if (param_value.param_index + 1 == param_value.param_count) {
                 _timeout_handler.remove(_all_params_timeout_cookie);
                 _all_params_callback(_all_params);

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -1408,21 +1408,20 @@ void MAVLinkParameters::process_param_request_list(const mavlink_message_t& mess
 {
     mavlink_param_request_list_t list_request{};
     mavlink_msg_param_request_list_decode(&message, &list_request);
-	int idx=0;
+    int idx=0;
     for (const auto& pair : _all_params) {
-	  	// make sure extended parameters never make it out via the param request list
-		// (use param extended list)
-		if(pair.second.needs_extended()){
-		  LogDebug()<<"Not forwarding param"<<pair.first<<" since it needs extended";
-		  continue;
-		}
+        // make sure extended parameters never make it out via the param request list
+        // (use param extended list)
+        if(pair.second.needs_extended()){
+          LogDebug()<<"Not forwarding param"<<pair.first<<" since it needs extended";
+          continue;
+        }
         auto new_work = std::make_shared<WorkItem>(WorkItem::Type::Value,pair.first,_timeout_s_callback());
         new_work->param_value = pair.second;
         new_work->extended = false;
-		// Consti10 - the count of parameters when queried from a non-ext perspective is different, since we need to hide the parameters
-		// that need the extended protocol
-        //new_work->param_count = static_cast<int>(_all_params.size());
-		new_work->param_count = get_current_parameters_count(false);
+        // Consti10 - the count of parameters when queried from a non-ext perspective is different, since we need to hide the parameters
+        // that need the extended protocol
+	new_work->param_count = get_current_parameters_count(false);
         new_work->param_index = idx++;
         _work_queue.push_back(new_work);
     }

--- a/src/mavsdk/core/mavlink_parameters.h
+++ b/src/mavsdk/core/mavlink_parameters.h
@@ -109,14 +109,24 @@ public:
         const SetParamCallback& callback,
         const void* cookie = nullptr);
 
-    // Result provide_server_param(const std::string& name, const ParamValue& value);
+    /**
+     * Add a new parameter to the parameter set (only for the server/providing side).
+     * It is recommended to not change the parameter set after first communicating with any client.
+     * (https://mavlink.io/en/services/parameter_ext.html#parameters_invariant)
+     * @param name the unique id for this parameter
+     * @param param_value the value for this parameter
+     * @return Result::ParamNameTooLong if the parameter name is too long,
+     * Result::Success otherwise.
+     */
+    Result provide_server_param(const std::string& name,parameters::ParamValue param_value);
+    // convenient implementations for the most commonly used types
     Result provide_server_param_float(const std::string& name, float value);
     Result provide_server_param_int(const std::string& name, int value);
     Result provide_server_param_custom(const std::string& name, const std::string& value);
     std::map<std::string, parameters::ParamValue> retrieve_all_server_params();
 
     std::pair<Result, parameters::ParamValue>
-    retrieve_server_param(const std::string& name, parameters::ParamValue value_type);
+    retrieve_server_param(const std::string& name,const parameters::ParamValue& value_type);
     std::pair<Result, float> retrieve_server_param_float(const std::string& name);
     std::pair<Result, int> retrieve_server_param_int(const std::string& name);
     std::pair<Result, std::string> retrieve_server_param_custom(const std::string& name);
@@ -274,9 +284,9 @@ private:
 
     bool _parameter_debugging{false};
 
-	// Return the n of parameters, either from an extended or non-extended perspective.
-	// ( we need to hide parameters that need extended from non-extended queries).
-	int get_current_parameters_count(bool extended)const;
+    // Return the n of parameters, either from an extended or non-extended perspective.
+    // ( we need to hide parameters that need extended from non-extended queries).
+    [[nodiscard]] int get_current_parameters_count(bool extended)const;
 };
 
 } // namespace mavsdk

--- a/src/mavsdk/core/mavlink_parameters.h
+++ b/src/mavsdk/core/mavlink_parameters.h
@@ -82,7 +82,9 @@ public:
         const std::string& name,
         int32_t value,
         std::optional<uint8_t> maybe_component_id,
-        bool extended = false,bool adhere_to_mavlink_specs= false);
+        bool extended = false,
+        // Needs to be false by default, I don't know where people using the library assume the internal type hack is applied
+        bool adhere_to_mavlink_specs= false);
 
     void set_param_int_async(
         const std::string& name,
@@ -90,7 +92,9 @@ public:
         const SetParamCallback& callback,
         const void* cookie,
         std::optional<uint8_t> maybe_component_id,
-        bool extended = false,bool adhere_to_mavlink_specs= false);
+        bool extended = false,
+        // Needs to be false by default, I don't know where people using the library assume the internal type hack is applied
+        bool adhere_to_mavlink_specs= false);
 
     Result set_param_float(
         const std::string& name,
@@ -218,8 +222,7 @@ public:
         const GetParamIntCallback& callback,
         const void* cookie,
         std::optional<uint8_t> maybe_component_id,
-        bool extended); // Needs to be false by default, I don't know where people using the library assume the internal
-    // type hack is applied
+        bool extended);
 
     std::pair<Result, std::string> get_param_custom(const std::string& name);
 

--- a/src/mavsdk/core/mavlink_parameters.h
+++ b/src/mavsdk/core/mavlink_parameters.h
@@ -276,20 +276,7 @@ private:
 
 	// Return the n of parameters, either from an extended or non-extended perspective.
 	// ( we need to hide parameters that need extended from non-extended queries).
-	int get_current_parameters_count(bool extended)const{
-	  if(extended){
-		// easy, we can do all parameters.
-		return static_cast<int>(_all_params.size());
-	  }
-	  // a bit messy, we need to loop through all params and only count the ones that are non-extended
-	  int count=0;
-	  for (auto const& [key, val] : _all_params){
-		if(!val.needs_extended()){
-		  count++;
-		}
-	  }
-	  return count;
-	}
+	int get_current_parameters_count(bool extended)const;
 };
 
 } // namespace mavsdk

--- a/src/mavsdk/core/mavlink_parameters.h
+++ b/src/mavsdk/core/mavlink_parameters.h
@@ -59,7 +59,7 @@ public:
 
     Result set_param(
         const std::string& name,
-		parameters::ParamValue value,
+        parameters::ParamValue value,
         std::optional<uint8_t> maybe_component_id,
         bool extended = false);
 
@@ -67,7 +67,7 @@ public:
 
     void set_param_async(
         const std::string& name,
-		parameters::ParamValue value,
+	parameters::ParamValue value,
         const SetParamCallback& callback,
         const void* cookie,
         std::optional<uint8_t> maybe_component_id,
@@ -138,7 +138,7 @@ public:
 
     void get_param_async(
         const std::string& name,
-		parameters::ParamValue value,
+	parameters::ParamValue value,
         const GetParamAnyCallback& callback,
         const void* cookie,
         std::optional<uint8_t> maybe_component_id,
@@ -175,8 +175,8 @@ public:
     void get_param_custom_async(
         const std::string& name, const GetParamCustomCallback& callback, const void* cookie);
 
-	// Note: When use_extended == false, this won't return any parameters that use a string as param value,
-	// since the non-extended protocol is incapable of doing so.
+    // Note: When use_extended == false, this won't return any parameters that use a string as param value,
+    // since the non-extended protocol is incapable of doing so.
     std::map<std::string, parameters::ParamValue> get_all_params(bool use_extended=false);
     using GetAllParamsCallback =
         std::function<void(std::map<std::string, parameters::ParamValue>)>;

--- a/src/mavsdk/core/mavlink_parameters.h
+++ b/src/mavsdk/core/mavlink_parameters.h
@@ -229,15 +229,16 @@ private:
     static constexpr size_t PARAM_ID_LEN = 16;
 
     struct WorkItem {
-        enum class Type { Get, Set, Value, Ack } type{Type::Get};
-        std::variant<
+        enum class Type { Get, Set, Value, Ack };
+        const Type type;
+        const std::string param_name;
+        using VariantCallback=std::variant<
             GetParamFloatCallback,
             GetParamIntCallback,
             GetParamCustomCallback,
             GetParamAnyCallback,
-            SetParamCallback>
-            callback{};
-        std::string param_name{};
+            SetParamCallback>;
+        VariantCallback callback{};
         parameters::ParamValue param_value{};
         std::optional<uint8_t> maybe_component_id{};
         bool extended{false};
@@ -250,7 +251,7 @@ private:
         int param_index{0};
         mavlink_message_t mavlink_message{};
 
-        explicit WorkItem(double new_timeout_s) : timeout_s(new_timeout_s){};
+        explicit WorkItem(Type type1,std::string param_name1,double new_timeout_s) : type(type1),param_name(std::move(param_name1)),timeout_s(new_timeout_s){};
     };
     LockedQueue<WorkItem> _work_queue{};
 

--- a/src/mavsdk/core/mavlink_parameters.h
+++ b/src/mavsdk/core/mavlink_parameters.h
@@ -65,6 +65,11 @@ public:
 
     using SetParamCallback = std::function<void(Result result)>;
 
+    /**
+     * Send a message to the server to change the parameter indexed by name to the specified value.
+     * Once the result of this operation is known, the user-specified callback is called with the result of this (set value) operation.
+     * Note that to change a server parameter, one needs to know not only the value to set, but also the exact type this value has.
+     */
     void set_param_async(
         const std::string& name,
 	parameters::ParamValue value,
@@ -77,7 +82,7 @@ public:
         const std::string& name,
         int32_t value,
         std::optional<uint8_t> maybe_component_id,
-        bool extended = false);
+        bool extended = false,bool adhere_to_mavlink_specs= false);
 
     void set_param_int_async(
         const std::string& name,
@@ -85,7 +90,7 @@ public:
         const SetParamCallback& callback,
         const void* cookie,
         std::optional<uint8_t> maybe_component_id,
-        bool extended = false);
+        bool extended = false,bool adhere_to_mavlink_specs= false);
 
     Result set_param_float(
         const std::string& name,
@@ -213,7 +218,8 @@ public:
         const GetParamIntCallback& callback,
         const void* cookie,
         std::optional<uint8_t> maybe_component_id,
-        bool extended);
+        bool extended); // Needs to be false by default, I don't know where people using the library assume the internal
+    // type hack is applied
 
     std::pair<Result, std::string> get_param_custom(const std::string& name);
 
@@ -287,8 +293,6 @@ private:
         std::optional<uint8_t> maybe_component_id{};
         bool extended{false};
         bool already_requested{false};
-        // This is only for set commands
-        bool exact_type_known{false};
         const void* cookie{nullptr};
         int retries_to_do{3};
         double timeout_s;

--- a/src/mavsdk/core/mavlink_parameters.h
+++ b/src/mavsdk/core/mavlink_parameters.h
@@ -123,10 +123,6 @@ public:
     Result provide_server_param_float(const std::string& name, float value);
     Result provide_server_param_int(const std::string& name, int value);
     Result provide_server_param_custom(const std::string& name, const std::string& value);
-    /**
-     * @return a copy of the current parameter set of the server.
-     */
-    std::map<std::string, parameters::ParamValue> retrieve_all_server_params();
 
     /**
      * Retrieve the current value for a parameter from the server parameter set.
@@ -143,6 +139,10 @@ public:
     std::pair<Result, float> retrieve_server_param_float(const std::string& name);
     std::pair<Result, int> retrieve_server_param_int(const std::string& name);
     std::pair<Result, std::string> retrieve_server_param_custom(const std::string& name);
+    /**
+     * @return a copy of the current parameter set of the server.
+     */
+    std::map<std::string, parameters::ParamValue> retrieve_all_server_params();
 
     using GetParamAnyCallback = std::function<void(Result, parameters::ParamValue)>;
     /**
@@ -177,8 +177,9 @@ public:
         bool extended = false);
 
     /**
-     * This could replace the code above. We use get_param_async to get the current type and value for a parameter, then check the type
-     * of the returned parameter and return the result with the appropriate error codes via the callback.
+     * This could replace the code above.
+     * We use get_param_async to get the current type and value for a parameter, then check the type
+     * of the obtained parameter and return the result with the appropriate error codes via the callback.
      */
     template<class T>
     using GetParamTypesafeCallback = std::function<void(Result,T value)>;
@@ -286,6 +287,7 @@ private:
         std::optional<uint8_t> maybe_component_id{};
         bool extended{false};
         bool already_requested{false};
+        // This is only for set commands
         bool exact_type_known{false};
         const void* cookie{nullptr};
         int retries_to_do{3};

--- a/src/mavsdk/core/mavlink_parameters.h
+++ b/src/mavsdk/core/mavlink_parameters.h
@@ -125,8 +125,8 @@ public:
     Result provide_server_param_custom(const std::string& name, const std::string& value);
     std::map<std::string, parameters::ParamValue> retrieve_all_server_params();
 
-    std::pair<Result, parameters::ParamValue>
-    retrieve_server_param(const std::string& name,const parameters::ParamValue& value_type);
+    template<class T>
+    std::pair<Result,T> retrieve_server_param(const std::string& name);
     std::pair<Result, float> retrieve_server_param_float(const std::string& name);
     std::pair<Result, int> retrieve_server_param_int(const std::string& name);
     std::pair<Result, std::string> retrieve_server_param_custom(const std::string& name);
@@ -279,8 +279,8 @@ private:
     void process_param_request_read(const mavlink_message_t& message);
     void process_param_ext_request_read(const mavlink_message_t& message);
     void process_param_request_list(const mavlink_message_t& message);
-	// request list from a component that wants to also do strings and therefore has to use the extended parameter protocol).
-  	void process_param_ext_request_list(const mavlink_message_t& message);
+    // request list from a component that wants to also do strings and therefore has to use the extended parameter protocol).
+    void process_param_ext_request_list(const mavlink_message_t& message);
 
     bool _parameter_debugging{false};
 

--- a/src/mavsdk/core/mavlink_parameters.h
+++ b/src/mavsdk/core/mavlink_parameters.h
@@ -178,8 +178,7 @@ public:
     // Note: When use_extended == false, this won't return any parameters that use a string as param value,
     // since the non-extended protocol is incapable of doing so.
     std::map<std::string, parameters::ParamValue> get_all_params(bool use_extended=false);
-    using GetAllParamsCallback =
-        std::function<void(std::map<std::string, parameters::ParamValue>)>;
+    using GetAllParamsCallback = std::function<void(std::map<std::string, parameters::ParamValue>)>;
     void get_all_params_async(const GetAllParamsCallback& callback,bool use_extended=false);
 
     using ParamFloatChangedCallback = std::function<void(float value)>;
@@ -205,8 +204,7 @@ public:
     const MAVLinkParameters& operator=(const MAVLinkParameters&) = delete;
 
 private:
-    using ParamChangedCallbacks = std::
-        variant<ParamFloatChangedCallback, ParamIntChangedCallback, ParamCustomChangedCallback>;
+    using ParamChangedCallbacks = std::variant<ParamFloatChangedCallback, ParamIntChangedCallback, ParamCustomChangedCallback>;
 
     void process_param_value(const mavlink_message_t& message);
     void process_param_set(const mavlink_message_t& message);
@@ -240,7 +238,7 @@ private:
             SetParamCallback>
             callback{};
         std::string param_name{};
-	  	parameters::ParamValue param_value{};
+        parameters::ParamValue param_value{};
         std::optional<uint8_t> maybe_component_id{};
         bool extended{false};
         bool already_requested{false};
@@ -261,7 +259,7 @@ private:
     struct ParamChangedSubscription {
         std::string param_name{};
         ParamChangedCallbacks callback{};
-	  	parameters::ParamValue value_type{};
+	parameters::ParamValue value_type{};
         bool any_type{false};
         const void* cookie{nullptr};
     };

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -607,7 +607,7 @@ uint8_t SystemImpl::get_own_mav_type() const
 
 MAVLinkParameters::Result SystemImpl::set_param(
     const std::string& name,
-    MAVLinkParameters::ParamValue value,
+    parameters::ParamValue value,
     std::optional<uint8_t> maybe_component_id,
     bool extended)
 {
@@ -635,14 +635,14 @@ SystemImpl::set_param_custom(const std::string& name, const std::string& value)
     return _params.set_param_custom(name, value);
 }
 
-std::map<std::string, MAVLinkParameters::ParamValue> SystemImpl::get_all_params()
+std::map<std::string, parameters::ParamValue> SystemImpl::get_all_params()
 {
     return _params.get_all_params();
 }
 
 void SystemImpl::set_param_async(
     const std::string& name,
-    MAVLinkParameters::ParamValue value,
+	parameters::ParamValue value,
     const SetParamCallback& callback,
     const void* cookie,
     std::optional<uint8_t> maybe_component_id,
@@ -691,7 +691,7 @@ SystemImpl::get_param_custom(const std::string& name)
 
 void SystemImpl::get_param_async(
     const std::string& name,
-    MAVLinkParameters::ParamValue value,
+	parameters::ParamValue value,
     const GetParamAnyCallback& callback,
     const void* cookie,
     std::optional<uint8_t> maybe_component_id,
@@ -944,7 +944,7 @@ FlightMode SystemImpl::get_flight_mode() const
 
 void SystemImpl::receive_float_param(
     MAVLinkParameters::Result result,
-    MAVLinkParameters::ParamValue value,
+	parameters::ParamValue value,
     const GetParamFloatCallback& callback)
 {
     if (callback) {
@@ -958,7 +958,7 @@ void SystemImpl::receive_float_param(
 
 void SystemImpl::receive_int_param(
     MAVLinkParameters::Result result,
-    MAVLinkParameters::ParamValue value,
+	parameters::ParamValue value,
     const GetParamIntCallback& callback)
 {
     if (callback) {

--- a/src/mavsdk/core/system_impl.h
+++ b/src/mavsdk/core/system_impl.h
@@ -126,7 +126,7 @@ public:
 
     MAVLinkParameters::Result set_param(
         const std::string& name,
-        MAVLinkParameters::ParamValue value,
+		parameters::ParamValue value,
         std::optional<uint8_t> maybe_component_id = {},
         bool extended = false);
 
@@ -142,7 +142,7 @@ public:
         std::optional<uint8_t> maybe_component_id = {},
         bool extended = false);
 
-    std::map<std::string, MAVLinkParameters::ParamValue> get_all_params();
+    std::map<std::string, parameters::ParamValue> get_all_params();
 
     MAVLinkParameters::Result set_param_custom(const std::string& name, const std::string& value);
 
@@ -174,7 +174,7 @@ public:
         uint8_t component_id = MAV_COMP_ID_AUTOPILOT1);
 
     using GetParamAnyCallback =
-        std::function<void(MAVLinkParameters::Result result, MAVLinkParameters::ParamValue value)>;
+        std::function<void(MAVLinkParameters::Result result, parameters::ParamValue value)>;
     using GetParamFloatCallback =
         std::function<void(MAVLinkParameters::Result result, float value)>;
     using GetParamIntCallback =
@@ -190,7 +190,7 @@ public:
     // the callback can just be set to nullptr.
     void get_param_async(
         const std::string& name,
-        MAVLinkParameters::ParamValue value,
+        parameters::ParamValue value,
         const GetParamAnyCallback& callback,
         const void* cookie,
         std::optional<uint8_t> maybe_component_id = {},
@@ -214,7 +214,7 @@ public:
 
     void set_param_async(
         const std::string& name,
-        MAVLinkParameters::ParamValue value,
+		parameters::ParamValue value,
         const SetParamCallback& callback,
         const void* cookie,
         std::optional<uint8_t> maybe_component_id = {},
@@ -312,11 +312,11 @@ private:
 
     static void receive_float_param(
         MAVLinkParameters::Result result,
-        MAVLinkParameters::ParamValue value,
+		parameters::ParamValue value,
         const GetParamFloatCallback& callback);
     static void receive_int_param(
         MAVLinkParameters::Result result,
-        MAVLinkParameters::ParamValue value,
+		parameters::ParamValue value,
         const GetParamIntCallback& callback);
 
     std::mutex _component_discovered_callback_mutex{};

--- a/src/mavsdk/plugins/camera/camera_definition.cpp
+++ b/src/mavsdk/plugins/camera/camera_definition.cpp
@@ -307,7 +307,7 @@ CameraDefinition::parse_options(
                         return std::make_pair<>(false, options);
                     }
 
-                    MAVLinkParameters::ParamValue new_param_value;
+				  	parameters::ParamValue new_param_value;
                     new_param_value.set_from_xml(
                         type_map[roption_parameter_str], roption_value_str);
                     new_parameter_range[roption_name_str] = new_param_value;
@@ -345,7 +345,7 @@ CameraDefinition::parse_range_options(
         return std::make_tuple<>(false, options, default_option);
     }
 
-    MAVLinkParameters::ParamValue min_value;
+  	parameters::ParamValue min_value;
     min_value.set_from_xml(type_map[param_name], min_str);
 
     const char* max_str = param_handle->Attribute("max");
@@ -358,7 +358,7 @@ CameraDefinition::parse_range_options(
     min_option->name = "min";
     min_option->value = min_value;
 
-    MAVLinkParameters::ParamValue max_value;
+  parameters::ParamValue max_value;
     max_value.set_from_xml(type_map[param_name], max_str);
 
     auto max_option = std::make_shared<Option>();
@@ -371,7 +371,7 @@ CameraDefinition::parse_range_options(
     }
 
     if (step_str) {
-        MAVLinkParameters::ParamValue step_value;
+	  parameters::ParamValue step_value;
         step_value.set_from_xml(type_map[param_name], step_str);
 
         auto step_option = std::make_shared<Option>();
@@ -392,7 +392,7 @@ CameraDefinition::parse_range_options(
         return std::make_tuple<>(false, options, default_option);
     }
 
-    MAVLinkParameters::ParamValue default_value;
+  parameters::ParamValue default_value;
     default_value.set_from_xml(type_map[param_name], default_str);
 
     default_option.name = default_str;
@@ -460,7 +460,7 @@ void CameraDefinition::assume_default_settings()
 }
 
 bool CameraDefinition::get_all_settings(
-    std::unordered_map<std::string, MAVLinkParameters::ParamValue>& settings)
+    std::unordered_map<std::string, parameters::ParamValue>& settings)
 {
     std::lock_guard<std::mutex> lock(_mutex);
 
@@ -473,7 +473,7 @@ bool CameraDefinition::get_all_settings(
 }
 
 bool CameraDefinition::get_possible_settings(
-    std::unordered_map<std::string, MAVLinkParameters::ParamValue>& settings)
+    std::unordered_map<std::string, parameters::ParamValue>& settings)
 {
     std::lock_guard<std::mutex> lock(_mutex);
 
@@ -481,7 +481,7 @@ bool CameraDefinition::get_possible_settings(
 }
 
 bool CameraDefinition::get_possible_settings_locked(
-    std::unordered_map<std::string, MAVLinkParameters::ParamValue>& settings)
+    std::unordered_map<std::string, parameters::ParamValue>& settings)
 {
     settings.clear();
 
@@ -522,7 +522,7 @@ bool CameraDefinition::get_possible_settings_locked(
 }
 
 bool CameraDefinition::set_setting(
-    const std::string& name, const MAVLinkParameters::ParamValue& value)
+    const std::string& name, const parameters::ParamValue& value)
 {
     std::lock_guard<std::mutex> lock(_mutex);
 
@@ -564,7 +564,7 @@ bool CameraDefinition::set_setting(
     return true;
 }
 
-bool CameraDefinition::get_setting(const std::string& name, MAVLinkParameters::ParamValue& value)
+bool CameraDefinition::get_setting(const std::string& name, parameters::ParamValue& value)
 {
     std::lock_guard<std::mutex> lock(_mutex);
 
@@ -584,7 +584,7 @@ bool CameraDefinition::get_setting(const std::string& name, MAVLinkParameters::P
 bool CameraDefinition::get_option_value(
     const std::string& param_name,
     const std::string& option_value,
-    MAVLinkParameters::ParamValue& value)
+	parameters::ParamValue& value)
 {
     std::lock_guard<std::mutex> lock(_mutex);
 
@@ -604,7 +604,7 @@ bool CameraDefinition::get_option_value(
 }
 
 bool CameraDefinition::get_all_options(
-    const std::string& name, std::vector<MAVLinkParameters::ParamValue>& values)
+    const std::string& name, std::vector<parameters::ParamValue>& values)
 {
     std::lock_guard<std::mutex> lock(_mutex);
 
@@ -623,7 +623,7 @@ bool CameraDefinition::get_all_options(
 }
 
 bool CameraDefinition::get_possible_options(
-    const std::string& name, std::vector<MAVLinkParameters::ParamValue>& values)
+    const std::string& name, std::vector<parameters::ParamValue>& values)
 {
     std::lock_guard<std::mutex> lock(_mutex);
 
@@ -634,7 +634,7 @@ bool CameraDefinition::get_possible_options(
         return false;
     }
 
-    std::unordered_map<std::string, MAVLinkParameters::ParamValue> settings;
+    std::unordered_map<std::string, parameters::ParamValue> settings;
     if (!get_possible_settings_locked(settings)) {
         return false;
     }
@@ -665,7 +665,7 @@ bool CameraDefinition::get_possible_options(
     }
 
     // TODO: use set instead of vector for this
-    std::vector<MAVLinkParameters::ParamValue> allowed_ranges{};
+    std::vector<parameters::ParamValue> allowed_ranges{};
 
     // Check allowed ranges.
     for (const auto& parameter : _parameter_map) {
@@ -718,7 +718,7 @@ bool CameraDefinition::get_possible_options(
 }
 
 void CameraDefinition::get_unknown_params(
-    std::vector<std::pair<std::string, MAVLinkParameters::ParamValue>>& params)
+    std::vector<std::pair<std::string, parameters::ParamValue>>& params)
 {
     std::lock_guard<std::mutex> lock(_mutex);
 

--- a/src/mavsdk/plugins/camera/camera_definition.h
+++ b/src/mavsdk/plugins/camera/camera_definition.h
@@ -27,23 +27,23 @@ public:
 
     struct Setting {
         std::string name;
-        MAVLinkParameters::ParamValue value;
+	  	parameters::ParamValue value;
     };
 
-    bool set_setting(const std::string& name, const MAVLinkParameters::ParamValue& value);
-    bool get_setting(const std::string& name, MAVLinkParameters::ParamValue& value);
-    bool get_all_settings(std::unordered_map<std::string, MAVLinkParameters::ParamValue>& settings);
+    bool set_setting(const std::string& name, const parameters::ParamValue& value);
+    bool get_setting(const std::string& name, parameters::ParamValue& value);
+    bool get_all_settings(std::unordered_map<std::string, parameters::ParamValue>& settings);
     bool
-    get_possible_settings(std::unordered_map<std::string, MAVLinkParameters::ParamValue>& settings);
+    get_possible_settings(std::unordered_map<std::string, parameters::ParamValue>& settings);
 
     bool get_option_value(
         const std::string& param_name,
         const std::string& option_value,
-        MAVLinkParameters::ParamValue& value);
+		parameters::ParamValue& value);
     bool
-    get_all_options(const std::string& name, std::vector<MAVLinkParameters::ParamValue>& values);
+    get_all_options(const std::string& name, std::vector<parameters::ParamValue>& values);
     bool get_possible_options(
-        const std::string& name, std::vector<MAVLinkParameters::ParamValue>& values);
+        const std::string& name, std::vector<parameters::ParamValue>& values);
 
     bool is_setting_range(const std::string& name);
 
@@ -52,7 +52,7 @@ public:
         const std::string& setting_name, const std::string& option_name, std::string& description);
 
     void
-    get_unknown_params(std::vector<std::pair<std::string, MAVLinkParameters::ParamValue>>& params);
+    get_unknown_params(std::vector<std::pair<std::string, parameters::ParamValue>>& params);
     void set_all_params_unknown();
 
     // Non-copyable
@@ -61,13 +61,13 @@ public:
 
 private:
     bool get_possible_settings_locked(
-        std::unordered_map<std::string, MAVLinkParameters::ParamValue>& settings);
+        std::unordered_map<std::string, parameters::ParamValue>& settings);
 
-    typedef std::unordered_map<std::string, MAVLinkParameters::ParamValue> parameter_range_t;
+    typedef std::unordered_map<std::string, parameters::ParamValue> parameter_range_t;
 
     struct Option {
         std::string name{};
-        MAVLinkParameters::ParamValue value{};
+	  parameters::ParamValue value{};
         std::vector<std::string> exclusions{};
         std::unordered_map<std::string, parameter_range_t> parameter_ranges{};
     };
@@ -77,7 +77,7 @@ private:
         bool is_control{false};
         bool is_readonly{false};
         bool is_writeonly{false};
-        MAVLinkParameters::ParamValue type{}; // for type only, doesn't hold a value
+	  	parameters::ParamValue type{}; // for type only, doesn't hold a value
         std::vector<std::string> updates{};
         std::vector<std::shared_ptr<Option>> options{};
         Option default_option{};
@@ -106,7 +106,7 @@ private:
     std::unordered_map<std::string, std::shared_ptr<Parameter>> _parameter_map{};
 
     struct InternalCurrentSetting {
-        MAVLinkParameters::ParamValue value{};
+	  	parameters::ParamValue value{};
         bool needs_updating{false};
     };
 

--- a/src/mavsdk/plugins/camera/camera_definition_test.cpp
+++ b/src/mavsdk/plugins/camera/camera_definition_test.cpp
@@ -42,7 +42,7 @@ TEST(CameraDefinition, E90CheckDefaultSettings)
     cd.assume_default_settings();
 
     {
-        std::unordered_map<std::string, MAVLinkParameters::ParamValue> settings{};
+        std::unordered_map<std::string, parameters::ParamValue> settings{};
         EXPECT_TRUE(cd.get_all_settings(settings));
         EXPECT_EQ(settings.size(), 17);
 
@@ -67,13 +67,13 @@ TEST(CameraDefinition, E90CheckDefaultSettings)
 
     // Get only settings for video mode.
     {
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         value.set<uint32_t>(1);
         EXPECT_TRUE(cd.set_setting("CAM_MODE", value));
     }
 
     {
-        std::unordered_map<std::string, MAVLinkParameters::ParamValue> settings{};
+        std::unordered_map<std::string, parameters::ParamValue> settings{};
         EXPECT_TRUE(cd.get_possible_settings(settings));
         EXPECT_EQ(settings.size(), 6);
         // LogDebug() << "Found settings:";
@@ -84,13 +84,13 @@ TEST(CameraDefinition, E90CheckDefaultSettings)
 
     // Get only settings for photo mode.
     {
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         value.set<uint32_t>(0);
         EXPECT_TRUE(cd.set_setting("CAM_MODE", value));
     }
 
     {
-        std::unordered_map<std::string, MAVLinkParameters::ParamValue> settings{};
+        std::unordered_map<std::string, parameters::ParamValue> settings{};
         EXPECT_TRUE(cd.get_possible_settings(settings));
         EXPECT_EQ(settings.size(), 9);
         // LogDebug() << "Found settings:";
@@ -110,70 +110,70 @@ TEST(CameraDefinition, E90ChangeSettings)
 
     {
         // Check default
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         ASSERT_TRUE(cd.get_setting("CAM_WBMODE", value));
         EXPECT_EQ(value.get<uint32_t>(), 0);
     }
 
     {
         // We can only set CAM_COLORMODE in photo mode
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         value.set<uint32_t>(0);
         ASSERT_TRUE(cd.set_setting("CAM_MODE", value));
     }
 
     {
         // Set WBMODE to 1
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         value.set<uint32_t>(1);
         EXPECT_TRUE(cd.set_setting("CAM_WBMODE", value));
     }
 
     {
         // Check if WBMODE was correctly set
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         ASSERT_TRUE(cd.get_setting("CAM_WBMODE", value));
         EXPECT_EQ(value.get<uint32_t>(), 1);
     }
 
     {
         // Interleave COLORMODE, first check default
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         ASSERT_TRUE(cd.get_setting("CAM_COLORMODE", value));
         EXPECT_EQ(value.get<uint32_t>(), 1);
     }
 
     {
         // Then set COLORMODE to 5
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         value.set<uint32_t>(5);
         ASSERT_TRUE(cd.set_setting("CAM_COLORMODE", value));
     }
 
     {
         // COLORMODE should now be 5
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         ASSERT_TRUE(cd.get_setting("CAM_COLORMODE", value));
         EXPECT_EQ(value.get<uint32_t>(), 5);
     }
 
     {
         // WBMODE should still be 1
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         ASSERT_TRUE(cd.get_setting("CAM_WBMODE", value));
         EXPECT_EQ(value.get<uint32_t>(), 1);
     }
 
     {
         // Change WBMODE to 7
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         value.set<uint32_t>(7);
         ASSERT_TRUE(cd.set_setting("CAM_WBMODE", value));
     }
 
     {
         // And check WBMODE again
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         ASSERT_TRUE(cd.get_setting("CAM_WBMODE", value));
         EXPECT_EQ(value.get<uint32_t>(), 7);
     }
@@ -188,88 +188,88 @@ TEST(CameraDefinition, E90ShowOptions)
     cd.assume_default_settings();
 
     {
-        std::vector<MAVLinkParameters::ParamValue> values;
+        std::vector<parameters::ParamValue> values;
         EXPECT_TRUE(cd.get_all_options("CAM_WBMODE", values));
         EXPECT_EQ(values.size(), 8);
     }
 
     {
-        std::vector<MAVLinkParameters::ParamValue> values;
+        std::vector<parameters::ParamValue> values;
         EXPECT_TRUE(cd.get_all_options("CAM_SHUTTERSPD", values));
         EXPECT_EQ(values.size(), 19);
     }
 
     {
         // Currently not applicable because exposure mode is in Auto.
-        std::vector<MAVLinkParameters::ParamValue> values;
+        std::vector<parameters::ParamValue> values;
         EXPECT_FALSE(cd.get_possible_options("CAM_SHUTTERSPD", values));
         EXPECT_EQ(values.size(), 0);
     }
 
     {
         // Set exposure mode to manual
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         value.set<uint32_t>(1);
         EXPECT_TRUE(cd.set_setting("CAM_EXPMODE", value));
 
         // Currently not applicable because exposure mode is in Auto.
-        std::vector<MAVLinkParameters::ParamValue> values;
+        std::vector<parameters::ParamValue> values;
         EXPECT_TRUE(cd.get_possible_options("CAM_SHUTTERSPD", values));
         EXPECT_EQ(values.size(), 12);
     }
 
     {
         // Test VIDRES without range restrictions in h.264.
-        std::vector<MAVLinkParameters::ParamValue> values;
+        std::vector<parameters::ParamValue> values;
         EXPECT_TRUE(cd.get_possible_options("CAM_VIDRES", values));
         EXPECT_EQ(values.size(), 32);
     }
 
     {
         // Set it to one that is allowed.
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         value.set<uint32_t>(3);
         EXPECT_TRUE(cd.set_setting("CAM_VIDRES", value));
     }
 
     {
         // Now switch to HEVC
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         value.set<uint32_t>(3);
         EXPECT_TRUE(cd.set_setting("CAM_VIDFMT", value));
     }
 
     {
         // Test VIDRES with range restrictions in HEVC.
-        std::vector<MAVLinkParameters::ParamValue> values;
+        std::vector<parameters::ParamValue> values;
         EXPECT_TRUE(cd.get_possible_options("CAM_VIDRES", values));
         EXPECT_EQ(values.size(), 26);
     }
 
     {
         // Then one that is allowed.
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         value.set<uint32_t>(5);
         EXPECT_TRUE(cd.set_setting("CAM_VIDRES", value));
     }
 
     {
         // Back to h.264
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         value.set<uint32_t>(1);
         EXPECT_TRUE(cd.set_setting("CAM_VIDFMT", value));
     }
 
     {
         // Test VIDRES without range restrictions in h.264.
-        std::vector<MAVLinkParameters::ParamValue> values;
+        std::vector<parameters::ParamValue> values;
         EXPECT_TRUE(cd.get_possible_options("CAM_VIDRES", values));
         EXPECT_EQ(values.size(), 32);
     }
 
     {
         // And 4K 60 Hz is now allowed again.
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         value.set<uint32_t>(0);
         EXPECT_TRUE(cd.set_setting("CAM_VIDRES", value));
     }
@@ -282,20 +282,20 @@ TEST(CameraDefinition, E90SettingsToUpdate)
     ASSERT_TRUE(cd.load_file(e90_unit_test_file));
 
     {
-        std::vector<std::pair<std::string, MAVLinkParameters::ParamValue>> params;
+        std::vector<std::pair<std::string, parameters::ParamValue>> params;
         cd.get_unknown_params(params);
         EXPECT_EQ(params.size(), 17);
     }
 
     {
-        MAVLinkParameters::ParamValue value;
+parameters::ParamValue value;
         value.set<uint32_t>(1);
         EXPECT_TRUE(cd.set_setting("CAM_MODE", value));
     }
 
     // Now that we set one param it should be less that we need to fetch.
     {
-        std::vector<std::pair<std::string, MAVLinkParameters::ParamValue>> params;
+        std::vector<std::pair<std::string, parameters::ParamValue>> params;
         cd.get_unknown_params(params);
         EXPECT_EQ(params.size(), 16);
     }
@@ -303,7 +303,7 @@ TEST(CameraDefinition, E90SettingsToUpdate)
     cd.set_all_params_unknown();
 
     {
-        std::vector<std::pair<std::string, MAVLinkParameters::ParamValue>> params;
+        std::vector<std::pair<std::string, parameters::ParamValue>> params;
         cd.get_unknown_params(params);
         EXPECT_EQ(params.size(), 17);
     }
@@ -318,7 +318,7 @@ TEST(CameraDefinition, E90SettingsCauseUpdates)
     cd.assume_default_settings();
 
     {
-        std::vector<std::pair<std::string, MAVLinkParameters::ParamValue>> params;
+        std::vector<std::pair<std::string, parameters::ParamValue>> params;
         cd.get_unknown_params(params);
         EXPECT_EQ(params.size(), 0);
         for (const auto& param : params) {
@@ -327,14 +327,14 @@ TEST(CameraDefinition, E90SettingsCauseUpdates)
     }
 
     {
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         value.set<uint32_t>(0);
         EXPECT_TRUE(cd.set_setting("CAM_MODE", value));
     }
 
     // Now that we set one param it should be less that we need to fetch.
     {
-        std::vector<std::pair<std::string, MAVLinkParameters::ParamValue>> params;
+        std::vector<std::pair<std::string, parameters::ParamValue>> params;
         cd.get_unknown_params(params);
         EXPECT_EQ(params.size(), 4);
 
@@ -378,10 +378,10 @@ TEST(CameraDefinition, E90OptionValues)
     CameraDefinition cd;
     ASSERT_TRUE(cd.load_file(e90_unit_test_file));
 
-    MAVLinkParameters::ParamValue value1;
+parameters::ParamValue value1;
     value1.set<float>(0.02f);
 
-    MAVLinkParameters::ParamValue value2;
+parameters::ParamValue value2;
 
     // First try the invalid case.
     EXPECT_FALSE(cd.get_option_value("CAM_BLABLA", "0.02", value2));
@@ -517,7 +517,7 @@ TEST(CameraDefinition, UVCCheckDefaultSettings)
 
     cd.assume_default_settings();
 
-    std::unordered_map<std::string, MAVLinkParameters::ParamValue> settings{};
+    std::unordered_map<std::string, parameters::ParamValue> settings{};
     EXPECT_TRUE(cd.get_all_settings(settings));
     EXPECT_EQ(settings.size(), 13);
 
@@ -549,25 +549,25 @@ TEST(CameraDefinition, UVCCheckPossibleSettings)
 
     // Get only settings for WB mode Auto.
     {
-        MAVLinkParameters::ParamValue value;
+parameters::ParamValue value;
         value.set<int32_t>(1);
         EXPECT_TRUE(cd.set_setting("wb-mode", value));
     }
 
     // And exposure mode aperture priority.
     {
-        MAVLinkParameters::ParamValue value;
+parameters::ParamValue value;
         value.set<int32_t>(3);
         EXPECT_TRUE(cd.set_setting("exp-mode", value));
     }
 
-    std::unordered_map<std::string, MAVLinkParameters::ParamValue> settings{};
+    std::unordered_map<std::string, parameters::ParamValue> settings{};
     EXPECT_TRUE(cd.get_possible_settings(settings));
     EXPECT_EQ(settings.size(), 10);
 
     // With exposure mode manual we will have one more setting.
     {
-        MAVLinkParameters::ParamValue value;
+parameters::ParamValue value;
         value.set<int32_t>(1);
         EXPECT_TRUE(cd.set_setting("exp-mode", value));
     }
@@ -583,21 +583,21 @@ TEST(CameraDefinition, UVCSetRangeSetting)
     ASSERT_TRUE(cd.load_file(uvc_unit_test_file));
 
     {
-        MAVLinkParameters::ParamValue value;
+parameters::ParamValue value;
         value.set<int32_t>(200);
         EXPECT_TRUE(cd.set_setting("brightness", value));
     }
 
     {
         // Try too big.
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         value.set<int32_t>(400);
         EXPECT_FALSE(cd.set_setting("brightness", value));
     }
 
     {
         // Try too small.
-        MAVLinkParameters::ParamValue value;
+		parameters::ParamValue value;
         value.set<int32_t>(-100);
         EXPECT_FALSE(cd.set_setting("brightness", value));
     }

--- a/src/mavsdk/plugins/camera/camera_impl.cpp
+++ b/src/mavsdk/plugins/camera/camera_impl.cpp
@@ -10,7 +10,7 @@
 #include <sstream>
 
 namespace mavsdk {
-
+using namespace parameters;
 CameraImpl::CameraImpl(System& system) : PluginImplBase(system)
 {
     _parent->register_plugin(this);
@@ -751,7 +751,7 @@ void CameraImpl::save_camera_mode(const float mavlink_camera_mode)
     // maintain (what if the MAVLink CAMERA_MODE enum evolves?), so
     // I am assuming here that in such a case, CAMERA_SETTINGS is
     // never sent by the camera.
-    MAVLinkParameters::ParamValue value;
+  parameters::ParamValue value;
     if (_camera_definition->get_setting("CAM_MODE", value)) {
         if (value.is<uint8_t>()) {
             value.set<uint8_t>(static_cast<uint8_t>(mavlink_camera_mode));
@@ -1395,7 +1395,7 @@ bool CameraImpl::get_possible_setting_options(std::vector<std::string>& settings
         return false;
     }
 
-    std::unordered_map<std::string, MAVLinkParameters::ParamValue> cd_settings{};
+    std::unordered_map<std::string, parameters::ParamValue> cd_settings{};
     _camera_definition->get_possible_settings(cd_settings);
 
     for (const auto& cd_setting : cd_settings) {
@@ -1420,7 +1420,7 @@ bool CameraImpl::get_possible_options(
         return false;
     }
 
-    std::vector<MAVLinkParameters::ParamValue> values;
+    std::vector<parameters::ParamValue> values;
     if (!_camera_definition->get_possible_options(setting_id, values)) {
         return false;
     }
@@ -1475,11 +1475,11 @@ void CameraImpl::set_option_async(
     }
 
     // We get it first so that we have the type of the param value.
-    MAVLinkParameters::ParamValue value;
+  parameters::ParamValue value;
 
     if (_camera_definition->is_setting_range(setting_id)) {
         // TODO: Get type from minimum.
-        std::vector<MAVLinkParameters::ParamValue> all_values;
+        std::vector<parameters::ParamValue> all_values;
         if (!_camera_definition->get_all_options(setting_id, all_values)) {
             if (callback) {
                 LogErr() << "Could not get all options to get type for range param.";
@@ -1523,7 +1523,7 @@ void CameraImpl::set_option_async(
             return;
         }
 
-        std::vector<MAVLinkParameters::ParamValue> possible_values;
+        std::vector<parameters::ParamValue> possible_values;
         _camera_definition->get_possible_options(setting_id, possible_values);
         bool allowed = false;
         for (const auto& possible_value : possible_values) {
@@ -1655,7 +1655,7 @@ void CameraImpl::get_option_async(
         return;
     }
 
-    MAVLinkParameters::ParamValue value;
+parameters::ParamValue value;
     // We should have this cached and don't need to get the param.
     if (_camera_definition->get_setting(setting_id, value)) {
         if (callback) {
@@ -1722,7 +1722,7 @@ void CameraImpl::notify_current_settings()
 
     for (auto& possible_setting : possible_setting_options) {
         // use the cache for this, presumably we updated it right before.
-        MAVLinkParameters::ParamValue value;
+	  parameters::ParamValue value;
         if (_camera_definition->get_setting(possible_setting, value)) {
             Camera::Setting setting{};
             setting.setting_id = possible_setting;
@@ -1794,7 +1794,7 @@ void CameraImpl::refresh_params()
         return;
     }
 
-    std::vector<std::pair<std::string, MAVLinkParameters::ParamValue>> params;
+    std::vector<std::pair<std::string, parameters::ParamValue>> params;
     _camera_definition->get_unknown_params(params);
     if (params.size() == 0) {
         // We're assuming that we changed one option and this did not cause
@@ -1808,13 +1808,13 @@ void CameraImpl::refresh_params()
     unsigned count = 0;
     for (const auto& param : params) {
         const std::string& param_name = param.first;
-        const MAVLinkParameters::ParamValue& param_value_type = param.second;
+        const parameters::ParamValue& param_value_type = param.second;
         const bool is_last = (count == params.size() - 1);
         _parent->get_param_async(
             param_name,
             param_value_type,
             [param_name, is_last, this](
-                MAVLinkParameters::Result result, MAVLinkParameters::ParamValue value) {
+                MAVLinkParameters::Result result, parameters::ParamValue value) {
                 if (result != MAVLinkParameters::Result::Success) {
                     return;
                 }

--- a/src/mavsdk/plugins/param/param.cpp
+++ b/src/mavsdk/plugins/param/param.cpp
@@ -55,7 +55,7 @@ Param::Result Param::set_param_custom(std::string name, std::string value) const
 
 Param::AllParams Param::get_all_params() const
 {
-    return _impl->get_all_params();
+    return _impl->get_all_params(false);
 }
 
 bool operator==(const Param::IntParam& lhs, const Param::IntParam& rhs)

--- a/src/mavsdk/plugins/param/param_impl.cpp
+++ b/src/mavsdk/plugins/param/param_impl.cpp
@@ -63,10 +63,9 @@ Param::Result ParamImpl::set_param_custom(const std::string& name, const std::st
     return result_from_mavlink_parameters_result(result);
 }
 
-Param::AllParams ParamImpl::get_all_params()
+Param::AllParams ParamImpl::get_all_params(const bool use_extended)
 {
     auto tmp = _parent->get_all_params();
-
     Param::AllParams res{};
     for (auto const& param_pair : tmp) {
         if (param_pair.second.is<float>()) {

--- a/src/mavsdk/plugins/param/param_impl.h
+++ b/src/mavsdk/plugins/param/param_impl.h
@@ -32,7 +32,11 @@ public:
 
     Param::Result set_param_custom(const std::string& name, const std::string& value);
 
-    Param::AllParams get_all_params();
+	/**
+	 * @param use_extended When not using the extended protocol, this cannot return any parameters where
+	 * value is of type string.
+	 */
+    Param::AllParams get_all_params(const bool use_extended=false);
 
 private:
     static Param::Result result_from_mavlink_parameters_result(MAVLinkParameters::Result result);

--- a/src/system_tests/param_custom_set_and_get.cpp
+++ b/src/system_tests/param_custom_set_and_get.cpp
@@ -74,4 +74,7 @@ TEST(SystemTest, ParamCustomSetAndGet)
     auto server_result_pair = param_server.retrieve_param_custom(param_name);
     EXPECT_EQ(server_result_pair.first, ParamServer::Result::Success);
     EXPECT_EQ(server_result_pair.second, data_shorter);
+
+	// this is just to make sure the get_all() doesn't crash
+	//const auto res_get_all=param.get_all_params();
 }

--- a/src/system_tests/param_get_all.cpp
+++ b/src/system_tests/param_get_all.cpp
@@ -59,21 +59,30 @@ TEST(SystemTest, ParamGetAll)
 
     auto param = Param{system};
 
+	const auto test_float_params=generate_float_params();
+	const auto test_int_params=generate_int_params();
     // Add many params
-    for (const auto& float_param : generate_float_params()) {
+    for (const auto& float_param : test_float_params) {
         EXPECT_EQ(
             param_server.provide_param_float(float_param.first, float_param.second),
             ParamServer::Result::Success);
     }
-    for (const auto& int_param : generate_int_params()) {
+    for (const auto& int_param :  test_int_params) {
         EXPECT_EQ(
             param_server.provide_param_int(int_param.first, int_param.second),
             ParamServer::Result::Success);
     }
 
-    auto all_params = param.get_all_params();
+    const auto all_params = param.get_all_params();
 
-    EXPECT_EQ(all_params.float_params.size(), generate_float_params().size());
-    EXPECT_EQ(all_params.int_params.size(), generate_int_params().size());
+    EXPECT_EQ(all_params.float_params.size(), test_float_params.size());
+    EXPECT_EQ(all_params.int_params.size(), test_int_params.size());
+	// Note: the order is not necessarily a requirement
+	for(int i=0;i<test_float_params.size();i++){
+		EXPECT_EQ(all_params.float_params.at(i), test_float_params.at(i));
+	}
+	for(int i=0;i<test_int_params.size();i++){
+		EXPECT_EQ(all_params.int_params.at(i), test_int_params.at(i));
+	}
     std::this_thread::sleep_for(std::chrono::seconds(1));
 }

--- a/src/system_tests/param_get_all.cpp
+++ b/src/system_tests/param_get_all.cpp
@@ -79,7 +79,6 @@ TEST(SystemTest, ParamGetAll)
     EXPECT_EQ(all_params.float_params.size(), test_float_params.size());
     EXPECT_EQ(all_params.int_params.size(), test_int_params.size());
 	// check that all the parameters we got have the right param value
-	// Note: the order is not necessarily a requirement
 	for(const auto& param: all_params.float_params){
 		EXPECT_EQ(param.value, test_float_params.find(param.name)->second);
 	}

--- a/src/system_tests/param_get_all.cpp
+++ b/src/system_tests/param_get_all.cpp
@@ -13,7 +13,7 @@ using namespace mavsdk;
 
 static constexpr unsigned num_params_per_type = 100;
 
-std::map<std::string, float> generate_float_params()
+static std::map<std::string, float> generate_float_params()
 {
   	std::map<std::string, float> params;
     for (unsigned i = 0; i < num_params_per_type; ++i) {
@@ -24,7 +24,7 @@ std::map<std::string, float> generate_float_params()
     return params;
 }
 
-std::map<std::string,int> generate_int_params()
+static std::map<std::string,int> generate_int_params()
 {
   	std::map<std::string,int> params;
     for (unsigned i = 0; i < num_params_per_type; ++i) {
@@ -33,6 +33,17 @@ std::map<std::string,int> generate_int_params()
 	  	params[id]=value;
     }
     return params;
+}
+
+static std::map<std::string,std::string> generate_string_params()
+{
+  std::map<std::string,std::string> params;
+  for (unsigned i = 0; i < num_params_per_type; ++i) {
+	const auto id=std::string("TEST_STRING") + std::to_string(i);
+	const std::string value= std::to_string(i);
+	params[id]=value;
+  }
+  return params;
 }
 
 TEST(SystemTest, ParamGetAll)
@@ -62,7 +73,8 @@ TEST(SystemTest, ParamGetAll)
 
 	const auto test_float_params=generate_float_params();
 	const auto test_int_params=generate_int_params();
-    // Add many params
+	const auto test_string_params=generate_string_params();
+    // Add many params (these don't need extended)
 	for (auto const& [key, val] : test_float_params){
 		EXPECT_EQ(
 			param_server.provide_param_float(key,val),
@@ -73,6 +85,12 @@ TEST(SystemTest, ParamGetAll)
             param_server.provide_param_int(key,val),
             ParamServer::Result::Success);
     }
+	// We also add a couple of std::string parameters - note that they won't show up in get_all_params() when using the non-extended version
+	for (auto const& [key, val] : test_string_params){
+		EXPECT_EQ(
+			param_server.provide_param_custom(key,val),
+			ParamServer::Result::Success);
+	}
 
     const auto all_params = param.get_all_params();
 

--- a/src/system_tests/param_get_all.cpp
+++ b/src/system_tests/param_get_all.cpp
@@ -92,16 +92,26 @@ TEST(SystemTest, ParamGetAll)
 			ParamServer::Result::Success);
 	}
 
-    const auto all_params = param.get_all_params();
+	{
+	  // Here we use the non-extended protocol
+	  const auto all_params = param.get_all_params();
+	  EXPECT_EQ(all_params.float_params.size(), test_float_params.size());
+	  EXPECT_EQ(all_params.int_params.size(), test_int_params.size());
+	  // check that all the parameters we got have the right param value
+	  for(const auto& param: all_params.float_params){
+		  EXPECT_EQ(param.value, test_float_params.find(param.name)->second);
+	  }
+	  for(const auto& param: all_params.int_params){
+		  EXPECT_EQ(param.value, test_int_params.find(param.name)->second);
+	  }
+	}
+	/*{
+		// now we do the same, but this time with the extended protocol
+		const auto all_params = param.get_all_params(true);
+		EXPECT_EQ(all_params.float_params.size(), test_float_params.size());
+		EXPECT_EQ(all_params.int_params.size(), test_int_params.size());
+		EXPECT_EQ(all_params.custom_params.size(), test_string_params.size());
+	}*/
 
-    EXPECT_EQ(all_params.float_params.size(), test_float_params.size());
-    EXPECT_EQ(all_params.int_params.size(), test_int_params.size());
-	// check that all the parameters we got have the right param value
-	for(const auto& param: all_params.float_params){
-		EXPECT_EQ(param.value, test_float_params.find(param.name)->second);
-	}
-	for(const auto& param: all_params.int_params){
-	  	EXPECT_EQ(param.value, test_int_params.find(param.name)->second);
-	}
     std::this_thread::sleep_for(std::chrono::seconds(1));
 }

--- a/src/system_tests/param_set_and_get.cpp
+++ b/src/system_tests/param_set_and_get.cpp
@@ -39,10 +39,12 @@ TEST(SystemTest, ParamSetAndGet)
 
     // First we try to get a param before it is available.
     // Disabled for now because the timeouts make it very slow to run.
-    // auto result_pair = param.get_param_float(param_name_float);
-    // EXPECT_EQ(result_pair.first, Param::Result::Timeout);
-    // result_pair = param.get_param_int(param_name_int);
-    // EXPECT_EQ(result_pair.first, Param::Result::Timeout);
+    {
+        auto result_pair = param.get_param_float(param_name_float);
+        EXPECT_EQ(result_pair.first, Param::Result::Timeout);
+        auto result_pair2 = param.get_param_int(param_name_int);
+        EXPECT_EQ(result_pair2.first, Param::Result::Timeout);
+    }
 
     // Then we make it available.
     EXPECT_EQ(
@@ -90,4 +92,6 @@ TEST(SystemTest, ParamSetAndGet)
     auto server_result_all_params = param_server.retrieve_all_params();
     EXPECT_EQ(server_result_all_params.int_params.size(), 1);
     EXPECT_EQ(server_result_all_params.float_params.size(), 1);
+    EXPECT_EQ(server_result_all_params.float_params[0].value, param_value_float + 1.0f);
+    EXPECT_EQ(server_result_all_params.int_params[0].value, param_value_int + 2);
 }

--- a/src/system_tests/param_set_and_get.cpp
+++ b/src/system_tests/param_set_and_get.cpp
@@ -63,6 +63,12 @@ TEST(SystemTest, ParamSetAndGet)
     EXPECT_EQ(result_pair.first, Param::Result::Success);
     EXPECT_EQ(result_pair.second, param_value_int);
 
+    // and we check that obtaining a value with the wrong type returns the proper error code
+    result_pair = param.get_param_int(param_name_float);
+    EXPECT_EQ(result_pair.first, Param::Result::WrongType);
+    result_pair = param.get_param_float(param_name_int);
+    EXPECT_EQ(result_pair.first, Param::Result::WrongType);
+
     // Let's now change the values
     auto result = param.set_param_float(param_name_float, param_value_float + 1.0f);
     EXPECT_EQ(result, Param::Result::Success);

--- a/third_party/mavlink/CMakeLists.txt
+++ b/third_party/mavlink/CMakeLists.txt
@@ -17,8 +17,8 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 ExternalProject_add(
     mavlink
-    GIT_REPOSITORY https://github.com/mavlink/mavlink
-    GIT_TAG 3b52eac09c2e37325e4bc49cd2667ea37bf1d7d2
+    GIT_REPOSITORY https://github.com/OpenHD/mavlink.git
+    GIT_TAG 136a30c6c06314367410b87f82c4d91812928f3a
     PREFIX mavlink
     CONFIGURE_COMMAND Python3::Interpreter
         -m pymavlink.tools.mavgen


### PR DESCRIPTION
Opening this pull request to show the fixes, **not ready to be merged yet.**.

Related to https://github.com/mavlink/MAVSDK/issues/1805

Fixes for mavlink_param when used as 
1) Server:
Do not forward parameters that need extended protocoll (string-values) on non-ext param requests, this made the original impl crash at run time.

The fix I went with seems to work but is not the nicest in my opinion - I basically try and hide parameters that only work with extended from a non-extended perspective.

2) Client:
Fix bug where reference goes out of scope, which resulted in the client crashing.





