### PR TITLE
add telemetry set_rate_sys_status()

### DIFF
--- a/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -2367,8 +2367,20 @@ public:
      */
     std::pair<Result, Telemetry::GpsGlobalOrigin> get_gps_global_origin() const;
 
+    /**
+     * @brief Set rate to 'SYS_STATUS' updates.
+     * SYS_STATUS message allows to recieve vehicle HEALTH information.
+     * This function is non-blocking. See 'set_rate_sys_status' for the blocking counterpart.
+     */
     void set_rate_sys_status_async(double rate_hz, const ResultCallback callback);
 
+    /**
+     * @brief Set rate to 'SYS_STATUS' updates.
+     * SYS_STATUS message allows to recieve vehicle HEALTH information.
+     * This function is non-blocking. See 'set_rate_sys_status_async' for the non-blocking counterpart.
+     * 
+     * @return Result of request.
+     */
     Result set_rate_sys_status(double rate_hz) const;
 
     /**

--- a/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -2367,6 +2367,10 @@ public:
      */
     std::pair<Result, Telemetry::GpsGlobalOrigin> get_gps_global_origin() const;
 
+    void set_rate_sys_status_async(double rate_hz, const ResultCallback callback);
+
+    Result set_rate_sys_status(double rate_hz) const;
+
     /**
      * @brief Copy constructor.
      */

--- a/src/mavsdk/plugins/telemetry/telemetry.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry.cpp
@@ -823,6 +823,16 @@ std::pair<Telemetry::Result, Telemetry::GpsGlobalOrigin> Telemetry::get_gps_glob
     return _impl->get_gps_global_origin();
 }
 
+Telemetry::Result Telemetry::set_rate_sys_status(double rate_hz) const
+{
+    return _impl->set_rate_sys_status(rate_hz);
+}
+
+void Telemetry::set_rate_sys_status_async(double rate_hz, const ResultCallback callback)
+{
+   _impl->set_rate_sys_status_async(rate_hz, callback);
+}
+
 bool operator==(const Telemetry::Position& lhs, const Telemetry::Position& rhs)
 {
     return ((std::isnan(rhs.latitude_deg) && std::isnan(lhs.latitude_deg)) ||

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -407,6 +407,12 @@ Telemetry::Result TelemetryImpl::set_rate_altitude(double rate_hz)
         _parent->set_msg_rate(MAVLINK_MSG_ID_ALTITUDE, rate_hz));
 }
 
+Telemetry::Result TelemetryImpl::set_rate_sys_status(double rate_hz)
+{
+    return telemetry_result_from_command_result(
+        _parent->set_msg_rate(MAVLINK_MSG_ID_SYS_STATUS, rate_hz));
+}
+
 void TelemetryImpl::set_rate_position_velocity_ned_async(
     double rate_hz, Telemetry::ResultCallback callback)
 {
@@ -654,6 +660,17 @@ void TelemetryImpl::set_rate_scaled_pressure_async(
 {
     _parent->set_msg_rate_async(
         MAVLINK_MSG_ID_SCALED_PRESSURE,
+        rate_hz,
+        [callback](MavlinkCommandSender::Result command_result, float) {
+            command_result_callback(command_result, callback);
+        });
+}
+
+void TelemetryImpl::set_rate_sys_status_async(
+    double rate_hz, Telemetry::ResultCallback callback)
+{
+    _parent->set_msg_rate_async(
+        MAVLINK_MSG_ID_SYS_STATUS,
         rate_hz,
         [callback](MavlinkCommandSender::Result command_result, float) {
             command_result_callback(command_result, callback);

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -355,7 +355,7 @@ Telemetry::Result TelemetryImpl::set_rate_gps_info(double rate_hz)
 Telemetry::Result TelemetryImpl::set_rate_battery(double rate_hz)
 {
     return telemetry_result_from_command_result(
-        _parent->set_msg_rate(MAVLINK_MSG_ID_SYS_STATUS, rate_hz));
+        _parent->set_msg_rate(MAVLINK_MSG_ID_BATTERY_STATUS, rate_hz));
 }
 
 Telemetry::Result TelemetryImpl::set_rate_rc_status(double rate_hz)
@@ -581,7 +581,7 @@ void TelemetryImpl::set_rate_gps_info_async(double rate_hz, Telemetry::ResultCal
 void TelemetryImpl::set_rate_battery_async(double rate_hz, Telemetry::ResultCallback callback)
 {
     _parent->set_msg_rate_async(
-        MAVLINK_MSG_ID_SYS_STATUS,
+        MAVLINK_MSG_ID_BATTERY_STATUS,
         rate_hz,
         [callback](MavlinkCommandSender::Result command_result, float) {
             command_result_callback(command_result, callback);

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.h
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.h
@@ -51,6 +51,7 @@ public:
     Telemetry::Result set_rate_scaled_pressure(double rate_hz);
     Telemetry::Result set_rate_unix_epoch_time(double rate_hz);
     Telemetry::Result set_rate_altitude(double rate_hz);
+    Telemetry::Result set_rate_sys_status(double rate_hz);
 
     void set_rate_position_velocity_ned_async(double rate_hz, Telemetry::ResultCallback callback);
     void set_rate_position_async(double rate_hz, Telemetry::ResultCallback callback);
@@ -77,6 +78,7 @@ public:
     void set_rate_scaled_pressure_async(double rate_hz, Telemetry::ResultCallback callback);
     void set_rate_unix_epoch_time_async(double rate_hz, Telemetry::ResultCallback callback);
     void set_rate_altitude_async(double rate_hz, Telemetry::ResultCallback callback);
+    void set_rate_sys_status_async(double rate_hz, Telemetry::ResultCallback callback);
 
     void get_gps_global_origin_async(const Telemetry::GetGpsGlobalOriginCallback callback);
     std::pair<Telemetry::Result, Telemetry::GpsGlobalOrigin> get_gps_global_origin();


### PR DESCRIPTION
This pr implements the set_rate_sys_status() function and changes the message sent by the set_rate_battery() function to MSG_ID_BATTERY. 

Previously, the MSG_ID_SYS_STATUS rate was set using the set_rate_battery() function, which can be misleading, this was described in issue #1996.