### PR TITLE
Ftp client: Fix burst download

### DIFF
--- a/src/mavsdk/core/mavlink_ftp_client.cpp
+++ b/src/mavsdk/core/mavlink_ftp_client.cpp
@@ -489,7 +489,6 @@ bool MavlinkFtpClient::download_burst_start(Work& work, DownloadBurstItem& item)
     work.payload.size = item.remote_path.length() + 1;
 
     start_timer();
-    item.status = DownloadBurstItem::Status::OPEN_FILE;
     send_mavlink_ftp_message(work.payload);
 
     return true;
@@ -528,7 +527,7 @@ bool MavlinkFtpClient::download_burst_continue(
             if (!item.ofstream) {
                 LogWarn() << "Write failed";
                 item.callback(ClientResult::FileIoError, {});
-                download_burst_end(work, item);
+                download_burst_end(work);
                 return false;
             }
         }
@@ -538,7 +537,7 @@ bool MavlinkFtpClient::download_burst_continue(
         if (!item.ofstream) {
             LogWarn() << "Write failed";
             item.callback(ClientResult::FileIoError, {});
-            download_burst_end(work, item);
+            download_burst_end(work);
             return false;
         }
 
@@ -559,7 +558,7 @@ bool MavlinkFtpClient::download_burst_continue(
                 // No missing data, we're done.
 
                 // Final step
-                download_burst_end(work, item);
+                download_burst_end(work);
             } else {
                 // The burst is supposedly complete but we still need data because
                 // we missed some, so request next without burst.
@@ -578,7 +577,6 @@ bool MavlinkFtpClient::download_burst_continue(
                 request_burst(work, item);
             } else {
                 // There might be more coming, just wait for now.
-                item.status = DownloadBurstItem::Status::BURST_IN_PROGRESS;
                 start_timer();
             }
         }
@@ -592,14 +590,14 @@ bool MavlinkFtpClient::download_burst_continue(
         if (item.ofstream.fail()) {
             LogWarn() << "Seek failed";
             item.callback(ClientResult::FileIoError, {});
-            download_burst_end(work, item);
+            download_burst_end(work);
             return false;
         }
 
         item.ofstream.write(reinterpret_cast<const char*>(payload->data), payload->size);
         if (!item.ofstream) {
             item.callback(ClientResult::FileIoError, {});
-            download_burst_end(work, item);
+            download_burst_end(work);
             return false;
         }
 
@@ -607,7 +605,7 @@ bool MavlinkFtpClient::download_burst_continue(
         if (missing.offset != payload->offset) {
             LogErr() << "Offset mismatch";
             item.callback(ClientResult::ProtocolError, {});
-            download_burst_end(work, item);
+            download_burst_end(work);
             return false;
         }
 
@@ -620,13 +618,12 @@ bool MavlinkFtpClient::download_burst_continue(
         }
 
         const size_t bytes_transferred = burst_bytes_transferred(item);
-        if (_debugging) {
-            LogDebug() << "Written " << bytes_transferred << " of " << item.file_size << " bytes";
-        }
+
+        LogDebug() << "Written " << bytes_transferred << " of " << item.file_size << " bytes";
 
         if (item.missing_data.empty()) {
             // Final step
-            download_burst_end(work, item);
+            download_burst_end(work);
         } else {
             item.callback(
                 ClientResult::Next,
@@ -639,14 +636,14 @@ bool MavlinkFtpClient::download_burst_continue(
 
     } else {
         LogErr() << "Unexpected req_opcode";
-        download_burst_end(work, item);
+        download_burst_end(work);
         return false;
     }
 
     return true;
 }
 
-void MavlinkFtpClient::download_burst_end(Work& work, DownloadBurstItem& item)
+void MavlinkFtpClient::download_burst_end(Work& work)
 {
     work.last_opcode = CMD_TERMINATE_SESSION;
 
@@ -658,7 +655,6 @@ void MavlinkFtpClient::download_burst_end(Work& work, DownloadBurstItem& item)
     work.payload.offset = 0;
     work.payload.size = 0;
 
-    item.status = DownloadBurstItem::Status::TERMINATE_REQUEST;
     start_timer();
     send_mavlink_ftp_message(work.payload);
 }
@@ -677,7 +673,6 @@ void MavlinkFtpClient::request_burst(Work& work, DownloadBurstItem& item)
     // Fill up the whole packet.
     work.payload.size = max_data_length;
 
-    item.status = DownloadBurstItem::Status::BURST_REQUEST;
     start_timer();
     send_mavlink_ftp_message(work.payload);
 }
@@ -700,7 +695,6 @@ void MavlinkFtpClient::request_next_rest(Work& work, DownloadBurstItem& item)
 
     work.payload.size = size;
 
-    item.status = DownloadBurstItem::Status::READ_REQUEST;
     start_timer();
     send_mavlink_ftp_message(work.payload);
 }
@@ -1206,30 +1200,18 @@ void MavlinkFtpClient::timeout()
                 send_mavlink_ftp_message(work->payload);
             },
             [&](DownloadBurstItem& item) {
-                switch (item.status) {
-                    case DownloadBurstItem::Status::NOT_STARTED:
-                    case DownloadBurstItem::Status::OPEN_FILE:
-                    case DownloadBurstItem::Status::BURST_REQUEST:
-                    case DownloadBurstItem::Status::TERMINATE_REQUEST:
-                    case DownloadBurstItem::Status::READ_REQUEST:
-                        if (--work->retries == 0) {
-                            item.callback(ClientResult::Timeout, {});
-                            work_queue_guard.pop_front();
-                            return;
-                        }
-                        if (_debugging) {
-                            LogDebug() << "Retries left: " << work->retries;
-                        }
+                if (--work->retries == 0) {
+                    item.callback(ClientResult::Timeout, {});
+                    work_queue_guard.pop_front();
+                    return;
+                }
+                if (_debugging) {
+                    LogDebug() << "Retries left: " << work->retries;
+                }
 
-                        {
-                            start_timer();
-                            send_mavlink_ftp_message(work->payload);
-                        }
-                        break;
-                    case DownloadBurstItem::Status::BURST_IN_PROGRESS:
-                        // we missed end of burst
-                        request_burst(*work, item);
-                        break;
+                {
+                    start_timer();
+                    send_mavlink_ftp_message(work->payload);
                 }
             },
             [&](UploadItem& item) {

--- a/src/mavsdk/core/mavlink_ftp_client.cpp
+++ b/src/mavsdk/core/mavlink_ftp_client.cpp
@@ -513,6 +513,11 @@ bool MavlinkFtpClient::download_burst_continue(
         }
 
         if (payload->offset != item.next_offset) {
+            if (payload->offset < item.next_offset) {
+                // Not sure why this would happen but we don't know how to deal with it and ignore
+                // it.
+                return false;
+            }
             // we missed a part
             item.missing_data.emplace_back(DownloadBurstItem::MissingData{
                 item.next_offset, payload->offset - item.next_offset});

--- a/src/mavsdk/core/mavlink_ftp_client.cpp
+++ b/src/mavsdk/core/mavlink_ftp_client.cpp
@@ -5,6 +5,8 @@
 #include <algorithm>
 #include <fstream>
 #include <filesystem>
+#include <algorithm>
+#include <numeric>
 
 #include "crc32.h"
 
@@ -202,6 +204,7 @@ void MavlinkFtpClient::process_mavlink_ftp_message(const mavlink_message_t& msg)
                     }
 
                 } else if (payload->opcode == RSP_NAK) {
+                    LogWarn() << "FTP: NAK received";
                     stop_timer();
                     item.callback(result_from_nak(payload), {});
                     work_queue_guard.pop_front();
@@ -495,21 +498,13 @@ bool MavlinkFtpClient::download_burst_continue(
     Work& work, DownloadBurstItem& item, PayloadHeader* payload)
 {
     if (payload->req_opcode == CMD_OPEN_FILE_RO) {
-        const size_t file_size = *(reinterpret_cast<uint32_t*>(payload->data));
-        item.transferred.resize(file_size, DownloadBurstItem::Transferred::No);
-
-        // We just use a vector of 0 and write that to the file to prepare it.
-        // We then fill in the chunks as they come in.
-        std::vector<char> empty;
-        empty.resize(file_size);
-        item.ofstream.write(empty.data(), empty.size());
+        std::memcpy(&(item.file_size), payload->data, sizeof(uint32_t));
 
         if (_debugging) {
-            LogDebug() << "Burst Download continue, got file size: " << file_size;
+            LogDebug() << "Burst Download continue, got file size: " << item.file_size;
         }
 
         request_burst(work, item);
-        return true;
 
     } else if (payload->req_opcode == CMD_BURST_READ_FILE) {
         if (_debugging) {
@@ -517,11 +512,19 @@ bool MavlinkFtpClient::download_burst_continue(
                        << " write: " << std::to_string(payload->size);
         }
 
-        item.ofstream.seekp(payload->offset);
-        if (item.ofstream.fail()) {
-            LogWarn() << "Seek failed";
-            item.callback(ClientResult::FileIoError, {});
-            return false;
+        if (payload->offset != item.next_offset) {
+            // we missed a part
+            item.missing_data.emplace_back(DownloadBurstItem::MissingData{
+                item.next_offset, payload->offset - item.next_offset});
+            // write some 0 instead
+            std::vector<char> empty(payload->offset - item.next_offset);
+            item.ofstream.write(empty.data(), empty.size());
+            if (!item.ofstream) {
+                LogWarn() << "Write failed";
+                item.callback(ClientResult::FileIoError, {});
+                download_burst_end(work);
+                return false;
+            }
         }
 
         // Write actual data to file.
@@ -529,62 +532,49 @@ bool MavlinkFtpClient::download_burst_continue(
         if (!item.ofstream) {
             LogWarn() << "Write failed";
             item.callback(ClientResult::FileIoError, {});
+            download_burst_end(work);
             return false;
         }
 
         // Keep track of what was written.
-        for (size_t i = payload->offset; i < payload->offset + payload->size; ++i) {
-            item.transferred[i] = DownloadBurstItem::Transferred::Yes;
-        }
+        item.next_offset = payload->offset + payload->size;
 
         if (_debugging) {
             LogDebug() << "Received " << payload->offset << " to "
                        << payload->size + payload->offset;
         }
 
-        const size_t bytes_transferred = burst_bytes_transferred(item);
-
-        if (bytes_transferred == item.transferred.size()) {
+        if (payload->size + payload->offset >= item.file_size) {
             if (_debugging) {
                 LogDebug() << "Burst complete";
             }
 
-            // Final step
-            work.last_opcode = CMD_TERMINATE_SESSION;
+            if (item.missing_data.empty()) {
+                // No missing data, we're done.
 
-            work.payload = {};
-            work.payload.seq_number = work.last_sent_seq_number++;
-            work.payload.session = _session;
-
-            work.payload.opcode = work.last_opcode;
-            work.payload.offset = 0;
-            work.payload.size = 0;
-
-            start_timer();
-            send_mavlink_ftp_message(work.payload);
-
-            return true;
-
+                // Final step
+                download_burst_end(work);
+            } else {
+                // The burst is supposedly complete but we still need data because
+                // we missed some, so request next without burst.
+                request_next_rest(work, item);
+            }
         } else {
             item.callback(
                 ClientResult::Next,
                 ProgressData{
-                    static_cast<uint32_t>(bytes_transferred),
-                    static_cast<uint32_t>(item.transferred.size())});
+                    static_cast<uint32_t>(burst_bytes_transferred(item)),
+                    static_cast<uint32_t>(item.file_size)});
 
             if (payload->burst_complete) {
-                // The burst is supposedly complete but we still need data, so request next without
-                // burst.
-                request_next_rest(work, item);
-
+                // This burst is complete but the file isn't. we need to start a
+                // new one
+                request_burst(work, item);
             } else {
                 // There might be more coming, just wait for now.
                 start_timer();
             }
-
-            return true;
         }
-
     } else if (payload->req_opcode == CMD_READ_FILE) {
         if (_debugging) {
             LogWarn() << "Burst download continue missing pieces, write at " << payload->offset
@@ -595,57 +585,73 @@ bool MavlinkFtpClient::download_burst_continue(
         if (item.ofstream.fail()) {
             LogWarn() << "Seek failed";
             item.callback(ClientResult::FileIoError, {});
+            download_burst_end(work);
             return false;
         }
 
         item.ofstream.write(reinterpret_cast<const char*>(payload->data), payload->size);
         if (!item.ofstream) {
             item.callback(ClientResult::FileIoError, {});
+            download_burst_end(work);
             return false;
         }
 
-        // Keep track of what was written.
-        for (size_t i = payload->offset; i < payload->offset + payload->size; ++i) {
-            item.transferred[i] = DownloadBurstItem::Transferred::Yes;
+        auto& missing = item.missing_data.front();
+        if (missing.offset != payload->offset) {
+            LogErr() << "Offset mismatch";
+            item.callback(ClientResult::ProtocolError, {});
+            download_burst_end(work);
+            return false;
+        }
+
+        if (missing.size <= payload->size) {
+            // we got all needed data for this chunk
+            item.missing_data.pop_front();
+        } else {
+            missing.offset += payload->size;
+            missing.size -= payload->size;
         }
 
         const size_t bytes_transferred = burst_bytes_transferred(item);
 
-        if (_debugging) {
-            LogDebug() << "Written " << bytes_transferred << " of " << item.transferred.size()
-                       << " bytes";
-        }
+        LogDebug() << "Written " << bytes_transferred << " of " << item.file_size << " bytes";
 
-        if (bytes_transferred == item.transferred.size()) {
+        if (item.missing_data.empty()) {
             // Final step
-            work.last_opcode = CMD_TERMINATE_SESSION;
-
-            work.payload = {};
-            work.payload.seq_number = work.last_sent_seq_number++;
-            work.payload.session = _session;
-
-            work.payload.opcode = work.last_opcode;
-            work.payload.offset = 0;
-            work.payload.size = 0;
-
-            start_timer();
-            send_mavlink_ftp_message(work.payload);
-            return true;
+            download_burst_end(work);
         } else {
             item.callback(
                 ClientResult::Next,
                 ProgressData{
                     static_cast<uint32_t>(bytes_transferred),
-                    static_cast<uint32_t>(item.transferred.size())});
+                    static_cast<uint32_t>(item.file_size)});
 
             request_next_rest(work, item);
-            return true;
         }
 
     } else {
         LogErr() << "Unexpected req_opcode";
+        download_burst_end(work);
         return false;
     }
+
+    return true;
+}
+
+void MavlinkFtpClient::download_burst_end(Work& work)
+{
+    work.last_opcode = CMD_TERMINATE_SESSION;
+
+    work.payload = {};
+    work.payload.seq_number = work.last_sent_seq_number++;
+    work.payload.session = _session;
+
+    work.payload.opcode = work.last_opcode;
+    work.payload.offset = 0;
+    work.payload.size = 0;
+
+    start_timer();
+    send_mavlink_ftp_message(work.payload);
 }
 
 void MavlinkFtpClient::request_burst(Work& work, DownloadBurstItem& item)
@@ -657,7 +663,7 @@ void MavlinkFtpClient::request_burst(Work& work, DownloadBurstItem& item)
     work.payload.seq_number = work.last_sent_seq_number++;
     work.payload.session = _session;
     work.payload.opcode = work.last_opcode;
-    work.payload.offset = 0;
+    work.payload.offset = item.next_offset;
 
     // Fill up the whole packet.
     work.payload.size = max_data_length;
@@ -668,28 +674,11 @@ void MavlinkFtpClient::request_burst(Work& work, DownloadBurstItem& item)
 
 void MavlinkFtpClient::request_next_rest(Work& work, DownloadBurstItem& item)
 {
-    const auto first_missing = std::find(
-        item.transferred.begin(), item.transferred.end(), DownloadBurstItem::Transferred::No);
-    if (first_missing == item.transferred.end()) {
-        LogErr() << "Nothing missing, this doesn't make sense.";
-        return;
-    }
-
-    const auto last_missing_plus_one =
-        std::find(first_missing, item.transferred.end(), DownloadBurstItem::Transferred::Yes);
-
-    const size_t offset = std::distance(item.transferred.begin(), first_missing);
-
-    const uint32_t size =
-        static_cast<uint32_t>(std::distance(first_missing, last_missing_plus_one));
-
-    if (size == 0) {
-        LogErr() << "Size is 0";
-        return;
-    }
+    const auto& missing = item.missing_data.front();
+    size_t size = std::min(missing.size, size_t(max_data_length));
 
     if (_debugging) {
-        LogDebug() << "Re-requesting from " << offset << " with size " << size;
+        LogDebug() << "Re-requesting from " << missing.offset << " with size " << size;
     }
 
     work.last_opcode = CMD_READ_FILE;
@@ -697,10 +686,9 @@ void MavlinkFtpClient::request_next_rest(Work& work, DownloadBurstItem& item)
     work.payload.seq_number = work.last_sent_seq_number++;
     work.payload.session = _session;
     work.payload.opcode = work.last_opcode;
-    work.payload.offset = offset;
+    work.payload.offset = missing.offset;
 
-    work.payload.size =
-        static_cast<uint8_t>(std::min(static_cast<uint32_t>(max_data_length), size));
+    work.payload.size = size;
 
     start_timer();
     send_mavlink_ftp_message(work.payload);
@@ -708,8 +696,13 @@ void MavlinkFtpClient::request_next_rest(Work& work, DownloadBurstItem& item)
 
 size_t MavlinkFtpClient::burst_bytes_transferred(DownloadBurstItem& item)
 {
-    return std::count(
-        item.transferred.begin(), item.transferred.end(), DownloadBurstItem::Transferred::Yes);
+    return item.next_offset - std::accumulate(
+                                  item.missing_data.begin(),
+                                  item.missing_data.end(),
+                                  size_t(0),
+                                  [](size_t acc, const DownloadBurstItem::MissingData& missing) {
+                                      return acc + missing.size;
+                                  });
 }
 
 bool MavlinkFtpClient::upload_start(Work& work, UploadItem& item)
@@ -1038,6 +1031,7 @@ MavlinkFtpClient::ClientResult MavlinkFtpClient::translate(ServerResult result)
         case ServerResult::ERR_FAIL_FILE_DOES_NOT_EXIST:
             return ClientResult::FileDoesNotExist;
         default:
+            LogInfo() << "Unknown error code: " << (int)result;
             return ClientResult::ProtocolError;
     }
 }
@@ -1211,13 +1205,8 @@ void MavlinkFtpClient::timeout()
                 }
 
                 {
-                    const size_t bytes_transferred = burst_bytes_transferred(item);
-                    if (bytes_transferred == 0 || bytes_transferred == item.transferred.size()) {
-                        start_timer();
-                        send_mavlink_ftp_message(work->payload);
-                    } else {
-                        request_next_rest(*work, item);
-                    }
+                    start_timer();
+                    send_mavlink_ftp_message(work->payload);
                 }
             },
             [&](UploadItem& item) {

--- a/src/mavsdk/core/mavlink_ftp_client.cpp
+++ b/src/mavsdk/core/mavlink_ftp_client.cpp
@@ -1237,6 +1237,7 @@ void MavlinkFtpClient::timeout()
                             if (item.current_offset < item.file_size) {
                                 item.missing_data.emplace_back(DownloadBurstItem::MissingData{
                                     item.current_offset, item.file_size - item.current_offset});
+                                item.current_offset = item.file_size;
                                 if (_debugging) {
                                     LogDebug() << "Adding " << item.current_offset << " with size "
                                                << item.file_size - item.current_offset;

--- a/src/mavsdk/core/mavlink_ftp_client.h
+++ b/src/mavsdk/core/mavlink_ftp_client.h
@@ -159,15 +159,6 @@ private:
         };
         std::deque<MissingData> missing_data{};
         size_t next_offset{0};
-        enum Status {
-            NOT_STARTED,
-            OPEN_FILE,
-            BURST_REQUEST,
-            TERMINATE_REQUEST,
-            READ_REQUEST,
-            BURST_IN_PROGRESS,
-        };
-        Status status{Status::NOT_STARTED};
     };
 
     struct UploadItem {
@@ -279,7 +270,7 @@ private:
 
     bool download_burst_start(Work& work, DownloadBurstItem& item);
     bool download_burst_continue(Work& work, DownloadBurstItem& item, PayloadHeader* payload);
-    void download_burst_end(Work& work, DownloadBurstItem& item);
+    void download_burst_end(Work& work);
     void request_burst(Work& work, DownloadBurstItem& item);
     void request_next_rest(Work& work, DownloadBurstItem& item);
     size_t burst_bytes_transferred(DownloadBurstItem& item);

--- a/src/mavsdk/core/mavlink_ftp_client.h
+++ b/src/mavsdk/core/mavlink_ftp_client.h
@@ -158,7 +158,7 @@ private:
             size_t size;
         };
         std::deque<MissingData> missing_data{};
-        size_t next_offset{0};
+        size_t current_offset{0};
     };
 
     struct UploadItem {

--- a/src/mavsdk/core/mavlink_ftp_client.h
+++ b/src/mavsdk/core/mavlink_ftp_client.h
@@ -3,6 +3,7 @@
 #include <cinttypes>
 #include <functional>
 #include <fstream>
+#include <deque>
 #include <unordered_map>
 #include <mutex>
 #include <optional>
@@ -151,12 +152,13 @@ private:
         std::string local_folder{};
         DownloadCallback callback{};
         std::ofstream ofstream{};
-        enum class Transferred {
-            No,
-            Yes,
+        uint32_t file_size{0};
+        struct MissingData {
+            size_t offset;
+            size_t size;
         };
-        std::vector<Transferred> transferred{};
-        int last_progress_percentage{-1};
+        std::deque<MissingData> missing_data{};
+        size_t next_offset{0};
     };
 
     struct UploadItem {
@@ -268,6 +270,7 @@ private:
 
     bool download_burst_start(Work& work, DownloadBurstItem& item);
     bool download_burst_continue(Work& work, DownloadBurstItem& item, PayloadHeader* payload);
+    void download_burst_end(Work& work);
     void request_burst(Work& work, DownloadBurstItem& item);
     void request_next_rest(Work& work, DownloadBurstItem& item);
     size_t burst_bytes_transferred(DownloadBurstItem& item);

--- a/src/mavsdk/core/mavlink_ftp_client.h
+++ b/src/mavsdk/core/mavlink_ftp_client.h
@@ -159,6 +159,15 @@ private:
         };
         std::deque<MissingData> missing_data{};
         size_t next_offset{0};
+        enum Status {
+            NOT_STARTED,
+            OPEN_FILE,
+            BURST_REQUEST,
+            TERMINATE_REQUEST,
+            READ_REQUEST,
+            BURST_IN_PROGRESS,
+        };
+        Status status{Status::NOT_STARTED};
     };
 
     struct UploadItem {
@@ -270,7 +279,7 @@ private:
 
     bool download_burst_start(Work& work, DownloadBurstItem& item);
     bool download_burst_continue(Work& work, DownloadBurstItem& item, PayloadHeader* payload);
-    void download_burst_end(Work& work);
+    void download_burst_end(Work& work, DownloadBurstItem& item);
     void request_burst(Work& work, DownloadBurstItem& item);
     void request_next_rest(Work& work, DownloadBurstItem& item);
     size_t burst_bytes_transferred(DownloadBurstItem& item);

--- a/src/mavsdk/core/mavlink_ftp_server.cpp
+++ b/src/mavsdk/core/mavlink_ftp_server.cpp
@@ -871,8 +871,7 @@ void MavlinkFtpServer::_work_write(const PayloadHeader& payload)
     }
 
     response.opcode = Opcode::RSP_ACK;
-    response.size = sizeof(uint32_t);
-    std::memcpy(response.data, &payload.size, response.size);
+    response.size = 0;
 
     _send_mavlink_ftp_message(response);
 }


### PR DESCRIPTION
I attempted FTP burst download with PX4 and encountered some issues. After a certain period, the burst download would halt, and the remaining data would be downloaded as missed parts. Upon inspecting the PX4 code, I discovered the following comment: `/* perform transfers in 35K chunks - this is determined empirically */`.

When attempting to resume burst download for incomplete files, I observed that missed parts were managed using a file-sized buffer with a binary value (1 or 0) for each byte. This implies that for a 10MB file, it requires 10MB of RAM to download.

With this pull request, instead of storing the entire missed parts in memory, we now only store the offset and size of the missing parts. Burst download is restarted if the file is not complete before checking missed parts.

To test the handling of missed parts, I modified my PX4 to skip 4 packets every 10,000.