### PR TITLE
telemetry: fix set battery rate

### DIFF
--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -356,7 +356,7 @@ Telemetry::Result TelemetryImpl::set_rate_gps_info(double rate_hz)
 Telemetry::Result TelemetryImpl::set_rate_battery(double rate_hz)
 {
     return telemetry_result_from_command_result(
-        _system_impl->set_msg_rate(MAVLINK_MSG_ID_SYS_STATUS, rate_hz));
+        _system_impl->set_msg_rate(MAVLINK_MSG_ID_BATTERY_STATUS, rate_hz));
 }
 
 Telemetry::Result TelemetryImpl::set_rate_rc_status(double rate_hz)
@@ -582,7 +582,7 @@ void TelemetryImpl::set_rate_gps_info_async(double rate_hz, Telemetry::ResultCal
 void TelemetryImpl::set_rate_battery_async(double rate_hz, Telemetry::ResultCallback callback)
 {
     _system_impl->set_msg_rate_async(
-        MAVLINK_MSG_ID_SYS_STATUS,
+        MAVLINK_MSG_ID_BATTERY_STATUS,
         rate_hz,
         [callback](MavlinkCommandSender::Result command_result, float) {
             command_result_callback(command_result, callback);


### PR DESCRIPTION
[set_rate_battery](https://github.com/mavlink/MAVSDK/blob/57fa6e80790a1af4d4bde21292ad5084112b506b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp#L585) is actually setting the rate of system status. It has also been mentioned in the [issue](https://github.com/mavlink/MAVSDK/issues/1996).