### PR TITLE
Detect external storage format

### DIFF
--- a/src/mavsdk/plugins/camera/camera_impl.h
+++ b/src/mavsdk/plugins/camera/camera_impl.h
@@ -143,6 +143,7 @@ private:
     void process_video_information(const mavlink_message_t& message);
     void process_video_stream_status(const mavlink_message_t& message);
     void process_flight_information(const mavlink_message_t& message);
+    void reset_following_format_storage();
 
     Camera::EulerAngle to_euler_angle_from_quaternion(Camera::Quaternion quaternion);
 


### PR DESCRIPTION
It could be that some other component (or the user, manually) formats the storage. MAVSDK can detect that by observing that the `image_count` became smaller than it was before (e.g. `image_count = 30` followed by `image_count = 0` means that the storage was formatted). Because we can lose messages, I don't check `image_count == 0`, but `last_image_count > new_image_count`. The only reason why the image count would get lower is because the storage was formatted.

Also, it _should_ work if just a few pictures are removed from the storage: here it just invalidates the whole photo list and MAVSDK has to start all over again, so that should be fine. Still, that's not a supported use case in the MAVLink specs.