### PR TITLE
ftp: split list_directory response

### DIFF
--- a/src/mavsdk/core/mavlink_ftp_client.cpp
+++ b/src/mavsdk/core/mavlink_ftp_client.cpp
@@ -167,7 +167,7 @@ void MavlinkFtpClient::process_mavlink_ftp_message(const mavlink_message_t& msg)
                     } else if (payload->req_opcode == CMD_TERMINATE_SESSION) {
                         stop_timer();
                         item.ofstream.close();
-                        call_callback(item.callback, ClientResult::Success, {});
+                        item.callback(ClientResult::Success, {});
                         work_queue_guard.pop_front();
 
                     } else {
@@ -176,7 +176,7 @@ void MavlinkFtpClient::process_mavlink_ftp_message(const mavlink_message_t& msg)
 
                 } else if (payload->opcode == RSP_NAK) {
                     stop_timer();
-                    call_callback(item.callback, result_from_nak(payload), {});
+                    item.callback(result_from_nak(payload), {});
                     terminate_session(*work);
                     work_queue_guard.pop_front();
                 }
@@ -197,7 +197,7 @@ void MavlinkFtpClient::process_mavlink_ftp_message(const mavlink_message_t& msg)
                     } else if (payload->req_opcode == CMD_TERMINATE_SESSION) {
                         stop_timer();
                         item.ofstream.close();
-                        call_callback(item.callback, ClientResult::Success, {});
+                        item.callback(ClientResult::Success, {});
                         work_queue_guard.pop_front();
 
                     } else {
@@ -215,7 +215,7 @@ void MavlinkFtpClient::process_mavlink_ftp_message(const mavlink_message_t& msg)
                     } else {
                         LogWarn() << "FTP: NAK received";
                         stop_timer();
-                        call_callback(item.callback, result_from_nak(payload), {});
+                        item.callback(result_from_nak(payload), {});
                         terminate_session(*work);
                         work_queue_guard.pop_front();
                     }
@@ -237,7 +237,7 @@ void MavlinkFtpClient::process_mavlink_ftp_message(const mavlink_message_t& msg)
                     } else if (payload->req_opcode == CMD_TERMINATE_SESSION) {
                         stop_timer();
                         item.ifstream.close();
-                        call_callback(item.callback, ClientResult::Success, {});
+                        item.callback(ClientResult::Success, {});
                         work_queue_guard.pop_front();
 
                     } else {
@@ -246,7 +246,7 @@ void MavlinkFtpClient::process_mavlink_ftp_message(const mavlink_message_t& msg)
 
                 } else if (payload->opcode == RSP_NAK) {
                     stop_timer();
-                    call_callback(item.callback, result_from_nak(payload), {});
+                    item.callback(result_from_nak(payload), {});
                     terminate_session(*work);
                     work_queue_guard.pop_front();
                 }
