### PR TITLE
Fix warnings in mavsdk server

### DIFF
--- a/src/mavsdk_server/src/plugins/action_server/action_server_service_impl.h
+++ b/src/mavsdk_server/src/plugins/action_server/action_server_service_impl.h
@@ -276,7 +276,7 @@ public:
 
         const mavsdk::ActionServer::ArmDisarmHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_arm_disarm(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     mavsdk::ActionServer::Result result,
                     const mavsdk::ActionServer::ArmDisarm arm_disarm) {
                     rpc::action_server::ArmDisarmResponse rpc_response;
@@ -333,7 +333,7 @@ public:
 
         const mavsdk::ActionServer::FlightModeChangeHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_flight_mode_change(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     mavsdk::ActionServer::Result result,
                     const mavsdk::ActionServer::FlightMode flight_mode_change) {
                     rpc::action_server::FlightModeChangeResponse rpc_response;
@@ -390,7 +390,7 @@ public:
 
         const mavsdk::ActionServer::TakeoffHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_takeoff(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     mavsdk::ActionServer::Result result, const bool takeoff) {
                     rpc::action_server::TakeoffResponse rpc_response;
 
@@ -445,7 +445,7 @@ public:
         auto subscribe_mutex = std::make_shared<std::mutex>();
 
         const mavsdk::ActionServer::LandHandle handle = _lazy_plugin.maybe_plugin()->subscribe_land(
-            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                 mavsdk::ActionServer::Result result, const bool land) {
                 rpc::action_server::LandResponse rpc_response;
 
@@ -501,7 +501,7 @@ public:
 
         const mavsdk::ActionServer::RebootHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_reboot(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     mavsdk::ActionServer::Result result, const bool reboot) {
                     rpc::action_server::RebootResponse rpc_response;
 
@@ -557,7 +557,7 @@ public:
 
         const mavsdk::ActionServer::ShutdownHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_shutdown(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     mavsdk::ActionServer::Result result, const bool shutdown) {
                     rpc::action_server::ShutdownResponse rpc_response;
 
@@ -613,7 +613,7 @@ public:
 
         const mavsdk::ActionServer::TerminateHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_terminate(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     mavsdk::ActionServer::Result result, const bool terminate) {
                     rpc::action_server::TerminateResponse rpc_response;
 

--- a/src/mavsdk_server/src/plugins/camera/camera_service_impl.h
+++ b/src/mavsdk_server/src/plugins/camera/camera_service_impl.h
@@ -976,7 +976,7 @@ public:
         auto subscribe_mutex = std::make_shared<std::mutex>();
 
         const mavsdk::Camera::ModeHandle handle = _lazy_plugin.maybe_plugin()->subscribe_mode(
-            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                 const mavsdk::Camera::Mode mode) {
                 rpc::camera::ModeResponse rpc_response;
 
@@ -1017,7 +1017,7 @@ public:
 
         const mavsdk::Camera::InformationHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_information(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Camera::Information information) {
                     rpc::camera::InformationResponse rpc_response;
 
@@ -1059,7 +1059,7 @@ public:
 
         const mavsdk::Camera::VideoStreamInfoHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_video_stream_info(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Camera::VideoStreamInfo video_stream_info) {
                     rpc::camera::VideoStreamInfoResponse rpc_response;
 
@@ -1101,7 +1101,7 @@ public:
 
         const mavsdk::Camera::CaptureInfoHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_capture_info(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Camera::CaptureInfo capture_info) {
                     rpc::camera::CaptureInfoResponse rpc_response;
 
@@ -1142,7 +1142,7 @@ public:
         auto subscribe_mutex = std::make_shared<std::mutex>();
 
         const mavsdk::Camera::StatusHandle handle = _lazy_plugin.maybe_plugin()->subscribe_status(
-            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                 const mavsdk::Camera::Status status) {
                 rpc::camera::StatusResponse rpc_response;
 
@@ -1183,7 +1183,7 @@ public:
 
         const mavsdk::Camera::CurrentSettingsHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_current_settings(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const std::vector<mavsdk::Camera::Setting> current_settings) {
                     rpc::camera::CurrentSettingsResponse rpc_response;
 
@@ -1227,7 +1227,7 @@ public:
 
         const mavsdk::Camera::PossibleSettingOptionsHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_possible_setting_options(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const std::vector<mavsdk::Camera::SettingOptions> possible_setting_options) {
                     rpc::camera::PossibleSettingOptionsResponse rpc_response;
 

--- a/src/mavsdk_server/src/plugins/camera_server/camera_server_service_impl.h
+++ b/src/mavsdk_server/src/plugins/camera_server/camera_server_service_impl.h
@@ -382,7 +382,7 @@ public:
 
         const mavsdk::CameraServer::TakePhotoHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_take_photo(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const int32_t take_photo) {
                     rpc::camera_server::TakePhotoResponse rpc_response;
 

--- a/src/mavsdk_server/src/plugins/component_information/component_information_service_impl.h
+++ b/src/mavsdk_server/src/plugins/component_information/component_information_service_impl.h
@@ -203,7 +203,7 @@ public:
 
         const mavsdk::ComponentInformation::FloatParamHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_float_param(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::ComponentInformation::FloatParamUpdate float_param) {
                     rpc::component_information::FloatParamResponse rpc_response;
 

--- a/src/mavsdk_server/src/plugins/component_information_server/component_information_server_service_impl.h
+++ b/src/mavsdk_server/src/plugins/component_information_server/component_information_server_service_impl.h
@@ -237,7 +237,7 @@ public:
 
         const mavsdk::ComponentInformationServer::FloatParamHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_float_param(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::ComponentInformationServer::FloatParamUpdate float_param) {
                     rpc::component_information_server::FloatParamResponse rpc_response;
 

--- a/src/mavsdk_server/src/plugins/gimbal/gimbal_service_impl.h
+++ b/src/mavsdk_server/src/plugins/gimbal/gimbal_service_impl.h
@@ -366,7 +366,7 @@ public:
         auto subscribe_mutex = std::make_shared<std::mutex>();
 
         const mavsdk::Gimbal::ControlHandle handle = _lazy_plugin.maybe_plugin()->subscribe_control(
-            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                 const mavsdk::Gimbal::ControlStatus control) {
                 rpc::gimbal::ControlResponse rpc_response;
 

--- a/src/mavsdk_server/src/plugins/mission/mission_service_impl.h
+++ b/src/mavsdk_server/src/plugins/mission/mission_service_impl.h
@@ -688,7 +688,7 @@ public:
 
         const mavsdk::Mission::MissionProgressHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_mission_progress(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Mission::MissionProgress mission_progress) {
                     rpc::mission::MissionProgressResponse rpc_response;
 

--- a/src/mavsdk_server/src/plugins/mission_raw/mission_raw_service_impl.h
+++ b/src/mavsdk_server/src/plugins/mission_raw/mission_raw_service_impl.h
@@ -477,7 +477,7 @@ public:
 
         const mavsdk::MissionRaw::MissionProgressHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_mission_progress(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::MissionRaw::MissionProgress mission_progress) {
                     rpc::mission_raw::MissionProgressResponse rpc_response;
 
@@ -519,7 +519,7 @@ public:
 
         const mavsdk::MissionRaw::MissionChangedHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_mission_changed(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const bool mission_changed) {
                     rpc::mission_raw::MissionChangedResponse rpc_response;
 

--- a/src/mavsdk_server/src/plugins/mission_raw_server/mission_raw_server_service_impl.h
+++ b/src/mavsdk_server/src/plugins/mission_raw_server/mission_raw_server_service_impl.h
@@ -268,7 +268,7 @@ public:
 
         const mavsdk::MissionRawServer::IncomingMissionHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_incoming_mission(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     mavsdk::MissionRawServer::Result result,
                     const mavsdk::MissionRawServer::MissionPlan incoming_mission) {
                     rpc::mission_raw_server::IncomingMissionResponse rpc_response;
@@ -321,7 +321,7 @@ public:
 
         const mavsdk::MissionRawServer::CurrentItemChangedHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_current_item_changed(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::MissionRawServer::MissionItem current_item_changed) {
                     rpc::mission_raw_server::CurrentItemChangedResponse rpc_response;
 
@@ -377,7 +377,7 @@ public:
 
         const mavsdk::MissionRawServer::ClearAllHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_clear_all(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const uint32_t clear_all) {
                     rpc::mission_raw_server::ClearAllResponse rpc_response;
 

--- a/src/mavsdk_server/src/plugins/shell/shell_service_impl.h
+++ b/src/mavsdk_server/src/plugins/shell/shell_service_impl.h
@@ -129,7 +129,7 @@ public:
         auto subscribe_mutex = std::make_shared<std::mutex>();
 
         const mavsdk::Shell::ReceiveHandle handle = _lazy_plugin.maybe_plugin()->subscribe_receive(
-            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                 const std::string receive) {
                 rpc::shell::ReceiveResponse rpc_response;
 

--- a/src/mavsdk_server/src/plugins/telemetry/telemetry_service_impl.h
+++ b/src/mavsdk_server/src/plugins/telemetry/telemetry_service_impl.h
@@ -1322,7 +1322,7 @@ public:
 
         const mavsdk::Telemetry::PositionHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_position(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::Position position) {
                     rpc::telemetry::PositionResponse rpc_response;
 
@@ -1362,7 +1362,7 @@ public:
         auto subscribe_mutex = std::make_shared<std::mutex>();
 
         const mavsdk::Telemetry::HomeHandle handle = _lazy_plugin.maybe_plugin()->subscribe_home(
-            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                 const mavsdk::Telemetry::Position home) {
                 rpc::telemetry::HomeResponse rpc_response;
 
@@ -1402,7 +1402,7 @@ public:
         auto subscribe_mutex = std::make_shared<std::mutex>();
 
         const mavsdk::Telemetry::InAirHandle handle = _lazy_plugin.maybe_plugin()->subscribe_in_air(
-            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                 const bool in_air) {
                 rpc::telemetry::InAirResponse rpc_response;
 
@@ -1443,7 +1443,7 @@ public:
 
         const mavsdk::Telemetry::LandedStateHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_landed_state(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::LandedState landed_state) {
                     rpc::telemetry::LandedStateResponse rpc_response;
 
@@ -1483,7 +1483,7 @@ public:
         auto subscribe_mutex = std::make_shared<std::mutex>();
 
         const mavsdk::Telemetry::ArmedHandle handle = _lazy_plugin.maybe_plugin()->subscribe_armed(
-            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                 const bool armed) {
                 rpc::telemetry::ArmedResponse rpc_response;
 
@@ -1524,7 +1524,7 @@ public:
 
         const mavsdk::Telemetry::VtolStateHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_vtol_state(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::VtolState vtol_state) {
                     rpc::telemetry::VtolStateResponse rpc_response;
 
@@ -1565,7 +1565,7 @@ public:
 
         const mavsdk::Telemetry::AttitudeQuaternionHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_attitude_quaternion(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::Quaternion attitude_quaternion) {
                     rpc::telemetry::AttitudeQuaternionResponse rpc_response;
 
@@ -1607,7 +1607,7 @@ public:
 
         const mavsdk::Telemetry::AttitudeEulerHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_attitude_euler(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::EulerAngle attitude_euler) {
                     rpc::telemetry::AttitudeEulerResponse rpc_response;
 
@@ -1649,7 +1649,7 @@ public:
 
         const mavsdk::Telemetry::AttitudeAngularVelocityBodyHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_attitude_angular_velocity_body(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::AngularVelocityBody attitude_angular_velocity_body) {
                     rpc::telemetry::AttitudeAngularVelocityBodyResponse rpc_response;
 
@@ -1693,7 +1693,7 @@ public:
 
         const mavsdk::Telemetry::CameraAttitudeQuaternionHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_camera_attitude_quaternion(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::Quaternion camera_attitude_quaternion) {
                     rpc::telemetry::CameraAttitudeQuaternionResponse rpc_response;
 
@@ -1735,7 +1735,7 @@ public:
 
         const mavsdk::Telemetry::CameraAttitudeEulerHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_camera_attitude_euler(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::EulerAngle camera_attitude_euler) {
                     rpc::telemetry::CameraAttitudeEulerResponse rpc_response;
 
@@ -1777,7 +1777,7 @@ public:
 
         const mavsdk::Telemetry::VelocityNedHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_velocity_ned(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::VelocityNed velocity_ned) {
                     rpc::telemetry::VelocityNedResponse rpc_response;
 
@@ -1819,7 +1819,7 @@ public:
 
         const mavsdk::Telemetry::GpsInfoHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_gps_info(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::GpsInfo gps_info) {
                     rpc::telemetry::GpsInfoResponse rpc_response;
 
@@ -1860,7 +1860,7 @@ public:
 
         const mavsdk::Telemetry::RawGpsHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_raw_gps(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::RawGps raw_gps) {
                     rpc::telemetry::RawGpsResponse rpc_response;
 
@@ -1901,7 +1901,7 @@ public:
 
         const mavsdk::Telemetry::BatteryHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_battery(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::Battery battery) {
                     rpc::telemetry::BatteryResponse rpc_response;
 
@@ -1942,7 +1942,7 @@ public:
 
         const mavsdk::Telemetry::FlightModeHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_flight_mode(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::FlightMode flight_mode) {
                     rpc::telemetry::FlightModeResponse rpc_response;
 
@@ -1983,7 +1983,7 @@ public:
 
         const mavsdk::Telemetry::HealthHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_health(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::Health health) {
                     rpc::telemetry::HealthResponse rpc_response;
 
@@ -2024,7 +2024,7 @@ public:
 
         const mavsdk::Telemetry::RcStatusHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_rc_status(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::RcStatus rc_status) {
                     rpc::telemetry::RcStatusResponse rpc_response;
 
@@ -2066,7 +2066,7 @@ public:
 
         const mavsdk::Telemetry::StatusTextHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_status_text(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::StatusText status_text) {
                     rpc::telemetry::StatusTextResponse rpc_response;
 
@@ -2108,7 +2108,7 @@ public:
 
         const mavsdk::Telemetry::ActuatorControlTargetHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_actuator_control_target(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::ActuatorControlTarget actuator_control_target) {
                     rpc::telemetry::ActuatorControlTargetResponse rpc_response;
 
@@ -2150,7 +2150,7 @@ public:
 
         const mavsdk::Telemetry::ActuatorOutputStatusHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_actuator_output_status(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::ActuatorOutputStatus actuator_output_status) {
                     rpc::telemetry::ActuatorOutputStatusResponse rpc_response;
 
@@ -2192,7 +2192,7 @@ public:
 
         const mavsdk::Telemetry::OdometryHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_odometry(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::Odometry odometry) {
                     rpc::telemetry::OdometryResponse rpc_response;
 
@@ -2233,7 +2233,7 @@ public:
 
         const mavsdk::Telemetry::PositionVelocityNedHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_position_velocity_ned(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::PositionVelocityNed position_velocity_ned) {
                     rpc::telemetry::PositionVelocityNedResponse rpc_response;
 
@@ -2275,7 +2275,7 @@ public:
 
         const mavsdk::Telemetry::GroundTruthHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_ground_truth(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::GroundTruth ground_truth) {
                     rpc::telemetry::GroundTruthResponse rpc_response;
 
@@ -2317,7 +2317,7 @@ public:
 
         const mavsdk::Telemetry::FixedwingMetricsHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_fixedwing_metrics(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::FixedwingMetrics fixedwing_metrics) {
                     rpc::telemetry::FixedwingMetricsResponse rpc_response;
 
@@ -2358,7 +2358,7 @@ public:
         auto subscribe_mutex = std::make_shared<std::mutex>();
 
         const mavsdk::Telemetry::ImuHandle handle = _lazy_plugin.maybe_plugin()->subscribe_imu(
-            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                 const mavsdk::Telemetry::Imu imu) {
                 rpc::telemetry::ImuResponse rpc_response;
 
@@ -2399,7 +2399,7 @@ public:
 
         const mavsdk::Telemetry::ScaledImuHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_scaled_imu(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::Imu scaled_imu) {
                     rpc::telemetry::ScaledImuResponse rpc_response;
 
@@ -2440,7 +2440,7 @@ public:
 
         const mavsdk::Telemetry::RawImuHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_raw_imu(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::Imu raw_imu) {
                     rpc::telemetry::RawImuResponse rpc_response;
 
@@ -2481,7 +2481,7 @@ public:
 
         const mavsdk::Telemetry::HealthAllOkHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_health_all_ok(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const bool health_all_ok) {
                     rpc::telemetry::HealthAllOkResponse rpc_response;
 
@@ -2522,7 +2522,7 @@ public:
 
         const mavsdk::Telemetry::UnixEpochTimeHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_unix_epoch_time(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const uint64_t unix_epoch_time) {
                     rpc::telemetry::UnixEpochTimeResponse rpc_response;
 
@@ -2563,7 +2563,7 @@ public:
 
         const mavsdk::Telemetry::DistanceSensorHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_distance_sensor(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::DistanceSensor distance_sensor) {
                     rpc::telemetry::DistanceSensorResponse rpc_response;
 
@@ -2605,7 +2605,7 @@ public:
 
         const mavsdk::Telemetry::ScaledPressureHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_scaled_pressure(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::ScaledPressure scaled_pressure) {
                     rpc::telemetry::ScaledPressureResponse rpc_response;
 
@@ -2647,7 +2647,7 @@ public:
 
         const mavsdk::Telemetry::HeadingHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_heading(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Telemetry::Heading heading) {
                     rpc::telemetry::HeadingResponse rpc_response;
 

--- a/src/mavsdk_server/src/plugins/tracking_server/tracking_server_service_impl.h
+++ b/src/mavsdk_server/src/plugins/tracking_server/tracking_server_service_impl.h
@@ -256,7 +256,7 @@ public:
 
         const mavsdk::TrackingServer::TrackingPointCommandHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_tracking_point_command(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::TrackingServer::TrackPoint tracking_point_command) {
                     rpc::tracking_server::TrackingPointCommandResponse rpc_response;
 
@@ -298,7 +298,7 @@ public:
 
         const mavsdk::TrackingServer::TrackingRectangleCommandHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_tracking_rectangle_command(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::TrackingServer::TrackRectangle tracking_rectangle_command) {
                     rpc::tracking_server::TrackingRectangleCommandResponse rpc_response;
 
@@ -340,7 +340,7 @@ public:
 
         const mavsdk::TrackingServer::TrackingOffCommandHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_tracking_off_command(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const int32_t tracking_off_command) {
                     rpc::tracking_server::TrackingOffCommandResponse rpc_response;
 

--- a/src/mavsdk_server/src/plugins/transponder/transponder_service_impl.h
+++ b/src/mavsdk_server/src/plugins/transponder/transponder_service_impl.h
@@ -303,7 +303,7 @@ public:
 
         const mavsdk::Transponder::TransponderHandle handle =
             _lazy_plugin.maybe_plugin()->subscribe_transponder(
-                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, handle](
+                [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](
                     const mavsdk::Transponder::AdsbVehicle transponder) {
                     rpc::transponder::TransponderResponse rpc_response;
 

--- a/templates/mavsdk_server/stream.j2
+++ b/templates/mavsdk_server/stream.j2
@@ -23,7 +23,7 @@ grpc::Status Subscribe{{ name.upper_camel_case }}(grpc::ServerContext* /* contex
     auto subscribe_mutex = std::make_shared<std::mutex>();
 
     {% if not is_finite %}const mavsdk::{{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}Handle handle = {% endif %}_lazy_plugin.maybe_plugin()->{% if not is_finite %}subscribe_{% endif %}{{ name.lower_snake_case }}{% if is_finite %}_async{% endif %}({% for param in params %}{% if not param.type_info.is_primitive %}translateFromRpc{{ param.name.upper_camel_case }}({% endif %}request->{{ param.name.lower_snake_case }}(){% if not param.type_info.is_primitive %}){% endif %}, {% endfor %}
-        [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex{% if not is_finite %}, handle{% endif %}](
+        [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex{% if not is_finite %}, &handle{% endif %}](
             {%- if has_result -%}mavsdk::{{ plugin_name.upper_camel_case }}::Result result,{%- endif -%}
             const {% if return_type.is_repeated %}std::vector<{% if not return_type.is_primitive %}{{ package.lower_snake_case.split('.')[0] }}::{{ plugin_name.upper_camel_case }}::{% endif %}{{ return_type.inner_name }}>{% else %}{%- if not return_type.is_primitive %}{{ package.lower_snake_case.split('.')[0] }}::{{ plugin_name.upper_camel_case }}::{% endif %}{{ return_type.name }}{% endif %} {{ name.lower_snake_case }}) {
 


### PR DESCRIPTION
Just a minor detail in the templates that creates a lot of warnings.