### PR TITLE
mavsdk_server: fix dl-lib linking

### DIFF
--- a/src/mavsdk_server/src/CMakeLists.txt
+++ b/src/mavsdk_server/src/CMakeLists.txt
@@ -76,6 +76,7 @@ target_link_libraries(mavsdk_server
     mavsdk
     gRPC::grpc++
     ${COMPONENTS_PROTOGENS}
+    ${CMAKE_DL_LIBS}
 )
 
 set_target_properties(mavsdk_server


### PR DESCRIPTION
Resolves https://github.com/mavlink/MAVSDK-Java/issues/131

Apply the changes that were suggested [here](https://github.com/mavlink/MAVSDK-Java/issues/131).