### PR TITLE
Use DEBUG_POSTFIX cmake property to distinguish between debug and release dll

### DIFF
--- a/src/mavsdk/core/CMakeLists.txt
+++ b/src/mavsdk/core/CMakeLists.txt
@@ -71,6 +71,11 @@ set_target_properties(mavsdk PROPERTIES
     VERSION ${MAVSDK_VERSION_STRING}
     SOVERSION ${MAVSDK_SOVERSION_STRING}
 )
+if (MSVC)
+    set_target_properties(mavsdk PROPERTIES
+        DEBUG_POSTFIX "d"
+    )
+endif()
 
 if (IOS)
     target_link_libraries(mavsdk


### PR DESCRIPTION
Since it's not possible to mix debug and release msvc runtime on
windows, it's important to link against a mavsdk debug lib when
compiling the program for debug and later link against the mavsdk
release lib when deploying the program. But this did not work until now
because the name for the debug and release dll was the same. For this
purpose CMake invented the 'DEBUG_POSTFIX' property for a target.
The generated CMake files to find mavsdk are correctly filled with the
appropriate library name so no need to change anything else here.