### PR TITLE
action: ignore InProgress updates

### DIFF
--- a/src/mavsdk/plugins/action/action_impl.cpp
+++ b/src/mavsdk/plugins/action/action_impl.cpp
@@ -831,6 +831,11 @@ Action::Result ActionImpl::action_result_from_command_result(MavlinkCommandSende
 void ActionImpl::command_result_callback(
     MavlinkCommandSender::Result command_result, const Action::ResultCallback& callback) const
 {
+    if (command_result == MavlinkCommandSender::Result::InProgress) {
+        // We only want to return once, so we can't call the callback on progress updates.
+        return;
+    }
+
     Action::Result action_result = action_result_from_command_result(command_result);
 
     if (callback) {


### PR DESCRIPTION
We can't call the callback more than once, otherwise we segfault with "promise already satisfied".

Fixes #2319 