### PR TITLE
Stop list directory job if received size is null

### DIFF
--- a/src/mavsdk/core/mavlink_ftp_client.cpp
+++ b/src/mavsdk/core/mavlink_ftp_client.cpp
@@ -978,6 +978,12 @@ bool MavlinkFtpClient::list_dir_continue(Work& work, ListDirItem& item, PayloadH
         return false;
     }
 
+    if (payload->size == 0) {
+        std::sort(item.dirs.begin(), item.dirs.end());
+        item.callback(ClientResult::Success, item.dirs);
+        return false;
+    }
+
     // Make sure there is a zero termination.
     payload->data[payload->size - 1] = '\0';
 

--- a/src/system_tests/ftp_download_file_burst.cpp
+++ b/src/system_tests/ftp_download_file_burst.cpp
@@ -192,7 +192,7 @@ TEST(SystemTest, FtpDownloadBurstBigFileLossy)
             }
         });
 
-    auto future_status = fut.wait_for(std::chrono::seconds(20));
+    auto future_status = fut.wait_for(std::chrono::seconds(30));
     ASSERT_EQ(future_status, std::future_status::ready);
     EXPECT_EQ(fut.get(), Ftp::Result::Success);
 


### PR DESCRIPTION
When we ask PX4 to list an empty directory, it sends back an ack with a empty payload.