### PR TITLE
Update to MavlinkPassthrough unsubscribe_message

### DIFF
--- a/examples/gimbal_device_tester/gimbal_device_tester.cpp
+++ b/examples/gimbal_device_tester/gimbal_device_tester.cpp
@@ -721,7 +721,7 @@ bool test_device_information(MavlinkPassthrough& mavlink_passthrough, AttitudeDa
                 });
 
             // We only need it once.
-            mavlink_passthrough.unsubscribe_message(handle);
+            mavlink_passthrough.unsubscribe_message(MAVLINK_MSG_ID_GIMBAL_DEVICE_INFORMATION, handle);
             prom.set_value();
         });
 

--- a/examples/gimbal_device_tester/gimbal_device_tester.cpp
+++ b/examples/gimbal_device_tester/gimbal_device_tester.cpp
@@ -721,7 +721,8 @@ bool test_device_information(MavlinkPassthrough& mavlink_passthrough, AttitudeDa
                 });
 
             // We only need it once.
-            mavlink_passthrough.unsubscribe_message(MAVLINK_MSG_ID_GIMBAL_DEVICE_INFORMATION, handle);
+            mavlink_passthrough.unsubscribe_message(
+                MAVLINK_MSG_ID_GIMBAL_DEVICE_INFORMATION, handle);
             prom.set_value();
         });
 

--- a/src/mavsdk/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.h
+++ b/src/mavsdk/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.h
@@ -215,6 +215,9 @@ public:
 
     /**
      * @brief Unsubscribe from subscribe_message.
+     *
+     * @param message_id The MAVLink message ID.
+     * @param handle The handle returned from subscribe_message.
      */
     void unsubscribe_message(uint16_t message_id, MessageHandle handle);
 

--- a/src/mavsdk/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.h
+++ b/src/mavsdk/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.h
@@ -216,7 +216,7 @@ public:
     /**
      * @brief Unsubscribe from subscribe_message.
      */
-    void unsubscribe_message(MessageHandle handle);
+    void unsubscribe_message(uint16_t message_id, MessageHandle handle);
 
     /**
      * @brief Get our own system ID.

--- a/src/mavsdk/plugins/mavlink_passthrough/mavlink_passthrough.cpp
+++ b/src/mavsdk/plugins/mavlink_passthrough/mavlink_passthrough.cpp
@@ -63,9 +63,9 @@ MavlinkPassthrough::subscribe_message(uint16_t message_id, const MessageCallback
     return _impl->subscribe_message(message_id, callback);
 }
 
-void MavlinkPassthrough::unsubscribe_message(MessageHandle handle)
+void MavlinkPassthrough::unsubscribe_message(uint16_t message_id, MessageHandle handle)
 {
-    _impl->unsubscribe_message(handle);
+    _impl->unsubscribe_message(message_id, handle);
 }
 
 std::ostream& operator<<(std::ostream& str, MavlinkPassthrough::Result const& result)

--- a/src/mavsdk/plugins/mavlink_passthrough/mavlink_passthrough_impl.cpp
+++ b/src/mavsdk/plugins/mavlink_passthrough/mavlink_passthrough_impl.cpp
@@ -210,8 +210,9 @@ MavlinkPassthrough::MessageHandle MavlinkPassthroughImpl::subscribe_message(
 void MavlinkPassthroughImpl::unsubscribe_message(
     uint16_t message_id, MavlinkPassthrough::MessageHandle handle)
 {
-    if (_message_subscriptions.find(message_id) != _message_subscriptions.end()) {
-        _message_subscriptions[message_id].unsubscribe(handle);
+    auto it = _message_subscriptions.find(message_id);
+    if (it != _message_subscriptions.end()) {
+        it->unsubscribe(handle);
     }
 }
 

--- a/src/mavsdk/plugins/mavlink_passthrough/mavlink_passthrough_impl.cpp
+++ b/src/mavsdk/plugins/mavlink_passthrough/mavlink_passthrough_impl.cpp
@@ -212,7 +212,7 @@ void MavlinkPassthroughImpl::unsubscribe_message(
 {
     auto it = _message_subscriptions.find(message_id);
     if (it != _message_subscriptions.end()) {
-        it->unsubscribe(handle);
+        it->second.unsubscribe(handle);
     }
 }
 

--- a/src/mavsdk/plugins/mavlink_passthrough/mavlink_passthrough_impl.cpp
+++ b/src/mavsdk/plugins/mavlink_passthrough/mavlink_passthrough_impl.cpp
@@ -207,12 +207,11 @@ MavlinkPassthrough::MessageHandle MavlinkPassthroughImpl::subscribe_message(
     return _message_subscriptions[message_id].subscribe(callback);
 }
 
-void MavlinkPassthroughImpl::unsubscribe_message(MavlinkPassthrough::MessageHandle handle)
+void MavlinkPassthroughImpl::unsubscribe_message(
+    uint16_t message_id, MavlinkPassthrough::MessageHandle handle)
 {
-    // We don't know which subscription holds the handle, so we have to go
-    // through all of them.
-    for (auto& subscription : _message_subscriptions) {
-        subscription.second.unsubscribe(handle);
+    if (_message_subscriptions.find(message_id) != _message_subscriptions.end()) {
+        _message_subscriptions[message_id].unsubscribe(handle);
     }
 }
 

--- a/src/mavsdk/plugins/mavlink_passthrough/mavlink_passthrough_impl.h
+++ b/src/mavsdk/plugins/mavlink_passthrough/mavlink_passthrough_impl.h
@@ -40,7 +40,7 @@ public:
     MavlinkPassthrough::MessageHandle
     subscribe_message(uint16_t message_id, const MavlinkPassthrough::MessageCallback& callback);
 
-    void unsubscribe_message(MavlinkPassthrough::MessageHandle handle);
+    void unsubscribe_message(uint16_t message_id, MavlinkPassthrough::MessageHandle handle);
 
     uint8_t get_our_sysid() const;
     uint8_t get_our_compid() const;


### PR DESCRIPTION
This updates MavlinkPassthrough to require a message id in unsubscribe_message.  It fixes the bug where unsubscribing from a passthrough message also unsubscribed from messages with the same handle id but different message ids.