### PR TITLE
Include planned home position in MissionImportData

### DIFF
--- a/src/mavsdk/plugins/mission_raw/include/plugins/mission_raw/mission_raw.h
+++ b/src/mavsdk/plugins/mission_raw/include/plugins/mission_raw/mission_raw.h
@@ -124,6 +124,7 @@ public:
         std::vector<MissionItem> mission_items{}; /**< @brief Mission items */
         std::vector<MissionItem> geofence_items{}; /**< @brief Geofence items */
         std::vector<MissionItem> rally_items{}; /**< @brief Rally items */
+        std::optional<MissionItem> plannedHomePosition;
     };
 
     /**

--- a/src/mavsdk/plugins/mission_raw/mission_import.h
+++ b/src/mavsdk/plugins/mission_raw/mission_import.h
@@ -16,7 +16,7 @@ public:
 
 private:
     static bool check_overall_version(const Json::Value& root);
-    static std::optional<std::vector<MissionRaw::MissionItem>>
+    static std::pair<std::optional<std::vector<MissionRaw::MissionItem>>, std::optional<MissionRaw::MissionItem>>
     import_mission(const Json::Value& root, SystemImpl::Autopilot autopilot);
     static std::optional<MissionRaw::MissionItem>
     import_simple_mission_item(const Json::Value& json_item);


### PR DESCRIPTION
The planned home position is useful for moving a planned mission to the current location of the vehicle. Using the first mission item (as was done until now in the PX4 integration tests) is not correct for a VTOL mission containing a VTOL takeoff item.