### PR TITLE
CI: remote -lts from filename

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -266,7 +266,7 @@ jobs:
         name: Rename LTS versions from debian12 to debian11
         run: |
           sudo apt update && sudo apt install -y rename
-          rename 's/debian12_arm64/debian11_arm64/' *.deb
+          rename 's/debian12_arm64-lts/debian11_arm64/' *.deb
       - name: Publish artefacts
         if: startsWith(github.ref, 'refs/tags/v')
         uses: svenstaro/upload-release-action@v1-release


### PR DESCRIPTION
We don't need it, we already call have debian11 vs debian12.