### PR TITLE
gimbal: mutex fixes and added env variable for v2

### DIFF
--- a/src/mavsdk/plugins/gimbal/gimbal_impl.h
+++ b/src/mavsdk/plugins/gimbal/gimbal_impl.h
@@ -67,10 +67,10 @@ public:
     const GimbalImpl& operator=(const GimbalImpl&) = delete;
 
 private:
+    void request_gimbal_information();
+
     void receive_attitude_update(Gimbal::Attitude attitude);
     void receive_control_status_update(Gimbal::ControlStatus control_status);
-
-    std::unique_ptr<GimbalProtocolBase> _gimbal_protocol{nullptr};
 
     void* _protocol_cookie{nullptr};
 
@@ -80,6 +80,7 @@ private:
     void process_gimbal_manager_information(const mavlink_message_t& message);
 
     std::mutex _mutex{};
+    std::unique_ptr<GimbalProtocolBase> _gimbal_protocol{nullptr};
     CallbackList<Gimbal::ControlStatus> _control_subscriptions{};
     CallbackList<Gimbal::Attitude> _attitude_subscriptions{};
 };


### PR DESCRIPTION
- Make sure that _gimbal_protocol is also protected by the mutex.
- Add MAVSDK_FORCE_GIMBAL_V2 to force usage of the gimbal v2 protocol and prevent the fallback to gimbal v1. This helps when we don't immediately detect all the components.
- Keep trying to request the GIMBAL_MANAGER_INFORMATION message.

With MAVSDK v3, I want to remove support for gimbal v1, it's just a pain.