### PR TITLE
info: wait up to 1.5s for information

### DIFF
--- a/src/mavsdk/plugins/info/info_impl.h
+++ b/src/mavsdk/plugins/info/info_impl.h
@@ -41,13 +41,15 @@ private:
     Info::Version::FlightSoftwareVersionType
         get_flight_software_version_type(FIRMWARE_VERSION_TYPE);
 
+    void wait_for_information() const;
+
     mutable std::mutex _mutex{};
 
     Info::Version _version{};
     Info::Product _product{};
     Info::Identification _identification{};
     Info::FlightInfo _flight_info{};
-    bool _information_received{false};
+    std::atomic<bool> _information_received{false};
     bool _flight_information_received{false};
     bool _was_armed{false};
 


### PR DESCRIPTION
Otherwise we miss it in Python because we construct the plugin just before accessing the info.

Bit of a hack but should work for now. Need to backport to v1.4.

Fixes: https://github.com/mavlink/MAVSDK-Python/issues/556.