### PR TITLE
mavsdk_server: default to the first autopilot 

### DIFF
--- a/src/mavsdk/core/lazy_plugin.h
+++ b/src/mavsdk/core/lazy_plugin.h
@@ -4,6 +4,7 @@
 #include <mutex>
 
 #include <mavsdk.h>
+#include <log.h>
 
 namespace mavsdk::mavsdk_server {
 
@@ -18,7 +19,7 @@ public:
             if (_mavsdk.systems().empty()) {
                 return nullptr;
             }
-            _plugin = std::make_unique<Plugin>(_mavsdk.systems()[0]);
+            _plugin = std::make_unique<Plugin>(first_autopilot());
         }
         return _plugin.get();
     }
@@ -27,6 +28,18 @@ private:
     Mavsdk& _mavsdk;
     std::unique_ptr<Plugin> _plugin{};
     std::mutex _mutex{};
+
+    std::shared_ptr<System> first_autopilot()
+    {
+        for (auto system : _mavsdk.systems()) {
+            if (system->has_autopilot()) {
+                return system;
+            }
+        }
+
+        LogErr() << "No autopilot found!";
+        return nullptr;
+    }
 };
 
 } // namespace mavsdk::mavsdk_server

--- a/src/mavsdk/core/mocks/system_mock.h
+++ b/src/mavsdk/core/mocks/system_mock.h
@@ -8,6 +8,7 @@ namespace testing {
 class MockSystem {
 public:
     MOCK_CONST_METHOD0(is_connected, bool()){};
+    MOCK_CONST_METHOD0(has_autopilot, bool()){};
 };
 
 } // namespace testing

--- a/src/mavsdk_server/src/connection_initiator.h
+++ b/src/mavsdk_server/src/connection_initiator.h
@@ -57,13 +57,14 @@ private:
 
         mavsdk.subscribe_on_new_system([this, &mavsdk]() {
             std::lock_guard<std::mutex> guard(_mutex);
-            const auto system = mavsdk.systems().at(0);
+            for (auto system : mavsdk.systems()) {
+                if (!_is_discovery_finished && system->has_autopilot() && system->is_connected()) {
+                    LogInfo() << "System discovered";
 
-            if (!_is_discovery_finished && system->is_connected()) {
-                LogInfo() << "System discovered";
-
-                _is_discovery_finished = true;
-                _discovery_promise->set_value(true);
+                    _is_discovery_finished = true;
+                    _discovery_promise->set_value(true);
+                    break;
+                }
             }
         });
 

--- a/src/mavsdk_server/test/connection_initiator_test.cpp
+++ b/src/mavsdk_server/test/connection_initiator_test.cpp
@@ -54,6 +54,7 @@ TEST(ConnectionInitiator, startHangsUntilSystemDiscovered)
     EXPECT_CALL(mavsdk, systems()).WillOnce(testing::Return(systems));
 
     EXPECT_CALL(*system, is_connected()).WillOnce(testing::Return(true));
+    EXPECT_CALL(*system, has_autopilot()).WillOnce(testing::Return(true));
 
     auto async_future = std::async(std::launch::async, [&initiator, &mavsdk]() {
         initiator.start(mavsdk, ARBITRARY_CONNECTION_URL);
@@ -80,6 +81,7 @@ TEST(ConnectionInitiator, connectionDetectedIfDiscoverCallbackCalledBeforeWait)
     EXPECT_CALL(mavsdk, systems()).WillOnce(testing::Return(systems));
 
     EXPECT_CALL(*system, is_connected()).WillOnce(testing::Return(true));
+    EXPECT_CALL(*system, has_autopilot()).WillOnce(testing::Return(true));
 
     initiator.start(mavsdk, ARBITRARY_CONNECTION_URL);
     change_callback();
@@ -99,6 +101,7 @@ TEST(ConnectionInitiator, doesNotCrashIfDiscoverCallbackCalledMoreThanOnce)
     EXPECT_CALL(mavsdk, systems()).WillRepeatedly(testing::Return(systems));
 
     EXPECT_CALL(*system, is_connected()).WillRepeatedly(testing::Return(true));
+    EXPECT_CALL(*system, has_autopilot()).WillOnce(testing::Return(true));
 
     initiator.start(mavsdk, ARBITRARY_CONNECTION_URL);
     change_callback();


### PR DESCRIPTION
Currently, `mavsdk_server` defaults to being a ground station (i.e. it does not expose the `Configuration`). When started, `mavsdk_server` connects to the first MAVLink `System` it detects.

The problem I have seen is that in some setups, there are sometimes MAVLink systems that are not an autopilot but that are advertising on the link that `mavsdk_server` is listening to. I had the issue with a Herelink radio, that advertises radio messages with sysid 42. For an app running on Herelink, if `mavsdk_server` picks up the system "42" first, then there is nothing to do other than restarting it and hoping that it picks up the right system.

Now I argue that the "right" system for `mavsdk_server`, given the current situation where it defaults to being a ground station, is a system that has an autopilot (i.e. a drone).

This PR makes `mavsdk_server` connect not to the first system it encounters, but to the first _drone_ (a.k.a. "system with an autopilot") it encounters.