### PR TITLE
Update mavlink

### DIFF
--- a/examples/gimbal_device_tester/gimbal_device_tester.cpp
+++ b/examples/gimbal_device_tester/gimbal_device_tester.cpp
@@ -202,7 +202,8 @@ private:
             0, // estimated delay
             0.0f, // feed forward angular velocity z
             estimator_status,
-            MAV_LANDED_STATE_IN_AIR);
+            MAV_LANDED_STATE_IN_AIR,
+            NAN); // angular velocity z
         _mavlink_passthrough.send_message(message);
     }
 

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -855,8 +855,7 @@ SystemImpl::make_command_ardupilot_mode(FlightMode flight_mode, uint8_t componen
         case MAV_TYPE::MAV_TYPE_VTOL_TILTROTOR:
         case MAV_TYPE::MAV_TYPE_VTOL_FIXEDROTOR:
         case MAV_TYPE::MAV_TYPE_VTOL_TAILSITTER:
-        case MAV_TYPE::MAV_TYPE_VTOL_RESERVED4:
-        case MAV_TYPE::MAV_TYPE_VTOL_RESERVED5: {
+        case MAV_TYPE::MAV_TYPE_VTOL_TILTWING: {
             const auto new_mode = flight_mode_to_ardupilot_plane_mode(flight_mode);
             if (new_mode == ardupilot::PlaneMode::Unknown) {
                 LogErr() << "Cannot translate flight mode to ArduPilot Plane mode.";

--- a/third_party/mavlink/CMakeLists.txt
+++ b/third_party/mavlink/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 ExternalProject_add(
     mavlink
     GIT_REPOSITORY https://github.com/mavlink/mavlink
-    GIT_TAG c65c498efd2d9673e1d7da37025686daa5a7d568
+    GIT_TAG 3ee5382d0c96134b0e1c250d8c2d54bfed0166fa
     PREFIX mavlink
     CONFIGURE_COMMAND ${CONFIGURE_COMMAND}
     COMMAND Python3::Interpreter


### PR DESCRIPTION
Apparently, RESERVED MAVLink messages can be renamed.

Maybe we shouldn't use them in the MAVSDK sources at all? I.e. should I remove the `case MAV_TYPE::MAV_TYPE_VTOL_RESERVED5:` line?

Having breaking changes like this creates problems when using custom dialects.