### PR TITLE
Only enable follow-me test if the improved followme' parameter exists

### DIFF
--- a/src/integration_tests/follow_me.cpp
+++ b/src/integration_tests/follow_me.cpp
@@ -230,7 +230,7 @@ bool autopilot_has_improved_followme(const std::shared_ptr<Param> param)
     // Check if the newly added parameter in the improved follow-me exists
     // Improved Follow-Me PR: https://github.com/PX4/PX4-Autopilot/pull/18026
     const std::pair<Param::Result, float> get_result = param->get_param_float("FLW_TGT_MAX_VEL");
-    
+
     if (get_result.first == Param::Result::Success) {
         return true;
     } else {


### PR DESCRIPTION
As discussed in the [Dev-Call](https://discuss.px4.io/t/px4-dev-call-july-06-2022/28093#q2-julianoes-is-reworked-follow-me-available-before-or-after-113-release-8), as the [improved Follow-me](https://github.com/PX4/PX4-Autopilot/pull/18026) didn't get into PX4 v1.13, the SITL tests were failing.

This PR adds capability to do `param_get` to PX4 to check if the improved Follow-me is supported, and if not, it would skip the test (this would also skip the test for flash constrained builds, and is more proper way of handling the test skipping criteria, as the version tag itself is not sufficient indicator of the features the vehicle supports)

Fixes #1845