### PR TITLE
Fix Gazebo simulation connection issue with port adjustments 

### DIFF
--- a/examples/autopilot_server/autopilot_server.cpp
+++ b/examples/autopilot_server/autopilot_server.cpp
@@ -59,7 +59,7 @@ int main(int argc, char** argv)
     // thread as a ground station.
 
     if (argc < 2) {
-        std::cerr << "Too few input arguments. usage: $ arm_authorizer_server <connection_url>"
+        std::cerr << "Too few input arguments. usage: argv[0]"
                   << std::endl;
         return 1;
     }


### PR DESCRIPTION
- Port number adjusted from 14551 to 14550 for Gazebo simulation connection.
- `agrc` value checked
- Added autonomous flight and landing feature 
- Integrated functionality to autonomously take off, fly for 20 seconds, and land the drone using MAVSDK. The program monitors altitude during flight and waits for the drone to land successfully before exiting.