### PR TITLE
The bool parameter now automatically creates on/off options. Reopen.

### DIFF
--- a/src/mavsdk/plugins/camera/camera_definition.cpp
+++ b/src/mavsdk/plugins/camera/camera_definition.cpp
@@ -116,7 +116,7 @@ bool CameraDefinition::parse_xml()
             LogErr() << "type attribute missing for " << param_name;
             return false;
         }
-        
+
         // Convert to std::string only once.
         auto type_str = std::string(type_str_res);
         if (type_str == "string") {
@@ -199,7 +199,7 @@ bool CameraDefinition::parse_xml()
             continue;
         }
 
-        auto get_default_opt = [&](){
+        auto get_default_opt = [&]() {
             auto maybe_default = find_default(new_parameter->options, default_str);
 
             if (!maybe_default.first) {
@@ -217,7 +217,7 @@ bool CameraDefinition::parse_xml()
                 continue;
             }
             new_parameter->options = maybe_options.second;
-            
+
             if (auto default_option = get_default_opt()) {
                 new_parameter->default_option = *default_option;
             } else {
@@ -231,11 +231,10 @@ bool CameraDefinition::parse_xml()
             Option false_option;
             true_option.name = "off";
             false_option.value.set<uint8_t>(false);
-            
+
             new_parameter->options = {
                 std::make_shared<Option>(std::move(true_option)),
-                std::make_shared<Option>(std::move(false_option))
-            };
+                std::make_shared<Option>(std::move(false_option))};
 
             if (auto default_option = get_default_opt()) {
                 new_parameter->default_option = *default_option;

--- a/src/mavsdk/plugins/camera/camera_definition.cpp
+++ b/src/mavsdk/plugins/camera/camera_definition.cpp
@@ -111,13 +111,11 @@ bool CameraDefinition::parse_xml()
         }
 
         const char* type_str_res = e_parameter->Attribute("type");
-        // The check for null pointer is required before the creation of std::string.
         if (!type_str_res) {
             LogErr() << "type attribute missing for " << param_name;
             return false;
         }
 
-        // Convert to std::string only once.
         auto type_str = std::string(type_str_res);
         if (type_str == "string") {
             LogDebug() << "Ignoring string params: " << param_name;


### PR DESCRIPTION
When a bool parameter is encountered the on/off options should be created automatically as per [documentation](https://mavlink.io/en/services/camera_def.html#parameter-definition).
This should solve the second part of issue https://github.com/mavlink/MAVSDK/issues/2046.
And is a reopen of #2056 PR which got automatically closed.