### PR TITLE
[Backport v1.4] cmake: install mavlink headers in correct dir

### DIFF
--- a/src/mavsdk/core/CMakeLists.txt
+++ b/src/mavsdk/core/CMakeLists.txt
@@ -113,6 +113,11 @@ install(FILES
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/mavsdk"
 )
 
+install(DIRECTORY
+    ${MAVLINK_HEADERS}/mavlink
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mavsdk
+)
+
 list(APPEND UNIT_TEST_SOURCES
     ${PROJECT_SOURCE_DIR}/mavsdk/core/mavsdk_time_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/mavsdk_math_test.cpp

--- a/src/mavsdk/plugins/mavlink_passthrough/CMakeLists.txt
+++ b/src/mavsdk/plugins/mavlink_passthrough/CMakeLists.txt
@@ -15,8 +15,3 @@ install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/../../../mavsdk/core/mavlink_include.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mavsdk/plugins/mavlink_passthrough
 )
-
-install(DIRECTORY
-    ${MAVLINK_HEADERS}
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mavsdk/plugins/mavlink_passthrough
-)


### PR DESCRIPTION
Backport of #1819.