### PR TITLE
Ftp: use call_user_callback

### DIFF
--- a/src/mavsdk/plugins/ftp/ftp_impl.cpp
+++ b/src/mavsdk/plugins/ftp/ftp_impl.cpp
@@ -42,9 +42,14 @@ void FtpImpl::download_async(
         use_burst,
         [callback, this](
             MavlinkFtpClient::ClientResult result, MavlinkFtpClient::ProgressData progress_data) {
-            callback(
-                result_from_mavlink_ftp_result(result),
-                progress_data_from_mavlink_ftp_progress_data(progress_data));
+            if (callback) {
+                _system_impl->call_user_callback(
+                    [temp_callback = callback, result, progress_data, this]() {
+                        temp_callback(
+                            result_from_mavlink_ftp_result(result),
+                            progress_data_from_mavlink_ftp_progress_data(progress_data));
+                    });
+            }
         });
 }
 
@@ -58,9 +63,14 @@ void FtpImpl::upload_async(
         remote_folder,
         [callback, this](
             MavlinkFtpClient::ClientResult result, MavlinkFtpClient::ProgressData progress_data) {
-            callback(
-                result_from_mavlink_ftp_result(result),
-                progress_data_from_mavlink_ftp_progress_data(progress_data));
+            if (callback) {
+                _system_impl->call_user_callback(
+                    [temp_callback = callback, result, progress_data, this]() {
+                        temp_callback(
+                            result_from_mavlink_ftp_result(result),
+                            progress_data_from_mavlink_ftp_progress_data(progress_data));
+                    });
+            }
         });
 }
 
@@ -100,7 +110,11 @@ void FtpImpl::create_directory_async(const std::string& path, Ftp::ResultCallbac
 {
     _system_impl->mavlink_ftp_client().create_directory_async(
         path, [callback, this](MavlinkFtpClient::ClientResult result) {
-            callback(result_from_mavlink_ftp_result(result));
+            if (callback) {
+                _system_impl->call_user_callback([temp_callback = callback, result, this]() {
+                    temp_callback(result_from_mavlink_ftp_result(result));
+                });
+            }
         });
 }
 
@@ -118,7 +132,11 @@ void FtpImpl::remove_directory_async(const std::string& path, Ftp::ResultCallbac
 {
     _system_impl->mavlink_ftp_client().remove_directory_async(
         path, [callback, this](MavlinkFtpClient::ClientResult result) {
-            callback(result_from_mavlink_ftp_result(result));
+            if (callback) {
+                _system_impl->call_user_callback([temp_callback = callback, result, this]() {
+                    temp_callback(result_from_mavlink_ftp_result(result));
+                });
+            }
         });
 }
 
@@ -136,7 +154,11 @@ void FtpImpl::remove_file_async(const std::string& path, Ftp::ResultCallback cal
 {
     _system_impl->mavlink_ftp_client().remove_file_async(
         path, [callback, this](MavlinkFtpClient::ClientResult result) {
-            callback(result_from_mavlink_ftp_result(result));
+            if (callback) {
+                _system_impl->call_user_callback([temp_callback = callback, result, this]() {
+                    temp_callback(result_from_mavlink_ftp_result(result));
+                });
+            }
         });
 }
 
@@ -155,7 +177,11 @@ void FtpImpl::rename_async(
 {
     _system_impl->mavlink_ftp_client().rename_async(
         from_path, to_path, [callback, this](MavlinkFtpClient::ClientResult result) {
-            callback(result_from_mavlink_ftp_result(result));
+            if (callback) {
+                _system_impl->call_user_callback([temp_callback = callback, result, this]() {
+                    temp_callback(result_from_mavlink_ftp_result(result));
+                });
+            }
         });
 }
 
@@ -181,7 +207,12 @@ void FtpImpl::are_files_identical_async(
         local_path,
         remote_path,
         [callback, this](MavlinkFtpClient::ClientResult result, bool identical) {
-            callback(result_from_mavlink_ftp_result(result), identical);
+            if (callback) {
+                _system_impl->call_user_callback(
+                    [temp_callback = callback, result, identical, this]() {
+                        temp_callback(result_from_mavlink_ftp_result(result), identical);
+                    });
+            }
         });
 }
 


### PR DESCRIPTION
I experienced dead locks while calling ftp functions inside ftp callback. For example, I was trying to start a download while in `are_files_identical_async` callback.
Currently, only `list_directory_async` is using `call_user_callback` since commit 50c23012a65bd5f28b8b19192068a555f582f911