### PR TITLE
Flight info & requesting messages improvements

### DIFF
--- a/src/mavsdk/core/request_message.h
+++ b/src/mavsdk/core/request_message.h
@@ -55,6 +55,7 @@ private:
     std::mutex _mutex{};
     std::vector<WorkItem> _work_items{};
     std::vector<int> _deferred_message_cleanup{};
+    std::map<uint8_t, std::set<uint32_t>> _unsupported_message_ids{};
 };
 
 } // namespace mavsdk

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -502,12 +502,14 @@ void SystemImpl::send_autopilot_version_request_async(
         // release.
         command.command = MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES;
         command.params.maybe_param1 = 1.0f;
+        send_command_async(command, callback);
     } else {
-        command.command = MAV_CMD_REQUEST_MESSAGE;
-        command.params.maybe_param1 = {static_cast<float>(MAVLINK_MSG_ID_AUTOPILOT_VERSION)};
+        _request_message.request(MAVLINK_MSG_ID_AUTOPILOT_VERSION, get_autopilot_id(),
+            [callback](MavlinkCommandSender::Result result, const mavlink_message_t&) {
+                callback(result, NAN);
+            }
+        );
     }
-
-    send_command_async(command, callback);
 }
 
 void SystemImpl::send_flight_information_request()
@@ -523,17 +525,21 @@ void SystemImpl::send_flight_information_request()
         // release.
         command.command = MAV_CMD_REQUEST_FLIGHT_INFORMATION;
         command.params.maybe_param1 = 1.0f;
-    } else {
-        command.command = MAV_CMD_REQUEST_MESSAGE;
-        command.params.maybe_param1 = {static_cast<float>(MAVLINK_MSG_ID_FLIGHT_INFORMATION)};
+        send_command_async(command,
+            [&prom](MavlinkCommandSender::Result result, float) { prom.set_value(result); });
+
+        if (fut.get() == MavlinkCommandSender::Result::Unsupported) {
+            _old_message_528_supported = false;
+            LogWarn() << "Trying alternative command (512)..";
+        }
     }
 
-    send_command_async(
-        command, [&prom](MavlinkCommandSender::Result result, float) { prom.set_value(result); });
-    if (fut.get() == MavlinkCommandSender::Result::Unsupported) {
-        _old_message_528_supported = false;
-        LogWarn() << "Trying alternative command (512)..";
-        send_flight_information_request();
+    if (!_old_message_528_supported) {
+        _request_message.request(MAVLINK_MSG_ID_FLIGHT_INFORMATION, get_autopilot_id(),
+            [&prom](MavlinkCommandSender::Result result, const mavlink_message_t&) {
+                prom.set_value(result);
+            }
+        );
     }
 }
 

--- a/src/mavsdk/plugins/info/info_impl.cpp
+++ b/src/mavsdk/plugins/info/info_impl.cpp
@@ -23,21 +23,19 @@ InfoImpl::~InfoImpl()
 
 void InfoImpl::init()
 {
-    if (_system_impl->autopilot() != SystemImpl::Autopilot::ArduPilot) {
-        _system_impl->register_mavlink_message_handler(
-            MAVLINK_MSG_ID_FLIGHT_INFORMATION,
-            [this](const mavlink_message_t& message) { process_flight_information(message); },
-            this);
-    }
+    _system_impl->register_mavlink_message_handler(
+        MAVLINK_MSG_ID_AUTOPILOT_VERSION,
+        [this](const mavlink_message_t& message) { process_autopilot_version(message); },
+        this);
+
+    _system_impl->register_mavlink_message_handler(
+        MAVLINK_MSG_ID_FLIGHT_INFORMATION,
+        [this](const mavlink_message_t& message) { process_flight_information(message); },
+        this);
 
     _system_impl->register_mavlink_message_handler(
         MAVLINK_MSG_ID_ATTITUDE,
         [this](const mavlink_message_t& message) { process_attitude(message); },
-        this);
-
-    _system_impl->register_mavlink_message_handler(
-        MAVLINK_MSG_ID_AUTOPILOT_VERSION,
-        [this](const mavlink_message_t& message) { process_autopilot_version(message); },
         this);
 }
 
