### PR TITLE
telemetry: remove gps_raw_timeout

### DIFF
--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -164,7 +164,6 @@ void TelemetryImpl::deinit()
 {
     _parent->remove_call_every(_calibration_cookie);
     _parent->unregister_statustext_handler(this);
-    _parent->unregister_timeout_handler(_gps_raw_timeout_cookie);
     _parent->unregister_timeout_handler(_unix_epoch_timeout_cookie);
     _parent->unregister_param_changed_handler(this);
     _parent->unregister_all_mavlink_message_handlers(this);
@@ -183,9 +182,6 @@ void TelemetryImpl::deinit()
 
 void TelemetryImpl::enable()
 {
-    _parent->register_timeout_handler(
-        [this]() { receive_gps_raw_timeout(); }, 2.0, &_gps_raw_timeout_cookie);
-
     _parent->register_timeout_handler(
         [this]() { receive_unix_epoch_timeout(); }, 2.0, &_unix_epoch_timeout_cookie);
 
@@ -998,8 +994,6 @@ void TelemetryImpl::process_gps_raw_int(const mavlink_message_t& message)
             _parent->call_user_callback([callback, arg]() { callback(arg); });
         }
     }
-
-    _parent->refresh_timeout_handler(_gps_raw_timeout_cookie);
 }
 
 void TelemetryImpl::process_ground_truth(const mavlink_message_t& message)

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.h
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.h
@@ -383,7 +383,6 @@ private:
     double _position_rate_hz{-1.0};
 
     void* _rc_channels_timeout_cookie{nullptr};
-    void* _gps_raw_timeout_cookie{nullptr};
     void* _unix_epoch_timeout_cookie{nullptr};
 
     // Battery info can be extracted from SYS_STATUS or from BATTERY_STATUS.


### PR DESCRIPTION
I wonder if this timeout is necessary, and I wonder if it could cause issues sometimes. Right now I have an issue where the MAVSDK health changes the global_position and local_position to "false" for no apparent reason, and I wonder if that could be this timeout.

Also none of the other telemetry streams have a timeout. So if a message stops coming, the state is "frozen". I wonder why this one should be different. Especially given that it is a fallback (MAVSDK should rely on the flags in the SYS_STATUS message if they are set properly).