### PR TITLE
ci: try to fix fetching tags on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -447,8 +447,6 @@ jobs:
         with:
           path: ./build/macos/third_party/install
           key: ${{ github.job }}-${{ matrix.name }}-${{ hashFiles('./third_party/**') }}
-      - name: fetch git tags for version
-        run: git fetch --prune --unshallow --tags
       - name: disable superbuild on cache hit
         if: steps.cache.outputs.cache-hit == 'true'
         run: echo "superbuild=-DSUPERBUILD=OFF" >> $GITHUB_ENV && echo "cmake_prefix_path=-DCMAKE_PREFIX_PATH=$(pwd)/build/macos/third_party/install" >> $GITHUB_ENV
@@ -502,8 +500,6 @@ jobs:
         with:
           path: ./build/${{ matrix.name }}/third_party/install
           key: ${{ github.job }}-${{ matrix.name }}-${{ hashFiles('./third_party/**', './tools/ios.toolchain.cmake') }}
-      - name: fetch git tags for version
-        run: git fetch --prune --unshallow --tags
       - name: disable superbuild on cache hit
         if: steps.cache.outputs.cache-hit == 'true'
         run: echo "superbuild=-DSUPERBUILD=OFF" >> $GITHUB_ENV && echo "cmake_prefix_path=-DCMAKE_PREFIX_PATH=$(pwd)/build/${{ matrix.name }}/third_party/install" >> $GITHUB_ENV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -447,6 +447,8 @@ jobs:
         with:
           path: ./build/macos/third_party/install
           key: ${{ github.job }}-${{ matrix.name }}-${{ hashFiles('./third_party/**') }}
+      - name: fetch git tags for version
+        run: git fetch --prune --unshallow --tags
       - name: disable superbuild on cache hit
         if: steps.cache.outputs.cache-hit == 'true'
         run: echo "superbuild=-DSUPERBUILD=OFF" >> $GITHUB_ENV && echo "cmake_prefix_path=-DCMAKE_PREFIX_PATH=$(pwd)/build/macos/third_party/install" >> $GITHUB_ENV
@@ -500,6 +502,8 @@ jobs:
         with:
           path: ./build/${{ matrix.name }}/third_party/install
           key: ${{ github.job }}-${{ matrix.name }}-${{ hashFiles('./third_party/**', './tools/ios.toolchain.cmake') }}
+      - name: fetch git tags for version
+        run: git fetch --prune --unshallow --tags
       - name: disable superbuild on cache hit
         if: steps.cache.outputs.cache-hit == 'true'
         run: echo "superbuild=-DSUPERBUILD=OFF" >> $GITHUB_ENV && echo "cmake_prefix_path=-DCMAKE_PREFIX_PATH=$(pwd)/build/${{ matrix.name }}/third_party/install" >> $GITHUB_ENV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -442,13 +442,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
       - uses: actions/cache@v3
         id: cache
         with:
           path: ./build/macos/third_party/install
           key: ${{ github.job }}-${{ matrix.name }}-${{ hashFiles('./third_party/**') }}
-      - name: fetch git tags for version
-        run: git fetch --prune --unshallow --tags
       - name: disable superbuild on cache hit
         if: steps.cache.outputs.cache-hit == 'true'
         run: echo "superbuild=-DSUPERBUILD=OFF" >> $GITHUB_ENV && echo "cmake_prefix_path=-DCMAKE_PREFIX_PATH=$(pwd)/build/macos/third_party/install" >> $GITHUB_ENV
@@ -497,13 +496,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
       - uses: actions/cache@v3
         id: cache
         with:
           path: ./build/${{ matrix.name }}/third_party/install
           key: ${{ github.job }}-${{ matrix.name }}-${{ hashFiles('./third_party/**', './tools/ios.toolchain.cmake') }}
-      - name: fetch git tags for version
-        run: git fetch --prune --unshallow --tags
       - name: disable superbuild on cache hit
         if: steps.cache.outputs.cache-hit == 'true'
         run: echo "superbuild=-DSUPERBUILD=OFF" >> $GITHUB_ENV && echo "cmake_prefix_path=-DCMAKE_PREFIX_PATH=$(pwd)/build/${{ matrix.name }}/third_party/install" >> $GITHUB_ENV


### PR DESCRIPTION
I'm not sure why this step is needed, and it now fails with:

```
fatal: remote error: upload-pack: not our ref 07daa576c40ea3c90a9f2b777b919debd49697b7
Errors during submodule fetch:
	mavsdk-proto
```

Just trying without it :see_no_evil: 

EDIT: seems fine now. @julianoes do you remember why you added the `git fetch` part?