### PR TITLE
v1.4 fix storage type translation (STORAGE_TYPE_OTHER)

### DIFF
--- a/src/mavsdk/plugins/camera/camera_impl.cpp
+++ b/src/mavsdk/plugins/camera/camera_impl.cpp
@@ -917,13 +917,35 @@ void CameraImpl::process_storage_information(const mavlink_message_t& message)
         _status.data.used_storage_mib = storage_information.used_capacity;
         _status.data.total_storage_mib = storage_information.total_capacity;
         _status.data.storage_id = storage_information.storage_id;
-        _status.data.storage_type =
-            static_cast<Camera::Status::StorageType>(storage_information.type);
+        _status.data.storage_type = storage_type_from_mavlink(storage_information.type);
         _status.received_storage_information = true;
     }
 
     check_status();
 }
+
+Camera::Status::StorageType
+CameraImpl::storage_type_from_mavlink(const int storage_type) const
+{
+    switch (storage_type) {
+        default:
+            LogErr() << "Unknown storage_type enum value: " << storage_type;
+        // FALLTHROUGH
+        case STORAGE_TYPE_UNKNOWN:
+            return mavsdk::Camera::Status::StorageType::Unknown;
+        case STORAGE_TYPE_USB_STICK:
+            return mavsdk::Camera::Status::StorageType::UsbStick;
+        case STORAGE_TYPE_SD:
+            return mavsdk::Camera::Status::StorageType::Sd;
+        case STORAGE_TYPE_MICROSD:
+            return mavsdk::Camera::Status::StorageType::Microsd;
+        case STORAGE_TYPE_HD:
+            return mavsdk::Camera::Status::StorageType::Hd;
+        case STORAGE_TYPE_OTHER:
+            return mavsdk::Camera::Status::StorageType::Other;
+    }
+}
+
 
 void CameraImpl::process_camera_image_captured(const mavlink_message_t& message)
 {

--- a/src/mavsdk/plugins/camera/camera_impl.cpp
+++ b/src/mavsdk/plugins/camera/camera_impl.cpp
@@ -925,8 +925,7 @@ CameraImpl::storage_status_from_mavlink(const int storage_status) const
     }
 }
 
-Camera::Status::StorageType
-CameraImpl::storage_type_from_mavlink(const int storage_type) const
+Camera::Status::StorageType CameraImpl::storage_type_from_mavlink(const int storage_type) const
 {
     switch (storage_type) {
         default:
@@ -946,7 +945,6 @@ CameraImpl::storage_type_from_mavlink(const int storage_type) const
             return mavsdk::Camera::Status::StorageType::Other;
     }
 }
-
 
 void CameraImpl::process_camera_image_captured(const mavlink_message_t& message)
 {

--- a/src/mavsdk/plugins/camera/camera_impl.cpp
+++ b/src/mavsdk/plugins/camera/camera_impl.cpp
@@ -894,25 +894,7 @@ void CameraImpl::process_storage_information(const mavlink_message_t& message)
 
     {
         std::lock_guard<std::mutex> lock(_status.mutex);
-        switch (storage_information.status) {
-            case STORAGE_STATUS_EMPTY:
-                _status.data.storage_status = Camera::Status::StorageStatus::NotAvailable;
-                break;
-            case STORAGE_STATUS_UNFORMATTED:
-                _status.data.storage_status = Camera::Status::StorageStatus::Unformatted;
-                break;
-            case STORAGE_STATUS_READY:
-                _status.data.storage_status = Camera::Status::StorageStatus::Formatted;
-                break;
-            case STORAGE_STATUS_NOT_SUPPORTED:
-                _status.data.storage_status = Camera::Status::StorageStatus::NotSupported;
-                break;
-            default:
-                _status.data.storage_status = Camera::Status::StorageStatus::NotSupported;
-                LogErr() << "Unknown storage status received.";
-                break;
-        }
-
+        _status.data.storage_status = storage_status_from_mavlink(storage_information.status);
         _status.data.available_storage_mib = storage_information.available_capacity;
         _status.data.used_storage_mib = storage_information.used_capacity;
         _status.data.total_storage_mib = storage_information.total_capacity;
@@ -922,6 +904,25 @@ void CameraImpl::process_storage_information(const mavlink_message_t& message)
     }
 
     check_status();
+}
+
+Camera::Status::StorageStatus
+CameraImpl::storage_status_from_mavlink(const int storage_status) const
+{
+    switch (storage_status) {
+        case STORAGE_STATUS_EMPTY:
+            return Camera::Status::StorageStatus::NotAvailable;
+        case STORAGE_STATUS_UNFORMATTED:
+            return Camera::Status::StorageStatus::Unformatted;
+        case STORAGE_STATUS_READY:
+            return Camera::Status::StorageStatus::Formatted;
+            break;
+        case STORAGE_STATUS_NOT_SUPPORTED:
+            return Camera::Status::StorageStatus::NotSupported;
+        default:
+            LogErr() << "Unknown storage status received.";
+            return Camera::Status::StorageStatus::NotSupported;
+    }
 }
 
 Camera::Status::StorageType

--- a/src/mavsdk/plugins/camera/camera_impl.h
+++ b/src/mavsdk/plugins/camera/camera_impl.h
@@ -133,6 +133,7 @@ private:
     void process_video_stream_status(const mavlink_message_t& message);
     void process_flight_information(const mavlink_message_t& message);
 
+    Camera::Status::StorageStatus storage_status_from_mavlink(const int storage_status) const;
     Camera::Status::StorageType storage_type_from_mavlink(const int storage_type) const;
 
     Camera::EulerAngle to_euler_angle_from_quaternion(Camera::Quaternion quaternion);

--- a/src/mavsdk/plugins/camera/camera_impl.h
+++ b/src/mavsdk/plugins/camera/camera_impl.h
@@ -133,6 +133,8 @@ private:
     void process_video_stream_status(const mavlink_message_t& message);
     void process_flight_information(const mavlink_message_t& message);
 
+    Camera::Status::StorageType storage_type_from_mavlink(const int storage_type) const;
+
     Camera::EulerAngle to_euler_angle_from_quaternion(Camera::Quaternion quaternion);
 
     void notify_mode();


### PR DESCRIPTION
We should not use `static_cast` to translate between a MAVLink enum and a MAVSDK enum, because their values don't necessarily correspond. Here STORAGE_TYPE_OTHER has a MAVLink value of 254 and fails to translate.

```c++
_status.data.storage_type = static_cast<Camera::Status::StorageType>(storage_information.type);
```