### PR TITLE
Expose params through mavlink_passthrough

### DIFF
--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -724,14 +724,16 @@ void SystemImpl::set_param_int_async(
     _params.set_param_int_async(name, value, callback, cookie, maybe_component_id, extended);
 }
 
-std::pair<MAVLinkParameters::Result, float> SystemImpl::get_param_float(const std::string& name)
+std::pair<MAVLinkParameters::Result, float> SystemImpl::get_param_float(
+    const std::string& name, std::optional<uint8_t> maybe_component_id, bool extended)
 {
-    return _params.get_param_float(name, {}, false);
+    return _params.get_param_float(name, maybe_component_id, extended);
 }
 
-std::pair<MAVLinkParameters::Result, int> SystemImpl::get_param_int(const std::string& name)
+std::pair<MAVLinkParameters::Result, int> SystemImpl::get_param_int(
+    const std::string& name, std::optional<uint8_t> maybe_component_id, bool extended)
 {
-    return _params.get_param_int(name, {}, false);
+    return _params.get_param_int(name, maybe_component_id, extended);
 }
 
 std::pair<MAVLinkParameters::Result, std::string>

--- a/src/mavsdk/core/system_impl.h
+++ b/src/mavsdk/core/system_impl.h
@@ -189,8 +189,14 @@ public:
     using GetParamCustomCallback =
         std::function<void(MAVLinkParameters::Result result, const std::string& value)>;
 
-    std::pair<MAVLinkParameters::Result, float> get_param_float(const std::string& name);
-    std::pair<MAVLinkParameters::Result, int> get_param_int(const std::string& name);
+    std::pair<MAVLinkParameters::Result, float> get_param_float(
+        const std::string& name,
+        std::optional<uint8_t> maybe_component_id = {},
+        bool extended = false);
+    std::pair<MAVLinkParameters::Result, int> get_param_int(
+        const std::string& name,
+        std::optional<uint8_t> maybe_component_id = {},
+        bool extended = false);
     std::pair<MAVLinkParameters::Result, std::string> get_param_custom(const std::string& name);
 
     // These methods can be used to cache a parameter when a system connects. For that

--- a/src/mavsdk/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.h
+++ b/src/mavsdk/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <functional>
+#include <optional>
 
 // This plugin provides/includes the mavlink 2.0 header files.
 #include "mavlink_include.h"
@@ -68,6 +69,11 @@ public:
         CommandTimeout, /**< @brief A timeout happened. */
         CommandTemporarilyRejected, /**< @brief Command has been rejected for now. */
         CommandFailed, /**< @brief Command has failed. */
+        ParamWrongType, /**< @brief Wrong type for requested param. */
+        ParamNameTooLong, /**< @brief Param name too long. */
+        ParamValueTooLong, /**< @brief Param value too long. */
+        ParamNotFound, /**< @brief Param not found. */
+        ParamValueUnsupported, /**< @brief Param value unsupported. */
     };
 
     /**
@@ -150,6 +156,18 @@ public:
         const uint8_t target_compid,
         const uint16_t command,
         MAV_RESULT result);
+
+    /**
+     * @brief Request param (int).
+     */
+    std::pair<Result, int32_t> get_param_int(
+        const std::string& name, std::optional<uint8_t> maybe_component_id, bool extended);
+
+    /**
+     * @brief Request param (float).
+     */
+    std::pair<Result, float> get_param_float(
+        const std::string& name, std::optional<uint8_t> maybe_component_id, bool extended);
 
     /**
      * @brief Callback type for message subscriptions.

--- a/src/mavsdk/plugins/mavlink_passthrough/mavlink_passthrough.cpp
+++ b/src/mavsdk/plugins/mavlink_passthrough/mavlink_passthrough.cpp
@@ -39,6 +39,18 @@ mavlink_message_t MavlinkPassthrough::make_command_ack_message(
     return _impl->make_command_ack_message(target_sysid, target_compid, command, result);
 }
 
+std::pair<MavlinkPassthrough::Result, int32_t> MavlinkPassthrough::get_param_int(
+    const std::string& name, std::optional<uint8_t> maybe_component_id, bool extended)
+{
+    return _impl->get_param_int(name, maybe_component_id, extended);
+}
+
+std::pair<MavlinkPassthrough::Result, float> MavlinkPassthrough::get_param_float(
+    const std::string& name, std::optional<uint8_t> maybe_component_id, bool extended)
+{
+    return _impl->get_param_float(name, maybe_component_id, extended);
+}
+
 MavlinkPassthrough::MessageHandle
 MavlinkPassthrough::subscribe_message(uint16_t message_id, const MessageCallback& callback)
 {

--- a/src/mavsdk/plugins/mavlink_passthrough/mavlink_passthrough_impl.h
+++ b/src/mavsdk/plugins/mavlink_passthrough/mavlink_passthrough_impl.h
@@ -29,6 +29,10 @@ public:
         const uint8_t target_compid,
         const uint16_t command,
         MAV_RESULT result);
+    std::pair<MavlinkPassthrough::Result, int32_t> get_param_int(
+        const std::string& name, std::optional<uint8_t> maybe_component_id, bool extended);
+    std::pair<MavlinkPassthrough::Result, float> get_param_float(
+        const std::string& name, std::optional<uint8_t> maybe_component_id, bool extended);
 
     MavlinkPassthrough::MessageHandle
     subscribe_message(uint16_t message_id, const MavlinkPassthrough::MessageCallback& callback);
@@ -45,6 +49,9 @@ private:
 
     static MavlinkPassthrough::Result
     to_mavlink_passthrough_result_from_mavlink_commands_result(MavlinkCommandSender::Result result);
+
+    static MavlinkPassthrough::Result
+    to_mavlink_passthrough_result_from_mavlink_params_result(MAVLinkParameters::Result result);
 
     std::unordered_map<uint16_t, CallbackList<const mavlink_message_t&>> _message_subscriptions{};
 };


### PR DESCRIPTION
The use-case is to request params from a component that is not exposed in a plugin (`param` or `camera`).

Since the command microservice is exposed in mavlink_passthrough, it feels like it makes sense to expose the params one as well :sweat_smile: 