### PR TITLE
gimbal: fix unregister message subscription

### DIFF
--- a/src/mavsdk/plugins/gimbal/gimbal_protocol_v2.cpp
+++ b/src/mavsdk/plugins/gimbal/gimbal_protocol_v2.cpp
@@ -18,6 +18,15 @@ GimbalProtocolV2::GimbalProtocolV2(
     _gimbal_manager_compid(gimbal_manager_compid)
 {}
 
+GimbalProtocolV2::~GimbalProtocolV2()
+{
+    if (_is_mavlink_manager_status_registered) {
+        _is_mavlink_manager_status_registered = false;
+
+        _system_impl.unregister_mavlink_message_handler(MAVLINK_MSG_ID_GIMBAL_MANAGER_STATUS, this);
+    }
+}
+
 void GimbalProtocolV2::process_gimbal_manager_status(const mavlink_message_t& message)
 {
     Gimbal::ControlMode new_control_mode;

--- a/src/mavsdk/plugins/gimbal/gimbal_protocol_v2.h
+++ b/src/mavsdk/plugins/gimbal/gimbal_protocol_v2.h
@@ -12,7 +12,7 @@ public:
         const mavlink_gimbal_manager_information_t& information,
         uint8_t gimbal_manager_sysid,
         uint8_t gimbal_manager_compid);
-    ~GimbalProtocolV2() override = default;
+    ~GimbalProtocolV2() override;
 
     Gimbal::Result set_pitch_and_yaw(float pitch_deg, float yaw_deg) override;
     void set_pitch_and_yaw_async(


### PR DESCRIPTION
We should unregister anything we have subscribed to when being destructed.

Related to #2207 