### PR TITLE
Retry home position until set. 

### DIFF
--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -198,7 +198,7 @@ void TelemetryImpl::enable()
     _parent->add_call_every([this]() { request_home_position_again(); }, 2.0f, &_homepos_cookie);
 }
 
-void TelemetryImpl::disable() 
+void TelemetryImpl::disable()
 {
     _parent->remove_call_every(_calibration_cookie);
     _parent->remove_call_every(_homepos_cookie);

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -195,7 +195,7 @@ void TelemetryImpl::enable()
     _parent->add_call_every([this]() { check_calibration(); }, 5.0, &_calibration_cookie);
 
     // We're going to retry until we have the Home Position.
-    _parent->add_call_every([this]() { request_home_position_again(); }, 2.0f, &_call_every_cookie);
+    _parent->add_call_every([this]() { request_home_position_again(); }, 2.0f, &_homepos_cookie);
 }
 
 void TelemetryImpl::disable() {}
@@ -205,7 +205,7 @@ void TelemetryImpl::request_home_position_again()
     {
         std::lock_guard<std::mutex> lock(_request_home_position_mutex);
         if (_health.is_home_position_ok) {
-            _parent->remove_call_every(_call_every_cookie);
+            _parent->remove_call_every(_homepos_cookie);
             return;
         }
     }

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -198,7 +198,11 @@ void TelemetryImpl::enable()
     _parent->add_call_every([this]() { request_home_position_again(); }, 2.0f, &_homepos_cookie);
 }
 
-void TelemetryImpl::disable() {}
+void TelemetryImpl::disable() 
+{
+    _parent->remove_call_every(_calibration_cookie);
+    _parent->remove_call_every(_homepos_cookie);
+}
 
 void TelemetryImpl::request_home_position_again()
 {

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -193,9 +193,25 @@ void TelemetryImpl::enable()
     //        For now, we just do the same as QGC does.
 
     _parent->add_call_every([this]() { check_calibration(); }, 5.0, &_calibration_cookie);
+
+    // We're going to retry until we have the Home Position.
+    _parent->add_call_every([this]() { request_home_position_again(); }, 2.0f, &_call_every_cookie);
 }
 
 void TelemetryImpl::disable() {}
+
+void TelemetryImpl::request_home_position_again()
+{
+    {
+        std::lock_guard<std::mutex> lock(_request_home_position_mutex);
+        if (_health.is_home_position_ok) {
+            _parent->remove_call_every(_call_every_cookie);
+            return;
+        }
+    }
+    LogWarn() << "Requesting Home Position Again.";
+    request_home_position_async();
+}
 
 Telemetry::Result TelemetryImpl::set_rate_position_velocity_ned(double rate_hz)
 {
@@ -2014,6 +2030,7 @@ bool TelemetryImpl::health_all_ok() const
         _health.is_global_position_ok && _health.is_home_position_ok) {
         return true;
     } else {
+        LogWarn() << "System status is usually fixed at 1 Hz";
         return false;
     }
 }

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.h
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.h
@@ -393,7 +393,7 @@ private:
     bool _has_bat_status{false};
 
     void* _calibration_cookie{nullptr};
-    void* _call_every_cookie{nullptr};
+    void* _homepos_cookie{nullptr};
 
     std::atomic<bool> _has_received_hitl_param{false};
 

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.h
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.h
@@ -234,6 +234,7 @@ private:
     void receive_statustext(const MavlinkStatustextHandler::Statustext&);
 
     void request_home_position_async();
+    void request_home_position_again();
     void check_calibration();
 
     static bool sys_status_present_enabled_health(
@@ -338,6 +339,8 @@ private:
     mutable std::mutex _scaled_pressure_mutex{};
     Telemetry::ScaledPressure _scaled_pressure{};
 
+    mutable std::mutex _request_home_position_mutex{};
+
     std::atomic<bool> _hitl_enabled{false};
 
     std::mutex _subscription_mutex{};
@@ -390,6 +393,7 @@ private:
     bool _has_bat_status{false};
 
     void* _calibration_cookie{nullptr};
+    void* _call_every_cookie{nullptr};
 
     std::atomic<bool> _has_received_hitl_param{false};
 


### PR DESCRIPTION
Sometimes, randomly the home position is not received/processed by MAVSDK which leads to `all_health_okay` to be never `true`. 
This has been often the case in integration tests, where one or two tests would randomly fail waiting for the health to be okay which never happens. 

In this PR, the retry mechanism is added for requesting the home position until it is received/set.

Glad to hear your feedback :)