### PR TITLE
[log_files] remove callback after get_entries

### DIFF
--- a/src/mavsdk/plugins/log_files/log_files_impl.cpp
+++ b/src/mavsdk/plugins/log_files/log_files_impl.cpp
@@ -110,7 +110,11 @@ std::pair<LogFiles::Result, std::vector<LogFiles::Entry>> LogFilesImpl::get_entr
         prom->set_value(std::make_pair<>(result, entries));
     });
 
-    return future_result.get();
+    auto result = future_result.get();
+
+    _entries_user_callback = nullptr;
+
+    return result;
 }
 
 void LogFilesImpl::get_entries_async(LogFiles::GetEntriesCallback callback)


### PR DESCRIPTION
This fixes an future/promise exception which causes a crash. This would occur if you clicked "Refresh" in the QGC Log Download menu while MAVSDK is running on another system. 