### PR TITLE
core: fix system tests subscription

### DIFF
--- a/src/mavsdk/core/callback_list_impl.h
+++ b/src/mavsdk/core/callback_list_impl.h
@@ -36,6 +36,12 @@ public:
 
     void unsubscribe(Handle<Args...> handle)
     {
+        // Ignore null handle.
+        if (handle._id == 0) {
+            LogErr() << "Invalid null handle";
+            return;
+        }
+
         // We want to allow unsubscribing while in a callback. This would
         // normally lead to a deadlock. Therefore, we just try to grab the
         // lock here, and if it's already taken, we schedule the removal
@@ -127,7 +133,7 @@ private:
     }
 
     mutable std::mutex _mutex{};
-    uint64_t _last_id{0};
+    uint64_t _last_id{1}; // Start at 1 because 0 is the "null handle"
     std::vector<std::pair<Handle<Args...>, std::function<void(Args...)>>> _list{};
 
     mutable std::mutex _remove_later_mutex{};

--- a/src/mavsdk/core/include/mavsdk/handle.h
+++ b/src/mavsdk/core/include/mavsdk/handle.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 namespace mavsdk {
 
 template<typename... Args> class CallbackListImpl;
@@ -10,10 +12,14 @@ template<typename... Args> class FakeHandle;
  * @brief A handle returned from subscribe which allows to unsubscribe again.
  */
 template<typename... Args> class Handle {
+public:
+    Handle() = default;
+    ~Handle() = default;
+
 private:
-    Handle() = delete;
     explicit Handle(uint64_t id) : _id(id) {}
-    uint64_t _id;
+    uint64_t _id{0};
+
     friend CallbackListImpl<Args...>;
     friend FakeHandle<Args...>;
 };

--- a/src/system_tests/system_tests_helper.cpp
+++ b/src/system_tests/system_tests_helper.cpp
@@ -1,4 +1,5 @@
 #include "system_tests_helper.h"
+#include <optional>
 
 namespace mavsdk {
 
@@ -8,17 +9,15 @@ std::future<std::shared_ptr<System>> wait_for_first_system_detected(Mavsdk& mavs
 
     auto prom = std::make_shared<std::promise<std::shared_ptr<System>>>();
 
-    // We pass a copy of the shared ptr to the promise to keep it alive after
-    // this function goes out of scope.
-    const Mavsdk::NewSystemHandle handle =
-        mavsdk.subscribe_on_new_system([&mavsdk, prom, handle]() {
-            const auto system = mavsdk.systems().at(0);
-            if (system->is_connected()) {
-                mavsdk.unsubscribe_on_new_system(handle);
-                LogInfo() << "Discovered system";
-                prom->set_value(system);
-            }
-        });
+    auto handle = std::make_shared<Mavsdk::NewSystemHandle>();
+    *handle = mavsdk.subscribe_on_new_system([prom, &mavsdk, handle]() {
+        const auto system = mavsdk.systems().at(0);
+        if (system->is_connected()) {
+            mavsdk.unsubscribe_on_new_system(*handle);
+            LogInfo() << "Discovered system";
+            prom->set_value(system);
+        }
+    });
 
     return prom->get_future();
 }


### PR DESCRIPTION
It turns out that the handle went out of scope and we segfaulted. Therefore, we need to create a shared_ptr containing it.

This also required the Handle to be default constructible, with id 0 which basically means it's a NullHandle.