### PR TITLE
core: fix burst implementation

### DIFF
--- a/src/mavsdk/core/mavlink_ftp_client.h
+++ b/src/mavsdk/core/mavlink_ftp_client.h
@@ -268,7 +268,9 @@ private:
 
     bool download_burst_start(Work& work, DownloadBurstItem& item);
     bool download_burst_continue(Work& work, DownloadBurstItem& item, PayloadHeader* payload);
-    void request_next_burst(Work& work, DownloadBurstItem& item);
+    void request_burst(Work& work, DownloadBurstItem& item);
+    void request_next_rest(Work& work, DownloadBurstItem& item);
+    size_t burst_bytes_transferred(DownloadBurstItem& item);
 
     bool upload_start(Work& work, UploadItem& item);
     bool upload_continue(Work& work, UploadItem& item);

--- a/src/mavsdk/core/mavlink_ftp_server.h
+++ b/src/mavsdk/core/mavlink_ftp_server.h
@@ -141,7 +141,7 @@ private:
     struct SessionInfo {
         uint32_t file_size{0};
         uint32_t burst_offset{0};
-        uint32_t burst_end{0};
+        uint8_t burst_chunk_size{0};
         std::ifstream ifstream;
         std::ofstream ofstream;
     } _session_info{};


### PR DESCRIPTION
This fixes the burst implementation which was implemented according to the docs rather than the existing implementations out there (like ArduPilot, MissionPlanner, and QGroundControl.

The difference is that the size field is used to signal the size of each burst packet rather than the overall burst. This means a burst transfer always has to be the whole file and can't be a partial file.

For discussion see https://github.com/mavlink/mavlink/issues/2052.