### PR TITLE
Include header <atomic> in connection.h to avoid compiler erros with msvc2019 16.4

### DIFF
--- a/src/mavsdk/core/connection.h
+++ b/src/mavsdk/core/connection.h
@@ -2,6 +2,7 @@
 
 #include "mavsdk.h"
 #include "mavlink_receiver.h"
+#include <atomic>
 #include <memory>
 #include <unordered_set>
 


### PR DESCRIPTION
Even though newer MSVC 2019 version compile perfectly fine it's worth including this header since it's used in 'Connection' class.