### PR TITLE
build: Install MAVLink headers within MAVSDK

### DIFF
--- a/src/MAVSDKConfig.cmake.in
+++ b/src/MAVSDKConfig.cmake.in
@@ -1,7 +1,5 @@
 include(CMakeFindDependencyMacro)
 
-find_dependency(MAVLink)
-
 if(NOT @BUILD_SHARED_LIBS@)
     if(${CMAKE_VERSION} VERSION_LESS "3.9.0")
         find_package(CURL REQUIRED CONFIG)

--- a/src/cmake/compiler_flags.cmake
+++ b/src/cmake/compiler_flags.cmake
@@ -49,6 +49,10 @@ else()
         endif()
 
         set(warnings "${warnings} -Wlogical-op")
+
+        # MAVLink warnings
+        set(warnings "${warnings} -Wno-address-of-packed-member")
+
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         set(warnings "${warnings} -Wno-missing-braces -Wno-unused-lambda-capture")
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")

--- a/src/mavsdk/core/CMakeLists.txt
+++ b/src/mavsdk/core/CMakeLists.txt
@@ -3,6 +3,12 @@ find_package(Threads REQUIRED)
 
 find_package(MAVLink REQUIRED)
 
+get_target_property(
+    MAVLINK_INCLUDE_DIR
+    MAVLink::mavlink
+    INTERFACE_INCLUDE_DIRECTORIES
+)
+
 configure_file(version.h.in version.h)
 configure_file(include/mavsdk/mavlink_include.h.in include/mavsdk/mavlink_include.h)
 
@@ -54,9 +60,8 @@ target_sources(mavsdk
 
 cmake_policy(SET CMP0079 NEW)
 target_link_libraries(mavsdk
-    PUBLIC
-    MAVLink::mavlink
     PRIVATE
+    MAVLink::mavlink
     CURL::libcurl
     Threads::Threads
 )
@@ -102,6 +107,7 @@ target_include_directories(mavsdk
     PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/mavsdk>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include/mavsdk>
+    $<BUILD_INTERFACE:${MAVLINK_INCLUDE_DIR}>
     $<INSTALL_INTERFACE:include>
     PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -127,6 +133,10 @@ install(FILES
     include/mavsdk/geometry.h
     include/mavsdk/server_component.h
     ${CMAKE_CURRENT_BINARY_DIR}/include/mavsdk/mavlink_include.h
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/mavsdk"
+)
+
+install(DIRECTORY ${MAVLINK_INCLUDE_DIR}/mavlink
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/mavsdk"
 )
 

--- a/tools/.doxygen
+++ b/tools/.doxygen
@@ -882,7 +882,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */mavlink/v2.0/*
+EXCLUDE_PATTERNS       = */mavlink/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION
This reverts a previous change which requires MAVLink to be installed standalone next to MAVSDK. Instead, the headers are, for now included as part of the MAVSDK install.

While this is not the right way to go about dependencies it avoids two problems:
1. It behaves the same as before. No MAVLink dependency is suddenly required disrupting an existing workflow.
2. It avoids a potential pitfall where a user of the library installs the MAVSDK library compiled with MAVLink from the common dialect but then later tries to use MAVLink headers containing their custom dialect. Intuitively, one would expect the message of the custom dialect to work via the mavlink_passthrough plugin, however, because the MAVlink parser has a static CRC_EXTRA table it won't parse the added custom messages unless the MAVSDK library is re-compiled with that custom dialect included.