### PR TITLE
log_files: remove hard-coded timeout values

### DIFF
--- a/src/mavsdk/plugins/log_files/log_files_impl.h
+++ b/src/mavsdk/plugins/log_files/log_files_impl.h
@@ -56,9 +56,6 @@ private:
     std::size_t determine_part_end();
     void reset_data();
 
-    static constexpr double LIST_TIMEOUT_S = 0.2;
-    static constexpr double DATA_TIMEOUT_S = 0.1;
-
     Time _time{};
 
     struct {


### PR DESCRIPTION
Instead, use the timeout which can be configured.

Also, make the initial list timeout quite big as it can take a while in reality.

Found when looking into #2091.