### PR TITLE
Enable offboard plugin with Ardupilot Rover

### DIFF
--- a/src/mavsdk/core/flight_mode.cpp
+++ b/src/mavsdk/core/flight_mode.cpp
@@ -40,6 +40,8 @@ FlightMode to_flight_mode_from_ardupilot_rover_mode(uint32_t custom_mode)
             return FlightMode::Manual;
         case ardupilot::RoverMode::Follow:
             return FlightMode::FollowMe;
+        case ardupilot::RoverMode::Guided:
+            return FlightMode::Offboard;
         default:
             return FlightMode::Unknown;
     }

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -910,11 +910,12 @@ ardupilot::RoverMode SystemImpl::flight_mode_to_ardupilot_rover_mode(FlightMode 
             return ardupilot::RoverMode::Manual;
         case FlightMode::FollowMe:
             return ardupilot::RoverMode::Follow;
+        case FlightMode::Offboard:
+            return ardupilot::RoverMode::Guided;
         case FlightMode::Unknown:
         case FlightMode::Ready:
         case FlightMode::Takeoff:
         case FlightMode::Land:
-        case FlightMode::Offboard:
         case FlightMode::Altctl:
         case FlightMode::Posctl:
         case FlightMode::Rattitude:

--- a/src/mavsdk/plugins/offboard/offboard_impl.cpp
+++ b/src/mavsdk/plugins/offboard/offboard_impl.cpp
@@ -760,10 +760,10 @@ void OffboardImpl::process_heartbeat(const mavlink_message_t& message)
 
     bool offboard_mode_active = false;
     if (heartbeat.base_mode & MAV_MODE_FLAG_CUSTOM_MODE_ENABLED) {
-        px4::px4_custom_mode px4_custom_mode;
-        px4_custom_mode.data = heartbeat.custom_mode;
+        FlightMode flight_mode = to_flight_mode_from_custom_mode(
+            _parent->autopilot(), _parent->get_vehicle_type(), heartbeat.custom_mode);
 
-        if (px4_custom_mode.main_mode == px4::PX4_CUSTOM_MAIN_MODE_OFFBOARD) {
+        if (flight_mode == FlightMode::Offboard) {
             offboard_mode_active = true;
         }
     }


### PR DESCRIPTION
This PR enables the use of the _offboard_ plugin with Ardupilot Rovers. Tested with a real R1 rover.
- Add the `ardupilot::Rover::Guided` <-> `FlightMode::Offboard` mapping in the _core_, to allow entering Offboard mode with an Ardupilot Rover.
- Update the flight mode monitoring callback in _offboard_ plugin, to also handle Ardupilot modes.