### PR TITLE
plugins/action: fix apm_takeoff

### DIFF
--- a/src/mavsdk/plugins/action/action_impl.cpp
+++ b/src/mavsdk/plugins/action/action_impl.cpp
@@ -410,6 +410,8 @@ void ActionImpl::takeoff_async_apm(const Action::ResultCallback& callback) const
                 }
                 send_takeoff_command();
             });
+    } else {
+        send_takeoff_command();
     }
 }
 


### PR DESCRIPTION
This pr fixes issue described in #1996.

Previously, if apm vehicle was already in offboard mode, send_takeoff_command was never executed.
Now it works as intended.