### PR TITLE
core: improve subscription race

### DIFF
--- a/src/mavsdk/core/mavsdk_impl.cpp
+++ b/src/mavsdk/core/mavsdk_impl.cpp
@@ -697,11 +697,13 @@ MavsdkImpl::subscribe_on_new_system(const Mavsdk::NewSystemCallback& callback)
 {
     std::lock_guard<std::recursive_mutex> lock(_systems_mutex);
 
-    if (callback != nullptr && is_any_system_connected()) {
-        call_user_callback([temp_callback = callback]() { temp_callback(); });
+    const auto handle = _new_system_callbacks.subscribe(callback);
+
+    if (is_any_system_connected()) {
+        _new_system_callbacks.queue([this](const auto& func) { call_user_callback(func); });
     }
 
-    return _new_system_callbacks.subscribe(callback);
+    return handle;
 }
 
 void MavsdkImpl::unsubscribe_on_new_system(Mavsdk::NewSystemHandle handle)


### PR DESCRIPTION
Often when waiting for a system, you only really want one, so the first one connecting. Therefore, you might immediately unsubscribe again inside the callback.

This pattern didn't work anymore with the new returned handle because we did not return from the function before calling the callback meaning the handle is not actually valid yet.

By adding the callback to the queue we can work around this case although the race condition still exists until we change when the callback is called in a later commit.

Edit: Actually looking at all the logic of queuing and de-queuing a callback it might as well work fine like this in practice.