### PR TITLE
mission_raw: add method to import plan from string

### DIFF
--- a/src/mavsdk/plugins/mission_raw/include/plugins/mission_raw/mission_raw.h
+++ b/src/mavsdk/plugins/mission_raw/include/plugins/mission_raw/mission_raw.h
@@ -417,7 +417,7 @@ public:
     void unsubscribe_mission_changed(MissionChangedHandle handle);
 
     /**
-     * @brief Import a QGroundControl missions in JSON .plan format.
+     * @brief Import a QGroundControl missions in JSON .plan format, from a file.
      *
      * Supported:
      * - Waypoints
@@ -431,6 +431,22 @@ public:
      */
     std::pair<Result, MissionRaw::MissionImportData>
     import_qgroundcontrol_mission(std::string qgc_plan_path) const;
+
+    /**
+     * @brief Import a QGroundControl missions in JSON .plan format, from a string.
+     *
+     * Supported:
+     * - Waypoints
+     * - Survey
+     * Not supported:
+     * - Structure Scan
+     *
+     * This function is blocking.
+     *
+     * @return Result of request.
+     */
+    std::pair<Result, MissionRaw::MissionImportData>
+    import_qgroundcontrol_mission_from_string(std::string qgc_plan) const;
 
     /**
      * @brief Copy constructor.

--- a/src/mavsdk/plugins/mission_raw/mission_raw.cpp
+++ b/src/mavsdk/plugins/mission_raw/mission_raw.cpp
@@ -152,6 +152,12 @@ MissionRaw::import_qgroundcontrol_mission(std::string qgc_plan_path) const
     return _impl->import_qgroundcontrol_mission(qgc_plan_path);
 }
 
+std::pair<MissionRaw::Result, MissionRaw::MissionImportData>
+MissionRaw::import_qgroundcontrol_mission_from_string(std::string qgc_plan) const
+{
+    return _impl->import_qgroundcontrol_mission_from_string(qgc_plan);
+}
+
 bool operator==(const MissionRaw::MissionProgress& lhs, const MissionRaw::MissionProgress& rhs)
 {
     return (rhs.current == lhs.current) && (rhs.total == lhs.total);

--- a/src/mavsdk/plugins/mission_raw/mission_raw_impl.cpp
+++ b/src/mavsdk/plugins/mission_raw/mission_raw_impl.cpp
@@ -543,6 +543,12 @@ MissionRawImpl::import_qgroundcontrol_mission(std::string qgc_plan_path)
     return MissionImport::parse_json(buf.str(), _parent->autopilot());
 }
 
+std::pair<MissionRaw::Result, MissionRaw::MissionImportData>
+MissionRawImpl::import_qgroundcontrol_mission_from_string(const std::string& qgc_plan)
+{
+    return MissionImport::parse_json(qgc_plan, _parent->autopilot());
+}
+
 MissionRaw::Result MissionRawImpl::convert_result(MavlinkMissionTransfer::Result result)
 {
     switch (result) {

--- a/src/mavsdk/plugins/mission_raw/mission_raw_impl.h
+++ b/src/mavsdk/plugins/mission_raw/mission_raw_impl.h
@@ -65,6 +65,9 @@ public:
     std::pair<MissionRaw::Result, MissionRaw::MissionImportData>
     import_qgroundcontrol_mission(std::string qgc_plan_path);
 
+    std::pair<MissionRaw::Result, MissionRaw::MissionImportData>
+    import_qgroundcontrol_mission_from_string(const std::string& qgc_plan);
+
 #if 0
     void import_qgroundcontrol_mission_async(
         std::string qgc_plan_path, const MissionRaw::ImportQgroundcontrolMissionCallback callback);

--- a/src/mavsdk_server/src/generated/mission_raw/mission_raw.grpc.pb.cc
+++ b/src/mavsdk_server/src/generated/mission_raw/mission_raw.grpc.pb.cc
@@ -37,6 +37,7 @@ static const char* MissionRawService_method_names[] = {
   "/mavsdk.rpc.mission_raw.MissionRawService/SubscribeMissionProgress",
   "/mavsdk.rpc.mission_raw.MissionRawService/SubscribeMissionChanged",
   "/mavsdk.rpc.mission_raw.MissionRawService/ImportQgroundcontrolMission",
+  "/mavsdk.rpc.mission_raw.MissionRawService/ImportQgroundcontrolMissionFromString",
 };
 
 std::unique_ptr< MissionRawService::Stub> MissionRawService::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
@@ -59,6 +60,7 @@ MissionRawService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& 
   , rpcmethod_SubscribeMissionProgress_(MissionRawService_method_names[10], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
   , rpcmethod_SubscribeMissionChanged_(MissionRawService_method_names[11], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
   , rpcmethod_ImportQgroundcontrolMission_(MissionRawService_method_names[12], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ImportQgroundcontrolMissionFromString_(MissionRawService_method_names[13], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status MissionRawService::Stub::UploadMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::UploadMissionRequest& request, ::mavsdk::rpc::mission_raw::UploadMissionResponse* response) {
@@ -346,6 +348,29 @@ void MissionRawService::Stub::async::ImportQgroundcontrolMission(::grpc::ClientC
   return result;
 }
 
+::grpc::Status MissionRawService::Stub::ImportQgroundcontrolMissionFromString(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest& request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_ImportQgroundcontrolMissionFromString_, context, request, response);
+}
+
+void MissionRawService::Stub::async::ImportQgroundcontrolMissionFromString(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_ImportQgroundcontrolMissionFromString_, context, request, response, std::move(f));
+}
+
+void MissionRawService::Stub::async::ImportQgroundcontrolMissionFromString(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_ImportQgroundcontrolMissionFromString_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>* MissionRawService::Stub::PrepareAsyncImportQgroundcontrolMissionFromStringRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_ImportQgroundcontrolMissionFromString_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>* MissionRawService::Stub::AsyncImportQgroundcontrolMissionFromStringRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncImportQgroundcontrolMissionFromStringRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
 MissionRawService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       MissionRawService_method_names[0],
@@ -477,6 +502,16 @@ MissionRawService::Service::Service() {
              ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse* resp) {
                return service->ImportQgroundcontrolMission(ctx, req, resp);
              }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      MissionRawService_method_names[13],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< MissionRawService::Service, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](MissionRawService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* req,
+             ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* resp) {
+               return service->ImportQgroundcontrolMissionFromString(ctx, req, resp);
+             }, this)));
 }
 
 MissionRawService::Service::~Service() {
@@ -567,6 +602,13 @@ MissionRawService::Service::~Service() {
 }
 
 ::grpc::Status MissionRawService::Service::ImportQgroundcontrolMission(::grpc::ServerContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status MissionRawService::Service::ImportQgroundcontrolMissionFromString(::grpc::ServerContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/src/mavsdk_server/src/generated/mission_raw/mission_raw.grpc.pb.h
+++ b/src/mavsdk_server/src/generated/mission_raw/mission_raw.grpc.pb.h
@@ -169,7 +169,7 @@ class MissionRawService final {
       return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::mission_raw::MissionChangedResponse>>(PrepareAsyncSubscribeMissionChangedRaw(context, request, cq));
     }
     //
-    // Import a QGroundControl missions in JSON .plan format.
+    // Import a QGroundControl missions in JSON .plan format, from a file.
     //
     // Supported:
     // - Waypoints
@@ -182,6 +182,21 @@ class MissionRawService final {
     }
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse>> PrepareAsyncImportQgroundcontrolMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse>>(PrepareAsyncImportQgroundcontrolMissionRaw(context, request, cq));
+    }
+    //
+    // Import a QGroundControl missions in JSON .plan format, from a string.
+    //
+    // Supported:
+    // - Waypoints
+    // - Survey
+    // Not supported:
+    // - Structure Scan
+    virtual ::grpc::Status ImportQgroundcontrolMissionFromString(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest& request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>> AsyncImportQgroundcontrolMissionFromString(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>>(AsyncImportQgroundcontrolMissionFromStringRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>> PrepareAsyncImportQgroundcontrolMissionFromString(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>>(PrepareAsyncImportQgroundcontrolMissionFromStringRaw(context, request, cq));
     }
     class async_interface {
      public:
@@ -251,7 +266,7 @@ class MissionRawService final {
       // @param callback Callback to notify about change.
       virtual void SubscribeMissionChanged(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::SubscribeMissionChangedRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::mission_raw::MissionChangedResponse>* reactor) = 0;
       //
-      // Import a QGroundControl missions in JSON .plan format.
+      // Import a QGroundControl missions in JSON .plan format, from a file.
       //
       // Supported:
       // - Waypoints
@@ -260,6 +275,16 @@ class MissionRawService final {
       // - Structure Scan
       virtual void ImportQgroundcontrolMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void ImportQgroundcontrolMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      //
+      // Import a QGroundControl missions in JSON .plan format, from a string.
+      //
+      // Supported:
+      // - Waypoints
+      // - Survey
+      // Not supported:
+      // - Structure Scan
+      virtual void ImportQgroundcontrolMissionFromString(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void ImportQgroundcontrolMissionFromString(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
     };
     typedef class async_interface experimental_async_interface;
     virtual class async_interface* async() { return nullptr; }
@@ -293,6 +318,8 @@ class MissionRawService final {
     virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::mission_raw::MissionChangedResponse>* PrepareAsyncSubscribeMissionChangedRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::SubscribeMissionChangedRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse>* AsyncImportQgroundcontrolMissionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse>* PrepareAsyncImportQgroundcontrolMissionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>* AsyncImportQgroundcontrolMissionFromStringRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>* PrepareAsyncImportQgroundcontrolMissionFromStringRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest& request, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
@@ -392,6 +419,13 @@ class MissionRawService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse>> PrepareAsyncImportQgroundcontrolMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse>>(PrepareAsyncImportQgroundcontrolMissionRaw(context, request, cq));
     }
+    ::grpc::Status ImportQgroundcontrolMissionFromString(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest& request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>> AsyncImportQgroundcontrolMissionFromString(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>>(AsyncImportQgroundcontrolMissionFromStringRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>> PrepareAsyncImportQgroundcontrolMissionFromString(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>>(PrepareAsyncImportQgroundcontrolMissionFromStringRaw(context, request, cq));
+    }
     class async final :
       public StubInterface::async_interface {
      public:
@@ -419,6 +453,8 @@ class MissionRawService final {
       void SubscribeMissionChanged(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::SubscribeMissionChangedRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::mission_raw::MissionChangedResponse>* reactor) override;
       void ImportQgroundcontrolMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse* response, std::function<void(::grpc::Status)>) override;
       void ImportQgroundcontrolMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void ImportQgroundcontrolMissionFromString(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* response, std::function<void(::grpc::Status)>) override;
+      void ImportQgroundcontrolMissionFromString(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
      private:
       friend class Stub;
       explicit async(Stub* stub): stub_(stub) { }
@@ -458,6 +494,8 @@ class MissionRawService final {
     ::grpc::ClientAsyncReader< ::mavsdk::rpc::mission_raw::MissionChangedResponse>* PrepareAsyncSubscribeMissionChangedRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::SubscribeMissionChangedRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse>* AsyncImportQgroundcontrolMissionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse>* PrepareAsyncImportQgroundcontrolMissionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>* AsyncImportQgroundcontrolMissionFromStringRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>* PrepareAsyncImportQgroundcontrolMissionFromStringRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_UploadMission_;
     const ::grpc::internal::RpcMethod rpcmethod_UploadGeofence_;
     const ::grpc::internal::RpcMethod rpcmethod_UploadRallyPoints_;
@@ -471,6 +509,7 @@ class MissionRawService final {
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeMissionProgress_;
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeMissionChanged_;
     const ::grpc::internal::RpcMethod rpcmethod_ImportQgroundcontrolMission_;
+    const ::grpc::internal::RpcMethod rpcmethod_ImportQgroundcontrolMissionFromString_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
 
@@ -533,7 +572,7 @@ class MissionRawService final {
     // @param callback Callback to notify about change.
     virtual ::grpc::Status SubscribeMissionChanged(::grpc::ServerContext* context, const ::mavsdk::rpc::mission_raw::SubscribeMissionChangedRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::mission_raw::MissionChangedResponse>* writer);
     //
-    // Import a QGroundControl missions in JSON .plan format.
+    // Import a QGroundControl missions in JSON .plan format, from a file.
     //
     // Supported:
     // - Waypoints
@@ -541,6 +580,15 @@ class MissionRawService final {
     // Not supported:
     // - Structure Scan
     virtual ::grpc::Status ImportQgroundcontrolMission(::grpc::ServerContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse* response);
+    //
+    // Import a QGroundControl missions in JSON .plan format, from a string.
+    //
+    // Supported:
+    // - Waypoints
+    // - Survey
+    // Not supported:
+    // - Structure Scan
+    virtual ::grpc::Status ImportQgroundcontrolMissionFromString(::grpc::ServerContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* response);
   };
   template <class BaseClass>
   class WithAsyncMethod_UploadMission : public BaseClass {
@@ -802,7 +850,27 @@ class MissionRawService final {
       ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_UploadMission<WithAsyncMethod_UploadGeofence<WithAsyncMethod_UploadRallyPoints<WithAsyncMethod_CancelMissionUpload<WithAsyncMethod_DownloadMission<WithAsyncMethod_CancelMissionDownload<WithAsyncMethod_StartMission<WithAsyncMethod_PauseMission<WithAsyncMethod_ClearMission<WithAsyncMethod_SetCurrentMissionItem<WithAsyncMethod_SubscribeMissionProgress<WithAsyncMethod_SubscribeMissionChanged<WithAsyncMethod_ImportQgroundcontrolMission<Service > > > > > > > > > > > > > AsyncService;
+  template <class BaseClass>
+  class WithAsyncMethod_ImportQgroundcontrolMissionFromString : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_ImportQgroundcontrolMissionFromString() {
+      ::grpc::Service::MarkMethodAsync(13);
+    }
+    ~WithAsyncMethod_ImportQgroundcontrolMissionFromString() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status ImportQgroundcontrolMissionFromString(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* /*request*/, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestImportQgroundcontrolMissionFromString(::grpc::ServerContext* context, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  typedef WithAsyncMethod_UploadMission<WithAsyncMethod_UploadGeofence<WithAsyncMethod_UploadRallyPoints<WithAsyncMethod_CancelMissionUpload<WithAsyncMethod_DownloadMission<WithAsyncMethod_CancelMissionDownload<WithAsyncMethod_StartMission<WithAsyncMethod_PauseMission<WithAsyncMethod_ClearMission<WithAsyncMethod_SetCurrentMissionItem<WithAsyncMethod_SubscribeMissionProgress<WithAsyncMethod_SubscribeMissionChanged<WithAsyncMethod_ImportQgroundcontrolMission<WithAsyncMethod_ImportQgroundcontrolMissionFromString<Service > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_UploadMission : public BaseClass {
    private:
@@ -1144,7 +1212,34 @@ class MissionRawService final {
     virtual ::grpc::ServerUnaryReactor* ImportQgroundcontrolMission(
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest* /*request*/, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_UploadMission<WithCallbackMethod_UploadGeofence<WithCallbackMethod_UploadRallyPoints<WithCallbackMethod_CancelMissionUpload<WithCallbackMethod_DownloadMission<WithCallbackMethod_CancelMissionDownload<WithCallbackMethod_StartMission<WithCallbackMethod_PauseMission<WithCallbackMethod_ClearMission<WithCallbackMethod_SetCurrentMissionItem<WithCallbackMethod_SubscribeMissionProgress<WithCallbackMethod_SubscribeMissionChanged<WithCallbackMethod_ImportQgroundcontrolMission<Service > > > > > > > > > > > > > CallbackService;
+  template <class BaseClass>
+  class WithCallbackMethod_ImportQgroundcontrolMissionFromString : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_ImportQgroundcontrolMissionFromString() {
+      ::grpc::Service::MarkMethodCallback(13,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* response) { return this->ImportQgroundcontrolMissionFromString(context, request, response); }));}
+    void SetMessageAllocatorFor_ImportQgroundcontrolMissionFromString(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(13);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_ImportQgroundcontrolMissionFromString() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status ImportQgroundcontrolMissionFromString(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* /*request*/, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* ImportQgroundcontrolMissionFromString(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* /*request*/, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* /*response*/)  { return nullptr; }
+  };
+  typedef WithCallbackMethod_UploadMission<WithCallbackMethod_UploadGeofence<WithCallbackMethod_UploadRallyPoints<WithCallbackMethod_CancelMissionUpload<WithCallbackMethod_DownloadMission<WithCallbackMethod_CancelMissionDownload<WithCallbackMethod_StartMission<WithCallbackMethod_PauseMission<WithCallbackMethod_ClearMission<WithCallbackMethod_SetCurrentMissionItem<WithCallbackMethod_SubscribeMissionProgress<WithCallbackMethod_SubscribeMissionChanged<WithCallbackMethod_ImportQgroundcontrolMission<WithCallbackMethod_ImportQgroundcontrolMissionFromString<Service > > > > > > > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_UploadMission : public BaseClass {
@@ -1363,6 +1458,23 @@ class MissionRawService final {
     }
     // disable synchronous version of this method
     ::grpc::Status ImportQgroundcontrolMission(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest* /*request*/, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_ImportQgroundcontrolMissionFromString : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_ImportQgroundcontrolMissionFromString() {
+      ::grpc::Service::MarkMethodGeneric(13);
+    }
+    ~WithGenericMethod_ImportQgroundcontrolMissionFromString() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status ImportQgroundcontrolMissionFromString(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* /*request*/, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -1625,6 +1737,26 @@ class MissionRawService final {
     }
     void RequestImportQgroundcontrolMission(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_ImportQgroundcontrolMissionFromString : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_ImportQgroundcontrolMissionFromString() {
+      ::grpc::Service::MarkMethodRaw(13);
+    }
+    ~WithRawMethod_ImportQgroundcontrolMissionFromString() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status ImportQgroundcontrolMissionFromString(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* /*request*/, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestImportQgroundcontrolMissionFromString(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1911,6 +2043,28 @@ class MissionRawService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     virtual ::grpc::ServerUnaryReactor* ImportQgroundcontrolMission(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_ImportQgroundcontrolMissionFromString : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_ImportQgroundcontrolMissionFromString() {
+      ::grpc::Service::MarkMethodRawCallback(13,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->ImportQgroundcontrolMissionFromString(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_ImportQgroundcontrolMissionFromString() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status ImportQgroundcontrolMissionFromString(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* /*request*/, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* ImportQgroundcontrolMissionFromString(
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
@@ -2210,7 +2364,34 @@ class MissionRawService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedImportQgroundcontrolMission(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest,::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_UploadMission<WithStreamedUnaryMethod_UploadGeofence<WithStreamedUnaryMethod_UploadRallyPoints<WithStreamedUnaryMethod_CancelMissionUpload<WithStreamedUnaryMethod_DownloadMission<WithStreamedUnaryMethod_CancelMissionDownload<WithStreamedUnaryMethod_StartMission<WithStreamedUnaryMethod_PauseMission<WithStreamedUnaryMethod_ClearMission<WithStreamedUnaryMethod_SetCurrentMissionItem<WithStreamedUnaryMethod_ImportQgroundcontrolMission<Service > > > > > > > > > > > StreamedUnaryService;
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_ImportQgroundcontrolMissionFromString : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_ImportQgroundcontrolMissionFromString() {
+      ::grpc::Service::MarkMethodStreamed(13,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>* streamer) {
+                       return this->StreamedImportQgroundcontrolMissionFromString(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_ImportQgroundcontrolMissionFromString() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status ImportQgroundcontrolMissionFromString(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* /*request*/, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedImportQgroundcontrolMissionFromString(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest,::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>* server_unary_streamer) = 0;
+  };
+  typedef WithStreamedUnaryMethod_UploadMission<WithStreamedUnaryMethod_UploadGeofence<WithStreamedUnaryMethod_UploadRallyPoints<WithStreamedUnaryMethod_CancelMissionUpload<WithStreamedUnaryMethod_DownloadMission<WithStreamedUnaryMethod_CancelMissionDownload<WithStreamedUnaryMethod_StartMission<WithStreamedUnaryMethod_PauseMission<WithStreamedUnaryMethod_ClearMission<WithStreamedUnaryMethod_SetCurrentMissionItem<WithStreamedUnaryMethod_ImportQgroundcontrolMission<WithStreamedUnaryMethod_ImportQgroundcontrolMissionFromString<Service > > > > > > > > > > > > StreamedUnaryService;
   template <class BaseClass>
   class WithSplitStreamingMethod_SubscribeMissionProgress : public BaseClass {
    private:
@@ -2266,7 +2447,7 @@ class MissionRawService final {
     virtual ::grpc::Status StreamedSubscribeMissionChanged(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::mission_raw::SubscribeMissionChangedRequest,::mavsdk::rpc::mission_raw::MissionChangedResponse>* server_split_streamer) = 0;
   };
   typedef WithSplitStreamingMethod_SubscribeMissionProgress<WithSplitStreamingMethod_SubscribeMissionChanged<Service > > SplitStreamedService;
-  typedef WithStreamedUnaryMethod_UploadMission<WithStreamedUnaryMethod_UploadGeofence<WithStreamedUnaryMethod_UploadRallyPoints<WithStreamedUnaryMethod_CancelMissionUpload<WithStreamedUnaryMethod_DownloadMission<WithStreamedUnaryMethod_CancelMissionDownload<WithStreamedUnaryMethod_StartMission<WithStreamedUnaryMethod_PauseMission<WithStreamedUnaryMethod_ClearMission<WithStreamedUnaryMethod_SetCurrentMissionItem<WithSplitStreamingMethod_SubscribeMissionProgress<WithSplitStreamingMethod_SubscribeMissionChanged<WithStreamedUnaryMethod_ImportQgroundcontrolMission<Service > > > > > > > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_UploadMission<WithStreamedUnaryMethod_UploadGeofence<WithStreamedUnaryMethod_UploadRallyPoints<WithStreamedUnaryMethod_CancelMissionUpload<WithStreamedUnaryMethod_DownloadMission<WithStreamedUnaryMethod_CancelMissionDownload<WithStreamedUnaryMethod_StartMission<WithStreamedUnaryMethod_PauseMission<WithStreamedUnaryMethod_ClearMission<WithStreamedUnaryMethod_SetCurrentMissionItem<WithSplitStreamingMethod_SubscribeMissionProgress<WithSplitStreamingMethod_SubscribeMissionChanged<WithStreamedUnaryMethod_ImportQgroundcontrolMission<WithStreamedUnaryMethod_ImportQgroundcontrolMissionFromString<Service > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace mission_raw

--- a/src/mavsdk_server/src/generated/mission_raw/mission_raw.pb.cc
+++ b/src/mavsdk_server/src/generated/mission_raw/mission_raw.pb.cc
@@ -329,6 +329,31 @@ struct ImportQgroundcontrolMissionResponseDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ImportQgroundcontrolMissionResponseDefaultTypeInternal _ImportQgroundcontrolMissionResponse_default_instance_;
+PROTOBUF_CONSTEXPR ImportQgroundcontrolMissionFromStringRequest::ImportQgroundcontrolMissionFromStringRequest(
+    ::_pbi::ConstantInitialized)
+  : qgc_plan_(&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}){}
+struct ImportQgroundcontrolMissionFromStringRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR ImportQgroundcontrolMissionFromStringRequestDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~ImportQgroundcontrolMissionFromStringRequestDefaultTypeInternal() {}
+  union {
+    ImportQgroundcontrolMissionFromStringRequest _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ImportQgroundcontrolMissionFromStringRequestDefaultTypeInternal _ImportQgroundcontrolMissionFromStringRequest_default_instance_;
+PROTOBUF_CONSTEXPR ImportQgroundcontrolMissionFromStringResponse::ImportQgroundcontrolMissionFromStringResponse(
+    ::_pbi::ConstantInitialized)
+  : mission_raw_result_(nullptr)
+  , mission_import_data_(nullptr){}
+struct ImportQgroundcontrolMissionFromStringResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR ImportQgroundcontrolMissionFromStringResponseDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~ImportQgroundcontrolMissionFromStringResponseDefaultTypeInternal() {}
+  union {
+    ImportQgroundcontrolMissionFromStringResponse _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ImportQgroundcontrolMissionFromStringResponseDefaultTypeInternal _ImportQgroundcontrolMissionFromStringResponse_default_instance_;
 PROTOBUF_CONSTEXPR MissionProgress::MissionProgress(
     ::_pbi::ConstantInitialized)
   : current_(0)
@@ -397,7 +422,7 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORIT
 }  // namespace mission_raw
 }  // namespace rpc
 }  // namespace mavsdk
-static ::_pb::Metadata file_level_metadata_mission_5fraw_2fmission_5fraw_2eproto[30];
+static ::_pb::Metadata file_level_metadata_mission_5fraw_2fmission_5fraw_2eproto[32];
 static const ::_pb::EnumDescriptor* file_level_enum_descriptors_mission_5fraw_2fmission_5fraw_2eproto[1];
 static constexpr ::_pb::ServiceDescriptor const** file_level_service_descriptors_mission_5fraw_2fmission_5fraw_2eproto = nullptr;
 
@@ -579,6 +604,21 @@ const uint32_t TableStruct_mission_5fraw_2fmission_5fraw_2eproto::offsets[] PROT
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse, mission_raw_result_),
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse, mission_import_data_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest, qgc_plan_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse, mission_raw_result_),
+  PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse, mission_import_data_),
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw::MissionProgress, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -650,10 +690,12 @@ static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protode
   { 154, -1, -1, sizeof(::mavsdk::rpc::mission_raw::MissionChangedResponse)},
   { 161, -1, -1, sizeof(::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest)},
   { 168, -1, -1, sizeof(::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse)},
-  { 176, -1, -1, sizeof(::mavsdk::rpc::mission_raw::MissionProgress)},
-  { 184, -1, -1, sizeof(::mavsdk::rpc::mission_raw::MissionItem)},
-  { 203, -1, -1, sizeof(::mavsdk::rpc::mission_raw::MissionImportData)},
-  { 212, -1, -1, sizeof(::mavsdk::rpc::mission_raw::MissionRawResult)},
+  { 176, -1, -1, sizeof(::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest)},
+  { 183, -1, -1, sizeof(::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse)},
+  { 191, -1, -1, sizeof(::mavsdk::rpc::mission_raw::MissionProgress)},
+  { 199, -1, -1, sizeof(::mavsdk::rpc::mission_raw::MissionItem)},
+  { 218, -1, -1, sizeof(::mavsdk::rpc::mission_raw::MissionImportData)},
+  { 227, -1, -1, sizeof(::mavsdk::rpc::mission_raw::MissionRawResult)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
@@ -683,6 +725,8 @@ static const ::_pb::Message* const file_default_instances[] = {
   &::mavsdk::rpc::mission_raw::_MissionChangedResponse_default_instance_._instance,
   &::mavsdk::rpc::mission_raw::_ImportQgroundcontrolMissionRequest_default_instance_._instance,
   &::mavsdk::rpc::mission_raw::_ImportQgroundcontrolMissionResponse_default_instance_._instance,
+  &::mavsdk::rpc::mission_raw::_ImportQgroundcontrolMissionFromStringRequest_default_instance_._instance,
+  &::mavsdk::rpc::mission_raw::_ImportQgroundcontrolMissionFromStringResponse_default_instance_._instance,
   &::mavsdk::rpc::mission_raw::_MissionProgress_default_instance_._instance,
   &::mavsdk::rpc::mission_raw::_MissionItem_default_instance_._instance,
   &::mavsdk::rpc::mission_raw::_MissionImportData_default_instance_._instance,
@@ -740,87 +784,98 @@ const char descriptor_table_protodef_mission_5fraw_2fmission_5fraw_2eproto[] PRO
   "onResponse\022D\n\022mission_raw_result\030\001 \001(\0132("
   ".mavsdk.rpc.mission_raw.MissionRawResult"
   "\022F\n\023mission_import_data\030\002 \001(\0132).mavsdk.r"
-  "pc.mission_raw.MissionImportData\"1\n\017Miss"
-  "ionProgress\022\017\n\007current\030\001 \001(\005\022\r\n\005total\030\002 "
-  "\001(\005\"\330\001\n\013MissionItem\022\013\n\003seq\030\001 \001(\r\022\r\n\005fram"
-  "e\030\002 \001(\r\022\017\n\007command\030\003 \001(\r\022\017\n\007current\030\004 \001("
-  "\r\022\024\n\014autocontinue\030\005 \001(\r\022\016\n\006param1\030\006 \001(\002\022"
-  "\016\n\006param2\030\007 \001(\002\022\016\n\006param3\030\010 \001(\002\022\016\n\006param"
-  "4\030\t \001(\002\022\t\n\001x\030\n \001(\005\022\t\n\001y\030\013 \001(\005\022\t\n\001z\030\014 \001(\002"
-  "\022\024\n\014mission_type\030\r \001(\r\"\306\001\n\021MissionImport"
-  "Data\022:\n\rmission_items\030\001 \003(\0132#.mavsdk.rpc"
-  ".mission_raw.MissionItem\022;\n\016geofence_ite"
-  "ms\030\002 \003(\0132#.mavsdk.rpc.mission_raw.Missio"
-  "nItem\0228\n\013rally_items\030\003 \003(\0132#.mavsdk.rpc."
-  "mission_raw.MissionItem\"\376\004\n\020MissionRawRe"
-  "sult\022\?\n\006result\030\001 \001(\0162/.mavsdk.rpc.missio"
-  "n_raw.MissionRawResult.Result\022\022\n\nresult_"
-  "str\030\002 \001(\t\"\224\004\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000"
-  "\022\022\n\016RESULT_SUCCESS\020\001\022\020\n\014RESULT_ERROR\020\002\022!"
-  "\n\035RESULT_TOO_MANY_MISSION_ITEMS\020\003\022\017\n\013RES"
-  "ULT_BUSY\020\004\022\022\n\016RESULT_TIMEOUT\020\005\022\033\n\027RESULT"
-  "_INVALID_ARGUMENT\020\006\022\026\n\022RESULT_UNSUPPORTE"
-  "D\020\007\022\037\n\033RESULT_NO_MISSION_AVAILABLE\020\010\022\035\n\031"
-  "RESULT_TRANSFER_CANCELLED\020\t\022\"\n\036RESULT_FA"
-  "ILED_TO_OPEN_QGC_PLAN\020\n\022#\n\037RESULT_FAILED"
-  "_TO_PARSE_QGC_PLAN\020\013\022\024\n\020RESULT_NO_SYSTEM"
-  "\020\014\022\021\n\rRESULT_DENIED\020\r\022&\n\"RESULT_MISSION_"
-  "TYPE_NOT_CONSISTENT\020\016\022\033\n\027RESULT_INVALID_"
-  "SEQUENCE\020\017\022\032\n\026RESULT_CURRENT_INVALID\020\020\022\031"
-  "\n\025RESULT_PROTOCOL_ERROR\020\021\022%\n!RESULT_INT_"
-  "MESSAGES_NOT_SUPPORTED\020\0222\202\r\n\021MissionRawS"
-  "ervice\022n\n\rUploadMission\022,.mavsdk.rpc.mis"
-  "sion_raw.UploadMissionRequest\032-.mavsdk.r"
-  "pc.mission_raw.UploadMissionResponse\"\000\022q"
-  "\n\016UploadGeofence\022-.mavsdk.rpc.mission_ra"
-  "w.UploadGeofenceRequest\032..mavsdk.rpc.mis"
-  "sion_raw.UploadGeofenceResponse\"\000\022z\n\021Upl"
-  "oadRallyPoints\0220.mavsdk.rpc.mission_raw."
-  "UploadRallyPointsRequest\0321.mavsdk.rpc.mi"
-  "ssion_raw.UploadRallyPointsResponse\"\000\022\204\001"
-  "\n\023CancelMissionUpload\0222.mavsdk.rpc.missi"
-  "on_raw.CancelMissionUploadRequest\0323.mavs"
-  "dk.rpc.mission_raw.CancelMissionUploadRe"
-  "sponse\"\004\200\265\030\001\022t\n\017DownloadMission\022..mavsdk"
-  ".rpc.mission_raw.DownloadMissionRequest\032"
-  "/.mavsdk.rpc.mission_raw.DownloadMission"
-  "Response\"\000\022\212\001\n\025CancelMissionDownload\0224.m"
-  "avsdk.rpc.mission_raw.CancelMissionDownl"
-  "oadRequest\0325.mavsdk.rpc.mission_raw.Canc"
-  "elMissionDownloadResponse\"\004\200\265\030\001\022k\n\014Start"
-  "Mission\022+.mavsdk.rpc.mission_raw.StartMi"
-  "ssionRequest\032,.mavsdk.rpc.mission_raw.St"
-  "artMissionResponse\"\000\022k\n\014PauseMission\022+.m"
-  "avsdk.rpc.mission_raw.PauseMissionReques"
-  "t\032,.mavsdk.rpc.mission_raw.PauseMissionR"
-  "esponse\"\000\022k\n\014ClearMission\022+.mavsdk.rpc.m"
-  "ission_raw.ClearMissionRequest\032,.mavsdk."
-  "rpc.mission_raw.ClearMissionResponse\"\000\022\206"
-  "\001\n\025SetCurrentMissionItem\0224.mavsdk.rpc.mi"
-  "ssion_raw.SetCurrentMissionItemRequest\0325"
-  ".mavsdk.rpc.mission_raw.SetCurrentMissio"
-  "nItemResponse\"\000\022\210\001\n\030SubscribeMissionProg"
-  "ress\0227.mavsdk.rpc.mission_raw.SubscribeM"
-  "issionProgressRequest\032/.mavsdk.rpc.missi"
-  "on_raw.MissionProgressResponse\"\0000\001\022\211\001\n\027S"
-  "ubscribeMissionChanged\0226.mavsdk.rpc.miss"
-  "ion_raw.SubscribeMissionChangedRequest\032."
-  ".mavsdk.rpc.mission_raw.MissionChangedRe"
-  "sponse\"\004\200\265\030\0000\001\022\234\001\n\033ImportQgroundcontrolM"
-  "ission\022:.mavsdk.rpc.mission_raw.ImportQg"
-  "roundcontrolMissionRequest\032;.mavsdk.rpc."
-  "mission_raw.ImportQgroundcontrolMissionR"
-  "esponse\"\004\200\265\030\001B(\n\025io.mavsdk.mission_rawB\017"
-  "MissionRawProtob\006proto3"
+  "pc.mission_raw.MissionImportData\"@\n,Impo"
+  "rtQgroundcontrolMissionFromStringRequest"
+  "\022\020\n\010qgc_plan\030\001 \001(\t\"\275\001\n-ImportQgroundcont"
+  "rolMissionFromStringResponse\022D\n\022mission_"
+  "raw_result\030\001 \001(\0132(.mavsdk.rpc.mission_ra"
+  "w.MissionRawResult\022F\n\023mission_import_dat"
+  "a\030\002 \001(\0132).mavsdk.rpc.mission_raw.Mission"
+  "ImportData\"1\n\017MissionProgress\022\017\n\007current"
+  "\030\001 \001(\005\022\r\n\005total\030\002 \001(\005\"\330\001\n\013MissionItem\022\013\n"
+  "\003seq\030\001 \001(\r\022\r\n\005frame\030\002 \001(\r\022\017\n\007command\030\003 \001"
+  "(\r\022\017\n\007current\030\004 \001(\r\022\024\n\014autocontinue\030\005 \001("
+  "\r\022\016\n\006param1\030\006 \001(\002\022\016\n\006param2\030\007 \001(\002\022\016\n\006par"
+  "am3\030\010 \001(\002\022\016\n\006param4\030\t \001(\002\022\t\n\001x\030\n \001(\005\022\t\n\001"
+  "y\030\013 \001(\005\022\t\n\001z\030\014 \001(\002\022\024\n\014mission_type\030\r \001(\r"
+  "\"\306\001\n\021MissionImportData\022:\n\rmission_items\030"
+  "\001 \003(\0132#.mavsdk.rpc.mission_raw.MissionIt"
+  "em\022;\n\016geofence_items\030\002 \003(\0132#.mavsdk.rpc."
+  "mission_raw.MissionItem\0228\n\013rally_items\030\003"
+  " \003(\0132#.mavsdk.rpc.mission_raw.MissionIte"
+  "m\"\376\004\n\020MissionRawResult\022\?\n\006result\030\001 \001(\0162/"
+  ".mavsdk.rpc.mission_raw.MissionRawResult"
+  ".Result\022\022\n\nresult_str\030\002 \001(\t\"\224\004\n\006Result\022\022"
+  "\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\020"
+  "\n\014RESULT_ERROR\020\002\022!\n\035RESULT_TOO_MANY_MISS"
+  "ION_ITEMS\020\003\022\017\n\013RESULT_BUSY\020\004\022\022\n\016RESULT_T"
+  "IMEOUT\020\005\022\033\n\027RESULT_INVALID_ARGUMENT\020\006\022\026\n"
+  "\022RESULT_UNSUPPORTED\020\007\022\037\n\033RESULT_NO_MISSI"
+  "ON_AVAILABLE\020\010\022\035\n\031RESULT_TRANSFER_CANCEL"
+  "LED\020\t\022\"\n\036RESULT_FAILED_TO_OPEN_QGC_PLAN\020"
+  "\n\022#\n\037RESULT_FAILED_TO_PARSE_QGC_PLAN\020\013\022\024"
+  "\n\020RESULT_NO_SYSTEM\020\014\022\021\n\rRESULT_DENIED\020\r\022"
+  "&\n\"RESULT_MISSION_TYPE_NOT_CONSISTENT\020\016\022"
+  "\033\n\027RESULT_INVALID_SEQUENCE\020\017\022\032\n\026RESULT_C"
+  "URRENT_INVALID\020\020\022\031\n\025RESULT_PROTOCOL_ERRO"
+  "R\020\021\022%\n!RESULT_INT_MESSAGES_NOT_SUPPORTED"
+  "\020\0222\277\016\n\021MissionRawService\022n\n\rUploadMissio"
+  "n\022,.mavsdk.rpc.mission_raw.UploadMission"
+  "Request\032-.mavsdk.rpc.mission_raw.UploadM"
+  "issionResponse\"\000\022q\n\016UploadGeofence\022-.mav"
+  "sdk.rpc.mission_raw.UploadGeofenceReques"
+  "t\032..mavsdk.rpc.mission_raw.UploadGeofenc"
+  "eResponse\"\000\022z\n\021UploadRallyPoints\0220.mavsd"
+  "k.rpc.mission_raw.UploadRallyPointsReque"
+  "st\0321.mavsdk.rpc.mission_raw.UploadRallyP"
+  "ointsResponse\"\000\022\204\001\n\023CancelMissionUpload\022"
+  "2.mavsdk.rpc.mission_raw.CancelMissionUp"
+  "loadRequest\0323.mavsdk.rpc.mission_raw.Can"
+  "celMissionUploadResponse\"\004\200\265\030\001\022t\n\017Downlo"
+  "adMission\022..mavsdk.rpc.mission_raw.Downl"
+  "oadMissionRequest\032/.mavsdk.rpc.mission_r"
+  "aw.DownloadMissionResponse\"\000\022\212\001\n\025CancelM"
+  "issionDownload\0224.mavsdk.rpc.mission_raw."
+  "CancelMissionDownloadRequest\0325.mavsdk.rp"
+  "c.mission_raw.CancelMissionDownloadRespo"
+  "nse\"\004\200\265\030\001\022k\n\014StartMission\022+.mavsdk.rpc.m"
+  "ission_raw.StartMissionRequest\032,.mavsdk."
+  "rpc.mission_raw.StartMissionResponse\"\000\022k"
+  "\n\014PauseMission\022+.mavsdk.rpc.mission_raw."
+  "PauseMissionRequest\032,.mavsdk.rpc.mission"
+  "_raw.PauseMissionResponse\"\000\022k\n\014ClearMiss"
+  "ion\022+.mavsdk.rpc.mission_raw.ClearMissio"
+  "nRequest\032,.mavsdk.rpc.mission_raw.ClearM"
+  "issionResponse\"\000\022\206\001\n\025SetCurrentMissionIt"
+  "em\0224.mavsdk.rpc.mission_raw.SetCurrentMi"
+  "ssionItemRequest\0325.mavsdk.rpc.mission_ra"
+  "w.SetCurrentMissionItemResponse\"\000\022\210\001\n\030Su"
+  "bscribeMissionProgress\0227.mavsdk.rpc.miss"
+  "ion_raw.SubscribeMissionProgressRequest\032"
+  "/.mavsdk.rpc.mission_raw.MissionProgress"
+  "Response\"\0000\001\022\211\001\n\027SubscribeMissionChanged"
+  "\0226.mavsdk.rpc.mission_raw.SubscribeMissi"
+  "onChangedRequest\032..mavsdk.rpc.mission_ra"
+  "w.MissionChangedResponse\"\004\200\265\030\0000\001\022\234\001\n\033Imp"
+  "ortQgroundcontrolMission\022:.mavsdk.rpc.mi"
+  "ssion_raw.ImportQgroundcontrolMissionReq"
+  "uest\032;.mavsdk.rpc.mission_raw.ImportQgro"
+  "undcontrolMissionResponse\"\004\200\265\030\001\022\272\001\n%Impo"
+  "rtQgroundcontrolMissionFromString\022D.mavs"
+  "dk.rpc.mission_raw.ImportQgroundcontrolM"
+  "issionFromStringRequest\032E.mavsdk.rpc.mis"
+  "sion_raw.ImportQgroundcontrolMissionFrom"
+  "StringResponse\"\004\200\265\030\001B(\n\025io.mavsdk.missio"
+  "n_rawB\017MissionRawProtob\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_deps[1] = {
   &::descriptor_table_mavsdk_5foptions_2eproto,
 };
 static ::_pbi::once_flag descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_mission_5fraw_2fmission_5fraw_2eproto = {
-    false, false, 4863, descriptor_table_protodef_mission_5fraw_2fmission_5fraw_2eproto,
+    false, false, 5310, descriptor_table_protodef_mission_5fraw_2fmission_5fraw_2eproto,
     "mission_raw/mission_raw.proto",
-    &descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_once, descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_deps, 1, 30,
+    &descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_once, descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_deps, 1, 32,
     schemas, file_default_instances, TableStruct_mission_5fraw_2fmission_5fraw_2eproto::offsets,
     file_level_metadata_mission_5fraw_2fmission_5fraw_2eproto, file_level_enum_descriptors_mission_5fraw_2fmission_5fraw_2eproto,
     file_level_service_descriptors_mission_5fraw_2fmission_5fraw_2eproto,
@@ -4600,6 +4655,436 @@ void ImportQgroundcontrolMissionResponse::InternalSwap(ImportQgroundcontrolMissi
 
 // ===================================================================
 
+class ImportQgroundcontrolMissionFromStringRequest::_Internal {
+ public:
+};
+
+ImportQgroundcontrolMissionFromStringRequest::ImportQgroundcontrolMissionFromStringRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor();
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringRequest)
+}
+ImportQgroundcontrolMissionFromStringRequest::ImportQgroundcontrolMissionFromStringRequest(const ImportQgroundcontrolMissionFromStringRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  qgc_plan_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    qgc_plan_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_qgc_plan().empty()) {
+    qgc_plan_.Set(from._internal_qgc_plan(), 
+      GetArenaForAllocation());
+  }
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringRequest)
+}
+
+inline void ImportQgroundcontrolMissionFromStringRequest::SharedCtor() {
+qgc_plan_.InitDefault();
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  qgc_plan_.Set("", GetArenaForAllocation());
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+}
+
+ImportQgroundcontrolMissionFromStringRequest::~ImportQgroundcontrolMissionFromStringRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringRequest)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void ImportQgroundcontrolMissionFromStringRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  qgc_plan_.Destroy();
+}
+
+void ImportQgroundcontrolMissionFromStringRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void ImportQgroundcontrolMissionFromStringRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringRequest)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  qgc_plan_.ClearToEmpty();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* ImportQgroundcontrolMissionFromStringRequest::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // string qgc_plan = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
+          auto str = _internal_mutable_qgc_plan();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringRequest.qgc_plan"));
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* ImportQgroundcontrolMissionFromStringRequest::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringRequest)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string qgc_plan = 1;
+  if (!this->_internal_qgc_plan().empty()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_qgc_plan().data(), static_cast<int>(this->_internal_qgc_plan().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringRequest.qgc_plan");
+    target = stream->WriteStringMaybeAliased(
+        1, this->_internal_qgc_plan(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringRequest)
+  return target;
+}
+
+size_t ImportQgroundcontrolMissionFromStringRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringRequest)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // string qgc_plan = 1;
+  if (!this->_internal_qgc_plan().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_qgc_plan());
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData ImportQgroundcontrolMissionFromStringRequest::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSizeCheck,
+    ImportQgroundcontrolMissionFromStringRequest::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*ImportQgroundcontrolMissionFromStringRequest::GetClassData() const { return &_class_data_; }
+
+void ImportQgroundcontrolMissionFromStringRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message* to,
+                      const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+  static_cast<ImportQgroundcontrolMissionFromStringRequest *>(to)->MergeFrom(
+      static_cast<const ImportQgroundcontrolMissionFromStringRequest &>(from));
+}
+
+
+void ImportQgroundcontrolMissionFromStringRequest::MergeFrom(const ImportQgroundcontrolMissionFromStringRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!from._internal_qgc_plan().empty()) {
+    _internal_set_qgc_plan(from._internal_qgc_plan());
+  }
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void ImportQgroundcontrolMissionFromStringRequest::CopyFrom(const ImportQgroundcontrolMissionFromStringRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ImportQgroundcontrolMissionFromStringRequest::IsInitialized() const {
+  return true;
+}
+
+void ImportQgroundcontrolMissionFromStringRequest::InternalSwap(ImportQgroundcontrolMissionFromStringRequest* other) {
+  using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &qgc_plan_, lhs_arena,
+      &other->qgc_plan_, rhs_arena
+  );
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata ImportQgroundcontrolMissionFromStringRequest::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_getter, &descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_once,
+      file_level_metadata_mission_5fraw_2fmission_5fraw_2eproto[26]);
+}
+
+// ===================================================================
+
+class ImportQgroundcontrolMissionFromStringResponse::_Internal {
+ public:
+  static const ::mavsdk::rpc::mission_raw::MissionRawResult& mission_raw_result(const ImportQgroundcontrolMissionFromStringResponse* msg);
+  static const ::mavsdk::rpc::mission_raw::MissionImportData& mission_import_data(const ImportQgroundcontrolMissionFromStringResponse* msg);
+};
+
+const ::mavsdk::rpc::mission_raw::MissionRawResult&
+ImportQgroundcontrolMissionFromStringResponse::_Internal::mission_raw_result(const ImportQgroundcontrolMissionFromStringResponse* msg) {
+  return *msg->mission_raw_result_;
+}
+const ::mavsdk::rpc::mission_raw::MissionImportData&
+ImportQgroundcontrolMissionFromStringResponse::_Internal::mission_import_data(const ImportQgroundcontrolMissionFromStringResponse* msg) {
+  return *msg->mission_import_data_;
+}
+ImportQgroundcontrolMissionFromStringResponse::ImportQgroundcontrolMissionFromStringResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor();
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse)
+}
+ImportQgroundcontrolMissionFromStringResponse::ImportQgroundcontrolMissionFromStringResponse(const ImportQgroundcontrolMissionFromStringResponse& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_mission_raw_result()) {
+    mission_raw_result_ = new ::mavsdk::rpc::mission_raw::MissionRawResult(*from.mission_raw_result_);
+  } else {
+    mission_raw_result_ = nullptr;
+  }
+  if (from._internal_has_mission_import_data()) {
+    mission_import_data_ = new ::mavsdk::rpc::mission_raw::MissionImportData(*from.mission_import_data_);
+  } else {
+    mission_import_data_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse)
+}
+
+inline void ImportQgroundcontrolMissionFromStringResponse::SharedCtor() {
+::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
+    reinterpret_cast<char*>(&mission_raw_result_) - reinterpret_cast<char*>(this)),
+    0, static_cast<size_t>(reinterpret_cast<char*>(&mission_import_data_) -
+    reinterpret_cast<char*>(&mission_raw_result_)) + sizeof(mission_import_data_));
+}
+
+ImportQgroundcontrolMissionFromStringResponse::~ImportQgroundcontrolMissionFromStringResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void ImportQgroundcontrolMissionFromStringResponse::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  if (this != internal_default_instance()) delete mission_raw_result_;
+  if (this != internal_default_instance()) delete mission_import_data_;
+}
+
+void ImportQgroundcontrolMissionFromStringResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void ImportQgroundcontrolMissionFromStringResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArenaForAllocation() == nullptr && mission_raw_result_ != nullptr) {
+    delete mission_raw_result_;
+  }
+  mission_raw_result_ = nullptr;
+  if (GetArenaForAllocation() == nullptr && mission_import_data_ != nullptr) {
+    delete mission_import_data_;
+  }
+  mission_import_data_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* ImportQgroundcontrolMissionFromStringResponse::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // .mavsdk.rpc.mission_raw.MissionRawResult mission_raw_result = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_mission_raw_result(), ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // .mavsdk.rpc.mission_raw.MissionImportData mission_import_data = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
+          ptr = ctx->ParseMessage(_internal_mutable_mission_import_data(), ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* ImportQgroundcontrolMissionFromStringResponse::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.mission_raw.MissionRawResult mission_raw_result = 1;
+  if (this->_internal_has_mission_raw_result()) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(1, _Internal::mission_raw_result(this),
+        _Internal::mission_raw_result(this).GetCachedSize(), target, stream);
+  }
+
+  // .mavsdk.rpc.mission_raw.MissionImportData mission_import_data = 2;
+  if (this->_internal_has_mission_import_data()) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(2, _Internal::mission_import_data(this),
+        _Internal::mission_import_data(this).GetCachedSize(), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse)
+  return target;
+}
+
+size_t ImportQgroundcontrolMissionFromStringResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.mission_raw.MissionRawResult mission_raw_result = 1;
+  if (this->_internal_has_mission_raw_result()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *mission_raw_result_);
+  }
+
+  // .mavsdk.rpc.mission_raw.MissionImportData mission_import_data = 2;
+  if (this->_internal_has_mission_import_data()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *mission_import_data_);
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData ImportQgroundcontrolMissionFromStringResponse::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSizeCheck,
+    ImportQgroundcontrolMissionFromStringResponse::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*ImportQgroundcontrolMissionFromStringResponse::GetClassData() const { return &_class_data_; }
+
+void ImportQgroundcontrolMissionFromStringResponse::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message* to,
+                      const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+  static_cast<ImportQgroundcontrolMissionFromStringResponse *>(to)->MergeFrom(
+      static_cast<const ImportQgroundcontrolMissionFromStringResponse &>(from));
+}
+
+
+void ImportQgroundcontrolMissionFromStringResponse::MergeFrom(const ImportQgroundcontrolMissionFromStringResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_has_mission_raw_result()) {
+    _internal_mutable_mission_raw_result()->::mavsdk::rpc::mission_raw::MissionRawResult::MergeFrom(from._internal_mission_raw_result());
+  }
+  if (from._internal_has_mission_import_data()) {
+    _internal_mutable_mission_import_data()->::mavsdk::rpc::mission_raw::MissionImportData::MergeFrom(from._internal_mission_import_data());
+  }
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void ImportQgroundcontrolMissionFromStringResponse::CopyFrom(const ImportQgroundcontrolMissionFromStringResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ImportQgroundcontrolMissionFromStringResponse::IsInitialized() const {
+  return true;
+}
+
+void ImportQgroundcontrolMissionFromStringResponse::InternalSwap(ImportQgroundcontrolMissionFromStringResponse* other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(ImportQgroundcontrolMissionFromStringResponse, mission_import_data_)
+      + sizeof(ImportQgroundcontrolMissionFromStringResponse::mission_import_data_)
+      - PROTOBUF_FIELD_OFFSET(ImportQgroundcontrolMissionFromStringResponse, mission_raw_result_)>(
+          reinterpret_cast<char*>(&mission_raw_result_),
+          reinterpret_cast<char*>(&other->mission_raw_result_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata ImportQgroundcontrolMissionFromStringResponse::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_getter, &descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_once,
+      file_level_metadata_mission_5fraw_2fmission_5fraw_2eproto[27]);
+}
+
+// ===================================================================
+
 class MissionProgress::_Internal {
  public:
 };
@@ -4800,7 +5285,7 @@ void MissionProgress::InternalSwap(MissionProgress* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata MissionProgress::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_getter, &descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_once,
-      file_level_metadata_mission_5fraw_2fmission_5fraw_2eproto[26]);
+      file_level_metadata_mission_5fraw_2fmission_5fraw_2eproto[28]);
 }
 
 // ===================================================================
