### PR TITLE
examples: add disconnection example

### DIFF
--- a/examples/disconnect/CMakeLists.txt
+++ b/examples/disconnect/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.10.2)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+project(disconnect)
+
+add_executable(disconnect
+    disconnect.cpp
+)
+
+find_package(MAVSDK REQUIRED)
+
+target_link_libraries(disconnect
+    MAVSDK::mavsdk
+)
+
+if(NOT MSVC)
+    add_compile_options(takeoff_and_land PRIVATE -Wall -Wextra)
+else()
+    add_compile_options(takeoff_and_land PRIVATE -WX -W2)
+endif()

--- a/examples/disconnect/disconnect.cpp
+++ b/examples/disconnect/disconnect.cpp
@@ -1,0 +1,89 @@
+//
+// This is an example how to desctruct Mavsdk when a system has disconnected
+// and restart it right after.
+//
+
+#include <future>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <mavsdk/mavsdk.h>
+
+using namespace mavsdk;
+
+void usage(const std::string& bin_name)
+{
+    std::cerr << "Usage : " << bin_name << " <connection_url>\n"
+              << "Connection URL format should be :\n"
+              << " For TCP : tcp://[server_host][:server_port]\n"
+              << " For UDP : udp://[bind_host][:bind_port]\n"
+              << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
+              << "For example, to connect to the simulator use URL: udp://:14540\n";
+}
+
+bool connect(Mavsdk* mavsdk, std::string connection_url)
+{
+    auto prom = std::promise<void>();
+    auto fut = prom.get_future();
+
+    Mavsdk::NewSystemHandle handle = mavsdk->subscribe_on_new_system([&mavsdk, &handle, &prom]() {
+        const auto system = mavsdk->systems().at(0);
+
+        if (system->is_connected()) {
+            mavsdk->unsubscribe_on_new_system(handle);
+            prom.set_value();
+        }
+    });
+    auto ret = mavsdk->add_any_connection(connection_url);
+    fut.wait();
+
+    return ret == ConnectionResult::Success;
+}
+
+void wait_for_disconnect(Mavsdk* mavsdk)
+{
+    auto system = mavsdk->systems()[0];
+
+    auto prom = std::promise<void>();
+    auto fut = prom.get_future();
+    System::IsConnectedHandle handle =
+        Handle<bool>(system->subscribe_is_connected([&system, &prom, &handle](bool connected) {
+            if (!connected) {
+                std::cout << "Disconnection detected" << std::endl;
+                system->unsubscribe_is_connected(handle);
+                prom.set_value();
+            }
+        }));
+
+    fut.wait();
+}
+
+int main(int argc, char** argv)
+{
+    if (argc != 2) {
+        usage(argv[0]);
+        return 1;
+    }
+
+    const std::string connection_url = argv[1];
+
+    std::unique_ptr<Mavsdk> mavsdk;
+
+    mavsdk = std::make_unique<Mavsdk>();
+
+    while (true) {
+        if (connect(mavsdk.get(), connection_url)) {
+            std::cout << "Connection successful" << std::endl;
+        } else {
+            break;
+        }
+
+        wait_for_disconnect(mavsdk.get());
+
+        // Destruct and construct Mavsdk.
+        mavsdk = std::make_unique<Mavsdk>();
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This is an example how to destruct Mavsdk when a system has disconnected.

Thanks to @jperez-droneup for creating the initial version of this example in https://github.com/mavlink/MAVSDK/issues/2075.

Note, I also tried to run this 3 times and then break out of the while with valgrind and it showed no leaks, so that makes me hopeful. There have been quite a few destruction bugs in the past but thanks to the system tests which create and destruct `Mavsdk` and `System`s all the time I was able to catch quite a few of them.