### PR TITLE
Switch to clang-format-12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,14 +144,14 @@ jobs:
         run: ./build/src/system_tests/system_tests_runner
 
   ubuntu20-proto-check:
-    name: ubuntu-20.04 (proto check)
-    runs-on: ubuntu-20.04
+    name: ubuntu-22.04 (proto check)
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: install clang-format
-        run: sudo apt-get update && sudo apt-get install -y clang-format-10
+        run: sudo apt-get update && sudo apt-get install -y clang-format-12
       - name: install pymavlink dependencies
         run: sudo apt-get install -y python3-future
       - name: install protoc-gen-mavsdk
@@ -177,14 +177,14 @@ jobs:
         run: git diff --exit-code
 
   ubuntu20-check-style:
-    name: ubuntu-20.04 (check style and docs)
+    name: ubuntu-22.04 (check style and docs)
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: install dependencies
-        run: sudo apt-get update && sudo apt-get install -y doxygen clang-format-10
+        run: sudo apt-get update && sudo apt-get install -y doxygen clang-format-12
       - name: install pymavlink dependencies
         run: sudo apt-get install -y python3-future
       - name: check style

--- a/docker/Dockerfile-Ubuntu-22.04
+++ b/docker/Dockerfile-Ubuntu-22.04
@@ -1,0 +1,59 @@
+#
+# Development environment for MAVSDK based on Ubuntu 22.04.
+#
+# Author: Julian Oes <julian@oes.ch>
+#
+
+FROM ubuntu:22.04
+MAINTAINER Julian Oes <julian@oes.ch>
+
+ENV DEBIAN_FRONTEND noninteractive
+
+
+RUN apt-get update \
+    && apt-get -y --quiet --no-install-recommends install \
+        autoconf \
+        automake \
+        autotools-dev \
+        build-essential \
+        ca-certificates \
+        ccache \
+        clang-format-12 \
+        cmake \
+        colordiff \
+        doxygen \
+        git \
+        golang-go \
+        libcurl4-openssl-dev \
+        libltdl-dev \
+        libtinyxml2-dev \
+        libtool \
+        libz-dev \
+        ninja-build \
+        python3 \
+        python3-pip \
+        python3-future \
+        ruby-dev \
+        software-properties-common \
+        sudo \
+        wget \
+    && apt-get -y autoremove \
+    && apt-get clean autoclean \
+    && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+RUN gem install --no-document fpm;
+
+RUN wget -qO- https://github.com/ncopa/su-exec/archive/dddd1567b7c76365e1e0aac561287975020a8fad.tar.gz | tar xvz && \
+    cd su-exec-* && make && mv su-exec /usr/local/bin && cd .. && rm -rf su-exec-*
+
+# Create user with id 1001 (Jenkins docker workflow default)
+RUN useradd --shell /bin/bash -u 1001 -c "" -m user
+
+ADD /sudoers.txt /etc/sudoers
+RUN chmod 440 /etc/sudoers
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+WORKDIR "/home/user/MAVSDK"

--- a/docker/Dockerfile-Ubuntu-22.04-PX4-SITL-v1.13
+++ b/docker/Dockerfile-Ubuntu-22.04-PX4-SITL-v1.13
@@ -1,8 +1,8 @@
 #
-# PX4 v1.13 SITL testing environment for MAVSDK based on Ubuntu 20.04.
+# PX4 v1.13 SITL testing environment for MAVSDK based on Ubuntu 22.04.
 # Author: Julian Oes <julian@oes.ch>
 #
-FROM mavsdk/mavsdk-ubuntu-20.04
+FROM mavsdk/mavsdk-ubuntu-22.04
 MAINTAINER Julian Oes <julian@oes.ch>
 
 ENV FIRMWARE_DIR ${WORKDIR}../Firmware
@@ -19,7 +19,9 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 RUN git clone https://github.com/PX4/Firmware.git ${FIRMWARE_DIR}
-RUN git -C ${FIRMWARE_DIR} switch release/1.13
+RUN git -C ${FIRMWARE_DIR} checkout v1.13.0
+# We need the updated ubuntu.sh script for Ubuntu 22.04
+RUN git -C ${FIRMWARE_DIR} checkout 1a620b450d235d654751b5f28d882bd426aa6e39 -- Tools/setup/ubuntu.sh
 RUN git -C ${FIRMWARE_DIR} submodule update --init --recursive
 RUN wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 RUN cd ${FIRMWARE_DIR} && Tools/setup/ubuntu.sh --no-nuttx

--- a/docker/build_and_push_docker_images.sh
+++ b/docker/build_and_push_docker_images.sh
@@ -14,9 +14,10 @@ $DOCKER_CMD build -f Dockerfile-Fedora-34 -t mavsdk/mavsdk-fedora-34 .
 $DOCKER_CMD build -f Dockerfile-Fedora-35 -t mavsdk/mavsdk-fedora-35 .
 $DOCKER_CMD build -f Dockerfile-Fedora-36 -t mavsdk/mavsdk-fedora-36 .
 $DOCKER_CMD build -f Dockerfile-Ubuntu-20.04 -t mavsdk/mavsdk-ubuntu-20.04 .