@@ -5307,7 +5792,7 @@ void MissionItem::InternalSwap(MissionItem* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata MissionItem::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_getter, &descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_once,
-      file_level_metadata_mission_5fraw_2fmission_5fraw_2eproto[27]);
+      file_level_metadata_mission_5fraw_2fmission_5fraw_2eproto[29]);
 }
 
 // ===================================================================
@@ -5551,7 +6036,7 @@ void MissionImportData::InternalSwap(MissionImportData* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata MissionImportData::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_getter, &descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_once,
-      file_level_metadata_mission_5fraw_2fmission_5fraw_2eproto[28]);
+      file_level_metadata_mission_5fraw_2fmission_5fraw_2eproto[30]);
 }
 
 // ===================================================================
@@ -5775,7 +6260,7 @@ void MissionRawResult::InternalSwap(MissionRawResult* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata MissionRawResult::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_getter, &descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_once,
-      file_level_metadata_mission_5fraw_2fmission_5fraw_2eproto[29]);
+      file_level_metadata_mission_5fraw_2fmission_5fraw_2eproto[31]);
 }
 
 // @@protoc_insertion_point(namespace_scope)
@@ -5886,6 +6371,14 @@ Arena::CreateMaybeMessage< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissi
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse*
 Arena::CreateMaybeMessage< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest*
