### PR TITLE
tune: fix stack overrun

### DIFF
--- a/src/mavsdk/plugins/tune/tune_impl.cpp
+++ b/src/mavsdk/plugins/tune/tune_impl.cpp
@@ -49,6 +49,11 @@ void TuneImpl::play_tune_async(
     }
 
     std::string tune_str("MFT" + std::to_string(tempo) + "O2");
+
+    // We need to reserve enough because inside the mavlink pack
+    // function it does a memcpy of the full length.
+    tune_str.reserve(MAVLINK_MSG_PLAY_TUNE_V2_FIELD_TUNE_LEN);
+
     int last_duration = 1;
 
     for (auto song_elem : song_elements) {
@@ -126,8 +131,6 @@ void TuneImpl::play_tune_async(
                 break;
         }
     }
-
-    LogDebug() << "About to send tune: " << tune_str;
 
     if (tune_str.size() > MAVLINK_MSG_PLAY_TUNE_V2_FIELD_TUNE_LEN - 1) {
         report_tune_result(callback, Tune::Result::TuneTooLong);


### PR DESCRIPTION
This fixes the case where the mavlink pack function does a memcpy on an array that is shorter.

Fixes "Illegal instruction" errors.

Or in address sanitizer:

```
Address 0x7f0f941f4ac0 is located in stack of thread T10 at offset 192 in frame
    #0 0x7f0f9d0f07f1 in mavsdk::TuneImpl::play_tune_async(mavsdk::Tune::TuneDescription const&, std::function<void (mavsdk::Tune::Result)> const&) (/home/julianoes/src/upstream/MAVSDK/build/debug/src/mavsdk/libmavsdk.so.1+0x9747f1)

  This frame has 10 object(s):
    [32, 40) '__for_begin' (line 54)
    [64, 72) '__for_end' (line 54)
    [96, 120) 'song_elements' (line 43)
    [160, 192) 'tune_str' (line 51)
    [224, 256) '<unknown>' <== Memory access at offset 192 partially underflows this variable
    [288, 320) '<unknown>' <== Memory access at offset 192 partially underflows this variable
    [352, 384) '<unknown>' <== Memory access at offset 192 partially underflows this variable
    [416, 448) '<unknown>' <== Memory access at offset 192 partially underflows this variable
```