### PR TITLE
core: remove always connected flag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,8 +113,6 @@ jobs:
         run: ./build/release/src/system_tests/system_tests_runner
       - name: test (mavsdk_server)
         run: ./build/release/src/mavsdk_server/test/unit_tests_mavsdk_server
-      - name: test FTP server
-        run: ./build/release/src/integration_tests/integration_tests_runner --gtest_filter="FtpTest.TestServer"
 
   ubuntu20-hunter:
     name: ubuntu-20.04 (mavsdk, hunter)

--- a/src/mavsdk/core/include/mavsdk/system.h
+++ b/src/mavsdk/core/include/mavsdk/system.h
@@ -43,10 +43,8 @@ public:
      *
      * @param system_id System id.
      * @param component_id Component id.
-     * @param connected If true then the system doesn't wait for heartbeat to go into connected
-     * state
      */
-    void init(uint8_t system_id, uint8_t component_id, bool connected) const;
+    void init(uint8_t system_id, uint8_t component_id) const;
 
     /**
      * @brief Checks whether the system has an autopilot.

--- a/src/mavsdk/core/mavsdk_impl.cpp
+++ b/src/mavsdk/core/mavsdk_impl.cpp
@@ -533,7 +533,7 @@ ConnectionResult MavsdkImpl::setup_udp_remote(
         new_conn->add_remote(remote_ip, remote_port);
         add_connection(new_conn);
         std::lock_guard<std::recursive_mutex> lock(_systems_mutex);
-        make_system_with_component(0, 0, true);
+        make_system_with_component(0, 0);
     }
     return ret;
 }
@@ -656,8 +656,7 @@ uint8_t MavsdkImpl::get_mav_type() const
     }
 }
 
-void MavsdkImpl::make_system_with_component(
-    uint8_t system_id, uint8_t comp_id, bool always_connected)
+void MavsdkImpl::make_system_with_component(uint8_t system_id, uint8_t comp_id)
 {
     // Needs _systems_lock
 
@@ -675,7 +674,7 @@ void MavsdkImpl::make_system_with_component(
 
     // Make a system with its first component
     auto new_system = std::make_shared<System>(*this);
-    new_system->init(system_id, comp_id, always_connected);
+    new_system->init(system_id, comp_id);
 
     _systems.emplace_back(system_id, new_system);
 }

--- a/src/mavsdk/core/mavsdk_impl.h
+++ b/src/mavsdk/core/mavsdk_impl.h
@@ -107,8 +107,7 @@ public:
 
 private:
     void add_connection(const std::shared_ptr<Connection>&);
-    void make_system_with_component(
-        uint8_t system_id, uint8_t component_id, bool always_connected = false);
+    void make_system_with_component(uint8_t system_id, uint8_t component_id);
 
     void work_thread();
     void process_user_callbacks_thread();

--- a/src/mavsdk/core/system.cpp
+++ b/src/mavsdk/core/system.cpp
@@ -15,9 +15,9 @@ System::System(MavsdkImpl& parent) : _system_impl(std::make_shared<SystemImpl>(p
 
 System::~System() = default;
 
-void System::init(uint8_t system_id, uint8_t component_id, bool connected) const
+void System::init(uint8_t system_id, uint8_t component_id) const
 {
-    return _system_impl->init(system_id, component_id, connected);
+    return _system_impl->init(system_id, component_id);
 }
 
 bool System::is_standalone() const

--- a/src/mavsdk/core/system_impl.h
+++ b/src/mavsdk/core/system_impl.h
@@ -40,7 +40,7 @@ public:
     explicit SystemImpl(MavsdkImpl& parent);
     ~SystemImpl() override;
 
-    void init(uint8_t system_id, uint8_t comp_id, bool connected);
+    void init(uint8_t system_id, uint8_t comp_id);
 
     void enable_timesync();
 
@@ -357,7 +357,6 @@ private:
 
     std::atomic<bool> _armed{false};
     std::atomic<bool> _hitl_enabled{false};
-    bool _always_connected{false};
 
     std::atomic<Autopilot> _autopilot{Autopilot::Unknown};
 


### PR DESCRIPTION
This flag was added when we didn't have the notion of a component, and therefore it was required for the FTP server implementation. I believe we should be able to remove it now.

Fixes #2076.