### PR TITLE
Integration tests: do not continue if flightmode unknown

### DIFF
--- a/src/integration_tests/action_transition_multicopter_fixedwing.cpp
+++ b/src/integration_tests/action_transition_multicopter_fixedwing.cpp
@@ -65,7 +65,7 @@ TEST_F(SitlTest, PX4ActionTransitionSync_standard_vtol)
         }
     });
 
-    EXPECT_EQ(fut.wait_for(std::chrono::seconds(20)), std::future_status::ready);
+    ASSERT_EQ(fut.wait_for(std::chrono::seconds(20)), std::future_status::ready);
 
     LogInfo() << "Transitioning to fixedwing";
     Action::Result transition_result = action->transition_to_fixedwing();


### PR DESCRIPTION
I got confused by the CI output because it seemed like the transition failed, but actually the problem seems to be above, where the `Hold` flight mode is never reached. This changes the test to fail in the right place.

Not sure what to do about the vtol not getting into `Hold`, though.

```
2022-06-28T23:30:46.4146524Z /__w/MAVSDK/MAVSDK/src/integration_tests/action_transition_multicopter_fixedwing.cpp:68: Failure
2022-06-28T23:30:46.4146848Z Expected equality of these values:
2022-06-28T23:30:46.4147164Z   fut.wait_for(std::chrono::seconds(20))
2022-06-28T23:30:46.4147498Z     Which is: 4-byte object <01-00 00-00>
2022-06-28T23:30:46.4147732Z   std::future_status::ready
2022-06-28T23:30:46.4148036Z     Which is: 4-byte object <00-00 00-00>
2022-06-28T23:30:46.4210141Z [34m[11:30:46|Info ] [0mTransitioning to fixedwing (action_transition_multicopter_fixedwing.cpp:70)
2022-06-28T23:30:46.4210629Z /__w/MAVSDK/MAVSDK/src/integration_tests/action_transition_multicopter_fixedwing.cpp:72: Failure
2022-06-28T23:30:46.4210958Z Expected equality of these values:
2022-06-28T23:30:46.4211193Z   transition_result
2022-06-28T23:30:46.4211414Z     Which is: Command Denied
2022-06-28T23:30:46.4211649Z   Action::Result::Success
2022-06-28T23:30:46.4211863Z     Which is: Success
```