### PR TITLE
[v1.4] Fix conflict in camera subscriptions

### DIFF
--- a/src/mavsdk/plugins/camera/camera_impl.cpp
+++ b/src/mavsdk/plugins/camera/camera_impl.cpp
@@ -200,6 +200,8 @@ void CameraImpl::manual_enable()
     _parent->add_call_every(
         [this]() { request_camera_information(); }, 10.0, &_camera_information_call_every_cookie);
 
+    _parent->add_call_every([this]() { request_status(); }, 5.0, &_status.call_every_cookie);
+
     // for backwards compatibility with Yuneec drones
     if (_parent->has_autopilot()) {
         request_flight_information();
@@ -222,6 +224,7 @@ void CameraImpl::manual_disable()
 {
     invalidate_params();
     _parent->remove_call_every(_camera_information_call_every_cookie);
+    _parent->remove_call_every(_status.call_every_cookie);
 
     if (_flight_information_call_every_cookie) {
         _parent->remove_call_every(_flight_information_call_every_cookie);
@@ -582,21 +585,6 @@ void CameraImpl::subscribe_information(const Camera::InformationCallback& callba
 {
     std::lock_guard<std::mutex> lock(_information.mutex);
     _information.subscription_callback = callback;
-
-    // If there was already a subscription, cancel the call
-    if (_status.call_every_cookie) {
-        _parent->remove_call_every(_status.call_every_cookie);
-    }
-
-    if (callback) {
-        if (_status.call_every_cookie == nullptr) {
-            _parent->add_call_every(
-                [this]() { request_status(); }, 5.0, &_status.call_every_cookie);
-        }
-    } else {
-        _parent->remove_call_every(_status.call_every_cookie);
-        _status.call_every_cookie = nullptr;
-    }
 }
 
 Camera::Result CameraImpl::start_video_streaming()
@@ -849,18 +837,7 @@ void CameraImpl::request_status()
 void CameraImpl::subscribe_status(const Camera::StatusCallback callback)
 {
     std::lock_guard<std::mutex> lock(_status.mutex);
-
     _status.subscription_callback = callback;
-
-    if (callback) {
-        if (_status.call_every_cookie == nullptr) {
-            _parent->add_call_every(
-                [this]() { request_status(); }, 5.0, &_status.call_every_cookie);
-        }
-    } else {
-        _parent->remove_call_every(_status.call_every_cookie);
-        _status.call_every_cookie = nullptr;
-    }
 }
 
 Camera::Status CameraImpl::status()


### PR DESCRIPTION
The fact that `_status.call_every_cookie` is shared between two subscriptions (camera status and camera information) makes them conflict: when unsubscribing from one, it cancels the call_every for both.

Also, depending on the order, it will `add_call_every` twice with the same cookie, which I believe ends up leaking one.

This PR makes it simpler by requesting the status updates in the plugin directly. I don't think it is worth trying to optimize the number of requests here (and I am pretty sure it ended up doubling them in SiteScan).