@@ -48,6 +46,13 @@ void InfoImpl::deinit()
 
 void InfoImpl::enable()
 {
+    // We can't rely on System to request the autopilot_version,
+    // so we do it here, anyway.
+    _system_impl->send_autopilot_version_request();
+
+    // We're going to retry until we have the version.
+    _system_impl->add_call_every([this]() { request_version_again(); }, 1.0f, &_call_every_cookie);
+
     // We're going to periodically ask for the flight information
     if (_system_impl->autopilot() != SystemImpl::Autopilot::ArduPilot) {
         _system_impl->send_flight_information_request();
@@ -55,9 +60,6 @@ void InfoImpl::enable()
         _system_impl->add_call_every(
             [this]() { request_flight_information(); }, 1.0f, &_flight_info_call_every_cookie);
     }
-
-    // We're going to retry until we have the version.
-    _system_impl->add_call_every([this]() { request_version_again(); }, 1.0f, &_call_every_cookie);
 }
 
 void InfoImpl::disable()

--- a/src/mavsdk/plugins/info/info_impl.h
+++ b/src/mavsdk/plugins/info/info_impl.h
@@ -31,29 +31,27 @@ public:
     InfoImpl& operator=(const InfoImpl&) = delete;
 
 private:
-    void request_version_again();
+    void request_autopilot_version();
     void request_flight_information();
-    void process_heartbeat(const mavlink_message_t& message);
     void process_autopilot_version(const mavlink_message_t& message);
     void process_flight_information(const mavlink_message_t& message);
     void process_attitude(const mavlink_message_t& message);
 
-    Info::Version::FlightSoftwareVersionType
-        get_flight_software_version_type(FIRMWARE_VERSION_TYPE);
+    void wait_for_autopilot_version() const;
+    void wait_for_flight_information() const;
 
-    void wait_for_information() const;
-
-    mutable std::mutex _mutex{};
+    mutable std::mutex _autopilot_version_mutex{};
+    mutable std::mutex _flight_information_mutex{};
 
     Info::Version _version{};
     Info::Product _product{};
     Info::Identification _identification{};
     Info::FlightInfo _flight_info{};
-    std::atomic<bool> _information_received{false};
+    std::atomic<bool> _autopilot_version_received{false};
     bool _flight_information_received{false};
     bool _was_armed{false};
 
-    void* _call_every_cookie{nullptr};
+    void* _autopilot_info_call_every_cookie{nullptr};
     void* _flight_info_call_every_cookie{nullptr};
 
     struct SpeedFactorMeasurement {
@@ -73,8 +71,13 @@ private:
     SteadyTimePoint _last_time_attitude_arrived{};
     uint32_t _last_time_boot_ms{0};
 
+    static Info::Version::FlightSoftwareVersionType
+        get_flight_software_version_type(FIRMWARE_VERSION_TYPE);
+
     static const std::string vendor_id_str(uint16_t vendor_id);
     static const std::string product_id_str(uint16_t product_id);
+    static const std::pair<std::string,std::string>
+        InfoImpl::usb_id_str(uint16_t vendor_id, uint16_t product_id);
 
     static std::string swap_and_translate_binary_to_str(uint8_t* binary, unsigned binary_len);
     static std::string translate_binary_to_str(uint8_t* binary, unsigned binary_len);


### PR DESCRIPTION
Ardupilot does not support MAVLINK_MSG_ID_FLIGHT_INFORMATION or MAV_CMD_REQUEST_FLIGHT_INFORMATION. Also there was some sort of deadlock occurring from the _system_impl->send_autopilot_version_request() in enable(), so just let system or the period caller request it slightly later.