### PR TITLE
geofence: Add support for circular geofences

### DIFF
--- a/examples/geofence_inclusion/geofence_inclusion.cpp
+++ b/examples/geofence_inclusion/geofence_inclusion.cpp
@@ -102,15 +102,18 @@ int main(int argc, char** argv)
 
     std::vector<Geofence::Polygon> polygons;
     Geofence::Polygon new_polygon{};
-    new_polygon.fence_type = Geofence::Polygon::FenceType::Inclusion;
+    new_polygon.fence_type = Geofence::FenceType::Inclusion;
     new_polygon.points = points;
 
     polygons.push_back(new_polygon);
 
+    Geofence::GeofenceData geofence_data{};
+    geofence_data.polygons = polygons;
+
     {
         std::cout << "Uploading geofence...\n";
 
-        const Geofence::Result result = geofence.upload_geofence(polygons);
+        const Geofence::Result result = geofence.upload_geofence(geofence_data);
 
         if (result != Geofence::Result::Success) {
             std::cerr << "Geofence upload failed: " << result << ", exiting.\n";

--- a/src/integration_tests/geofence_inclusion.cpp
+++ b/src/integration_tests/geofence_inclusion.cpp
@@ -42,12 +42,15 @@ TEST_F(SitlTest, PX4GeofenceInclusion)
 
     std::vector<Geofence::Polygon> polygons;
     Geofence::Polygon new_polygon{};
-    new_polygon.fence_type = Geofence::Polygon::FenceType::Inclusion;
+    new_polygon.fence_type = Geofence::FenceType::Inclusion;
     new_polygon.points = points;
 
     polygons.push_back(new_polygon);
 
-    EXPECT_EQ(Geofence::Result::Success, geofence->upload_geofence(polygons));
+    Geofence::GeofenceData geofence_data{};
+    geofence_data.polygons = polygons;
+
+    EXPECT_EQ(Geofence::Result::Success, geofence->upload_geofence(geofence_data));
 
     EXPECT_EQ(Geofence::Result::Success, geofence->clear_geofence());
 }

--- a/src/mavsdk/plugins/geofence/geofence.cpp
+++ b/src/mavsdk/plugins/geofence/geofence.cpp
@@ -11,6 +11,8 @@ namespace mavsdk {
 
 using Point = Geofence::Point;
 using Polygon = Geofence::Polygon;
+using Circle = Geofence::Circle;
+using GeofenceData = Geofence::GeofenceData;
 
 Geofence::Geofence(System& system) : PluginBase(), _impl{std::make_unique<GeofenceImpl>(system)} {}
 
@@ -21,14 +23,14 @@ Geofence::Geofence(std::shared_ptr<System> system) :
 
 Geofence::~Geofence() {}
 
-void Geofence::upload_geofence_async(std::vector<Polygon> polygons, const ResultCallback callback)
+void Geofence::upload_geofence_async(GeofenceData geofence_data, const ResultCallback callback)
 {
-    _impl->upload_geofence_async(polygons, callback);
+    _impl->upload_geofence_async(geofence_data, callback);
 }
 
-Geofence::Result Geofence::upload_geofence(std::vector<Polygon> polygons) const
+Geofence::Result Geofence::upload_geofence(GeofenceData geofence_data) const
 {
-    return _impl->upload_geofence(polygons);
+    return _impl->upload_geofence(geofence_data);
 }
 
 void Geofence::clear_geofence_async(const ResultCallback callback)
@@ -59,17 +61,6 @@ std::ostream& operator<<(std::ostream& str, Geofence::Point const& point)
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, Geofence::Polygon::FenceType const& fence_type)
-{
-    switch (fence_type) {
-        case Geofence::Polygon::FenceType::Inclusion:
-            return str << "Inclusion";
-        case Geofence::Polygon::FenceType::Exclusion:
-            return str << "Exclusion";
-        default:
-            return str << "Unknown";
-    }
-}
 bool operator==(const Geofence::Polygon& lhs, const Geofence::Polygon& rhs)
 {
     return (rhs.points == lhs.points) && (rhs.fence_type == lhs.fence_type);
@@ -85,6 +76,47 @@ std::ostream& operator<<(std::ostream& str, Geofence::Polygon const& polygon)
         str << (it + 1 != polygon.points.end() ? ", " : "]\n");
     }
     str << "    fence_type: " << polygon.fence_type << '\n';
+    str << '}';
+    return str;
+}
+
+bool operator==(const Geofence::Circle& lhs, const Geofence::Circle& rhs)
+{
+    return (rhs.point == lhs.point) &&
+           ((std::isnan(rhs.radius) && std::isnan(lhs.radius)) || rhs.radius == lhs.radius) &&
+           (rhs.fence_type == lhs.fence_type);
+}
+
+std::ostream& operator<<(std::ostream& str, Geofence::Circle const& circle)
+{
+    str << std::setprecision(15);
+    str << "circle:" << '\n' << "{\n";
+    str << "    point: " << circle.point << '\n';
+    str << "    radius: " << circle.radius << '\n';
+    str << "    fence_type: " << circle.fence_type << '\n';
+    str << '}';
+    return str;
+}
+
+bool operator==(const Geofence::GeofenceData& lhs, const Geofence::GeofenceData& rhs)
+{
+    return (rhs.polygons == lhs.polygons) && (rhs.circles == lhs.circles);
+}
+
+std::ostream& operator<<(std::ostream& str, Geofence::GeofenceData const& geofence_data)
+{
+    str << std::setprecision(15);
+    str << "geofence_data:" << '\n' << "{\n";
+    str << "    polygons: [";
+    for (auto it = geofence_data.polygons.begin(); it != geofence_data.polygons.end(); ++it) {
+        str << *it;
+        str << (it + 1 != geofence_data.polygons.end() ? ", " : "]\n");
+    }
+    str << "    circles: [";
+    for (auto it = geofence_data.circles.begin(); it != geofence_data.circles.end(); ++it) {
+        str << *it;
+        str << (it + 1 != geofence_data.circles.end() ? ", " : "]\n");
+    }
     str << '}';
     return str;
 }
@@ -108,6 +140,18 @@ std::ostream& operator<<(std::ostream& str, Geofence::Result const& result)
             return str << "Invalid Argument";
         case Geofence::Result::NoSystem:
             return str << "No System";
