### PR TITLE
added optional mavsdk server built with grpc proto reflection. This a…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.13)
 option(HUNTER_ENABLED "Enable Hunter package manager support" OFF)
 option(SUPERBUILD "Build dependencies" ON)
 option(BUILD_MAVSDK_SERVER "Build mavsdk_server" OFF)
+option(BUILD_WITH_PROTO_REFLECTION "Build MAVSDK Server with Proto Reflection" OFF)
 option(BUILD_SHARED_LIBS "Build core as shared libraries instead of static ones" ON)
 
 if(SUPERBUILD AND HUNTER_ENABLED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.13)
 option(HUNTER_ENABLED "Enable Hunter package manager support" OFF)
 option(SUPERBUILD "Build dependencies" ON)
 option(BUILD_MAVSDK_SERVER "Build mavsdk_server" OFF)
-option(BUILD_WITH_PROTO_REFLECTION "Build MAVSDK Server with Proto Reflection" OFF)
+option(BUILD_WITH_PROTO_REFLECTION "Build mavsdk_server with proto reflection" OFF)
 option(BUILD_SHARED_LIBS "Build core as shared libraries instead of static ones" ON)
 
 if(SUPERBUILD AND HUNTER_ENABLED)

--- a/src/mavsdk_server/src/CMakeLists.txt
+++ b/src/mavsdk_server/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2)
 
 set(COMPONENTS_LIST ${ENABLED_PLUGINS})
+set(OPTIONAL_TARGETS "")
 list(APPEND COMPONENTS_LIST core)
 
 foreach(COMPONENT_NAME ${COMPONENTS_LIST})
@@ -43,10 +44,15 @@ else()
     add_library(mavsdk_server ${MAVSDK_SERVER_SOURCES})
 endif()
 
+if(BUILD_WITH_PROTO_REFLECTION)
+    list(APPEND OPTIONAL_TARGETS gRPC::grpc++_reflection)
+endif()
+
 target_link_libraries(mavsdk_server
     PRIVATE
     mavsdk
     gRPC::grpc++
+    ${OPTIONAL_TARGETS}
     ${COMPONENTS_PROTOGENS}
 )
 

--- a/src/mavsdk_server/src/CMakeLists.txt
+++ b/src/mavsdk_server/src/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)
 
 set(COMPONENTS_LIST ${ENABLED_PLUGINS})
-set(OPTIONAL_TARGETS "")
 list(APPEND COMPONENTS_LIST core)
 
 foreach(COMPONENT_NAME ${COMPONENTS_LIST})
@@ -44,18 +43,16 @@ else()
     add_library(mavsdk_server ${MAVSDK_SERVER_SOURCES})
 endif()
 
-if(BUILD_WITH_PROTO_REFLECTION)
-    list(APPEND OPTIONAL_TARGETS gRPC::grpc++_reflection)
-endif()
-
 target_link_libraries(mavsdk_server
     PRIVATE
     mavsdk
     gRPC::grpc++
-    ${OPTIONAL_TARGETS}
     ${COMPONENTS_PROTOGENS}
 )
 
+if(BUILD_WITH_PROTO_REFLECTION)
+    target_link_libraries(mavsdk_server PRIVATE gRPC::grpc++_reflection)
+endif()
 
 foreach(plugin ${COMPONENTS_LIST})
     string(TOUPPER ${plugin} plugin_uppercase)

--- a/src/mavsdk_server/src/CMakeLists.txt
+++ b/src/mavsdk_server/src/CMakeLists.txt
@@ -51,6 +51,7 @@ target_link_libraries(mavsdk_server
 )
 
 if(BUILD_WITH_PROTO_REFLECTION)
+    add_definitions(-DENABLE_PROTO_REFLECTION)
     target_link_libraries(mavsdk_server PRIVATE gRPC::grpc++_reflection)
 endif()
 

--- a/src/mavsdk_server/src/grpc_server.cpp
+++ b/src/mavsdk_server/src/grpc_server.cpp
@@ -142,7 +142,7 @@ int GrpcServer::run()
     builder.RegisterService(&_tune_service);
 #endif
 
-#ifdef BUILD_WITH_PROTO_REFLECTION
+#ifdef ENABLE_PROTO_REFLECTION
     grpc::reflection::InitProtoReflectionServerBuilderPlugin();
 #endif
 

