### PR TITLE
CI: Remove deprecated ubuntu-18.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,7 +181,7 @@ jobs:
     container: mavsdk/mavsdk-${{ matrix.container_name }}
     strategy:
       matrix:
-        container_name: [ubuntu-18.04, ubuntu-20.04]
+        container_name: [ubuntu-20.04]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Seems like Ubuntu 18.04 is not supported anymore in github actions: https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

Removing it because I have seen CI jobs hang indefinitely because of that (Ubuntu 18.04 would never run).