### PR TITLE
core: send heartbeats to UDP remote

### DIFF
--- a/src/mavsdk/core/mavsdk_impl.cpp
+++ b/src/mavsdk/core/mavsdk_impl.cpp
@@ -538,6 +538,13 @@ std::pair<ConnectionResult, Mavsdk::ConnectionHandle> MavsdkImpl::setup_udp_remo
         if (_systems.empty()) {
             make_system_with_component(0, 0);
         }
+
+        // With a UDP remote, we need to initiate the connection by sending
+        // heartbeats.
+        auto new_configuration = get_configuration();
+        new_configuration.set_always_send_heartbeats(true);
+        set_configuration(new_configuration);
+
         return {ret, handle};
     } else {
         return {ret, Mavsdk::ConnectionHandle{}};


### PR DESCRIPTION
With a UDP remote, we need to initiate the connection by sending heartbeats. This functionality had been broken once we did no longer mark a UDP remote connection as "always connected".

Follow up to https://github.com/mavlink/MAVSDK/pull/2077.

Thanks to @reedev for narrowing this down.