+Arena::CreateMaybeMessage< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse*
+Arena::CreateMaybeMessage< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse >(arena);
 }
 template<> PROTOBUF_NOINLINE ::mavsdk::rpc::mission_raw::MissionProgress*
 Arena::CreateMaybeMessage< ::mavsdk::rpc::mission_raw::MissionProgress >(Arena* arena) {

--- a/src/mavsdk_server/src/generated/mission_raw/mission_raw.pb.h
+++ b/src/mavsdk_server/src/generated/mission_raw/mission_raw.pb.h
@@ -74,6 +74,12 @@ extern DownloadMissionRequestDefaultTypeInternal _DownloadMissionRequest_default
 class DownloadMissionResponse;
 struct DownloadMissionResponseDefaultTypeInternal;
 extern DownloadMissionResponseDefaultTypeInternal _DownloadMissionResponse_default_instance_;
+class ImportQgroundcontrolMissionFromStringRequest;
+struct ImportQgroundcontrolMissionFromStringRequestDefaultTypeInternal;
+extern ImportQgroundcontrolMissionFromStringRequestDefaultTypeInternal _ImportQgroundcontrolMissionFromStringRequest_default_instance_;
+class ImportQgroundcontrolMissionFromStringResponse;
+struct ImportQgroundcontrolMissionFromStringResponseDefaultTypeInternal;
+extern ImportQgroundcontrolMissionFromStringResponseDefaultTypeInternal _ImportQgroundcontrolMissionFromStringResponse_default_instance_;
 class ImportQgroundcontrolMissionRequest;
 struct ImportQgroundcontrolMissionRequestDefaultTypeInternal;
 extern ImportQgroundcontrolMissionRequestDefaultTypeInternal _ImportQgroundcontrolMissionRequest_default_instance_;
@@ -152,6 +158,8 @@ template<> ::mavsdk::rpc::mission_raw::ClearMissionRequest* Arena::CreateMaybeMe
 template<> ::mavsdk::rpc::mission_raw::ClearMissionResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::mission_raw::ClearMissionResponse>(Arena*);
 template<> ::mavsdk::rpc::mission_raw::DownloadMissionRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::mission_raw::DownloadMissionRequest>(Arena*);
 template<> ::mavsdk::rpc::mission_raw::DownloadMissionResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::mission_raw::DownloadMissionResponse>(Arena*);
+template<> ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest>(Arena*);
+template<> ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>(Arena*);
 template<> ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest* Arena::CreateMaybeMessage<::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest>(Arena*);
 template<> ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse>(Arena*);
 template<> ::mavsdk::rpc::mission_raw::MissionChangedResponse* Arena::CreateMaybeMessage<::mavsdk::rpc::mission_raw::MissionChangedResponse>(Arena*);
@@ -3905,6 +3913,326 @@ class ImportQgroundcontrolMissionResponse final :
 };
 // -------------------------------------------------------------------
 
