### PR TITLE
mavsdk_server: fix dl-lib linking

### DIFF
--- a/src/mavsdk_server/src/CMakeLists.txt
+++ b/src/mavsdk_server/src/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(mavsdk_server
     PRIVATE
     mavsdk
     gRPC::grpc++
+    ${CMAKE_DL_LIBS}
 )
 
 if(BUILD_WITH_PROTO_REFLECTION)


### PR DESCRIPTION
Porting https://github.com/mavlink/MAVSDK/pull/2180 to `main`.