### PR TITLE
Do not set GCS mode as default

### DIFF
--- a/src/mavsdk/core/mavsdk_impl.h
+++ b/src/mavsdk/core/mavsdk_impl.h
@@ -141,7 +141,7 @@ private:
 
     Time _time{};
 
-    Mavsdk::Configuration _configuration{Mavsdk::Configuration::UsageType::GroundStation};
+    Mavsdk::Configuration _configuration{Mavsdk::Configuration::UsageType::Custom};
 
     struct UserCallback {
         UserCallback() = default;


### PR DESCRIPTION
Setting the GCS mode as default has hidden side-effects. Most notably that the connection is considered a valid datalink, and thus affects datalink failsafes in Autopilots. 

When used on-board, this is an unwanted side-effect. While you can configure this, the default is set to the "less-safe" option, which could leave a careless user in the situation where datalink failsafes get disabled unintentionally. 