+class ImportQgroundcontrolMissionFromStringRequest final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringRequest) */ {
+ public:
+  inline ImportQgroundcontrolMissionFromStringRequest() : ImportQgroundcontrolMissionFromStringRequest(nullptr) {}
+  ~ImportQgroundcontrolMissionFromStringRequest() override;
+  explicit PROTOBUF_CONSTEXPR ImportQgroundcontrolMissionFromStringRequest(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  ImportQgroundcontrolMissionFromStringRequest(const ImportQgroundcontrolMissionFromStringRequest& from);
+  ImportQgroundcontrolMissionFromStringRequest(ImportQgroundcontrolMissionFromStringRequest&& from) noexcept
+    : ImportQgroundcontrolMissionFromStringRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline ImportQgroundcontrolMissionFromStringRequest& operator=(const ImportQgroundcontrolMissionFromStringRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ImportQgroundcontrolMissionFromStringRequest& operator=(ImportQgroundcontrolMissionFromStringRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const ImportQgroundcontrolMissionFromStringRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const ImportQgroundcontrolMissionFromStringRequest* internal_default_instance() {
+    return reinterpret_cast<const ImportQgroundcontrolMissionFromStringRequest*>(
+               &_ImportQgroundcontrolMissionFromStringRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    26;
+
+  friend void swap(ImportQgroundcontrolMissionFromStringRequest& a, ImportQgroundcontrolMissionFromStringRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(ImportQgroundcontrolMissionFromStringRequest* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ImportQgroundcontrolMissionFromStringRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  ImportQgroundcontrolMissionFromStringRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<ImportQgroundcontrolMissionFromStringRequest>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const ImportQgroundcontrolMissionFromStringRequest& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom(const ImportQgroundcontrolMissionFromStringRequest& from);
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message* to, const ::PROTOBUF_NAMESPACE_ID::Message& from);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ImportQgroundcontrolMissionFromStringRequest* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringRequest";
+  }
+  protected:
+  explicit ImportQgroundcontrolMissionFromStringRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kQgcPlanFieldNumber = 1,
+  };
+  // string qgc_plan = 1;
+  void clear_qgc_plan();
+  const std::string& qgc_plan() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_qgc_plan(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_qgc_plan();
+  PROTOBUF_NODISCARD std::string* release_qgc_plan();
+  void set_allocated_qgc_plan(std::string* qgc_plan);
+  private:
+  const std::string& _internal_qgc_plan() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_qgc_plan(const std::string& value);
+  std::string* _internal_mutable_qgc_plan();
+  public:
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr qgc_plan_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_mission_5fraw_2fmission_5fraw_2eproto;
+};
+// -------------------------------------------------------------------
+
+class ImportQgroundcontrolMissionFromStringResponse final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse) */ {
+ public:
+  inline ImportQgroundcontrolMissionFromStringResponse() : ImportQgroundcontrolMissionFromStringResponse(nullptr) {}
+  ~ImportQgroundcontrolMissionFromStringResponse() override;
+  explicit PROTOBUF_CONSTEXPR ImportQgroundcontrolMissionFromStringResponse(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  ImportQgroundcontrolMissionFromStringResponse(const ImportQgroundcontrolMissionFromStringResponse& from);
+  ImportQgroundcontrolMissionFromStringResponse(ImportQgroundcontrolMissionFromStringResponse&& from) noexcept
+    : ImportQgroundcontrolMissionFromStringResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline ImportQgroundcontrolMissionFromStringResponse& operator=(const ImportQgroundcontrolMissionFromStringResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ImportQgroundcontrolMissionFromStringResponse& operator=(ImportQgroundcontrolMissionFromStringResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const ImportQgroundcontrolMissionFromStringResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const ImportQgroundcontrolMissionFromStringResponse* internal_default_instance() {
+    return reinterpret_cast<const ImportQgroundcontrolMissionFromStringResponse*>(
+               &_ImportQgroundcontrolMissionFromStringResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    27;
+
+  friend void swap(ImportQgroundcontrolMissionFromStringResponse& a, ImportQgroundcontrolMissionFromStringResponse& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(ImportQgroundcontrolMissionFromStringResponse* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ImportQgroundcontrolMissionFromStringResponse* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  ImportQgroundcontrolMissionFromStringResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<ImportQgroundcontrolMissionFromStringResponse>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const ImportQgroundcontrolMissionFromStringResponse& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom(const ImportQgroundcontrolMissionFromStringResponse& from);
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message* to, const ::PROTOBUF_NAMESPACE_ID::Message& from);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ImportQgroundcontrolMissionFromStringResponse* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse";
+  }
+  protected:
+  explicit ImportQgroundcontrolMissionFromStringResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kMissionRawResultFieldNumber = 1,
+    kMissionImportDataFieldNumber = 2,
+  };
+  // .mavsdk.rpc.mission_raw.MissionRawResult mission_raw_result = 1;
+  bool has_mission_raw_result() const;
+  private:
+  bool _internal_has_mission_raw_result() const;
+  public:
+  void clear_mission_raw_result();
+  const ::mavsdk::rpc::mission_raw::MissionRawResult& mission_raw_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::mission_raw::MissionRawResult* release_mission_raw_result();
+  ::mavsdk::rpc::mission_raw::MissionRawResult* mutable_mission_raw_result();
+  void set_allocated_mission_raw_result(::mavsdk::rpc::mission_raw::MissionRawResult* mission_raw_result);
+  private:
+  const ::mavsdk::rpc::mission_raw::MissionRawResult& _internal_mission_raw_result() const;
+  ::mavsdk::rpc::mission_raw::MissionRawResult* _internal_mutable_mission_raw_result();
+  public:
+  void unsafe_arena_set_allocated_mission_raw_result(
+      ::mavsdk::rpc::mission_raw::MissionRawResult* mission_raw_result);
+  ::mavsdk::rpc::mission_raw::MissionRawResult* unsafe_arena_release_mission_raw_result();
+
+  // .mavsdk.rpc.mission_raw.MissionImportData mission_import_data = 2;
+  bool has_mission_import_data() const;
+  private:
+  bool _internal_has_mission_import_data() const;
+  public:
+  void clear_mission_import_data();
+  const ::mavsdk::rpc::mission_raw::MissionImportData& mission_import_data() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::mission_raw::MissionImportData* release_mission_import_data();
+  ::mavsdk::rpc::mission_raw::MissionImportData* mutable_mission_import_data();
+  void set_allocated_mission_import_data(::mavsdk::rpc::mission_raw::MissionImportData* mission_import_data);
+  private:
+  const ::mavsdk::rpc::mission_raw::MissionImportData& _internal_mission_import_data() const;
+  ::mavsdk::rpc::mission_raw::MissionImportData* _internal_mutable_mission_import_data();
+  public:
+  void unsafe_arena_set_allocated_mission_import_data(
+      ::mavsdk::rpc::mission_raw::MissionImportData* mission_import_data);
+  ::mavsdk::rpc::mission_raw::MissionImportData* unsafe_arena_release_mission_import_data();
+
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::mavsdk::rpc::mission_raw::MissionRawResult* mission_raw_result_;
+  ::mavsdk::rpc::mission_raw::MissionImportData* mission_import_data_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_mission_5fraw_2fmission_5fraw_2eproto;
+};
+// -------------------------------------------------------------------
+
 class MissionProgress final :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.mission_raw.MissionProgress) */ {
  public:
@@ -3953,7 +4281,7 @@ class MissionProgress final :
                &_MissionProgress_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    26;
+    28;
 
   friend void swap(MissionProgress& a, MissionProgress& b) {
     a.Swap(&b);
@@ -4107,7 +4435,7 @@ class MissionItem final :
                &_MissionItem_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    27;
+    29;
 
   friend void swap(MissionItem& a, MissionItem& b) {
     a.Swap(&b);
@@ -4382,7 +4710,7 @@ class MissionImportData final :
                &_MissionImportData_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    28;
+    30;
 
   friend void swap(MissionImportData& a, MissionImportData& b) {
     a.Swap(&b);
@@ -4574,7 +4902,7 @@ class MissionRawResult final :
                &_MissionRawResult_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    29;
+    31;
 
   friend void swap(MissionRawResult& a, MissionRawResult& b) {
     a.Swap(&b);
@@ -6280,6 +6608,244 @@ inline void ImportQgroundcontrolMissionResponse::set_allocated_mission_import_da
 
 // -------------------------------------------------------------------
 
+// ImportQgroundcontrolMissionFromStringRequest
+
+// string qgc_plan = 1;
+inline void ImportQgroundcontrolMissionFromStringRequest::clear_qgc_plan() {
+  qgc_plan_.ClearToEmpty();
+}
+inline const std::string& ImportQgroundcontrolMissionFromStringRequest::qgc_plan() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringRequest.qgc_plan)
+  return _internal_qgc_plan();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void ImportQgroundcontrolMissionFromStringRequest::set_qgc_plan(ArgT0&& arg0, ArgT... args) {
+ 
+ qgc_plan_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringRequest.qgc_plan)
+}
+inline std::string* ImportQgroundcontrolMissionFromStringRequest::mutable_qgc_plan() {
+  std::string* _s = _internal_mutable_qgc_plan();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringRequest.qgc_plan)
+  return _s;
+}
+inline const std::string& ImportQgroundcontrolMissionFromStringRequest::_internal_qgc_plan() const {
+  return qgc_plan_.Get();
+}
+inline void ImportQgroundcontrolMissionFromStringRequest::_internal_set_qgc_plan(const std::string& value) {
+  
+  qgc_plan_.Set(value, GetArenaForAllocation());
+}
+inline std::string* ImportQgroundcontrolMissionFromStringRequest::_internal_mutable_qgc_plan() {
+  
+  return qgc_plan_.Mutable(GetArenaForAllocation());
+}
+inline std::string* ImportQgroundcontrolMissionFromStringRequest::release_qgc_plan() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringRequest.qgc_plan)
+  return qgc_plan_.Release();
+}
+inline void ImportQgroundcontrolMissionFromStringRequest::set_allocated_qgc_plan(std::string* qgc_plan) {
+  if (qgc_plan != nullptr) {
+    
+  } else {
+    
+  }
+  qgc_plan_.SetAllocated(qgc_plan, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (qgc_plan_.IsDefault()) {
+    qgc_plan_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringRequest.qgc_plan)
+}
+
+// -------------------------------------------------------------------
+
+// ImportQgroundcontrolMissionFromStringResponse
+
+// .mavsdk.rpc.mission_raw.MissionRawResult mission_raw_result = 1;
+inline bool ImportQgroundcontrolMissionFromStringResponse::_internal_has_mission_raw_result() const {
+  return this != internal_default_instance() && mission_raw_result_ != nullptr;
+}
+inline bool ImportQgroundcontrolMissionFromStringResponse::has_mission_raw_result() const {
+  return _internal_has_mission_raw_result();
+}
+inline void ImportQgroundcontrolMissionFromStringResponse::clear_mission_raw_result() {
+  if (GetArenaForAllocation() == nullptr && mission_raw_result_ != nullptr) {
+    delete mission_raw_result_;
+  }
+  mission_raw_result_ = nullptr;
+}
+inline const ::mavsdk::rpc::mission_raw::MissionRawResult& ImportQgroundcontrolMissionFromStringResponse::_internal_mission_raw_result() const {
+  const ::mavsdk::rpc::mission_raw::MissionRawResult* p = mission_raw_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::mission_raw::MissionRawResult&>(
+      ::mavsdk::rpc::mission_raw::_MissionRawResult_default_instance_);
+}
+inline const ::mavsdk::rpc::mission_raw::MissionRawResult& ImportQgroundcontrolMissionFromStringResponse::mission_raw_result() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse.mission_raw_result)
+  return _internal_mission_raw_result();
+}
+inline void ImportQgroundcontrolMissionFromStringResponse::unsafe_arena_set_allocated_mission_raw_result(
+    ::mavsdk::rpc::mission_raw::MissionRawResult* mission_raw_result) {
+  if (GetArenaForAllocation() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(mission_raw_result_);
+  }
+  mission_raw_result_ = mission_raw_result;
+  if (mission_raw_result) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse.mission_raw_result)
+}
+inline ::mavsdk::rpc::mission_raw::MissionRawResult* ImportQgroundcontrolMissionFromStringResponse::release_mission_raw_result() {
+  
+  ::mavsdk::rpc::mission_raw::MissionRawResult* temp = mission_raw_result_;
+  mission_raw_result_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
+  temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  if (GetArenaForAllocation() == nullptr) { delete old; }
+#else  // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArenaForAllocation() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return temp;
+}
+inline ::mavsdk::rpc::mission_raw::MissionRawResult* ImportQgroundcontrolMissionFromStringResponse::unsafe_arena_release_mission_raw_result() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse.mission_raw_result)
+  
+  ::mavsdk::rpc::mission_raw::MissionRawResult* temp = mission_raw_result_;
+  mission_raw_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::mission_raw::MissionRawResult* ImportQgroundcontrolMissionFromStringResponse::_internal_mutable_mission_raw_result() {
+  
+  if (mission_raw_result_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::mission_raw::MissionRawResult>(GetArenaForAllocation());
+    mission_raw_result_ = p;
+  }
+  return mission_raw_result_;
+}
+inline ::mavsdk::rpc::mission_raw::MissionRawResult* ImportQgroundcontrolMissionFromStringResponse::mutable_mission_raw_result() {
+  ::mavsdk::rpc::mission_raw::MissionRawResult* _msg = _internal_mutable_mission_raw_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse.mission_raw_result)
+  return _msg;
+}
+inline void ImportQgroundcontrolMissionFromStringResponse::set_allocated_mission_raw_result(::mavsdk::rpc::mission_raw::MissionRawResult* mission_raw_result) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
+  if (message_arena == nullptr) {
+    delete mission_raw_result_;
+  }
+  if (mission_raw_result) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(mission_raw_result);
+    if (message_arena != submessage_arena) {
+      mission_raw_result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, mission_raw_result, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  mission_raw_result_ = mission_raw_result;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse.mission_raw_result)
+}
+
+// .mavsdk.rpc.mission_raw.MissionImportData mission_import_data = 2;
+inline bool ImportQgroundcontrolMissionFromStringResponse::_internal_has_mission_import_data() const {
+  return this != internal_default_instance() && mission_import_data_ != nullptr;
+}
+inline bool ImportQgroundcontrolMissionFromStringResponse::has_mission_import_data() const {
+  return _internal_has_mission_import_data();
+}
+inline void ImportQgroundcontrolMissionFromStringResponse::clear_mission_import_data() {
+  if (GetArenaForAllocation() == nullptr && mission_import_data_ != nullptr) {
+    delete mission_import_data_;
+  }
+  mission_import_data_ = nullptr;
+}
+inline const ::mavsdk::rpc::mission_raw::MissionImportData& ImportQgroundcontrolMissionFromStringResponse::_internal_mission_import_data() const {
+  const ::mavsdk::rpc::mission_raw::MissionImportData* p = mission_import_data_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::mission_raw::MissionImportData&>(
+      ::mavsdk::rpc::mission_raw::_MissionImportData_default_instance_);
+}
+inline const ::mavsdk::rpc::mission_raw::MissionImportData& ImportQgroundcontrolMissionFromStringResponse::mission_import_data() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse.mission_import_data)
+  return _internal_mission_import_data();
+}
+inline void ImportQgroundcontrolMissionFromStringResponse::unsafe_arena_set_allocated_mission_import_data(
+    ::mavsdk::rpc::mission_raw::MissionImportData* mission_import_data) {
+  if (GetArenaForAllocation() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(mission_import_data_);
+  }
+  mission_import_data_ = mission_import_data;
+  if (mission_import_data) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse.mission_import_data)
+}
+inline ::mavsdk::rpc::mission_raw::MissionImportData* ImportQgroundcontrolMissionFromStringResponse::release_mission_import_data() {
+  
+  ::mavsdk::rpc::mission_raw::MissionImportData* temp = mission_import_data_;
+  mission_import_data_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
+  temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  if (GetArenaForAllocation() == nullptr) { delete old; }
+#else  // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArenaForAllocation() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return temp;
+}
+inline ::mavsdk::rpc::mission_raw::MissionImportData* ImportQgroundcontrolMissionFromStringResponse::unsafe_arena_release_mission_import_data() {
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse.mission_import_data)
+  
+  ::mavsdk::rpc::mission_raw::MissionImportData* temp = mission_import_data_;
+  mission_import_data_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::mission_raw::MissionImportData* ImportQgroundcontrolMissionFromStringResponse::_internal_mutable_mission_import_data() {
+  
+  if (mission_import_data_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::mission_raw::MissionImportData>(GetArenaForAllocation());
+    mission_import_data_ = p;
+  }
+  return mission_import_data_;
+}
+inline ::mavsdk::rpc::mission_raw::MissionImportData* ImportQgroundcontrolMissionFromStringResponse::mutable_mission_import_data() {
+  ::mavsdk::rpc::mission_raw::MissionImportData* _msg = _internal_mutable_mission_import_data();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse.mission_import_data)
+  return _msg;
+}
+inline void ImportQgroundcontrolMissionFromStringResponse::set_allocated_mission_import_data(::mavsdk::rpc::mission_raw::MissionImportData* mission_import_data) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
+  if (message_arena == nullptr) {
+    delete mission_import_data_;
+  }
+  if (mission_import_data) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(mission_import_data);
+    if (message_arena != submessage_arena) {
+      mission_import_data = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, mission_import_data, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  mission_import_data_ = mission_import_data;
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse.mission_import_data)
+}
+
+// -------------------------------------------------------------------
+
 // MissionProgress
 
 // int32 current = 1;
