### PR TITLE
Use mission_type argument in integration test

### DIFF
--- a/src/integration_tests/mission_raw_import_and_fly.cpp
+++ b/src/integration_tests/mission_raw_import_and_fly.cpp
@@ -199,6 +199,6 @@ MissionRaw::MissionItem create_mission_item(
     new_raw_item_nav.x = int32_t(std::round(_x * 1e7));
     new_raw_item_nav.y = int32_t(std::round(_y * 1e7));
     new_raw_item_nav.z = float(_z);
-    new_raw_item_nav.mission_type = 0;
+    new_raw_item_nav.mission_type = _mission_type;
     return new_raw_item_nav;
 }


### PR DESCRIPTION
Seems like this got forgotten. Should not change anything, just the compiler warning.

> /src/integration_tests/mission_raw_import_and_fly.cpp: In function ‘mavsdk::MissionRaw::MissionItem create_mission_item(uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, float, float, float, float, double, double, double, uint32_t)’:
/src/integration_tests/mission_raw_import_and_fly.cpp:187:14: warning: unused parameter ‘_mission_type’ [-Wunused-parameter]
  187 |     uint32_t _mission_type)
      |     ~~~~~~~~~^~~~~~~~~~~~~
