### PR TITLE
core: add way to remove a connection

### DIFF
--- a/src/mavsdk/core/include/mavsdk/handle.h
+++ b/src/mavsdk/core/include/mavsdk/handle.h
@@ -7,6 +7,7 @@ namespace mavsdk {
 template<typename... Args> class CallbackListImpl;
 template<typename... Args> class CallbackList;
 template<typename... Args> class FakeHandle;
+class MavsdkImpl;
 
 /**
  * @brief A handle returned from subscribe which allows to unsubscribe again.
@@ -17,11 +18,14 @@ public:
     ~Handle() = default;
 
 private:
+    bool operator==(const Handle& other) const { return _id == other._id; }
+
     explicit Handle(uint64_t id) : _id(id) {}
     uint64_t _id{0};
 
     friend CallbackListImpl<Args...>;
     friend FakeHandle<Args...>;
+    friend MavsdkImpl; // For connections.
 };
 
 } // namespace mavsdk

--- a/src/mavsdk/core/include/mavsdk/mavsdk.h
+++ b/src/mavsdk/core/include/mavsdk/mavsdk.h
@@ -95,6 +95,35 @@ public:
         ForwardingOption forwarding_option = ForwardingOption::ForwardingOff);
 
     /**
+     * @brief Handle type to remove a connection.
+     */
+    using ConnectionHandle = Handle<>;
+
+    /**
+     * @brief Adds Connection via URL Additionally returns a handle to remove
+     *        the connection later.
+     *
+     * Supports connection: Serial, TCP or UDP.
+     * Connection URL format should be:
+     * - UDP:    udp://[host][:bind_port]
+     * - TCP:    tcp://[host][:remote_port]
+     * - Serial: serial://dev_node[:baudrate]
+     *
+     * For UDP, the host can be set to either:
+     *   - zero IP: 0.0.0.0 -> behave like a server and listen for heartbeats.
+     *   - some IP: 192.168.1.12 -> behave like a client, initiate connection
+     *     and start sending heartbeats.
+     *
+     * @param connection_url connection URL string.
+     * @param forwarding_option message forwarding option (when multiple interfaces are used).
+     * @return A pair containing the result of adding the connection as well
+     *         as a handle to remove it later.
+     */
+    std::pair<ConnectionResult, ConnectionHandle> add_any_connection_with_handle(
+        const std::string& connection_url,
+        ForwardingOption forwarding_option = ForwardingOption::ForwardingOff);
+
+    /**
      * @brief Adds a UDP connection to the specified port number.
      *
      * Any incoming connections are accepted (0.0.0.0).
@@ -165,6 +194,13 @@ public:
         int baudrate = DEFAULT_SERIAL_BAUDRATE,
         bool flow_control = false,
         ForwardingOption forwarding_option = ForwardingOption::ForwardingOff);
+
+    /**
+     * Remove connection again.
+     *
+     * @param handle Handle returned when connection was added.
+     */
+    void remove_connection(ConnectionHandle handle);
 
     /**
      * @brief Get a vector of systems which have been discovered or set-up.

--- a/src/mavsdk/core/mavsdk.cpp
+++ b/src/mavsdk/core/mavsdk.cpp
@@ -19,30 +19,36 @@ std::string Mavsdk::version() const
 ConnectionResult
 Mavsdk::add_any_connection(const std::string& connection_url, ForwardingOption forwarding_option)
 {
+    return _impl->add_any_connection(connection_url, forwarding_option).first;
+}
+
+std::pair<ConnectionResult, Mavsdk::ConnectionHandle> Mavsdk::add_any_connection_with_handle(
+    const std::string& connection_url, ForwardingOption forwarding_option)
+{
     return _impl->add_any_connection(connection_url, forwarding_option);
 }
 
 ConnectionResult Mavsdk::add_udp_connection(int local_port, ForwardingOption forwarding_option)
 {
-    return Mavsdk::add_udp_connection(DEFAULT_UDP_BIND_IP, local_port, forwarding_option);
+    return _impl->add_udp_connection(DEFAULT_UDP_BIND_IP, local_port, forwarding_option).first;
 }
 
 ConnectionResult Mavsdk::add_udp_connection(
     const std::string& local_bind_ip, const int local_port, ForwardingOption forwarding_option)
 {
-    return _impl->add_udp_connection(local_bind_ip, local_port, forwarding_option);
+    return _impl->add_udp_connection(local_bind_ip, local_port, forwarding_option).first;
 }
 
 ConnectionResult Mavsdk::setup_udp_remote(
     const std::string& remote_ip, int remote_port, ForwardingOption forwarding_option)
 {
-    return _impl->setup_udp_remote(remote_ip, remote_port, forwarding_option);
+    return _impl->setup_udp_remote(remote_ip, remote_port, forwarding_option).first;
 }
 
 ConnectionResult Mavsdk::add_tcp_connection(
     const std::string& remote_ip, const int remote_port, ForwardingOption forwarding_option)
 {
-    return _impl->add_tcp_connection(remote_ip, remote_port, forwarding_option);
+    return _impl->add_tcp_connection(remote_ip, remote_port, forwarding_option).first;
 }
 
 ConnectionResult Mavsdk::add_serial_connection(
@@ -51,7 +57,12 @@ ConnectionResult Mavsdk::add_serial_connection(
     bool flow_control,
     ForwardingOption forwarding_option)
 {
-    return _impl->add_serial_connection(dev_path, baudrate, flow_control, forwarding_option);
+    return _impl->add_serial_connection(dev_path, baudrate, flow_control, forwarding_option).first;
+}
+
+void Mavsdk::remove_connection(ConnectionHandle handle)
+{
+    _impl->remove_connection(handle);
 }
 
 std::vector<std::shared_ptr<System>> Mavsdk::systems() const


### PR DESCRIPTION
This adds the method add_any_connection_with_handle which returns a handle that can later be used to remove a connection again using remove_connection.

Untested, @jperez-droneup if you want to give this a try.