### PR TITLE
UDP connection can disconnect when heartbeats are not received

### DIFF
--- a/src/mavsdk/core/mavsdk_impl.cpp
+++ b/src/mavsdk/core/mavsdk_impl.cpp
@@ -533,7 +533,7 @@ ConnectionResult MavsdkImpl::setup_udp_remote(
         new_conn->add_remote(remote_ip, remote_port);
         add_connection(new_conn);
         std::lock_guard<std::recursive_mutex> lock(_systems_mutex);
-        make_system_with_component(0, 0, true);
+        make_system_with_component(0, 0, !_configuration.get_always_send_heartbeats());
     }
     return ret;
 }


### PR DESCRIPTION
Creating a UDP connection to a vehicle/simulator via `setup_udp_remote` or `add_any_connection` will set the `always_connected` flag to true in all cases. This means that even though MAVSDK could be sending heartbeats (configured in the `Mavsdk::Configuration::_always_send_heartbeats`), the lack of response on those heartbeats does not lead to realizing/announcing the disconnect. With this change, if the Mavsdk will properly use heartbeats to detect connection and disconnection if it is configured to send those heartbeats. This means that the system will not be considered connected (and fire the `subscribe_on_new_system` callback) until the first heartbeat response is received, and will be considered disconnected (and fire the `subscribe_is_connected` callback) when the configured amount of time passes without a heartbeat response.