### PR TITLE
Preserve symlinks in zip file

### DIFF
--- a/src/mavsdk_server/tools/package_mavsdk_server_framework.bash
+++ b/src/mavsdk_server/tools/package_mavsdk_server_framework.bash
@@ -24,7 +24,7 @@ chmod +x ${BUILD_DIR}/mavsdk_server.xcframework/ios-x86_64-simulator/mavsdk_serv
 chmod +x ${BUILD_DIR}/mavsdk_server.xcframework/macos-x86_64/mavsdk_server.framework/mavsdk_server
 
 cd ${BUILD_DIR}
-zip -9 -r mavsdk_server.xcframework.zip mavsdk_server.xcframework
+zip -9 -y -r mavsdk_server.xcframework.zip mavsdk_server.xcframework
 
 shasum -a 256 mavsdk_server.xcframework.zip | awk '{ print $1 }' > mavsdk_server.xcframework.zip.sha256
 


### PR DESCRIPTION
Hi!

When trying to build an app for macOS, Xcode complains about not being able to follow a symlink. After some investigation it turns out that the `Current` folder (`/mavsdk_server.xcframework/macos-x86_64/mavsdk_server.framework/Versions/Current`) is in fact not a symlink, but it should be.

Updating the `zip` command to preserve symlinks should fix the issue.