+$DOCKER_CMD build -f Dockerfile-Ubuntu-22.04 -t mavsdk/mavsdk-ubuntu-22.04 .
 $DOCKER_CMD build -f Dockerfile-Ubuntu-20.04-PX4-SITL-v1.11 -t mavsdk/mavsdk-ubuntu-20.04-px4-sitl-v1.11 .
 $DOCKER_CMD build -f Dockerfile-Ubuntu-20.04-PX4-SITL-v1.12 -t mavsdk/mavsdk-ubuntu-20.04-px4-sitl-v1.12 .
-$DOCKER_CMD build -f Dockerfile-Ubuntu-20.04-PX4-SITL-v1.13 -t mavsdk/mavsdk-ubuntu-20.04-px4-sitl-v1.13 .
+$DOCKER_CMD build -f Dockerfile-Ubuntu-22.04-PX4-SITL-v1.13 -t mavsdk/mavsdk-ubuntu-22.04-px4-sitl-v1.13 .
 $DOCKER_CMD build -f Dockerfile-Ubuntu-20.04-APM-SITL-Copter-4.1.2 -t mavsdk/mavsdk-ubuntu-20.04-apm-sitl-copter-4.1.2 .
 $DOCKER_CMD build -f Dockerfile-Ubuntu-20.04-APM-SITL-Rover-4.1.2 -t mavsdk/mavsdk-ubuntu-20.04-apm-sitl-rover-4.1.2 .
 $DOCKER_CMD build -f Dockerfile.dockcross-linux-armv6-custom -t mavsdk/mavsdk-dockcross-linux-armv6-custom .
@@ -27,9 +28,10 @@ $DOCKER_CMD push mavsdk/mavsdk-fedora-34:latest
 $DOCKER_CMD push mavsdk/mavsdk-fedora-35:latest
 $DOCKER_CMD push mavsdk/mavsdk-fedora-36:latest
 $DOCKER_CMD push mavsdk/mavsdk-ubuntu-20.04:latest
+$DOCKER_CMD push mavsdk/mavsdk-ubuntu-22.04:latest
 $DOCKER_CMD push mavsdk/mavsdk-ubuntu-20.04-px4-sitl-v1.11:latest
 $DOCKER_CMD push mavsdk/mavsdk-ubuntu-20.04-px4-sitl-v1.12:latest
-$DOCKER_CMD push mavsdk/mavsdk-ubuntu-20.04-px4-sitl-v1.13:latest
+$DOCKER_CMD push mavsdk/mavsdk-ubuntu-22.04-px4-sitl-v1.13:latest
 $DOCKER_CMD push mavsdk/mavsdk-ubuntu-20.04-apm-sitl-copter-4.1.2:latest
 $DOCKER_CMD push mavsdk/mavsdk-ubuntu-20.04-apm-sitl-rover-4.1.2:latest
 $DOCKER_CMD push mavsdk/mavsdk-dockcross-linux-armv6-custom:latest

--- a/src/mavsdk/core/mavlink_parameters.h
+++ b/src/mavsdk/core/mavlink_parameters.h
@@ -73,7 +73,7 @@ public:
 
         [[nodiscard]] std::string get_string() const;
 
-        template<typename T>[[nodiscard]] bool is() const
+        template<typename T> [[nodiscard]] bool is() const
         {
             return (std::get_if<T>(&_value) != nullptr);
         }

--- a/tools/fix_style.sh
+++ b/tools/fix_style.sh
@@ -3,10 +3,14 @@
 # This script runs clang-format over all files ending in .h, .c, .cpp listed
 # by git in the given directory.
 
-version_required_major="10"
+version_required_major="12"
 
 # Try to find the latest version of clang
-if command -v clang-format-10 >/dev/null; then
+if command -v clang-format-12 >/dev/null; then
+    clang_format=clang-format-12
+elif command -v clang-format-11 >/dev/null; then
+    clang_format=clang-format-11
+elif command -v clang-format-10 >/dev/null; then
     clang_format=clang-format-10
 elif command -v clang-format-9 >/dev/null; then
     clang_format=clang-format-9
@@ -29,7 +33,7 @@ if [[ $version =~ $semver_regex ]]; then
 version_major=${BASH_REMATCH[1]}
 if [ "$version_required_major" -gt "$version_major" ]; then
     echo "Clang version $version_major too old (required: $version_required_major)"
-    echo "You can use clang-format-10 from docker:"
+    echo "You can use clang-format-12 from docker:"
     echo ""
     echo "    'tools/run-docker.sh tools/fix_style.sh .'"
     exit 1

--- a/tools/run-docker.sh
+++ b/tools/run-docker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-dockerimage=mavsdk/mavsdk-ubuntu-20.04-px4-sitl-v1.11
+dockerimage=mavsdk/mavsdk-ubuntu-22.04-px4-sitl-v1.13
 
 if type podman > /dev/null 2> /dev/null
 then


### PR DESCRIPTION
`clang-format-12` is a nice choice because it is available for both Ubuntu
20.04 as well as Ubuntu 22.04.

This also bases the PX4 v1.13 SITL build on top of Ubuntu 22.04.