### PR TITLE
Fix vehicle type detection

### DIFF
--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -217,7 +217,7 @@ void SystemImpl::process_heartbeat(const mavlink_message_t& message)
     } else {
         const auto new_vehicle_type = static_cast<MAV_TYPE>(heartbeat.type);
         if (heartbeat.autopilot != MAV_AUTOPILOT_INVALID && _vehicle_type != new_vehicle_type &&
-            _new_vehicle_type != MAV_TYPE_GENERIC) {
+            new_vehicle_type != MAV_TYPE_GENERIC) {
             LogWarn() << "Vehicle type changed (new type: " << static_cast<unsigned>(heartbeat.type)
                       << ", old type: " << static_cast<unsigned>(_vehicle_type) << ")";
             _vehicle_type = new_vehicle_type;

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -217,7 +217,7 @@ void SystemImpl::process_heartbeat(const mavlink_message_t& message)
     } else {
         const auto new_vehicle_type = static_cast<MAV_TYPE>(heartbeat.type);
         if (heartbeat.autopilot != MAV_AUTOPILOT_INVALID && _vehicle_type != new_vehicle_type &&
-            _vehicle_type != MAV_TYPE_GENERIC) {
+            _new_vehicle_type != MAV_TYPE_GENERIC) {
             LogWarn() << "Vehicle type changed (new type: " << static_cast<unsigned>(heartbeat.type)
                       << ", old type: " << static_cast<unsigned>(_vehicle_type) << ")";
             _vehicle_type = new_vehicle_type;


### PR DESCRIPTION
Following #1760 The vehicle type can never be changed from generic. As such the vehicle will always operate as generic, breaking plane/quad/rover type detection :)

I believe this was the original intention of the change. @pweids might be able to confirm.

