### PR TITLE
mavsdk_server: fix linking

### DIFF
--- a/src/mavsdk_server/src/CMakeLists.txt
+++ b/src/mavsdk_server/src/CMakeLists.txt
@@ -93,7 +93,7 @@ if(NOT IOS AND NOT ANDROID)
         mavsdk_server_bin.cpp
     )
 
-    target_link_libraries(mavsdk_server_bin
+    target_link_libraries(mavsdk_server_bin PRIVATE
         mavsdk_server
         mavsdk
     )
@@ -103,6 +103,10 @@ if(NOT IOS AND NOT ANDROID)
         set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
         set_target_properties(mavsdk_server_bin PROPERTIES LINK_SEARCH_START_STATIC ON)
         set_target_properties(mavsdk_server_bin PROPERTIES LINK_SEARCH_END_STATIC ON)
+    endif()
+
+    if(NOT BUILD_STATIC_MAVSDK_SERVER AND ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU"))
+        target_link_libraries(mavsdk_server_bin PRIVATE dl)
     endif()
 
     # MSVC fails to generate the `mavsdk_server` binary while having

--- a/src/mavsdk_server/test/CMakeLists.txt
+++ b/src/mavsdk_server/test/CMakeLists.txt
@@ -47,4 +47,8 @@ if (BUILD_STATIC_MAVSDK_SERVER)
     set_target_properties(unit_tests_mavsdk_server PROPERTIES LINK_SEARCH_END_STATIC ON)
 endif()
 
+if(NOT BUILD_STATIC_MAVSDK_SERVER AND ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU"))
+    target_link_libraries(unit_tests_mavsdk_server PRIVATE dl)
+endif()
+
 add_test(unit_tests unit_tests_mavsdk_server)


### PR DESCRIPTION
This fixes linking on Debian Bullseye for me with
cmake 3.26.0
GCC 10.2.1

The error was:
```
/usr/bin/ld: libmavsdk_server.so.1.4.0: undefined reference to `dlsym'
/usr/bin/ld: libmavsdk_server.so.1.4.0: undefined reference to `dlopen'
/usr/bin/ld: libmavsdk_server.so.1.4.0: undefined reference to `dlclose'
/usr/bin/ld: libmavsdk_server.so.1.4.0: undefined reference to `dlerror'
/usr/bin/ld: libmavsdk_server.so.1.4.0: undefined reference to `dladdr'
```