### PR TITLE
core: another workaround for winch

### DIFF
--- a/src/mavsdk/core/mavlink_command_sender.cpp
+++ b/src/mavsdk/core/mavlink_command_sender.cpp
@@ -158,11 +158,12 @@ void MavlinkCommandSender::receive_command_ack(mavlink_message_t message)
         // Currently, the gripper/winch sends the ack with source sysid/compid 1/1 instead of 1/169.
         // Until that's fixed, we ignore the component ID for any commands going to the winch.
         const bool compid_exception =
-            (work->identification.target_component_id == MAV_COMP_ID_WINCH);
+            (work->identification.target_component_id == MAV_COMP_ID_WINCH) ||
+            (work->identification.target_component_id == 69);
 
         if (work->identification.command != command_ack.command ||
             (work->identification.target_system_id != 0 &&
-             work->identification.target_system_id != message.sysid) ||
+             work->identification.target_system_id != message.sysid && !compid_exception) ||
             (work->identification.target_component_id != 0 &&
              work->identification.target_component_id != message.compid && !compid_exception)) {
             if (_command_debugging) {


### PR DESCRIPTION
It looks like the Watts winch reel has either on component 169 or 69.

Also, it sends back acks to 255/0 instead of where it actually came from.