### PR TITLE
Use a uniform distribution to drop messages in lossy test

### DIFF
--- a/src/integration_tests/mission_transfer_lossy.cpp
+++ b/src/integration_tests/mission_transfer_lossy.cpp
@@ -1,11 +1,13 @@
-#include <iostream>
-#include <future>
 #include <atomic>
-#include "log.h"
+#include <future>
+#include <iostream>
+#include <random>
+
 #include "integration_test_helper.h"
+#include "log.h"
 #include "mavsdk.h"
-#include "plugins/mission/mission.h"
 #include "plugins/mavlink_passthrough/mavlink_passthrough.h"
+#include "plugins/mission/mission.h"
 
 using namespace mavsdk;
 
@@ -13,7 +15,8 @@ static void set_link_lossy(std::shared_ptr<MavlinkPassthrough> mavlink_passthrou
 static std::vector<Mission::MissionItem> create_mission_items();
 static bool should_keep_message(const mavlink_message_t& message);
 
-static std::atomic<size_t> _lossy_counter{0};
+static std::default_random_engine generator;
+static std::uniform_real_distribution<double> distribution(0.0, 1.0);
 
 TEST_F(SitlTest, PX4MissionTransferLossy)
 {
@@ -70,7 +73,7 @@ bool should_keep_message(const mavlink_message_t& message)
         // message.msgid == MAVLINK_MSG_ID_MISSION_ACK || FIXME: we rely on ack
         message.msgid == MAVLINK_MSG_ID_MISSION_COUNT ||
         message.msgid == MAVLINK_MSG_ID_MISSION_ITEM_INT) {
-        should_keep = (_lossy_counter++ % 10 != 0);
+        should_keep = distribution(generator) < 0.9;
     }
     return should_keep;
 }

--- a/src/integration_tests/mission_transfer_lossy.cpp
+++ b/src/integration_tests/mission_transfer_lossy.cpp
@@ -73,7 +73,7 @@ bool should_keep_message(const mavlink_message_t& message)
         // message.msgid == MAVLINK_MSG_ID_MISSION_ACK || FIXME: we rely on ack
         message.msgid == MAVLINK_MSG_ID_MISSION_COUNT ||
         message.msgid == MAVLINK_MSG_ID_MISSION_ITEM_INT) {
-        should_keep = distribution(generator) < 0.9;
+        should_keep = distribution(generator) < 0.95;
     }
     return should_keep;
 }


### PR DESCRIPTION
This test seems flaky to me in the CI, and I can't help but to think that maybe, sometimes, it gets into a state where dropping _exactly every tenth_ message make it fail.

I changed it for a uniform distribution, which seems deterministic when running on my computer (not sure what the default seed is), but at least it's dropping 10% of the messages, and not exactly every tenth message.

Without this PR (I see a lot of 73):

```
[12:34:32|Debug] Dropped outgoing message: 44 (mavsdk_impl.cpp:359)
[12:34:32|Debug] Dropped incoming message: 51 (mavsdk_impl.cpp:251)
[12:34:33|Debug] Dropped outgoing message: 73 (mavsdk_impl.cpp:359)
[12:34:33|Debug] Dropped outgoing message: 73 (mavsdk_impl.cpp:359)
[12:34:33|Debug] Dropped outgoing message: 73 (mavsdk_impl.cpp:359)
[12:34:34|Debug] Dropped outgoing message: 73 (mavsdk_impl.cpp:359)
[12:34:34|Debug] Dropped outgoing message: 73 (mavsdk_impl.cpp:359)
[12:34:34|Debug] Dropped outgoing message: 73 (mavsdk_impl.cpp:359)
[12:34:34|Debug] Dropped outgoing message: 73 (mavsdk_impl.cpp:359)
[12:34:35|Debug] Dropped outgoing message: 73 (mavsdk_impl.cpp:359)
[12:34:35|Debug] Dropped incoming message: 44 (mavsdk_impl.cpp:251)
[12:34:35|Debug] Dropped incoming message: 73 (mavsdk_impl.cpp:251)
[12:34:36|Debug] Dropped incoming message: 73 (mavsdk_impl.cpp:251)
[12:34:36|Debug] Dropped incoming message: 73 (mavsdk_impl.cpp:251)
[12:34:37|Debug] Dropped incoming message: 73 (mavsdk_impl.cpp:251)
[12:34:37|Debug] Dropped incoming message: 73 (mavsdk_impl.cpp:251)
[12:34:38|Debug] Dropped incoming message: 73 (mavsdk_impl.cpp:251)
[12:34:38|Debug] Dropped incoming message: 73 (mavsdk_impl.cpp:251)
[12:34:39|Debug] Dropped incoming message: 73 (mavsdk_impl.cpp:251)
[12:34:39|Debug] Dropped incoming message: 73 (mavsdk_impl.cpp:251)
[12:34:40|Debug] Dropped incoming message: 73 (mavsdk_impl.cpp:251)
```

With this PR:

```
[12:33:55|Debug] Dropped outgoing message: 73 (mavsdk_impl.cpp:359)
[12:33:55|Debug] Dropped incoming message: 51 (mavsdk_impl.cpp:251)
[12:33:55|Debug] Dropped incoming message: 51 (mavsdk_impl.cpp:251)
[12:33:56|Debug] Dropped outgoing message: 73 (mavsdk_impl.cpp:359)
[12:33:56|Debug] Dropped outgoing message: 73 (mavsdk_impl.cpp:359)
[12:33:56|Debug] Dropped incoming message: 51 (mavsdk_impl.cpp:251)
[12:33:57|Debug] Dropped incoming message: 51 (mavsdk_impl.cpp:251)
[12:33:57|Debug] Dropped outgoing message: 43 (mavsdk_impl.cpp:359)
[12:33:57|Debug] Dropped incoming message: 44 (mavsdk_impl.cpp:251)
[12:33:58|Debug] Dropped incoming message: 73 (mavsdk_impl.cpp:251)
[12:33:58|Debug] Dropped outgoing message: 51 (mavsdk_impl.cpp:359)
[12:33:59|Debug] Dropped outgoing message: 51 (mavsdk_impl.cpp:359)
[12:33:59|Debug] Dropped incoming message: 73 (mavsdk_impl.cpp:251)
[12:34:00|Debug] Dropped incoming message: 73 (mavsdk_impl.cpp:251)
[12:34:00|Debug] Dropped outgoing message: 51 (mavsdk_impl.cpp:359)
[12:34:01|Debug] Dropped outgoing message: 51 (mavsdk_impl.cpp:359)
[12:34:01|Debug] Dropped outgoing message: 51 (mavsdk_impl.cpp:359)
[12:34:02|Debug] Dropped outgoing message: 51 (mavsdk_impl.cpp:359)
```

I'd say let's see how it goes in the CI.