### PR TITLE
Tools: change the absolute path for generate_from_protos.sh

### DIFF
--- a/tools/generate_from_protos.sh
+++ b/tools/generate_from_protos.sh
@@ -91,7 +91,7 @@ command -v ${protoc_binary} > /dev/null && command -v ${protoc_grpc_binary} > /d
 }
 
 echo "Installing protoc-gen-mavsdk locally into build folder"
-python -m pip install --upgrade --target=${build_dir}/pb_plugins  ${script_dir}/../proto/pb_plugins
+python3 -m pip install --upgrade --target=${build_dir}/pb_plugins ${script_dir}/../proto/pb_plugins
 
 protoc_gen_mavsdk="${build_dir}/pb_plugins/bin/protoc-gen-mavsdk"
 export PYTHONPATH="${build_dir}/pb_plugins:${PYTHONPATH}"
@@ -177,4 +177,4 @@ for plugin in ${plugin_list_and_core}; do
 done
 
 # Generate grpc_server.h and grpc_server.cpp files according to plugin list
-python3 tools/grpc_server_jinja.py $plugin_list
+python3 ${script_dir}/grpc_server_jinja.py $plugin_list


### PR DESCRIPTION
  * Change the python executable to python3 (In MacOS the default python is python2.7)
  * Use relative path for grpc_server_jinja.py

_**Todo**_: the grpc_server_jinja.py also use absolute path. The **generate_from_protos.sh** script only works well in the **MAVSDK root path.**

```
Traceback (most recent call last):
  File "/Users/tbago/MAVSDK/tools/grpc_server_jinja.py", line 30, in <module>
    main()
  File "/Users/tbago/MAVSDK/tools/grpc_server_jinja.py", line 19, in main
    template = env.get_template("grpc_server.h.j2")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tbago/MAVSDK/build/pb_plugins/jinja2/environment.py", line 1010, in get_template
    return self._load_template(name, globals)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tbago/MAVSDK/build/pb_plugins/jinja2/environment.py", line 969, in _load_template
    template = self.loader.load(self, name, self.make_globals(globals))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tbago/MAVSDK/build/pb_plugins/jinja2/loaders.py", line 126, in load
    source, filename, uptodate = self.get_source(environment, name)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tbago/MAVSDK/build/pb_plugins/jinja2/loaders.py", line 218, in get_source
    raise TemplateNotFound(template)
jinja2.exceptions.TemplateNotFound: grpc_server.h.j2
```