### PR TITLE
telemetry: do not interrupt calibration checks too early

### DIFF
--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -2704,7 +2704,7 @@ void TelemetryImpl::check_calibration()
         std::lock_guard<std::mutex> lock(_health_mutex);
         if ((_has_received_gyro_calibration && _has_received_accel_calibration &&
              _has_received_mag_calibration) ||
-            _has_received_hitl_param) {
+            _hitl_enabled) {
             _system_impl->remove_call_every(_calibration_cookie);
             return;
         }


### PR DESCRIPTION
Bringing https://github.com/mavlink/MAVSDK/pull/2132 upstream.