### PR TITLE
Move to zlib-ng which has better CMake support

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -14,7 +14,7 @@ if (SUPERBUILD)
 
     if(NOT BUILD_WITHOUT_CURL)
         if(NOT IOS)
-            build_target(zlib)
+            build_target(zlib-ng)
         endif()
         build_target(curl)
     endif()

--- a/third_party/zlib-ng/CMakeLists.txt
+++ b/third_party/zlib-ng/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(external-zlib-ng)
+include(ExternalProject)
+
+list(APPEND CMAKE_ARGS
+    "-DCMAKE_PREFIX_PATH:PATH=${CMAKE_PREFIX_PATH}"
+    "-DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}"
+    "-DCMAKE_TOOLCHAIN_FILE:PATH=${CMAKE_TOOLCHAIN_FILE}"
+    "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+    "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+    "-DBUILD_SHARED_LIBS=OFF"
+    "-DZLIB_COMPAT=ON"
+    "-DZLIB_ENABLE_TESTS=OFF"
+    "-DWITH_GTEST=OFF"
+    )
+
+if(IOS)
+    list(APPEND CMAKE_ARGS
+        "-DPLATFORM=${PLATFORM}"
+        "-DDEPLOYMENT_TARGET=${DEPLOYMENT_TARGET}"
+        "-DENABLE_STRICT_TRY_COMPILE=${ENABLE_STRICT_TRY_COMPILE}"
+        )
+endif()
+
+message(STATUS "Preparing external project \"zlib-ng\" with args:")
+foreach(CMAKE_ARG ${CMAKE_ARGS})
+    message(STATUS "-- ${CMAKE_ARG}")
+endforeach()
+
+ExternalProject_add(
+    zlib-ng
+    URL https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.1.6.tar.gz
+    PREFIX zlib-ng
+    CMAKE_ARGS "${CMAKE_ARGS}"
+    )


### PR DESCRIPTION
Because zlib-ng has better CMake support and explicitly tries to keep API compatibility with zlib (see `-DZLIB_COMPAT=ON`), it feels like it may be easier to maintain here.

@julianoes: what do you think?