### PR TITLE
Easier discovery

### DIFF
--- a/examples/battery/battery.cpp
+++ b/examples/battery/battery.cpp
@@ -29,37 +29,6 @@ void usage(const std::string& bin_name)
               << "For example, to connect to the simulator use URL: udp://:14540\n";
 }
 
-std::shared_ptr<System> get_system(Mavsdk& mavsdk)
-{
-    std::cout << "Waiting to discover system...\n";
-    auto prom = std::promise<std::shared_ptr<System>>{};
-    auto fut = prom.get_future();
-
-    // We wait for new systems to be discovered, once we find one that has an
-    // autopilot, we decide to use it.
-    Mavsdk::NewSystemHandle handle = mavsdk.subscribe_on_new_system([&mavsdk, &prom, &handle]() {
-        auto system = mavsdk.systems().back();
-
-        if (system->has_autopilot()) {
-            std::cout << "Discovered autopilot\n";
-
-            // Unsubscribe again as we only want to find one system.
-            mavsdk.unsubscribe_on_new_system(handle);
-            prom.set_value(system);
-        }
-    });
-
-    // We usually receive heartbeats at 1Hz, therefore we should find a
-    // system after around 3 seconds max, surely.
-    if (fut.wait_for(seconds(3)) == std::future_status::timeout) {
-        std::cerr << "No autopilot found.\n";
-        return {};
-    }
-
-    // Get discovered system now.
-    return fut.get();
-}
-
 int main(int argc, char** argv)
 {
     if (argc != 2) {
@@ -75,14 +44,15 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto system = get_system(mavsdk);
+    auto system = mavsdk.first_autopilot(3.0);
     if (!system) {
+        std::cerr << "Timed out waiting for system\n";
         return 1;
     }
 
     // Instantiate plugins.
-    auto telemetry = Telemetry{system};
-    auto mavlink_passthrough = MavlinkPassthrough{system};
+    auto telemetry = Telemetry{system.value()};
+    auto mavlink_passthrough = MavlinkPassthrough{system.value()};
 
     subscribe_armed(telemetry);
 

--- a/examples/calibrate/calibrate.cpp
+++ b/examples/calibrate/calibrate.cpp
@@ -30,37 +30,6 @@ void usage(const std::string& bin_name)
               << "For example, to connect to the simulator use URL: udp://:14540\n";
 }
 
-std::shared_ptr<System> get_system(Mavsdk& mavsdk)
-{
-    std::cout << "Waiting to discover system...\n";
-    auto prom = std::promise<std::shared_ptr<System>>{};
-    auto fut = prom.get_future();
-
-    // We wait for new systems to be discovered, once we find one that has an
-    // autopilot, we decide to use it.
-    Mavsdk::NewSystemHandle handle = mavsdk.subscribe_on_new_system([&mavsdk, &prom, &handle]() {
-        auto system = mavsdk.systems().back();
-
-        if (system->has_autopilot()) {
-            std::cout << "Discovered autopilot\n";
-
-            // Unsubscribe again as we only want to find one system.
-            mavsdk.unsubscribe_on_new_system(handle);
-            prom.set_value(system);
-        }
-    });
-
-    // We usually receive heartbeats at 1Hz, therefore we should find a
-    // system after around 3 seconds max, surely.
-    if (fut.wait_for(seconds(3)) == std::future_status::timeout) {
-        std::cerr << "No autopilot found.\n";
-        return {};
-    }
-
-    // Get discovered system now.
-    return fut.get();
-}
-
 int main(int argc, char** argv)
 {
     if (argc != 2) {
@@ -76,13 +45,14 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto system = get_system(mavsdk);
+    auto system = mavsdk.first_autopilot(3.0);
     if (!system) {
+        std::cerr << "Timed out waiting for system\n";
         return 1;
     }
 
     // Instantiate plugin.
-    auto calibration = Calibration(system);
+    auto calibration = Calibration(system.value());
 
     // Run calibrations
     calibrate_accelerometer(calibration);

--- a/examples/fly_mission/fly_mission.cpp
+++ b/examples/fly_mission/fly_mission.cpp
@@ -49,37 +49,6 @@ void usage(const std::string& bin_name)
               << "For example, to connect to the simulator use URL: udp://:14540\n";
 }
 
-std::shared_ptr<System> get_system(Mavsdk& mavsdk)
-{
-    std::cout << "Waiting to discover system...\n";
-    auto prom = std::promise<std::shared_ptr<System>>{};
-    auto fut = prom.get_future();
-
-    // We wait for new systems to be discovered, once we find one that has an
-    // autopilot, we decide to use it.
-    Mavsdk::NewSystemHandle handle = mavsdk.subscribe_on_new_system([&mavsdk, &prom, &handle]() {
-        auto system = mavsdk.systems().back();
-
-        if (system->has_autopilot()) {
-            std::cout << "Discovered autopilot\n";
-
-            // Unsubscribe again as we only want to find one system.
-            mavsdk.unsubscribe_on_new_system(handle);
-            prom.set_value(system);
-        }
-    });
-
-    // We usually receive heartbeats at 1Hz, therefore we should find a
-    // system after around 3 seconds max, surely.
-    if (fut.wait_for(seconds(3)) == std::future_status::timeout) {
-        std::cerr << "No autopilot found.\n";
-        return {};
-    }
-
-    // Get discovered system now.
-    return fut.get();
-}
-
 int main(int argc, char** argv)
 {
     if (argc != 2) {
@@ -95,14 +64,15 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto system = get_system(mavsdk);
+    auto system = mavsdk.first_autopilot(3.0);
     if (!system) {
+        std::cerr << "Timed out waiting for system\n";
         return 1;
     }
 
-    auto action = Action{system};
-    auto mission = Mission{system};
-    auto telemetry = Telemetry{system};
+    auto action = Action{system.value()};
+    auto mission = Mission{system.value()};
+    auto telemetry = Telemetry{system.value()};
 
     while (!telemetry.health_all_ok()) {
         std::cout << "Waiting for system to be ready\n";

--- a/examples/fly_qgc_mission/fly_qgc_mission.cpp
+++ b/examples/fly_qgc_mission/fly_qgc_mission.cpp
@@ -41,37 +41,6 @@ void usage(const std::string& bin_name)
               << "For example, to connect to the simulator use URL: udp://:14540\n";
 }
 
-std::shared_ptr<System> get_system(Mavsdk& mavsdk)
-{
-    std::cout << "Waiting to discover system...\n";
-    auto prom = std::promise<std::shared_ptr<System>>{};
-    auto fut = prom.get_future();
-
-    // We wait for new systems to be discovered, once we find one that has an
-    // autopilot, we decide to use it.
-    Mavsdk::NewSystemHandle handle = mavsdk.subscribe_on_new_system([&mavsdk, &prom, &handle]() {
-        auto system = mavsdk.systems().back();
-
-        if (system->has_autopilot()) {
-            std::cout << "Discovered autopilot\n";
-
-            // Unsubscribe again as we only want to find one system.
-            mavsdk.unsubscribe_on_new_system(handle);
-            prom.set_value(system);
-        }
-    });
-
-    // We usually receive heartbeats at 1Hz, therefore we should find a
-    // system after around 3 seconds max, surely.
-    if (fut.wait_for(seconds(3)) == std::future_status::timeout) {
-        std::cerr << "No autopilot found.\n";
-        return {};
-    }
-
-    // Get discovered system now.
-    return fut.get();
-}
-
 int main(int argc, char** argv)
 {
     if (argc != 3) {
@@ -87,13 +56,15 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto system = get_system(mavsdk);
+    auto system = mavsdk.first_autopilot(3.0);
     if (!system) {
+        std::cerr << "Timed out waiting for system\n";
         return 1;
     }
-    auto action = Action{system};
-    auto mission_raw = MissionRaw{system};
-    auto telemetry = Telemetry{system};
+
+    auto action = Action{system.value()};
+    auto mission_raw = MissionRaw{system.value()};
+    auto telemetry = Telemetry{system.value()};
 
     while (!telemetry.health_all_ok()) {
         std::cout << "Waiting for system to be ready\n";

--- a/examples/geofence/geofence.cpp
+++ b/examples/geofence/geofence.cpp
@@ -31,37 +31,6 @@ void usage(const std::string& bin_name)
               << "For example, to connect to the simulator use URL: udp://:14540\n";
 }
 
-std::shared_ptr<System> get_system(Mavsdk& mavsdk)
-{
-    std::cout << "Waiting to discover system...\n";
-    auto prom = std::promise<std::shared_ptr<System>>{};
-    auto fut = prom.get_future();
-
-    // We wait for new systems to be discovered, once we find one that has an
-    // autopilot, we decide to use it.
-    Mavsdk::NewSystemHandle handle = mavsdk.subscribe_on_new_system([&mavsdk, &prom, &handle]() {
-        auto system = mavsdk.systems().back();
-
-        if (system->has_autopilot()) {
-            std::cout << "Discovered autopilot\n";
-
-            // Unsubscribe again as we only want to find one system.
-            mavsdk.unsubscribe_on_new_system(handle);
-            prom.set_value(system);
-        }
-    });
-
-    // We usually receive heartbeats at 1Hz, therefore we should find a
-    // system after around 3 seconds max, surely.
-    if (fut.wait_for(seconds(3)) == std::future_status::timeout) {
-        std::cerr << "No autopilot found.\n";
-        return {};
-    }
-
-    // Get discovered system now.
-    return fut.get();
-}
-
 int main(int argc, char** argv)
 {
     if (argc != 2) {
@@ -77,14 +46,15 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto system = get_system(mavsdk);
+    auto system = mavsdk.first_autopilot(3.0);
     if (!system) {
+        std::cerr << "Timed out waiting for system\n";
         return 1;
     }
 
     // Instantiate plugins.
-    auto telemetry = Telemetry{system};
-    auto geofence = Geofence{system};
+    auto telemetry = Telemetry{system.value()};
+    auto geofence = Geofence{system.value()};
 
     while (!telemetry.health_all_ok()) {
         std::cout << "Waiting for system to be ready\n";

--- a/examples/gimbal/gimbal.cpp
+++ b/examples/gimbal/gimbal.cpp
@@ -28,37 +28,6 @@ void usage(const std::string& bin_name)
               << "For example, to connect to the simulator use URL: udp://:14540\n";
 }
 
-std::shared_ptr<System> get_system(Mavsdk& mavsdk)
-{
-    std::cout << "Waiting to discover system...\n";
-    auto prom = std::promise<std::shared_ptr<System>>{};
-    auto fut = prom.get_future();
-
-    // We wait for new systems to be discovered, once we find one that has an
-    // autopilot, we decide to use it.
-    Mavsdk::NewSystemHandle handle = mavsdk.subscribe_on_new_system([&mavsdk, &prom, &handle]() {
-        auto system = mavsdk.systems().back();
-
-        if (system->has_autopilot()) {
-            std::cout << "Discovered autopilot\n";
-
-            // Unsubscribe again as we only want to find one system.
-            mavsdk.unsubscribe_on_new_system(handle);
-            prom.set_value(system);
-        }
-    });
-
-    // We usually receive heartbeats at 1Hz, therefore we should find a
-    // system after around 3 seconds max, surely.
-    if (fut.wait_for(seconds(3)) == std::future_status::timeout) {
-        std::cerr << "No autopilot found.\n";
-        return {};
-    }
-
-    // Get discovered system now.
-    return fut.get();
-}
-
 int main(int argc, char** argv)
 {
     if (argc != 2) {
@@ -74,14 +43,15 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto system = get_system(mavsdk);
+    auto system = mavsdk.first_autopilot(3.0);
     if (!system) {
+        std::cerr << "Timed out waiting for system\n";
         return 1;
     }
 
     // Instantiate plugins.
-    auto telemetry = Telemetry{system};
-    auto gimbal = Gimbal{system};
+    auto telemetry = Telemetry{system.value()};
+    auto gimbal = Gimbal{system.value()};
 
     // We want to listen to the camera/gimbal angle of the drone at 5 Hz.
     const Telemetry::Result set_rate_result = telemetry.set_rate_camera_attitude(5.0);

--- a/examples/manual_control/manual_control.cpp
+++ b/examples/manual_control/manual_control.cpp
@@ -36,37 +36,6 @@ struct JoystickMapping {
     bool throttle_inverted = true;
 } joystick_mapping{};
 
-std::shared_ptr<System> get_system(Mavsdk& mavsdk)
-{
-    std::cout << "Waiting to discover system...\n";
-    auto prom = std::promise<std::shared_ptr<System>>{};
-    auto fut = prom.get_future();
-
-    // We wait for new systems to be discovered, once we find one that has an
-    // autopilot, we decide to use it.
-    Mavsdk::NewSystemHandle handle = mavsdk.subscribe_on_new_system([&mavsdk, &prom, &handle]() {
-        auto system = mavsdk.systems().back();
-
-        if (system->has_autopilot()) {
-            std::cout << "Discovered autopilot\n";
-
-            // Unsubscribe again as we only want to find one system.
-            mavsdk.unsubscribe_on_new_system(handle);
-            prom.set_value(system);
-        }
-    });
-
-    // We usually receive heartbeats at 1Hz, therefore we should find a
-    // system after around 3 seconds max, surely.
-    if (fut.wait_for(seconds(3)) == std::future_status::timeout) {
-        std::cerr << "No autopilot found.\n";
-        return {};
-    }
-
-    // Get discovered system now.
-    return fut.get();
-}
-
 void usage(const std::string& bin_name)
 {
     std::cerr << "Usage : " << bin_name << " <connection_url>\n"
@@ -98,15 +67,16 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto system = get_system(mavsdk);
+    auto system = mavsdk.first_autopilot(3.0);
     if (!system) {
+        std::cerr << "Timed out waiting for system\n";
         return 1;
     }
 
     // Instantiate plugins.
-    auto action = Action{system};
-    auto telemetry = Telemetry{system};
-    auto manual_control = ManualControl{system};
+    auto action = Action{system.value()};
+    auto telemetry = Telemetry{system.value()};
+    auto manual_control = ManualControl{system.value()};
 
     while (!telemetry.health_all_ok()) {
         std::cout << "Waiting for system to be ready\n";

--- a/examples/mavshell/mavshell.cpp
+++ b/examples/mavshell/mavshell.cpp
@@ -18,37 +18,6 @@ void usage(const std::string& bin_name)
               << "For example, to connect to the simulator use URL: udp://:14540\n";
 }
 
-std::shared_ptr<System> get_system(Mavsdk& mavsdk)
-{
-    std::cout << "Waiting to discover system...\n";
-    auto prom = std::promise<std::shared_ptr<System>>{};
-    auto fut = prom.get_future();
-
-    // We wait for new systems to be discovered, once we find one that has an
-    // autopilot, we decide to use it.
-    Mavsdk::NewSystemHandle handle = mavsdk.subscribe_on_new_system([&mavsdk, &prom, &handle]() {
-        auto system = mavsdk.systems().back();
-
-        if (system->has_autopilot()) {
-            std::cout << "Discovered autopilot\n";
-
-            // Unsubscribe again as we only want to find one system.
-            mavsdk.unsubscribe_on_new_system(handle);
-            prom.set_value(system);
-        }
-    });
-
-    // We usually receive heartbeats at 1Hz, therefore we should find a
-    // system after around 3 seconds max, surely.
-    if (fut.wait_for(seconds(3)) == std::future_status::timeout) {
-        std::cerr << "No autopilot found.\n";
-        return {};
-    }
-
-    // Get discovered system now.
-    return fut.get();
-}
-
 int main(int argc, char** argv)
 {
     if (argc != 2) {
@@ -64,13 +33,14 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto system = get_system(mavsdk);
+    auto system = mavsdk.first_autopilot(3.0);
     if (!system) {
+        std::cerr << "Timed out waiting for system\n";
         return 1;
     }
 
     // Instantiate plugins.
-    run_interactive_shell(system);
+    run_interactive_shell(system.value());
 
     return 0;
 }

--- a/examples/offboard/offboard.cpp
+++ b/examples/offboard/offboard.cpp
@@ -30,37 +30,6 @@ void usage(const std::string& bin_name)
               << "For example, to connect to the simulator use URL: udp://:14540\n";
 }
 
-std::shared_ptr<System> get_system(Mavsdk& mavsdk)
-{
-    std::cout << "Waiting to discover system...\n";
-    auto prom = std::promise<std::shared_ptr<System>>{};
-    auto fut = prom.get_future();
-
-    // We wait for new systems to be discovered, once we find one that has an
-    // autopilot, we decide to use it.
-    Mavsdk::NewSystemHandle handle = mavsdk.subscribe_on_new_system([&mavsdk, &prom, &handle]() {
-        auto system = mavsdk.systems().back();
-
-        if (system->has_autopilot()) {
-            std::cout << "Discovered autopilot\n";
-
-            // Unsubscribe again as we only want to find one system.
-            mavsdk.unsubscribe_on_new_system(handle);
-            prom.set_value(system);
-        }
-    });
-
-    // We usually receive heartbeats at 1Hz, therefore we should find a
-    // system after around 3 seconds max, surely.
-    if (fut.wait_for(seconds(3)) == std::future_status::timeout) {
-        std::cerr << "No autopilot found.\n";
-        return {};
-    }
-
-    // Get discovered system now.
-    return fut.get();
-}
-
 //
 // Does Offboard control using NED co-ordinates.
 //
@@ -339,15 +308,16 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto system = get_system(mavsdk);
+    auto system = mavsdk.first_autopilot(3.0);
     if (!system) {
+        std::cerr << "Timed out waiting for system\n";
         return 1;
     }
 
     // Instantiate plugins.
-    auto action = Action{system};
-    auto offboard = Offboard{system};
-    auto telemetry = Telemetry{system};
+    auto action = Action{system.value()};
+    auto offboard = Offboard{system.value()};
+    auto telemetry = Telemetry{system.value()};
 
     while (!telemetry.health_all_ok()) {
         std::cout << "Waiting for system to be ready\n";

--- a/examples/sniffer/sniffer.cpp
+++ b/examples/sniffer/sniffer.cpp
@@ -22,37 +22,6 @@ void usage(const std::string& bin_name)
               << "For example, to connect to the simulator use URL: udp://:14540\n";
 }
 
-std::shared_ptr<System> get_system(Mavsdk& mavsdk)
-{
-    std::cout << "Waiting to discover system...\n";
-    auto prom = std::promise<std::shared_ptr<System>>{};
-    auto fut = prom.get_future();
-
-    // We wait for new systems to be discovered, once we find one that has an
-    // autopilot, we decide to use it.
-    Mavsdk::NewSystemHandle handle = mavsdk.subscribe_on_new_system([&mavsdk, &prom, &handle]() {
-        auto system = mavsdk.systems().back();
-
-        if (system->has_autopilot()) {
-            std::cout << "Discovered autopilot\n";
-
-            // Unsubscribe again as we only want to find one system.
-            mavsdk.unsubscribe_on_new_system(handle);
-            prom.set_value(system);
-        }
-    });
-
-    // We usually receive heartbeats at 1Hz, therefore we should find a
-    // system after around 3 seconds max, surely.
-    if (fut.wait_for(seconds(3)) == std::future_status::timeout) {
-        std::cerr << "No autopilot found.\n";
-        return {};
-    }
-
-    // Get discovered system now.
-    return fut.get();
-}
-
 int main(int argc, char** argv)
 {
     if (argc != 2) {
@@ -68,8 +37,9 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto system = get_system(mavsdk);
+    auto system = mavsdk.first_autopilot(3.0);
     if (!system) {
+        std::cerr << "Timed out waiting for system\n";
         return 1;
     }
 

--- a/examples/system_info/system_info.cpp
+++ b/examples/system_info/system_info.cpp
@@ -25,37 +25,6 @@ void usage(const std::string& bin_name)
               << "For example, to connect to the simulator use URL: udp://:14540\n";
 }
 
-std::shared_ptr<System> get_system(Mavsdk& mavsdk)
-{
-    std::cout << "Waiting to discover system...\n";
-    auto prom = std::promise<std::shared_ptr<System>>{};
-    auto fut = prom.get_future();
-
-    // We wait for new systems to be discovered, once we find one that has an
-    // autopilot, we decide to use it.
-    Mavsdk::NewSystemHandle handle = mavsdk.subscribe_on_new_system([&mavsdk, &prom, &handle]() {
-        auto system = mavsdk.systems().back();
-
-        if (system->has_autopilot()) {
-            std::cout << "Discovered autopilot\n";
-
-            // Unsubscribe again as we only want to find one system.
-            mavsdk.unsubscribe_on_new_system(handle);
-            prom.set_value(system);
-        }
-    });
-
-    // We usually receive heartbeats at 1Hz, therefore we should find a
-    // system after around 3 seconds max, surely.
-    if (fut.wait_for(seconds(3)) == std::future_status::timeout) {
-        std::cerr << "No autopilot found.\n";
-        return {};
-    }
-
-    // Get discovered system now.
-    return fut.get();
-}
-
 int main(int argc, char** argv)
 {
     if (argc != 2) {
@@ -71,12 +40,13 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto system = get_system(mavsdk);
+    auto system = mavsdk.first_autopilot(3.0);
     if (!system) {
+        std::cerr << "Timed out waiting for system\n";
         return 1;
     }
 
-    auto info = Info{system};
+    auto info = Info{system.value()};
 
     // Wait until version/firmware information has been populated from the vehicle
     while (info.get_identification().first == Info::Result::InformationNotReceivedYet) {

--- a/examples/takeoff_and_land/takeoff_and_land.cpp
+++ b/examples/takeoff_and_land/takeoff_and_land.cpp
@@ -26,37 +26,6 @@ void usage(const std::string& bin_name)
               << "For example, to connect to the simulator use URL: udp://:14540\n";
 }
 
-std::shared_ptr<System> get_system(Mavsdk& mavsdk)
-{
-    std::cout << "Waiting to discover system...\n";
-    auto prom = std::promise<std::shared_ptr<System>>{};
-    auto fut = prom.get_future();
-
-    // We wait for new systems to be discovered, once we find one that has an
-    // autopilot, we decide to use it.
-    Mavsdk::NewSystemHandle handle = mavsdk.subscribe_on_new_system([&mavsdk, &prom, &handle]() {
-        auto system = mavsdk.systems().back();
-
-        if (system->has_autopilot()) {
-            std::cout << "Discovered autopilot\n";
-
-            // Unsubscribe again as we only want to find one system.
-            mavsdk.unsubscribe_on_new_system(handle);
-            prom.set_value(system);
-        }
-    });
-
-    // We usually receive heartbeats at 1Hz, therefore we should find a
-    // system after around 3 seconds max, surely.
-    if (fut.wait_for(seconds(3)) == std::future_status::timeout) {
-        std::cerr << "No autopilot found.\n";
-        return {};
-    }
-
-    // Get discovered system now.
-    return fut.get();
-}
-
 int main(int argc, char** argv)
 {
     if (argc != 2) {
@@ -72,14 +41,15 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto system = get_system(mavsdk);
+    auto system = mavsdk.first_autopilot(3.0);
     if (!system) {
+        std::cerr << "Timed out waiting for system\n";
         return 1;
     }
 
     // Instantiate plugins.
-    auto telemetry = Telemetry{system};
-    auto action = Action{system};
+    auto telemetry = Telemetry{system.value()};
+    auto action = Action{system.value()};
 
     // We want to listen to the altitude of the drone at 1 Hz.
     const auto set_rate_result = telemetry.set_rate_position(1.0);

--- a/examples/transponder/transponder.cpp
+++ b/examples/transponder/transponder.cpp
@@ -25,37 +25,6 @@ void usage(const std::string& bin_name)
               << "For example, to connect to the simulator use URL: udp://:14540\n";
 }
 
-std::shared_ptr<System> get_system(Mavsdk& mavsdk)
-{
-    std::cout << "Waiting to discover system...\n";
-    auto prom = std::promise<std::shared_ptr<System>>{};
-    auto fut = prom.get_future();
-
-    // We wait for new systems to be discovered, once we find one that has an
-    // autopilot, we decide to use it.
-    Mavsdk::NewSystemHandle handle = mavsdk.subscribe_on_new_system([&mavsdk, &prom, &handle]() {
-        auto system = mavsdk.systems().back();
-
-        if (system->has_autopilot()) {
-            std::cout << "Discovered autopilot\n";
-
-            // Unsubscribe again as we only want to find one system.
-            mavsdk.unsubscribe_on_new_system(handle);
-            prom.set_value(system);
-        }
-    });
-
-    // We usually receive heartbeats at 1Hz, therefore we should find a
-    // system after around 3 seconds max, surely.
-    if (fut.wait_for(seconds(3)) == std::future_status::timeout) {
-        std::cerr << "No autopilot found.\n";
-        return {};
-    }
-
-    // Get discovered system now.
-    return fut.get();
-}
-
 int main(int argc, char** argv)
 {
     if (argc != 2) {
@@ -71,13 +40,14 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto system = get_system(mavsdk);
+    auto system = mavsdk.first_autopilot(3.0);
     if (!system) {
+        std::cerr << "Timed out waiting for system\n";
         return 1;
     }
 
     // Instantiate plugin.
-    auto transponder = Transponder{system};
+    auto transponder = Transponder{system.value()};
 
     // We want to listen to the transponder of the drone at 1 Hz.
     std::cout << "Setting transponder update rate\n";

--- a/examples/tune/tune.cpp
+++ b/examples/tune/tune.cpp
@@ -23,37 +23,6 @@ void usage(const std::string& bin_name)
               << "For example, to connect to the simulator use URL: udp://:14540\n";
 }
 
-std::shared_ptr<System> get_system(Mavsdk& mavsdk)
-{
-    std::cout << "Waiting to discover system...\n";
-    auto prom = std::promise<std::shared_ptr<System>>{};
-    auto fut = prom.get_future();
-
-    // We wait for new systems to be discovered, once we find one that has an
-    // autopilot, we decide to use it.
-    Mavsdk::NewSystemHandle handle = mavsdk.subscribe_on_new_system([&mavsdk, &prom, &handle]() {
-        auto system = mavsdk.systems().back();
-
-        if (system->has_autopilot()) {
-            std::cout << "Discovered autopilot\n";
-
-            // Unsubscribe again as we only want to find one system.
-            mavsdk.unsubscribe_on_new_system(handle);
-            prom.set_value(system);
-        }
-    });
-
-    // We usually receive heartbeats at 1Hz, therefore we should find a
-    // system after around 3 seconds max, surely.
-    if (fut.wait_for(seconds(3)) == std::future_status::timeout) {
-        std::cerr << "No autopilot found.\n";
-        return {};
-    }
-
-    // Get discovered system now.
-    return fut.get();
-}
-
 int main(int argc, char** argv)
 {
     if (argc != 2) {
@@ -69,13 +38,14 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto system = get_system(mavsdk);
+    auto system = mavsdk.first_autopilot(3.0);
     if (!system) {
+        std::cerr << "Timed out waiting for system\n";
         return 1;
     }
 
     // Instantiate plugin.
-    Tune tune(system);
+    Tune tune(system.value());
 
     std::vector<Tune::SongElement> song_elements;
     song_elements.push_back(Tune::SongElement::Duration4);

--- a/examples/vtol_transition/vtol_transition.cpp
+++ b/examples/vtol_transition/vtol_transition.cpp
@@ -27,37 +27,6 @@ void usage(const std::string& bin_name)
               << "For example, to connect to the simulator use URL: udp://:14540\n";
 }
 
-std::shared_ptr<System> get_system(Mavsdk& mavsdk)
-{
-    std::cout << "Waiting to discover system...\n";
-    auto prom = std::promise<std::shared_ptr<System>>{};
-    auto fut = prom.get_future();
-
-    // We wait for new systems to be discovered, once we find one that has an
-    // autopilot, we decide to use it.
-    Mavsdk::NewSystemHandle handle = mavsdk.subscribe_on_new_system([&mavsdk, &prom, &handle]() {
-        auto system = mavsdk.systems().back();
-
-        if (system->has_autopilot()) {
-            std::cout << "Discovered autopilot\n";
-
-            // Unsubscribe again as we only want to find one system.
-            mavsdk.unsubscribe_on_new_system(handle);
-            prom.set_value(system);
-        }
-    });
-
-    // We usually receive heartbeats at 1Hz, therefore we should find a
-    // system after around 3 seconds max, surely.
-    if (fut.wait_for(seconds(3)) == std::future_status::timeout) {
-        std::cerr << "No autopilot found.\n";
-        return {};
-    }
-
-    // Get discovered system now.
-    return fut.get();
-}
-
 int main(int argc, char** argv)
 {
     if (argc != 2) {
@@ -73,14 +42,15 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto system = get_system(mavsdk);
+    auto system = mavsdk.first_autopilot(3.0);
     if (!system) {
+        std::cerr << "Timed out waiting for system\n";
         return 1;
     }
 
     // Instantiate plugins.
-    auto telemetry = Telemetry{system};
-    auto action = Action{system};
+    auto telemetry = Telemetry{system.value()};
+    auto action = Action{system.value()};
 
     // We want to listen to the altitude of the drone at 1 Hz.
     const Telemetry::Result set_rate_result = telemetry.set_rate_position(1.0);

--- a/src/mavsdk/core/include/mavsdk/mavsdk.h
+++ b/src/mavsdk/core/include/mavsdk/mavsdk.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <memory>
+#include <optional>
 #include <vector>
 #include <functional>
 
@@ -173,6 +174,17 @@ public:
     std::vector<std::shared_ptr<System>> systems() const;
 
     /**
+     * @brief Get the first system that has been discovered.
+     *
+     * @param timeout_s A timeout in seconds.
+     *                  A timeout of 0 will not wait and return immediately.
+     *                  A negative timeout will wait forever.
+     *
+     * @return A system or nothing if nothing was discovered within the timeout.
+     */
+    std::optional<std::shared_ptr<System>> first_system(double timeout_s) const;
+
+    /**
      * @brief Possible configurations.
      */
     class Configuration {
@@ -303,15 +315,16 @@ public:
      *
      * This gets called whenever a system is added.
      *
-     * @note Only one subscriber is possible at any time. On a second
-     * subscription, the previous one is overwritten. To unsubscribe, pass nullptr;
-     *
      * @param callback Callback to subscribe.
+     *
+     * @return A handle to unsubscribe again.
      */
     NewSystemHandle subscribe_on_new_system(const NewSystemCallback& callback);
 
     /**
      * @brief unsubscribe from subscribe_on_new_system.
+     *
+     * @param handle Handle received on subscription.
      */
     void unsubscribe_on_new_system(NewSystemHandle handle);
 

--- a/src/mavsdk/core/include/mavsdk/mavsdk.h
+++ b/src/mavsdk/core/include/mavsdk/mavsdk.h
@@ -174,7 +174,10 @@ public:
     std::vector<std::shared_ptr<System>> systems() const;
 
     /**
-     * @brief Get the first system that has been discovered.
+     * @brief Get the first autopilot that has been discovered.
+     *
+     * @note This requires a MAVLink component with component ID 1 sending
+     *       heartbeats.
      *
      * @param timeout_s A timeout in seconds.
      *                  A timeout of 0 will not wait and return immediately.
@@ -182,7 +185,7 @@ public:
      *
      * @return A system or nothing if nothing was discovered within the timeout.
      */
-    std::optional<std::shared_ptr<System>> first_system(double timeout_s) const;
+    std::optional<std::shared_ptr<System>> first_autopilot(double timeout_s) const;
 
     /**
      * @brief Possible configurations.

--- a/src/mavsdk/core/mavsdk.cpp
+++ b/src/mavsdk/core/mavsdk.cpp
@@ -59,6 +59,11 @@ std::vector<std::shared_ptr<System>> Mavsdk::systems() const
     return _impl->systems();
 }
 
+std::optional<std::shared_ptr<System>> Mavsdk::first_system(double timeout_s) const
+{
+    return _impl->first_system(timeout_s);
+}
+
 void Mavsdk::set_configuration(Configuration configuration)
 {
     _impl->set_configuration(configuration);

--- a/src/mavsdk/core/mavsdk.cpp
+++ b/src/mavsdk/core/mavsdk.cpp
@@ -59,9 +59,9 @@ std::vector<std::shared_ptr<System>> Mavsdk::systems() const
     return _impl->systems();
 }
 
-std::optional<std::shared_ptr<System>> Mavsdk::first_system(double timeout_s) const
+std::optional<std::shared_ptr<System>> Mavsdk::first_autopilot(double timeout_s) const
 {
-    return _impl->first_system(timeout_s);
+    return _impl->first_autopilot(timeout_s);
 }
 
 void Mavsdk::set_configuration(Configuration configuration)

--- a/src/mavsdk/core/mavsdk_impl.cpp
+++ b/src/mavsdk/core/mavsdk_impl.cpp
@@ -123,8 +123,10 @@ std::optional<std::shared_ptr<System>> MavsdkImpl::first_autopilot(double timeou
 {
     {
         std::lock_guard<std::recursive_mutex> lock(_systems_mutex);
-        if (!_systems.empty()) {
-            return {_systems[0].second};
+        for (auto system : _systems) {
+            if (system.second->is_connected() && system.second->has_autopilot()) {
+                return system.second;
+            }
         }
     }
 

--- a/src/mavsdk/core/mavsdk_impl.cpp
+++ b/src/mavsdk/core/mavsdk_impl.cpp
@@ -119,7 +119,7 @@ std::vector<std::shared_ptr<System>> MavsdkImpl::systems() const
     return systems_result;
 }
 
-std::optional<std::shared_ptr<System>> MavsdkImpl::first_system(double timeout_s)
+std::optional<std::shared_ptr<System>> MavsdkImpl::first_autopilot(double timeout_s)
 {
     {
         std::lock_guard<std::recursive_mutex> lock(_systems_mutex);
@@ -138,7 +138,7 @@ std::optional<std::shared_ptr<System>> MavsdkImpl::first_system(double timeout_s
     std::once_flag flag;
     auto handle = subscribe_on_new_system([this, &prom, &flag]() {
         const auto system = systems().at(0);
-        if (system->is_connected()) {
+        if (system->is_connected() && system->has_autopilot()) {
             std::call_once(flag, [&prom, &system]() { prom.set_value(system); });
         }
     });

--- a/src/mavsdk/core/mavsdk_impl.h
+++ b/src/mavsdk/core/mavsdk_impl.h
@@ -67,7 +67,7 @@ public:
 
     std::vector<std::shared_ptr<System>> systems() const;
 
-    std::optional<std::shared_ptr<System>> first_system(double timeout_s);
+    std::optional<std::shared_ptr<System>> first_autopilot(double timeout_s);
 
     void set_configuration(Mavsdk::Configuration new_configuration);
     Mavsdk::Configuration get_configuration() const;

--- a/src/mavsdk/core/mavsdk_impl.h
+++ b/src/mavsdk/core/mavsdk_impl.h
@@ -67,6 +67,8 @@ public:
 
     std::vector<std::shared_ptr<System>> systems() const;
 
+    std::optional<std::shared_ptr<System>> first_system(double timeout_s);
+
     void set_configuration(Mavsdk::Configuration new_configuration);
     Mavsdk::Configuration get_configuration() const;
 


### PR DESCRIPTION
This adds an easy blocking API which allows to wait for the first system. This should cover a big percentage of use cases, especially for the integration tests and examples.