### PR TITLE
CI: downgrade to Python 3.11 for macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -389,6 +389,11 @@ jobs:
           - name: macOS-framework
             build-framework: ON
     steps:
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          architecture: 'x64'
       - uses: actions/checkout@v3
         with:
           submodules: recursive
@@ -443,6 +448,11 @@ jobs:
             platform: SIMULATOR64
             sdk: iphonesimulator
     steps:
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          architecture: 'x64'
       - uses: actions/checkout@v3
         with:
           submodules: recursive


### PR DESCRIPTION
This is to avoid the problem with future trying to import imp which is now importlib.

The dependency goes to mavlink and then in turn to pymavlink, so it'll be a while until this trickles down.