--- a/src/mavsdk_server/src/grpc_server.cpp
+++ b/src/mavsdk_server/src/grpc_server.cpp
@@ -142,6 +142,10 @@ int GrpcServer::run()
     builder.RegisterService(&_tune_service);
 #endif
 
+#ifdef BUILD_WITH_PROTO_REFLECTION
+    grpc::reflection::InitProtoReflectionServerBuilderPlugin();
+#endif
+
     grpc::EnableDefaultHealthCheckService(true);
     _server = builder.BuildAndStart();
 

--- a/src/mavsdk_server/src/grpc_server.h
+++ b/src/mavsdk_server/src/grpc_server.h
@@ -5,7 +5,7 @@
 #include <grpcpp/server.h>
 #include <grpcpp/server_builder.h>
 
-#ifdef BUILD_WITH_PROTO_REFLECTION
+#ifdef ENABLE_PROTO_REFLECTION
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #endif
 

--- a/src/mavsdk_server/src/grpc_server.h
+++ b/src/mavsdk_server/src/grpc_server.h
@@ -4,6 +4,11 @@
 
 #include <grpcpp/server.h>
 #include <grpcpp/server_builder.h>
+
+#ifdef BUILD_WITH_PROTO_REFLECTION
+#include <grpcpp/ext/proto_server_reflection_plugin.h>
+#endif
+
 #include <memory>
 
 #include "mavsdk.h"

--- a/templates/grpc_server.cpp.j2
+++ b/templates/grpc_server.cpp.j2
@@ -28,7 +28,7 @@ int GrpcServer::run()
 #endif
 {% endfor %}
 
-#ifdef BUILD_WITH_PROTO_REFLECTION
+#ifdef ENABLE_PROTO_REFLECTION
     grpc::reflection::InitProtoReflectionServerBuilderPlugin();
 #endif
 

--- a/templates/grpc_server.cpp.j2
+++ b/templates/grpc_server.cpp.j2
@@ -28,6 +28,10 @@ int GrpcServer::run()
 #endif
 {% endfor %}
 
+#ifdef BUILD_WITH_PROTO_REFLECTION
+    grpc::reflection::InitProtoReflectionServerBuilderPlugin();
+#endif
+
     grpc::EnableDefaultHealthCheckService(true);
     _server = builder.BuildAndStart();
 

--- a/templates/grpc_server.h.j2
+++ b/templates/grpc_server.h.j2
@@ -5,7 +5,7 @@
 #include <grpcpp/server.h>
 #include <grpcpp/server_builder.h>
 
-#ifdef BUILD_WITH_PROTO_REFLECTION
+#ifdef ENABLE_PROTO_REFLECTION
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #endif
 

--- a/templates/grpc_server.h.j2
+++ b/templates/grpc_server.h.j2
@@ -4,6 +4,11 @@
 
 #include <grpcpp/server.h>
 #include <grpcpp/server_builder.h>
+
+#ifdef BUILD_WITH_PROTO_REFLECTION
+#include <grpcpp/ext/proto_server_reflection_plugin.h>
+#endif
+
 #include <memory>
 
 #include "mavsdk.h"


### PR DESCRIPTION
…llows quick debugging using tools like grpcurl. The feature can be tested as follows:

1. Build the server with the following command from the src directory:

`cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_MAVSDK_SERVER=ON -DBUILD_WITH_PROTO_REFLECTION=ON -Bbuild/default -H.
`

2. Run the SITL with this server.
3. Use [grpcurl](https://github.com/fullstorydev/grpcurl) like follows:

`./grpcurl -plaintext localhost:50051 mavsdk.rpc.telemetry.TelemetryService/SubscribePosition`

This should print the telemetry:

`{
  "position": {
    "latitude_deg": 47.397742099999995,
    "longitude_deg": 8.5455937,
    "absolute_altitude_m": 488.07004,
    "relative_altitude_m": 0.010000001
  }
}`
`
{
  "position": {
    "latitude_deg": 47.397742099999995,
    "longitude_deg": 8.5455937,
    "absolute_altitude_m": 488.07004,
    "relative_altitude_m": 0.010000001
  }
}`
`
{
  "position": {
    "latitude_deg": 47.397742099999995,
    "longitude_deg": 8.5455937,
    "absolute_altitude_m": 488.07004,
    "relative_altitude_m": 0.010000001
  }
}`