### PR TITLE
mission_raw: add home position at 0 for ArduPilot

### DIFF
--- a/src/mavsdk/core/mavlink_mission_transfer.cpp
+++ b/src/mavsdk/core/mavlink_mission_transfer.cpp
@@ -237,11 +237,27 @@ void MavlinkMissionTransfer::UploadWorkItem::start()
         return;
     }
 
-    int count = 0;
-    for (const auto& item : _items) {
-        if (count++ != item.seq) {
-            callback_and_reset(Result::InvalidSequence);
-            return;
+    // Mission items for ArduPilot are off by one because the home position is
+    // item 0, and the sequence starts counting at 0 from 1.
+    // This is only for missions, rally points, and geofence items are normal.
+    const bool is_ardupilot_mission =
+        _sender.autopilot() == Sender::Autopilot::ArduPilot && _type == MAV_MISSION_TYPE_MISSION;
+
+    if (is_ardupilot_mission) {
+        for (unsigned i = 1; i < _items.size(); ++i) {
+            if (_items[i].seq != i - 1) {
+                LogWarn() << "Invalid sequence for ArduPilot items";
+                callback_and_reset(Result::InvalidSequence);
+                return;
+            }
+        }
+    } else {
+        for (unsigned i = 0; i < _items.size(); ++i) {
+            if (_items[i].seq != i - 0) {
+                LogWarn() << "Invalid sequence";
+                callback_and_reset(Result::InvalidSequence);
+                return;
+            }
         }
     }
 

--- a/src/mavsdk/plugins/mission_raw/mission_import.cpp
+++ b/src/mavsdk/plugins/mission_raw/mission_import.cpp
@@ -7,7 +7,7 @@
 namespace mavsdk {
 
 std::pair<MissionRaw::Result, MissionRaw::MissionImportData>
-MissionImport::parse_json(const std::string& raw_json)
+MissionImport::parse_json(const std::string& raw_json, Sender::Autopilot autopilot)
 {
     Json::CharReaderBuilder builder;
     const std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
@@ -23,7 +23,7 @@ MissionImport::parse_json(const std::string& raw_json)
         return {MissionRaw::Result::FailedToParseQgcPlan, {}};
     }
 
-    auto maybe_mission_items = import_mission(root);
+    auto maybe_mission_items = import_mission(root, autopilot);
     if (!maybe_mission_items.has_value()) {
         return {MissionRaw::Result::FailedToParseQgcPlan, {}};
     }
@@ -60,7 +60,7 @@ bool MissionImport::check_overall_version(const Json::Value& root)
 }
 
 std::optional<std::vector<MissionRaw::MissionItem>>
-MissionImport::import_mission(const Json::Value& root)
+MissionImport::import_mission(const Json::Value& root, Sender::Autopilot autopilot)
 {
     // We need a mission part.
     const auto mission = root["mission"];
@@ -116,6 +116,34 @@ MissionImport::import_mission(const Json::Value& root)
     unsigned sequence = 0;
     for (auto& mission_item : mission_items) {
         mission_item.seq = sequence++;
+    }
+
+    // Add home position at 0 for ArduPilot
+    if (autopilot == Sender::Autopilot::ArduPilot) {
+        const auto home = mission["plannedHomePosition"];
+        if (!home.empty()) {
+            if (home.isArray() && home.size() != 3) {
+                LogErr() << "Unknown plannedHomePosition format";
+                return std::nullopt;
+            }
+
+            mission_items.insert(
+                mission_items.begin(),
+                MissionRaw::MissionItem{
+                    0,
+                    MAV_FRAME_GLOBAL_INT,
+                    MAV_CMD_NAV_WAYPOINT,
+                    0, // current
+                    1, // autocontinue
+                    0.0f,
+                    0.0f,
+                    0.0f,
+                    0.0f,
+                    static_cast<int32_t>(std::round(home[0].asDouble() * 1e7)),
+                    static_cast<int32_t>(std::round(home[1].asDouble() * 1e7)),
+                    home[2].asFloat(),
+                    MAV_MISSION_TYPE_MISSION});
+        }
     }
 
     // Returning an empty vector is ok here if there were really no mission items.

--- a/src/mavsdk/plugins/mission_raw/mission_import.h
+++ b/src/mavsdk/plugins/mission_raw/mission_import.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "plugins/mission_raw/mission_raw.h"
+#include "sender.h"
 #include <optional>
 #include <string>
 #include <utility>
@@ -11,16 +12,16 @@ namespace mavsdk {
 class MissionImport {
 public:
     static std::pair<MissionRaw::Result, MissionRaw::MissionImportData>
-    parse_json(const std::string& raw_json);
+    parse_json(const std::string& raw_json, Sender::Autopilot autopilot);
 
 private:
     static bool check_overall_version(const Json::Value& root);
     static std::optional<std::vector<MissionRaw::MissionItem>>
-    import_mission(const Json::Value& root);
-    static std::optional<std::vector<MissionRaw::MissionItem>>
     import_geofence(const Json::Value& root);
     static std::optional<std::vector<MissionRaw::MissionItem>>
     import_rally_points(const Json::Value& root);
+    static std::optional<std::vector<MissionRaw::MissionItem>>
+    import_mission(const Json::Value& root, Sender::Autopilot autopilot);
     static std::optional<MissionRaw::MissionItem>
     import_simple_mission_item(const Json::Value& json_item);
     static std::optional<std::vector<MissionRaw::MissionItem>>

--- a/src/mavsdk/plugins/mission_raw/mission_raw_impl.cpp
+++ b/src/mavsdk/plugins/mission_raw/mission_raw_impl.cpp
@@ -540,7 +540,7 @@ MissionRawImpl::import_qgroundcontrol_mission(std::string qgc_plan_path)
     buf << file.rdbuf();
     file.close();
 
-    return MissionImport::parse_json(buf.str());
+    return MissionImport::parse_json(buf.str(), _parent->autopilot());
 }
 
 MissionRaw::Result MissionRawImpl::convert_result(MavlinkMissionTransfer::Result result)


### PR DESCRIPTION
ArduPilot stores the home position in mission item 0. This means that we need to add the home position as saved in the .plan file to the mission raw list of mission items.