### PR TITLE
Fix illegal instruction on RPi 4

### DIFF
--- a/third_party/absl/CMakeLists.txt
+++ b/third_party/absl/CMakeLists.txt
@@ -31,5 +31,6 @@ ExternalProject_add(
     GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
     GIT_TAG 20240116.1
     PREFIX absl
+    PATCH_COMMAND git checkout . && git apply ${PROJECT_SOURCE_DIR}/rpi-no-crypto.patch
     CMAKE_ARGS "${CMAKE_ARGS}"
     )

--- a/third_party/absl/CMakeLists.txt
+++ b/third_party/absl/CMakeLists.txt
@@ -29,7 +29,7 @@ endforeach()
 ExternalProject_add(
     absl
     GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
-    GIT_TAG 20230802.1
+    GIT_TAG 20240116.1
     PREFIX absl
     CMAKE_ARGS "${CMAKE_ARGS}"
     )

--- a/third_party/absl/rpi-no-crypto.patch
+++ b/third_party/absl/rpi-no-crypto.patch
@@ -1,0 +1,19 @@
+diff --git a/absl/random/internal/platform.h b/absl/random/internal/platform.h
+index d779f481..ea30118f 100644
+--- a/absl/random/internal/platform.h
++++ b/absl/random/internal/platform.h
+@@ -116,10 +116,10 @@
+ 
+ // http://infocenter.arm.com/help/topic/com.arm.doc.ihi0053c/IHI0053C_acle_2_0.pdf
+ // Rely on NEON+CRYPTO extensions for ARM.
+-#if defined(__ARM_NEON) && defined(__ARM_FEATURE_CRYPTO)
+-#undef ABSL_HAVE_ACCELERATED_AES
+-#define ABSL_HAVE_ACCELERATED_AES 1
+-#endif
++//#if defined(__ARM_NEON) && defined(__ARM_FEATURE_CRYPTO)
++//#undef ABSL_HAVE_ACCELERATED_AES
++//#define ABSL_HAVE_ACCELERATED_AES 1
++//#endif
+ 
+ #endif
+ 


### PR DESCRIPTION
The absl library tries to make use of the crypto libraries on arm64 platforms. However, it turns out that the RPi 4 chip does not have the crypto extensions. Hence, we need to patch absl to refrain from using the hardware crypto stuff and fallback to slower software implementations. This is only required for a random back-off timer at the moment, so shouldn't matter too much.

Note that the RPi 5 has the crypto extensions but our build is the same for both.

Fixes https://github.com/mavlink/MAVSDK-Python/issues/654.
Fixes https://github.com/mavlink/MAVSDK-Python/issues/651.