### PR TITLE
Fix calibration in telemetry health

### DIFF
--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -2407,7 +2407,7 @@ void TelemetryImpl::check_calibration()
         std::lock_guard<std::mutex> lock(_health_mutex);
         if ((_has_received_gyro_calibration && _has_received_accel_calibration &&
              _has_received_mag_calibration) ||
-            _has_received_hitl_param) {
+            _hitl_enabled) {
             _parent->remove_call_every(_calibration_cookie);
             return;
         }


### PR DESCRIPTION
The calibration check should be stopped when the drone is actually found to be running in hitl mode, and not when the hitl param is received (because the hitl param may say that the drone is not running hitl, in which case we need to continue checking the calibration).

Without this fix, the health booleans related to the calibration tend to be "stuck" on the default `false` value (because MAVSDK stops checking and never gets to the point where it realizes that the check is actually fine).