### PR TITLE
Add missing switch-case parameter

### DIFF
--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -1002,6 +1002,8 @@ ardupilot::PlaneMode SystemImpl::flight_mode_to_ardupilot_plane_mode(FlightMode 
             return ardupilot::PlaneMode::Fbwa;
         case FlightMode::Stabilized:
             return ardupilot::PlaneMode::Stabilize;
+        case FlightMode::Offboard:
+            return ardupilot::PlaneMode::Guided;
         case FlightMode::Unknown:
             return ardupilot::PlaneMode::Unknown;
         default:


### PR DESCRIPTION
Without that, functions such as goto_location are reporting that they cannot convert the System's flight mode to the Ardupilot one :)