### PR TITLE
core: second in flight command fix

### DIFF
--- a/src/mavsdk/core/mavlink_command_sender.cpp
+++ b/src/mavsdk/core/mavlink_command_sender.cpp
@@ -107,13 +107,11 @@ void MavlinkCommandSender::queue_command_async(
     CommandIdentification identification = identification_from_command(command);
 
     for (const auto& work : _work_queue) {
-        if (work->identification == identification) {
+        if (work->identification == identification && callback == nullptr) {
             if (_command_debugging) {
                 LogDebug() << "Dropping command " << static_cast<int>(identification.command)
                            << " that is already being sent";
             }
-            auto temp_callback = callback;
-            call_callback(temp_callback, Result::Denied, NAN);
             return;
         }
     }


### PR DESCRIPTION
In order to prevent too many commands from clogging the queue, we remove them if they look identical.

This changes it so that we only drop a command if it does not come with a callback. If it has a callback associated with it, it's better to call it anyway, otherwise odd races or just Denied results when you don't expect it tend to be the result.

This is the same as I fixed previously, however, this time also for CommandLong which I forgot last time.