### PR TITLE
Add overrides in impl_h template

### DIFF
--- a/templates/plugin_impl_h/file.j2
+++ b/templates/plugin_impl_h/file.j2
@@ -23,8 +23,7 @@ public:
 
     void init() override;
     void deinit() override;
-    
-    
+
 {% if not is_server %}
     void enable() override;
     void disable() override;

--- a/templates/plugin_impl_h/file.j2
+++ b/templates/plugin_impl_h/file.j2
@@ -23,6 +23,12 @@ public:
 
     void init() override;
     void deinit() override;
+    
+    
+{% if not is_server %}
+    void enable() override;
+    void disable() override;
+{% endif %}
 
 {% for method in methods %}
 {{ indent(method, 1) }}


### PR DESCRIPTION
This adds 

```cpp
    void init() override;
    void deinit() override;
```

to the auto-generated implementation header, to mimic this part here in the corresponding cpp template:

https://github.com/mavlink/MAVSDK/blob/e7231dc8f390b96f4682e6810ac3d2fe554b5b8b/templates/plugin_impl_cpp/file.j2#L35-L39

Otherwise I get an `inherited member is not allowed` error in the impl.cpp file.

Speaking of which, what are servers in MAVSDK? I noticed that there are server plugins, but I didn't know that they are treated differently until I saw the template.