### PR TITLE
Change dl with CMAKE_DL_LIBS

### DIFF
--- a/src/mavsdk_server/src/CMakeLists.txt
+++ b/src/mavsdk_server/src/CMakeLists.txt
@@ -106,7 +106,7 @@ if(NOT IOS AND NOT ANDROID)
     endif()
 
     if(NOT BUILD_STATIC_MAVSDK_SERVER AND ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU"))
-        target_link_libraries(mavsdk_server_bin PRIVATE dl)
+        target_link_libraries(mavsdk_server_bin PRIVATE ${CMAKE_DL_LIBS})
     endif()
 
     # MSVC fails to generate the `mavsdk_server` binary while having

--- a/src/mavsdk_server/test/CMakeLists.txt
+++ b/src/mavsdk_server/test/CMakeLists.txt
@@ -48,7 +48,7 @@ if (BUILD_STATIC_MAVSDK_SERVER)
 endif()
 
 if(NOT BUILD_STATIC_MAVSDK_SERVER AND ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU"))
-    target_link_libraries(unit_tests_mavsdk_server PRIVATE dl)
+    target_link_libraries(unit_tests_mavsdk_server PRIVATE ${CMAKE_DL_LIBS})
 endif()
 
 add_test(unit_tests unit_tests_mavsdk_server)


### PR DESCRIPTION
Not sure if it actually makes a big difference for us, but `CMAKE_DL_LIBS` may be different depending on the platform (but the [CMake docs](https://cmake.org/cmake/help/v3.26/variable/CMAKE_DL_LIBS.html) doesn't really specify how).

Feels like it doesn't hurt, and it could be worth the change :innocent:.