### PR TITLE
Add support for pkgconfig

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,6 +99,10 @@ configure_file(MAVSDKConfig.cmake.in
 configure_file(MAVSDKConfig.cmake.in
     "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/MAVSDKConfig.cmake" @ONLY)
 
+# Pkg-config
+configure_file(mavsdk.pc.in
+    "${PROJECT_BINARY_DIR}/mavsdk.pc" @ONLY)
+
 include(CMakePackageConfigHelpers)
 # Supply version to config
 write_basic_package_version_file(
@@ -110,3 +114,7 @@ install(FILES
     "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/MAVSDKConfig.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/MAVSDKConfigVersion.cmake"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MAVSDK)
+
+install(FILES
+    "${PROJECT_BINARY_DIR}/mavsdk.pc"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/src/mavsdk.pc.in
+++ b/src/mavsdk.pc.in
@@ -8,4 +8,4 @@ Description: API and library for MAVLink compatible systems written in C++17
 Version: @MAVSDK_VERSION_STRING@
 Requires.private: libcurl jsoncpp tinyxml2
 Libs: -L"${libdir}" -lmavsdk
-Cflags: -I"${includedir}"
+Cflags: -I"${includedir}" -I"${includedir}/mavsdk"

--- a/src/mavsdk.pc.in
+++ b/src/mavsdk.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_FULL_BINDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: libmavsdk
+Description: API and library for MAVLink compatible systems written in C++17
+Version: @MAVSDK_VERSION_STRING@
+Requires.private: libcurl jsoncpp tinyxml2
+Libs: -L"${libdir}" -lmavsdk
+Cflags: -I"${includedir}"

--- a/src/mavsdk.pc.in
+++ b/src/mavsdk.pc.in
@@ -3,7 +3,7 @@ exec_prefix=@CMAKE_INSTALL_FULL_BINDIR@
 libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
-Name: libmavsdk
+Name: MAVSDK
 Description: API and library for MAVLink compatible systems written in C++17
 Version: @MAVSDK_VERSION_STRING@
 Requires.private: libcurl jsoncpp tinyxml2


### PR DESCRIPTION
This adds support for pkgconfig. Closes #1428.

The way to get the library in cmake using pkgconfig is:

```
find_package(PkgConfig REQUIRED)
pkg_check_modules(MAVSDK REQUIRED mavsdk)

target_link_libraries(gimbal
    ${MAVSDK_LIBRARIES}
)

target_include_directories(gimbal
    PRIVATE ${MAVSDK_INCLUDE_DIRS}
)
```