+        default:
+            return str << "Unknown";
+    }
+}
+
+std::ostream& operator<<(std::ostream& str, Geofence::FenceType const& fence_type)
+{
+    switch (fence_type) {
+        case Geofence::FenceType::Inclusion:
+            return str << "Inclusion";
+        case Geofence::FenceType::Exclusion:
+            return str << "Exclusion";
         default:
             return str << "Unknown";
     }

--- a/src/mavsdk/plugins/geofence/geofence_impl.cpp
+++ b/src/mavsdk/plugins/geofence/geofence_impl.cpp
@@ -27,21 +27,22 @@ void GeofenceImpl::enable() {}
 
 void GeofenceImpl::disable() {}
 
-Geofence::Result GeofenceImpl::upload_geofence(const std::vector<Geofence::Polygon>& polygons)
+Geofence::Result GeofenceImpl::upload_geofence(const Geofence::GeofenceData& geofence_data)
 {
     auto prom = std::promise<Geofence::Result>();
     auto fut = prom.get_future();
 
-    upload_geofence_async(polygons, [&prom](Geofence::Result result) { prom.set_value(result); });
+    upload_geofence_async(
+        geofence_data, [&prom](Geofence::Result result) { prom.set_value(result); });
     return fut.get();
 }
 
 void GeofenceImpl::upload_geofence_async(
-    const std::vector<Geofence::Polygon>& polygons, const Geofence::ResultCallback& callback)
+    const Geofence::GeofenceData& geofence_data, const Geofence::ResultCallback& callback)
 {
     // We can just create these items on the stack because they get copied
     // later in the MavlinkMissionTransfer constructor.
-    const auto items = assemble_items(polygons);
+    const auto items = assemble_items(geofence_data);
 
     _parent->mission_transfer().upload_items_async(
         MAV_MISSION_TYPE_FENCE, items, [this, callback](MavlinkMissionTransfer::Result result) {
@@ -74,27 +75,18 @@ void GeofenceImpl::clear_geofence_async(const Geofence::ResultCallback& callback
 }
 
 std::vector<MavlinkMissionTransfer::ItemInt>
-GeofenceImpl::assemble_items(const std::vector<Geofence::Polygon>& polygons)
+GeofenceImpl::assemble_items(const Geofence::GeofenceData& geofence_data)
 {
     std::vector<MavlinkMissionTransfer::ItemInt> items;
 
     uint16_t sequence = 0;
-    for (auto& polygon : polygons) {
-        uint16_t command;
-        switch (polygon.fence_type) {
-            case Geofence::Polygon::FenceType::Inclusion:
-                command = MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION;
-                break;
-            case Geofence::Polygon::FenceType::Exclusion:
-                command = MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION;
-                break;
-            default:
-                LogErr() << "Unknown type";
-                continue;
-        }
+
+    for (auto& polygon : geofence_data.polygons) {
+        const uint16_t command = polygon.fence_type == Geofence::FenceType::Inclusion ?
+                                     MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION :
+                                     MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION;
 
         for (auto& point : polygon.points) {
-            // FIXME: check if these two  make sense.
             const uint8_t current = (sequence == 0 ? 1 : 0);
             const uint8_t autocontinue = 0;
             const float param1 = float(polygon.points.size());
@@ -116,6 +108,31 @@ GeofenceImpl::assemble_items(const std::vector<Geofence::Polygon>& polygons)
             ++sequence;
         }
     }
+
+    for (auto& circle : geofence_data.circles) {
+        const uint8_t current = (sequence == 0 ? 1 : 0);
+        const uint8_t autocontinue = 0;
+        const uint8_t command = circle.fence_type == Geofence::FenceType::Inclusion ?
+                                    MAV_CMD_NAV_FENCE_CIRCLE_INCLUSION :
+                                    MAV_CMD_NAV_FENCE_CIRCLE_EXCLUSION;
+
+        items.push_back(MavlinkMissionTransfer::ItemInt{
+            sequence,
+            MAV_FRAME_GLOBAL_INT,
+            command,
+            current,
+            autocontinue,
+            circle.radius,
+            0.0f,
+            0.0f,
+            0.0f,
+            int32_t(std::round(circle.point.latitude_deg * 1e7)),
+            int32_t(std::round(circle.point.longitude_deg * 1e7)),
+            0.0f,
+            MAV_MISSION_TYPE_FENCE});
+        ++sequence;
+    }
+
     return items;
 }
 

--- a/src/mavsdk/plugins/geofence/geofence_impl.cpp
+++ b/src/mavsdk/plugins/geofence/geofence_impl.cpp
@@ -82,9 +82,10 @@ GeofenceImpl::assemble_items(const Geofence::GeofenceData& geofence_data)
     uint16_t sequence = 0;
 
     for (auto& polygon : geofence_data.polygons) {
-        const uint16_t command = polygon.fence_type == Geofence::FenceType::Inclusion ?
-                                     MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION :
-                                     MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION;
+        const uint16_t command =
+            (polygon.fence_type == Geofence::FenceType::Inclusion ?
+                 MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION :
+                 MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION);
 
         for (auto& point : polygon.points) {
             const uint8_t current = (sequence == 0 ? 1 : 0);
@@ -112,9 +113,10 @@ GeofenceImpl::assemble_items(const Geofence::GeofenceData& geofence_data)
     for (auto& circle : geofence_data.circles) {
         const uint8_t current = (sequence == 0 ? 1 : 0);
         const uint8_t autocontinue = 0;
-        const uint8_t command = circle.fence_type == Geofence::FenceType::Inclusion ?
-                                    MAV_CMD_NAV_FENCE_CIRCLE_INCLUSION :
-                                    MAV_CMD_NAV_FENCE_CIRCLE_EXCLUSION;
+        const uint16_t command =
+            (circle.fence_type == Geofence::FenceType::Inclusion ?
+                 MAV_CMD_NAV_FENCE_CIRCLE_INCLUSION :
+                 MAV_CMD_NAV_FENCE_CIRCLE_EXCLUSION);
 
         items.push_back(MavlinkMissionTransfer::ItemInt{
             sequence,

--- a/src/mavsdk/plugins/geofence/geofence_impl.h
+++ b/src/mavsdk/plugins/geofence/geofence_impl.h
@@ -23,10 +23,10 @@ public:
     void enable() override;
     void disable() override;
 
-    Geofence::Result upload_geofence(const std::vector<Geofence::Polygon>& polygons);
+    Geofence::Result upload_geofence(const Geofence::GeofenceData& geofence_data);
 
     void upload_geofence_async(
-        const std::vector<Geofence::Polygon>& polygons, const Geofence::ResultCallback& callback);
+        const Geofence::GeofenceData& geofence_data, const Geofence::ResultCallback& callback);
 
     Geofence::Result clear_geofence();
 
@@ -38,7 +38,7 @@ public:
 
 private:
     std::vector<MavlinkMissionTransfer::ItemInt>
-    assemble_items(const std::vector<Geofence::Polygon>& polygons);
+    assemble_items(const Geofence::GeofenceData& geofence_data);
 
     static Geofence::Result convert_result(MavlinkMissionTransfer::Result result);
 };

--- a/src/mavsdk/plugins/geofence/include/plugins/geofence/geofence.h
+++ b/src/mavsdk/plugins/geofence/include/plugins/geofence/geofence.h
@@ -59,6 +59,21 @@ public:
     ~Geofence() override;
 
     /**
+     * @brief Geofence types.
+     */
+    enum class FenceType {
+        Inclusion, /**< @brief Type representing an inclusion fence. */
+        Exclusion, /**< @brief Type representing an exclusion fence. */
+    };
+
+    /**
+     * @brief Stream operator to print information about a `Geofence::FenceType`.
+     *
+     * @return A reference to the stream.
+     */
+    friend std::ostream& operator<<(std::ostream& str, Geofence::FenceType const& fence_type);
+
+    /**
      * @brief Point type.
      */
     struct Point {
@@ -84,22 +99,6 @@ public:
      * @brief Polygon type.
      */
     struct Polygon {
-        /**
-         * @brief Geofence polygon types.
-         */
-        enum class FenceType {
-            Inclusion, /**< @brief Type representing an inclusion fence. */
-            Exclusion, /**< @brief Type representing an exclusion fence. */
-        };
-
-        /**
-         * @brief Stream operator to print information about a `Geofence::FenceType`.
-         *
-         * @return A reference to the stream.
-         */
-        friend std::ostream&
-        operator<<(std::ostream& str, Geofence::Polygon::FenceType const& fence_type);
-
         std::vector<Point> points{}; /**< @brief Points defining the polygon */
         FenceType fence_type{}; /**< @brief Fence type */
     };
@@ -119,13 +118,58 @@ public:
     friend std::ostream& operator<<(std::ostream& str, Geofence::Polygon const& polygon);
 
     /**
+     * @brief Circular type.
+     */
+    struct Circle {
+        Point point{}; /**< @brief Point defining the center */
+        float radius{float(NAN)}; /**< @brief Radius of the circular fence */
+        FenceType fence_type{}; /**< @brief Fence type */
+    };
+
+    /**
+     * @brief Equal operator to compare two `Geofence::Circle` objects.
+     *
+     * @return `true` if items are equal.
+     */
+    friend bool operator==(const Geofence::Circle& lhs, const Geofence::Circle& rhs);
+
+    /**
+     * @brief Stream operator to print information about a `Geofence::Circle`.
+     *
+     * @return A reference to the stream.
+     */
+    friend std::ostream& operator<<(std::ostream& str, Geofence::Circle const& circle);
+
+    /**
+     * @brief Geofence data type.
+     */
+    struct GeofenceData {
+        std::vector<Polygon> polygons{}; /**< @brief Polygon(s) representing the geofence(s) */
+        std::vector<Circle> circles{}; /**< @brief Circle(s) representing the geofence(s) */
+    };
+
+    /**
+     * @brief Equal operator to compare two `Geofence::GeofenceData` objects.
+     *
+     * @return `true` if items are equal.
+     */
+    friend bool operator==(const Geofence::GeofenceData& lhs, const Geofence::GeofenceData& rhs);
+
+    /**
+     * @brief Stream operator to print information about a `Geofence::GeofenceData`.
+     *
+     * @return A reference to the stream.
+     */
+    friend std::ostream& operator<<(std::ostream& str, Geofence::GeofenceData const& geofence_data);
+
+    /**
      * @brief Possible results returned for geofence requests.
      */
     enum class Result {
         Unknown, /**< @brief Unknown result. */
         Success, /**< @brief Request succeeded. */
         Error, /**< @brief Error. */
-        TooManyGeofenceItems, /**< @brief Too many Polygon objects in the geofence. */
+        TooManyGeofenceItems, /**< @brief Too many objects in the geofence. */
         Busy, /**< @brief Vehicle is busy. */
         Timeout, /**< @brief Request timed out. */
         InvalidArgument, /**< @brief Invalid argument. */
@@ -145,26 +189,26 @@ public:
     using ResultCallback = std::function<void(Result)>;
 
     /**
-     * @brief Upload a geofence.
+     * @brief Upload geofences.
      *
-     * Polygons are uploaded to a drone. Once uploaded, the geofence will remain
-     * on the drone even if a connection is lost.
+     * Polygon and Circular geofences are uploaded to a drone. Once uploaded, the geofence will
+     * remain on the drone even if a connection is lost.
      *
      * This function is non-blocking. See 'upload_geofence' for the blocking counterpart.
      */
-    void upload_geofence_async(std::vector<Polygon> polygons, const ResultCallback callback);
+    void upload_geofence_async(GeofenceData geofence_data, const ResultCallback callback);
 
     /**
-     * @brief Upload a geofence.
+     * @brief Upload geofences.
      *
-     * Polygons are uploaded to a drone. Once uploaded, the geofence will remain
-     * on the drone even if a connection is lost.
+     * Polygon and Circular geofences are uploaded to a drone. Once uploaded, the geofence will
+     * remain on the drone even if a connection is lost.
      *
      * This function is blocking. See 'upload_geofence_async' for the non-blocking counterpart.
      *
      * @return Result of request.
      */
-    Result upload_geofence(std::vector<Polygon> polygons) const;
+    Result upload_geofence(GeofenceData geofence_data) const;
 
     /**
      * @brief Clear all geofences saved on the vehicle.

--- a/src/mavsdk_server/src/generated/geofence/geofence.grpc.pb.h
+++ b/src/mavsdk_server/src/generated/geofence/geofence.grpc.pb.h
@@ -39,9 +39,9 @@ class GeofenceService final {
    public:
     virtual ~StubInterface() {}
     //
-    // Upload a geofence.
+    // Upload geofences.
     //
-    // Polygons are uploaded to a drone. Once uploaded, the geofence will remain
+    // Polygon and Circular geofences are uploaded to a drone. Once uploaded, the geofence will remain
     // on the drone even if a connection is lost.
     virtual ::grpc::Status UploadGeofence(::grpc::ClientContext* context, const ::mavsdk::rpc::geofence::UploadGeofenceRequest& request, ::mavsdk::rpc::geofence::UploadGeofenceResponse* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::geofence::UploadGeofenceResponse>> AsyncUploadGeofence(::grpc::ClientContext* context, const ::mavsdk::rpc::geofence::UploadGeofenceRequest& request, ::grpc::CompletionQueue* cq) {
@@ -63,9 +63,9 @@ class GeofenceService final {
      public:
       virtual ~async_interface() {}
       //
-      // Upload a geofence.
+      // Upload geofences.
       //
-      // Polygons are uploaded to a drone. Once uploaded, the geofence will remain
+      // Polygon and Circular geofences are uploaded to a drone. Once uploaded, the geofence will remain
       // on the drone even if a connection is lost.
       virtual void UploadGeofence(::grpc::ClientContext* context, const ::mavsdk::rpc::geofence::UploadGeofenceRequest* request, ::mavsdk::rpc::geofence::UploadGeofenceResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void UploadGeofence(::grpc::ClientContext* context, const ::mavsdk::rpc::geofence::UploadGeofenceRequest* request, ::mavsdk::rpc::geofence::UploadGeofenceResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
@@ -132,9 +132,9 @@ class GeofenceService final {
     Service();
     virtual ~Service();
     //
-    // Upload a geofence.
+    // Upload geofences.
     //
-    // Polygons are uploaded to a drone. Once uploaded, the geofence will remain
+    // Polygon and Circular geofences are uploaded to a drone. Once uploaded, the geofence will remain
     // on the drone even if a connection is lost.
     virtual ::grpc::Status UploadGeofence(::grpc::ServerContext* context, const ::mavsdk::rpc::geofence::UploadGeofenceRequest* request, ::mavsdk::rpc::geofence::UploadGeofenceResponse* response);
     //

--- a/src/mavsdk_server/src/generated/geofence/geofence.pb.cc
+++ b/src/mavsdk_server/src/generated/geofence/geofence.pb.cc
@@ -50,9 +50,37 @@ struct PolygonDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 PolygonDefaultTypeInternal _Polygon_default_instance_;
+PROTOBUF_CONSTEXPR Circle::Circle(
+    ::_pbi::ConstantInitialized)
+  : point_(nullptr)
+  , radius_(0)
+  , fence_type_(0)
+{}
+struct CircleDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR CircleDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~CircleDefaultTypeInternal() {}
+  union {
+    Circle _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 CircleDefaultTypeInternal _Circle_default_instance_;
+PROTOBUF_CONSTEXPR GeofenceData::GeofenceData(
+    ::_pbi::ConstantInitialized)
+  : polygons_()
+  , circles_(){}
+struct GeofenceDataDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR GeofenceDataDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~GeofenceDataDefaultTypeInternal() {}
+  union {
+    GeofenceData _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 GeofenceDataDefaultTypeInternal _GeofenceData_default_instance_;
 PROTOBUF_CONSTEXPR UploadGeofenceRequest::UploadGeofenceRequest(
     ::_pbi::ConstantInitialized)
-  : polygons_(){}
+  : geofence_data_(nullptr){}
 struct UploadGeofenceRequestDefaultTypeInternal {
   PROTOBUF_CONSTEXPR UploadGeofenceRequestDefaultTypeInternal()
       : _instance(::_pbi::ConstantInitialized{}) {}
@@ -114,7 +142,7 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORIT
 }  // namespace geofence
 }  // namespace rpc
 }  // namespace mavsdk
-static ::_pb::Metadata file_level_metadata_geofence_2fgeofence_2eproto[7];
+static ::_pb::Metadata file_level_metadata_geofence_2fgeofence_2eproto[9];
 static const ::_pb::EnumDescriptor* file_level_enum_descriptors_geofence_2fgeofence_2eproto[2];
 static constexpr ::_pb::ServiceDescriptor const** file_level_service_descriptors_geofence_2fgeofence_2eproto = nullptr;
 
@@ -136,12 +164,29 @@ const uint32_t TableStruct_geofence_2fgeofence_2eproto::offsets[] PROTOBUF_SECTI
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::geofence::Polygon, points_),
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::geofence::Polygon, fence_type_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::geofence::Circle, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::geofence::Circle, point_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::geofence::Circle, radius_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::geofence::Circle, fence_type_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::geofence::GeofenceData, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::geofence::GeofenceData, polygons_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::geofence::GeofenceData, circles_),
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::geofence::UploadGeofenceRequest, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   ~0u,  // no _inlined_string_donated_
-  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::geofence::UploadGeofenceRequest, polygons_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::geofence::UploadGeofenceRequest, geofence_data_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::geofence::UploadGeofenceResponse, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -174,16 +219,20 @@ const uint32_t TableStruct_geofence_2fgeofence_2eproto::offsets[] PROTOBUF_SECTI
 static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, -1, sizeof(::mavsdk::rpc::geofence::Point)},
   { 8, -1, -1, sizeof(::mavsdk::rpc::geofence::Polygon)},
-  { 16, -1, -1, sizeof(::mavsdk::rpc::geofence::UploadGeofenceRequest)},
-  { 23, -1, -1, sizeof(::mavsdk::rpc::geofence::UploadGeofenceResponse)},
-  { 30, -1, -1, sizeof(::mavsdk::rpc::geofence::ClearGeofenceRequest)},
-  { 36, -1, -1, sizeof(::mavsdk::rpc::geofence::ClearGeofenceResponse)},
-  { 43, -1, -1, sizeof(::mavsdk::rpc::geofence::GeofenceResult)},
+  { 16, -1, -1, sizeof(::mavsdk::rpc::geofence::Circle)},
+  { 25, -1, -1, sizeof(::mavsdk::rpc::geofence::GeofenceData)},
+  { 33, -1, -1, sizeof(::mavsdk::rpc::geofence::UploadGeofenceRequest)},
+  { 40, -1, -1, sizeof(::mavsdk::rpc::geofence::UploadGeofenceResponse)},
+  { 47, -1, -1, sizeof(::mavsdk::rpc::geofence::ClearGeofenceRequest)},
+  { 53, -1, -1, sizeof(::mavsdk::rpc::geofence::ClearGeofenceResponse)},
+  { 60, -1, -1, sizeof(::mavsdk::rpc::geofence::GeofenceResult)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
   &::mavsdk::rpc::geofence::_Point_default_instance_._instance,
   &::mavsdk::rpc::geofence::_Polygon_default_instance_._instance,
+  &::mavsdk::rpc::geofence::_Circle_default_instance_._instance,
+  &::mavsdk::rpc::geofence::_GeofenceData_default_instance_._instance,
   &::mavsdk::rpc::geofence::_UploadGeofenceRequest_default_instance_._instance,
   &::mavsdk::rpc::geofence::_UploadGeofenceResponse_default_instance_._instance,
   &::mavsdk::rpc::geofence::_ClearGeofenceRequest_default_instance_._instance,
@@ -193,40 +242,49 @@ static const ::_pb::Message* const file_default_instances[] = {
 
 const char descriptor_table_protodef_geofence_2fgeofence_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) =
   "\n\027geofence/geofence.proto\022\023mavsdk.rpc.ge"
-  "ofence\"4\n\005Point\022\024\n\014latitude_deg\030\001 \001(\001\022\025\n"
-  "\rlongitude_deg\030\002 \001(\001\"\262\001\n\007Polygon\022*\n\006poin"
-  "ts\030\001 \003(\0132\032.mavsdk.rpc.geofence.Point\022:\n\n"
-  "fence_type\030\002 \001(\0162&.mavsdk.rpc.geofence.P"
-  "olygon.FenceType\"\?\n\tFenceType\022\030\n\024FENCE_T"
-  "YPE_INCLUSION\020\000\022\030\n\024FENCE_TYPE_EXCLUSION\020"
-  "\001\"G\n\025UploadGeofenceRequest\022.\n\010polygons\030\001"
-  " \003(\0132\034.mavsdk.rpc.geofence.Polygon\"V\n\026Up"
-  "loadGeofenceResponse\022<\n\017geofence_result\030"
-  "\001 \001(\0132#.mavsdk.rpc.geofence.GeofenceResu"
-  "lt\"\026\n\024ClearGeofenceRequest\"U\n\025ClearGeofe"
-  "nceResponse\022<\n\017geofence_result\030\001 \001(\0132#.m"
-  "avsdk.rpc.geofence.GeofenceResult\"\241\002\n\016Ge"
-  "ofenceResult\022:\n\006result\030\001 \001(\0162*.mavsdk.rp"
-  "c.geofence.GeofenceResult.Result\022\022\n\nresu"
-  "lt_str\030\002 \001(\t\"\276\001\n\006Result\022\022\n\016RESULT_UNKNOW"
-  "N\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\020\n\014RESULT_ERROR\020"
-  "\002\022\"\n\036RESULT_TOO_MANY_GEOFENCE_ITEMS\020\003\022\017\n"
-  "\013RESULT_BUSY\020\004\022\022\n\016RESULT_TIMEOUT\020\005\022\033\n\027RE"
-  "SULT_INVALID_ARGUMENT\020\006\022\024\n\020RESULT_NO_SYS"
-  "TEM\020\0072\350\001\n\017GeofenceService\022k\n\016UploadGeofe"
-  "nce\022*.mavsdk.rpc.geofence.UploadGeofence"
-  "Request\032+.mavsdk.rpc.geofence.UploadGeof"
-  "enceResponse\"\000\022h\n\rClearGeofence\022).mavsdk"
-  ".rpc.geofence.ClearGeofenceRequest\032*.mav"
-  "sdk.rpc.geofence.ClearGeofenceResponse\"\000"
-  "B#\n\022io.mavsdk.geofenceB\rGeofenceProtob\006p"
-  "roto3"
+  "ofence\032\024mavsdk_options.proto\"4\n\005Point\022\024\n"
+  "\014latitude_deg\030\001 \001(\001\022\025\n\rlongitude_deg\030\002 \001"
+  "(\001\"i\n\007Polygon\022*\n\006points\030\001 \003(\0132\032.mavsdk.r"
+  "pc.geofence.Point\0222\n\nfence_type\030\002 \001(\0162\036."
+  "mavsdk.rpc.geofence.FenceType\"\200\001\n\006Circle"
+  "\022)\n\005point\030\001 \001(\0132\032.mavsdk.rpc.geofence.Po"
+  "int\022\027\n\006radius\030\002 \001(\002B\007\202\265\030\003NaN\0222\n\nfence_ty"
+  "pe\030\003 \001(\0162\036.mavsdk.rpc.geofence.FenceType"
+  "\"l\n\014GeofenceData\022.\n\010polygons\030\001 \003(\0132\034.mav"
+  "sdk.rpc.geofence.Polygon\022,\n\007circles\030\002 \003("
+  "\0132\033.mavsdk.rpc.geofence.Circle\"Q\n\025Upload"
+  "GeofenceRequest\0228\n\rgeofence_data\030\001 \001(\0132!"
+  ".mavsdk.rpc.geofence.GeofenceData\"V\n\026Upl"
+  "oadGeofenceResponse\022<\n\017geofence_result\030\001"
+  " \001(\0132#.mavsdk.rpc.geofence.GeofenceResul"
+  "t\"\026\n\024ClearGeofenceRequest\"U\n\025ClearGeofen"
+  "ceResponse\022<\n\017geofence_result\030\001 \001(\0132#.ma"
+  "vsdk.rpc.geofence.GeofenceResult\"\241\002\n\016Geo"
+  "fenceResult\022:\n\006result\030\001 \001(\0162*.mavsdk.rpc"
+  ".geofence.GeofenceResult.Result\022\022\n\nresul"
+  "t_str\030\002 \001(\t\"\276\001\n\006Result\022\022\n\016RESULT_UNKNOWN"
+  "\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\020\n\014RESULT_ERROR\020\002"
+  "\022\"\n\036RESULT_TOO_MANY_GEOFENCE_ITEMS\020\003\022\017\n\013"
+  "RESULT_BUSY\020\004\022\022\n\016RESULT_TIMEOUT\020\005\022\033\n\027RES"
+  "ULT_INVALID_ARGUMENT\020\006\022\024\n\020RESULT_NO_SYST"
+  "EM\020\007*\?\n\tFenceType\022\030\n\024FENCE_TYPE_INCLUSIO"
+  "N\020\000\022\030\n\024FENCE_TYPE_EXCLUSION\020\0012\350\001\n\017Geofen"
+  "ceService\022k\n\016UploadGeofence\022*.mavsdk.rpc"
+  ".geofence.UploadGeofenceRequest\032+.mavsdk"
+  ".rpc.geofence.UploadGeofenceResponse\"\000\022h"
+  "\n\rClearGeofence\022).mavsdk.rpc.geofence.Cl"
+  "earGeofenceRequest\032*.mavsdk.rpc.geofence"
+  ".ClearGeofenceResponse\"\000B#\n\022io.mavsdk.ge"
+  "ofenceB\rGeofenceProtob\006proto3"
   ;
+static const ::_pbi::DescriptorTable* const descriptor_table_geofence_2fgeofence_2eproto_deps[1] = {
+  &::descriptor_table_mavsdk_5foptions_2eproto,
+};
 static ::_pbi::once_flag descriptor_table_geofence_2fgeofence_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_geofence_2fgeofence_2eproto = {
-    false, false, 1125, descriptor_table_protodef_geofence_2fgeofence_2eproto,
+    false, false, 1389, descriptor_table_protodef_geofence_2fgeofence_2eproto,
     "geofence/geofence.proto",
-    &descriptor_table_geofence_2fgeofence_2eproto_once, nullptr, 0, 7,
+    &descriptor_table_geofence_2fgeofence_2eproto_once, descriptor_table_geofence_2fgeofence_2eproto_deps, 1, 9,
     schemas, file_default_instances, TableStruct_geofence_2fgeofence_2eproto::offsets,
     file_level_metadata_geofence_2fgeofence_2eproto, file_level_enum_descriptors_geofence_2fgeofence_2eproto,
     file_level_service_descriptors_geofence_2fgeofence_2eproto,
@@ -240,30 +298,9 @@ PROTOBUF_ATTRIBUTE_INIT_PRIORITY2 static ::_pbi::AddDescriptorsRunner dynamic_in
 namespace mavsdk {
 namespace rpc {
 namespace geofence {
-const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* Polygon_FenceType_descriptor() {
-  ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&descriptor_table_geofence_2fgeofence_2eproto);
-  return file_level_enum_descriptors_geofence_2fgeofence_2eproto[0];
-}
-bool Polygon_FenceType_IsValid(int value) {
-  switch (value) {
-    case 0:
-    case 1:
-      return true;
-    default:
-      return false;
-  }
-}
-
-#if (__cplusplus < 201703) && (!defined(_MSC_VER) || (_MSC_VER >= 1900 && _MSC_VER < 1912))
-constexpr Polygon_FenceType Polygon::FENCE_TYPE_INCLUSION;
-constexpr Polygon_FenceType Polygon::FENCE_TYPE_EXCLUSION;
-constexpr Polygon_FenceType Polygon::FenceType_MIN;
-constexpr Polygon_FenceType Polygon::FenceType_MAX;
-constexpr int Polygon::FenceType_ARRAYSIZE;
-#endif  // (__cplusplus < 201703) && (!defined(_MSC_VER) || (_MSC_VER >= 1900 && _MSC_VER < 1912))
 const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* GeofenceResult_Result_descriptor() {
   ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&descriptor_table_geofence_2fgeofence_2eproto);
-  return file_level_enum_descriptors_geofence_2fgeofence_2eproto[1];
+  return file_level_enum_descriptors_geofence_2fgeofence_2eproto[0];
 }
 bool GeofenceResult_Result_IsValid(int value) {
   switch (value) {
@@ -294,6 +331,20 @@ constexpr GeofenceResult_Result GeofenceResult::Result_MIN;
 constexpr GeofenceResult_Result GeofenceResult::Result_MAX;
 constexpr int GeofenceResult::Result_ARRAYSIZE;
 #endif  // (__cplusplus < 201703) && (!defined(_MSC_VER) || (_MSC_VER >= 1900 && _MSC_VER < 1912))
+const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* FenceType_descriptor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&descriptor_table_geofence_2fgeofence_2eproto);
+  return file_level_enum_descriptors_geofence_2fgeofence_2eproto[1];
+}
+bool FenceType_IsValid(int value) {
+  switch (value) {
+    case 0:
+    case 1:
+      return true;
+    default:
+      return false;
+  }
+}
+
 
 // ===================================================================
 
@@ -596,12 +647,12 @@ const char* Polygon::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) 
         } else
           goto handle_unusual;
         continue;
-      // .mavsdk.rpc.geofence.Polygon.FenceType fence_type = 2;
+      // .mavsdk.rpc.geofence.FenceType fence_type = 2;
       case 2:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 16)) {
           uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
-          _internal_set_fence_type(static_cast<::mavsdk::rpc::geofence::Polygon_FenceType>(val));
+          _internal_set_fence_type(static_cast<::mavsdk::rpc::geofence::FenceType>(val));
         } else
           goto handle_unusual;
         continue;
@@ -642,7 +693,7 @@ uint8_t* Polygon::_InternalSerialize(
         InternalWriteMessage(1, repfield, repfield.GetCachedSize(), target, stream);
   }
 
-  // .mavsdk.rpc.geofence.Polygon.FenceType fence_type = 2;
+  // .mavsdk.rpc.geofence.FenceType fence_type = 2;
   if (this->_internal_fence_type() != 0) {
     target = stream->EnsureSpace(target);
     target = ::_pbi::WireFormatLite::WriteEnumToArray(
@@ -672,7 +723,7 @@ size_t Polygon::ByteSizeLong() const {
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
   }
 
-  // .mavsdk.rpc.geofence.Polygon.FenceType fence_type = 2;
+  // .mavsdk.rpc.geofence.FenceType fence_type = 2;
   if (this->_internal_fence_type() != 0) {
     total_size += 1 +
       ::_pbi::WireFormatLite::EnumSize(this->_internal_fence_type());
@@ -733,29 +784,44 @@ void Polygon::InternalSwap(Polygon* other) {
 
 // ===================================================================
 
-class UploadGeofenceRequest::_Internal {
+class Circle::_Internal {
  public:
+  static const ::mavsdk::rpc::geofence::Point& point(const Circle* msg);
 };
 
-UploadGeofenceRequest::UploadGeofenceRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+const ::mavsdk::rpc::geofence::Point&
+Circle::_Internal::point(const Circle* msg) {
+  return *msg->point_;
+}
+Circle::Circle(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
-  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned),
-  polygons_(arena) {
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
   SharedCtor();
-  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.geofence.UploadGeofenceRequest)
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.geofence.Circle)
 }
-UploadGeofenceRequest::UploadGeofenceRequest(const UploadGeofenceRequest& from)
-  : ::PROTOBUF_NAMESPACE_ID::Message(),
-      polygons_(from.polygons_) {
+Circle::Circle(const Circle& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
-  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.geofence.UploadGeofenceRequest)
+  if (from._internal_has_point()) {
+    point_ = new ::mavsdk::rpc::geofence::Point(*from.point_);
+  } else {
+    point_ = nullptr;
+  }
+  ::memcpy(&radius_, &from.radius_,
+    static_cast<size_t>(reinterpret_cast<char*>(&fence_type_) -
+    reinterpret_cast<char*>(&radius_)) + sizeof(fence_type_));
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.geofence.Circle)
 }
 
-inline void UploadGeofenceRequest::SharedCtor() {
+inline void Circle::SharedCtor() {
+::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
+    reinterpret_cast<char*>(&point_) - reinterpret_cast<char*>(this)),
+    0, static_cast<size_t>(reinterpret_cast<char*>(&fence_type_) -
+    reinterpret_cast<char*>(&point_)) + sizeof(fence_type_));
 }
 
-UploadGeofenceRequest::~UploadGeofenceRequest() {
-  // @@protoc_insertion_point(destructor:mavsdk.rpc.geofence.UploadGeofenceRequest)
+Circle::~Circle() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.geofence.Circle)
   if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
   (void)arena;
     return;
@@ -763,25 +829,273 @@ UploadGeofenceRequest::~UploadGeofenceRequest() {
   SharedDtor();
 }
 
-inline void UploadGeofenceRequest::SharedDtor() {
+inline void Circle::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  if (this != internal_default_instance()) delete point_;
 }
 
-void UploadGeofenceRequest::SetCachedSize(int size) const {
+void Circle::SetCachedSize(int size) const {
   _cached_size_.Set(size);
 }
 
-void UploadGeofenceRequest::Clear() {
-// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.geofence.UploadGeofenceRequest)
+void Circle::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.geofence.Circle)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArenaForAllocation() == nullptr && point_ != nullptr) {
+    delete point_;
+  }
+  point_ = nullptr;
+  ::memset(&radius_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&fence_type_) -
+      reinterpret_cast<char*>(&radius_)) + sizeof(fence_type_));
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* Circle::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // .mavsdk.rpc.geofence.Point point = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_point(), ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // float radius = 2 [(.mavsdk.options.default_value) = "NaN"];
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 21)) {
+          radius_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<float>(ptr);
+          ptr += sizeof(float);
+        } else
+          goto handle_unusual;
+        continue;
+      // .mavsdk.rpc.geofence.FenceType fence_type = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 24)) {
+          uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+          _internal_set_fence_type(static_cast<::mavsdk::rpc::geofence::FenceType>(val));
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* Circle::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.geofence.Circle)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.geofence.Point point = 1;
+  if (this->_internal_has_point()) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(1, _Internal::point(this),
+        _Internal::point(this).GetCachedSize(), target, stream);
+  }
+
+  // float radius = 2 [(.mavsdk.options.default_value) = "NaN"];
+  static_assert(sizeof(uint32_t) == sizeof(float), "Code assumes uint32_t and float are the same size.");
+  float tmp_radius = this->_internal_radius();
+  uint32_t raw_radius;
+  memcpy(&raw_radius, &tmp_radius, sizeof(tmp_radius));
+  if (raw_radius != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteFloatToArray(2, this->_internal_radius(), target);
+  }
+
+  // .mavsdk.rpc.geofence.FenceType fence_type = 3;
+  if (this->_internal_fence_type() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteEnumToArray(
+      3, this->_internal_fence_type(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.geofence.Circle)
+  return target;
+}
+
+size_t Circle::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.geofence.Circle)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.geofence.Point point = 1;
+  if (this->_internal_has_point()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *point_);
+  }
+
+  // float radius = 2 [(.mavsdk.options.default_value) = "NaN"];
+  static_assert(sizeof(uint32_t) == sizeof(float), "Code assumes uint32_t and float are the same size.");
+  float tmp_radius = this->_internal_radius();
+  uint32_t raw_radius;
+  memcpy(&raw_radius, &tmp_radius, sizeof(tmp_radius));
+  if (raw_radius != 0) {
+    total_size += 1 + 4;
+  }
+
+  // .mavsdk.rpc.geofence.FenceType fence_type = 3;
+  if (this->_internal_fence_type() != 0) {
+    total_size += 1 +
+      ::_pbi::WireFormatLite::EnumSize(this->_internal_fence_type());
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData Circle::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSizeCheck,
+    Circle::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*Circle::GetClassData() const { return &_class_data_; }
+
+void Circle::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message* to,
+                      const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+  static_cast<Circle *>(to)->MergeFrom(
+      static_cast<const Circle &>(from));
+}
+
+
+void Circle::MergeFrom(const Circle& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.geofence.Circle)
+  GOOGLE_DCHECK_NE(&from, this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_has_point()) {
+    _internal_mutable_point()->::mavsdk::rpc::geofence::Point::MergeFrom(from._internal_point());
+  }
+  static_assert(sizeof(uint32_t) == sizeof(float), "Code assumes uint32_t and float are the same size.");
+  float tmp_radius = from._internal_radius();
+  uint32_t raw_radius;
+  memcpy(&raw_radius, &tmp_radius, sizeof(tmp_radius));
+  if (raw_radius != 0) {
+    _internal_set_radius(from._internal_radius());
+  }
+  if (from._internal_fence_type() != 0) {
+    _internal_set_fence_type(from._internal_fence_type());
+  }
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void Circle::CopyFrom(const Circle& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.geofence.Circle)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool Circle::IsInitialized() const {
+  return true;
+}
+
+void Circle::InternalSwap(Circle* other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(Circle, fence_type_)
+      + sizeof(Circle::fence_type_)
+      - PROTOBUF_FIELD_OFFSET(Circle, point_)>(
+          reinterpret_cast<char*>(&point_),
+          reinterpret_cast<char*>(&other->point_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata Circle::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_geofence_2fgeofence_2eproto_getter, &descriptor_table_geofence_2fgeofence_2eproto_once,
+      file_level_metadata_geofence_2fgeofence_2eproto[2]);
+}
+
+// ===================================================================
+
+class GeofenceData::_Internal {
+ public:
+};
+
+GeofenceData::GeofenceData(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned),
+  polygons_(arena),
+  circles_(arena) {
+  SharedCtor();
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.geofence.GeofenceData)
+}
+GeofenceData::GeofenceData(const GeofenceData& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message(),
+      polygons_(from.polygons_),
+      circles_(from.circles_) {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.geofence.GeofenceData)
+}
+
+inline void GeofenceData::SharedCtor() {
+}
+
+GeofenceData::~GeofenceData() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.geofence.GeofenceData)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void GeofenceData::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+}
+
+void GeofenceData::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void GeofenceData::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.geofence.GeofenceData)
   uint32_t cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
   polygons_.Clear();
+  circles_.Clear();
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
-const char* UploadGeofenceRequest::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+const char* GeofenceData::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
 #define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
   while (!ctx->Done(&ptr)) {
     uint32_t tag;
@@ -797,6 +1111,222 @@ const char* UploadGeofenceRequest::_InternalParse(const char* ptr, ::_pbi::Parse
             CHK_(ptr);
             if (!ctx->DataAvailable(ptr)) break;
           } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<10>(ptr));
+        } else
+          goto handle_unusual;
+        continue;
+      // repeated .mavsdk.rpc.geofence.Circle circles = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(_internal_add_circles(), ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<18>(ptr));
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* GeofenceData::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.geofence.GeofenceData)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // repeated .mavsdk.rpc.geofence.Polygon polygons = 1;
+  for (unsigned i = 0,
+      n = static_cast<unsigned>(this->_internal_polygons_size()); i < n; i++) {
+    const auto& repfield = this->_internal_polygons(i);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+        InternalWriteMessage(1, repfield, repfield.GetCachedSize(), target, stream);
+  }
+
+  // repeated .mavsdk.rpc.geofence.Circle circles = 2;
+  for (unsigned i = 0,
+      n = static_cast<unsigned>(this->_internal_circles_size()); i < n; i++) {
+    const auto& repfield = this->_internal_circles(i);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+        InternalWriteMessage(2, repfield, repfield.GetCachedSize(), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.geofence.GeofenceData)
+  return target;
+}
+
+size_t GeofenceData::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.geofence.GeofenceData)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated .mavsdk.rpc.geofence.Polygon polygons = 1;
+  total_size += 1UL * this->_internal_polygons_size();
+  for (const auto& msg : this->polygons_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  // repeated .mavsdk.rpc.geofence.Circle circles = 2;
+  total_size += 1UL * this->_internal_circles_size();
+  for (const auto& msg : this->circles_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData GeofenceData::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSizeCheck,
+    GeofenceData::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GeofenceData::GetClassData() const { return &_class_data_; }
+
+void GeofenceData::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message* to,
+                      const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+  static_cast<GeofenceData *>(to)->MergeFrom(
+      static_cast<const GeofenceData &>(from));
+}
+
+
+void GeofenceData::MergeFrom(const GeofenceData& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.geofence.GeofenceData)
+  GOOGLE_DCHECK_NE(&from, this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  polygons_.MergeFrom(from.polygons_);
+  circles_.MergeFrom(from.circles_);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void GeofenceData::CopyFrom(const GeofenceData& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.geofence.GeofenceData)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool GeofenceData::IsInitialized() const {
+  return true;
+}
+
+void GeofenceData::InternalSwap(GeofenceData* other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  polygons_.InternalSwap(&other->polygons_);
+  circles_.InternalSwap(&other->circles_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata GeofenceData::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_geofence_2fgeofence_2eproto_getter, &descriptor_table_geofence_2fgeofence_2eproto_once,
+      file_level_metadata_geofence_2fgeofence_2eproto[3]);
+}
+
+// ===================================================================
+
+class UploadGeofenceRequest::_Internal {
+ public:
+  static const ::mavsdk::rpc::geofence::GeofenceData& geofence_data(const UploadGeofenceRequest* msg);
+};
+
+const ::mavsdk::rpc::geofence::GeofenceData&
+UploadGeofenceRequest::_Internal::geofence_data(const UploadGeofenceRequest* msg) {
+  return *msg->geofence_data_;
+}
+UploadGeofenceRequest::UploadGeofenceRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor();
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.geofence.UploadGeofenceRequest)
+}
+UploadGeofenceRequest::UploadGeofenceRequest(const UploadGeofenceRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_geofence_data()) {
+    geofence_data_ = new ::mavsdk::rpc::geofence::GeofenceData(*from.geofence_data_);
+  } else {
+    geofence_data_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.geofence.UploadGeofenceRequest)
+}
+
+inline void UploadGeofenceRequest::SharedCtor() {
+geofence_data_ = nullptr;
+}
+
+UploadGeofenceRequest::~UploadGeofenceRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.geofence.UploadGeofenceRequest)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void UploadGeofenceRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  if (this != internal_default_instance()) delete geofence_data_;
+}
+
+void UploadGeofenceRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void UploadGeofenceRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.geofence.UploadGeofenceRequest)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArenaForAllocation() == nullptr && geofence_data_ != nullptr) {
+    delete geofence_data_;
+  }
+  geofence_data_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* UploadGeofenceRequest::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // .mavsdk.rpc.geofence.GeofenceData geofence_data = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_geofence_data(), ptr);
+          CHK_(ptr);
         } else
           goto handle_unusual;
         continue;
@@ -829,12 +1359,11 @@ uint8_t* UploadGeofenceRequest::_InternalSerialize(
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // repeated .mavsdk.rpc.geofence.Polygon polygons = 1;
-  for (unsigned i = 0,
-      n = static_cast<unsigned>(this->_internal_polygons_size()); i < n; i++) {
-    const auto& repfield = this->_internal_polygons(i);
+  // .mavsdk.rpc.geofence.GeofenceData geofence_data = 1;
+  if (this->_internal_has_geofence_data()) {
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
-        InternalWriteMessage(1, repfield, repfield.GetCachedSize(), target, stream);
+      InternalWriteMessage(1, _Internal::geofence_data(this),
+        _Internal::geofence_data(this).GetCachedSize(), target, stream);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -853,11 +1382,11 @@ size_t UploadGeofenceRequest::ByteSizeLong() const {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  // repeated .mavsdk.rpc.geofence.Polygon polygons = 1;
-  total_size += 1UL * this->_internal_polygons_size();
-  for (const auto& msg : this->polygons_) {
-    total_size +=
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  // .mavsdk.rpc.geofence.GeofenceData geofence_data = 1;
+  if (this->_internal_has_geofence_data()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *geofence_data_);
   }
 
   return MaybeComputeUnknownFieldsSize(total_size, &_cached_size_);
@@ -882,7 +1411,9 @@ void UploadGeofenceRequest::MergeFrom(const UploadGeofenceRequest& from) {
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
-  polygons_.MergeFrom(from.polygons_);
+  if (from._internal_has_geofence_data()) {
+    _internal_mutable_geofence_data()->::mavsdk::rpc::geofence::GeofenceData::MergeFrom(from._internal_geofence_data());
+  }
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
 
@@ -900,13 +1431,13 @@ bool UploadGeofenceRequest::IsInitialized() const {
 void UploadGeofenceRequest::InternalSwap(UploadGeofenceRequest* other) {
   using std::swap;
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
-  polygons_.InternalSwap(&other->polygons_);
+  swap(geofence_data_, other->geofence_data_);
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata UploadGeofenceRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_geofence_2fgeofence_2eproto_getter, &descriptor_table_geofence_2fgeofence_2eproto_once,
-      file_level_metadata_geofence_2fgeofence_2eproto[2]);
+      file_level_metadata_geofence_2fgeofence_2eproto[4]);
 }
 
 // ===================================================================
@@ -1093,7 +1624,7 @@ void UploadGeofenceResponse::InternalSwap(UploadGeofenceResponse* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata UploadGeofenceResponse::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_geofence_2fgeofence_2eproto_getter, &descriptor_table_geofence_2fgeofence_2eproto_once,
-      file_level_metadata_geofence_2fgeofence_2eproto[3]);
+      file_level_metadata_geofence_2fgeofence_2eproto[5]);
 }
 
 // ===================================================================
@@ -1132,7 +1663,7 @@ const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*ClearGeofenceRequest::GetClass
 ::PROTOBUF_NAMESPACE_ID::Metadata ClearGeofenceRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_geofence_2fgeofence_2eproto_getter, &descriptor_table_geofence_2fgeofence_2eproto_once,
-      file_level_metadata_geofence_2fgeofence_2eproto[4]);
+      file_level_metadata_geofence_2fgeofence_2eproto[6]);
 }
 
 // ===================================================================
@@ -1319,7 +1850,7 @@ void ClearGeofenceResponse::InternalSwap(ClearGeofenceResponse* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata ClearGeofenceResponse::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_geofence_2fgeofence_2eproto_getter, &descriptor_table_geofence_2fgeofence_2eproto_once,
-      file_level_metadata_geofence_2fgeofence_2eproto[5]);
+      file_level_metadata_geofence_2fgeofence_2eproto[7]);
 }
 
 // ===================================================================
@@ -1543,7 +2074,7 @@ void GeofenceResult::InternalSwap(GeofenceResult* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata GeofenceResult::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_geofence_2fgeofence_2eproto_getter, &descriptor_table_geofence_2fgeofence_2eproto_once,
-      file_level_metadata_geofence_2fgeofence_2eproto[6]);
+      file_level_metadata_geofence_2fgeofence_2eproto[8]);
 }
 
 // @@protoc_insertion_point(namespace_scope)
@@ -1558,6 +2089,14 @@ Arena::CreateMaybeMessage< ::mavsdk::rpc::geofence::Point >(Arena* arena) {
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::geofence::Polygon*
 Arena::CreateMaybeMessage< ::mavsdk::rpc::geofence::Polygon >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::geofence::Polygon >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::geofence::Circle*
+Arena::CreateMaybeMessage< ::mavsdk::rpc::geofence::Circle >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::geofence::Circle >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::geofence::GeofenceData*
+Arena::CreateMaybeMessage< ::mavsdk::rpc::geofence::GeofenceData >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::geofence::GeofenceData >(arena);
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::geofence::UploadGeofenceRequest*
 Arena::CreateMaybeMessage< ::mavsdk::rpc::geofence::UploadGeofenceRequest >(Arena* arena) {

--- a/src/mavsdk_server/src/generated/geofence/geofence.pb.h
+++ b/src/mavsdk_server/src/generated/geofence/geofence.pb.h
@@ -32,6 +32,7 @@
 #include <google/protobuf/extension_set.h>  // IWYU pragma: export
 #include <google/protobuf/generated_enum_reflection.h>
 #include <google/protobuf/unknown_field_set.h>
+#include "mavsdk_options.pb.h"
 // @@protoc_insertion_point(includes)
 #include <google/protobuf/port_def.inc>
 #define PROTOBUF_INTERNAL_EXPORT_geofence_2fgeofence_2eproto
@@ -49,12 +50,18 @@ extern const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table
 namespace mavsdk {
 namespace rpc {
 namespace geofence {
+class Circle;
+struct CircleDefaultTypeInternal;
+extern CircleDefaultTypeInternal _Circle_default_instance_;
 class ClearGeofenceRequest;
 struct ClearGeofenceRequestDefaultTypeInternal;
 extern ClearGeofenceRequestDefaultTypeInternal _ClearGeofenceRequest_default_instance_;
 class ClearGeofenceResponse;
 struct ClearGeofenceResponseDefaultTypeInternal;
 extern ClearGeofenceResponseDefaultTypeInternal _ClearGeofenceResponse_default_instance_;
+class GeofenceData;
+struct GeofenceDataDefaultTypeInternal;
+extern GeofenceDataDefaultTypeInternal _GeofenceData_default_instance_;
 class GeofenceResult;
 struct GeofenceResultDefaultTypeInternal;
 extern GeofenceResultDefaultTypeInternal _GeofenceResult_default_instance_;
@@ -74,8 +81,10 @@ extern UploadGeofenceResponseDefaultTypeInternal _UploadGeofenceResponse_default
 }  // namespace rpc
 }  // namespace mavsdk
 PROTOBUF_NAMESPACE_OPEN
+template<> ::mavsdk::rpc::geofence::Circle* Arena::CreateMaybeMessage<::mavsdk::rpc::geofence::Circle>(Arena*);
 template<> ::mavsdk::rpc::geofence::ClearGeofenceRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::geofence::ClearGeofenceRequest>(Arena*);
 template<> ::mavsdk::rpc::geofence::ClearGeofenceResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::geofence::ClearGeofenceResponse>(Arena*);
+template<> ::mavsdk::rpc::geofence::GeofenceData* Arena::CreateMaybeMessage<::mavsdk::rpc::geofence::GeofenceData>(Arena*);
 template<> ::mavsdk::rpc::geofence::GeofenceResult* Arena::CreateMaybeMessage<::mavsdk::rpc::geofence::GeofenceResult>(Arena*);
 template<> ::mavsdk::rpc::geofence::Point* Arena::CreateMaybeMessage<::mavsdk::rpc::geofence::Point>(Arena*);
 template<> ::mavsdk::rpc::geofence::Polygon* Arena::CreateMaybeMessage<::mavsdk::rpc::geofence::Polygon>(Arena*);
@@ -86,31 +95,6 @@ namespace mavsdk {
 namespace rpc {
 namespace geofence {
 
-enum Polygon_FenceType : int {
-  Polygon_FenceType_FENCE_TYPE_INCLUSION = 0,
-  Polygon_FenceType_FENCE_TYPE_EXCLUSION = 1,
-  Polygon_FenceType_Polygon_FenceType_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::min(),
-  Polygon_FenceType_Polygon_FenceType_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::max()
-};
-bool Polygon_FenceType_IsValid(int value);
-constexpr Polygon_FenceType Polygon_FenceType_FenceType_MIN = Polygon_FenceType_FENCE_TYPE_INCLUSION;
-constexpr Polygon_FenceType Polygon_FenceType_FenceType_MAX = Polygon_FenceType_FENCE_TYPE_EXCLUSION;
-constexpr int Polygon_FenceType_FenceType_ARRAYSIZE = Polygon_FenceType_FenceType_MAX + 1;
-
-const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* Polygon_FenceType_descriptor();
-template<typename T>
-inline const std::string& Polygon_FenceType_Name(T enum_t_value) {
-  static_assert(::std::is_same<T, Polygon_FenceType>::value ||
-    ::std::is_integral<T>::value,
-    "Incorrect type passed to function Polygon_FenceType_Name.");
-  return ::PROTOBUF_NAMESPACE_ID::internal::NameOfEnum(
-    Polygon_FenceType_descriptor(), enum_t_value);
-}
-inline bool Polygon_FenceType_Parse(
-    ::PROTOBUF_NAMESPACE_ID::ConstStringParam name, Polygon_FenceType* value) {
-  return ::PROTOBUF_NAMESPACE_ID::internal::ParseNamedEnum<Polygon_FenceType>(
-    Polygon_FenceType_descriptor(), name, value);
-}
 enum GeofenceResult_Result : int {
   GeofenceResult_Result_RESULT_UNKNOWN = 0,
   GeofenceResult_Result_RESULT_SUCCESS = 1,
@@ -141,6 +125,31 @@ inline bool GeofenceResult_Result_Parse(
     ::PROTOBUF_NAMESPACE_ID::ConstStringParam name, GeofenceResult_Result* value) {
   return ::PROTOBUF_NAMESPACE_ID::internal::ParseNamedEnum<GeofenceResult_Result>(
     GeofenceResult_Result_descriptor(), name, value);
+}
+enum FenceType : int {
+  FENCE_TYPE_INCLUSION = 0,
+  FENCE_TYPE_EXCLUSION = 1,
+  FenceType_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::min(),
+  FenceType_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::max()
+};
+bool FenceType_IsValid(int value);
+constexpr FenceType FenceType_MIN = FENCE_TYPE_INCLUSION;
+constexpr FenceType FenceType_MAX = FENCE_TYPE_EXCLUSION;
+constexpr int FenceType_ARRAYSIZE = FenceType_MAX + 1;
+
+const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* FenceType_descriptor();
+template<typename T>
+inline const std::string& FenceType_Name(T enum_t_value) {
+  static_assert(::std::is_same<T, FenceType>::value ||
+    ::std::is_integral<T>::value,
+    "Incorrect type passed to function FenceType_Name.");
+  return ::PROTOBUF_NAMESPACE_ID::internal::NameOfEnum(
+    FenceType_descriptor(), enum_t_value);
+}
+inline bool FenceType_Parse(
+    ::PROTOBUF_NAMESPACE_ID::ConstStringParam name, FenceType* value) {
+  return ::PROTOBUF_NAMESPACE_ID::internal::ParseNamedEnum<FenceType>(
+    FenceType_descriptor(), name, value);
 }
 // ===================================================================
 
@@ -414,36 +423,6 @@ class Polygon final :
 
   // nested types ----------------------------------------------------
 
-  typedef Polygon_FenceType FenceType;
-  static constexpr FenceType FENCE_TYPE_INCLUSION =
-    Polygon_FenceType_FENCE_TYPE_INCLUSION;
-  static constexpr FenceType FENCE_TYPE_EXCLUSION =
-    Polygon_FenceType_FENCE_TYPE_EXCLUSION;
-  static inline bool FenceType_IsValid(int value) {
-    return Polygon_FenceType_IsValid(value);
-  }
-  static constexpr FenceType FenceType_MIN =
-    Polygon_FenceType_FenceType_MIN;
-  static constexpr FenceType FenceType_MAX =
-    Polygon_FenceType_FenceType_MAX;
-  static constexpr int FenceType_ARRAYSIZE =
-    Polygon_FenceType_FenceType_ARRAYSIZE;
-  static inline const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor*
-  FenceType_descriptor() {
-    return Polygon_FenceType_descriptor();
-  }
-  template<typename T>
-  static inline const std::string& FenceType_Name(T enum_t_value) {
-    static_assert(::std::is_same<T, FenceType>::value ||
-      ::std::is_integral<T>::value,
-      "Incorrect type passed to function FenceType_Name.");
-    return Polygon_FenceType_Name(enum_t_value);
-  }
-  static inline bool FenceType_Parse(::PROTOBUF_NAMESPACE_ID::ConstStringParam name,
-      FenceType* value) {
-    return Polygon_FenceType_Parse(name, value);
-  }
-
   // accessors -------------------------------------------------------
 
   enum : int {
@@ -468,13 +447,13 @@ class Polygon final :
   const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::mavsdk::rpc::geofence::Point >&
       points() const;
 
-  // .mavsdk.rpc.geofence.Polygon.FenceType fence_type = 2;
+  // .mavsdk.rpc.geofence.FenceType fence_type = 2;
   void clear_fence_type();
-  ::mavsdk::rpc::geofence::Polygon_FenceType fence_type() const;
-  void set_fence_type(::mavsdk::rpc::geofence::Polygon_FenceType value);
+  ::mavsdk::rpc::geofence::FenceType fence_type() const;
+  void set_fence_type(::mavsdk::rpc::geofence::FenceType value);
   private:
-  ::mavsdk::rpc::geofence::Polygon_FenceType _internal_fence_type() const;
-  void _internal_set_fence_type(::mavsdk::rpc::geofence::Polygon_FenceType value);
+  ::mavsdk::rpc::geofence::FenceType _internal_fence_type() const;
+  void _internal_set_fence_type(::mavsdk::rpc::geofence::FenceType value);
   public:
 
   // @@protoc_insertion_point(class_scope:mavsdk.rpc.geofence.Polygon)
@@ -486,6 +465,352 @@ class Polygon final :
   typedef void DestructorSkippable_;
   ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::mavsdk::rpc::geofence::Point > points_;
   int fence_type_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_geofence_2fgeofence_2eproto;
+};
+// -------------------------------------------------------------------
+
+class Circle final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.geofence.Circle) */ {
+ public:
+  inline Circle() : Circle(nullptr) {}
+  ~Circle() override;
+  explicit PROTOBUF_CONSTEXPR Circle(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  Circle(const Circle& from);
+  Circle(Circle&& from) noexcept
+    : Circle() {
+    *this = ::std::move(from);
+  }
+
+  inline Circle& operator=(const Circle& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline Circle& operator=(Circle&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const Circle& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const Circle* internal_default_instance() {
+    return reinterpret_cast<const Circle*>(
+               &_Circle_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    2;
+
+  friend void swap(Circle& a, Circle& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(Circle* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(Circle* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  Circle* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<Circle>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const Circle& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom(const Circle& from);
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message* to, const ::PROTOBUF_NAMESPACE_ID::Message& from);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(Circle* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.geofence.Circle";
+  }
+  protected:
+  explicit Circle(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kPointFieldNumber = 1,
+    kRadiusFieldNumber = 2,
+    kFenceTypeFieldNumber = 3,
+  };
+  // .mavsdk.rpc.geofence.Point point = 1;
+  bool has_point() const;
+  private:
+  bool _internal_has_point() const;
+  public:
+  void clear_point();
+  const ::mavsdk::rpc::geofence::Point& point() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::geofence::Point* release_point();
+  ::mavsdk::rpc::geofence::Point* mutable_point();
+  void set_allocated_point(::mavsdk::rpc::geofence::Point* point);
+  private:
+  const ::mavsdk::rpc::geofence::Point& _internal_point() const;
+  ::mavsdk::rpc::geofence::Point* _internal_mutable_point();
+  public:
+  void unsafe_arena_set_allocated_point(
+      ::mavsdk::rpc::geofence::Point* point);
+  ::mavsdk::rpc::geofence::Point* unsafe_arena_release_point();
+
+  // float radius = 2 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_radius();
+  float radius() const;
+  void set_radius(float value);
+  private:
+  float _internal_radius() const;
+  void _internal_set_radius(float value);
+  public:
+
+  // .mavsdk.rpc.geofence.FenceType fence_type = 3;
+  void clear_fence_type();
+  ::mavsdk::rpc::geofence::FenceType fence_type() const;
+  void set_fence_type(::mavsdk::rpc::geofence::FenceType value);
+  private:
+  ::mavsdk::rpc::geofence::FenceType _internal_fence_type() const;
+  void _internal_set_fence_type(::mavsdk::rpc::geofence::FenceType value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.geofence.Circle)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::mavsdk::rpc::geofence::Point* point_;
+  float radius_;
+  int fence_type_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_geofence_2fgeofence_2eproto;
+};
+// -------------------------------------------------------------------
+
+class GeofenceData final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.geofence.GeofenceData) */ {
+ public:
+  inline GeofenceData() : GeofenceData(nullptr) {}
+  ~GeofenceData() override;
+  explicit PROTOBUF_CONSTEXPR GeofenceData(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  GeofenceData(const GeofenceData& from);
+  GeofenceData(GeofenceData&& from) noexcept
+    : GeofenceData() {
+    *this = ::std::move(from);
+  }
+
+  inline GeofenceData& operator=(const GeofenceData& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline GeofenceData& operator=(GeofenceData&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const GeofenceData& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const GeofenceData* internal_default_instance() {
+    return reinterpret_cast<const GeofenceData*>(
+               &_GeofenceData_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    3;
+
+  friend void swap(GeofenceData& a, GeofenceData& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(GeofenceData* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(GeofenceData* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  GeofenceData* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<GeofenceData>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const GeofenceData& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom(const GeofenceData& from);
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message* to, const ::PROTOBUF_NAMESPACE_ID::Message& from);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(GeofenceData* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.geofence.GeofenceData";
+  }
+  protected:
+  explicit GeofenceData(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kPolygonsFieldNumber = 1,
+    kCirclesFieldNumber = 2,
+  };
+  // repeated .mavsdk.rpc.geofence.Polygon polygons = 1;
+  int polygons_size() const;
+  private:
+  int _internal_polygons_size() const;
+  public:
+  void clear_polygons();
+  ::mavsdk::rpc::geofence::Polygon* mutable_polygons(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::mavsdk::rpc::geofence::Polygon >*
+      mutable_polygons();
+  private:
+  const ::mavsdk::rpc::geofence::Polygon& _internal_polygons(int index) const;
+  ::mavsdk::rpc::geofence::Polygon* _internal_add_polygons();
+  public:
+  const ::mavsdk::rpc::geofence::Polygon& polygons(int index) const;
+  ::mavsdk::rpc::geofence::Polygon* add_polygons();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::mavsdk::rpc::geofence::Polygon >&
+      polygons() const;
+
+  // repeated .mavsdk.rpc.geofence.Circle circles = 2;
+  int circles_size() const;
+  private:
+  int _internal_circles_size() const;
+  public:
+  void clear_circles();
+  ::mavsdk::rpc::geofence::Circle* mutable_circles(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::mavsdk::rpc::geofence::Circle >*
+      mutable_circles();
+  private:
+  const ::mavsdk::rpc::geofence::Circle& _internal_circles(int index) const;
+  ::mavsdk::rpc::geofence::Circle* _internal_add_circles();
+  public:
+  const ::mavsdk::rpc::geofence::Circle& circles(int index) const;
+  ::mavsdk::rpc::geofence::Circle* add_circles();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::mavsdk::rpc::geofence::Circle >&
+      circles() const;
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.geofence.GeofenceData)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::mavsdk::rpc::geofence::Polygon > polygons_;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::mavsdk::rpc::geofence::Circle > circles_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_geofence_2fgeofence_2eproto;
 };
@@ -539,7 +864,7 @@ class UploadGeofenceRequest final :
                &_UploadGeofenceRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    2;
+    4;
 
   friend void swap(UploadGeofenceRequest& a, UploadGeofenceRequest& b) {
     a.Swap(&b);
@@ -610,25 +935,25 @@ class UploadGeofenceRequest final :
   // accessors -------------------------------------------------------
 
   enum : int {
-    kPolygonsFieldNumber = 1,
+    kGeofenceDataFieldNumber = 1,
   };
-  // repeated .mavsdk.rpc.geofence.Polygon polygons = 1;
-  int polygons_size() const;
+  // .mavsdk.rpc.geofence.GeofenceData geofence_data = 1;
+  bool has_geofence_data() const;
   private:
-  int _internal_polygons_size() const;
+  bool _internal_has_geofence_data() const;
   public:
-  void clear_polygons();
-  ::mavsdk::rpc::geofence::Polygon* mutable_polygons(int index);
-  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::mavsdk::rpc::geofence::Polygon >*
-      mutable_polygons();
+  void clear_geofence_data();
+  const ::mavsdk::rpc::geofence::GeofenceData& geofence_data() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::geofence::GeofenceData* release_geofence_data();
+  ::mavsdk::rpc::geofence::GeofenceData* mutable_geofence_data();
+  void set_allocated_geofence_data(::mavsdk::rpc::geofence::GeofenceData* geofence_data);
   private:
-  const ::mavsdk::rpc::geofence::Polygon& _internal_polygons(int index) const;
-  ::mavsdk::rpc::geofence::Polygon* _internal_add_polygons();
+  const ::mavsdk::rpc::geofence::GeofenceData& _internal_geofence_data() const;
+  ::mavsdk::rpc::geofence::GeofenceData* _internal_mutable_geofence_data();
   public:
-  const ::mavsdk::rpc::geofence::Polygon& polygons(int index) const;
-  ::mavsdk::rpc::geofence::Polygon* add_polygons();
-  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::mavsdk::rpc::geofence::Polygon >&
-      polygons() const;
+  void unsafe_arena_set_allocated_geofence_data(
+      ::mavsdk::rpc::geofence::GeofenceData* geofence_data);
+  ::mavsdk::rpc::geofence::GeofenceData* unsafe_arena_release_geofence_data();
 
   // @@protoc_insertion_point(class_scope:mavsdk.rpc.geofence.UploadGeofenceRequest)
  private:
@@ -637,7 +962,7 @@ class UploadGeofenceRequest final :
   template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
-  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::mavsdk::rpc::geofence::Polygon > polygons_;
+  ::mavsdk::rpc::geofence::GeofenceData* geofence_data_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_geofence_2fgeofence_2eproto;
 };
@@ -691,7 +1016,7 @@ class UploadGeofenceResponse final :
                &_UploadGeofenceResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    3;
+    5;
 
   friend void swap(UploadGeofenceResponse& a, UploadGeofenceResponse& b) {
     a.Swap(&b);
@@ -842,7 +1167,7 @@ class ClearGeofenceRequest final :
                &_ClearGeofenceRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    4;
+    6;
 
   friend void swap(ClearGeofenceRequest& a, ClearGeofenceRequest& b) {
     a.Swap(&b);
@@ -959,7 +1284,7 @@ class ClearGeofenceResponse final :
                &_ClearGeofenceResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    5;
+    7;
 
   friend void swap(ClearGeofenceResponse& a, ClearGeofenceResponse& b) {
     a.Swap(&b);
@@ -1111,7 +1436,7 @@ class GeofenceResult final :
                &_GeofenceResult_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    6;
+    8;
 
   friend void swap(GeofenceResult& a, GeofenceResult& b) {
     a.Swap(&b);
@@ -1357,68 +1682,336 @@ Polygon::points() const {
   return points_;
 }
 
-// .mavsdk.rpc.geofence.Polygon.FenceType fence_type = 2;
+// .mavsdk.rpc.geofence.FenceType fence_type = 2;
 inline void Polygon::clear_fence_type() {
   fence_type_ = 0;
 }
-inline ::mavsdk::rpc::geofence::Polygon_FenceType Polygon::_internal_fence_type() const {
-  return static_cast< ::mavsdk::rpc::geofence::Polygon_FenceType >(fence_type_);
+inline ::mavsdk::rpc::geofence::FenceType Polygon::_internal_fence_type() const {
+  return static_cast< ::mavsdk::rpc::geofence::FenceType >(fence_type_);
 }
-inline ::mavsdk::rpc::geofence::Polygon_FenceType Polygon::fence_type() const {
+inline ::mavsdk::rpc::geofence::FenceType Polygon::fence_type() const {
   // @@protoc_insertion_point(field_get:mavsdk.rpc.geofence.Polygon.fence_type)
   return _internal_fence_type();
 }
-inline void Polygon::_internal_set_fence_type(::mavsdk::rpc::geofence::Polygon_FenceType value) {
+inline void Polygon::_internal_set_fence_type(::mavsdk::rpc::geofence::FenceType value) {
   
   fence_type_ = value;
 }
-inline void Polygon::set_fence_type(::mavsdk::rpc::geofence::Polygon_FenceType value) {
+inline void Polygon::set_fence_type(::mavsdk::rpc::geofence::FenceType value) {
   _internal_set_fence_type(value);
   // @@protoc_insertion_point(field_set:mavsdk.rpc.geofence.Polygon.fence_type)
 }
 
 // -------------------------------------------------------------------
 
-// UploadGeofenceRequest
+// Circle
+
+// .mavsdk.rpc.geofence.Point point = 1;
+inline bool Circle::_internal_has_point() const {
+  return this != internal_default_instance() && point_ != nullptr;
+}
+inline bool Circle::has_point() const {
+  return _internal_has_point();
+}
+inline void Circle::clear_point() {
+  if (GetArenaForAllocation() == nullptr && point_ != nullptr) {
+    delete point_;
+  }
+  point_ = nullptr;
+}
+inline const ::mavsdk::rpc::geofence::Point& Circle::_internal_point() const {
+  const ::mavsdk::rpc::geofence::Point* p = point_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::geofence::Point&>(
+      ::mavsdk::rpc::geofence::_Point_default_instance_);
+}
+inline const ::mavsdk::rpc::geofence::Point& Circle::point() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.geofence.Circle.point)
+  return _internal_point();
+}
+inline void Circle::unsafe_arena_set_allocated_point(
+    ::mavsdk::rpc::geofence::Point* point) {
+  if (GetArenaForAllocation() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(point_);
+  }
+  point_ = point;
+  if (point) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.geofence.Circle.point)
+}
+inline ::mavsdk::rpc::geofence::Point* Circle::release_point() {
+  
+  ::mavsdk::rpc::geofence::Point* temp = point_;
+  point_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
+  temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  if (GetArenaForAllocation() == nullptr) { delete old; }
+#else  // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArenaForAllocation() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return temp;
+}
+inline ::mavsdk::rpc::geofence::Point* Circle::unsafe_arena_release_point() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.geofence.Circle.point)
+  
+  ::mavsdk::rpc::geofence::Point* temp = point_;
+  point_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::geofence::Point* Circle::_internal_mutable_point() {
+  
+  if (point_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::geofence::Point>(GetArenaForAllocation());
+    point_ = p;
+  }
+  return point_;
+}
+inline ::mavsdk::rpc::geofence::Point* Circle::mutable_point() {
+  ::mavsdk::rpc::geofence::Point* _msg = _internal_mutable_point();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.geofence.Circle.point)
+  return _msg;
+}
+inline void Circle::set_allocated_point(::mavsdk::rpc::geofence::Point* point) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
+  if (message_arena == nullptr) {
+    delete point_;
+  }
+  if (point) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(point);
+    if (message_arena != submessage_arena) {
+      point = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, point, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  point_ = point;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.geofence.Circle.point)
+}
+
+// float radius = 2 [(.mavsdk.options.default_value) = "NaN"];
+inline void Circle::clear_radius() {
+  radius_ = 0;
+}
+inline float Circle::_internal_radius() const {
+  return radius_;
+}
+inline float Circle::radius() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.geofence.Circle.radius)
+  return _internal_radius();
+}
+inline void Circle::_internal_set_radius(float value) {
+  
+  radius_ = value;
+}
+inline void Circle::set_radius(float value) {
+  _internal_set_radius(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.geofence.Circle.radius)
+}
+
+// .mavsdk.rpc.geofence.FenceType fence_type = 3;
+inline void Circle::clear_fence_type() {
+  fence_type_ = 0;
+}
+inline ::mavsdk::rpc::geofence::FenceType Circle::_internal_fence_type() const {
+  return static_cast< ::mavsdk::rpc::geofence::FenceType >(fence_type_);
+}
+inline ::mavsdk::rpc::geofence::FenceType Circle::fence_type() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.geofence.Circle.fence_type)
+  return _internal_fence_type();
+}
+inline void Circle::_internal_set_fence_type(::mavsdk::rpc::geofence::FenceType value) {
+  
+  fence_type_ = value;
+}
+inline void Circle::set_fence_type(::mavsdk::rpc::geofence::FenceType value) {
+  _internal_set_fence_type(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.geofence.Circle.fence_type)
+}
+
+// -------------------------------------------------------------------
+
+// GeofenceData
 
 // repeated .mavsdk.rpc.geofence.Polygon polygons = 1;
-inline int UploadGeofenceRequest::_internal_polygons_size() const {
+inline int GeofenceData::_internal_polygons_size() const {
   return polygons_.size();
 }
-inline int UploadGeofenceRequest::polygons_size() const {
+inline int GeofenceData::polygons_size() const {
   return _internal_polygons_size();
 }
-inline void UploadGeofenceRequest::clear_polygons() {
+inline void GeofenceData::clear_polygons() {
   polygons_.Clear();
 }
-inline ::mavsdk::rpc::geofence::Polygon* UploadGeofenceRequest::mutable_polygons(int index) {
-  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.geofence.UploadGeofenceRequest.polygons)
+inline ::mavsdk::rpc::geofence::Polygon* GeofenceData::mutable_polygons(int index) {
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.geofence.GeofenceData.polygons)
   return polygons_.Mutable(index);
 }
 inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::mavsdk::rpc::geofence::Polygon >*
-UploadGeofenceRequest::mutable_polygons() {
-  // @@protoc_insertion_point(field_mutable_list:mavsdk.rpc.geofence.UploadGeofenceRequest.polygons)
+GeofenceData::mutable_polygons() {
+  // @@protoc_insertion_point(field_mutable_list:mavsdk.rpc.geofence.GeofenceData.polygons)
   return &polygons_;
 }
-inline const ::mavsdk::rpc::geofence::Polygon& UploadGeofenceRequest::_internal_polygons(int index) const {
+inline const ::mavsdk::rpc::geofence::Polygon& GeofenceData::_internal_polygons(int index) const {
   return polygons_.Get(index);
 }
-inline const ::mavsdk::rpc::geofence::Polygon& UploadGeofenceRequest::polygons(int index) const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.geofence.UploadGeofenceRequest.polygons)
+inline const ::mavsdk::rpc::geofence::Polygon& GeofenceData::polygons(int index) const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.geofence.GeofenceData.polygons)
   return _internal_polygons(index);
 }
-inline ::mavsdk::rpc::geofence::Polygon* UploadGeofenceRequest::_internal_add_polygons() {
+inline ::mavsdk::rpc::geofence::Polygon* GeofenceData::_internal_add_polygons() {
   return polygons_.Add();
 }
-inline ::mavsdk::rpc::geofence::Polygon* UploadGeofenceRequest::add_polygons() {
+inline ::mavsdk::rpc::geofence::Polygon* GeofenceData::add_polygons() {
   ::mavsdk::rpc::geofence::Polygon* _add = _internal_add_polygons();
-  // @@protoc_insertion_point(field_add:mavsdk.rpc.geofence.UploadGeofenceRequest.polygons)
+  // @@protoc_insertion_point(field_add:mavsdk.rpc.geofence.GeofenceData.polygons)
   return _add;
 }
 inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::mavsdk::rpc::geofence::Polygon >&
-UploadGeofenceRequest::polygons() const {
-  // @@protoc_insertion_point(field_list:mavsdk.rpc.geofence.UploadGeofenceRequest.polygons)
+GeofenceData::polygons() const {
+  // @@protoc_insertion_point(field_list:mavsdk.rpc.geofence.GeofenceData.polygons)
   return polygons_;
+}
+
+// repeated .mavsdk.rpc.geofence.Circle circles = 2;
+inline int GeofenceData::_internal_circles_size() const {
+  return circles_.size();
+}
+inline int GeofenceData::circles_size() const {
+  return _internal_circles_size();
+}
+inline void GeofenceData::clear_circles() {
+  circles_.Clear();
+}
+inline ::mavsdk::rpc::geofence::Circle* GeofenceData::mutable_circles(int index) {
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.geofence.GeofenceData.circles)
+  return circles_.Mutable(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::mavsdk::rpc::geofence::Circle >*
+GeofenceData::mutable_circles() {
+  // @@protoc_insertion_point(field_mutable_list:mavsdk.rpc.geofence.GeofenceData.circles)
+  return &circles_;
+}
+inline const ::mavsdk::rpc::geofence::Circle& GeofenceData::_internal_circles(int index) const {
+  return circles_.Get(index);
+}
+inline const ::mavsdk::rpc::geofence::Circle& GeofenceData::circles(int index) const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.geofence.GeofenceData.circles)
+  return _internal_circles(index);
+}
+inline ::mavsdk::rpc::geofence::Circle* GeofenceData::_internal_add_circles() {
+  return circles_.Add();
+}
+inline ::mavsdk::rpc::geofence::Circle* GeofenceData::add_circles() {
+  ::mavsdk::rpc::geofence::Circle* _add = _internal_add_circles();
+  // @@protoc_insertion_point(field_add:mavsdk.rpc.geofence.GeofenceData.circles)
+  return _add;
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::mavsdk::rpc::geofence::Circle >&
+GeofenceData::circles() const {
+  // @@protoc_insertion_point(field_list:mavsdk.rpc.geofence.GeofenceData.circles)
+  return circles_;
+}
+
+// -------------------------------------------------------------------
+
+// UploadGeofenceRequest
+
+// .mavsdk.rpc.geofence.GeofenceData geofence_data = 1;
+inline bool UploadGeofenceRequest::_internal_has_geofence_data() const {
+  return this != internal_default_instance() && geofence_data_ != nullptr;
+}
+inline bool UploadGeofenceRequest::has_geofence_data() const {
+  return _internal_has_geofence_data();
+}
+inline void UploadGeofenceRequest::clear_geofence_data() {
+  if (GetArenaForAllocation() == nullptr && geofence_data_ != nullptr) {
+    delete geofence_data_;
+  }
+  geofence_data_ = nullptr;
+}
+inline const ::mavsdk::rpc::geofence::GeofenceData& UploadGeofenceRequest::_internal_geofence_data() const {
+  const ::mavsdk::rpc::geofence::GeofenceData* p = geofence_data_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::geofence::GeofenceData&>(
+      ::mavsdk::rpc::geofence::_GeofenceData_default_instance_);
+}
+inline const ::mavsdk::rpc::geofence::GeofenceData& UploadGeofenceRequest::geofence_data() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.geofence.UploadGeofenceRequest.geofence_data)
+  return _internal_geofence_data();
+}
+inline void UploadGeofenceRequest::unsafe_arena_set_allocated_geofence_data(
+    ::mavsdk::rpc::geofence::GeofenceData* geofence_data) {
+  if (GetArenaForAllocation() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(geofence_data_);
+  }
+  geofence_data_ = geofence_data;
+  if (geofence_data) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.geofence.UploadGeofenceRequest.geofence_data)
+}
+inline ::mavsdk::rpc::geofence::GeofenceData* UploadGeofenceRequest::release_geofence_data() {
+  
+  ::mavsdk::rpc::geofence::GeofenceData* temp = geofence_data_;
+  geofence_data_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
+  temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  if (GetArenaForAllocation() == nullptr) { delete old; }
+#else  // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArenaForAllocation() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return temp;
+}
+inline ::mavsdk::rpc::geofence::GeofenceData* UploadGeofenceRequest::unsafe_arena_release_geofence_data() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.geofence.UploadGeofenceRequest.geofence_data)
+  
+  ::mavsdk::rpc::geofence::GeofenceData* temp = geofence_data_;
+  geofence_data_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::geofence::GeofenceData* UploadGeofenceRequest::_internal_mutable_geofence_data() {
+  
+  if (geofence_data_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::geofence::GeofenceData>(GetArenaForAllocation());
+    geofence_data_ = p;
+  }
+  return geofence_data_;
+}
+inline ::mavsdk::rpc::geofence::GeofenceData* UploadGeofenceRequest::mutable_geofence_data() {
+  ::mavsdk::rpc::geofence::GeofenceData* _msg = _internal_mutable_geofence_data();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.geofence.UploadGeofenceRequest.geofence_data)
+  return _msg;
+}
+inline void UploadGeofenceRequest::set_allocated_geofence_data(::mavsdk::rpc::geofence::GeofenceData* geofence_data) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
+  if (message_arena == nullptr) {
+    delete geofence_data_;
+  }
+  if (geofence_data) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(geofence_data);
+    if (message_arena != submessage_arena) {
+      geofence_data = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, geofence_data, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  geofence_data_ = geofence_data;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.geofence.UploadGeofenceRequest.geofence_data)
 }
 
 // -------------------------------------------------------------------
@@ -1702,6 +2295,10 @@ inline void GeofenceResult::set_allocated_result_str(std::string* result_str) {
 
 // -------------------------------------------------------------------
 
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 
 // @@protoc_insertion_point(namespace_scope)
 
@@ -1711,15 +2308,15 @@ inline void GeofenceResult::set_allocated_result_str(std::string* result_str) {
 
 PROTOBUF_NAMESPACE_OPEN
 
-template <> struct is_proto_enum< ::mavsdk::rpc::geofence::Polygon_FenceType> : ::std::true_type {};
-template <>
-inline const EnumDescriptor* GetEnumDescriptor< ::mavsdk::rpc::geofence::Polygon_FenceType>() {
-  return ::mavsdk::rpc::geofence::Polygon_FenceType_descriptor();
-}
 template <> struct is_proto_enum< ::mavsdk::rpc::geofence::GeofenceResult_Result> : ::std::true_type {};
 template <>
 inline const EnumDescriptor* GetEnumDescriptor< ::mavsdk::rpc::geofence::GeofenceResult_Result>() {
   return ::mavsdk::rpc::geofence::GeofenceResult_Result_descriptor();
+}
+template <> struct is_proto_enum< ::mavsdk::rpc::geofence::FenceType> : ::std::true_type {};
+template <>
+inline const EnumDescriptor* GetEnumDescriptor< ::mavsdk::rpc::geofence::FenceType>() {
+  return ::mavsdk::rpc::geofence::FenceType_descriptor();
 }
 
 PROTOBUF_NAMESPACE_CLOSE


### PR DESCRIPTION
At the moment, Geofence plugin supports only polygon fences. This pull request adds support for circular fences. 