### PR TITLE
Require configuration for Mavsdk ctor

### DIFF
--- a/examples/autopilot_server/autopilot_server.cpp
+++ b/examples/autopilot_server/autopilot_server.cpp
@@ -66,8 +66,7 @@ int main(int argc, char** argv)
             std::cout << "Connected autopilot server side!" << std::endl;
         }
 
-        auto server_component =
-            mavsdkTester.server_component_by_type(Mavsdk::ComponentType::Autopilot);
+        auto server_component = mavsdkTester.server_component();
 
         // Create server plugins
         auto paramServer = mavsdk::ParamServer{server_component};

--- a/examples/autopilot_server/autopilot_server.cpp
+++ b/examples/autopilot_server/autopilot_server.cpp
@@ -58,9 +58,8 @@ int main(int argc, char** argv)
     // We run the server plugins on a seperate thead so we can use the main
     // thread as a ground station.
     std::thread autopilotThread([]() {
-        mavsdk::Mavsdk mavsdkTester;
-        mavsdk::Mavsdk::Configuration configuration(mavsdk::Mavsdk::ComponentType::Autopilot);
-        mavsdkTester.set_configuration(configuration);
+        mavsdk::Mavsdk mavsdkTester{
+            mavsdk::Mavsdk::Configuration{mavsdk::Mavsdk::ComponentType::Autopilot}};
 
         auto result = mavsdkTester.add_any_connection("udp://127.0.0.1:14551");
         if (result == mavsdk::ConnectionResult::Success) {
@@ -146,9 +145,7 @@ int main(int argc, char** argv)
 
     // Now this is the main thread, we run client plugins to act as the GCS
     // to communicate with the autopilot server plugins.
-    mavsdk::Mavsdk mavsdk;
-    mavsdk::Mavsdk::Configuration configuration(mavsdk::Mavsdk::ComponentType::GroundStation);
-    mavsdk.set_configuration(configuration);
+    mavsdk::Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     auto result = mavsdk.add_any_connection("udp://:14551");
     if (result == mavsdk::ConnectionResult::Success) {

--- a/examples/battery/battery.cpp
+++ b/examples/battery/battery.cpp
@@ -36,7 +36,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
 
     if (connection_result != ConnectionResult::Success) {

--- a/examples/calibrate/calibrate.cpp
+++ b/examples/calibrate/calibrate.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
 
     if (connection_result != ConnectionResult::Success) {

--- a/examples/camera/camera.cpp
+++ b/examples/camera/camera.cpp
@@ -33,7 +33,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
 
     if (connection_result != ConnectionResult::Success) {

--- a/examples/camera_server/camera_client.cpp
+++ b/examples/camera_server/camera_client.cpp
@@ -9,9 +9,8 @@ int main(int argc, const char* argv[])
 {
     // we run client plugins to act as the GCS
     // to communicate with the camera server plugins.
-    mavsdk::Mavsdk mavsdk;
-    mavsdk::Mavsdk::Configuration configuration(mavsdk::Mavsdk::ComponentType::GroundStation);
-    mavsdk.set_configuration(configuration);
+    mavsdk::Mavsdk mavsdk{
+        mavsdk::Mavsdk::Configuration{mavsdk::Mavsdk::ComponentType::GroundStation}};
 
     auto result = mavsdk.add_any_connection("udp://:14030");
     if (result == mavsdk::ConnectionResult::Success) {

--- a/examples/camera_server/camera_server.cpp
+++ b/examples/camera_server/camera_server.cpp
@@ -15,8 +15,7 @@ int main(int argc, char** argv)
     }
     std::cout << "Created camera server connection" << std::endl;
 
-    auto camera_server = mavsdk::CameraServer{
-        mavsdk.server_component_by_type(mavsdk::Mavsdk::ComponentType::Camera)};
+    auto camera_server = mavsdk::CameraServer{mavsdk.server_component()};
 
     // First add all subscriptions. This defines the camera capabilities.
 

--- a/examples/camera_server/camera_server.cpp
+++ b/examples/camera_server/camera_server.cpp
@@ -5,9 +5,7 @@
 
 int main(int argc, char** argv)
 {
-    mavsdk::Mavsdk mavsdk;
-    mavsdk::Mavsdk::Configuration configuration(mavsdk::Mavsdk::ComponentType::Camera);
-    mavsdk.set_configuration(configuration);
+    mavsdk::Mavsdk mavsdk{mavsdk::Mavsdk::Configuration{mavsdk::Mavsdk::ComponentType::Camera}};
 
     // 14030 is the default camera port for PX4 SITL
     auto result = mavsdk.add_any_connection("udp://127.0.0.1:14030");

--- a/examples/camera_settings/camera_settings.cpp
+++ b/examples/camera_settings/camera_settings.cpp
@@ -197,7 +197,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
 
     if (connection_result != ConnectionResult::Success) {

--- a/examples/distance_sensor/distance_sensor.cpp
+++ b/examples/distance_sensor/distance_sensor.cpp
@@ -36,7 +36,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
 
     if (connection_result != ConnectionResult::Success) {

--- a/examples/fly_mission/fly_mission.cpp
+++ b/examples/fly_mission/fly_mission.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
 
     if (connection_result != ConnectionResult::Success) {

--- a/examples/fly_multiple_drones/fly_multiple_drones.cpp
+++ b/examples/fly_multiple_drones/fly_multiple_drones.cpp
@@ -85,7 +85,7 @@ int main(int argc, char* argv[])
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     // Half of argc is how many udp ports is being used
     size_t total_ports_used = argc / 2;

--- a/examples/fly_qgc_mission/fly_qgc_mission.cpp
+++ b/examples/fly_qgc_mission/fly_qgc_mission.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     const ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
     if (connection_result != ConnectionResult::Success) {

--- a/examples/follow_me/follow_me.cpp
+++ b/examples/follow_me/follow_me.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
 
     if (connection_result != ConnectionResult::Success) {

--- a/examples/ftp_client/ftp_client.cpp
+++ b/examples/ftp_client/ftp_client.cpp
@@ -186,7 +186,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
 
     if (connection_result != ConnectionResult::Success) {

--- a/examples/ftp_server/ftp_server.cpp
+++ b/examples/ftp_server/ftp_server.cpp
@@ -28,9 +28,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
-    Mavsdk::Configuration configuration(Mavsdk::ComponentType::CompanionComputer);
-    mavsdk.set_configuration(configuration);
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::CompanionComputer}};
     ConnectionResult connection_result = mavsdk.setup_udp_remote(argv[1], std::stoi(argv[2]));
     if (connection_result != ConnectionResult::Success) {
         std::cerr << "Error setting up Mavlink FTP server.\n";

--- a/examples/ftp_server/ftp_server.cpp
+++ b/examples/ftp_server/ftp_server.cpp
@@ -35,8 +35,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto component =
-        mavsdk.server_component_by_type(mavsdk::Mavsdk::ComponentType::CompanionComputer);
+    auto component = mavsdk.server_component();
     auto ftp_server = FtpServer{component};
     ftp_server.set_root_dir(argv[3]);
 

--- a/examples/geofence/geofence.cpp
+++ b/examples/geofence/geofence.cpp
@@ -38,7 +38,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
 
     if (connection_result != ConnectionResult::Success) {

--- a/examples/gimbal/gimbal.cpp
+++ b/examples/gimbal/gimbal.cpp
@@ -35,7 +35,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
 
     if (connection_result != ConnectionResult::Success) {

--- a/examples/gimbal_device_tester/gimbal_device_tester.cpp
+++ b/examples/gimbal_device_tester/gimbal_device_tester.cpp
@@ -796,7 +796,9 @@ void usage(const std::string& bin_name)
 
 int main(int argc, char** argv)
 {
-    Mavsdk mavsdk;
+    Mavsdk::Configuration config(Mavsdk::ComponentType::Autopilot);
+    config.set_system_id(own_sysid);
+    Mavsdk mavsdk{config};
     std::string connection_url;
     ConnectionResult connection_result;
 
@@ -815,10 +817,6 @@ int main(int argc, char** argv)
         std::cout << "-> connection failed: " << connection_result << '\n';
         return 1;
     }
-
-    Mavsdk::Configuration config(Mavsdk::ComponentType::Autopilot);
-    config.set_system_id(own_sysid);
-    mavsdk.set_configuration(config);
 
     {
         std::promise<void> prom;

--- a/examples/logfile_download/logfile_download.cpp
+++ b/examples/logfile_download/logfile_download.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv)
         }
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
 
     if (connection_result != ConnectionResult::Success) {

--- a/examples/manual_control/manual_control.cpp
+++ b/examples/manual_control/manual_control.cpp
@@ -59,7 +59,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
 
     if (connection_result != ConnectionResult::Success) {

--- a/examples/mavshell/mavshell.cpp
+++ b/examples/mavshell/mavshell.cpp
@@ -25,7 +25,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
 
     if (connection_result != ConnectionResult::Success) {

--- a/examples/multiple_drones/multiple_drones.cpp
+++ b/examples/multiple_drones/multiple_drones.cpp
@@ -36,7 +36,7 @@ int main(int argc, char* argv[])
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     size_t total_udp_ports = argc - 1;
 

--- a/examples/offboard/offboard.cpp
+++ b/examples/offboard/offboard.cpp
@@ -299,7 +299,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
 
     if (connection_result != ConnectionResult::Success) {

--- a/examples/parachute/parachute.cpp
+++ b/examples/parachute/parachute.cpp
@@ -79,12 +79,11 @@ int main(int argc, char* argv[])
 
     const std::string connection_url = argv[1];
 
-    Mavsdk mavsdk;
-
     // We start with sysid 1 but adapt to the one of the autopilot once
     // we have discoverd it.
     uint8_t our_sysid = 1;
-    mavsdk.set_configuration(Mavsdk::Configuration{our_sysid, MAV_COMP_ID_PARACHUTE, false});
+
+    Mavsdk mavsdk{Mavsdk::Configuration{our_sysid, MAV_COMP_ID_PARACHUTE, false}};
 
     const ConnectionResult connection_result = mavsdk.add_any_connection(connection_url);
 

--- a/examples/set_actuator/set_actuator.cpp
+++ b/examples/set_actuator/set_actuator.cpp
@@ -32,7 +32,7 @@ int main(int argc, char** argv)
     const int index = std::stod(argv[2]);
     const float value = std::stof(argv[3]);
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     const ConnectionResult connection_result = mavsdk.add_any_connection(connection_url);
 
     if (connection_result != ConnectionResult::Success) {

--- a/examples/sniffer/sniffer.cpp
+++ b/examples/sniffer/sniffer.cpp
@@ -29,7 +29,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
 
     if (connection_result != ConnectionResult::Success) {

--- a/examples/system_info/system_info.cpp
+++ b/examples/system_info/system_info.cpp
@@ -32,7 +32,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
 
     if (connection_result != ConnectionResult::Success) {

--- a/examples/takeoff_and_land/takeoff_and_land.cpp
+++ b/examples/takeoff_and_land/takeoff_and_land.cpp
@@ -33,7 +33,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
 
     if (connection_result != ConnectionResult::Success) {

--- a/examples/terminate/terminate.cpp
+++ b/examples/terminate/terminate.cpp
@@ -35,7 +35,7 @@ int main(int argc, char* argv[])
 
     const std::string connection_url = argv[1];
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     std::cout << "Waiting to discover system...\n";
     auto prom = std::promise<std::shared_ptr<System>>{};

--- a/examples/transponder/transponder.cpp
+++ b/examples/transponder/transponder.cpp
@@ -32,7 +32,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
 
     if (connection_result != ConnectionResult::Success) {

--- a/examples/tune/tune.cpp
+++ b/examples/tune/tune.cpp
@@ -30,7 +30,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
 
     if (connection_result != ConnectionResult::Success) {

--- a/examples/vtol_transition/vtol_transition.cpp
+++ b/examples/vtol_transition/vtol_transition.cpp
@@ -34,7 +34,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
 
     if (connection_result != ConnectionResult::Success) {

--- a/src/integration_tests/action_goto.cpp
+++ b/src/integration_tests/action_goto.cpp
@@ -9,7 +9,7 @@ using namespace mavsdk;
 
 TEST_F(SitlTest, PX4ActionGoto)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/action_hold.cpp
+++ b/src/integration_tests/action_hold.cpp
@@ -9,7 +9,7 @@ using namespace mavsdk;
 
 TEST_F(SitlTest, PX4ActionHold)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/action_hover_async.cpp
+++ b/src/integration_tests/action_hover_async.cpp
@@ -9,7 +9,7 @@ using namespace mavsdk;
 
 TEST_F(SitlTest, ActionHoverAsync)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/action_hover_sync.cpp
+++ b/src/integration_tests/action_hover_sync.cpp
@@ -46,7 +46,7 @@ TEST_F(SitlTest, APMActionHoverSyncLower)
 
 void takeoff_and_hover_at_altitude(float altitude_m)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);
@@ -123,7 +123,7 @@ void takeoff_and_hover_at_altitude(float altitude_m)
 
 void takeoff_and_hover_at_altitude_apm(float altitude_m)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/action_takeoff_and_kill.cpp
+++ b/src/integration_tests/action_takeoff_and_kill.cpp
@@ -8,7 +8,7 @@ using namespace mavsdk;
 
 TEST_F(SitlTest, ActionTakeoffAndKill)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ASSERT_EQ(mavsdk.add_udp_connection(), ConnectionResult::Success);
 
     {

--- a/src/integration_tests/action_transition_multicopter_fixedwing.cpp
+++ b/src/integration_tests/action_transition_multicopter_fixedwing.cpp
@@ -10,7 +10,7 @@ using namespace mavsdk;
 TEST_F(SitlTest, PX4ActionTransitionSync_standard_vtol)
 {
     // Init & connect
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/calibration.cpp
+++ b/src/integration_tests/calibration.cpp
@@ -16,7 +16,7 @@ static void receive_calibration_callback(
 
 TEST(HardwareTest, CalibrationGyro)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);
@@ -45,7 +45,7 @@ TEST(HardwareTest, CalibrationGyro)
 
 TEST(HardwareTest, CalibrationAccelerometer)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);
@@ -74,7 +74,7 @@ TEST(HardwareTest, CalibrationAccelerometer)
 
 TEST(HardwareTest, CalibrationMagnetometer)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);
@@ -103,7 +103,7 @@ TEST(HardwareTest, CalibrationMagnetometer)
 
 TEST(HardwareTest, CalibrationLevelHorizon)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);
@@ -132,7 +132,7 @@ TEST(HardwareTest, CalibrationLevelHorizon)
 
 TEST(HardwareTest, CalibrationGimbalAccelerometer)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);
@@ -161,7 +161,7 @@ TEST(HardwareTest, CalibrationGimbalAccelerometer)
 
 TEST(HardwareTest, CalibrationGyroWithTelemetry)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);
@@ -204,7 +204,7 @@ TEST(HardwareTest, CalibrationGyroWithTelemetry)
 
 TEST(HardwareTest, CalibrationGyroCancelled)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/camera_capture_info.cpp
+++ b/src/integration_tests/camera_capture_info.cpp
@@ -9,7 +9,7 @@ using namespace mavsdk;
 
 TEST(CameraTest, CaptureInfo)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/camera_format.cpp
+++ b/src/integration_tests/camera_format.cpp
@@ -9,7 +9,7 @@ using namespace mavsdk;
 
 TEST(CameraTest, Format)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/camera_mode.cpp
+++ b/src/integration_tests/camera_mode.cpp
@@ -9,7 +9,7 @@ using namespace mavsdk;
 
 TEST(CameraTest, SetModeSync)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);
@@ -48,7 +48,7 @@ TEST(CameraTest, SetModeSync)
 
 TEST(CameraTest, SetModeAsync)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/camera_settings.cpp
+++ b/src/integration_tests/camera_settings.cpp
@@ -36,7 +36,7 @@ void contains_num_options(
 
 TEST(CameraTest, ShowSettingsAndOptions)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);
@@ -125,7 +125,7 @@ TEST(CameraTest, ShowSettingsAndOptions)
 
 TEST(CameraTest, SetSettings)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult connection_ret = mavsdk.add_udp_connection();
     ASSERT_EQ(connection_ret, ConnectionResult::Success);
@@ -263,7 +263,7 @@ receive_current_settings(bool& subscription_called, const std::vector<Camera::Se
 
 TEST(CameraTest, SubscribeCurrentSettings)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult connection_ret = mavsdk.add_udp_connection();
     ASSERT_EQ(connection_ret, ConnectionResult::Success);
@@ -327,7 +327,7 @@ static void receive_possible_setting_options(
 
 TEST(CameraTest, SubscribePossibleSettings)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult connection_ret = mavsdk.add_udp_connection();
     ASSERT_EQ(connection_ret, ConnectionResult::Success);

--- a/src/integration_tests/camera_status.cpp
+++ b/src/integration_tests/camera_status.cpp
@@ -11,7 +11,7 @@ static void print_camera_status(const Camera::Status& status);
 
 TEST(CameraTest, Status)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/camera_take_photo.cpp
+++ b/src/integration_tests/camera_take_photo.cpp
@@ -10,12 +10,9 @@ static void receive_capture_info(Camera::CaptureInfo capture_info, bool& receive
 
 TEST(CameraTest, TakePhotoSingle)
 {
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
-    Mavsdk mavsdk_camera;
-    mavsdk_camera.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Camera});
+    Mavsdk mavsdk_camera{Mavsdk::Configuration{Mavsdk::ComponentType::Camera}};
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
     ASSERT_EQ(mavsdk_camera.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
@@ -56,7 +53,7 @@ TEST(CameraTest, TakePhotoSingle)
 
 TEST(CameraTest, TakePhotosMultiple)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     const int num_photos_to_take = 3;
 

--- a/src/integration_tests/camera_take_photo.cpp
+++ b/src/integration_tests/camera_take_photo.cpp
@@ -17,8 +17,7 @@ TEST(CameraTest, TakePhotoSingle)
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
     ASSERT_EQ(mavsdk_camera.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto camera_server =
-        CameraServer{mavsdk_camera.server_component_by_type(Mavsdk::ComponentType::Camera)};
+    auto camera_server = CameraServer{mavsdk_camera.server_component()};
     camera_server.subscribe_take_photo([&camera_server](int32_t index) {
         LogInfo() << "Let's take photo " << index;
 

--- a/src/integration_tests/camera_take_photo_interval.cpp
+++ b/src/integration_tests/camera_take_photo_interval.cpp
@@ -17,7 +17,7 @@ static std::atomic<bool> _received_result{false};
 
 TEST(CameraTest, TakePhotoInterval)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/connection.cpp
+++ b/src/integration_tests/connection.cpp
@@ -28,14 +28,12 @@ static void
 connection_test(const std::string& client_system_address, const std::string& server_system_address)
 {
     // Start instance as a UDP server pretending to be an autopilot
-    Mavsdk mavsdk_server;
-    Mavsdk::Configuration config_autopilot(Mavsdk::ComponentType::Autopilot);
-    mavsdk_server.set_configuration(config_autopilot);
+    Mavsdk mavsdk_server{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     ConnectionResult ret_server = mavsdk_server.add_any_connection(server_system_address);
     ASSERT_EQ(ret_server, ConnectionResult::Success);
 
     // Start instance as a UDP client, connecting to the server above
-    Mavsdk mavsdk_client;
+    Mavsdk mavsdk_client{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ConnectionResult ret_client = mavsdk_client.add_any_connection(client_system_address);
     ASSERT_EQ(ret_client, ConnectionResult::Success);
 

--- a/src/integration_tests/follow_me.cpp
+++ b/src/integration_tests/follow_me.cpp
@@ -31,7 +31,7 @@ const size_t N_LOCATIONS = 100ul;
 /* Test FollowMe with a stationary target at one location */
 TEST_F(SitlTest, PX4FollowMeOneLocation)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ConnectionResult::Success, ret);
@@ -114,7 +114,7 @@ TEST_F(SitlTest, PX4FollowMeOneLocation)
 /* Test FollowMe with a dynamically moving target */
 TEST_F(SitlTest, PX4FollowMeMultiLocationWithConfig)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ConnectionResult::Success, ret);

--- a/src/integration_tests/geofence.cpp
+++ b/src/integration_tests/geofence.cpp
@@ -11,7 +11,7 @@ static Geofence::Point add_point(double latitude_deg, double longitude_deg);
 
 TEST_F(SitlTest, PX4GeofenceInclusion)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/gimbal.cpp
+++ b/src/integration_tests/gimbal.cpp
@@ -23,7 +23,7 @@ void receive_gimbal_attitude_euler_angles(Telemetry::EulerAngle euler_angle);
 
 TEST(SitlTestGimbal, GimbalMove)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);
@@ -75,7 +75,7 @@ TEST(SitlTestGimbal, GimbalMove)
 
 TEST(SitlTestGimbal, GimbalAngles)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);
@@ -127,7 +127,7 @@ TEST(SitlTestGimbal, GimbalAngles)
 
 TEST(SitlTestGimbal, GimbalTakeoffAndMove)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);
@@ -243,7 +243,7 @@ void gimbal_pattern(std::shared_ptr<Gimbal> gimbal)
 
 TEST(SitlTestGimbal, GimbalROIOffboard)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/info.cpp
+++ b/src/integration_tests/info.cpp
@@ -7,7 +7,7 @@ using namespace mavsdk;
 
 TEST_F(SitlTest, PX4Info)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/log_files.cpp
+++ b/src/integration_tests/log_files.cpp
@@ -11,7 +11,7 @@ using namespace mavsdk;
 
 TEST(HardwareTest, LogFiles)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     // ConnectionResult ret = mavsdk.add_serial_connection("/dev/ttyACM0");
     ConnectionResult ret = mavsdk.add_udp_connection();
@@ -66,7 +66,7 @@ TEST(HardwareTest, LogFiles)
 
 TEST(HardwareTest, LogFilesDownloadFailsIfPathIsDirectory)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     // ConnectionResult ret = mavsdk.add_serial_connection("/dev/ttyACM0");
     ConnectionResult ret = mavsdk.add_udp_connection();
@@ -122,7 +122,7 @@ TEST(HardwareTest, LogFilesDownloadFailsIfPathIsDirectory)
 
 TEST(HardwareTest, LogFilesDownloadFailsIfFileAlreadyExists)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     // ConnectionResult ret = mavsdk.add_serial_connection("/dev/ttyACM0");
     ConnectionResult ret = mavsdk.add_udp_connection();

--- a/src/integration_tests/logging.cpp
+++ b/src/integration_tests/logging.cpp
@@ -7,7 +7,7 @@ using namespace mavsdk;
 
 TEST_F(SitlTest, PX4Logging)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/mavlink_passthrough.cpp
+++ b/src/integration_tests/mavlink_passthrough.cpp
@@ -9,7 +9,7 @@ using namespace mavsdk;
 
 TEST_F(SitlTest, PX4MavlinkPassthrough)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ASSERT_EQ(mavsdk.add_udp_connection(), ConnectionResult::Success);
 
     {

--- a/src/integration_tests/mission.cpp
+++ b/src/integration_tests/mission.cpp
@@ -38,7 +38,7 @@ static std::atomic<bool> pause_already_done{false};
 
 TEST_F(SitlTest, PX4MissionAddWaypointsAndFly)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     {
         auto prom = std::make_shared<std::promise<void>>();

--- a/src/integration_tests/mission_cancellation.cpp
+++ b/src/integration_tests/mission_cancellation.cpp
@@ -24,7 +24,7 @@ static Mission::MissionItem add_waypoint(
 
 TEST_F(SitlTest, PX4MissionUploadCancellation)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);
@@ -80,7 +80,7 @@ TEST_F(SitlTest, PX4MissionUploadCancellation)
 
 TEST_F(SitlTest, PX4MissionDownloadCancellation)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/mission_change_speed.cpp
+++ b/src/integration_tests/mission_change_speed.cpp
@@ -22,7 +22,7 @@ const static float speeds[4] = {10.0f, 3.0f, 8.0f, 5.0f};
 // Test to check speed set for mission items.
 TEST_F(SitlTest, PX4MissionChangeSpeed)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/mission_raw_import_and_fly.cpp
+++ b/src/integration_tests/mission_raw_import_and_fly.cpp
@@ -28,7 +28,7 @@ void test_mission_raw(
 
 TEST_F(SitlTest, PX4MissionRawImportAndFly)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);
@@ -89,7 +89,7 @@ TEST_F(SitlTest, PX4MissionRawImportAndFly)
 
 TEST_F(SitlTest, APMissionRawImportAndFly)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/mission_raw_mission_changed.cpp
+++ b/src/integration_tests/mission_raw_mission_changed.cpp
@@ -16,7 +16,7 @@ static void validate_items(const std::vector<MissionRaw::MissionItem>& items);
 
 TEST_F(SitlTest, PX4MissionRawMissionChanged)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/mission_rtl.cpp
+++ b/src/integration_tests/mission_rtl.cpp
@@ -34,7 +34,7 @@ TEST_F(SitlTest, PX4MissionWithRTLHigherAnyway)
 
 void do_mission_with_rtl(float mission_altitude_m, float return_altitude_m)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     {
         auto prom = std::make_shared<std::promise<void>>();

--- a/src/integration_tests/mission_set_current.cpp
+++ b/src/integration_tests/mission_set_current.cpp
@@ -18,7 +18,7 @@ add_waypoint(double latitude_deg, double longitude_deg, float relative_altitude_
 // Test to check speed set for mission items.
 TEST_F(SitlTest, PX4MissionSetCurrent)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/mission_takeoff_land.cpp
+++ b/src/integration_tests/mission_takeoff_land.cpp
@@ -15,7 +15,7 @@ using namespace mavsdk;
 
 TEST_F(SitlTest, MissionTakeoffAndLand)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     float mission_altitude_m = 20;
 
     {

--- a/src/integration_tests/mission_transfer_lossy.cpp
+++ b/src/integration_tests/mission_transfer_lossy.cpp
@@ -19,7 +19,7 @@ static std::uniform_real_distribution<double> distribution(0.0, 1.0);
 
 TEST_F(SitlTest, PX4MissionTransferLossy)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ASSERT_EQ(mavsdk.add_udp_connection(), ConnectionResult::Success);
 
     {

--- a/src/integration_tests/mission_transition.cpp
+++ b/src/integration_tests/mission_transition.cpp
@@ -15,7 +15,7 @@ using namespace mavsdk;
 
 TEST_F(SitlTest, MissionTakeoffTransitionAndLand_standard_vtol)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     float mission_altitude_m = 40;
 
     {

--- a/src/integration_tests/offboard_acceleration.cpp
+++ b/src/integration_tests/offboard_acceleration.cpp
@@ -11,7 +11,7 @@ using namespace mavsdk;
 
 TEST_F(SitlTest, PX4OffboardAccelerationNED)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ConnectionResult::Success, ret);

--- a/src/integration_tests/offboard_attitude.cpp
+++ b/src/integration_tests/offboard_attitude.cpp
@@ -18,7 +18,7 @@ static void turn_yaw(const Offboard& offboard);
 
 TEST(SitlTestDisabled, OffboardAttitudeRate)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ConnectionResult::Success, ret);

--- a/src/integration_tests/offboard_position.cpp
+++ b/src/integration_tests/offboard_position.cpp
@@ -12,7 +12,7 @@ using namespace mavsdk;
 
 TEST_F(SitlTest, OffboardPositionNED)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ConnectionResult::Success, ret);

--- a/src/integration_tests/offboard_velocity.cpp
+++ b/src/integration_tests/offboard_velocity.cpp
@@ -12,7 +12,7 @@ using namespace mavsdk;
 
 TEST_F(SitlTest, OffboardVelocityNED)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ConnectionResult::Success, ret);
@@ -134,7 +134,7 @@ TEST_F(SitlTest, OffboardVelocityNED)
 
 TEST_F(SitlTest, OffboardVelocityBody)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ConnectionResult::Success, ret);

--- a/src/integration_tests/param.cpp
+++ b/src/integration_tests/param.cpp
@@ -8,7 +8,7 @@ using namespace mavsdk;
 
 TEST_F(SitlTest, PX4ParamSad)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);
@@ -46,7 +46,7 @@ TEST_F(SitlTest, PX4ParamSad)
 
 TEST_F(SitlTest, PX4ParamHappy)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);
@@ -127,7 +127,7 @@ TEST_F(SitlTest, PX4ParamHappy)
 
 TEST_F(SitlTest, GetAllParams)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);
@@ -168,7 +168,7 @@ TEST_F(SitlTest, GetAllParams)
 
 TEST_F(SitlTest, APParam)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/statustext.cpp
+++ b/src/integration_tests/statustext.cpp
@@ -15,14 +15,10 @@ static const auto type = ServerUtility::StatusTextType::Info;
 
 TEST(StatusTextTest, TestServer)
 {
-    Mavsdk mavsdk_gcs;
-    Mavsdk::Configuration config_gcs(Mavsdk::ComponentType::GroundStation);
-    mavsdk_gcs.set_configuration(config_gcs);
+    Mavsdk mavsdk_gcs{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ASSERT_EQ(mavsdk_gcs.add_udp_connection(24550), ConnectionResult::Success);
 
-    Mavsdk mavsdk_onboard;
-    Mavsdk::Configuration config_onboard(Mavsdk::ComponentType::CompanionComputer);
-    mavsdk_onboard.set_configuration(config_onboard);
+    Mavsdk mavsdk_onboard{Mavsdk::Configuration{Mavsdk::ComponentType::CompanionComputer}};
     ASSERT_EQ(mavsdk_onboard.setup_udp_remote("127.0.0.1", 24550), ConnectionResult::Success);
 
     // Let the two connect to each other.

--- a/src/integration_tests/system_connection_async.cpp
+++ b/src/integration_tests/system_connection_async.cpp
@@ -14,7 +14,7 @@ static uint8_t _sysid = 0;
 
 TEST_F(SitlTest, SystemConnectionAsync)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ASSERT_EQ(mavsdk.add_udp_connection(), ConnectionResult::Success);
 

--- a/src/integration_tests/system_multi_components.cpp
+++ b/src/integration_tests/system_multi_components.cpp
@@ -25,7 +25,7 @@ using namespace std::chrono;
  */
 TEST(SitlTestMultiple, SystemMultipleComponents)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     // For both Autopilot and Camera
     ASSERT_EQ(mavsdk.add_udp_connection(), ConnectionResult::Success);

--- a/src/integration_tests/telemetry_async.cpp
+++ b/src/integration_tests/telemetry_async.cpp
@@ -60,7 +60,7 @@ static bool _received_altitude = false;
 
 TEST_F(SitlTest, PX4TelemetryAsync)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/telemetry_gps_origin.cpp
+++ b/src/integration_tests/telemetry_gps_origin.cpp
@@ -6,7 +6,7 @@ using namespace mavsdk;
 
 TEST(SitlTestDisabled, TelemetryGpsOrigin)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/telemetry_health.cpp
+++ b/src/integration_tests/telemetry_health.cpp
@@ -10,7 +10,7 @@ void print_rc_status(Telemetry::RcStatus rc_status);
 
 TEST_F(SitlTest, TelemetryHealth)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/telemetry_modes.cpp
+++ b/src/integration_tests/telemetry_modes.cpp
@@ -12,7 +12,7 @@ static std::atomic<Telemetry::FlightMode> _flight_mode{Telemetry::FlightMode::Un
 
 TEST(SitlTestDisabled, TelemetryFlightModes)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/integration_tests/telemetry_sync.cpp
+++ b/src/integration_tests/telemetry_sync.cpp
@@ -7,7 +7,7 @@ using namespace mavsdk;
 
 TEST_F(SitlTest, PX4TelemetrySync)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
     ConnectionResult ret = mavsdk.add_udp_connection();
     ASSERT_EQ(ret, ConnectionResult::Success);

--- a/src/mavsdk/core/include/mavsdk/mavsdk.h
+++ b/src/mavsdk/core/include/mavsdk/mavsdk.h
@@ -381,6 +381,14 @@ public:
     void unsubscribe_on_new_system(NewSystemHandle handle);
 
     /**
+     * @brief Get server component with default type of Mavsdk instance.
+     *
+     * @return A valid shared pointer to a server component if it was successful, an empty pointer
+     * otherwise.
+     */
+    std::shared_ptr<ServerComponent> server_component(unsigned instance = 0);
+
+    /**
      * @brief Get server component by a high level type.
      *
      * This represents a server component of the MAVSDK instance.

--- a/src/mavsdk/core/include/mavsdk/mavsdk.h
+++ b/src/mavsdk/core/include/mavsdk/mavsdk.h
@@ -52,18 +52,6 @@ public:
     static constexpr double DEFAULT_TIMEOUT_S = 0.5;
 
     /**
-     * @brief Constructor.
-     */
-    Mavsdk();
-
-    /**
-     * @brief Destructor.
-     *
-     * Disconnects all connected vehicles and releases all resources.
-     */
-    ~Mavsdk();
-
-    /**
      * @brief Returns the version of MAVSDK.
      *
      * Note, you're not supposed to request the version too many times.
@@ -308,6 +296,31 @@ public:
 
         static Mavsdk::ComponentType component_type_for_component_id(uint8_t component_id);
     };
+
+    /**
+     * @brief Default constructor without configuration, no longer recommended.
+     *
+     * @note This has been removed because MAVSDK used to identify itself as a
+     *       ground station by default which isn't always the safest choice.
+     *       For instance, when MAVSDK is used on a companion computer (set as
+     *       a ground station) it means that the appropriate failsafe doesn't
+     *       trigger.
+     */
+    Mavsdk() = delete;
+
+    /**
+     * @brief Constructor with configuration.
+     *
+     * @param configuration Configuration to use in MAVSDK instance.
+     */
+    Mavsdk(Configuration configuration);
+
+    /**
+     * @brief Destructor.
+     *
+     * Disconnects all connected vehicles and releases all resources.
+     */
+    ~Mavsdk();
 
     /**
      * @brief Set `Configuration` of SDK.

--- a/src/mavsdk/core/mavsdk.cpp
+++ b/src/mavsdk/core/mavsdk.cpp
@@ -95,6 +95,11 @@ void Mavsdk::unsubscribe_on_new_system(NewSystemHandle handle)
     _impl->unsubscribe_on_new_system(handle);
 }
 
+std::shared_ptr<ServerComponent> Mavsdk::server_component(unsigned instance)
+{
+    return _impl->server_component(instance);
+}
+
 std::shared_ptr<ServerComponent>
 Mavsdk::server_component_by_type(ComponentType server_component_type, unsigned instance)
 {

--- a/src/mavsdk/core/mavsdk.cpp
+++ b/src/mavsdk/core/mavsdk.cpp
@@ -4,9 +4,9 @@
 
 namespace mavsdk {
 
-Mavsdk::Mavsdk()
+Mavsdk::Mavsdk(Configuration configuration)
 {
-    _impl = std::make_shared<MavsdkImpl>();
+    _impl = std::make_shared<MavsdkImpl>(configuration);
 }
 
 Mavsdk::~Mavsdk() = default;

--- a/src/mavsdk/core/mavsdk_impl.cpp
+++ b/src/mavsdk/core/mavsdk_impl.cpp
@@ -19,7 +19,9 @@ namespace mavsdk {
 
 template class CallbackList<>;
 
-MavsdkImpl::MavsdkImpl() : timeout_handler(time), call_every_handler(time)
+MavsdkImpl::MavsdkImpl(const Mavsdk::Configuration& configuration) :
+    timeout_handler(time),
+    call_every_handler(time)
 {
     LogInfo() << "MAVSDK version: " << mavsdk_version;
 
@@ -36,6 +38,8 @@ MavsdkImpl::MavsdkImpl() : timeout_handler(time), call_every_handler(time)
             _message_logging_on = true;
         }
     }
+
+    set_configuration(configuration);
 
     _work_thread = new std::thread(&MavsdkImpl::work_thread, this);
 

--- a/src/mavsdk/core/mavsdk_impl.cpp
+++ b/src/mavsdk/core/mavsdk_impl.cpp
@@ -168,6 +168,22 @@ std::optional<std::shared_ptr<System>> MavsdkImpl::first_autopilot(double timeou
     }
 }
 
+std::shared_ptr<ServerComponent> MavsdkImpl::server_component(unsigned instance)
+{
+    auto component_type = _configuration.get_component_type();
+    switch (component_type) {
+        case Mavsdk::ComponentType::Autopilot:
+        case Mavsdk::ComponentType::GroundStation:
+        case Mavsdk::ComponentType::CompanionComputer:
+        case Mavsdk::ComponentType::Camera:
+        case Mavsdk::ComponentType::Custom:
+            return server_component_by_type(component_type, instance);
+        default:
+            LogErr() << "Unknown component type";
+            return {};
+    }
+}
+
 std::shared_ptr<ServerComponent>
 MavsdkImpl::server_component_by_type(Mavsdk::ComponentType server_component_type, unsigned instance)
 {

--- a/src/mavsdk/core/mavsdk_impl.h
+++ b/src/mavsdk/core/mavsdk_impl.h
@@ -100,6 +100,8 @@ public:
     void intercept_incoming_messages_async(std::function<bool(mavlink_message_t&)> callback);
     void intercept_outgoing_messages_async(std::function<bool(mavlink_message_t&)> callback);
 
+    std::shared_ptr<ServerComponent> server_component(unsigned instance = 0);
+
     std::shared_ptr<ServerComponent>
     server_component_by_type(Mavsdk::ComponentType server_component_type, unsigned instance = 0);
     std::shared_ptr<ServerComponent> server_component_by_id(uint8_t component_id);

--- a/src/mavsdk/core/mavsdk_impl.h
+++ b/src/mavsdk/core/mavsdk_impl.h
@@ -45,7 +45,7 @@ public:
     /** @brief Default Component ID for Camera configuration type. */
     static constexpr int DEFAULT_COMPONENT_ID_CAMERA = MAV_COMP_ID_CAMERA;
 
-    MavsdkImpl();
+    MavsdkImpl(const Mavsdk::Configuration& configuration);
     ~MavsdkImpl();
     MavsdkImpl(const MavsdkImpl&) = delete;
     void operator=(const MavsdkImpl&) = delete;

--- a/src/mavsdk/core/mavsdk_test.cpp
+++ b/src/mavsdk/core/mavsdk_test.cpp
@@ -5,6 +5,6 @@ using namespace mavsdk;
 
 TEST(Mavsdk, version)
 {
-    Mavsdk mavsdk;
+    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ASSERT_GT(mavsdk.version().size(), 5);
 }

--- a/src/mavsdk_server/src/mavsdk_server.cpp
+++ b/src/mavsdk_server/src/mavsdk_server.cpp
@@ -6,11 +6,12 @@
 #include "mavsdk.h"
 #include "grpc_server.h"
 
+using namespace mavsdk;
 using namespace mavsdk::mavsdk_server;
 
 class MavsdkServer::Impl {
 public:
-    Impl() {}
+    Impl() : _mavsdk(Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}) {}
     ~Impl() {}
 
     bool connect(const std::string& connection_url)

--- a/src/system_tests/action_arm_disarm.cpp
+++ b/src/system_tests/action_arm_disarm.cpp
@@ -17,8 +17,7 @@ TEST(SystemTest, ActionArmDisarm)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto action_server =
-        ActionServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto action_server = ActionServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);

--- a/src/system_tests/action_arm_disarm.cpp
+++ b/src/system_tests/action_arm_disarm.cpp
@@ -9,12 +9,9 @@ using namespace mavsdk;
 
 TEST(SystemTest, ActionArmDisarm)
 {
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
     ASSERT_EQ(

--- a/src/system_tests/camera_take_photo.cpp
+++ b/src/system_tests/camera_take_photo.cpp
@@ -18,8 +18,7 @@ TEST(SystemTest, CameraTakePhoto)
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
     ASSERT_EQ(mavsdk_camera.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto camera_server =
-        CameraServer{mavsdk_camera.server_component_by_type(Mavsdk::ComponentType::Camera)};
+    auto camera_server = CameraServer{mavsdk_camera.server_component()};
     camera_server.subscribe_take_photo([&camera_server](int32_t index) {
         LogInfo() << "Let's take photo " << index;
 

--- a/src/system_tests/camera_take_photo.cpp
+++ b/src/system_tests/camera_take_photo.cpp
@@ -11,12 +11,9 @@ using namespace mavsdk;
 
 TEST(SystemTest, CameraTakePhoto)
 {
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
-    Mavsdk mavsdk_camera;
-    mavsdk_camera.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Camera});
+    Mavsdk mavsdk_camera{Mavsdk::Configuration{Mavsdk::ComponentType::Camera}};
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
     ASSERT_EQ(mavsdk_camera.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);

--- a/src/system_tests/component_information.cpp
+++ b/src/system_tests/component_information.cpp
@@ -19,14 +19,10 @@ using namespace mavsdk;
 // split across system_impl, and server_component_impl.
 TEST(SystemTest, DISABLED_ComponentInformationConnect)
 {
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
 
-    Mavsdk mavsdk_companion;
-    mavsdk_companion.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::CompanionComputer});
+    Mavsdk mavsdk_companion{Mavsdk::Configuration{Mavsdk::ComponentType::CompanionComputer}};
     ASSERT_EQ(
         mavsdk_companion.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 

--- a/src/system_tests/component_information.cpp
+++ b/src/system_tests/component_information.cpp
@@ -30,8 +30,7 @@ TEST(SystemTest, DISABLED_ComponentInformationConnect)
     ASSERT_TRUE(maybe_system);
     auto system = maybe_system.value();
 
-    auto server = ComponentInformationServer{
-        mavsdk_companion.server_component_by_type(Mavsdk::ComponentType::CompanionComputer)};
+    auto server = ComponentInformationServer{mavsdk_companion.server_component()};
 
     auto param = ComponentInformationServer::FloatParam{};
     param.name = "ANG_RATE_ACC_MAX";

--- a/src/system_tests/ftp_compare_files.cpp
+++ b/src/system_tests/ftp_compare_files.cpp
@@ -29,13 +29,10 @@ TEST(SystemTest, FtpCompareFiles)
     ASSERT_TRUE(create_temp_file(temp_dir_provided / temp_file_same, 1000));
     ASSERT_TRUE(create_temp_file(temp_dir_provided / temp_file_different, 1000, 42));
 
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);

--- a/src/system_tests/ftp_compare_files.cpp
+++ b/src/system_tests/ftp_compare_files.cpp
@@ -39,8 +39,7 @@ TEST(SystemTest, FtpCompareFiles)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);

--- a/src/system_tests/ftp_create_dir.cpp
+++ b/src/system_tests/ftp_create_dir.cpp
@@ -21,13 +21,10 @@ static const fs::path temp_dir = "folder";
 
 TEST(SystemTest, FtpCreateDir)
 {
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);

--- a/src/system_tests/ftp_create_dir.cpp
+++ b/src/system_tests/ftp_create_dir.cpp
@@ -31,8 +31,7 @@ TEST(SystemTest, FtpCreateDir)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);

--- a/src/system_tests/ftp_download_file.cpp
+++ b/src/system_tests/ftp_download_file.cpp
@@ -26,13 +26,10 @@ TEST(SystemTest, FtpDownloadFile)
     ASSERT_TRUE(create_temp_file(temp_dir_provided / temp_file, 50));
     ASSERT_TRUE(reset_directories(temp_dir_downloaded));
 
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
@@ -101,13 +98,10 @@ TEST(SystemTest, FtpDownloadBigFile)
     ASSERT_TRUE(create_temp_file(temp_dir_provided / temp_file, 50000));
     ASSERT_TRUE(reset_directories(temp_dir_downloaded));
 
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
@@ -157,13 +151,10 @@ TEST(SystemTest, FtpDownloadBigFileLossy)
     ASSERT_TRUE(create_temp_file(temp_dir_provided / temp_file, 10000));
     ASSERT_TRUE(reset_directories(temp_dir_downloaded));
 
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     unsigned counter = 0;
@@ -224,13 +215,10 @@ TEST(SystemTest, FtpDownloadStopAndTryAgain)
     ASSERT_TRUE(create_temp_file(temp_dir_provided / temp_file, 1000));
     ASSERT_TRUE(reset_directories(temp_dir_downloaded));
 
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     // Once we received half, we want to stop all traffic.
@@ -314,13 +302,10 @@ TEST(SystemTest, FtpDownloadFileOutsideOfRoot)
     ASSERT_TRUE(create_temp_file(temp_dir_provided / temp_file, 50));
     ASSERT_TRUE(reset_directories(temp_dir_downloaded));
 
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);

--- a/src/system_tests/ftp_download_file.cpp
+++ b/src/system_tests/ftp_download_file.cpp
@@ -36,8 +36,7 @@ TEST(SystemTest, FtpDownloadFile)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);
@@ -108,8 +107,7 @@ TEST(SystemTest, FtpDownloadBigFile)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     ftp_server.set_root_dir(temp_dir_provided.string());
 
@@ -167,8 +165,7 @@ TEST(SystemTest, FtpDownloadBigFileLossy)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     ftp_server.set_root_dir(temp_dir_provided.string());
 
@@ -232,8 +229,7 @@ TEST(SystemTest, FtpDownloadStopAndTryAgain)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     ftp_server.set_root_dir(temp_dir_provided.string());
 
@@ -312,8 +308,7 @@ TEST(SystemTest, FtpDownloadFileOutsideOfRoot)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);

--- a/src/system_tests/ftp_download_file_burst.cpp
+++ b/src/system_tests/ftp_download_file_burst.cpp
@@ -26,13 +26,10 @@ TEST(SystemTest, FtpDownloadBurstFile)
     ASSERT_TRUE(create_temp_file(temp_dir_provided / temp_file, 50));
     ASSERT_TRUE(reset_directories(temp_dir_downloaded));
 
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
@@ -101,13 +98,10 @@ TEST(SystemTest, FtpDownloadBurstBigFile)
     ASSERT_TRUE(create_temp_file(temp_dir_provided / temp_file, 50000));
     ASSERT_TRUE(reset_directories(temp_dir_downloaded));
 
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
@@ -157,13 +151,10 @@ TEST(SystemTest, FtpDownloadBurstBigFileLossy)
     ASSERT_TRUE(create_temp_file(temp_dir_provided / temp_file, 10000));
     ASSERT_TRUE(reset_directories(temp_dir_downloaded));
 
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     unsigned counter = 0;
@@ -224,13 +215,10 @@ TEST(SystemTest, FtpDownloadBurstStopAndTryAgain)
     ASSERT_TRUE(create_temp_file(temp_dir_provided / temp_file, 1000));
     ASSERT_TRUE(reset_directories(temp_dir_downloaded));
 
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     // Once we received half, we want to stop all traffic.
@@ -314,13 +302,10 @@ TEST(SystemTest, FtpDownloadBurstFileOutsideOfRoot)
     ASSERT_TRUE(create_temp_file(temp_dir_provided / temp_file, 50));
     ASSERT_TRUE(reset_directories(temp_dir_downloaded));
 
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);

--- a/src/system_tests/ftp_download_file_burst.cpp
+++ b/src/system_tests/ftp_download_file_burst.cpp
@@ -36,8 +36,7 @@ TEST(SystemTest, FtpDownloadBurstFile)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);
@@ -108,8 +107,7 @@ TEST(SystemTest, FtpDownloadBurstBigFile)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     ftp_server.set_root_dir(temp_dir_provided.string());
 
@@ -167,8 +165,7 @@ TEST(SystemTest, FtpDownloadBurstBigFileLossy)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     ftp_server.set_root_dir(temp_dir_provided.string());
 
@@ -232,8 +229,7 @@ TEST(SystemTest, FtpDownloadBurstStopAndTryAgain)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     ftp_server.set_root_dir(temp_dir_provided.string());
 
@@ -312,8 +308,7 @@ TEST(SystemTest, FtpDownloadBurstFileOutsideOfRoot)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);

--- a/src/system_tests/ftp_list_dir.cpp
+++ b/src/system_tests/ftp_list_dir.cpp
@@ -39,13 +39,10 @@ TEST(SystemTest, FtpListDir)
 
     std::sort(truth_list.begin(), truth_list.end());
 
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);

--- a/src/system_tests/ftp_list_dir.cpp
+++ b/src/system_tests/ftp_list_dir.cpp
@@ -49,8 +49,7 @@ TEST(SystemTest, FtpListDir)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);

--- a/src/system_tests/ftp_remove_dir.cpp
+++ b/src/system_tests/ftp_remove_dir.cpp
@@ -22,13 +22,10 @@ static const fs::path temp_file = "file.bin";
 
 TEST(SystemTest, FtpRemoveDir)
 {
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
@@ -67,13 +64,10 @@ TEST(SystemTest, FtpRemoveDirNotEmpty)
     ASSERT_TRUE(reset_directories(temp_dir_provided / temp_dir));
     ASSERT_TRUE(create_temp_file(temp_dir_provided / temp_dir / temp_file, 100));
 
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);

--- a/src/system_tests/ftp_remove_dir.cpp
+++ b/src/system_tests/ftp_remove_dir.cpp
@@ -32,8 +32,7 @@ TEST(SystemTest, FtpRemoveDir)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);
@@ -74,8 +73,7 @@ TEST(SystemTest, FtpRemoveDirNotEmpty)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);

--- a/src/system_tests/ftp_remove_file.cpp
+++ b/src/system_tests/ftp_remove_file.cpp
@@ -24,13 +24,10 @@ TEST(SystemTest, FtpRemoveFile)
 {
     ASSERT_TRUE(create_temp_file(temp_dir_provided / temp_file, 50));
 
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
@@ -64,13 +61,10 @@ TEST(SystemTest, FtpRemoveFile)
 
 TEST(SystemTest, FtpRemoveFileThatDoesNotExist)
 {
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
@@ -102,13 +96,10 @@ TEST(SystemTest, FtpRemoveFileThatDoesNotExist)
 
 TEST(SystemTest, FtpRemoveFileOutsideOfRoot)
 {
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);

--- a/src/system_tests/ftp_remove_file.cpp
+++ b/src/system_tests/ftp_remove_file.cpp
@@ -34,8 +34,7 @@ TEST(SystemTest, FtpRemoveFile)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);
@@ -71,8 +70,7 @@ TEST(SystemTest, FtpRemoveFileThatDoesNotExist)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);
@@ -106,8 +104,7 @@ TEST(SystemTest, FtpRemoveFileOutsideOfRoot)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);

--- a/src/system_tests/ftp_rename_file.cpp
+++ b/src/system_tests/ftp_rename_file.cpp
@@ -36,8 +36,7 @@ TEST(SystemTest, FtpRenameFile)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);

--- a/src/system_tests/ftp_rename_file.cpp
+++ b/src/system_tests/ftp_rename_file.cpp
@@ -26,13 +26,10 @@ TEST(SystemTest, FtpRenameFile)
     ASSERT_TRUE(reset_directories(temp_dir_provided));
     ASSERT_TRUE(create_temp_file(temp_dir_provided / temp_file, 50));
 
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);

--- a/src/system_tests/ftp_upload_file.cpp
+++ b/src/system_tests/ftp_upload_file.cpp
@@ -30,13 +30,10 @@ TEST(SystemTest, FtpUploadFile)
     ASSERT_TRUE(create_temp_file(temp_dir_to_upload / temp_file, 50));
     ASSERT_TRUE(reset_directories(temp_dir_provided));
 
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
@@ -103,13 +100,10 @@ TEST(SystemTest, FtpUploadBigFile)
     ASSERT_TRUE(create_temp_file(temp_dir_to_upload / temp_file, 10000));
     ASSERT_TRUE(reset_directories(temp_dir_provided));
 
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
@@ -160,13 +154,10 @@ TEST(SystemTest, FtpUploadBigFileLossy)
     ASSERT_TRUE(create_temp_file(temp_dir_to_upload / temp_file, 10000));
     ASSERT_TRUE(reset_directories(temp_dir_provided));
 
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     unsigned counter = 0;
@@ -226,13 +217,10 @@ TEST(SystemTest, FtpUploadStopAndTryAgain)
     ASSERT_TRUE(create_temp_file(temp_dir_to_upload / temp_file, 1000));
     ASSERT_TRUE(reset_directories(temp_dir_provided));
 
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     // Once we received half, we want to stop all traffic.
@@ -317,13 +305,10 @@ TEST(SystemTest, FtpUploadFileOutsideOfRoot)
     // A test trying to push something into the parent (../) directory which
     // shouldn't be allowed!
 
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);

--- a/src/system_tests/ftp_upload_file.cpp
+++ b/src/system_tests/ftp_upload_file.cpp
@@ -40,8 +40,7 @@ TEST(SystemTest, FtpUploadFile)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);
@@ -110,8 +109,7 @@ TEST(SystemTest, FtpUploadBigFile)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);
@@ -170,8 +168,7 @@ TEST(SystemTest, FtpUploadBigFileLossy)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);
@@ -234,8 +231,7 @@ TEST(SystemTest, FtpUploadStopAndTryAgain)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     ftp_server.set_root_dir(temp_dir_provided.string());
 
@@ -315,8 +311,7 @@ TEST(SystemTest, FtpUploadFileOutsideOfRoot)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto ftp_server =
-        FtpServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto ftp_server = FtpServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);

--- a/src/system_tests/mission_raw_upload.cpp
+++ b/src/system_tests/mission_raw_upload.cpp
@@ -19,8 +19,7 @@ TEST(SystemTest, MissionRawUpload)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto mission_raw_server = MissionRawServer{
-        mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto mission_raw_server = MissionRawServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);

--- a/src/system_tests/mission_raw_upload.cpp
+++ b/src/system_tests/mission_raw_upload.cpp
@@ -11,12 +11,9 @@
 using namespace mavsdk;
 TEST(SystemTest, MissionRawUpload)
 {
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
     ASSERT_EQ(

--- a/src/system_tests/param_custom_set_and_get.cpp
+++ b/src/system_tests/param_custom_set_and_get.cpp
@@ -39,8 +39,7 @@ TEST(SystemTest, ParamCustomSetAndGet)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto param_server =
-        ParamServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto param_server = ParamServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);
@@ -99,8 +98,7 @@ TEST(SystemTest, ParamCustomSetAndGetLossy)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto param_server =
-        ParamServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto param_server = ParamServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);

--- a/src/system_tests/param_custom_set_and_get.cpp
+++ b/src/system_tests/param_custom_set_and_get.cpp
@@ -29,13 +29,10 @@ static std::string generate_uppercase_ascii(size_t length)
 
 TEST(SystemTest, ParamCustomSetAndGet)
 {
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
@@ -85,13 +82,10 @@ TEST(SystemTest, ParamCustomSetAndGet)
 
 TEST(SystemTest, ParamCustomSetAndGetLossy)
 {
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     // Drop every third message

--- a/src/system_tests/param_get_all.cpp
+++ b/src/system_tests/param_get_all.cpp
@@ -70,8 +70,7 @@ TEST(SystemTest, ParamGetAll)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto param_server =
-        ParamServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto param_server = ParamServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);
@@ -135,8 +134,7 @@ TEST(SystemTest, ParamGetAllLossy)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto param_server =
-        ParamServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto param_server = ParamServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);

--- a/src/system_tests/param_get_all.cpp
+++ b/src/system_tests/param_get_all.cpp
@@ -60,13 +60,10 @@ static void assert_equal(const std::map<std::string, T1>& values, const std::vec
 
 TEST(SystemTest, ParamGetAll)
 {
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
@@ -121,13 +118,10 @@ TEST(SystemTest, ParamGetAll)
 
 TEST(SystemTest, ParamGetAllLossy)
 {
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     // Drop every third message

--- a/src/system_tests/param_set_and_get.cpp
+++ b/src/system_tests/param_set_and_get.cpp
@@ -18,13 +18,10 @@ static constexpr double reduced_timeout_s = 0.1;
 
 TEST(SystemTest, ParamSetAndGet)
 {
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
@@ -100,9 +97,7 @@ TEST(SystemTest, ParamSetAndGet)
 
 TEST(SystemTest, ParamSetAndGetLossy)
 {
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
     // Drop every third message
@@ -112,8 +107,7 @@ TEST(SystemTest, ParamSetAndGetLossy)
     mavsdk_groundstation.intercept_incoming_messages_async(drop_some);
     mavsdk_groundstation.intercept_incoming_messages_async(drop_some);
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);

--- a/src/system_tests/param_set_and_get.cpp
+++ b/src/system_tests/param_set_and_get.cpp
@@ -28,8 +28,7 @@ TEST(SystemTest, ParamSetAndGet)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto param_server =
-        ParamServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto param_server = ParamServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);
@@ -114,8 +113,7 @@ TEST(SystemTest, ParamSetAndGetLossy)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto param_server =
-        ParamServer{mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto param_server = ParamServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);

--- a/src/system_tests/telemetry_subscription.cpp
+++ b/src/system_tests/telemetry_subscription.cpp
@@ -18,8 +18,7 @@ TEST(SystemTest, TelemetrySubscription)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udp://127.0.0.1:17000"), ConnectionResult::Success);
 
-    auto telemetry_server = TelemetryServer{
-        mavsdk_autopilot.server_component_by_type(Mavsdk::ComponentType::Autopilot)};
+    auto telemetry_server = TelemetryServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);

--- a/src/system_tests/telemetry_subscription.cpp
+++ b/src/system_tests/telemetry_subscription.cpp
@@ -10,12 +10,9 @@ using namespace mavsdk;
 
 TEST(SystemTest, TelemetrySubscription)
 {
-    Mavsdk mavsdk_groundstation;
-    mavsdk_groundstation.set_configuration(
-        Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation});
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
-    Mavsdk mavsdk_autopilot;
-    mavsdk_autopilot.set_configuration(Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot});
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{Mavsdk::ComponentType::Autopilot}};
 
     ASSERT_EQ(mavsdk_groundstation.add_any_connection("udp://:17000"), ConnectionResult::Success);
     ASSERT_EQ(


### PR DESCRIPTION
We no longer allow Mavsdk to be instantiated by default. Instead a configuration with a component type of the Mavsdk component needs to be supplied.

The reasoning behind the (breaking) change is that we no longer want to assume a potentially safety critical/dangerous default.

In the past Mavsdk would identify itself as a ground station, as that likely is the most used purpose. However, when used as a companion computer, this can likely be dangerous if the component type is not changed to companion computer. It means that the autopilot will assume that it has connection with a ground station even though it does not but only to a local companion computer process.

With this change, the component type needs to be based to the construction of Mavsdk, so it's an explicit choice whenever it is used.

This PR also changes the server component API to avoid having to specify the component type twice, once for the Mavsdk instantiation and once when selecting the server component.

Follow up to #2169.