### PR TITLE
Fix ci workers to macos-12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -458,7 +458,7 @@ jobs:
 
   macOS:
     name: ${{ matrix.name }}
-    runs-on: macos-latest
+    runs-on: macos-12
     strategy:
       matrix:
         include:
@@ -513,7 +513,7 @@ jobs:
 
   iOS:
     name: ${{ matrix.name }}
-    runs-on: macos-latest
+    runs-on: macos-12
     strategy:
       matrix:
         include:
@@ -555,7 +555,7 @@ jobs:
   iOS-XCFramework:
     name: iOS XCFramework
     needs: [macOS, iOS]
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Fix workers to use `macos-12`.

Note that `macos-12` still defaults to [xcode 13.4.1](https://github.com/actions/runner-images/blob/macOS-11/20220906.1/images/macos/macos-12-Readme.md#xcode). When that changes to xcode 14, we can probably remove the bitcode support.