### PR TITLE
Just for testing

### DIFF
--- a/src/mavsdk_server/src/grpc_server.cpp
+++ b/src/mavsdk_server/src/grpc_server.cpp
@@ -301,7 +301,7 @@ void GrpcServer::stop()
 
 void GrpcServer::setup_port(grpc::ServerBuilder& builder)
 {
-    const std::string server_address("0.0.0.0:" + std::to_string(_port));
+    const std::string server_address("127.0.0.1:" + std::to_string(_port));
     builder.AddListeningPort(server_address, grpc::InsecureServerCredentials(), &_bound_port);
 }
 


### PR DESCRIPTION
There is this weird crash on iOS when the wifi hotspot (of Herelink, not on the iOS device) is stopped. Not when e.g. mavlink-router is stopped, but really when the wifi hotspot is stopped. I don't get what and can't manage to get a good stack trace.

I have no clue how the wifi connection would be related to a crash (mavsdk_server receives datagrams over UDP, it should not care about the wifi connection at all).

Anyway, I am wondering if maybe there is something in the gRPC server. This is completely a guess, I want to see what happens if the gRPC server only accepts localhost connections.