### PR TITLE
Update absl to 20230802.1

### DIFF
--- a/third_party/absl/CMakeLists.txt
+++ b/third_party/absl/CMakeLists.txt
@@ -29,7 +29,7 @@ endforeach()
 ExternalProject_add(
     absl
     GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
-    GIT_TAG 20230125.3
+    GIT_TAG 20230802.1
     PREFIX absl
     CMAKE_ARGS "${CMAKE_ARGS}"
     )


### PR DESCRIPTION
Required for Alpine 3.19, where it currently fails with:

> [  7%] Building CXX object absl/base/CMakeFiles/malloc_internal.dir/internal/low_level_alloc.cc.o
In file included from /home/mavsdk/third_party/absl/build/absl/src/absl/absl/base/internal/low_level_alloc.cc:26:
/home/mavsdk/third_party/absl/build/absl/src/absl/absl/base/internal/direct_mmap.h:75:25: error: 'off64_t' has not been declared
   75 |                         off64_t offset) noexcept {