### PR TITLE
telemetry: fix distance_sensor unit

### DIFF
--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -1437,9 +1437,12 @@ void TelemetryImpl::process_distance_sensor(const mavlink_message_t& message)
 
     Telemetry::DistanceSensor distance_sensor_struct{};
 
-    distance_sensor_struct.minimum_distance_m = distance_sensor_msg.min_distance;
-    distance_sensor_struct.maximum_distance_m = distance_sensor_msg.max_distance;
-    distance_sensor_struct.current_distance_m = distance_sensor_msg.current_distance;
+    distance_sensor_struct.minimum_distance_m =
+        static_cast<float>(distance_sensor_msg.min_distance) * 1e-2f; // cm to m
+    distance_sensor_struct.maximum_distance_m =
+        static_cast<float>(distance_sensor_msg.max_distance) * 1e-2f; // cm to m
+    distance_sensor_struct.current_distance_m =
+        static_cast<float>(distance_sensor_msg.current_distance) * 1e-2f; // cm to m
 
     set_distance_sensor(distance_sensor_struct);
 


### PR DESCRIPTION
The scaling was wrong.

Thanks to @potaito and @reedev for catching it.