### PR TITLE
tools: Refactor changelog generation

### DIFF
--- a/tools/generate_debian_changelog.sh
+++ b/tools/generate_debian_changelog.sh
@@ -1,20 +1,71 @@
 #!/usr/bin/env bash
 
-# We want to extract "1.2.3" from "v1.2.3-5-g123abc".
-tag_version=`git describe --always --tags | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/'`
-
-# Default to 1 for package version
-if [ "$#" == 1 ]; then
-    package_version=$1
-else
-    package_version="1"
-fi
+set -e
 
 # Date according to RFC 5322
-date=`date -R`
+DATE=$(date -R)
+AUTHOR="MAVSDK Team"
+EMAIL=""
+PRE_RELEASE=1
 
-echo "mavsdk ($tag_version-$package_version) unstable; urgency=medium"
+# Fetch tags from upstream in case they're not synced
+git fetch --tags
+
+# Get the tag which points to the current commit hash; if the current commit is not tagged, the version core defaults to the current hash
+CURRENT_REF="$(git rev-parse --short HEAD)"
+CURRENT_TAG=$(git tag --points-at "$CURRENT_REF" | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')
+if [ ! -z "$CURRENT_TAG" ]; then
+    VERSION=$CURRENT_TAG
+else
+    # dpkg-buildpacakge expects the version to start with a digit, hence the 0
+    VERSION="0v$CURRENT_REF"
+fi
+
+function usage() {
+cat << EOF
+    Usage:
+    $0 <options ...>
+        --version <version core; default=0v[CURRENT_REF] or [CURRENT_TAG]>
+        --pre <pre-release number; default=1>
+        --author <author name; default=MAVSDK Team>
+        --email <author email; default=[empty]>
+    Examples:
+        ./generate_debian_changelog.sh
+            --version=1.0.0
+            --pre=1
+            --author="Example Name"
+            --email="mavsdk@example.com"
+EOF
+}
+
+function usage_and_exit() {
+    usage
+    exit $1
+}
+
+for i in "$@"
+do
+    case $i in
+        --version=*)
+        VERSION="${i#*=}"
+        ;;
+        --pre=*)
+        PRE_RELEASE="${i#*=}"
+        ;;
+        --author=*)
+        AUTHOR="${i#*=}"
+        ;;
+        --email=*)
+        EMAIL="${i#*=}"
+        ;;
+        *) # unknown option
+        usage_and_exit 1
+        ;;
+    esac
+done
+
+echo "mavsdk ($VERSION-$PRE_RELEASE) unstable; urgency=medium"
 echo ""
-echo "  * Initial release"
+echo "  * Auterion MAVSDK release"
 echo ""
-echo " -- Helge Bahmann <helge@auterion.com>  $date"
+echo " -- $AUTHOR <$EMAIL>  $DATE"


### PR DESCRIPTION
This PR reworks the `generate_debian_changelog.sh`. Namely it:

* Adds args for author and email, so we stop tagging every mavsdk dev with Helge's name; when not provided, by default the author is "MAVSDK Team"
* Replaces the previous git describe used for the default tag version with either the current commit hash (+ "0v" prepended) or the tag which points to the commit hash. This is to prevent `dpkg-buildpackage` errors, since in the cases where a commit is not tagged and its hash does not start with a digit, the deb build fails:
```
dpkg-buildpackage: error: version number does not start with digit
```
This meant you basically couldn't reliably issue a build on a non-tagged mavsdk commit.