### PR TITLE
[v1.4] cmake: copy correct mavlink directory

### DIFF
--- a/src/mavsdk/plugins/mavlink_passthrough/CMakeLists.txt
+++ b/src/mavsdk/plugins/mavlink_passthrough/CMakeLists.txt
@@ -17,6 +17,6 @@ install(FILES
 )
 
 install(DIRECTORY
-    ${MAVLINK_HEADERS}
+    ${MAVLINK_HEADERS}/mavlink
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mavsdk/plugins/mavlink_passthrough
 )


### PR DESCRIPTION
Hopefully, this time I get it right.