@@ -6787,6 +7353,10 @@ inline void MissionRawResult::set_allocated_result_str(std::string* result_str) 
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/src/mavsdk_server/src/plugins/mission_raw/mission_raw_service_impl.h
+++ b/src/mavsdk_server/src/plugins/mission_raw/mission_raw_service_impl.h
@@ -660,6 +660,39 @@ public:
         return grpc::Status::OK;
     }
 
+    grpc::Status ImportQgroundcontrolMissionFromString(
+        grpc::ServerContext* /* context */,
+        const rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* request,
+        rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            if (response != nullptr) {
+                auto result = mavsdk::MissionRaw::Result::NoSystem;
+                fillResponseWithResult(response, result);
+            }
+
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn()
+                << "ImportQgroundcontrolMissionFromString sent with a null request! Ignoring...";
+            return grpc::Status::OK;
+        }
+
+        auto result = _lazy_plugin.maybe_plugin()->import_qgroundcontrol_mission_from_string(
+            request->qgc_plan());
+
+        if (response != nullptr) {
+            fillResponseWithResult(response, result.first);
+
+            response->set_allocated_mission_import_data(
+                translateToRpcMissionImportData(result.second).release());
+        }
+
+        return grpc::Status::OK;
+    }
+
     void stop()
     {
         _stopped.store(true);


### PR DESCRIPTION
This enables to import mission plan files without having to write them to some location first.

Depends on https://github.com/mavlink/MAVSDK-Proto/pull/305.

Closes #1948.