### PR TITLE
Added new code for MAV_CMD_DO_SET_SERVO ArduPilot

### DIFF
--- a/src/mavsdk/plugins/action/action_impl.cpp
+++ b/src/mavsdk/plugins/action/action_impl.cpp
@@ -521,29 +521,29 @@ void ActionImpl::set_actuator_async(
 
     if (_system_impl->autopilot() == SystemImpl::Autopilot::ArduPilot) {
         command.command = MAV_CMD_DO_SET_SERVO;
-        command.params.maybe_param1 = index;
+        command.params.maybe_param1 = static_cast<float>(index);
         command.params.maybe_param2 = value;
     } else {
         command.command = MAV_CMD_DO_SET_ACTUATOR;
-            switch (index % 6) {
-                case 1:
-                    command.params.maybe_param1 = value;
-                    break;
-                case 2:
-                    command.params.maybe_param2 = value;
-                    break;
-                case 3:
-                    command.params.maybe_param3 = value;
-                    break;
-                case 4:
-                    command.params.maybe_param4 = value;
-                    break;
-                case 5:
-                    command.params.maybe_param5 = value;
-                    break;
-                case 6:
-                    command.params.maybe_param6 = value;
-                    break;
+        switch (index % 6) {
+            case 1:
+                command.params.maybe_param1 = value;
+                break;
+            case 2:
+                command.params.maybe_param2 = value;
+                break;
+            case 3:
+                command.params.maybe_param3 = value;
+                break;
+            case 4:
+                command.params.maybe_param4 = value;
+                break;
+            case 5:
+                command.params.maybe_param5 = value;
+                break;
+            case 6:
+                command.params.maybe_param6 = value;
+                break;
         }
         command.params.maybe_param7 = static_cast<float>(index) / 6.0f;
     }

--- a/src/mavsdk/plugins/action/action_impl.cpp
+++ b/src/mavsdk/plugins/action/action_impl.cpp
@@ -517,31 +517,36 @@ void ActionImpl::set_actuator_async(
     const int index, const float value, const Action::ResultCallback& callback)
 {
     MavlinkCommandSender::CommandLong command{};
-
-    command.command = MAV_CMD_DO_SET_ACTUATOR;
     command.target_component_id = _system_impl->get_autopilot_id();
 
-    switch (index % 6) {
-        case 1:
-            command.params.maybe_param1 = value;
-            break;
-        case 2:
-            command.params.maybe_param2 = value;
-            break;
-        case 3:
-            command.params.maybe_param3 = value;
-            break;
-        case 4:
-            command.params.maybe_param4 = value;
-            break;
-        case 5:
-            command.params.maybe_param5 = value;
-            break;
-        case 6:
-            command.params.maybe_param6 = value;
-            break;
+    if (_system_impl->autopilot() == SystemImpl::Autopilot::ArduPilot) {
+        command.command = MAV_CMD_DO_SET_SERVO;
+        command.params.maybe_param1 = index;
+        command.params.maybe_param2 = value;
+    } else {
+        command.command = MAV_CMD_DO_SET_ACTUATOR;
+            switch (index % 6) {
+                case 1:
+                    command.params.maybe_param1 = value;
+                    break;
+                case 2:
+                    command.params.maybe_param2 = value;
+                    break;
+                case 3:
+                    command.params.maybe_param3 = value;
+                    break;
+                case 4:
+                    command.params.maybe_param4 = value;
+                    break;
+                case 5:
+                    command.params.maybe_param5 = value;
+                    break;
+                case 6:
+                    command.params.maybe_param6 = value;
+                    break;
+        }
+        command.params.maybe_param7 = static_cast<float>(index) / 6.0f;
     }
-    command.params.maybe_param7 = static_cast<float>(index) / 6.0f;
 
     _system_impl->send_command_async(
         command, [this, callback](MavlinkCommandSender::Result result, float) {


### PR DESCRIPTION
Pull request in support of https://github.com/mavlink/MAVSDK/issues/2111
I added support for actuator control in ArduPilot by modifying the set_actuator function from the Action plugin. I added an if statement that uses the MAV_CMD_DO_SET_SERVO command on ArduPilot systems due to the MAV_CMD_DO_SET_ACTUATOR command not being implemented in ArduPilot. PX4 will continue to use MAV_CMD_DO_SET_ACTUATOR as before.

A word on MAV_CMD_DO_SET_ACTUATOR: this command is capable of setting multiple actuator values at once, while MAV_CMD_DO_SET_SERVO only sets one actuator at a time. Since the set_actuator function is only setting one actuator at a time, MAV_CMD_DO_SET_SERVO is a one-to-one substitute of MAV_CMD_DO_SET_ACTUATOR.