### PR TITLE
camera_server: send status before/after capture

### DIFF
--- a/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
+++ b/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
@@ -200,6 +200,8 @@ CameraServerImpl::set_video_streaming(CameraServer::VideoStreaming video_streami
 CameraServer::Result CameraServerImpl::set_in_progress(bool in_progress)
 {
     _is_image_capture_in_progress = in_progress;
+
+    send_capture_status();
     return CameraServer::Result::Success;
 }
 


### PR DESCRIPTION
If we don't send out the status before and after a capture, the photo button in QGC stays "busy".