### PR TITLE
Build deb package for Ubuntu 22.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,7 +181,7 @@ jobs:
     container: mavsdk/mavsdk-${{ matrix.container_name }}
     strategy:
       matrix:
-        container_name: [ubuntu-18.04, ubuntu-20.04]
+        container_name: [ubuntu-20.04, ubuntu-22.04]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -190,14 +190,6 @@ jobs:
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config --global --add safe.directory /github/workspace
-      - name: Install latest cmake
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y apt-transport-https ca-certificates gnupg software-properties-common wget
-          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
-          sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
-          sudo apt-get update
-          sudo apt-get install -y cmake python3-pip
       - name: configure
         run: cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_MAVSDK_SERVER=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=install -DWERROR=OFF -Bbuild/release -H.
       - name: build


### PR DESCRIPTION
The `deb-package` job fails on Ubuntu 22.04 because of some key when we try to install the latest CMake. But since 18.04 is now obsolete, and [Ubuntu 22.04](https://github.com/actions/runner-images/blob/ubuntu20/20230402.1/images/linux/Ubuntu2004-Readme.md#tools) in CI has a recent cmake (3.26+), I don't think we need this task anymore.

If that works, it will bring `.deb` packages for 22.04 (while removing them for 18.04).

Kind of related to https://github.com/mavlink/MAVSDK/pull/2017, but a bit different.

