### PR TITLE
Make commands thread-safe

### DIFF
--- a/src/mavsdk/plugins/action/action.cpp
+++ b/src/mavsdk/plugins/action/action.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/action/action.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "action_impl.h"
 #include "plugins/action/action.h"
@@ -197,6 +198,7 @@ Action::Result Action::transition_to_multicopter() const
 
 void Action::get_takeoff_altitude_async(const GetTakeoffAltitudeCallback callback)
 {
+    std::lock_guard<std::mutex> lock(_impl->get_takeoff_altitude_mutex);
     _impl->get_takeoff_altitude_async(callback);
 }
 
@@ -217,6 +219,7 @@ Action::Result Action::set_takeoff_altitude(float altitude) const
 
 void Action::get_maximum_speed_async(const GetMaximumSpeedCallback callback)
 {
+    std::lock_guard<std::mutex> lock(_impl->get_maximum_speed_mutex);
     _impl->get_maximum_speed_async(callback);
 }
 
@@ -237,6 +240,7 @@ Action::Result Action::set_maximum_speed(float speed) const
 
 void Action::get_return_to_launch_altitude_async(const GetReturnToLaunchAltitudeCallback callback)
 {
+    std::lock_guard<std::mutex> lock(_impl->get_return_to_launch_altitude_mutex);
     _impl->get_return_to_launch_altitude_async(callback);
 }
 

--- a/src/mavsdk/plugins/action/action_impl.h
+++ b/src/mavsdk/plugins/action/action_impl.h
@@ -100,6 +100,14 @@ public:
     Action::Result set_return_to_launch_altitude(const float relative_altitude_m) const;
     std::pair<Action::Result, float> get_return_to_launch_altitude() const;
 
+    std::mutex arm_mutex{};
+    std::mutex disarm_mutex{};
+    std::mutex takeoff_mutex{};
+    std::mutex land_mutex{};
+    std::mutex get_takeoff_altitude_mutex{};
+    std::mutex get_return_to_launch_altitude_mutex{};
+    std::mutex get_maximum_speed_mutex{};
+
 private:
     void process_extended_sys_state(const mavlink_message_t& message);
 

--- a/src/mavsdk/plugins/action_server/action_server.cpp
+++ b/src/mavsdk/plugins/action_server/action_server.cpp
@@ -4,6 +4,7 @@
 // https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/action_server/action_server.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "action_server_impl.h"
 #include "plugins/action_server/action_server.h"

--- a/src/mavsdk/plugins/calibration/calibration.cpp
+++ b/src/mavsdk/plugins/calibration/calibration.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/calibration/calibration.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "calibration_impl.h"
 #include "plugins/calibration/calibration.h"

--- a/src/mavsdk/plugins/camera/camera.cpp
+++ b/src/mavsdk/plugins/camera/camera.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/camera/camera.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "camera_impl.h"
 #include "plugins/camera/camera.h"
@@ -112,6 +113,7 @@ Camera::Result Camera::set_mode(Mode mode) const
 
 void Camera::list_photos_async(PhotosRange photos_range, const ListPhotosCallback callback)
 {
+    std::lock_guard<std::mutex> lock(_impl->list_photos_mutex);
     _impl->list_photos_async(photos_range, callback);
 }
 
@@ -231,6 +233,7 @@ Camera::Result Camera::set_setting(Setting setting) const
 
 void Camera::get_setting_async(Setting setting, const GetSettingCallback callback)
 {
+    std::lock_guard<std::mutex> lock(_impl->get_setting_mutex);
     _impl->get_setting_async(setting, callback);
 }
 

--- a/src/mavsdk/plugins/camera/camera_impl.h
+++ b/src/mavsdk/plugins/camera/camera_impl.h
@@ -97,6 +97,9 @@ public:
     CameraImpl(const CameraImpl&) = delete;
     CameraImpl& operator=(const CameraImpl&) = delete;
 
+    std::mutex get_setting_mutex{};
+    std::mutex list_photos_mutex{};
+
 private:
     bool get_possible_setting_options(std::vector<std::string>& settings);
     bool get_possible_options(const std::string& setting_id, std::vector<Camera::Option>& options);

--- a/src/mavsdk/plugins/camera_server/camera_server.cpp
+++ b/src/mavsdk/plugins/camera_server/camera_server.cpp
@@ -4,6 +4,7 @@
 // https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/camera_server/camera_server.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "camera_server_impl.h"
 #include "plugins/camera_server/camera_server.h"

--- a/src/mavsdk/plugins/component_information/component_information.cpp
+++ b/src/mavsdk/plugins/component_information/component_information.cpp
@@ -4,6 +4,7 @@
 // https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/component_information/component_information.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "component_information_impl.h"
 #include "plugins/component_information/component_information.h"

