### PR TITLE
Add the ability to send commands which does not receive ack

### DIFF
--- a/src/mavsdk/core/mavlink_command_sender.h
+++ b/src/mavsdk/core/mavlink_command_sender.h
@@ -73,11 +73,11 @@ public:
         } params{};
     };
 
-    Result send_command(const CommandInt& command);
-    Result send_command(const CommandLong& command);
+    Result send_command(const CommandInt& command, bool no_ack = false);
+    Result send_command(const CommandLong& command, bool no_ack = false);
 
-    void queue_command_async(const CommandInt& command, const CommandResultCallback& callback);
-    void queue_command_async(const CommandLong& command, const CommandResultCallback& callback);
+    void queue_command_async(const CommandInt& command, const CommandResultCallback& callback, bool no_ack = false);
+    void queue_command_async(const CommandLong& command, const CommandResultCallback& callback, bool no_ack = false);
 
     void do_work();
 
@@ -118,6 +118,7 @@ private:
         double timeout_s{0.5};
         int retries_to_do{3};
         bool already_sent{false};
+        bool no_ack{false};
     };
 
     template<typename CommandType>

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -1037,7 +1037,7 @@ MavlinkCommandSender::Result SystemImpl::send_command(MavlinkCommandSender::Comm
 }
 
 void SystemImpl::send_command_async(
-    MavlinkCommandSender::CommandLong command, const CommandResultCallback& callback)
+    MavlinkCommandSender::CommandLong command, const CommandResultCallback& callback, bool no_ack)
 {
     if (_target_address.system_id == 0 && _components.empty()) {
         if (callback) {
@@ -1047,11 +1047,11 @@ void SystemImpl::send_command_async(
     }
     command.target_system_id = get_system_id();
 
-    _command_sender.queue_command_async(command, callback);
+    _command_sender.queue_command_async(command, callback, no_ack);
 }
 
 void SystemImpl::send_command_async(
-    MavlinkCommandSender::CommandInt command, const CommandResultCallback& callback)
+    MavlinkCommandSender::CommandInt command, const CommandResultCallback& callback, bool no_ack)
 {
     if (_target_address.system_id == 0 && _components.empty()) {
         if (callback) {

--- a/src/mavsdk/core/system_impl.h
+++ b/src/mavsdk/core/system_impl.h
@@ -85,9 +85,9 @@ public:
     MavlinkCommandSender::Result send_command(MavlinkCommandSender::CommandInt& command);
 
     void send_command_async(
-        MavlinkCommandSender::CommandLong command, const CommandResultCallback& callback);
+        MavlinkCommandSender::CommandLong command, const CommandResultCallback& callback, bool no_ack = false);
     void send_command_async(
-        MavlinkCommandSender::CommandInt command, const CommandResultCallback& callback);
+        MavlinkCommandSender::CommandInt command, const CommandResultCallback& callback, bool no_ack = false);
 
     MavlinkCommandSender::Result set_msg_rate(
         uint16_t message_id, double rate_hz, uint8_t maybe_component_id = MAV_COMP_ID_AUTOPILOT1);


### PR DESCRIPTION
Hi,

I have a device which, for some undocumented reason, does not send ack after some commands.
I need to add an extra argument to the send_command functions and return immediately after sending if this argument is `true`.

I don't know if you are interested in this patch but I think it may help someone one day.

Sync functions are not tested, sorry.