### PR TITLE
Ftp server : use a thread to send ftp burst

### DIFF
--- a/src/mavsdk/core/mavlink_ftp_server.h
+++ b/src/mavsdk/core/mavlink_ftp_server.h
@@ -9,6 +9,7 @@
 #include <utility>
 #include <variant>
 #include <vector>
+#include <thread>
 
 #include "mavlink_include.h"
 
@@ -133,9 +134,8 @@ private:
     void _work_rename(const PayloadHeader& payload);
     void _work_calc_file_CRC32(const PayloadHeader& payload);
 
-    void _send_burst_packet();
+    bool _send_burst_packet();
     void _make_burst_packet(PayloadHeader& packet);
-    void* _burst_call_every_cookie{nullptr};
 
     std::mutex _mutex{};
     struct SessionInfo {
@@ -144,6 +144,8 @@ private:
         uint8_t burst_chunk_size{0};
         std::ifstream ifstream;
         std::ofstream ofstream;
+        bool burst_stop{false};
+        std::thread burst_thread;
     } _session_info{};
 
     uint8_t _network_id = 0;

--- a/src/system_tests/ftp_download_file_burst.cpp
+++ b/src/system_tests/ftp_download_file_burst.cpp
@@ -259,7 +259,7 @@ TEST(SystemTest, FtpDownloadBurstStopAndTryAgain)
 
     // Once we received half, we want to stop all traffic.
     int received = 0;
-    auto drop_at_some_point_in = [&received](mavlink_message_t& message) {
+    auto drop_at_some_point_in = [&received, msg_count](mavlink_message_t& message) {
         if (message.msgid == MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL) {
             received++;
         }
@@ -269,7 +269,7 @@ TEST(SystemTest, FtpDownloadBurstStopAndTryAgain)
         return true;
     };
 
-    auto drop_at_some_point_out = [&received](mavlink_message_t& message) {
+    auto drop_at_some_point_out = [&received, msg_count](mavlink_message_t& message) {
         if (received >= msg_count / 2) {
             return false;
         }

--- a/src/system_tests/ftp_download_file_burst.cpp
+++ b/src/system_tests/ftp_download_file_burst.cpp
@@ -207,42 +207,6 @@ TEST(SystemTest, FtpDownloadBurstBigFileLossy)
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 }
 
-uint8_t get_target_system_id(const mavlink_message_t& message)
-{
-    // Checks whether connection knows target system ID by extracting target system if set.
-    const mavlink_msg_entry_t* meta = mavlink_get_msg_entry(message.msgid);
-
-    if (meta == nullptr || !(meta->flags & MAV_MSG_ENTRY_FLAG_HAVE_TARGET_SYSTEM)) {
-        return 0;
-    }
-
-    // Don't look at the target system offset if it is outside the payload length.
-    // This can happen if the fields are trimmed.
-    if (meta->target_system_ofs >= message.len) {
-        return 0;
-    }
-
-    return (_MAV_PAYLOAD(&message))[meta->target_system_ofs];
-}
-
-uint8_t get_target_component_id(const mavlink_message_t& message)
-{
-    // Checks whether connection knows target system ID by extracting target system if set.
-    const mavlink_msg_entry_t* meta = mavlink_get_msg_entry(message.msgid);
-
-    if (meta == nullptr || !(meta->flags & MAV_MSG_ENTRY_FLAG_HAVE_TARGET_COMPONENT)) {
-        return 0;
-    }
-
-    // Don't look at the target component offset if it is outside the payload length.
-    // This can happen if the fields are trimmed.
-    if (meta->target_component_ofs >= message.len) {
-        return 0;
-    }
-
-    return (_MAV_PAYLOAD(&message))[meta->target_component_ofs];
-}
-
 TEST(SystemTest, FtpDownloadBurstStopAndTryAgain)
 {
     constexpr int file_size = 1000;

--- a/src/system_tests/ftp_download_file_burst.cpp
+++ b/src/system_tests/ftp_download_file_burst.cpp
@@ -209,7 +209,7 @@ TEST(SystemTest, FtpDownloadBurstBigFileLossy)
 
 TEST(SystemTest, FtpDownloadBurstStopAndTryAgain)
 {
-    ASSERT_TRUE(create_temp_file(temp_dir_provided / temp_file, 5000));
+    ASSERT_TRUE(create_temp_file(temp_dir_provided / temp_file, 1000));
     ASSERT_TRUE(reset_directories(temp_dir_downloaded));
 
     Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
@@ -219,8 +219,8 @@ TEST(SystemTest, FtpDownloadBurstStopAndTryAgain)
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     // Once we received half, we want to stop all traffic.
-    bool got_enough = false;
-    auto drop_at_some_point = [&got_enough](mavlink_message_t&) { return !got_enough; };
+    bool got_half = false;
+    auto drop_at_some_point = [&got_half](mavlink_message_t&) { return !got_half; };
 
     mavsdk_groundstation.intercept_incoming_messages_async(drop_at_some_point);
     mavsdk_groundstation.intercept_outgoing_messages_async(drop_at_some_point);
@@ -247,9 +247,9 @@ TEST(SystemTest, FtpDownloadBurstStopAndTryAgain)
         ("" / temp_file).string(),
         temp_dir_downloaded.string(),
         true,
-        [&prom, &got_enough](Ftp::Result result, Ftp::ProgressData progress_data) {
+        [&prom, &got_half](Ftp::Result result, Ftp::ProgressData progress_data) {
             if (progress_data.bytes_transferred > 500) {
-                got_enough = true;
+                got_half = true;
             }
             if (result != Ftp::Result::Next) {
                 prom.set_value(result);


### PR DESCRIPTION
Currently, 100 packets are sent per second. With a 255 bytes payload, send rate is 25kB/s. With a thread, we use the line at its maximum speed.