### PR TITLE
Add pure mode

### DIFF
--- a/src/mavsdk/core/flight_mode.cpp
+++ b/src/mavsdk/core/flight_mode.cpp
@@ -8,9 +8,9 @@
 namespace mavsdk {
 
 FlightMode to_flight_mode_from_custom_mode(
-    Sender::Autopilot autopilot, MAV_TYPE mav_type, uint32_t custom_mode)
+    System::CompatibilityMode compatibility_mode, MAV_TYPE mav_type, uint32_t custom_mode)
 {
-    if (autopilot == Sender::Autopilot::ArduPilot) {
+    if (compatibility_mode == System::CompatibilityMode::Ardupilot) {
         switch (mav_type) {
             case MAV_TYPE::MAV_TYPE_SURFACE_BOAT:
             case MAV_TYPE::MAV_TYPE_GROUND_ROVER:

--- a/src/mavsdk/core/flight_mode.h
+++ b/src/mavsdk/core/flight_mode.h
@@ -24,7 +24,7 @@ enum class FlightMode {
 };
 
 FlightMode to_flight_mode_from_custom_mode(
-    Sender::Autopilot autopilot, MAV_TYPE mav_type, uint32_t custom_mode);
+    System::CompatibilityMode compatibility_mode, MAV_TYPE mav_type, uint32_t custom_mode);
 FlightMode to_flight_mode_from_px4_mode(uint32_t custom_mode);
 FlightMode to_flight_mode_from_ardupilot_rover_mode(uint32_t custom_mode);
 FlightMode to_flight_mode_from_ardupilot_copter_mode(uint32_t custom_mode);

--- a/src/mavsdk/core/include/mavsdk/system.h
+++ b/src/mavsdk/core/include/mavsdk/system.h
@@ -151,6 +151,26 @@ public:
     void enable_timesync();
 
     /**
+     * @brief Possible compatibility modes for this system.
+     */
+    enum class CompatibilityMode {
+        Unknown, // Unknown, not set or detected yet.
+        Pure, // No compatibility, everything up to common spec.
+        Px4, // Compatibility with PX4.
+        Ardupilot, // Compatibility with ArduPilot.
+    };
+
+    friend std::ostream& operator<<(std::ostream& str, CompatibilityMode const& compatibility_mode);
+
+    /**
+     * @brief Set compatibility mode.
+     *
+     * This disables auto-detection based on the heartbeat and sticks to
+     * set compatibility mode.
+     */
+    void set_compatibility_mode(CompatibilityMode compatibility_mode);
+
+    /**
      * @brief Copy constructor (object is not copyable).
      */
     System(const System&) = delete;

--- a/src/mavsdk/core/mavlink_command_sender.cpp
+++ b/src/mavsdk/core/mavlink_command_sender.cpp
@@ -465,7 +465,7 @@ float MavlinkCommandSender::maybe_reserved(const std::optional<float>& maybe_par
         return maybe_param.value();
 
     } else {
-        if (_parent.autopilot() == SystemImpl::Autopilot::ArduPilot) {
+        if (_parent.compatibility_mode() == System::CompatibilityMode::Ardupilot) {
             return 0.0f;
         } else {
             return NAN;

--- a/src/mavsdk/core/mavlink_mission_transfer.cpp
+++ b/src/mavsdk/core/mavlink_mission_transfer.cpp
@@ -330,7 +330,7 @@ void MavlinkMissionTransfer::UploadWorkItem::send_cancel_and_finish()
 void MavlinkMissionTransfer::UploadWorkItem::process_mission_request(
     const mavlink_message_t& request_message)
 {
-    if (_sender.autopilot() == Sender::Autopilot::ArduPilot) {
+    if (_sender.compatibility_mode() == System::CompatibilityMode::Ardupilot) {
         // ArduCopter 3.6 sends MISSION_REQUEST (not _INT) but actually accepts ITEM_INT in reply
         mavlink_mission_request_t request;
         mavlink_msg_mission_request_decode(&request_message, &request);

--- a/src/mavsdk/core/mavlink_mission_transfer.h
+++ b/src/mavsdk/core/mavlink_mission_transfer.h
@@ -12,11 +12,22 @@
 #include "timeout_handler.h"
 #include "timeout_s_callback.h"
 #include "locked_queue.h"
-#include "sender.h"
+#include "mavsdk.h"
 
 namespace mavsdk {
 
-class MavlinkMissionTransfer {
+class Sender {
+public:
+    Sender() = default;
+    virtual ~Sender() = default;
+    virtual bool send_message(mavlink_message_t& message) = 0;
+    [[nodiscard]] virtual uint8_t get_own_system_id() const = 0;
+    [[nodiscard]] virtual uint8_t get_own_component_id() const = 0;
+    [[nodiscard]] virtual uint8_t get_system_id() const = 0;
+    [[nodiscard]] virtual System::CompatibilityMode compatibility_mode() const = 0;
+};
+
+class MAVLinkMissionTransfer {
 public:
     enum class Result {
         Success,

--- a/src/mavsdk/core/mavlink_mission_transfer.h
+++ b/src/mavsdk/core/mavlink_mission_transfer.h
@@ -27,7 +27,7 @@ public:
     [[nodiscard]] virtual System::CompatibilityMode compatibility_mode() const = 0;
 };
 
-class MAVLinkMissionTransfer {
+class MavlinkMissionTransfer {
 public:
     enum class Result {
         Success,

--- a/src/mavsdk/core/mavlink_mission_transfer_test.cpp
+++ b/src/mavsdk/core/mavlink_mission_transfer_test.cpp
@@ -42,7 +42,8 @@ protected:
         ON_CALL(mock_sender, get_own_component_id())
             .WillByDefault(Return(own_address.component_id));
         ON_CALL(mock_sender, get_system_id()).WillByDefault(Return(target_address.system_id));
-        ON_CALL(mock_sender, autopilot()).WillByDefault(Return(Sender::Autopilot::Px4));
+        ON_CALL(mock_sender, compatibility_mode())
+            .WillByDefault(Return(System::CompatibilityMode::Px4));
     }
 
     MockSender mock_sender;

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -193,7 +193,8 @@ void MAVLinkParameters::set_param_int_async(
 
     // PX4 only uses int32_t, so we can be sure and don't need to check the exact type first
     // by getting the param, or checking the cache.
-    const bool exact_int_type_known = (_sender.autopilot() == SystemImpl::Autopilot::Px4);
+    const bool exact_int_type_known =
+        (_sender.compatibility_mode() == System::CompatibilityMode::Px4);
 
     const auto set_step = [=]() {
         auto new_work = std::make_shared<WorkItem>(_timeout_s_callback());
@@ -806,9 +807,10 @@ void MAVLinkParameters::do_work()
                     param_value_buf.data(),
                     work->param_value.get_mav_param_ext_type());
             } else {
-                float value_set = (_sender.autopilot() == SystemImpl::Autopilot::ArduPilot) ?
-                                      work->param_value.get_4_float_bytes_cast() :
-                                      work->param_value.get_4_float_bytes_bytewise();
+                float value_set =
+                    (_sender.compatibility_mode() == System::CompatibilityMode::Ardupilot) ?
+                        work->param_value.get_4_float_bytes_cast() :
+                        work->param_value.get_4_float_bytes_bytewise();
 
                 mavlink_msg_param_set_pack(
                     _sender.get_own_system_id(),
@@ -914,7 +916,7 @@ void MAVLinkParameters::do_work()
                     work->param_index);
             } else {
                 float param_value;
-                if (_sender.autopilot() == SystemImpl::Autopilot::ArduPilot) {
+                if (_sender.compatibility_mode() == System::CompatibilityMode::Ardupilot) {
                     param_value = work->param_value.get_4_float_bytes_cast();
                 } else {
                     param_value = work->param_value.get_4_float_bytes_bytewise();
@@ -975,7 +977,7 @@ void MAVLinkParameters::process_param_value(const mavlink_message_t& message)
     }
 
     ParamValue received_value;
-    if (_sender.autopilot() == SystemImpl::Autopilot::ArduPilot) {
+    if (_sender.compatibility_mode() == System::CompatibilityMode::Ardupilot) {
         received_value.set_from_mavlink_param_value_cast(param_value);
     } else {
         received_value.set_from_mavlink_param_value_bytewise(param_value);
@@ -1098,7 +1100,7 @@ void MAVLinkParameters::notify_param_subscriptions(const mavlink_param_value_t& 
 
         ParamValue value;
 
-        if (_sender.autopilot() == SystemImpl::Autopilot::ArduPilot) {
+        if (_sender.compatibility_mode() == System::CompatibilityMode::Ardupilot) {
             value.set_from_mavlink_param_value_cast(param_value);
         } else {
             value.set_from_mavlink_param_value_bytewise(param_value);

--- a/src/mavsdk/core/mocks/sender_mock.h
+++ b/src/mavsdk/core/mocks/sender_mock.h
@@ -11,7 +11,7 @@ public:
     MOCK_METHOD(uint8_t, get_own_system_id, (), (const, override));
     MOCK_METHOD(uint8_t, get_own_component_id, (), (const, override));
     MOCK_METHOD(uint8_t, get_system_id, (), (const, override));
-    MOCK_METHOD(Autopilot, autopilot, (), (const, override));
+    MOCK_METHOD(System::CompatibilityMode, compatibility_mode, (), (const, override));
 };
 
 } // namespace testing

--- a/src/mavsdk/core/server_component_impl.cpp
+++ b/src/mavsdk/core/server_component_impl.cpp
@@ -382,10 +382,10 @@ uint8_t ServerComponentImpl::OurSender::get_system_id() const
     return current_target_system_id;
 }
 
-Sender::Autopilot ServerComponentImpl::OurSender::autopilot() const
+System::CompatibilityMode ServerComponentImpl::OurSender::compatibility_mode() const
 {
     // FIXME: hard-coded to PX4 for now to avoid the dependency into mavsdk_impl.
-    return Sender::Autopilot::Px4;
+    return System::CompatibilityMode::Px4;
 }
 
 } // namespace mavsdk

--- a/src/mavsdk/core/server_component_impl.h
+++ b/src/mavsdk/core/server_component_impl.h
@@ -34,7 +34,7 @@ public:
         [[nodiscard]] uint8_t get_own_system_id() const override;
         [[nodiscard]] uint8_t get_own_component_id() const override;
         [[nodiscard]] uint8_t get_system_id() const override;
-        [[nodiscard]] Autopilot autopilot() const override;
+        [[nodiscard]] System::CompatibilityMode compatibility_mode() const override;
 
         uint8_t current_target_system_id{0};
 

--- a/src/mavsdk/core/system.cpp
+++ b/src/mavsdk/core/system.cpp
@@ -75,4 +75,25 @@ void System::enable_timesync()
     _system_impl->enable_timesync();
 }
 
+void System::set_compatibility_mode(CompatibilityMode compatibility_mode)
+{
+    _system_impl->set_compatibility_mode(compatibility_mode);
+}
+
+std::ostream& operator<<(std::ostream& str, const System::CompatibilityMode& compatibility_mode)
+{
+    switch (compatibility_mode) {
+        default:
+            // Passthrough
+        case System::CompatibilityMode::Unknown:
+            return str << "Unknown";
+        case System::CompatibilityMode::Pure:
+            return str << "Pure";
+        case System::CompatibilityMode::Px4:
+            return str << "PX4";
+        case System::CompatibilityMode::Ardupilot:
+            return str << "ArduPilot";
+    }
+}
+
 } // namespace mavsdk

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -236,8 +236,8 @@ void SystemImpl::process_heartbeat(const mavlink_message_t& message)
         _hitl_enabled = (heartbeat.base_mode & MAV_MODE_FLAG_HIL_ENABLED) != 0;
     }
     if (heartbeat.base_mode & MAV_MODE_FLAG_CUSTOM_MODE_ENABLED) {
-        _flight_mode =
-            to_flight_mode_from_custom_mode(_autopilot, _vehicle_type, heartbeat.custom_mode);
+        _flight_mode = to_flight_mode_from_custom_mode(
+            _compatibility_mode, _vehicle_type, heartbeat.custom_mode);
     }
 
     set_connected();
@@ -953,105 +953,6 @@ SystemImpl::make_command_px4_mode(FlightMode flight_mode, uint8_t component_id)
 FlightMode SystemImpl::get_flight_mode() const
 {
     return _flight_mode;
-}
-
-SystemImpl::FlightMode SystemImpl::to_flight_mode_from_custom_mode(uint32_t custom_mode)
-{
-    if (compatibility_mode() == System::CompatibilityMode::Ardupilot) {
-        switch (_vehicle_type) {
-            case MAV_TYPE::MAV_TYPE_SURFACE_BOAT:
-            case MAV_TYPE::MAV_TYPE_GROUND_ROVER:
-                return to_flight_mode_from_ardupilot_rover_mode(custom_mode);
-            default:
-                return to_flight_mode_from_ardupilot_copter_mode(custom_mode);
-        }
-    } else {
-        return to_flight_mode_from_px4_mode(custom_mode);
-    }
-}
-
-SystemImpl::FlightMode SystemImpl::to_flight_mode_from_ardupilot_rover_mode(uint32_t custom_mode)
-{
-    switch (static_cast<ardupilot::RoverMode>(custom_mode)) {
-        case ardupilot::RoverMode::Auto:
-            return FlightMode::Mission;
-        case ardupilot::RoverMode::Acro:
-            return FlightMode::Acro;
-        case ardupilot::RoverMode::Hold:
-            return FlightMode::Hold;
-        case ardupilot::RoverMode::RTL:
-            return FlightMode::ReturnToLaunch;
-        case ardupilot::RoverMode::Manual:
-            return FlightMode::Manual;
-        case ardupilot::RoverMode::Follow:
-            return FlightMode::FollowMe;
-        default:
-            return FlightMode::Unknown;
-    }
-}
-SystemImpl::FlightMode SystemImpl::to_flight_mode_from_ardupilot_copter_mode(uint32_t custom_mode)
-{
-    switch (static_cast<ardupilot::CopterMode>(custom_mode)) {
-        case ardupilot::CopterMode::Auto:
-            return FlightMode::Mission;
-        case ardupilot::CopterMode::Acro:
-            return FlightMode::Acro;
-        case ardupilot::CopterMode::Alt_Hold:
-        case ardupilot::CopterMode::POS_HOLD:
-        case ardupilot::CopterMode::Flow_Hold:
-            return FlightMode::Hold;
-        case ardupilot::CopterMode::RTL:
-        case ardupilot::CopterMode::Auto_RTL:
-            return FlightMode::ReturnToLaunch;
-        case ardupilot::CopterMode::Land:
-            return FlightMode::Land;
-        default:
-            return FlightMode::Unknown;
-    }
-}
-
-SystemImpl::FlightMode SystemImpl::to_flight_mode_from_px4_mode(uint32_t custom_mode)
-{
-    px4::px4_custom_mode px4_custom_mode;
-    px4_custom_mode.data = custom_mode;
-
-    switch (px4_custom_mode.main_mode) {
-        case px4::PX4_CUSTOM_MAIN_MODE_OFFBOARD:
-            return FlightMode::Offboard;
-        case px4::PX4_CUSTOM_MAIN_MODE_MANUAL:
-            return FlightMode::Manual;
-        case px4::PX4_CUSTOM_MAIN_MODE_POSCTL:
-            return FlightMode::Posctl;
-        case px4::PX4_CUSTOM_MAIN_MODE_ALTCTL:
-            return FlightMode::Altctl;
-        case px4::PX4_CUSTOM_MAIN_MODE_RATTITUDE:
-            return FlightMode::Rattitude;
-        case px4::PX4_CUSTOM_MAIN_MODE_ACRO:
-            return FlightMode::Acro;
-        case px4::PX4_CUSTOM_MAIN_MODE_STABILIZED:
-            return FlightMode::Stabilized;
-        case px4::PX4_CUSTOM_MAIN_MODE_AUTO:
-            switch (px4_custom_mode.sub_mode) {
-                case px4::PX4_CUSTOM_SUB_MODE_AUTO_READY:
-                    return FlightMode::Ready;
-                case px4::PX4_CUSTOM_SUB_MODE_AUTO_TAKEOFF:
-                    return FlightMode::Takeoff;
-                case px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER:
-                    return FlightMode::Hold;
-                case px4::PX4_CUSTOM_SUB_MODE_AUTO_MISSION:
-                    return FlightMode::Mission;
-                case px4::PX4_CUSTOM_SUB_MODE_AUTO_RTL:
-                    return FlightMode::ReturnToLaunch;
-                case px4::PX4_CUSTOM_SUB_MODE_AUTO_LAND:
-                    return FlightMode::Land;
-                case px4::PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET:
-                    return FlightMode::FollowMe;
-                default:
-                    return FlightMode::Unknown;
-            }
-        default:
-            return FlightMode::Unknown;
-    }
 }
 
 void SystemImpl::receive_float_param(

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -203,10 +203,17 @@ void SystemImpl::process_heartbeat(const mavlink_message_t& message)
     mavlink_heartbeat_t heartbeat;
     mavlink_msg_heartbeat_decode(&message, &heartbeat);
 
-    if (heartbeat.autopilot == MAV_AUTOPILOT_PX4) {
-        _autopilot = Autopilot::Px4;
-    } else if (heartbeat.autopilot == MAV_AUTOPILOT_ARDUPILOTMEGA) {
-        _autopilot = Autopilot::ArduPilot;
+    {
+        std::lock_guard<std::mutex> lock(_statustext_handler_callbacks_mutex);
+        if (!_compatibility_mode_fixed) {
+            if (heartbeat.autopilot == MAV_AUTOPILOT_PX4) {
+                _compatibility_mode = System::CompatibilityMode::Px4;
+                LogDebug() << "Auto-detected " << _compatibility_mode;
+            } else if (heartbeat.autopilot == MAV_AUTOPILOT_ARDUPILOTMEGA) {
+                _compatibility_mode = System::CompatibilityMode::Ardupilot;
+                LogDebug() << "Auto-detected " << _compatibility_mode;
+            }
+        }
     }
 
     // Only set the vehicle type if the heartbeat is from an autopilot component
@@ -763,7 +770,7 @@ void SystemImpl::set_flight_mode_async(
 std::pair<MavlinkCommandSender::Result, MavlinkCommandSender::CommandLong>
 SystemImpl::make_command_flight_mode(FlightMode flight_mode, uint8_t component_id)
 {
-    if (_autopilot == Autopilot::ArduPilot) {
+    if (compatibility_mode() == System::CompatibilityMode::Ardupilot) {
         return make_command_ardupilot_mode(flight_mode, component_id);
     } else {
         return make_command_px4_mode(flight_mode, component_id);
@@ -946,6 +953,105 @@ SystemImpl::make_command_px4_mode(FlightMode flight_mode, uint8_t component_id)
 FlightMode SystemImpl::get_flight_mode() const
 {
     return _flight_mode;
+}
+
+SystemImpl::FlightMode SystemImpl::to_flight_mode_from_custom_mode(uint32_t custom_mode)
+{
+    if (compatibility_mode() == System::CompatibilityMode::Ardupilot) {
+        switch (_vehicle_type) {
+            case MAV_TYPE::MAV_TYPE_SURFACE_BOAT:
+            case MAV_TYPE::MAV_TYPE_GROUND_ROVER:
+                return to_flight_mode_from_ardupilot_rover_mode(custom_mode);
+            default:
+                return to_flight_mode_from_ardupilot_copter_mode(custom_mode);
+        }
+    } else {
+        return to_flight_mode_from_px4_mode(custom_mode);
+    }
+}
+
+SystemImpl::FlightMode SystemImpl::to_flight_mode_from_ardupilot_rover_mode(uint32_t custom_mode)
+{
+    switch (static_cast<ardupilot::RoverMode>(custom_mode)) {
+        case ardupilot::RoverMode::Auto:
+            return FlightMode::Mission;
+        case ardupilot::RoverMode::Acro:
+            return FlightMode::Acro;
+        case ardupilot::RoverMode::Hold:
+            return FlightMode::Hold;
+        case ardupilot::RoverMode::RTL:
+            return FlightMode::ReturnToLaunch;
+        case ardupilot::RoverMode::Manual:
+            return FlightMode::Manual;
+        case ardupilot::RoverMode::Follow:
+            return FlightMode::FollowMe;
+        default:
+            return FlightMode::Unknown;
+    }
+}
+SystemImpl::FlightMode SystemImpl::to_flight_mode_from_ardupilot_copter_mode(uint32_t custom_mode)
+{
+    switch (static_cast<ardupilot::CopterMode>(custom_mode)) {
+        case ardupilot::CopterMode::Auto:
+            return FlightMode::Mission;
+        case ardupilot::CopterMode::Acro:
+            return FlightMode::Acro;
+        case ardupilot::CopterMode::Alt_Hold:
+        case ardupilot::CopterMode::POS_HOLD:
+        case ardupilot::CopterMode::Flow_Hold:
+            return FlightMode::Hold;
+        case ardupilot::CopterMode::RTL:
+        case ardupilot::CopterMode::Auto_RTL:
+            return FlightMode::ReturnToLaunch;
+        case ardupilot::CopterMode::Land:
+            return FlightMode::Land;
+        default:
+            return FlightMode::Unknown;
+    }
+}
+
+SystemImpl::FlightMode SystemImpl::to_flight_mode_from_px4_mode(uint32_t custom_mode)
+{
+    px4::px4_custom_mode px4_custom_mode;
+    px4_custom_mode.data = custom_mode;
+
+    switch (px4_custom_mode.main_mode) {
+        case px4::PX4_CUSTOM_MAIN_MODE_OFFBOARD:
+            return FlightMode::Offboard;
+        case px4::PX4_CUSTOM_MAIN_MODE_MANUAL:
+            return FlightMode::Manual;
+        case px4::PX4_CUSTOM_MAIN_MODE_POSCTL:
+            return FlightMode::Posctl;
+        case px4::PX4_CUSTOM_MAIN_MODE_ALTCTL:
+            return FlightMode::Altctl;
+        case px4::PX4_CUSTOM_MAIN_MODE_RATTITUDE:
+            return FlightMode::Rattitude;
+        case px4::PX4_CUSTOM_MAIN_MODE_ACRO:
+            return FlightMode::Acro;
+        case px4::PX4_CUSTOM_MAIN_MODE_STABILIZED:
+            return FlightMode::Stabilized;
+        case px4::PX4_CUSTOM_MAIN_MODE_AUTO:
+            switch (px4_custom_mode.sub_mode) {
+                case px4::PX4_CUSTOM_SUB_MODE_AUTO_READY:
+                    return FlightMode::Ready;
+                case px4::PX4_CUSTOM_SUB_MODE_AUTO_TAKEOFF:
+                    return FlightMode::Takeoff;
+                case px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER:
+                    return FlightMode::Hold;
+                case px4::PX4_CUSTOM_SUB_MODE_AUTO_MISSION:
+                    return FlightMode::Mission;
+                case px4::PX4_CUSTOM_SUB_MODE_AUTO_RTL:
+                    return FlightMode::ReturnToLaunch;
+                case px4::PX4_CUSTOM_SUB_MODE_AUTO_LAND:
+                    return FlightMode::Land;
+                case px4::PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET:
+                    return FlightMode::FollowMe;
+                default:
+                    return FlightMode::Unknown;
+            }
+        default:
+            return FlightMode::Unknown;
+    }
 }
 
 void SystemImpl::receive_float_param(
@@ -1209,6 +1315,20 @@ void SystemImpl::subscribe_param_custom(
     const void* cookie)
 {
     _params.subscribe_param_custom_changed(name, callback, cookie);
+}
+
+void SystemImpl::set_compatibility_mode(System::CompatibilityMode compatibility_mode)
+{
+    std::lock_guard<std::mutex> lock(_compatibility_mode_mutex);
+    _compatibility_mode = compatibility_mode;
+
+    if (compatibility_mode == System::CompatibilityMode::Unknown) {
+        LogDebug() << "Compatibility reset to Unknown/automatic";
+        _compatibility_mode_fixed = false;
+    } else {
+        LogDebug() << "Compatibility fixed to " << compatibility_mode;
+        _compatibility_mode_fixed = true;
+    }
 }
 
 } // namespace mavsdk

--- a/src/mavsdk/core/system_impl.h
+++ b/src/mavsdk/core/system_impl.h
@@ -75,7 +75,7 @@ public:
 
     bool send_message(mavlink_message_t& message) override;
 
-    Autopilot autopilot() const override { return _autopilot; };
+    System::CompatibilityMode compatibility_mode() const override { return _compatibility_mode; };
 
     using CommandResultCallback = MavlinkCommandSender::CommandResultCallback;
 
@@ -269,11 +269,13 @@ public:
     void intercept_incoming_messages(std::function<bool(mavlink_message_t&)> callback);
     void intercept_outgoing_messages(std::function<bool(mavlink_message_t&)> callback);
 
+    double timeout_s() const;
+
+    void set_compatibility_mode(System::CompatibilityMode compatibility_mode);
+
     // Non-copyable
     SystemImpl(const SystemImpl&) = delete;
     const SystemImpl& operator=(const SystemImpl&) = delete;
-
-    double timeout_s() const;
 
 private:
     static bool is_autopilot(uint8_t comp_id);
@@ -340,8 +342,6 @@ private:
     std::atomic<bool> _hitl_enabled{false};
     bool _always_connected{false};
 
-    std::atomic<Autopilot> _autopilot{Autopilot::Unknown};
-
     MavsdkImpl& _parent;
 
     std::thread* _system_thread{nullptr};
@@ -383,6 +383,10 @@ private:
 
     std::mutex _mavlink_ftp_files_mutex{};
     std::unordered_map<std::string, std::string> _mavlink_ftp_files{};
+
+    std::mutex _compatibility_mode_mutex{};
+    System::CompatibilityMode _compatibility_mode{System::CompatibilityMode::Unknown};
+    bool _compatibility_mode_fixed{false};
 };
 
 } // namespace mavsdk

--- a/src/mavsdk/plugins/action/action_impl.cpp
+++ b/src/mavsdk/plugins/action/action_impl.cpp
@@ -425,6 +425,8 @@ void ActionImpl::land_async(const Action::ResultCallback& callback) const
     command.params.maybe_param4 = NAN; // Don't change yaw.
     command.target_component_id = _parent->get_autopilot_id();
 
+    // We don't know the altitude of the landing spot, so we don't set it.
+
     _parent->send_command_async(
         command, [this, callback](MavlinkCommandSender::Result result, float) {
             command_result_callback(result, callback);

--- a/src/mavsdk/plugins/action/action_impl.cpp
+++ b/src/mavsdk/plugins/action/action_impl.cpp
@@ -493,8 +493,12 @@ void ActionImpl::do_orbit_async(
     const double absolute_altitude_m,
     const Action::ResultCallback& callback)
 {
-    MavlinkCommandSender::CommandInt command{};
+    // The DO_ORBIT command is marked as WIP, hence only supported for PX4 for now.
+    if (_parent->compatibility_mode() != System::CompatibilityMode::Px4) {
+        _parent->call_user_callback([callback]() { callback(Action::Result::Unsupported); });
+    }
 
+    MavlinkCommandSender::CommandInt command{};
     command.command = MAV_CMD_DO_ORBIT;
     command.target_component_id = _parent->get_autopilot_id();
     command.params.maybe_param1 = radius_m;

--- a/src/mavsdk/plugins/action/action_impl.cpp
+++ b/src/mavsdk/plugins/action/action_impl.cpp
@@ -378,6 +378,10 @@ void ActionImpl::takeoff_async_px4(const Action::ResultCallback& callback) const
     command.command = MAV_CMD_NAV_TAKEOFF;
     command.target_component_id = _parent->get_autopilot_id();
 
+    if (_parent->compatibility_mode() == System::CompatibilityMode::Ardupilot) {
+        command.params.maybe_param7 = get_takeoff_altitude().second;
+    }
+
     _parent->send_command_async(
         command, [this, callback](MavlinkCommandSender::Result result, float) {
             command_result_callback(result, callback);
@@ -655,7 +659,7 @@ void ActionImpl::get_takeoff_altitude_async(
 
 std::pair<Action::Result, float> ActionImpl::get_takeoff_altitude() const
 {
-    if (_parent->autopilot() == SystemImpl::Autopilot::ArduPilot) {
+    if (_parent->compatibility_mode() == System::CompatibilityMode::Ardupilot) {
         return std::make_pair<>(Action::Result::Success, _takeoff_altitude);
     } else {
         auto result = _parent->get_param_float(TAKEOFF_ALT_PARAM);

--- a/src/mavsdk/plugins/action/action_impl.cpp
+++ b/src/mavsdk/plugins/action/action_impl.cpp
@@ -335,8 +335,8 @@ void ActionImpl::reboot_async(const Action::ResultCallback& callback) const
     command.command = MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN;
     command.params.maybe_param1 = 1.0f; // reboot autopilot
     command.params.maybe_param2 = 1.0f; // reboot onboard computer
-    command.params.maybe_param3 = 1.0f; // reboot camera
-    command.params.maybe_param4 = 1.0f; // reboot gimbal
+    command.params.maybe_param3 = 1.0f; // reboot component
+    command.params.maybe_param4 = 0.0f; // all components
     command.target_component_id = _parent->get_autopilot_id();
 
     _parent->send_command_async(
@@ -352,8 +352,8 @@ void ActionImpl::shutdown_async(const Action::ResultCallback& callback) const
     command.command = MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN;
     command.params.maybe_param1 = 2.0f; // shutdown autopilot
     command.params.maybe_param2 = 2.0f; // shutdown onboard computer
-    command.params.maybe_param3 = 2.0f; // shutdown camera
-    command.params.maybe_param4 = 2.0f; // shutdown gimbal
+    command.params.maybe_param3 = 2.0f; // shutdown component
+    command.params.maybe_param4 = 0.0f; // all components
     command.target_component_id = _parent->get_autopilot_id();
 
     _parent->send_command_async(

--- a/src/mavsdk/plugins/action/action_impl.cpp
+++ b/src/mavsdk/plugins/action/action_impl.cpp
@@ -364,7 +364,7 @@ void ActionImpl::shutdown_async(const Action::ResultCallback& callback) const
 
 void ActionImpl::takeoff_async(const Action::ResultCallback& callback) const
 {
-    if (_parent->autopilot() == SystemImpl::Autopilot::Px4) {
+    if (_parent->compatibility_mode() == System::CompatibilityMode::Px4) {
         takeoff_async_px4(callback);
     } else {
         takeoff_async_apm(callback);
@@ -466,9 +466,9 @@ void ActionImpl::goto_location_async(
 
     if (_parent->compatibility_mode() == System::CompatibilityMode::Px4) {
         // Change to Hold mode first
-        if (_parent->get_flight_mode() != SystemImpl::FlightMode::Hold) {
+        if (_parent->get_flight_mode() != FlightMode::Hold) {
             _parent->set_flight_mode_async(
-                SystemImpl::FlightMode::Hold,
+                FlightMode::Hold,
                 [this, callback, send_do_reposition](MavlinkCommandSender::Result result, float) {
                     Action::Result action_result = action_result_from_command_result(result);
                     if (action_result != Action::Result::Success) {

--- a/src/mavsdk/plugins/action/action_impl.cpp
+++ b/src/mavsdk/plugins/action/action_impl.cpp
@@ -520,6 +520,7 @@ void ActionImpl::hold_async(const Action::ResultCallback& callback) const
 void ActionImpl::set_actuator_async(
     const int index, const float value, const Action::ResultCallback& callback)
 {
+    // TODO: improve the API to accept multiple actuators.
     MavlinkCommandSender::CommandLong command{};
 
     command.command = MAV_CMD_DO_SET_ACTUATOR;

--- a/src/mavsdk/plugins/action/action_impl.cpp
+++ b/src/mavsdk/plugins/action/action_impl.cpp
@@ -257,7 +257,7 @@ void ActionImpl::arm_async(const Action::ResultCallback& callback) const
 
 bool ActionImpl::need_hold_before_arm() const
 {
-    if (_parent->autopilot() == SystemImpl::Autopilot::Px4) {
+    if (_parent->compatibility_mode() == System::CompatibilityMode::Px4) {
         return need_hold_before_arm_px4();
     } else {
         return need_hold_before_arm_apm();

--- a/src/mavsdk/plugins/action/action_impl.cpp
+++ b/src/mavsdk/plugins/action/action_impl.cpp
@@ -563,14 +563,16 @@ void ActionImpl::transition_to_fixedwing_async(const Action::ResultCallback& cal
 {
     if (!_vtol_transition_support_known) {
         if (callback) {
-            callback(Action::Result::VtolTransitionSupportUnknown);
+            _parent->call_user_callback(
+                [callback]() { callback(Action::Result::VtolTransitionSupportUnknown); });
         }
         return;
     }
 
     if (!_vtol_transition_possible) {
         if (callback) {
-            callback(Action::Result::NoVtolTransitionSupport);
+            _parent->call_user_callback(
+                [callback]() { callback(Action::Result::NoVtolTransitionSupport); });
         }
         return;
     }

--- a/src/mavsdk/plugins/action/action_impl.h
+++ b/src/mavsdk/plugins/action/action_impl.h
@@ -121,7 +121,7 @@ private:
     std::atomic<bool> _vtol_transition_support_known{false};
     std::atomic<bool> _vtol_transition_possible{false};
 
-    float _takeoff_altitude{2.0};
+    std::atomic<float> _takeoff_altitude{2.0};
 
     static constexpr uint8_t VEHICLE_MODE_FLAG_CUSTOM_MODE_ENABLED = 1;
     static constexpr auto TAKEOFF_ALT_PARAM = "MIS_TAKEOFF_ALT";

--- a/src/mavsdk/plugins/calibration/calibration_impl.cpp
+++ b/src/mavsdk/plugins/calibration/calibration_impl.cpp
@@ -83,7 +83,7 @@ void CalibrationImpl::calibrate_gyro_async(const CalibrationCallback& callback)
 void CalibrationImpl::call_callback(
     const CalibrationCallback& callback,
     const Calibration::Result& result,
-    const Calibration::ProgressData progress_data)
+    const Calibration::ProgressData& progress_data)
 {
     if (callback) {
         _parent->call_user_callback(

--- a/src/mavsdk/plugins/calibration/calibration_impl.cpp
+++ b/src/mavsdk/plugins/calibration/calibration_impl.cpp
@@ -43,6 +43,12 @@ void CalibrationImpl::disable() {}
 
 void CalibrationImpl::calibrate_gyro_async(const CalibrationCallback& callback)
 {
+    // The calibration is currently implemented using a PX4 specific
+    // API based on statustext for progress and instructions.
+    if (_parent->compatibility_mode() != System::CompatibilityMode::Px4) {
+        call_callback(callback, Calibration::Result::Unsupported, {});
+    }
+
     std::lock_guard<std::mutex> lock(_calibration_mutex);
 
     if (_parent->is_armed()) {
@@ -87,6 +93,12 @@ void CalibrationImpl::call_callback(
 
 void CalibrationImpl::calibrate_accelerometer_async(const CalibrationCallback& callback)
 {
+    // The calibration is currently implemented using a PX4 specific
+    // API based on statustext for progress and instructions.
+    if (_parent->compatibility_mode() != System::CompatibilityMode::Px4) {
+        call_callback(callback, Calibration::Result::Unsupported, {});
+    }
+
     std::lock_guard<std::mutex> lock(_calibration_mutex);
 
     if (_parent->is_armed()) {
@@ -120,6 +132,12 @@ void CalibrationImpl::calibrate_accelerometer_async(const CalibrationCallback& c
 
 void CalibrationImpl::calibrate_magnetometer_async(const CalibrationCallback& callback)
 {
+    // The calibration is currently implemented using a PX4 specific
+    // API based on statustext for progress and instructions.
+    if (_parent->compatibility_mode() != System::CompatibilityMode::Px4) {
+        call_callback(callback, Calibration::Result::Unsupported, {});
+    }
+
     std::lock_guard<std::mutex> lock(_calibration_mutex);
 
     if (_parent->is_armed()) {
@@ -153,6 +171,12 @@ void CalibrationImpl::calibrate_magnetometer_async(const CalibrationCallback& ca
 
 void CalibrationImpl::calibrate_level_horizon_async(const CalibrationCallback& callback)
 {
+    // The calibration is currently implemented using a PX4 specific
+    // API based on statustext for progress and instructions.
+    if (_parent->compatibility_mode() != System::CompatibilityMode::Px4) {
+        call_callback(callback, Calibration::Result::Unsupported, {});
+    }
+
     std::lock_guard<std::mutex> lock(_calibration_mutex);
 
     if (_parent->is_armed()) {
@@ -224,6 +248,12 @@ void CalibrationImpl::calibrate_gimbal_accelerometer_async(const CalibrationCall
 
 Calibration::Result CalibrationImpl::cancel()
 {
+    // The calibration is currently implemented using a PX4 specific
+    // API based on statustext for progress and instructions.
+    if (_parent->compatibility_mode() != System::CompatibilityMode::Px4) {
+        return Calibration::Result::Unsupported;
+    }
+
     std::lock_guard<std::mutex> lock(_calibration_mutex);
 
     uint8_t target_component_id = MAV_COMP_ID_AUTOPILOT1;

--- a/src/mavsdk/plugins/calibration/calibration_impl.h
+++ b/src/mavsdk/plugins/calibration/calibration_impl.h
@@ -30,13 +30,13 @@ public:
         const Calibration::CalibrateGimbalAccelerometerCallback& callback);
 
 private:
-    typedef std::function<void(const Calibration::Result result, const Calibration::ProgressData)>
-        CalibrationCallback;
+    using CalibrationCallback =
+        std::function<void(const Calibration::Result result, const Calibration::ProgressData)>;
 
     void call_callback(
         const CalibrationCallback& callback,
         const Calibration::Result& result,
-        const Calibration::ProgressData progress_data);
+        const Calibration::ProgressData& progress_data);
 
     void receive_statustext(const MavlinkStatustextHandler::Statustext&);
 
@@ -47,7 +47,6 @@ private:
 
     void report_started();
     void report_done();
-    void report_warning(const std::string& warning);
     void report_failed(const std::string& failed);
     void report_cancelled();
     void report_progress(float progress);
@@ -56,14 +55,6 @@ private:
     CalibrationStatustextParser _parser{};
 
     mutable std::mutex _calibration_mutex{};
-
-    bool _is_gyro_ok = false;
-    bool _is_accelerometer_ok = false;
-    bool _is_magnetometer_ok = false;
-
-    std::atomic<bool> _is_gyro_running = {false};
-    std::atomic<bool> _is_accelerometer_running = {false};
-    std::atomic<bool> _is_magnetometer_running = {false};
 
     enum class State {
         None,

--- a/src/mavsdk/plugins/failure/failure_impl.cpp
+++ b/src/mavsdk/plugins/failure/failure_impl.cpp
@@ -23,6 +23,12 @@ void FailureImpl::deinit() {}
 
 void FailureImpl::enable()
 {
+    if (_parent->compatibility_mode() != System::CompatibilityMode::Px4) {
+        // Probably only PX4 implements this param.
+        _enabled = EnabledState::Unknown;
+        return;
+    }
+
     constexpr auto param_name = "SYS_FAILURE_EN";
 
     _parent->get_param_int_async(

--- a/src/mavsdk/plugins/follow_me/follow_me_impl.cpp
+++ b/src/mavsdk/plugins/follow_me/follow_me_impl.cpp
@@ -270,11 +270,6 @@ void FollowMeImpl::send_target_location()
         return;
     }
 
-    dl_time_t now = _time.steady_time();
-    // needed by http://mavlink.org/messages/common#FOLLOW_TARGET
-    uint64_t elapsed_msec =
-        static_cast<uint64_t>(_time.elapsed_since_s(now) * 1000); // milliseconds
-
     std::lock_guard<std::mutex> lock(_mutex);
     //   LogDebug() << debug_str <<  "Lat: " << _target_location.latitude_deg << " Lon: " <<
     //   _target_location.longitude_deg <<
@@ -298,7 +293,7 @@ void FollowMeImpl::send_target_location()
         _parent->get_own_system_id(),
         _parent->get_own_component_id(),
         &msg,
-        elapsed_msec,
+        _time.elapsed_ms(),
         _estimation_capabilities,
         lat_int,
         lon_int,

--- a/src/mavsdk/plugins/follow_me/follow_me_impl.cpp
+++ b/src/mavsdk/plugins/follow_me/follow_me_impl.cpp
@@ -274,9 +274,9 @@ void FollowMeImpl::send_target_location()
     //   LogDebug() << debug_str <<  "Lat: " << _target_location.latitude_deg << " Lon: " <<
     //   _target_location.longitude_deg <<
     //	" Alt: " << _target_location.absolute_altitude_m;
-    const int32_t lat_int = int32_t(std::round(_target_location.latitude_deg * 1e7));
-    const int32_t lon_int = int32_t(std::round(_target_location.longitude_deg * 1e7));
-    const float alt = static_cast<float>(_target_location.absolute_altitude_m);
+    const auto lat_int = static_cast<int32_t>(std::round(_target_location.latitude_deg * 1e7));
+    const auto lon_int = static_cast<int32_t>(std::round(_target_location.longitude_deg * 1e7));
+    const auto alt = static_cast<float>(_target_location.absolute_altitude_m);
 
     const float pos_std_dev[] = {NAN, NAN, NAN};
     const float vel[] = {

--- a/src/mavsdk/plugins/info/info_impl.cpp
+++ b/src/mavsdk/plugins/info/info_impl.cpp
@@ -1,5 +1,4 @@
 #include <functional>
-#include <cstring>
 #include <numeric>
 #include "info_impl.h"
 #include "system.h"

--- a/src/mavsdk/plugins/mission_raw/mission_raw_impl.cpp
+++ b/src/mavsdk/plugins/mission_raw/mission_raw_impl.cpp
@@ -379,7 +379,7 @@ void MissionRawImpl::clear_mission_async(const MissionRaw::ResultCallback& callb
     reset_mission_progress();
 
     // For ArduPilot to clear a mission we need to upload an empty mission.
-    if (_parent->autopilot() == SystemImpl::Autopilot::ArduPilot) {
+    if (_parent->compatibility_mode() == System::CompatibilityMode::Ardupilot) {
         std::vector<MissionRaw::MissionItem> mission_items{empty_item};
         upload_mission_async(mission_items, callback);
     } else {

--- a/src/mavsdk/plugins/mission_raw/mission_raw_impl.cpp
+++ b/src/mavsdk/plugins/mission_raw/mission_raw_impl.cpp
@@ -469,6 +469,13 @@ MissionRaw::MissionProgress MissionRawImpl::mission_progress()
 
 void MissionRawImpl::subscribe_mission_changed(MissionRaw::MissionChangedCallback callback)
 {
+    // Listening for MISSION_ACKs can work, however, it is not guaranteed that these acks
+    // will be received. This should be specced properly, hence it's not in Pure mode.
+    if (_parent->compatibility_mode() == System::CompatibilityMode::Pure) {
+        LogErr() << "mission changed subscription not supported";
+        return;
+    }
+
     std::lock_guard<std::mutex> lock(_mission_changed.mutex);
     _mission_changed.callback = callback;
 }

--- a/src/mavsdk/plugins/offboard/offboard_impl.cpp
+++ b/src/mavsdk/plugins/offboard/offboard_impl.cpp
@@ -375,14 +375,6 @@ Offboard::Result OffboardImpl::set_actuator_control(Offboard::ActuatorControl ac
 
 Offboard::Result OffboardImpl::send_position_ned()
 {
-    const static uint16_t IGNORE_VX = (1 << 3);
-    const static uint16_t IGNORE_VY = (1 << 4);
-    const static uint16_t IGNORE_VZ = (1 << 5);
-    const static uint16_t IGNORE_AX = (1 << 6);
-    const static uint16_t IGNORE_AY = (1 << 7);
-    const static uint16_t IGNORE_AZ = (1 << 8);
-    const static uint16_t IGNORE_YAW_RATE = (1 << 11);
-
     const auto position_ned_yaw = [this]() {
         std::lock_guard<std::mutex> lock(_mutex);
         return _position_ned_yaw;
@@ -397,7 +389,10 @@ Offboard::Result OffboardImpl::send_position_ned()
         _parent->get_system_id(),
         _parent->get_autopilot_id(),
         MAV_FRAME_LOCAL_NED,
-        IGNORE_VX | IGNORE_VY | IGNORE_VZ | IGNORE_AX | IGNORE_AY | IGNORE_AZ | IGNORE_YAW_RATE,
+        POSITION_TARGET_TYPEMASK_VX_IGNORE | POSITION_TARGET_TYPEMASK_VY_IGNORE |
+            POSITION_TARGET_TYPEMASK_VZ_IGNORE | POSITION_TARGET_TYPEMASK_AX_IGNORE |
+            POSITION_TARGET_TYPEMASK_AY_IGNORE | POSITION_TARGET_TYPEMASK_AZ_IGNORE |
+            POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE,
         position_ned_yaw.north_m,
         position_ned_yaw.east_m,
         position_ned_yaw.down_m,
@@ -415,14 +410,6 @@ Offboard::Result OffboardImpl::send_position_ned()
 
 Offboard::Result OffboardImpl::send_position_global()
 {
-    const static uint16_t IGNORE_VX = (1 << 3);
-    const static uint16_t IGNORE_VY = (1 << 4);
-    const static uint16_t IGNORE_VZ = (1 << 5);
-    const static uint16_t IGNORE_AX = (1 << 6);
-    const static uint16_t IGNORE_AY = (1 << 7);
-    const static uint16_t IGNORE_AZ = (1 << 8);
-    const static uint16_t IGNORE_YAW_RATE = (1 << 11);
-
     const auto position_global_yaw = [this]() {
         std::lock_guard<std::mutex> lock(_mutex);
         return _position_global_yaw;
@@ -453,7 +440,10 @@ Offboard::Result OffboardImpl::send_position_global()
         _parent->get_system_id(),
         _parent->get_autopilot_id(),
         frame,
-        IGNORE_VX | IGNORE_VY | IGNORE_VZ | IGNORE_AX | IGNORE_AY | IGNORE_AZ | IGNORE_YAW_RATE,
+        POSITION_TARGET_TYPEMASK_VX_IGNORE | POSITION_TARGET_TYPEMASK_VY_IGNORE |
+            POSITION_TARGET_TYPEMASK_VZ_IGNORE | POSITION_TARGET_TYPEMASK_AX_IGNORE |
+            POSITION_TARGET_TYPEMASK_AY_IGNORE | POSITION_TARGET_TYPEMASK_AZ_IGNORE |
+            POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE,
         (int32_t)(position_global_yaw.lat_deg * 1.0e7),
         (int32_t)(position_global_yaw.lon_deg * 1.0e7),
         position_global_yaw.alt_m,
@@ -471,14 +461,6 @@ Offboard::Result OffboardImpl::send_position_global()
 
 Offboard::Result OffboardImpl::send_velocity_ned()
 {
-    const static uint16_t IGNORE_X = (1 << 0);
-    const static uint16_t IGNORE_Y = (1 << 1);
-    const static uint16_t IGNORE_Z = (1 << 2);
-    const static uint16_t IGNORE_AX = (1 << 6);
-    const static uint16_t IGNORE_AY = (1 << 7);
-    const static uint16_t IGNORE_AZ = (1 << 8);
-    const static uint16_t IGNORE_YAW_RATE = (1 << 11);
-
     const auto velocity_ned_yaw = [this]() {
         std::lock_guard<std::mutex> lock(_mutex);
         return _velocity_ned_yaw;
@@ -493,7 +475,10 @@ Offboard::Result OffboardImpl::send_velocity_ned()
         _parent->get_system_id(),
         _parent->get_autopilot_id(),
         MAV_FRAME_LOCAL_NED,
-        IGNORE_X | IGNORE_Y | IGNORE_Z | IGNORE_AX | IGNORE_AY | IGNORE_AZ | IGNORE_YAW_RATE,
+        POSITION_TARGET_TYPEMASK_X_IGNORE | POSITION_TARGET_TYPEMASK_Y_IGNORE |
+            POSITION_TARGET_TYPEMASK_Z_IGNORE | POSITION_TARGET_TYPEMASK_AX_IGNORE |
+            POSITION_TARGET_TYPEMASK_AY_IGNORE | POSITION_TARGET_TYPEMASK_AZ_IGNORE |
+            POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE,
         0.0f, // x,
         0.0f, // y,
         0.0f, // z,
@@ -511,11 +496,6 @@ Offboard::Result OffboardImpl::send_velocity_ned()
 
 Offboard::Result OffboardImpl::send_position_velocity_ned()
 {
-    const static uint16_t IGNORE_AX = (1 << 6);
-    const static uint16_t IGNORE_AY = (1 << 7);
-    const static uint16_t IGNORE_AZ = (1 << 8);
-    const static uint16_t IGNORE_YAW_RATE = (1 << 11);
-
     const auto position_and_velocity = [this]() {
         std::lock_guard<std::mutex> lock(_mutex);
         return std::make_pair<>(_position_ned_yaw, _velocity_ned_yaw);
@@ -530,7 +510,8 @@ Offboard::Result OffboardImpl::send_position_velocity_ned()
         _parent->get_system_id(),
         _parent->get_autopilot_id(),
         MAV_FRAME_LOCAL_NED,
-        IGNORE_AX | IGNORE_AY | IGNORE_AZ | IGNORE_YAW_RATE,
+        POSITION_TARGET_TYPEMASK_AX_IGNORE | POSITION_TARGET_TYPEMASK_AY_IGNORE |
+            POSITION_TARGET_TYPEMASK_AZ_IGNORE | POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE,
         position_and_velocity.first.north_m,
         position_and_velocity.first.east_m,
         position_and_velocity.first.down_m,
@@ -548,15 +529,6 @@ Offboard::Result OffboardImpl::send_position_velocity_ned()
 
 Offboard::Result OffboardImpl::send_acceleration_ned()
 {
-    const static uint16_t IGNORE_X = (1 << 0);
-    const static uint16_t IGNORE_Y = (1 << 1);
-    const static uint16_t IGNORE_Z = (1 << 2);
-    const static uint16_t IGNORE_VX = (1 << 3);
-    const static uint16_t IGNORE_VY = (1 << 4);
-    const static uint16_t IGNORE_VZ = (1 << 5);
-    const static uint16_t IGNORE_YAW = (1 << 10);
-    const static uint16_t IGNORE_YAW_RATE = (1 << 11);
-
     const auto acceleration_ned = [this]() {
         std::lock_guard<std::mutex> lock(_mutex);
         return _acceleration_ned;
@@ -571,8 +543,10 @@ Offboard::Result OffboardImpl::send_acceleration_ned()
         _parent->get_system_id(),
         _parent->get_autopilot_id(),
         MAV_FRAME_LOCAL_NED,
-        IGNORE_X | IGNORE_Y | IGNORE_Z | IGNORE_VX | IGNORE_VY | IGNORE_VZ | IGNORE_YAW |
-            IGNORE_YAW_RATE,
+        POSITION_TARGET_TYPEMASK_X_IGNORE | POSITION_TARGET_TYPEMASK_Y_IGNORE |
+            POSITION_TARGET_TYPEMASK_Z_IGNORE | POSITION_TARGET_TYPEMASK_VX_IGNORE |
+            POSITION_TARGET_TYPEMASK_VY_IGNORE | POSITION_TARGET_TYPEMASK_VZ_IGNORE |
+            POSITION_TARGET_TYPEMASK_YAW_IGNORE | POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE,
         0.0f, // x,
         0.0f, // y,
         0.0f, // z,
@@ -590,14 +564,6 @@ Offboard::Result OffboardImpl::send_acceleration_ned()
 
 Offboard::Result OffboardImpl::send_velocity_body()
 {
-    const static uint16_t IGNORE_X = (1 << 0);
-    const static uint16_t IGNORE_Y = (1 << 1);
-    const static uint16_t IGNORE_Z = (1 << 2);
-    const static uint16_t IGNORE_AX = (1 << 6);
-    const static uint16_t IGNORE_AY = (1 << 7);
-    const static uint16_t IGNORE_AZ = (1 << 8);
-    const static uint16_t IGNORE_YAW = (1 << 10);
-
     const auto velocity_body_yawspeed = [this]() {
         std::lock_guard<std::mutex> lock(_mutex);
         return _velocity_body_yawspeed;
@@ -612,7 +578,10 @@ Offboard::Result OffboardImpl::send_velocity_body()
         _parent->get_system_id(),
         _parent->get_autopilot_id(),
         MAV_FRAME_BODY_NED,
-        IGNORE_X | IGNORE_Y | IGNORE_Z | IGNORE_AX | IGNORE_AY | IGNORE_AZ | IGNORE_YAW,
+        POSITION_TARGET_TYPEMASK_X_IGNORE | POSITION_TARGET_TYPEMASK_Y_IGNORE |
+            POSITION_TARGET_TYPEMASK_Z_IGNORE | POSITION_TARGET_TYPEMASK_AX_IGNORE |
+            POSITION_TARGET_TYPEMASK_AY_IGNORE | POSITION_TARGET_TYPEMASK_AZ_IGNORE |
+            POSITION_TARGET_TYPEMASK_YAW_IGNORE,
         0.0f, // x
         0.0f, // y
         0.0f, // z
@@ -630,10 +599,6 @@ Offboard::Result OffboardImpl::send_velocity_body()
 
 Offboard::Result OffboardImpl::send_attitude()
 {
-    const static uint8_t IGNORE_BODY_ROLL_RATE = (1 << 0);
-    const static uint8_t IGNORE_BODY_PITCH_RATE = (1 << 1);
-    const static uint8_t IGNORE_BODY_YAW_RATE = (1 << 2);
-
     const auto attitude = [this]() {
         std::lock_guard<std::mutex> lock(_mutex);
         return _attitude;
@@ -668,7 +633,9 @@ Offboard::Result OffboardImpl::send_attitude()
         static_cast<uint32_t>(_parent->get_time().elapsed_ms()),
         _parent->get_system_id(),
         _parent->get_autopilot_id(),
-        IGNORE_BODY_ROLL_RATE | IGNORE_BODY_PITCH_RATE | IGNORE_BODY_YAW_RATE,
+        ATTITUDE_TARGET_TYPEMASK_BODY_ROLL_RATE_IGNORE |
+            ATTITUDE_TARGET_TYPEMASK_BODY_PITCH_RATE_IGNORE |
+            ATTITUDE_TARGET_TYPEMASK_BODY_YAW_RATE_IGNORE,
         q,
         0,
         0,
@@ -681,8 +648,6 @@ Offboard::Result OffboardImpl::send_attitude()
 
 Offboard::Result OffboardImpl::send_attitude_rate()
 {
-    const static uint8_t IGNORE_ATTITUDE = (1 << 7);
-
     const auto attitude_rate = [this]() {
         std::lock_guard<std::mutex> lock(_mutex);
         return _attitude_rate;
@@ -698,7 +663,7 @@ Offboard::Result OffboardImpl::send_attitude_rate()
         static_cast<uint32_t>(_parent->get_time().elapsed_ms()),
         _parent->get_system_id(),
         _parent->get_autopilot_id(),
-        IGNORE_ATTITUDE,
+        ATTITUDE_TARGET_TYPEMASK_ATTITUDE_IGNORE,
         0,
         to_rad_from_deg(attitude_rate.roll_deg_s),
         to_rad_from_deg(attitude_rate.pitch_deg_s),

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -2519,7 +2519,7 @@ void TelemetryImpl::check_calibration()
                 },
                 this);
 
-        } else {
+        } else if (_parent->compatibility_mode() == System::CompatibilityMode::Px4) {
             _parent->get_param_int_async(
                 std::string("CAL_GYRO0_ID"),
                 [this](MAVLinkParameters::Result result, int32_t value) {
@@ -2618,7 +2618,7 @@ void TelemetryImpl::process_parameter_update(const std::string& name)
                 },
                 this);
         }
-    } else {
+    } else if (_parent->compatibility_mode() == System::CompatibilityMode::Px4) {
         if (name.compare("CAL_GYRO0_ID") == 0) {
             _parent->get_param_int_async(
                 std::string("CAL_GYRO0_ID"),

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -2450,7 +2450,7 @@ void TelemetryImpl::check_calibration()
         }
     }
     if (_parent->has_autopilot()) {
-        if (_parent->autopilot() == SystemImpl::Autopilot::ArduPilot) {
+        if (_parent->compatibility_mode() == System::CompatibilityMode::Ardupilot) {
             // We need to ask for the home position from ArduPilot
             request_home_position_async();
 
@@ -2553,7 +2553,7 @@ void TelemetryImpl::check_calibration()
 
 void TelemetryImpl::process_parameter_update(const std::string& name)
 {
-    if (_parent->autopilot() == SystemImpl::Autopilot::ArduPilot) {
+    if (_parent->compatibility_mode() == System::CompatibilityMode::Ardupilot) {
         if (name.compare("INS_GYROFFS_X") == 0) {
             _parent->get_param_float_async(
                 std::string("INS_GYROFFS_X"),


### PR DESCRIPTION
This is work towards a MAVLink standard mode also called pure mode. It adds a setter for a `System` to implement MAVLink according to the standard without PX4 or ArduPilot specific hacks.