### PR TITLE
Unregister to prevent fulfilling promise twice

### DIFF
--- a/src/integration_tests/action_hover_async.cpp
+++ b/src/integration_tests/action_hover_async.cpp
@@ -24,6 +24,9 @@ TEST_F(SitlTest, ActionHoverAsync)
             if (mavsdk.systems().size() == 1) {
                 system = mavsdk.systems().at(0);
                 ASSERT_TRUE(system->has_autopilot());
+
+                // Unregister to prevent fulfilling promise twice.
+                mavsdk.subscribe_on_new_system(nullptr);
                 prom.set_value();
             }
         });

--- a/src/integration_tests/action_takeoff_and_kill.cpp
+++ b/src/integration_tests/action_takeoff_and_kill.cpp
@@ -19,6 +19,8 @@ TEST_F(SitlTest, ActionTakeoffAndKill)
             const auto system = mavsdk.systems().at(0);
 
             if (system->is_connected()) {
+                // Unregister to prevent fulfilling promise twice.
+                mavsdk.subscribe_on_new_system(nullptr);
                 prom.set_value();
             }
         });


### PR DESCRIPTION
Not sure if that was this one [here](https://github.com/mavlink/MAVSDK/runs/7082798986?check_suite_focus=true), since I would have expected to see "Waiting to discover vehicle" in the logs. But I would expect even more log output for the next ones, so... :sweat_smile: 