### PR TITLE
add arm64-lts docker workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -235,6 +235,9 @@ jobs:
     strategy:
       matrix:
         arch_name: [armv6, armv7, arm64, arm64-lts]
+        include:
+          - arch_name: arm64-lts
+            rename_distro: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -255,6 +258,11 @@ jobs:
         run: ./dockcross-linux-${{ matrix.arch_name }}-custom cmake --build build/linux-${{ matrix.arch_name }} -j2 --target install
       - name: create deb packages
         run: ./dockcross-linux-${{ matrix.arch_name }}-custom tools/create_packages.sh ./build/linux-${{ matrix.arch_name }}/install . ${{ matrix.arch_name }} libmavsdk-dev
+      - if: ${{ matrix.rename_distro }}
+        name: Rename LTS versions from debian12 to debian11
+        run: |
+          sudo apt update && sudo apt install -y rename
+          rename 's/debian12_arm64/debian11_arm64/' *.deb
       - name: Publish artefacts
         if: startsWith(github.ref, 'refs/tags/v')
         uses: svenstaro/upload-release-action@v1-release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -234,7 +234,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        arch_name: [armv6, armv7, arm64]
+        arch_name: [armv6, armv7, arm64, arm64-lts]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docker/Dockerfile.dockcross-linux-arm64-lts-custom
+++ b/docker/Dockerfile.dockcross-linux-arm64-lts-custom
@@ -1,0 +1,6 @@
+FROM dockcross/linux-arm64-lts
+
+ENV DEFAULT_DOCKCROSS_IMAGE mavsdk/mavsdk-dockcross-linux-arm64-lts-custom
+
+RUN apt install rubygems -y
+RUN gem install fpm

--- a/docker/build_and_push_docker_images.sh
+++ b/docker/build_and_push_docker_images.sh
@@ -14,8 +14,10 @@ $DOCKER_CMD build -f Dockerfile-dev -t mavsdk/mavsdk-dev .
 $DOCKER_CMD build -f Dockerfile.dockcross-linux-armv6-custom -t mavsdk/mavsdk-dockcross-linux-armv6-custom .
 $DOCKER_CMD build -f Dockerfile.dockcross-linux-armv7-custom -t mavsdk/mavsdk-dockcross-linux-armv7-custom .
 $DOCKER_CMD build -f Dockerfile.dockcross-linux-arm64-custom -t mavsdk/mavsdk-dockcross-linux-arm64-custom .
+$DOCKER_CMD build -f Dockerfile.dockcross-linux-arm64-lts-custom -t mavsdk/mavsdk-dockcross-linux-arm64-lts-custom .
 
 $DOCKER_CMD push mavsdk/mavsdk-dev:latest
 $DOCKER_CMD push mavsdk/mavsdk-dockcross-linux-armv6-custom:latest
 $DOCKER_CMD push mavsdk/mavsdk-dockcross-linux-armv7-custom:latest
 $DOCKER_CMD push mavsdk/mavsdk-dockcross-linux-arm64-custom:latest
+$DOCKER_CMD push mavsdk/mavsdk-dockcross-linux-arm64-lts-custom:latest


### PR DESCRIPTION
This is an attempt to add an arm64-lts target which is needed on Jetson Jetpack 5.