### PR TITLE
Remove 0 in debian package name

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Depends: libmavsdk0 (= ${binary:Version}), ${misc:Depends}
 Description: MAVSDK API for Mavlink-controlled vehicles
  This provides the development headers for the mavsdk C++ library.
 
-Package: libmavsdk0
+Package: libmavsdk
 Architecture: any
 Multi-Arch: same
 Depends: ${shlibs:Depends}, ${misc:Depends}, libjsoncpp1, libcurl4, libtinyxml2-6a


### PR DESCRIPTION
I don't really understand this 0. If it is to make a difference between major versions of MAVSDK, why don't we do that in the other package, `libmavsdk-dev`? It should be `libmavsdk0-dev`, right? But then:

* `libmavsdk0-dev` and `libmavsdk1-dev` would conflict on the system anyway, because the headers don't have the version number (we don't `#include mavsdk0/action.h`).
* The `MAVSDKConfig.cmake` and `mavsdk.pc` files would conflict, unless we rename them `MAVSDK0Config.cmake` and `mavsdk0.pc`

But it feels a bit weird to me.