@@ -255,7 +255,7 @@ void MavlinkFtpClient::process_mavlink_ftp_message(const mavlink_message_t& msg)
                 if (payload->opcode == RSP_ACK) {
                     if (payload->req_opcode == CMD_REMOVE_FILE) {
                         stop_timer();
-                        call_callback(item.callback, ClientResult::Success);
+                        item.callback(ClientResult::Success);
                         work_queue_guard.pop_front();
 
                     } else {
@@ -264,7 +264,7 @@ void MavlinkFtpClient::process_mavlink_ftp_message(const mavlink_message_t& msg)
 
                 } else if (payload->opcode == RSP_NAK) {
                     stop_timer();
-                    call_callback(item.callback, result_from_nak(payload));
+                    item.callback(result_from_nak(payload));
                     terminate_session(*work);
                     work_queue_guard.pop_front();
                 }
@@ -273,7 +273,7 @@ void MavlinkFtpClient::process_mavlink_ftp_message(const mavlink_message_t& msg)
                 if (payload->opcode == RSP_ACK) {
                     if (payload->req_opcode == CMD_RENAME) {
                         stop_timer();
-                        call_callback(item.callback, ClientResult::Success);
+                        item.callback(ClientResult::Success);
                         work_queue_guard.pop_front();
 
                     } else {
@@ -282,7 +282,7 @@ void MavlinkFtpClient::process_mavlink_ftp_message(const mavlink_message_t& msg)
 
                 } else if (payload->opcode == RSP_NAK) {
                     stop_timer();
-                    call_callback(item.callback, result_from_nak(payload));
+                    item.callback(result_from_nak(payload));
                     terminate_session(*work);
                     work_queue_guard.pop_front();
                 }
@@ -291,7 +291,7 @@ void MavlinkFtpClient::process_mavlink_ftp_message(const mavlink_message_t& msg)
                 if (payload->opcode == RSP_ACK) {
                     if (payload->req_opcode == CMD_CREATE_DIRECTORY) {
                         stop_timer();
-                        call_callback(item.callback, ClientResult::Success);
+                        item.callback(ClientResult::Success);
                         work_queue_guard.pop_front();
 
                     } else {
@@ -300,7 +300,7 @@ void MavlinkFtpClient::process_mavlink_ftp_message(const mavlink_message_t& msg)
 
                 } else if (payload->opcode == RSP_NAK) {
                     stop_timer();
-                    call_callback(item.callback, result_from_nak(payload));
+                    item.callback(result_from_nak(payload));
                     terminate_session(*work);
                     work_queue_guard.pop_front();
                 }
@@ -309,7 +309,7 @@ void MavlinkFtpClient::process_mavlink_ftp_message(const mavlink_message_t& msg)
                 if (payload->opcode == RSP_ACK) {
                     if (payload->req_opcode == CMD_REMOVE_DIRECTORY) {
                         stop_timer();
-                        call_callback(item.callback, ClientResult::Success);
+                        item.callback(ClientResult::Success);
                         work_queue_guard.pop_front();
 
                     } else {
@@ -318,7 +318,7 @@ void MavlinkFtpClient::process_mavlink_ftp_message(const mavlink_message_t& msg)
 
                 } else if (payload->opcode == RSP_NAK) {
                     stop_timer();
-                    call_callback(item.callback, result_from_nak(payload));
+                    item.callback(result_from_nak(payload));
                     terminate_session(*work);
                     work_queue_guard.pop_front();
                 }
@@ -328,8 +328,7 @@ void MavlinkFtpClient::process_mavlink_ftp_message(const mavlink_message_t& msg)
                     if (payload->req_opcode == CMD_CALC_FILE_CRC32) {
                         stop_timer();
                         uint32_t remote_crc = *reinterpret_cast<uint32_t*>(payload->data);
-                        call_callback(
-                            item.callback, ClientResult::Success, remote_crc == item.local_crc);
+                        item.callback(ClientResult::Success, remote_crc == item.local_crc);
                         work_queue_guard.pop_front();
 
                     } else {
@@ -338,7 +337,7 @@ void MavlinkFtpClient::process_mavlink_ftp_message(const mavlink_message_t& msg)
 
                 } else if (payload->opcode == RSP_NAK) {
                     stop_timer();
-                    call_callback(item.callback, result_from_nak(payload), false);
+                    item.callback(result_from_nak(payload), false);
                     terminate_session(*work);
                     work_queue_guard.pop_front();
                 }
@@ -361,9 +360,9 @@ void MavlinkFtpClient::process_mavlink_ftp_message(const mavlink_message_t& msg)
                     stop_timer();
                     if (payload->data[0] == ERR_EOF) {
                         std::sort(item.dirs.begin(), item.dirs.end());
-                        call_callback(item.callback, ClientResult::Success, item.dirs);
+                        item.callback(ClientResult::Success, item.dirs);
                     } else {
-                        call_callback(item.callback, result_from_nak(payload), {});
+                        item.callback(result_from_nak(payload), {});
                     }
                     terminate_session(*work);
                     work_queue_guard.pop_front();
@@ -385,7 +384,7 @@ bool MavlinkFtpClient::download_start(Work& work, DownloadItem& item)
     item.ofstream.open(local_path, std::fstream::trunc | std::fstream::binary);
     if (!item.ofstream) {
         LogErr() << "Could not open it!";
-        call_callback(item.callback, ClientResult::FileIoError, {});
+        item.callback(ClientResult::FileIoError, {});
         return false;
     }
 
@@ -422,7 +421,7 @@ bool MavlinkFtpClient::download_continue(Work& work, DownloadItem& item, Payload
         if (item.bytes_transferred < item.file_size) {
             item.ofstream.write(reinterpret_cast<const char*>(payload->data), payload->size);
             if (!item.ofstream) {
-                call_callback(item.callback, ClientResult::FileIoError, {});
+                item.callback(ClientResult::FileIoError, {});
                 return false;
             }
             item.bytes_transferred += payload->size;
@@ -432,8 +431,7 @@ bool MavlinkFtpClient::download_continue(Work& work, DownloadItem& item, Payload
                            << " bytes";
             }
         }
-        call_callback(
-            item.callback,
+        item.callback(
             ClientResult::Next,
             ProgressData{
                 static_cast<uint32_t>(item.bytes_transferred),
@@ -484,7 +482,7 @@ bool MavlinkFtpClient::download_burst_start(Work& work, DownloadBurstItem& item)
     item.ofstream.open(local_path, std::fstream::trunc | std::fstream::binary);
     if (!item.ofstream) {
         LogErr() << "Could not open it!";
-        call_callback(item.callback, ClientResult::FileIoError, {});
+        item.callback(ClientResult::FileIoError, {});
         return false;
     }
 
@@ -539,7 +537,7 @@ bool MavlinkFtpClient::download_burst_continue(
             item.ofstream.write(empty.data(), empty.size());
             if (!item.ofstream) {
                 LogWarn() << "Write failed";
-                call_callback(item.callback, ClientResult::FileIoError, {});
+                item.callback(ClientResult::FileIoError, {});
                 download_burst_end(work);
                 return false;
             }
@@ -549,7 +547,7 @@ bool MavlinkFtpClient::download_burst_continue(
         item.ofstream.write(reinterpret_cast<const char*>(payload->data), payload->size);
         if (!item.ofstream) {
             LogWarn() << "Write failed";
-            call_callback(item.callback, ClientResult::FileIoError, {});
+            item.callback(ClientResult::FileIoError, {});
             download_burst_end(work);
             return false;
         }
@@ -578,8 +576,7 @@ bool MavlinkFtpClient::download_burst_continue(
                 request_next_rest(work, item);
             }
         } else {
-            call_callback(
-                item.callback,
+            item.callback(
                 ClientResult::Next,
                 ProgressData{
                     static_cast<uint32_t>(burst_bytes_transferred(item)),
@@ -603,14 +600,14 @@ bool MavlinkFtpClient::download_burst_continue(
         item.ofstream.seekp(payload->offset);
         if (item.ofstream.fail()) {
             LogWarn() << "Seek failed";
-            call_callback(item.callback, ClientResult::FileIoError, {});
+            item.callback(ClientResult::FileIoError, {});
             download_burst_end(work);
             return false;
         }
 
         item.ofstream.write(reinterpret_cast<const char*>(payload->data), payload->size);
         if (!item.ofstream) {
-            call_callback(item.callback, ClientResult::FileIoError, {});
+            item.callback(ClientResult::FileIoError, {});
             download_burst_end(work);
             return false;
         }
@@ -618,7 +615,7 @@ bool MavlinkFtpClient::download_burst_continue(
         auto& missing = item.missing_data.front();
         if (missing.offset != payload->offset) {
             LogErr() << "Offset mismatch";
-            call_callback(item.callback, ClientResult::ProtocolError, {});
+            item.callback(ClientResult::ProtocolError, {});
             download_burst_end(work);
             return false;
         }
@@ -646,8 +643,7 @@ bool MavlinkFtpClient::download_burst_continue(
             // Final step
             download_burst_end(work);
         } else {
-            call_callback(
-                item.callback,
+            item.callback(
                 ClientResult::Next,
                 ProgressData{
                     static_cast<uint32_t>(bytes_transferred),
@@ -736,13 +732,13 @@ bool MavlinkFtpClient::upload_start(Work& work, UploadItem& item)
 {
     std::error_code ec;
     if (!fs::exists(item.local_file_path, ec)) {
-        call_callback(item.callback, ClientResult::FileDoesNotExist, {});
+        item.callback(ClientResult::FileDoesNotExist, {});
         return false;
     }
 
     item.ifstream.open(item.local_file_path, std::fstream::binary);
     if (!item.ifstream) {
-        call_callback(item.callback, ClientResult::FileIoError, {});
+        item.callback(ClientResult::FileIoError, {});
         return false;
     }
 
@@ -757,7 +753,7 @@ bool MavlinkFtpClient::upload_start(Work& work, UploadItem& item)
         fs::path(item.remote_folder) / fs::path(item.local_file_path).filename();
 
     if (remote_file_path.string().size() >= max_data_length) {
-        call_callback(item.callback, ClientResult::InvalidParameter, {});
+        item.callback(ClientResult::InvalidParameter, {});
         return false;
     }
 
@@ -800,7 +796,7 @@ bool MavlinkFtpClient::upload_continue(Work& work, UploadItem& item)
         int bytes_read = item.ifstream.gcount();
 
         if (!item.ifstream) {
-            call_callback(item.callback, ClientResult::FileIoError, {});
+            item.callback(ClientResult::FileIoError, {});
             return false;
         }
 
@@ -826,8 +822,7 @@ bool MavlinkFtpClient::upload_continue(Work& work, UploadItem& item)
         send_mavlink_ftp_message(work.payload, work.target_compid);
     }
 
-    call_callback(
-        item.callback,
+    item.callback(
         ClientResult::Next,
         ProgressData{
             static_cast<uint32_t>(item.bytes_transferred), static_cast<uint32_t>(item.file_size)});
@@ -838,7 +833,7 @@ bool MavlinkFtpClient::upload_continue(Work& work, UploadItem& item)
 bool MavlinkFtpClient::remove_start(Work& work, RemoveItem& item)
 {
     if (item.path.length() >= max_data_length) {
-        call_callback(item.callback, ClientResult::InvalidParameter);
+        item.callback(ClientResult::InvalidParameter);
         return false;
     }
 
@@ -860,7 +855,7 @@ bool MavlinkFtpClient::remove_start(Work& work, RemoveItem& item)
 bool MavlinkFtpClient::rename_start(Work& work, RenameItem& item)
 {
     if (item.from_path.length() + item.to_path.length() + 1 >= max_data_length) {
-        call_callback(item.callback, ClientResult::InvalidParameter);
+        item.callback(ClientResult::InvalidParameter);
         return false;
     }
 
@@ -888,7 +883,7 @@ bool MavlinkFtpClient::rename_start(Work& work, RenameItem& item)
 bool MavlinkFtpClient::create_dir_start(Work& work, CreateDirItem& item)
 {
     if (item.path.length() + 1 >= max_data_length) {
-        call_callback(item.callback, ClientResult::InvalidParameter);
+        item.callback(ClientResult::InvalidParameter);
         return false;
     }
 
@@ -910,7 +905,7 @@ bool MavlinkFtpClient::create_dir_start(Work& work, CreateDirItem& item)
 bool MavlinkFtpClient::remove_dir_start(Work& work, RemoveDirItem& item)
 {
     if (item.path.length() + 1 >= max_data_length) {
-        call_callback(item.callback, ClientResult::InvalidParameter);
+        item.callback(ClientResult::InvalidParameter);
         return false;
     }
 
@@ -932,13 +927,13 @@ bool MavlinkFtpClient::remove_dir_start(Work& work, RemoveDirItem& item)
 bool MavlinkFtpClient::compare_files_start(Work& work, CompareFilesItem& item)
 {
     if (item.remote_path.length() + 1 >= max_data_length) {
-        call_callback(item.callback, ClientResult::InvalidParameter, false);
+        item.callback(ClientResult::InvalidParameter, false);
         return false;
     }
 
     auto result_local = calc_local_file_crc32(item.local_path, item.local_crc);
     if (result_local != ClientResult::Success) {
-        call_callback(item.callback, result_local, false);
+        item.callback(result_local, false);
         return false;
     }
 
@@ -961,7 +956,7 @@ bool MavlinkFtpClient::compare_files_start(Work& work, CompareFilesItem& item)
 bool MavlinkFtpClient::list_dir_start(Work& work, ListDirItem& item)
 {
     if (item.path.length() + 1 >= max_data_length) {
-        call_callback(item.callback, ClientResult::InvalidParameter, {});
+        item.callback(ClientResult::InvalidParameter, {});
         return false;
     }
 
@@ -993,7 +988,7 @@ bool MavlinkFtpClient::list_dir_continue(Work& work, ListDirItem& item, PayloadH
 
     if (payload->size == 0) {
         std::sort(item.dirs.begin(), item.dirs.end());
-        call_callback(item.callback, ClientResult::Success, item.dirs);
+        item.callback(ClientResult::Success, item.dirs);
         return false;
     }
 
@@ -1220,7 +1215,7 @@ void MavlinkFtpClient::timeout()
         overloaded{
             [&](DownloadItem& item) {
                 if (--work->retries == 0) {
-                    call_callback(item.callback, ClientResult::Timeout, {});
+                    item.callback(ClientResult::Timeout, {});
                     work_queue_guard.pop_front();
                     return;
                 }
@@ -1233,7 +1228,7 @@ void MavlinkFtpClient::timeout()
             },
             [&](DownloadBurstItem& item) {
                 if (--work->retries == 0) {
-                    call_callback(item.callback, ClientResult::Timeout, {});
+                    item.callback(ClientResult::Timeout, {});
                     work_queue_guard.pop_front();
                     return;
                 }
@@ -1250,7 +1245,7 @@ void MavlinkFtpClient::timeout()
                         if (item.current_offset == item.file_size && item.missing_data.empty()) {
                             // We are done anyway.
                             item.ofstream.close();
-                            call_callback(item.callback, ClientResult::Success, {});
+                            item.callback(ClientResult::Success, {});
                             download_burst_end(*work);
                             work_queue_guard.pop_front();
                         } else {
@@ -1277,7 +1272,7 @@ void MavlinkFtpClient::timeout()
             },
             [&](UploadItem& item) {
                 if (--work->retries == 0) {
-                    call_callback(item.callback, ClientResult::Timeout, {});
+                    item.callback(ClientResult::Timeout, {});
                     work_queue_guard.pop_front();
                     return;
                 }
@@ -1290,7 +1285,7 @@ void MavlinkFtpClient::timeout()
             },
             [&](RemoveItem& item) {
                 if (--work->retries == 0) {
-                    call_callback(item.callback, ClientResult::Timeout);
+                    item.callback(ClientResult::Timeout);
                     work_queue_guard.pop_front();
                     return;
                 }
@@ -1303,7 +1298,7 @@ void MavlinkFtpClient::timeout()
             },
             [&](RenameItem& item) {
                 if (--work->retries == 0) {
-                    call_callback(item.callback, ClientResult::Timeout);
+                    item.callback(ClientResult::Timeout);
                     work_queue_guard.pop_front();
                     return;
                 }
@@ -1316,7 +1311,7 @@ void MavlinkFtpClient::timeout()
             },
             [&](CreateDirItem& item) {
                 if (--work->retries == 0) {
-                    call_callback(item.callback, ClientResult::Timeout);
+                    item.callback(ClientResult::Timeout);
                     work_queue_guard.pop_front();
                     return;
                 }
@@ -1329,7 +1324,7 @@ void MavlinkFtpClient::timeout()
             },
             [&](RemoveDirItem& item) {
                 if (--work->retries == 0) {
-                    call_callback(item.callback, ClientResult::Timeout);
+                    item.callback(ClientResult::Timeout);
                     work_queue_guard.pop_front();
                     return;
                 }
@@ -1342,7 +1337,7 @@ void MavlinkFtpClient::timeout()
             },
             [&](CompareFilesItem& item) {
                 if (--work->retries == 0) {
-                    call_callback(item.callback, ClientResult::Timeout, false);
+                    item.callback(ClientResult::Timeout, false);
                     work_queue_guard.pop_front();
                     return;
                 }
@@ -1355,7 +1350,7 @@ void MavlinkFtpClient::timeout()
             },
             [&](ListDirItem& item) {
                 if (--work->retries == 0) {
-                    call_callback(item.callback, ClientResult::Timeout, {});
+                    item.callback(ClientResult::Timeout, {});
                     work_queue_guard.pop_front();
                     return;
                 }
@@ -1464,22 +1459,4 @@ std::ostream& operator<<(std::ostream& str, MavlinkFtpClient::ClientResult const
     }
 }
 
-template<typename CallbackT>
-void MavlinkFtpClient::call_callback(
-    const CallbackT& callback,
-    MavlinkFtpClient::ClientResult result,
-    const typename CallbackT::second_argument_type& extra_arg)
-{
-    _system_impl.call_user_callback(
-        [temp_callback = callback, temp_result = result, temp_extra_arg = extra_arg]() {
-            temp_callback(temp_result, temp_extra_arg);
-        });
-}
-template<typename CallbackT>
-void MavlinkFtpClient::call_callback(
-    const CallbackT& callback, MavlinkFtpClient::ClientResult result)
-{
-    _system_impl.call_user_callback(
-        [temp_callback = callback, temp_result = result]() { temp_callback(temp_result); });
-}
 } // namespace mavsdk

--- a/src/mavsdk/core/mavlink_ftp_client.h
+++ b/src/mavsdk/core/mavlink_ftp_client.h
@@ -299,13 +299,6 @@ private:
 
     void terminate_session(Work& work);
 
-    template<typename CallbackT> void call_callback(const CallbackT& callback, ClientResult result);
-    template<typename CallbackT>
-    void call_callback(
-        const CallbackT& callback,
-        ClientResult result,
-        const typename CallbackT::second_argument_type& extra_arg);
-
     static ClientResult result_from_nak(PayloadHeader* payload);
 
     void timeout();

--- a/src/mavsdk/core/mavlink_ftp_client.h
+++ b/src/mavsdk/core/mavlink_ftp_client.h
@@ -62,7 +62,8 @@ public:
     using ResultCallback = std::function<void(ClientResult)>;
     using UploadCallback = std::function<void(ClientResult, ProgressData)>;
     using DownloadCallback = std::function<void(ClientResult, ProgressData)>;
-    using ListDirectoryCallback = std::function<void(ClientResult, std::vector<std::string>)>;
+    using ListDirectoryCallback =
+        std::function<void(ClientResult, std::vector<std::string>, std::vector<std::string>)>;
     using AreFilesIdenticalCallback = std::function<void(ClientResult, bool)>;
 
     void do_work();
@@ -206,6 +207,7 @@ private:
         ListDirectoryCallback callback{};
         uint32_t offset{0};
         std::vector<std::string> dirs{};
+        std::vector<std::string> files{};
     };
 
     using Item = std::variant<

--- a/src/mavsdk/plugins/ftp/ftp.cpp
+++ b/src/mavsdk/plugins/ftp/ftp.cpp
@@ -9,6 +9,7 @@
 
 namespace mavsdk {
 
+using ListDirectoryData = Ftp::ListDirectoryData;
 using ProgressData = Ftp::ProgressData;
 
 Ftp::Ftp(System& system) : PluginBase(), _impl{std::make_unique<FtpImpl>(system)} {}
@@ -37,7 +38,7 @@ void Ftp::list_directory_async(std::string remote_dir, const ListDirectoryCallba
     _impl->list_directory_async(remote_dir, callback);
 }
 
-std::pair<Ftp::Result, std::vector<std::string>> Ftp::list_directory(std::string remote_dir) const
+std::pair<Ftp::Result, Ftp::ListDirectoryData> Ftp::list_directory(std::string remote_dir) const
 {
     return _impl->list_directory(remote_dir);
 }
@@ -100,6 +101,29 @@ Ftp::are_files_identical(std::string local_file_path, std::string remote_file_pa
 Ftp::Result Ftp::set_target_compid(uint32_t compid) const
 {
     return _impl->set_target_compid(compid);
+}
+
+bool operator==(const Ftp::ListDirectoryData& lhs, const Ftp::ListDirectoryData& rhs)
+{
+    return (rhs.dirs == lhs.dirs) && (rhs.files == lhs.files);
+}
+
+std::ostream& operator<<(std::ostream& str, Ftp::ListDirectoryData const& list_directory_data)
+{
+    str << std::setprecision(15);
+    str << "list_directory_data:" << '\n' << "{\n";
+    str << "    dirs: [";
+    for (auto it = list_directory_data.dirs.begin(); it != list_directory_data.dirs.end(); ++it) {
+        str << *it;
+        str << (it + 1 != list_directory_data.dirs.end() ? ", " : "]\n");
+    }
+    str << "    files: [";
+    for (auto it = list_directory_data.files.begin(); it != list_directory_data.files.end(); ++it) {
+        str << *it;
+        str << (it + 1 != list_directory_data.files.end() ? ", " : "]\n");
+    }
+    str << '}';
+    return str;
 }
 
 bool operator==(const Ftp::ProgressData& lhs, const Ftp::ProgressData& rhs)

--- a/src/mavsdk/plugins/ftp/ftp_impl.h
+++ b/src/mavsdk/plugins/ftp/ftp_impl.h
@@ -25,7 +25,7 @@ public:
     void enable() override;
     void disable() override;
 
-    std::pair<Ftp::Result, std::vector<std::string>> list_directory(const std::string& path);
+    std::pair<Ftp::Result, Ftp::ListDirectoryData> list_directory(const std::string& path);
     Ftp::Result create_directory(const std::string& path);
     Ftp::Result remove_directory(const std::string& path);
     Ftp::Result remove_file(const std::string& path);

--- a/src/mavsdk/plugins/ftp/include/plugins/ftp/ftp.h
+++ b/src/mavsdk/plugins/ftp/include/plugins/ftp/ftp.h
@@ -59,6 +59,29 @@ public:
     ~Ftp() override;
 
     /**
+     * @brief
+     */
+    struct ListDirectoryData {
+        std::vector<std::string> dirs{}; /**< @brief The found directories. */
+        std::vector<std::string> files{}; /**< @brief The found files. */
+    };
+
+    /**
+     * @brief Equal operator to compare two `Ftp::ListDirectoryData` objects.
+     *
+     * @return `true` if items are equal.
+     */
+    friend bool operator==(const Ftp::ListDirectoryData& lhs, const Ftp::ListDirectoryData& rhs);
+
+    /**
+     * @brief Stream operator to print information about a `Ftp::ListDirectoryData`.
+     *
+     * @return A reference to the stream.
+     */
+    friend std::ostream&
+    operator<<(std::ostream& str, Ftp::ListDirectoryData const& list_directory_data);
+
+    /**
      * @brief Progress data type for file transfer.
      */
     struct ProgressData {
@@ -139,7 +162,7 @@ public:
     /**
      * @brief Callback type for list_directory_async.
      */
-    using ListDirectoryCallback = std::function<void(Result, std::vector<std::string>)>;
+    using ListDirectoryCallback = std::function<void(Result, ListDirectoryData)>;
 
     /**
      * @brief Lists items from a remote directory.
@@ -155,7 +178,7 @@ public:
      *
      * @return Result of request.
      */
-    std::pair<Result, std::vector<std::string>> list_directory(std::string remote_dir) const;
+    std::pair<Result, Ftp::ListDirectoryData> list_directory(std::string remote_dir) const;
 
     /**
      * @brief Creates a remote directory.

--- a/src/mavsdk_server/src/generated/ftp/ftp.pb.cc
+++ b/src/mavsdk_server/src/generated/ftp/ftp.pb.cc
@@ -199,6 +199,26 @@ struct ListDirectoryRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ListDirectoryRequestDefaultTypeInternal _ListDirectoryRequest_default_instance_;
 
+inline constexpr ListDirectoryData::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : dirs_{},
+        files_{},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR ListDirectoryData::ListDirectoryData(::_pbi::ConstantInitialized)
+    : _impl_(::_pbi::ConstantInitialized()) {}
+struct ListDirectoryDataDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR ListDirectoryDataDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~ListDirectoryDataDefaultTypeInternal() {}
+  union {
+    ListDirectoryData _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ListDirectoryDataDefaultTypeInternal _ListDirectoryData_default_instance_;
+
 inline constexpr FtpResult::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : result_str_(
@@ -365,8 +385,8 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
 inline constexpr ListDirectoryResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : _cached_size_{0},
-        paths_{},
-        ftp_result_{nullptr} {}
+        ftp_result_{nullptr},
+        data_{nullptr} {}
 
 template <typename>
 PROTOBUF_CONSTEXPR ListDirectoryResponse::ListDirectoryResponse(::_pbi::ConstantInitialized)
@@ -443,7 +463,7 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
 }  // namespace ftp
 }  // namespace rpc
 }  // namespace mavsdk
-static ::_pb::Metadata file_level_metadata_ftp_2fftp_2eproto[20];
+static ::_pb::Metadata file_level_metadata_ftp_2fftp_2eproto[21];
 static const ::_pb::EnumDescriptor* file_level_enum_descriptors_ftp_2fftp_2eproto[1];
 static constexpr const ::_pb::ServiceDescriptor**
     file_level_service_descriptors_ftp_2fftp_2eproto = nullptr;
@@ -503,6 +523,16 @@ const ::uint32_t TableStruct_ftp_2fftp_2eproto::offsets[] PROTOBUF_SECTION_VARIA
     ~0u,  // no _split_
     ~0u,  // no sizeof(Split)
     PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::ftp::ListDirectoryRequest, _impl_.remote_dir_),
+    ~0u,  // no _has_bits_
+    PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::ftp::ListDirectoryData, _internal_metadata_),
+    ~0u,  // no _extensions_
+    ~0u,  // no _oneof_case_
+    ~0u,  // no _weak_field_map_
+    ~0u,  // no _inlined_string_donated_
+    ~0u,  // no _split_
+    ~0u,  // no sizeof(Split)
+    PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::ftp::ListDirectoryData, _impl_.dirs_),
+    PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::ftp::ListDirectoryData, _impl_.files_),
     PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::ftp::ListDirectoryResponse, _impl_._has_bits_),
     PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::ftp::ListDirectoryResponse, _internal_metadata_),
     ~0u,  // no _extensions_
@@ -512,9 +542,9 @@ const ::uint32_t TableStruct_ftp_2fftp_2eproto::offsets[] PROTOBUF_SECTION_VARIA
     ~0u,  // no _split_
     ~0u,  // no sizeof(Split)
     PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::ftp::ListDirectoryResponse, _impl_.ftp_result_),
-    PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::ftp::ListDirectoryResponse, _impl_.paths_),
+    PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::ftp::ListDirectoryResponse, _impl_.data_),
     0,
-    ~0u,
+    1,
     ~0u,  // no _has_bits_
     PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::ftp::CreateDirectoryRequest, _internal_metadata_),
     ~0u,  // no _extensions_
@@ -662,21 +692,22 @@ static const ::_pbi::MigrationSchema
         {23, -1, -1, sizeof(::mavsdk::rpc::ftp::SubscribeUploadRequest)},
         {33, 43, -1, sizeof(::mavsdk::rpc::ftp::UploadResponse)},
         {45, -1, -1, sizeof(::mavsdk::rpc::ftp::ListDirectoryRequest)},
-        {54, 64, -1, sizeof(::mavsdk::rpc::ftp::ListDirectoryResponse)},
-        {66, -1, -1, sizeof(::mavsdk::rpc::ftp::CreateDirectoryRequest)},
-        {75, 84, -1, sizeof(::mavsdk::rpc::ftp::CreateDirectoryResponse)},
-        {85, -1, -1, sizeof(::mavsdk::rpc::ftp::RemoveDirectoryRequest)},
-        {94, 103, -1, sizeof(::mavsdk::rpc::ftp::RemoveDirectoryResponse)},
-        {104, -1, -1, sizeof(::mavsdk::rpc::ftp::RemoveFileRequest)},
-        {113, 122, -1, sizeof(::mavsdk::rpc::ftp::RemoveFileResponse)},
-        {123, -1, -1, sizeof(::mavsdk::rpc::ftp::RenameRequest)},
-        {133, 142, -1, sizeof(::mavsdk::rpc::ftp::RenameResponse)},
-        {143, -1, -1, sizeof(::mavsdk::rpc::ftp::AreFilesIdenticalRequest)},
-        {153, 163, -1, sizeof(::mavsdk::rpc::ftp::AreFilesIdenticalResponse)},
-        {165, -1, -1, sizeof(::mavsdk::rpc::ftp::SetTargetCompidRequest)},
-        {174, 183, -1, sizeof(::mavsdk::rpc::ftp::SetTargetCompidResponse)},
-        {184, -1, -1, sizeof(::mavsdk::rpc::ftp::ProgressData)},
-        {194, -1, -1, sizeof(::mavsdk::rpc::ftp::FtpResult)},
+        {54, -1, -1, sizeof(::mavsdk::rpc::ftp::ListDirectoryData)},
+        {64, 74, -1, sizeof(::mavsdk::rpc::ftp::ListDirectoryResponse)},
+        {76, -1, -1, sizeof(::mavsdk::rpc::ftp::CreateDirectoryRequest)},
+        {85, 94, -1, sizeof(::mavsdk::rpc::ftp::CreateDirectoryResponse)},
+        {95, -1, -1, sizeof(::mavsdk::rpc::ftp::RemoveDirectoryRequest)},
+        {104, 113, -1, sizeof(::mavsdk::rpc::ftp::RemoveDirectoryResponse)},
+        {114, -1, -1, sizeof(::mavsdk::rpc::ftp::RemoveFileRequest)},
+        {123, 132, -1, sizeof(::mavsdk::rpc::ftp::RemoveFileResponse)},
+        {133, -1, -1, sizeof(::mavsdk::rpc::ftp::RenameRequest)},
+        {143, 152, -1, sizeof(::mavsdk::rpc::ftp::RenameResponse)},
+        {153, -1, -1, sizeof(::mavsdk::rpc::ftp::AreFilesIdenticalRequest)},
+        {163, 173, -1, sizeof(::mavsdk::rpc::ftp::AreFilesIdenticalResponse)},
+        {175, -1, -1, sizeof(::mavsdk::rpc::ftp::SetTargetCompidRequest)},
+        {184, 193, -1, sizeof(::mavsdk::rpc::ftp::SetTargetCompidResponse)},
+        {194, -1, -1, sizeof(::mavsdk::rpc::ftp::ProgressData)},
+        {204, -1, -1, sizeof(::mavsdk::rpc::ftp::FtpResult)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
@@ -685,6 +716,7 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::ftp::_SubscribeUploadRequest_default_instance_._instance,
     &::mavsdk::rpc::ftp::_UploadResponse_default_instance_._instance,
     &::mavsdk::rpc::ftp::_ListDirectoryRequest_default_instance_._instance,
+    &::mavsdk::rpc::ftp::_ListDirectoryData_default_instance_._instance,
     &::mavsdk::rpc::ftp::_ListDirectoryResponse_default_instance_._instance,
     &::mavsdk::rpc::ftp::_CreateDirectoryRequest_default_instance_._instance,
     &::mavsdk::rpc::ftp::_CreateDirectoryResponse_default_instance_._instance,
@@ -714,64 +746,66 @@ const char descriptor_table_protodef_ftp_2fftp_2eproto[] PROTOBUF_SECTION_VARIAB
     "p_result\030\001 \001(\0132\031.mavsdk.rpc.ftp.FtpResul"
     "t\0223\n\rprogress_data\030\002 \001(\0132\034.mavsdk.rpc.ft"
     "p.ProgressData\"*\n\024ListDirectoryRequest\022\022"
-    "\n\nremote_dir\030\001 \001(\t\"U\n\025ListDirectoryRespo"
-    "nse\022-\n\nftp_result\030\001 \001(\0132\031.mavsdk.rpc.ftp"
-    ".FtpResult\022\r\n\005paths\030\002 \003(\t\",\n\026CreateDirec"
-    "toryRequest\022\022\n\nremote_dir\030\001 \001(\t\"H\n\027Creat"
-    "eDirectoryResponse\022-\n\nftp_result\030\001 \001(\0132\031"
-    ".mavsdk.rpc.ftp.FtpResult\",\n\026RemoveDirec"
-    "toryRequest\022\022\n\nremote_dir\030\001 \001(\t\"H\n\027Remov"
-    "eDirectoryResponse\022-\n\nftp_result\030\001 \001(\0132\031"
-    ".mavsdk.rpc.ftp.FtpResult\"-\n\021RemoveFileR"
-    "equest\022\030\n\020remote_file_path\030\001 \001(\t\"C\n\022Remo"
-    "veFileResponse\022-\n\nftp_result\030\001 \001(\0132\031.mav"
-    "sdk.rpc.ftp.FtpResult\"A\n\rRenameRequest\022\030"
-    "\n\020remote_from_path\030\001 \001(\t\022\026\n\016remote_to_pa"
-    "th\030\002 \001(\t\"\?\n\016RenameResponse\022-\n\nftp_result"
-    "\030\001 \001(\0132\031.mavsdk.rpc.ftp.FtpResult\"M\n\030Are"
-    "FilesIdenticalRequest\022\027\n\017local_file_path"
-    "\030\001 \001(\t\022\030\n\020remote_file_path\030\002 \001(\t\"a\n\031AreF"
-    "ilesIdenticalResponse\022-\n\nftp_result\030\001 \001("
-    "\0132\031.mavsdk.rpc.ftp.FtpResult\022\025\n\rare_iden"
-    "tical\030\002 \001(\010\"(\n\026SetTargetCompidRequest\022\016\n"
-    "\006compid\030\001 \001(\r\"H\n\027SetTargetCompidResponse"
-    "\022-\n\nftp_result\030\001 \001(\0132\031.mavsdk.rpc.ftp.Ft"
-    "pResult\">\n\014ProgressData\022\031\n\021bytes_transfe"
-    "rred\030\001 \001(\r\022\023\n\013total_bytes\030\002 \001(\r\"\216\003\n\tFtpR"
-    "esult\0220\n\006result\030\001 \001(\0162 .mavsdk.rpc.ftp.F"
-    "tpResult.Result\022\022\n\nresult_str\030\002 \001(\t\"\272\002\n\006"
-    "Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESULT_SUC"
-    "CESS\020\001\022\017\n\013RESULT_NEXT\020\002\022\022\n\016RESULT_TIMEOU"
-    "T\020\003\022\017\n\013RESULT_BUSY\020\004\022\030\n\024RESULT_FILE_IO_E"
-    "RROR\020\005\022\026\n\022RESULT_FILE_EXISTS\020\006\022\036\n\032RESULT"
-    "_FILE_DOES_NOT_EXIST\020\007\022\031\n\025RESULT_FILE_PR"
-    "OTECTED\020\010\022\034\n\030RESULT_INVALID_PARAMETER\020\t\022"
-    "\026\n\022RESULT_UNSUPPORTED\020\n\022\031\n\025RESULT_PROTOC"
-    "OL_ERROR\020\013\022\024\n\020RESULT_NO_SYSTEM\020\0142\204\007\n\nFtp"
-    "Service\022k\n\021SubscribeDownload\022(.mavsdk.rp"
-    "c.ftp.SubscribeDownloadRequest\032 .mavsdk."
-    "rpc.ftp.DownloadResponse\"\010\200\265\030\000\210\265\030\0010\001\022e\n\017"
-    "SubscribeUpload\022&.mavsdk.rpc.ftp.Subscri"
-    "beUploadRequest\032\036.mavsdk.rpc.ftp.UploadR"
-    "esponse\"\010\200\265\030\000\210\265\030\0010\001\022^\n\rListDirectory\022$.m"
-    "avsdk.rpc.ftp.ListDirectoryRequest\032%.mav"
-    "sdk.rpc.ftp.ListDirectoryResponse\"\000\022d\n\017C"
-    "reateDirectory\022&.mavsdk.rpc.ftp.CreateDi"
-    "rectoryRequest\032\'.mavsdk.rpc.ftp.CreateDi"
-    "rectoryResponse\"\000\022d\n\017RemoveDirectory\022&.m"
-    "avsdk.rpc.ftp.RemoveDirectoryRequest\032\'.m"
-    "avsdk.rpc.ftp.RemoveDirectoryResponse\"\000\022"
-    "U\n\nRemoveFile\022!.mavsdk.rpc.ftp.RemoveFil"
-    "eRequest\032\".mavsdk.rpc.ftp.RemoveFileResp"
-    "onse\"\000\022I\n\006Rename\022\035.mavsdk.rpc.ftp.Rename"
-    "Request\032\036.mavsdk.rpc.ftp.RenameResponse\""
-    "\000\022j\n\021AreFilesIdentical\022(.mavsdk.rpc.ftp."
-    "AreFilesIdenticalRequest\032).mavsdk.rpc.ft"
-    "p.AreFilesIdenticalResponse\"\000\022h\n\017SetTarg"
-    "etCompid\022&.mavsdk.rpc.ftp.SetTargetCompi"
-    "dRequest\032\'.mavsdk.rpc.ftp.SetTargetCompi"
-    "dResponse\"\004\200\265\030\001B\031\n\rio.mavsdk.ftpB\010FtpPro"
-    "tob\006proto3"
+    "\n\nremote_dir\030\001 \001(\t\"0\n\021ListDirectoryData\022"
+    "\014\n\004dirs\030\001 \003(\t\022\r\n\005files\030\002 \003(\t\"w\n\025ListDire"
+    "ctoryResponse\022-\n\nftp_result\030\001 \001(\0132\031.mavs"
+    "dk.rpc.ftp.FtpResult\022/\n\004data\030\002 \001(\0132!.mav"
+    "sdk.rpc.ftp.ListDirectoryData\",\n\026CreateD"
+    "irectoryRequest\022\022\n\nremote_dir\030\001 \001(\t\"H\n\027C"
+    "reateDirectoryResponse\022-\n\nftp_result\030\001 \001"
+    "(\0132\031.mavsdk.rpc.ftp.FtpResult\",\n\026RemoveD"
+    "irectoryRequest\022\022\n\nremote_dir\030\001 \001(\t\"H\n\027R"
+    "emoveDirectoryResponse\022-\n\nftp_result\030\001 \001"
+    "(\0132\031.mavsdk.rpc.ftp.FtpResult\"-\n\021RemoveF"
+    "ileRequest\022\030\n\020remote_file_path\030\001 \001(\t\"C\n\022"
+    "RemoveFileResponse\022-\n\nftp_result\030\001 \001(\0132\031"
+    ".mavsdk.rpc.ftp.FtpResult\"A\n\rRenameReque"
+    "st\022\030\n\020remote_from_path\030\001 \001(\t\022\026\n\016remote_t"
+    "o_path\030\002 \001(\t\"\?\n\016RenameResponse\022-\n\nftp_re"
+    "sult\030\001 \001(\0132\031.mavsdk.rpc.ftp.FtpResult\"M\n"
+    "\030AreFilesIdenticalRequest\022\027\n\017local_file_"
+    "path\030\001 \001(\t\022\030\n\020remote_file_path\030\002 \001(\t\"a\n\031"
+    "AreFilesIdenticalResponse\022-\n\nftp_result\030"
+    "\001 \001(\0132\031.mavsdk.rpc.ftp.FtpResult\022\025\n\rare_"
+    "identical\030\002 \001(\010\"(\n\026SetTargetCompidReques"
+    "t\022\016\n\006compid\030\001 \001(\r\"H\n\027SetTargetCompidResp"
+    "onse\022-\n\nftp_result\030\001 \001(\0132\031.mavsdk.rpc.ft"
+    "p.FtpResult\">\n\014ProgressData\022\031\n\021bytes_tra"
+    "nsferred\030\001 \001(\r\022\023\n\013total_bytes\030\002 \001(\r\"\216\003\n\t"
+    "FtpResult\0220\n\006result\030\001 \001(\0162 .mavsdk.rpc.f"
+    "tp.FtpResult.Result\022\022\n\nresult_str\030\002 \001(\t\""
+    "\272\002\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESULT"
+    "_SUCCESS\020\001\022\017\n\013RESULT_NEXT\020\002\022\022\n\016RESULT_TI"
+    "MEOUT\020\003\022\017\n\013RESULT_BUSY\020\004\022\030\n\024RESULT_FILE_"
+    "IO_ERROR\020\005\022\026\n\022RESULT_FILE_EXISTS\020\006\022\036\n\032RE"
+    "SULT_FILE_DOES_NOT_EXIST\020\007\022\031\n\025RESULT_FIL"
+    "E_PROTECTED\020\010\022\034\n\030RESULT_INVALID_PARAMETE"
+    "R\020\t\022\026\n\022RESULT_UNSUPPORTED\020\n\022\031\n\025RESULT_PR"
+    "OTOCOL_ERROR\020\013\022\024\n\020RESULT_NO_SYSTEM\020\0142\204\007\n"
+    "\nFtpService\022k\n\021SubscribeDownload\022(.mavsd"
+    "k.rpc.ftp.SubscribeDownloadRequest\032 .mav"
+    "sdk.rpc.ftp.DownloadResponse\"\010\200\265\030\000\210\265\030\0010\001"
+    "\022e\n\017SubscribeUpload\022&.mavsdk.rpc.ftp.Sub"
+    "scribeUploadRequest\032\036.mavsdk.rpc.ftp.Upl"
+    "oadResponse\"\010\200\265\030\000\210\265\030\0010\001\022^\n\rListDirectory"
+    "\022$.mavsdk.rpc.ftp.ListDirectoryRequest\032%"
+    ".mavsdk.rpc.ftp.ListDirectoryResponse\"\000\022"
+    "d\n\017CreateDirectory\022&.mavsdk.rpc.ftp.Crea"
+    "teDirectoryRequest\032\'.mavsdk.rpc.ftp.Crea"
+    "teDirectoryResponse\"\000\022d\n\017RemoveDirectory"
+    "\022&.mavsdk.rpc.ftp.RemoveDirectoryRequest"
+    "\032\'.mavsdk.rpc.ftp.RemoveDirectoryRespons"
+    "e\"\000\022U\n\nRemoveFile\022!.mavsdk.rpc.ftp.Remov"
+    "eFileRequest\032\".mavsdk.rpc.ftp.RemoveFile"
+    "Response\"\000\022I\n\006Rename\022\035.mavsdk.rpc.ftp.Re"
+    "nameRequest\032\036.mavsdk.rpc.ftp.RenameRespo"
+    "nse\"\000\022j\n\021AreFilesIdentical\022(.mavsdk.rpc."
+    "ftp.AreFilesIdenticalRequest\032).mavsdk.rp"
+    "c.ftp.AreFilesIdenticalResponse\"\000\022h\n\017Set"
+    "TargetCompid\022&.mavsdk.rpc.ftp.SetTargetC"
+    "ompidRequest\032\'.mavsdk.rpc.ftp.SetTargetC"
+    "ompidResponse\"\004\200\265\030\001B\031\n\rio.mavsdk.ftpB\010Ft"
+    "pProtob\006proto3"
 };
 static const ::_pbi::DescriptorTable* const descriptor_table_ftp_2fftp_2eproto_deps[1] =
     {
@@ -781,13 +815,13 @@ static ::absl::once_flag descriptor_table_ftp_2fftp_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_ftp_2fftp_2eproto = {
     false,
     false,
-    2770,
+    2854,
     descriptor_table_protodef_ftp_2fftp_2eproto,
     "ftp/ftp.proto",
     &descriptor_table_ftp_2fftp_2eproto_once,
     descriptor_table_ftp_2fftp_2eproto_deps,
     1,
-    20,
+    21,
     schemas,
     file_default_instances,
     TableStruct_ftp_2fftp_2eproto::offsets,
@@ -2029,6 +2063,217 @@ void ListDirectoryRequest::InternalSwap(ListDirectoryRequest* PROTOBUF_RESTRICT 
 }
 // ===================================================================
 
+class ListDirectoryData::_Internal {
+ public:
+};
+
+ListDirectoryData::ListDirectoryData(::google::protobuf::Arena* arena)
+    : ::google::protobuf::Message(arena) {
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.ftp.ListDirectoryData)
+}
+inline PROTOBUF_NDEBUG_INLINE ListDirectoryData::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from)
+      : dirs_{visibility, arena, from.dirs_},
+        files_{visibility, arena, from.files_},
+        _cached_size_{0} {}
+
+ListDirectoryData::ListDirectoryData(
+    ::google::protobuf::Arena* arena,
+    const ListDirectoryData& from)
+    : ::google::protobuf::Message(arena) {
+  ListDirectoryData* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_);
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.ftp.ListDirectoryData)
+}
+inline PROTOBUF_NDEBUG_INLINE ListDirectoryData::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : dirs_{visibility, arena},
+        files_{visibility, arena},
+        _cached_size_{0} {}
+
+inline void ListDirectoryData::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+}
+ListDirectoryData::~ListDirectoryData() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.ftp.ListDirectoryData)
+  _internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  SharedDtor();
+}
+inline void ListDirectoryData::SharedDtor() {
+  ABSL_DCHECK(GetArena() == nullptr);
+  _impl_.~Impl_();
+}
+
+PROTOBUF_NOINLINE void ListDirectoryData::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.ftp.ListDirectoryData)
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.dirs_.Clear();
+  _impl_.files_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+const char* ListDirectoryData::_InternalParse(
+    const char* ptr, ::_pbi::ParseContext* ctx) {
+  ptr = ::_pbi::TcParser::ParseLoop(this, ptr, ctx, &_table_.header);
+  return ptr;
+}
+
+
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<1, 2, 0, 50, 2> ListDirectoryData::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    2, 8,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967292,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    2,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    &_ListDirectoryData_default_instance_._instance,
+    ::_pbi::TcParser::GenericFallback,  // fallback
+  }, {{
+    // repeated string files = 2;
+    {::_pbi::TcParser::FastUR1,
+     {18, 63, 0, PROTOBUF_FIELD_OFFSET(ListDirectoryData, _impl_.files_)}},
+    // repeated string dirs = 1;
+    {::_pbi::TcParser::FastUR1,
+     {10, 63, 0, PROTOBUF_FIELD_OFFSET(ListDirectoryData, _impl_.dirs_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // repeated string dirs = 1;
+    {PROTOBUF_FIELD_OFFSET(ListDirectoryData, _impl_.dirs_), 0, 0,
+    (0 | ::_fl::kFcRepeated | ::_fl::kUtf8String | ::_fl::kRepSString)},
+    // repeated string files = 2;
+    {PROTOBUF_FIELD_OFFSET(ListDirectoryData, _impl_.files_), 0, 0,
+    (0 | ::_fl::kFcRepeated | ::_fl::kUtf8String | ::_fl::kRepSString)},
+  }},
+  // no aux_entries
+  {{
+    "\40\4\5\0\0\0\0\0"
+    "mavsdk.rpc.ftp.ListDirectoryData"
+    "dirs"
+    "files"
+  }},
+};
+
+::uint8_t* ListDirectoryData::_InternalSerialize(
+    ::uint8_t* target,
+    ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.ftp.ListDirectoryData)
+  ::uint32_t cached_has_bits = 0;
+  (void)cached_has_bits;
+
+  // repeated string dirs = 1;
+  for (int i = 0, n = this->_internal_dirs_size(); i < n; ++i) {
+    const auto& s = this->_internal_dirs().Get(i);
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+        s.data(), static_cast<int>(s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "mavsdk.rpc.ftp.ListDirectoryData.dirs");
+    target = stream->WriteString(1, s, target);
+  }
+
+  // repeated string files = 2;
+  for (int i = 0, n = this->_internal_files_size(); i < n; ++i) {
+    const auto& s = this->_internal_files().Get(i);
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+        s.data(), static_cast<int>(s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "mavsdk.rpc.ftp.ListDirectoryData.files");
+    target = stream->WriteString(2, s, target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target =
+        ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+            _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.ftp.ListDirectoryData)
+  return target;
+}
+
+::size_t ListDirectoryData::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.ftp.ListDirectoryData)
+  ::size_t total_size = 0;
+
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated string dirs = 1;
+  total_size += 1 * ::google::protobuf::internal::FromIntSize(_internal_dirs().size());
+  for (int i = 0, n = _internal_dirs().size(); i < n; ++i) {
+    total_size += ::google::protobuf::internal::WireFormatLite::StringSize(
+        _internal_dirs().Get(i));
+  }
+  // repeated string files = 2;
+  total_size += 1 * ::google::protobuf::internal::FromIntSize(_internal_files().size());
+  for (int i = 0, n = _internal_files().size(); i < n; ++i) {
+    total_size += ::google::protobuf::internal::WireFormatLite::StringSize(
+        _internal_files().Get(i));
+  }
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::google::protobuf::Message::ClassData ListDirectoryData::_class_data_ = {
+    ListDirectoryData::MergeImpl,
+    nullptr,  // OnDemandRegisterArenaDtor
+};
+const ::google::protobuf::Message::ClassData* ListDirectoryData::GetClassData() const {
+  return &_class_data_;
+}
+
+void ListDirectoryData::MergeImpl(::google::protobuf::Message& to_msg, const ::google::protobuf::Message& from_msg) {
+  auto* const _this = static_cast<ListDirectoryData*>(&to_msg);
+  auto& from = static_cast<const ListDirectoryData&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.ftp.ListDirectoryData)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  _this->_internal_mutable_dirs()->MergeFrom(from._internal_dirs());
+  _this->_internal_mutable_files()->MergeFrom(from._internal_files());
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void ListDirectoryData::CopyFrom(const ListDirectoryData& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.ftp.ListDirectoryData)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+PROTOBUF_NOINLINE bool ListDirectoryData::IsInitialized() const {
+  return true;
+}
+
+::_pbi::CachedSize* ListDirectoryData::AccessCachedSize() const {
+  return &_impl_._cached_size_;
+}
+void ListDirectoryData::InternalSwap(ListDirectoryData* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  _impl_.dirs_.InternalSwap(&other->_impl_.dirs_);
+  _impl_.files_.InternalSwap(&other->_impl_.files_);
+}
+
+::google::protobuf::Metadata ListDirectoryData::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_ftp_2fftp_2eproto_getter, &descriptor_table_ftp_2fftp_2eproto_once,
+      file_level_metadata_ftp_2fftp_2eproto[5]);
+}
+// ===================================================================
+
 class ListDirectoryResponse::_Internal {
  public:
   using HasBits = decltype(std::declval<ListDirectoryResponse>()._impl_._has_bits_);
@@ -2038,10 +2283,17 @@ class ListDirectoryResponse::_Internal {
   static void set_has_ftp_result(HasBits* has_bits) {
     (*has_bits)[0] |= 1u;
   }
+  static const ::mavsdk::rpc::ftp::ListDirectoryData& data(const ListDirectoryResponse* msg);
+  static void set_has_data(HasBits* has_bits) {
+    (*has_bits)[0] |= 2u;
+  }
 };
 
 const ::mavsdk::rpc::ftp::FtpResult& ListDirectoryResponse::_Internal::ftp_result(const ListDirectoryResponse* msg) {
   return *msg->_impl_.ftp_result_;
+}
+const ::mavsdk::rpc::ftp::ListDirectoryData& ListDirectoryResponse::_Internal::data(const ListDirectoryResponse* msg) {
+  return *msg->_impl_.data_;
 }
 ListDirectoryResponse::ListDirectoryResponse(::google::protobuf::Arena* arena)
     : ::google::protobuf::Message(arena) {
@@ -2052,8 +2304,7 @@ inline PROTOBUF_NDEBUG_INLINE ListDirectoryResponse::Impl_::Impl_(
     ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
     const Impl_& from)
       : _has_bits_{from._has_bits_},
-        _cached_size_{0},
-        paths_{visibility, arena, from.paths_} {}
+        _cached_size_{0} {}
 
 ListDirectoryResponse::ListDirectoryResponse(
     ::google::protobuf::Arena* arena,
@@ -2068,18 +2319,25 @@ ListDirectoryResponse::ListDirectoryResponse(
   _impl_.ftp_result_ = (cached_has_bits & 0x00000001u)
                 ? CreateMaybeMessage<::mavsdk::rpc::ftp::FtpResult>(arena, *from._impl_.ftp_result_)
                 : nullptr;
+  _impl_.data_ = (cached_has_bits & 0x00000002u)
+                ? CreateMaybeMessage<::mavsdk::rpc::ftp::ListDirectoryData>(arena, *from._impl_.data_)
+                : nullptr;
 
   // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.ftp.ListDirectoryResponse)
 }
 inline PROTOBUF_NDEBUG_INLINE ListDirectoryResponse::Impl_::Impl_(
     ::google::protobuf::internal::InternalVisibility visibility,
     ::google::protobuf::Arena* arena)
-      : _cached_size_{0},
-        paths_{visibility, arena} {}
+      : _cached_size_{0} {}
 
 inline void ListDirectoryResponse::SharedCtor(::_pb::Arena* arena) {
   new (&_impl_) Impl_(internal_visibility(), arena);
-  _impl_.ftp_result_ = {};
+  ::memset(reinterpret_cast<char *>(&_impl_) +
+               offsetof(Impl_, ftp_result_),
+           0,
+           offsetof(Impl_, data_) -
+               offsetof(Impl_, ftp_result_) +
+               sizeof(Impl_::data_));
 }
 ListDirectoryResponse::~ListDirectoryResponse() {
   // @@protoc_insertion_point(destructor:mavsdk.rpc.ftp.ListDirectoryResponse)
@@ -2089,6 +2347,7 @@ ListDirectoryResponse::~ListDirectoryResponse() {
 inline void ListDirectoryResponse::SharedDtor() {
   ABSL_DCHECK(GetArena() == nullptr);
   delete _impl_.ftp_result_;
+  delete _impl_.data_;
   _impl_.~Impl_();
 }
 
@@ -2099,11 +2358,16 @@ PROTOBUF_NOINLINE void ListDirectoryResponse::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  _impl_.paths_.Clear();
   cached_has_bits = _impl_._has_bits_[0];
-  if (cached_has_bits & 0x00000001u) {
-    ABSL_DCHECK(_impl_.ftp_result_ != nullptr);
-    _impl_.ftp_result_->Clear();
+  if (cached_has_bits & 0x00000003u) {
+    if (cached_has_bits & 0x00000001u) {
+      ABSL_DCHECK(_impl_.ftp_result_ != nullptr);
+      _impl_.ftp_result_->Clear();
+    }
+    if (cached_has_bits & 0x00000002u) {
+      ABSL_DCHECK(_impl_.data_ != nullptr);
+      _impl_.data_->Clear();
+    }
   }
   _impl_._has_bits_.Clear();
   _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
@@ -2117,7 +2381,7 @@ const char* ListDirectoryResponse::_InternalParse(
 
 
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<1, 2, 1, 50, 2> ListDirectoryResponse::_table_ = {
+const ::_pbi::TcParseTable<1, 2, 2, 0, 2> ListDirectoryResponse::_table_ = {
   {
     PROTOBUF_FIELD_OFFSET(ListDirectoryResponse, _impl_._has_bits_),
     0, // no _extensions_
@@ -2126,14 +2390,14 @@ const ::_pbi::TcParseTable<1, 2, 1, 50, 2> ListDirectoryResponse::_table_ = {
     4294967292,  // skipmap
     offsetof(decltype(_table_), field_entries),
     2,  // num_field_entries
-    1,  // num_aux_entries
+    2,  // num_aux_entries
     offsetof(decltype(_table_), aux_entries),
     &_ListDirectoryResponse_default_instance_._instance,
     ::_pbi::TcParser::GenericFallback,  // fallback
   }, {{
-    // repeated string paths = 2;
-    {::_pbi::TcParser::FastUR1,
-     {18, 63, 0, PROTOBUF_FIELD_OFFSET(ListDirectoryResponse, _impl_.paths_)}},
+    // .mavsdk.rpc.ftp.ListDirectoryData data = 2;
+    {::_pbi::TcParser::FastMtS1,
+     {18, 1, 1, PROTOBUF_FIELD_OFFSET(ListDirectoryResponse, _impl_.data_)}},
     // .mavsdk.rpc.ftp.FtpResult ftp_result = 1;
     {::_pbi::TcParser::FastMtS1,
      {10, 0, 0, PROTOBUF_FIELD_OFFSET(ListDirectoryResponse, _impl_.ftp_result_)}},
@@ -2143,15 +2407,13 @@ const ::_pbi::TcParseTable<1, 2, 1, 50, 2> ListDirectoryResponse::_table_ = {
     // .mavsdk.rpc.ftp.FtpResult ftp_result = 1;
     {PROTOBUF_FIELD_OFFSET(ListDirectoryResponse, _impl_.ftp_result_), _Internal::kHasBitsOffset + 0, 0,
     (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
-    // repeated string paths = 2;
-    {PROTOBUF_FIELD_OFFSET(ListDirectoryResponse, _impl_.paths_), -1, 0,
-    (0 | ::_fl::kFcRepeated | ::_fl::kUtf8String | ::_fl::kRepSString)},
+    // .mavsdk.rpc.ftp.ListDirectoryData data = 2;
+    {PROTOBUF_FIELD_OFFSET(ListDirectoryResponse, _impl_.data_), _Internal::kHasBitsOffset + 1, 1,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
   }}, {{
     {::_pbi::TcParser::GetTable<::mavsdk::rpc::ftp::FtpResult>()},
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::ftp::ListDirectoryData>()},
   }}, {{
-    "\44\0\5\0\0\0\0\0"
-    "mavsdk.rpc.ftp.ListDirectoryResponse"
-    "paths"
   }},
 };
 
@@ -2170,12 +2432,11 @@ const ::_pbi::TcParseTable<1, 2, 1, 50, 2> ListDirectoryResponse::_table_ = {
         _Internal::ftp_result(this).GetCachedSize(), target, stream);
   }
 
-  // repeated string paths = 2;
-  for (int i = 0, n = this->_internal_paths_size(); i < n; ++i) {
-    const auto& s = this->_internal_paths().Get(i);
-    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
-        s.data(), static_cast<int>(s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "mavsdk.rpc.ftp.ListDirectoryResponse.paths");
-    target = stream->WriteString(2, s, target);
+  // .mavsdk.rpc.ftp.ListDirectoryData data = 2;
+  if (cached_has_bits & 0x00000002u) {
+    target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+        2, _Internal::data(this),
+        _Internal::data(this).GetCachedSize(), target, stream);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -2195,19 +2456,21 @@ const ::_pbi::TcParseTable<1, 2, 1, 50, 2> ListDirectoryResponse::_table_ = {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  // repeated string paths = 2;
-  total_size += 1 * ::google::protobuf::internal::FromIntSize(_internal_paths().size());
-  for (int i = 0, n = _internal_paths().size(); i < n; ++i) {
-    total_size += ::google::protobuf::internal::WireFormatLite::StringSize(
-        _internal_paths().Get(i));
-  }
-  // .mavsdk.rpc.ftp.FtpResult ftp_result = 1;
   cached_has_bits = _impl_._has_bits_[0];
-  if (cached_has_bits & 0x00000001u) {
-    total_size +=
-        1 + ::google::protobuf::internal::WireFormatLite::MessageSize(*_impl_.ftp_result_);
-  }
+  if (cached_has_bits & 0x00000003u) {
+    // .mavsdk.rpc.ftp.FtpResult ftp_result = 1;
+    if (cached_has_bits & 0x00000001u) {
+      total_size +=
+          1 + ::google::protobuf::internal::WireFormatLite::MessageSize(*_impl_.ftp_result_);
+    }
 
+    // .mavsdk.rpc.ftp.ListDirectoryData data = 2;
+    if (cached_has_bits & 0x00000002u) {
+      total_size +=
+          1 + ::google::protobuf::internal::WireFormatLite::MessageSize(*_impl_.data_);
+    }
+
+  }
   return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
 }
 
@@ -2227,10 +2490,16 @@ void ListDirectoryResponse::MergeImpl(::google::protobuf::Message& to_msg, const
   ::uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
-  _this->_internal_mutable_paths()->MergeFrom(from._internal_paths());
-  if ((from._impl_._has_bits_[0] & 0x00000001u) != 0) {
-    _this->_internal_mutable_ftp_result()->::mavsdk::rpc::ftp::FtpResult::MergeFrom(
-        from._internal_ftp_result());
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    if (cached_has_bits & 0x00000001u) {
+      _this->_internal_mutable_ftp_result()->::mavsdk::rpc::ftp::FtpResult::MergeFrom(
+          from._internal_ftp_result());
+    }
+    if (cached_has_bits & 0x00000002u) {
+      _this->_internal_mutable_data()->::mavsdk::rpc::ftp::ListDirectoryData::MergeFrom(
+          from._internal_data());
+    }
   }
   _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
 }
@@ -2253,14 +2522,18 @@ void ListDirectoryResponse::InternalSwap(ListDirectoryResponse* PROTOBUF_RESTRIC
   using std::swap;
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
   swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
-  _impl_.paths_.InternalSwap(&other->_impl_.paths_);
-  swap(_impl_.ftp_result_, other->_impl_.ftp_result_);
+  ::google::protobuf::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(ListDirectoryResponse, _impl_.data_)
+      + sizeof(ListDirectoryResponse::_impl_.data_)
+      - PROTOBUF_FIELD_OFFSET(ListDirectoryResponse, _impl_.ftp_result_)>(
+          reinterpret_cast<char*>(&_impl_.ftp_result_),
+          reinterpret_cast<char*>(&other->_impl_.ftp_result_));
 }
 
 ::google::protobuf::Metadata ListDirectoryResponse::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_ftp_2fftp_2eproto_getter, &descriptor_table_ftp_2fftp_2eproto_once,
-      file_level_metadata_ftp_2fftp_2eproto[5]);
+      file_level_metadata_ftp_2fftp_2eproto[6]);
 }
 // ===================================================================
 
@@ -2450,7 +2723,7 @@ void CreateDirectoryRequest::InternalSwap(CreateDirectoryRequest* PROTOBUF_RESTR
 ::google::protobuf::Metadata CreateDirectoryRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_ftp_2fftp_2eproto_getter, &descriptor_table_ftp_2fftp_2eproto_once,
-      file_level_metadata_ftp_2fftp_2eproto[6]);
+      file_level_metadata_ftp_2fftp_2eproto[7]);
 }
 // ===================================================================
 
@@ -2657,7 +2930,7 @@ void CreateDirectoryResponse::InternalSwap(CreateDirectoryResponse* PROTOBUF_RES
 ::google::protobuf::Metadata CreateDirectoryResponse::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_ftp_2fftp_2eproto_getter, &descriptor_table_ftp_2fftp_2eproto_once,
-      file_level_metadata_ftp_2fftp_2eproto[7]);
+      file_level_metadata_ftp_2fftp_2eproto[8]);
 }
 // ===================================================================
 
@@ -2847,7 +3120,7 @@ void RemoveDirectoryRequest::InternalSwap(RemoveDirectoryRequest* PROTOBUF_RESTR
 ::google::protobuf::Metadata RemoveDirectoryRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_ftp_2fftp_2eproto_getter, &descriptor_table_ftp_2fftp_2eproto_once,
-      file_level_metadata_ftp_2fftp_2eproto[8]);
+      file_level_metadata_ftp_2fftp_2eproto[9]);
 }
 // ===================================================================
 
@@ -3054,7 +3327,7 @@ void RemoveDirectoryResponse::InternalSwap(RemoveDirectoryResponse* PROTOBUF_RES
 ::google::protobuf::Metadata RemoveDirectoryResponse::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_ftp_2fftp_2eproto_getter, &descriptor_table_ftp_2fftp_2eproto_once,
-      file_level_metadata_ftp_2fftp_2eproto[9]);
+      file_level_metadata_ftp_2fftp_2eproto[10]);
 }
 // ===================================================================
 
@@ -3244,7 +3517,7 @@ void RemoveFileRequest::InternalSwap(RemoveFileRequest* PROTOBUF_RESTRICT other)
 ::google::protobuf::Metadata RemoveFileRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_ftp_2fftp_2eproto_getter, &descriptor_table_ftp_2fftp_2eproto_once,
-      file_level_metadata_ftp_2fftp_2eproto[10]);
+      file_level_metadata_ftp_2fftp_2eproto[11]);
 }
 // ===================================================================
 
@@ -3451,7 +3724,7 @@ void RemoveFileResponse::InternalSwap(RemoveFileResponse* PROTOBUF_RESTRICT othe
 ::google::protobuf::Metadata RemoveFileResponse::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_ftp_2fftp_2eproto_getter, &descriptor_table_ftp_2fftp_2eproto_once,
-      file_level_metadata_ftp_2fftp_2eproto[11]);
+      file_level_metadata_ftp_2fftp_2eproto[12]);
 }
 // ===================================================================
 
@@ -3670,7 +3943,7 @@ void RenameRequest::InternalSwap(RenameRequest* PROTOBUF_RESTRICT other) {
 ::google::protobuf::Metadata RenameRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_ftp_2fftp_2eproto_getter, &descriptor_table_ftp_2fftp_2eproto_once,
-      file_level_metadata_ftp_2fftp_2eproto[12]);
+      file_level_metadata_ftp_2fftp_2eproto[13]);
 }
 // ===================================================================
 
@@ -3877,7 +4150,7 @@ void RenameResponse::InternalSwap(RenameResponse* PROTOBUF_RESTRICT other) {
 ::google::protobuf::Metadata RenameResponse::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_ftp_2fftp_2eproto_getter, &descriptor_table_ftp_2fftp_2eproto_once,
-      file_level_metadata_ftp_2fftp_2eproto[13]);
+      file_level_metadata_ftp_2fftp_2eproto[14]);
 }
 // ===================================================================
 
@@ -4096,7 +4369,7 @@ void AreFilesIdenticalRequest::InternalSwap(AreFilesIdenticalRequest* PROTOBUF_R
 ::google::protobuf::Metadata AreFilesIdenticalRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_ftp_2fftp_2eproto_getter, &descriptor_table_ftp_2fftp_2eproto_once,
-      file_level_metadata_ftp_2fftp_2eproto[14]);
+      file_level_metadata_ftp_2fftp_2eproto[15]);
 }
 // ===================================================================
 
@@ -4336,7 +4609,7 @@ void AreFilesIdenticalResponse::InternalSwap(AreFilesIdenticalResponse* PROTOBUF
 ::google::protobuf::Metadata AreFilesIdenticalResponse::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_ftp_2fftp_2eproto_getter, &descriptor_table_ftp_2fftp_2eproto_once,
-      file_level_metadata_ftp_2fftp_2eproto[15]);
+      file_level_metadata_ftp_2fftp_2eproto[16]);
 }
 // ===================================================================
 
@@ -4506,7 +4779,7 @@ void SetTargetCompidRequest::InternalSwap(SetTargetCompidRequest* PROTOBUF_RESTR
 ::google::protobuf::Metadata SetTargetCompidRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_ftp_2fftp_2eproto_getter, &descriptor_table_ftp_2fftp_2eproto_once,
-      file_level_metadata_ftp_2fftp_2eproto[16]);
+      file_level_metadata_ftp_2fftp_2eproto[17]);
 }
 // ===================================================================
 
@@ -4713,7 +4986,7 @@ void SetTargetCompidResponse::InternalSwap(SetTargetCompidResponse* PROTOBUF_RES
 ::google::protobuf::Metadata SetTargetCompidResponse::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_ftp_2fftp_2eproto_getter, &descriptor_table_ftp_2fftp_2eproto_once,
-      file_level_metadata_ftp_2fftp_2eproto[17]);
+      file_level_metadata_ftp_2fftp_2eproto[18]);
 }
 // ===================================================================
 
@@ -4917,7 +5190,7 @@ void ProgressData::InternalSwap(ProgressData* PROTOBUF_RESTRICT other) {
 ::google::protobuf::Metadata ProgressData::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_ftp_2fftp_2eproto_getter, &descriptor_table_ftp_2fftp_2eproto_once,
-      file_level_metadata_ftp_2fftp_2eproto[18]);
+      file_level_metadata_ftp_2fftp_2eproto[19]);
 }
 // ===================================================================
 
@@ -5133,7 +5406,7 @@ void FtpResult::InternalSwap(FtpResult* PROTOBUF_RESTRICT other) {
 ::google::protobuf::Metadata FtpResult::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_ftp_2fftp_2eproto_getter, &descriptor_table_ftp_2fftp_2eproto_once,
-      file_level_metadata_ftp_2fftp_2eproto[19]);
+      file_level_metadata_ftp_2fftp_2eproto[20]);
 }
 // @@protoc_insertion_point(namespace_scope)
 }  // namespace ftp

--- a/src/mavsdk_server/src/generated/ftp/ftp.pb.h
+++ b/src/mavsdk_server/src/generated/ftp/ftp.pb.h
@@ -78,6 +78,9 @@ extern DownloadResponseDefaultTypeInternal _DownloadResponse_default_instance_;
 class FtpResult;
 struct FtpResultDefaultTypeInternal;
 extern FtpResultDefaultTypeInternal _FtpResult_default_instance_;
+class ListDirectoryData;
+struct ListDirectoryDataDefaultTypeInternal;
+extern ListDirectoryDataDefaultTypeInternal _ListDirectoryData_default_instance_;
 class ListDirectoryRequest;
 struct ListDirectoryRequestDefaultTypeInternal;
 extern ListDirectoryRequestDefaultTypeInternal _ListDirectoryRequest_default_instance_;
@@ -650,7 +653,7 @@ class SetTargetCompidRequest final :
                &_SetTargetCompidRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    16;
+    17;
 
   friend void swap(SetTargetCompidRequest& a, SetTargetCompidRequest& b) {
     a.Swap(&b);
@@ -825,7 +828,7 @@ class RenameRequest final :
                &_RenameRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    12;
+    13;
 
   friend void swap(RenameRequest& a, RenameRequest& b) {
     a.Swap(&b);
@@ -1024,7 +1027,7 @@ class RemoveFileRequest final :
                &_RemoveFileRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    10;
+    11;
 
   friend void swap(RemoveFileRequest& a, RemoveFileRequest& b) {
     a.Swap(&b);
@@ -1205,7 +1208,7 @@ class RemoveDirectoryRequest final :
                &_RemoveDirectoryRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    8;
+    9;
 
   friend void swap(RemoveDirectoryRequest& a, RemoveDirectoryRequest& b) {
     a.Swap(&b);
@@ -1386,7 +1389,7 @@ class ProgressData final :
                &_ProgressData_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    18;
+    19;
 
   friend void swap(ProgressData& a, ProgressData& b) {
     a.Swap(&b);
@@ -1695,6 +1698,229 @@ class ListDirectoryRequest final :
   friend struct ::TableStruct_ftp_2fftp_2eproto;
 };// -------------------------------------------------------------------
 
+class ListDirectoryData final :
+    public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.ftp.ListDirectoryData) */ {
+ public:
+  inline ListDirectoryData() : ListDirectoryData(nullptr) {}
+  ~ListDirectoryData() override;
+  template<typename = void>
+  explicit PROTOBUF_CONSTEXPR ListDirectoryData(::google::protobuf::internal::ConstantInitialized);
+
+  inline ListDirectoryData(const ListDirectoryData& from)
+      : ListDirectoryData(nullptr, from) {}
+  ListDirectoryData(ListDirectoryData&& from) noexcept
+    : ListDirectoryData() {
+    *this = ::std::move(from);
+  }
+
+  inline ListDirectoryData& operator=(const ListDirectoryData& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ListDirectoryData& operator=(ListDirectoryData&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetArena() == from.GetArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const ListDirectoryData& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const ListDirectoryData* internal_default_instance() {
+    return reinterpret_cast<const ListDirectoryData*>(
+               &_ListDirectoryData_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    5;
+
+  friend void swap(ListDirectoryData& a, ListDirectoryData& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(ListDirectoryData* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetArena() != nullptr &&
+        GetArena() == other->GetArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetArena() == other->GetArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ListDirectoryData* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  ListDirectoryData* New(::google::protobuf::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<ListDirectoryData>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const ListDirectoryData& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom( const ListDirectoryData& from) {
+    ListDirectoryData::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::google::protobuf::Message& to_msg, const ::google::protobuf::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  ::size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::google::protobuf::internal::ParseContext* ctx) final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target, ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  ::google::protobuf::internal::CachedSize* AccessCachedSize() const final;
+  void SharedCtor(::google::protobuf::Arena* arena);
+  void SharedDtor();
+  void InternalSwap(ListDirectoryData* other);
+
+  private:
+  friend class ::google::protobuf::internal::AnyMetadata;
+  static ::absl::string_view FullMessageName() {
+    return "mavsdk.rpc.ftp.ListDirectoryData";
+  }
+  protected:
+  explicit ListDirectoryData(::google::protobuf::Arena* arena);
+  ListDirectoryData(::google::protobuf::Arena* arena, const ListDirectoryData& from);
+  public:
+
+  static const ClassData _class_data_;
+  const ::google::protobuf::Message::ClassData*GetClassData() const final;
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kDirsFieldNumber = 1,
+    kFilesFieldNumber = 2,
+  };
+  // repeated string dirs = 1;
+  int dirs_size() const;
+  private:
+  int _internal_dirs_size() const;
+
+  public:
+  void clear_dirs() ;
+  const std::string& dirs(int index) const;
+  std::string* mutable_dirs(int index);
+  void set_dirs(int index, const std::string& value);
+  void set_dirs(int index, std::string&& value);
+  void set_dirs(int index, const char* value);
+  void set_dirs(int index, const char* value, std::size_t size);
+  void set_dirs(int index, absl::string_view value);
+  std::string* add_dirs();
+  void add_dirs(const std::string& value);
+  void add_dirs(std::string&& value);
+  void add_dirs(const char* value);
+  void add_dirs(const char* value, std::size_t size);
+  void add_dirs(absl::string_view value);
+  const ::google::protobuf::RepeatedPtrField<std::string>& dirs() const;
+  ::google::protobuf::RepeatedPtrField<std::string>* mutable_dirs();
+
+  private:
+  const ::google::protobuf::RepeatedPtrField<std::string>& _internal_dirs() const;
+  ::google::protobuf::RepeatedPtrField<std::string>* _internal_mutable_dirs();
+
+  public:
+  // repeated string files = 2;
+  int files_size() const;
+  private:
+  int _internal_files_size() const;
+
+  public:
+  void clear_files() ;
+  const std::string& files(int index) const;
+  std::string* mutable_files(int index);
+  void set_files(int index, const std::string& value);
+  void set_files(int index, std::string&& value);
+  void set_files(int index, const char* value);
+  void set_files(int index, const char* value, std::size_t size);
+  void set_files(int index, absl::string_view value);
+  std::string* add_files();
+  void add_files(const std::string& value);
+  void add_files(std::string&& value);
+  void add_files(const char* value);
+  void add_files(const char* value, std::size_t size);
+  void add_files(absl::string_view value);
+  const ::google::protobuf::RepeatedPtrField<std::string>& files() const;
+  ::google::protobuf::RepeatedPtrField<std::string>* mutable_files();
+
+  private:
+  const ::google::protobuf::RepeatedPtrField<std::string>& _internal_files() const;
+  ::google::protobuf::RepeatedPtrField<std::string>* _internal_mutable_files();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.ftp.ListDirectoryData)
+ private:
+  class _Internal;
+
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      1, 2, 0,
+      50, 2>
+      _table_;
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+
+        inline explicit constexpr Impl_(
+            ::google::protobuf::internal::ConstantInitialized) noexcept;
+        inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                              ::google::protobuf::Arena* arena);
+        inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                              ::google::protobuf::Arena* arena, const Impl_& from);
+    ::google::protobuf::RepeatedPtrField<std::string> dirs_;
+    ::google::protobuf::RepeatedPtrField<std::string> files_;
+    mutable ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_ftp_2fftp_2eproto;
+};// -------------------------------------------------------------------
+
 class FtpResult final :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.ftp.FtpResult) */ {
  public:
@@ -1754,7 +1980,7 @@ class FtpResult final :
                &_FtpResult_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    19;
+    20;
 
   friend void swap(FtpResult& a, FtpResult& b) {
     a.Swap(&b);
@@ -1978,7 +2204,7 @@ class CreateDirectoryRequest final :
                &_CreateDirectoryRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    6;
+    7;
 
   friend void swap(CreateDirectoryRequest& a, CreateDirectoryRequest& b) {
     a.Swap(&b);
@@ -2159,7 +2385,7 @@ class AreFilesIdenticalRequest final :
                &_AreFilesIdenticalRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    14;
+    15;
 
   friend void swap(AreFilesIdenticalRequest& a, AreFilesIdenticalRequest& b) {
     a.Swap(&b);
@@ -2556,7 +2782,7 @@ class SetTargetCompidResponse final :
                &_SetTargetCompidResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    17;
+    18;
 
   friend void swap(SetTargetCompidResponse& a, SetTargetCompidResponse& b) {
     a.Swap(&b);
@@ -2737,7 +2963,7 @@ class RenameResponse final :
                &_RenameResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    13;
+    14;
 
   friend void swap(RenameResponse& a, RenameResponse& b) {
     a.Swap(&b);
@@ -2918,7 +3144,7 @@ class RemoveFileResponse final :
                &_RemoveFileResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    11;
+    12;
 
   friend void swap(RemoveFileResponse& a, RemoveFileResponse& b) {
     a.Swap(&b);
@@ -3099,7 +3325,7 @@ class RemoveDirectoryResponse final :
                &_RemoveDirectoryResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    9;
+    10;
 
   friend void swap(RemoveDirectoryResponse& a, RemoveDirectoryResponse& b) {
     a.Swap(&b);
@@ -3280,7 +3506,7 @@ class ListDirectoryResponse final :
                &_ListDirectoryResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    5;
+    6;
 
   friend void swap(ListDirectoryResponse& a, ListDirectoryResponse& b) {
     a.Swap(&b);
@@ -3353,37 +3579,9 @@ class ListDirectoryResponse final :
   // accessors -------------------------------------------------------
 
   enum : int {
-    kPathsFieldNumber = 2,
     kFtpResultFieldNumber = 1,
+    kDataFieldNumber = 2,
   };
-  // repeated string paths = 2;
-  int paths_size() const;
-  private:
-  int _internal_paths_size() const;
-
-  public:
-  void clear_paths() ;
-  const std::string& paths(int index) const;
-  std::string* mutable_paths(int index);
-  void set_paths(int index, const std::string& value);
-  void set_paths(int index, std::string&& value);
-  void set_paths(int index, const char* value);
-  void set_paths(int index, const char* value, std::size_t size);
-  void set_paths(int index, absl::string_view value);
-  std::string* add_paths();
-  void add_paths(const std::string& value);
-  void add_paths(std::string&& value);
-  void add_paths(const char* value);
-  void add_paths(const char* value, std::size_t size);
-  void add_paths(absl::string_view value);
-  const ::google::protobuf::RepeatedPtrField<std::string>& paths() const;
-  ::google::protobuf::RepeatedPtrField<std::string>* mutable_paths();
-
-  private:
-  const ::google::protobuf::RepeatedPtrField<std::string>& _internal_paths() const;
-  ::google::protobuf::RepeatedPtrField<std::string>* _internal_mutable_paths();
-
-  public:
   // .mavsdk.rpc.ftp.FtpResult ftp_result = 1;
   bool has_ftp_result() const;
   void clear_ftp_result() ;
@@ -3399,14 +3597,29 @@ class ListDirectoryResponse final :
   ::mavsdk::rpc::ftp::FtpResult* _internal_mutable_ftp_result();
 
   public:
+  // .mavsdk.rpc.ftp.ListDirectoryData data = 2;
+  bool has_data() const;
+  void clear_data() ;
+  const ::mavsdk::rpc::ftp::ListDirectoryData& data() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::ftp::ListDirectoryData* release_data();
+  ::mavsdk::rpc::ftp::ListDirectoryData* mutable_data();
+  void set_allocated_data(::mavsdk::rpc::ftp::ListDirectoryData* value);
+  void unsafe_arena_set_allocated_data(::mavsdk::rpc::ftp::ListDirectoryData* value);
+  ::mavsdk::rpc::ftp::ListDirectoryData* unsafe_arena_release_data();
+
+  private:
+  const ::mavsdk::rpc::ftp::ListDirectoryData& _internal_data() const;
+  ::mavsdk::rpc::ftp::ListDirectoryData* _internal_mutable_data();
+
+  public:
   // @@protoc_insertion_point(class_scope:mavsdk.rpc.ftp.ListDirectoryResponse)
  private:
   class _Internal;
 
   friend class ::google::protobuf::internal::TcParser;
   static const ::google::protobuf::internal::TcParseTable<
-      1, 2, 1,
-      50, 2>
+      1, 2, 2,
+      0, 2>
       _table_;
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -3424,8 +3637,8 @@ class ListDirectoryResponse final :
                               ::google::protobuf::Arena* arena, const Impl_& from);
     ::google::protobuf::internal::HasBits<1> _has_bits_;
     mutable ::google::protobuf::internal::CachedSize _cached_size_;
-    ::google::protobuf::RepeatedPtrField<std::string> paths_;
     ::mavsdk::rpc::ftp::FtpResult* ftp_result_;
+    ::mavsdk::rpc::ftp::ListDirectoryData* data_;
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
   union { Impl_ _impl_; };
@@ -3689,7 +3902,7 @@ class CreateDirectoryResponse final :
                &_CreateDirectoryResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    7;
+    8;
 
   friend void swap(CreateDirectoryResponse& a, CreateDirectoryResponse& b) {
     a.Swap(&b);
@@ -3870,7 +4083,7 @@ class AreFilesIdenticalResponse final :
                &_AreFilesIdenticalResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    15;
+    16;
 
   friend void swap(AreFilesIdenticalResponse& a, AreFilesIdenticalResponse& b) {
     a.Swap(&b);
@@ -4710,6 +4923,212 @@ inline void ListDirectoryRequest::set_allocated_remote_dir(std::string* value) {
 
 // -------------------------------------------------------------------
 
+// ListDirectoryData
+
+// repeated string dirs = 1;
+inline int ListDirectoryData::_internal_dirs_size() const {
+  return _internal_dirs().size();
+}
+inline int ListDirectoryData::dirs_size() const {
+  return _internal_dirs_size();
+}
+inline void ListDirectoryData::clear_dirs() {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  _impl_.dirs_.Clear();
+}
+inline std::string* ListDirectoryData::add_dirs()
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  std::string* _s = _internal_mutable_dirs()->Add();
+  // @@protoc_insertion_point(field_add_mutable:mavsdk.rpc.ftp.ListDirectoryData.dirs)
+  return _s;
+}
+inline const std::string& ListDirectoryData::dirs(int index) const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.ftp.ListDirectoryData.dirs)
+  return _internal_dirs().Get(index);
+}
+inline std::string* ListDirectoryData::mutable_dirs(int index)
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.ftp.ListDirectoryData.dirs)
+  return _internal_mutable_dirs()->Mutable(index);
+}
+inline void ListDirectoryData::set_dirs(int index, const std::string& value) {
+  _internal_mutable_dirs()->Mutable(index)->assign(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.ftp.ListDirectoryData.dirs)
+}
+inline void ListDirectoryData::set_dirs(int index, std::string&& value) {
+  _internal_mutable_dirs()->Mutable(index)->assign(std::move(value));
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.ftp.ListDirectoryData.dirs)
+}
+inline void ListDirectoryData::set_dirs(int index, const char* value) {
+  ABSL_DCHECK(value != nullptr);
+  _internal_mutable_dirs()->Mutable(index)->assign(value);
+  // @@protoc_insertion_point(field_set_char:mavsdk.rpc.ftp.ListDirectoryData.dirs)
+}
+inline void ListDirectoryData::set_dirs(int index, const char* value,
+                              std::size_t size) {
+  _internal_mutable_dirs()->Mutable(index)->assign(
+      reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_set_pointer:mavsdk.rpc.ftp.ListDirectoryData.dirs)
+}
+inline void ListDirectoryData::set_dirs(int index, absl::string_view value) {
+  _internal_mutable_dirs()->Mutable(index)->assign(value.data(),
+                                                     value.size());
+  // @@protoc_insertion_point(field_set_string_piece:mavsdk.rpc.ftp.ListDirectoryData.dirs)
+}
+inline void ListDirectoryData::add_dirs(const std::string& value) {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  _internal_mutable_dirs()->Add()->assign(value);
+  // @@protoc_insertion_point(field_add:mavsdk.rpc.ftp.ListDirectoryData.dirs)
+}
+inline void ListDirectoryData::add_dirs(std::string&& value) {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  _internal_mutable_dirs()->Add(std::move(value));
+  // @@protoc_insertion_point(field_add:mavsdk.rpc.ftp.ListDirectoryData.dirs)
+}
+inline void ListDirectoryData::add_dirs(const char* value) {
+  ABSL_DCHECK(value != nullptr);
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  _internal_mutable_dirs()->Add()->assign(value);
+  // @@protoc_insertion_point(field_add_char:mavsdk.rpc.ftp.ListDirectoryData.dirs)
+}
+inline void ListDirectoryData::add_dirs(const char* value, std::size_t size) {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  _internal_mutable_dirs()->Add()->assign(
+      reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_add_pointer:mavsdk.rpc.ftp.ListDirectoryData.dirs)
+}
+inline void ListDirectoryData::add_dirs(absl::string_view value) {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  _internal_mutable_dirs()->Add()->assign(value.data(), value.size());
+  // @@protoc_insertion_point(field_add_string_piece:mavsdk.rpc.ftp.ListDirectoryData.dirs)
+}
+inline const ::google::protobuf::RepeatedPtrField<std::string>&
+ListDirectoryData::dirs() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_list:mavsdk.rpc.ftp.ListDirectoryData.dirs)
+  return _internal_dirs();
+}
+inline ::google::protobuf::RepeatedPtrField<std::string>*
+ListDirectoryData::mutable_dirs() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_mutable_list:mavsdk.rpc.ftp.ListDirectoryData.dirs)
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  return _internal_mutable_dirs();
+}
+inline const ::google::protobuf::RepeatedPtrField<std::string>&
+ListDirectoryData::_internal_dirs() const {
+  PROTOBUF_TSAN_READ(&_impl_._tsan_detect_race);
+  return _impl_.dirs_;
+}
+inline ::google::protobuf::RepeatedPtrField<std::string>*
+ListDirectoryData::_internal_mutable_dirs() {
+  PROTOBUF_TSAN_READ(&_impl_._tsan_detect_race);
+  return &_impl_.dirs_;
+}
+
+// repeated string files = 2;
+inline int ListDirectoryData::_internal_files_size() const {
+  return _internal_files().size();
+}
+inline int ListDirectoryData::files_size() const {
+  return _internal_files_size();
+}
+inline void ListDirectoryData::clear_files() {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  _impl_.files_.Clear();
+}
+inline std::string* ListDirectoryData::add_files()
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  std::string* _s = _internal_mutable_files()->Add();
+  // @@protoc_insertion_point(field_add_mutable:mavsdk.rpc.ftp.ListDirectoryData.files)
+  return _s;
+}
+inline const std::string& ListDirectoryData::files(int index) const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.ftp.ListDirectoryData.files)
+  return _internal_files().Get(index);
+}
+inline std::string* ListDirectoryData::mutable_files(int index)
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.ftp.ListDirectoryData.files)
+  return _internal_mutable_files()->Mutable(index);
+}
+inline void ListDirectoryData::set_files(int index, const std::string& value) {
+  _internal_mutable_files()->Mutable(index)->assign(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.ftp.ListDirectoryData.files)
+}
+inline void ListDirectoryData::set_files(int index, std::string&& value) {
+  _internal_mutable_files()->Mutable(index)->assign(std::move(value));
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.ftp.ListDirectoryData.files)
+}
+inline void ListDirectoryData::set_files(int index, const char* value) {
+  ABSL_DCHECK(value != nullptr);
+  _internal_mutable_files()->Mutable(index)->assign(value);
+  // @@protoc_insertion_point(field_set_char:mavsdk.rpc.ftp.ListDirectoryData.files)
+}
+inline void ListDirectoryData::set_files(int index, const char* value,
+                              std::size_t size) {
+  _internal_mutable_files()->Mutable(index)->assign(
+      reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_set_pointer:mavsdk.rpc.ftp.ListDirectoryData.files)
+}
+inline void ListDirectoryData::set_files(int index, absl::string_view value) {
+  _internal_mutable_files()->Mutable(index)->assign(value.data(),
+                                                     value.size());
+  // @@protoc_insertion_point(field_set_string_piece:mavsdk.rpc.ftp.ListDirectoryData.files)
+}
+inline void ListDirectoryData::add_files(const std::string& value) {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  _internal_mutable_files()->Add()->assign(value);
+  // @@protoc_insertion_point(field_add:mavsdk.rpc.ftp.ListDirectoryData.files)
+}
+inline void ListDirectoryData::add_files(std::string&& value) {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  _internal_mutable_files()->Add(std::move(value));
+  // @@protoc_insertion_point(field_add:mavsdk.rpc.ftp.ListDirectoryData.files)
+}
+inline void ListDirectoryData::add_files(const char* value) {
+  ABSL_DCHECK(value != nullptr);
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  _internal_mutable_files()->Add()->assign(value);
+  // @@protoc_insertion_point(field_add_char:mavsdk.rpc.ftp.ListDirectoryData.files)
+}
+inline void ListDirectoryData::add_files(const char* value, std::size_t size) {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  _internal_mutable_files()->Add()->assign(
+      reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_add_pointer:mavsdk.rpc.ftp.ListDirectoryData.files)
+}
+inline void ListDirectoryData::add_files(absl::string_view value) {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  _internal_mutable_files()->Add()->assign(value.data(), value.size());
+  // @@protoc_insertion_point(field_add_string_piece:mavsdk.rpc.ftp.ListDirectoryData.files)
+}
+inline const ::google::protobuf::RepeatedPtrField<std::string>&
+ListDirectoryData::files() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_list:mavsdk.rpc.ftp.ListDirectoryData.files)
+  return _internal_files();
+}
+inline ::google::protobuf::RepeatedPtrField<std::string>*
+ListDirectoryData::mutable_files() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_mutable_list:mavsdk.rpc.ftp.ListDirectoryData.files)
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  return _internal_mutable_files();
+}
+inline const ::google::protobuf::RepeatedPtrField<std::string>&
+ListDirectoryData::_internal_files() const {
+  PROTOBUF_TSAN_READ(&_impl_._tsan_detect_race);
+  return _impl_.files_;
+}
+inline ::google::protobuf::RepeatedPtrField<std::string>*
+ListDirectoryData::_internal_mutable_files() {
+  PROTOBUF_TSAN_READ(&_impl_._tsan_detect_race);
+  return &_impl_.files_;
+}
+
+// -------------------------------------------------------------------
+
 // ListDirectoryResponse
 
 // .mavsdk.rpc.ftp.FtpResult ftp_result = 1;
@@ -4808,105 +5227,100 @@ inline void ListDirectoryResponse::set_allocated_ftp_result(::mavsdk::rpc::ftp::
   // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.ftp.ListDirectoryResponse.ftp_result)
 }
 
-// repeated string paths = 2;
-inline int ListDirectoryResponse::_internal_paths_size() const {
-  return _internal_paths().size();
+// .mavsdk.rpc.ftp.ListDirectoryData data = 2;
+inline bool ListDirectoryResponse::has_data() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000002u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.data_ != nullptr);
+  return value;
 }
-inline int ListDirectoryResponse::paths_size() const {
-  return _internal_paths_size();
-}
-inline void ListDirectoryResponse::clear_paths() {
+inline void ListDirectoryResponse::clear_data() {
   PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
-  _impl_.paths_.Clear();
+  if (_impl_.data_ != nullptr) _impl_.data_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000002u;
 }
-inline std::string* ListDirectoryResponse::add_paths()
-    ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
-  std::string* _s = _internal_mutable_paths()->Add();
-  // @@protoc_insertion_point(field_add_mutable:mavsdk.rpc.ftp.ListDirectoryResponse.paths)
-  return _s;
-}
-inline const std::string& ListDirectoryResponse::paths(int index) const
-    ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.ftp.ListDirectoryResponse.paths)
-  return _internal_paths().Get(index);
-}
-inline std::string* ListDirectoryResponse::mutable_paths(int index)
-    ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.ftp.ListDirectoryResponse.paths)
-  return _internal_mutable_paths()->Mutable(index);
-}
-inline void ListDirectoryResponse::set_paths(int index, const std::string& value) {
-  _internal_mutable_paths()->Mutable(index)->assign(value);
-  // @@protoc_insertion_point(field_set:mavsdk.rpc.ftp.ListDirectoryResponse.paths)
-}
-inline void ListDirectoryResponse::set_paths(int index, std::string&& value) {
-  _internal_mutable_paths()->Mutable(index)->assign(std::move(value));
-  // @@protoc_insertion_point(field_set:mavsdk.rpc.ftp.ListDirectoryResponse.paths)
-}
-inline void ListDirectoryResponse::set_paths(int index, const char* value) {
-  ABSL_DCHECK(value != nullptr);
-  _internal_mutable_paths()->Mutable(index)->assign(value);
-  // @@protoc_insertion_point(field_set_char:mavsdk.rpc.ftp.ListDirectoryResponse.paths)
-}
-inline void ListDirectoryResponse::set_paths(int index, const char* value,
-                              std::size_t size) {
-  _internal_mutable_paths()->Mutable(index)->assign(
-      reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_set_pointer:mavsdk.rpc.ftp.ListDirectoryResponse.paths)
-}
-inline void ListDirectoryResponse::set_paths(int index, absl::string_view value) {
-  _internal_mutable_paths()->Mutable(index)->assign(value.data(),
-                                                     value.size());
-  // @@protoc_insertion_point(field_set_string_piece:mavsdk.rpc.ftp.ListDirectoryResponse.paths)
-}
-inline void ListDirectoryResponse::add_paths(const std::string& value) {
-  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
-  _internal_mutable_paths()->Add()->assign(value);
-  // @@protoc_insertion_point(field_add:mavsdk.rpc.ftp.ListDirectoryResponse.paths)
-}
-inline void ListDirectoryResponse::add_paths(std::string&& value) {
-  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
-  _internal_mutable_paths()->Add(std::move(value));
-  // @@protoc_insertion_point(field_add:mavsdk.rpc.ftp.ListDirectoryResponse.paths)
-}
-inline void ListDirectoryResponse::add_paths(const char* value) {
-  ABSL_DCHECK(value != nullptr);
-  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
-  _internal_mutable_paths()->Add()->assign(value);
-  // @@protoc_insertion_point(field_add_char:mavsdk.rpc.ftp.ListDirectoryResponse.paths)
-}
-inline void ListDirectoryResponse::add_paths(const char* value, std::size_t size) {
-  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
-  _internal_mutable_paths()->Add()->assign(
-      reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_add_pointer:mavsdk.rpc.ftp.ListDirectoryResponse.paths)
-}
-inline void ListDirectoryResponse::add_paths(absl::string_view value) {
-  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
-  _internal_mutable_paths()->Add()->assign(value.data(), value.size());
-  // @@protoc_insertion_point(field_add_string_piece:mavsdk.rpc.ftp.ListDirectoryResponse.paths)
-}
-inline const ::google::protobuf::RepeatedPtrField<std::string>&
-ListDirectoryResponse::paths() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_list:mavsdk.rpc.ftp.ListDirectoryResponse.paths)
-  return _internal_paths();
-}
-inline ::google::protobuf::RepeatedPtrField<std::string>*
-ListDirectoryResponse::mutable_paths() ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_mutable_list:mavsdk.rpc.ftp.ListDirectoryResponse.paths)
-  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
-  return _internal_mutable_paths();
-}
-inline const ::google::protobuf::RepeatedPtrField<std::string>&
-ListDirectoryResponse::_internal_paths() const {
+inline const ::mavsdk::rpc::ftp::ListDirectoryData& ListDirectoryResponse::_internal_data() const {
   PROTOBUF_TSAN_READ(&_impl_._tsan_detect_race);
-  return _impl_.paths_;
+  const ::mavsdk::rpc::ftp::ListDirectoryData* p = _impl_.data_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::ftp::ListDirectoryData&>(::mavsdk::rpc::ftp::_ListDirectoryData_default_instance_);
 }
-inline ::google::protobuf::RepeatedPtrField<std::string>*
-ListDirectoryResponse::_internal_mutable_paths() {
-  PROTOBUF_TSAN_READ(&_impl_._tsan_detect_race);
-  return &_impl_.paths_;
+inline const ::mavsdk::rpc::ftp::ListDirectoryData& ListDirectoryResponse::data() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.ftp.ListDirectoryResponse.data)
+  return _internal_data();
+}
+inline void ListDirectoryResponse::unsafe_arena_set_allocated_data(::mavsdk::rpc::ftp::ListDirectoryData* value) {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.data_);
+  }
+  _impl_.data_ = reinterpret_cast<::mavsdk::rpc::ftp::ListDirectoryData*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000002u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000002u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.ftp.ListDirectoryResponse.data)
+}
+inline ::mavsdk::rpc::ftp::ListDirectoryData* ListDirectoryResponse::release_data() {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+
+  _impl_._has_bits_[0] &= ~0x00000002u;
+  ::mavsdk::rpc::ftp::ListDirectoryData* released = _impl_.data_;
+  _impl_.data_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+  released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+  if (GetArena() == nullptr) {
+    delete old;
+  }
+#else   // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArena() != nullptr) {
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+  }
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return released;
+}
+inline ::mavsdk::rpc::ftp::ListDirectoryData* ListDirectoryResponse::unsafe_arena_release_data() {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.ftp.ListDirectoryResponse.data)
+
+  _impl_._has_bits_[0] &= ~0x00000002u;
+  ::mavsdk::rpc::ftp::ListDirectoryData* temp = _impl_.data_;
+  _impl_.data_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::ftp::ListDirectoryData* ListDirectoryResponse::_internal_mutable_data() {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  _impl_._has_bits_[0] |= 0x00000002u;
+  if (_impl_.data_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::ftp::ListDirectoryData>(GetArena());
+    _impl_.data_ = reinterpret_cast<::mavsdk::rpc::ftp::ListDirectoryData*>(p);
+  }
+  return _impl_.data_;
+}
+inline ::mavsdk::rpc::ftp::ListDirectoryData* ListDirectoryResponse::mutable_data() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::mavsdk::rpc::ftp::ListDirectoryData* _msg = _internal_mutable_data();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.ftp.ListDirectoryResponse.data)
+  return _msg;
+}
+inline void ListDirectoryResponse::set_allocated_data(::mavsdk::rpc::ftp::ListDirectoryData* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  if (message_arena == nullptr) {
+    delete reinterpret_cast<::mavsdk::rpc::ftp::ListDirectoryData*>(_impl_.data_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = reinterpret_cast<::mavsdk::rpc::ftp::ListDirectoryData*>(value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000002u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000002u;
+  }
+
+  _impl_.data_ = reinterpret_cast<::mavsdk::rpc::ftp::ListDirectoryData*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.ftp.ListDirectoryResponse.data)
 }
 
 // -------------------------------------------------------------------

--- a/src/mavsdk_server/src/plugins/ftp/ftp_service_impl.h
+++ b/src/mavsdk_server/src/plugins/ftp/ftp_service_impl.h
@@ -42,6 +42,38 @@ public:
         response->set_allocated_ftp_result(rpc_ftp_result);
     }
 
+    static std::unique_ptr<rpc::ftp::ListDirectoryData>
+    translateToRpcListDirectoryData(const mavsdk::Ftp::ListDirectoryData& list_directory_data)
+    {
+        auto rpc_obj = std::make_unique<rpc::ftp::ListDirectoryData>();
+
+        for (const auto& elem : list_directory_data.dirs) {
+            rpc_obj->add_dirs(elem);
+        }
+
+        for (const auto& elem : list_directory_data.files) {
+            rpc_obj->add_files(elem);
+        }
+
+        return rpc_obj;
+    }
+
+    static mavsdk::Ftp::ListDirectoryData
+    translateFromRpcListDirectoryData(const rpc::ftp::ListDirectoryData& list_directory_data)
+    {
+        mavsdk::Ftp::ListDirectoryData obj;
+
+        for (const auto& elem : list_directory_data.dirs()) {
+            obj.dirs.push_back(elem);
+        }
+
+        for (const auto& elem : list_directory_data.files()) {
+            obj.files.push_back(elem);
+        }
+
+        return obj;
+    }
+
     static std::unique_ptr<rpc::ftp::ProgressData>
     translateToRpcProgressData(const mavsdk::Ftp::ProgressData& progress_data)
     {
@@ -269,9 +301,7 @@ public:
         if (response != nullptr) {
             fillResponseWithResult(response, result.first);
 
-            for (auto elem : result.second) {
-                response->add_paths(elem);
-            }
+            response->set_allocated_data(translateToRpcListDirectoryData(result.second).release());
         }
 
         return grpc::Status::OK;

--- a/src/system_tests/ftp_list_dir.cpp
+++ b/src/system_tests/ftp_list_dir.cpp
@@ -25,7 +25,8 @@ TEST(SystemTest, FtpListDir)
 {
     ASSERT_TRUE(reset_directories(temp_dir_provided));
 
-    std::vector<std::string> truth_list;
+    std::vector<std::string> truth_files;
+    std::vector<std::string> truth_dirs;
 
     for (unsigned i = 0; i < 100; ++i) {
         auto foldername = std::string(temp_dir + std::to_string(i));
@@ -33,11 +34,12 @@ TEST(SystemTest, FtpListDir)
         ASSERT_TRUE(reset_directories(temp_dir_provided / fs::path(foldername)));
         ASSERT_TRUE(create_temp_file(temp_dir_provided / fs::path(filename), i));
 
-        truth_list.push_back(std::string("D") + foldername);
-        truth_list.push_back(std::string("F") + filename + std::string("\t") + std::to_string(i));
+        truth_dirs.push_back(foldername);
+        truth_files.push_back(filename);
     }
 
-    std::sort(truth_list.begin(), truth_list.end());
+    std::sort(truth_dirs.begin(), truth_dirs.end());
+    std::sort(truth_files.begin(), truth_files.end());
 
     Mavsdk mavsdk_groundstation{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
@@ -68,7 +70,8 @@ TEST(SystemTest, FtpListDir)
     auto ret = ftp.list_directory("./");
     EXPECT_EQ(ret.first, Ftp::Result::Success);
 
-    EXPECT_EQ(ret.second, truth_list);
+    EXPECT_EQ(ret.second.files, truth_files);
+    EXPECT_EQ(ret.second.dirs, truth_dirs);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 }


### PR DESCRIPTION
This way we get a clear list of files and folders instead of an odd list with F or D prefixes.

Depends on https://github.com/mavlink/MAVSDK-Proto/pull/343.

Closes #2308.