### PR TITLE
Request mode change for action MAV_CMD_DO_REPOSITION

### DIFF
--- a/src/mavsdk/plugins/action/action_impl.cpp
+++ b/src/mavsdk/plugins/action/action_impl.cpp
@@ -455,7 +455,7 @@ void ActionImpl::goto_location_async(
             command.params.x = int32_t(std::round(latitude_deg * 1e7));
             command.params.y = int32_t(std::round(longitude_deg * 1e7));
             command.params.maybe_z = altitude_amsl_m;
-            command.params.maybe_param2 = MAV_DO_REPOSITION_FLAGS_CHANGE_MODE;
+            command.params.maybe_param2 = static_cast<float>(MAV_DO_REPOSITION_FLAGS_CHANGE_MODE);
 
             _system_impl->send_command_async(
                 command, [this, callback](MavlinkCommandSender::Result result, float) {

--- a/src/mavsdk/plugins/action/action_impl.cpp
+++ b/src/mavsdk/plugins/action/action_impl.cpp
@@ -455,7 +455,7 @@ void ActionImpl::goto_location_async(
             command.params.x = int32_t(std::round(latitude_deg * 1e7));
             command.params.y = int32_t(std::round(longitude_deg * 1e7));
             command.params.maybe_z = altitude_amsl_m;
-            command.params.maybe_param2 = 1;
+            command.params.maybe_param2 = MAV_DO_REPOSITION_FLAGS_CHANGE_MODE;
 
             _system_impl->send_command_async(
                 command, [this, callback](MavlinkCommandSender::Result result, float) {

--- a/src/mavsdk/plugins/action/action_impl.cpp
+++ b/src/mavsdk/plugins/action/action_impl.cpp
@@ -455,6 +455,7 @@ void ActionImpl::goto_location_async(
             command.params.x = int32_t(std::round(latitude_deg * 1e7));
             command.params.y = int32_t(std::round(longitude_deg * 1e7));
             command.params.maybe_z = altitude_amsl_m;
+            command.params.maybe_param2 = 1;
 
             _system_impl->send_command_async(
                 command, [this, callback](MavlinkCommandSender::Result result, float) {


### PR DESCRIPTION
**Problem Description**
The goto action in the examples of MAVSDK-Python is currently broken with PX4 `main` (reported in https://github.com/mavlink/MAVSDK-Python/issues/633)

PX4 returns an unsupported error, as the following.
```
Traceback (most recent call last):
  File "goto.py", line 47, in <module>
    asyncio.run(run())
  File "/usr/lib/python3.8/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "goto.py", line 38, in run
    await drone.action.goto_location(47.397606, 8.543060, flying_alt, 0)
  File "/home/yunpeng/.local/lib/python3.8/site-packages/mavsdk/action.py", line 548, in goto_location
    raise ActionError(result, "goto_location()", latitude_deg, longitude_deg, absolute_altitude_m, yaw_deg)
mavsdk.action.ActionError: UNSUPPORTED: 'Unsupported'; origin: goto_location(); params: (47.397606, 8.54306, 508.1050109863281, 0)
```

It seems that this is a regression from https://github.com/PX4/PX4-Autopilot/pull/22078, where PX4 requires a mode switch request to be set

**Testing**
Was not able to test it yet, given that the problem is in MAVDK python.

