### PR TITLE
PR Add battery status message for v1

### DIFF
--- a/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -373,7 +373,11 @@ public:
      */
     struct Battery {
         uint32_t id{0}; /**< @brief Battery ID, for systems with multiple batteries */
+        float temperature_cdegC{float(NAN)}; /**< @brief Temperature of the battery. INT16_MAX for unknown temperature. */
         float voltage_v{float(NAN)}; /**< @brief Voltage in volts */
+        float current_battery_cA{float(NAN)}; /**< @brief Battery current, -1: autopilot does not measure the current */
+        float current_consumed_mAh{float(NAN)}; /**< @brief Consumed charge, -1: autopilot does not provide consumption estimate */
+        float energy_consumed_hJ{float(NAN)}; /**< @brief Consumed energy, -1: autopilot does not provide energy consumption estimate */
         float remaining_percent{
             float(NAN)}; /**< @brief Estimated battery remaining (range: 0.0 to 1.0) */
     };

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -1163,12 +1163,16 @@ void TelemetryImpl::process_battery_status(const mavlink_message_t& message)
 
     Telemetry::Battery new_battery;
     new_battery.id = bat_status.id;
+    new_battery.temperature_cdegC = bat_status.temperature;
     new_battery.voltage_v = 0.0f;
     for (int i = 0; i < 255; i++) {
         if (bat_status.voltages[i] == std::numeric_limits<uint16_t>::max())
             break;
         new_battery.voltage_v += static_cast<float>(bat_status.voltages[i]) * 1e-3f;
     }
+    new_battery.current_battery_cA = bat_status.current_battery;
+    new_battery.current_consumed_mAh = bat_status.current_consumed;
+    new_battery.energy_consumed_hJ = bat_status.energy_consumed;
     // FIXME: it is strange calling it percent when the range goes from 0 to 1.
     new_battery.remaining_percent = bat_status.battery_remaining * 1e-2f;
 


### PR DESCRIPTION
I am interested in receiving more information about the battery status through MAVSDK. Mainly I need the current consumption, but I took the opportunity to add the other information.
   - temperature
   - current_battery
   - current_consumed
   - energy_consumed

I don't see the _temperature_ and _energy_consumed_ in my flight logs so not sure if it is relevant to add them. I also saw that there was already a PR in progress for adding messages for the v2 battery but nothing done for v1 from what I found.