--- a/src/mavsdk/plugins/component_information_server/component_information_server.cpp
+++ b/src/mavsdk/plugins/component_information_server/component_information_server.cpp
@@ -4,6 +4,7 @@
 // https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/component_information_server/component_information_server.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "component_information_server_impl.h"
 #include "plugins/component_information_server/component_information_server.h"

--- a/src/mavsdk/plugins/failure/failure.cpp
+++ b/src/mavsdk/plugins/failure/failure.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/failure/failure.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "failure_impl.h"
 #include "plugins/failure/failure.h"

--- a/src/mavsdk/plugins/follow_me/follow_me.cpp
+++ b/src/mavsdk/plugins/follow_me/follow_me.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/follow_me/follow_me.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "follow_me_impl.h"
 #include "plugins/follow_me/follow_me.h"

--- a/src/mavsdk/plugins/ftp/ftp.cpp
+++ b/src/mavsdk/plugins/ftp/ftp.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/ftp/ftp.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "ftp_impl.h"
 #include "plugins/ftp/ftp.h"
@@ -36,6 +37,7 @@ void Ftp::upload_async(
 
 void Ftp::list_directory_async(std::string remote_dir, const ListDirectoryCallback callback)
 {
+    std::lock_guard<std::mutex> lock(_impl->list_directory_mutex);
     _impl->list_directory_async(remote_dir, callback);
 }
 
@@ -90,6 +92,7 @@ void Ftp::are_files_identical_async(
     std::string remote_file_path,
     const AreFilesIdenticalCallback callback)
 {
+    std::lock_guard<std::mutex> lock(_impl->are_files_identical_mutex);
     _impl->are_files_identical_async(local_file_path, remote_file_path, callback);
 }
 

--- a/src/mavsdk/plugins/ftp/ftp_impl.h
+++ b/src/mavsdk/plugins/ftp/ftp_impl.h
@@ -67,6 +67,9 @@ public:
     uint8_t get_our_compid() { return _parent->get_own_component_id(); };
     Ftp::Result set_target_compid(uint8_t component_id);
 
+    std::mutex are_files_identical_mutex{};
+    std::mutex list_directory_mutex{};
+
 private:
     Ftp::Result result_from_mavlink_ftp_result(MavlinkFtp::ClientResult result);
     Ftp::ProgressData

--- a/src/mavsdk/plugins/geofence/geofence.cpp
+++ b/src/mavsdk/plugins/geofence/geofence.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/geofence/geofence.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "geofence_impl.h"
 #include "plugins/geofence/geofence.h"

--- a/src/mavsdk/plugins/gimbal/gimbal.cpp
+++ b/src/mavsdk/plugins/gimbal/gimbal.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/gimbal/gimbal.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "gimbal_impl.h"
 #include "plugins/gimbal/gimbal.h"

--- a/src/mavsdk/plugins/info/info.cpp
+++ b/src/mavsdk/plugins/info/info.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/info/info.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "info_impl.h"
 #include "plugins/info/info.h"

--- a/src/mavsdk/plugins/log_files/log_files.cpp
+++ b/src/mavsdk/plugins/log_files/log_files.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/log_files/log_files.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "log_files_impl.h"
 #include "plugins/log_files/log_files.h"
@@ -23,6 +24,7 @@ LogFiles::~LogFiles() {}
 
 void LogFiles::get_entries_async(const GetEntriesCallback callback)
 {
+    std::lock_guard<std::mutex> lock(_impl->get_entries_mutex);
     _impl->get_entries_async(callback);
 }
 

--- a/src/mavsdk/plugins/log_files/log_files_impl.h
+++ b/src/mavsdk/plugins/log_files/log_files_impl.h
@@ -32,6 +32,8 @@ public:
 
     LogFiles::Result erase_all_log_files();
 
+    std::mutex get_entries_mutex{};
+
 private:
     void request_end();
 

--- a/src/mavsdk/plugins/manual_control/manual_control.cpp
+++ b/src/mavsdk/plugins/manual_control/manual_control.cpp
@@ -4,6 +4,7 @@
 // https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/manual_control/manual_control.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "manual_control_impl.h"
 #include "plugins/manual_control/manual_control.h"

--- a/src/mavsdk/plugins/mission/mission.cpp
+++ b/src/mavsdk/plugins/mission/mission.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/mission/mission.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "mission_impl.h"
 #include "plugins/mission/mission.h"
@@ -48,6 +49,7 @@ Mission::Result Mission::cancel_mission_upload() const
 
 void Mission::download_mission_async(const DownloadMissionCallback callback)
 {
+    std::lock_guard<std::mutex> lock(_impl->download_mission_mutex);
     _impl->download_mission_async(callback);
 }
 

--- a/src/mavsdk/plugins/mission/mission_impl.h
+++ b/src/mavsdk/plugins/mission/mission_impl.h
@@ -73,6 +73,8 @@ public:
     MissionImpl(const MissionImpl&) = delete;
     const MissionImpl& operator=(const MissionImpl&) = delete;
 
+    std::mutex download_mission_mutex{};
+
 private:
     int current_mission_item_locked() const;
     int total_mission_items_locked() const;

--- a/src/mavsdk/plugins/mission_raw/mission_raw.cpp
+++ b/src/mavsdk/plugins/mission_raw/mission_raw.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/mission_raw/mission_raw.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "mission_raw_impl.h"
 #include "plugins/mission_raw/mission_raw.h"
@@ -43,6 +44,7 @@ MissionRaw::Result MissionRaw::cancel_mission_upload() const
 
 void MissionRaw::download_mission_async(const DownloadMissionCallback callback)
 {
+    std::lock_guard<std::mutex> lock(_impl->download_mission_mutex);
     _impl->download_mission_async(callback);
 }
 

--- a/src/mavsdk/plugins/mission_raw/mission_raw_impl.h
+++ b/src/mavsdk/plugins/mission_raw/mission_raw_impl.h
@@ -68,6 +68,8 @@ public:
     MissionRawImpl(const MissionRawImpl&) = delete;
     const MissionRawImpl& operator=(const MissionRawImpl&) = delete;
 
+    std::mutex download_mission_mutex{};
+
 private:
     void reset_mission_progress();
 

--- a/src/mavsdk/plugins/mission_raw_server/mission_raw_server.cpp
+++ b/src/mavsdk/plugins/mission_raw_server/mission_raw_server.cpp
@@ -4,6 +4,7 @@
 // https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/mission_raw_server/mission_raw_server.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "mission_raw_server_impl.h"
 #include "plugins/mission_raw_server/mission_raw_server.h"

--- a/src/mavsdk/plugins/mocap/mocap.cpp
+++ b/src/mavsdk/plugins/mocap/mocap.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/mocap/mocap.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "mocap_impl.h"
 #include "plugins/mocap/mocap.h"

--- a/src/mavsdk/plugins/offboard/offboard.cpp
+++ b/src/mavsdk/plugins/offboard/offboard.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/offboard/offboard.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "offboard_impl.h"
 #include "plugins/offboard/offboard.h"

--- a/src/mavsdk/plugins/param/param.cpp
+++ b/src/mavsdk/plugins/param/param.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/param/param.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "param_impl.h"
 #include "plugins/param/param.h"

--- a/src/mavsdk/plugins/param_server/param_server.cpp
+++ b/src/mavsdk/plugins/param_server/param_server.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/param_server/param_server.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "param_server_impl.h"
 #include "plugins/param_server/param_server.h"

--- a/src/mavsdk/plugins/rtk/rtk.cpp
+++ b/src/mavsdk/plugins/rtk/rtk.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/rtk/rtk.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "rtk_impl.h"
 #include "plugins/rtk/rtk.h"

--- a/src/mavsdk/plugins/server_utility/server_utility.cpp
+++ b/src/mavsdk/plugins/server_utility/server_utility.cpp
@@ -4,6 +4,7 @@
 // https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/server_utility/server_utility.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "server_utility_impl.h"
 #include "plugins/server_utility/server_utility.h"

--- a/src/mavsdk/plugins/shell/shell.cpp
+++ b/src/mavsdk/plugins/shell/shell.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/shell/shell.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "shell_impl.h"
 #include "plugins/shell/shell.h"

--- a/src/mavsdk/plugins/telemetry/telemetry.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/telemetry/telemetry.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "telemetry_impl.h"
 #include "plugins/telemetry/telemetry.h"
@@ -779,6 +780,7 @@ Telemetry::Result Telemetry::set_rate_distance_sensor(double rate_hz) const
 
 void Telemetry::get_gps_global_origin_async(const GetGpsGlobalOriginCallback callback)
 {
+    std::lock_guard<std::mutex> lock(_impl->get_gps_global_origin_mutex);
     _impl->get_gps_global_origin_async(callback);
 }
 

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.h
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.h
@@ -200,6 +200,8 @@ public:
     TelemetryImpl(const TelemetryImpl&) = delete;
     TelemetryImpl& operator=(const TelemetryImpl&) = delete;
 
+    std::mutex get_gps_global_origin_mutex{};
+
 private:
     void set_position_velocity_ned(Telemetry::PositionVelocityNed position_velocity_ned);
     void set_position(Telemetry::Position position);

--- a/src/mavsdk/plugins/telemetry_server/telemetry_server.cpp
+++ b/src/mavsdk/plugins/telemetry_server/telemetry_server.cpp
@@ -4,6 +4,7 @@
 // https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/telemetry_server/telemetry_server.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "telemetry_server_impl.h"
 #include "plugins/telemetry_server/telemetry_server.h"

--- a/src/mavsdk/plugins/tracking_server/tracking_server.cpp
+++ b/src/mavsdk/plugins/tracking_server/tracking_server.cpp
@@ -4,6 +4,7 @@
 // https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/tracking_server/tracking_server.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "tracking_server_impl.h"
 #include "plugins/tracking_server/tracking_server.h"

--- a/src/mavsdk/plugins/transponder/transponder.cpp
+++ b/src/mavsdk/plugins/transponder/transponder.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/transponder/transponder.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "transponder_impl.h"
 #include "plugins/transponder/transponder.h"

--- a/src/mavsdk/plugins/tune/tune.cpp
+++ b/src/mavsdk/plugins/tune/tune.cpp
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/tune/tune.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "tune_impl.h"
 #include "plugins/tune/tune.h"

--- a/templates/plugin_cpp/file.j2
+++ b/templates/plugin_cpp/file.j2
@@ -3,6 +3,7 @@
 // (see https://github.com/mavlink/MAVSDK-Proto/blob/master/protos/{{ plugin_name.lower_snake_case }}/{{ plugin_name.lower_snake_case }}.proto)
 
 #include <iomanip>
+#include <mutex>
 
 #include "{{ plugin_name.lower_snake_case }}_impl.h"
 #include "plugins/{{ plugin_name.lower_snake_case }}/{{ plugin_name.lower_snake_case }}.h"

--- a/templates/plugin_cpp/request.j2
+++ b/templates/plugin_cpp/request.j2
@@ -1,6 +1,7 @@
 {% if is_async %}
 void {{ plugin_name.upper_camel_case }}::{{ name.lower_snake_case }}_async({% for param in params %}{% if param.type_info.name.endswith("Result") %}Result{% else %}{{ param.type_info.name }}{% endif %} {{ param.name.lower_snake_case }}, {% endfor %}const {{ name.upper_camel_case }}Callback callback)
 {
+    std::lock_guard<std::mutex> lock(_{{ name.lower_snake_case }}_mutex);
     _impl->{{ name.lower_snake_case }}_async({% for param in params %}{{ param.name.lower_snake_case }}, {% endfor %}callback);
 }
 {% endif %}

--- a/templates/plugin_cpp/request.j2
+++ b/templates/plugin_cpp/request.j2
@@ -1,7 +1,7 @@
 {% if is_async %}
 void {{ plugin_name.upper_camel_case }}::{{ name.lower_snake_case }}_async({% for param in params %}{% if param.type_info.name.endswith("Result") %}Result{% else %}{{ param.type_info.name }}{% endif %} {{ param.name.lower_snake_case }}, {% endfor %}const {{ name.upper_camel_case }}Callback callback)
 {
-    std::lock_guard<std::mutex> lock(_{{ name.lower_snake_case }}_mutex);
+    std::lock_guard<std::mutex> lock(_impl->{{ name.lower_snake_case }}_mutex);
     _impl->{{ name.lower_snake_case }}_async({% for param in params %}{{ param.name.lower_snake_case }}, {% endfor %}callback);
 }
 {% endif %}

--- a/templates/plugin_impl_h/request.j2
+++ b/templates/plugin_impl_h/request.j2
@@ -4,4 +4,6 @@ void {{ name.lower_snake_case }}_async({% for param in params %}{{ param.type_in
 
 {% if is_sync %}
 {% if has_result %}std::pair<{{ plugin_name.upper_camel_case }}::Result{% endif %}{% if has_result %}, {% endif %}{% if return_type.is_repeated %}std::vector<{% if not return_type.is_primitive%}{{ plugin_name.upper_camel_case }}::{% endif %}{{ return_type.inner_name }}>{% else %}{% if not return_type.is_primitive%}{{ plugin_name.upper_camel_case }}::{% endif %}{{ return_type.name }}{% endif %}{% if has_result %}>{% endif %} {{ name.lower_snake_case }}({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_snake_case }}{{ ", " if not loop.last }}{% endfor %});
+
+std::mutex {{ name.lower_snake_case }}_mutex{};
 {% endif %}


### PR DESCRIPTION
We cannot send twice the same command in MAVLink (because there is no way to differentiate the answers), and therefore MAVSDK drops a new command if an older similar command is already running. MAVSDK returns the failing code "Denied" in that case.

However, the MAVSDK command functions are not thread-safe at the moment. So if I call `land_async()` concurrently, there is a chance that two commands will get in the queue at the same time, creating problems.

I believe this is what I observe from MAVSDK-Swift (because mavsdk_server calls the MAVSDK functions concurrently).

This tries to fix it at the MAVSDK-C++ level, by making the "request" functions thread-safe.

Still needs further testing to check that it fixes my MAVSDK-Swift issue :grin:.