### PR TITLE
Camera definition: accept bool type in xml

### DIFF
--- a/src/mavsdk/core/param_value.cpp
+++ b/src/mavsdk/core/param_value.cpp
@@ -264,7 +264,10 @@ bool ParamValue::set_from_mavlink_param_ext_value(
 
 bool ParamValue::set_from_xml(const std::string& type_str, const std::string& value_str)
 {
-    if (type_str == "uint8") {
+    if (type_str == "bool") {
+        // bool is internally handled as uint8_t
+        _value = static_cast<uint8_t>(std::stoi(value_str));
+    } else if (type_str == "uint8") {
         _value = static_cast<uint8_t>(std::stoi(value_str));
     } else if (type_str == "int8") {
         _value = static_cast<int8_t>(std::stoi(value_str));
@@ -293,7 +296,9 @@ bool ParamValue::set_from_xml(const std::string& type_str, const std::string& va
 
 bool ParamValue::set_empty_type_from_xml(const std::string& type_str)
 {
-    if (type_str == "uint8") {
+    if (type_str == "bool") {
+        _value = uint8_t(0);
+    } else if (type_str == "uint8") {
         _value = uint8_t(0);
     } else if (type_str == "int8") {
         _value = int8_t(0);

--- a/src/mavsdk/core/param_value.cpp
+++ b/src/mavsdk/core/param_value.cpp
@@ -264,25 +264,25 @@ bool ParamValue::set_from_mavlink_param_ext_value(
 
 bool ParamValue::set_from_xml(const std::string& type_str, const std::string& value_str)
 {
-    if (strcmp(type_str.c_str(), "uint8") == 0) {
+    if (type_str == "uint8") {
         _value = static_cast<uint8_t>(std::stoi(value_str));
-    } else if (strcmp(type_str.c_str(), "int8") == 0) {
+    } else if (type_str == "int8") {
         _value = static_cast<int8_t>(std::stoi(value_str));
-    } else if (strcmp(type_str.c_str(), "uint16") == 0) {
+    } else if (type_str == "uint16") {
         _value = static_cast<uint16_t>(std::stoi(value_str));
-    } else if (strcmp(type_str.c_str(), "int16") == 0) {
+    } else if (type_str == "int16") {
         _value = static_cast<int16_t>(std::stoi(value_str));
-    } else if (strcmp(type_str.c_str(), "uint32") == 0) {
+    } else if (type_str == "uint32") {
         _value = static_cast<uint32_t>(std::stoi(value_str));
-    } else if (strcmp(type_str.c_str(), "int32") == 0) {
+    } else if (type_str == "int32") {
         _value = static_cast<int32_t>(std::stoi(value_str));
-    } else if (strcmp(type_str.c_str(), "uint64") == 0) {
+    } else if (type_str == "uint64") {
         _value = static_cast<uint64_t>(std::stoll(value_str));
-    } else if (strcmp(type_str.c_str(), "int64") == 0) {
+    } else if (type_str == "int64") {
         _value = static_cast<int64_t>(std::stoll(value_str));
-    } else if (strcmp(type_str.c_str(), "float") == 0) {
+    } else if (type_str == "float") {
         _value = static_cast<float>(std::stof(value_str));
-    } else if (strcmp(type_str.c_str(), "double") == 0) {
+    } else if (type_str == "double") {
         _value = static_cast<double>(std::stod(value_str));
     } else {
         LogErr() << "Unknown type: " << type_str;
@@ -293,25 +293,25 @@ bool ParamValue::set_from_xml(const std::string& type_str, const std::string& va
 
 bool ParamValue::set_empty_type_from_xml(const std::string& type_str)
 {
-    if (strcmp(type_str.c_str(), "uint8") == 0) {
+    if (type_str == "uint8") {
         _value = uint8_t(0);
-    } else if (strcmp(type_str.c_str(), "int8") == 0) {
+    } else if (type_str == "int8") {
         _value = int8_t(0);
-    } else if (strcmp(type_str.c_str(), "uint16") == 0) {
+    } else if (type_str == "uint16") {
         _value = uint16_t(0);
-    } else if (strcmp(type_str.c_str(), "int16") == 0) {
+    } else if (type_str == "int16") {
         _value = int16_t(0);
-    } else if (strcmp(type_str.c_str(), "uint32") == 0) {
+    } else if (type_str == "uint32") {
         _value = uint32_t(0);
-    } else if (strcmp(type_str.c_str(), "int32") == 0) {
+    } else if (type_str == "int32") {
         _value = int32_t(0);
-    } else if (strcmp(type_str.c_str(), "uint64") == 0) {
+    } else if (type_str == "uint64") {
         _value = uint64_t(0);
-    } else if (strcmp(type_str.c_str(), "int64") == 0) {
+    } else if (type_str == "int64") {
         _value = int64_t(0);
-    } else if (strcmp(type_str.c_str(), "float") == 0) {
+    } else if (type_str == "float") {
         _value = 0.0f;
-    } else if (strcmp(type_str.c_str(), "double") == 0) {
+    } else if (type_str == "double") {
         _value = 0.0;
     } else {
         LogErr() << "Unknown type: " << type_str;

--- a/src/mavsdk/plugins/camera/camera_definition.cpp
+++ b/src/mavsdk/plugins/camera/camera_definition.cpp
@@ -116,12 +116,12 @@ bool CameraDefinition::parse_xml()
             return false;
         }
 
-        if (strcmp(type_str, "string") == 0) {
+        if (std::string(type_str) == "string") {
             LogDebug() << "Ignoring string params: " << param_name;
             continue;
         }
 
-        if (strcmp(type_str, "custom") == 0) {
+        if (std::string(type_str) == "custom") {
             LogDebug() << "Ignoring custom params: " << param_name;
             continue;
         }
@@ -135,7 +135,7 @@ bool CameraDefinition::parse_xml()
         new_parameter->is_control = true;
         const char* control_str = e_parameter->Attribute("control");
         if (control_str) {
-            if (strcmp(control_str, "0") == 0) {
+            if (std::string(control_str) == "0") {
                 new_parameter->is_control = false;
             }
         }
@@ -143,7 +143,7 @@ bool CameraDefinition::parse_xml()
         new_parameter->is_readonly = false;
         const char* readonly_str = e_parameter->Attribute("readonly");
         if (readonly_str) {
-            if (strcmp(readonly_str, "1") == 0) {
+            if (std::string(readonly_str) == "1") {
                 new_parameter->is_readonly = true;
             }
         }
@@ -151,7 +151,7 @@ bool CameraDefinition::parse_xml()
         new_parameter->is_writeonly = false;
         const char* writeonly_str = e_parameter->Attribute("writeonly");
         if (writeonly_str) {
-            if (strcmp(writeonly_str, "1") == 0) {
+            if (std::string(writeonly_str) == "1") {
                 new_parameter->is_writeonly = true;
             }
         }
@@ -162,7 +162,7 @@ bool CameraDefinition::parse_xml()
         }
 
         // Be definition custom types do not have control.
-        if (strcmp(type_map[param_name].c_str(), "custom") == 0) {
+        if (std::string(type_map[param_name]) == "custom") {
             new_parameter->is_control = false;
         }
 

--- a/src/mavsdk/plugins/camera/camera_definition_test.cpp
+++ b/src/mavsdk/plugins/camera/camera_definition_test.cpp
@@ -346,20 +346,20 @@ TEST(CameraDefinition, E90SettingsCauseUpdates)
         bool found_photoratio = false;
 
         for (const auto& param : params) {
-            if (strcmp("CAM_SHUTTERSPD", param.first.c_str()) == 0) {
+            if (param.first == "CAM_SHUTTERSPD") {
                 found_shutterspd = true;
             }
-            if (strcmp("CAM_ISO", param.first.c_str()) == 0) {
+            if (param.first == "CAM_ISO") {
                 found_iso = true;
             }
-            if (strcmp("CAM_VIDRES", param.first.c_str()) == 0) {
+            if (param.first == "CAM_VIDRES") {
                 found_vidres = true;
             }
             // We don't yet handle ASPECTRATIO
-            // if (strcmp("CAM_ASPECTRATIO", param.first.c_str()) == 0) {
+            // if (param.first == "CAM_ASPECTRATIO") {
             //    found_aspectratio = true;
             //}
-            if (strcmp("CAM_PHOTORATIO", param.first.c_str()) == 0) {
+            if (param.first == "CAM_PHOTORATIO") {
                 found_photoratio = true;
             }
         }

--- a/src/mavsdk/plugins/camera/camera_impl.cpp
+++ b/src/mavsdk/plugins/camera/camera_impl.cpp
@@ -1229,30 +1229,39 @@ bool CameraImpl::load_stored_definition(
     const mavlink_camera_information_t& camera_information, std::string& camera_definition_out)
 {
     // TODO: we might also try to support the correct version of the xml files.
-    if (strcmp((const char*)(camera_information.vendor_name), "Yuneec") == 0) {
-        if (strcmp((const char*)(camera_information.model_name), "E90") == 0) {
+
+    const auto vendor_name = std::string(
+        reinterpret_cast<const char*>(std::begin(camera_information.vendor_name)),
+        reinterpret_cast<const char*>(std::end(camera_information.vendor_name)));
+
+    const auto model_name = std::string(
+        reinterpret_cast<const char*>(std::begin(camera_information.model_name)),
+        reinterpret_cast<const char*>(std::end(camera_information.model_name)));
+
+    if (vendor_name == "Yuneec") {
+        if (model_name == "E90") {
             LogInfo() << "Using cached file for Yuneec E90.";
             camera_definition_out = e90xml;
             return true;
-        } else if (strcmp((const char*)(camera_information.model_name), "E50") == 0) {
+        } else if (model_name == "E50") {
             LogInfo() << "Using cached file for Yuneec E50.";
             camera_definition_out = e50xml;
             return true;
-        } else if (strcmp((const char*)(camera_information.model_name), "CGOET") == 0) {
+        } else if (model_name == "CGOET") {
             LogInfo() << "Using cached file for Yuneec ET.";
             camera_definition_out = cgoetxml;
             return true;
-        } else if (strcmp((const char*)(camera_information.model_name), "E10T") == 0) {
+        } else if (model_name == "E10T") {
             LogInfo() << "Using cached file for Yuneec E10T.";
             camera_definition_out = e10txml;
             return true;
-        } else if (strcmp((const char*)(camera_information.model_name), "E30Z") == 0) {
+        } else if (model_name == "E30Z") {
             LogInfo() << "Using cached file for Yuneec E30Z.";
             camera_definition_out = e30zxml;
             return true;
         }
-    } else if (strcmp((const char*)(camera_information.vendor_name), "Sony") == 0) {
-        if (strcmp((const char*)(camera_information.model_name), "ILCE-7RM4") == 0) {
+    } else if (vendor_name == "Sony") {
+        if (model_name == "ILCE-7RM4") {
             LogInfo() << "Using cached file for Sony ILCE-7RM4.";
             camera_definition_out = ILCE7RM4xml;
             return true;

--- a/src/mavsdk/plugins/camera/camera_impl.cpp
+++ b/src/mavsdk/plugins/camera/camera_impl.cpp
@@ -1140,6 +1140,11 @@ void CameraImpl::process_camera_information(const mavlink_message_t& message)
     mavlink_camera_information_t camera_information;
     mavlink_msg_camera_information_decode(&message, &camera_information);
 
+    // Make sure all strings are zero terminated, so we don't overrun anywhere.
+    camera_information.vendor_name[sizeof(camera_information.vendor_name) - 1] = '\0';
+    camera_information.model_name[sizeof(camera_information.model_name) - 1] = '\0';
+    camera_information.cam_definition_uri[sizeof(camera_information.cam_definition_uri) - 1] = '\0';
+
     std::lock_guard<std::mutex> lock(_information.mutex);
 
     _information.data.vendor_name = (char*)(camera_information.vendor_name);


### PR DESCRIPTION
It was raised in #2046 that the bool type is rejected even though it's listed in the docs: https://mavlink.io/en/services/camera_def.html#parameter-types

This is an attempt to fix that, plus getting rid of `strcmp` while we're at it.

Closes #2046.