### PR TITLE
core: fix some bugs in fs_canonical

### DIFF
--- a/src/mavsdk/core/CMakeLists.txt
+++ b/src/mavsdk/core/CMakeLists.txt
@@ -121,22 +121,23 @@ install(FILES
 
 list(APPEND UNIT_TEST_SOURCES
     ${PROJECT_SOURCE_DIR}/mavsdk/core/callback_list_test.cpp
-    ${PROJECT_SOURCE_DIR}/mavsdk/core/mavsdk_time_test.cpp
-    ${PROJECT_SOURCE_DIR}/mavsdk/core/mavsdk_math_test.cpp
-    ${PROJECT_SOURCE_DIR}/mavsdk/core/mavlink_channels_test.cpp
-    ${PROJECT_SOURCE_DIR}/mavsdk/core/unittests_main.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/call_every_handler_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/cli_arg_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/curl_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/locked_queue_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/fs_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/geometry_test.cpp
     # TODO: add this again
     #${PROJECT_SOURCE_DIR}/mavsdk/core/http_loader_test.cpp
-    ${PROJECT_SOURCE_DIR}/mavsdk/core/timeout_handler_test.cpp
-    ${PROJECT_SOURCE_DIR}/mavsdk/core/call_every_handler_test.cpp
-    ${PROJECT_SOURCE_DIR}/mavsdk/core/curl_test.cpp
-    ${PROJECT_SOURCE_DIR}/mavsdk/core/cli_arg_test.cpp
-    ${PROJECT_SOURCE_DIR}/mavsdk/core/locked_queue_test.cpp
-    ${PROJECT_SOURCE_DIR}/mavsdk/core/safe_queue_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/mavsdk_math_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/mavsdk_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/mavsdk_time_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/mavlink_channels_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/mavlink_mission_transfer_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/mavlink_statustext_handler_test.cpp
-    ${PROJECT_SOURCE_DIR}/mavsdk/core/geometry_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/ringbuffer_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/safe_queue_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/timeout_handler_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/unittests_main.cpp
 )
 set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} PARENT_SCOPE)

--- a/src/mavsdk/core/fs_test.cpp
+++ b/src/mavsdk/core/fs_test.cpp
@@ -1,0 +1,9 @@
+#include <gtest/gtest.h>
+#include "fs.h"
+
+TEST(Filesystem, SimpleCanonicalPathIsCorrect)
+{
+    const auto path = "/bin/path";
+    const auto canonical_path = mavsdk::fs_canonical(path);
+    ASSERT_EQ("blah", canonical_path);
+}

--- a/src/mavsdk/core/fs_test.cpp
+++ b/src/mavsdk/core/fs_test.cpp
@@ -2,8 +2,7 @@
 #include <unistd.h>
 #include "fs.h"
 
-#if defined(WINDOWS)
-#else
+#if !defined(WINDOWS)
 #define PATH_MAX 4096
 
 TEST(Filesystem, AbsolutePathUnchanged)

--- a/src/mavsdk/core/fs_test.cpp
+++ b/src/mavsdk/core/fs_test.cpp
@@ -1,9 +1,80 @@
 #include <gtest/gtest.h>
+#include <unistd.h>
 #include "fs.h"
 
-TEST(Filesystem, SimpleCanonicalPathIsCorrect)
+#if defined(WINDOWS)
+#else
+#define PATH_MAX 4096
+
+TEST(Filesystem, AbsolutePathUnchanged)
 {
-    const auto path = "/bin/path";
-    const auto canonical_path = mavsdk::fs_canonical(path);
-    ASSERT_EQ("blah", canonical_path);
+    const std::string path = "/sbin/init";
+    ASSERT_EQ(path, mavsdk::fs_canonical(path));
 }
+
+TEST(Filesystem, RemoveFinalSlash)
+{
+    const std::string path = "/usr/local/include/mavsdk/";
+    const std::string canonical_path = "/usr/local/include/mavsdk";
+    ASSERT_EQ(canonical_path, mavsdk::fs_canonical(path));
+}
+
+TEST(Filesystem, RemoveDuplicateSlashes)
+{
+    const std::string path = "//////opt/////ros////foxy";
+    const std::string canonical_path = "/opt/ros/foxy";
+    ASSERT_EQ(canonical_path, mavsdk::fs_canonical(path));
+}
+
+TEST(Filesystem, RemoveInternalDots)
+{
+    const std::string path = "/sys/./class/./input";
+    const std::string canonical_path = "/sys/class/input";
+    ASSERT_EQ(canonical_path, mavsdk::fs_canonical(path));
+}
+
+TEST(Filesystem, ResolveDoubleDots)
+{
+    const std::string path = "/bin/../dev/../etc/crontab/../shadow";
+    const std::string canonical_path = "/etc/shadow";
+    ASSERT_EQ(canonical_path, mavsdk::fs_canonical(path));
+}
+
+TEST(Filesystem, RelativePathEmpty)
+{
+    char cwd[PATH_MAX];
+    getcwd(cwd, PATH_MAX);
+    const std::string path = "";
+    const std::string canonical_path = std::string(cwd);
+    ASSERT_EQ(canonical_path, mavsdk::fs_canonical(path));
+}
+
+TEST(Filesystem, RelativePathDot)
+{
+    char cwd[PATH_MAX];
+    getcwd(cwd, PATH_MAX);
+    const std::string path = ".";
+    const std::string canonical_path = std::string(cwd);
+    ASSERT_EQ(canonical_path, mavsdk::fs_canonical(path));
+}
+
+TEST(Filesystem, RelativePathBare)
+{
+    char cwd[PATH_MAX];
+    getcwd(cwd, PATH_MAX);
+    const std::string path = "src/mavsdk/core/fs_test.cpp";
+    const std::string canonical_path = std::string(cwd) + mavsdk::path_separator + path;
+    ASSERT_EQ(canonical_path, mavsdk::fs_canonical(path));
+}
+
+TEST(Filesystem, RelativePathDotSlash)
+{
+    char cwd[PATH_MAX];
+    getcwd(cwd, PATH_MAX);
+    const std::string bare_path = "src/mavsdk/plugins/mavlink_passthrough";
+    const std::string dotslash_path = "./" + bare_path;
+    const std::string canonical_path = std::string(cwd) + mavsdk::path_separator + bare_path;
+    ASSERT_EQ(canonical_path, mavsdk::fs_canonical(dotslash_path));
+}
+
+#endif


### PR DESCRIPTION
* When given a relative path the function would fail to add correct path separation. For instance, if the current working directory is `/home/ubuntu`, when `fs_canonical("example")`, or `fs_canonical("./example")` is run, it returns `/home/ubuntuexample`.
* MAVSDK claims to support different path separators, but `/` was hardcoded in some cases.
* Along with that, the path separator was assumed to be one character in some cases, particularly when `/` was hardcoded. The datatype of the `path_separator` constant is string, so this assumption is not necessarily correct.

This PR fixes all of these things, and also makes the code more efficient by using a double-ended queue instead of two stacks and avoiding double initialization of object when possible.