### PR TITLE
Updated smart battery example to use non deprecated code

### DIFF
--- a/examples/battery/battery.cpp
+++ b/examples/battery/battery.cpp
@@ -57,7 +57,7 @@ int main(int argc, char** argv)
     auto telemetry = Telemetry{system};
     auto mavlink_passthrough = MavlinkPassthrough{system};
 
-    //Subscribe to armed status messages.
+    // Subscribe to armed status messages.
     //You can test this on SITL using MAVProxy by typing "arm throttle" and "disarm throttle".
     subscribe_armed(telemetry);
 


### PR DESCRIPTION
The smart battery example was not working as it depended on code sections of that were deprecated.
The example was updated to use the new available methods and constructors.