### PR TITLE
camera-server: Add ability to support taking image in photo mode and photo in image mode

### DIFF
--- a/src/mavsdk/plugins/camera_server/camera_server.cpp
+++ b/src/mavsdk/plugins/camera_server/camera_server.cpp
@@ -332,6 +332,16 @@ CameraServer::respond_tracking_off_command(CameraFeedback stop_video_feedback) c
     return _impl->respond_tracking_off_command(stop_video_feedback);
 }
 
+CameraServer::Result CameraServer::support_image_in_video_mode(bool support) const
+{
+    return _impl->support_image_in_video_mode(support);
+}
+
+CameraServer::Result CameraServer::support_video_in_image_mode(bool support) const
+{
+    return _impl->support_video_in_image_mode(support);
+}
+
 bool operator==(const CameraServer::Information& lhs, const CameraServer::Information& rhs)
 {
     return (rhs.vendor_name == lhs.vendor_name) && (rhs.model_name == lhs.model_name) &&

--- a/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
+++ b/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
@@ -933,6 +933,18 @@ CameraServerImpl::respond_tracking_off_command(CameraServer::CameraFeedback trac
     return CameraServer::Result::Success;
 }
 
+CameraServer::Result CameraServerImpl::support_image_in_video_mode(bool allow)
+{
+    _support_image_in_video_mode = allow;
+    return CameraServer::Result::Success;
+}
+
+CameraServer::Result CameraServerImpl::support_video_in_image_mode(bool allow)
+{
+    _support_video_in_image_mode = allow;
+    return CameraServer::Result::Success;
+}
+
 void CameraServerImpl::start_image_capture_interval(float interval_s, int32_t count, int32_t index)
 {
     // If count == 0, it means capture "forever" until a stop command is received.
@@ -1006,6 +1018,14 @@ std::optional<mavlink_command_ack_t> CameraServerImpl::process_camera_informatio
 
     if (!_set_mode_callbacks.empty()) {
         capability_flags |= CAMERA_CAP_FLAGS::CAMERA_CAP_FLAGS_HAS_MODES;
+    }
+
+    if (_support_image_in_video_mode) {
+        capability_flags |= CAMERA_CAP_FLAGS::CAMERA_CAP_FLAGS_CAN_CAPTURE_IMAGE_IN_VIDEO_MODE;
+    }
+
+    if (_support_video_in_image_mode) {
+        capability_flags |= CAMERA_CAP_FLAGS::CAMERA_CAP_FLAGS_CAN_CAPTURE_VIDEO_IN_IMAGE_MODE;
     }
 
     if (_is_video_streaming_set) {

--- a/src/mavsdk/plugins/camera_server/camera_server_impl.h
+++ b/src/mavsdk/plugins/camera_server/camera_server_impl.h
@@ -119,6 +119,9 @@ public:
     CameraServer::Result
     respond_tracking_off_command(CameraServer::CameraFeedback tracking_off_feedback);
 
+    CameraServer::Result support_image_in_video_mode(bool allow);
+    CameraServer::Result support_video_in_image_mode(bool allow);
+
 private:
     enum StatusFlags {
         IN_PROGRESS = 1 << 0,
@@ -196,6 +199,9 @@ private:
     void send_capture_status();
 
     bool _is_information_set{};
+
+    bool _support_image_in_video_mode{false};
+    bool _support_video_in_image_mode{false};
 
     // CAMERA_TRACKING_STATUS messages sending fields
     std::mutex _tracking_status_mutex{};

--- a/src/mavsdk/plugins/camera_server/include/plugins/camera_server/camera_server.h
+++ b/src/mavsdk/plugins/camera_server/include/plugins/camera_server/camera_server.h
@@ -1001,6 +1001,26 @@ public:
     Result respond_tracking_off_command(CameraFeedback stop_video_feedback) const;
 
     /**
+     * @brief Set support for capturing images while in video mode. Affects CAMERA_CAP_FLAGS flags
+     * sent in CAMERA_INFORMATION.
+     *
+     * This function is blocking.
+     *
+     * @return Result of request.
+     */
+    Result support_image_in_video_mode(bool support) const;
+
+    /**
+     * @brief Set support for capturing video while in image mode. Affects CAMERA_CAP_FLAGS flags
+     * sent in CAMERA_INFORMATION.
+     *
+     * This function is blocking.
+     *
+     * @return Result of request.
+     */
+    Result support_video_in_image_mode(bool support) const;
+
+    /**
      * @brief Copy constructor.
      */
     CameraServer(const CameraServer& other);

--- a/src/mavsdk_server/src/generated/camera_server/camera_server.grpc.pb.cc
+++ b/src/mavsdk_server/src/generated/camera_server/camera_server.grpc.pb.cc
@@ -63,6 +63,8 @@ static const char* CameraServerService_method_names[] = {
   "/mavsdk.rpc.camera_server.CameraServerService/RespondTrackingPointCommand",
   "/mavsdk.rpc.camera_server.CameraServerService/RespondTrackingRectangleCommand",
   "/mavsdk.rpc.camera_server.CameraServerService/RespondTrackingOffCommand",
+  "/mavsdk.rpc.camera_server.CameraServerService/SupportImageInVideoMode",
+  "/mavsdk.rpc.camera_server.CameraServerService/SupportVideoInImageMode",
 };
 
 std::unique_ptr< CameraServerService::Stub> CameraServerService::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
@@ -111,6 +113,8 @@ CameraServerService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>
   , rpcmethod_RespondTrackingPointCommand_(CameraServerService_method_names[36], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_RespondTrackingRectangleCommand_(CameraServerService_method_names[37], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_RespondTrackingOffCommand_(CameraServerService_method_names[38], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SupportImageInVideoMode_(CameraServerService_method_names[39], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SupportVideoInImageMode_(CameraServerService_method_names[40], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status CameraServerService::Stub::SetInformation(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetInformationRequest& request, ::mavsdk::rpc::camera_server::SetInformationResponse* response) {
@@ -891,6 +895,52 @@ void CameraServerService::Stub::async::RespondTrackingOffCommand(::grpc::ClientC
   return result;
 }
 
+::grpc::Status CameraServerService::Stub::SupportImageInVideoMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest& request, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_SupportImageInVideoMode_, context, request, response);
+}
+
+void CameraServerService::Stub::async::SupportImageInVideoMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest* request, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SupportImageInVideoMode_, context, request, response, std::move(f));
+}
+
+void CameraServerService::Stub::async::SupportImageInVideoMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest* request, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SupportImageInVideoMode_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>* CameraServerService::Stub::PrepareAsyncSupportImageInVideoModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse, ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_SupportImageInVideoMode_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>* CameraServerService::Stub::AsyncSupportImageInVideoModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncSupportImageInVideoModeRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::Status CameraServerService::Stub::SupportVideoInImageMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest& request, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_SupportVideoInImageMode_, context, request, response);
+}
+
+void CameraServerService::Stub::async::SupportVideoInImageMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest* request, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SupportVideoInImageMode_, context, request, response, std::move(f));
+}
+
+void CameraServerService::Stub::async::SupportVideoInImageMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest* request, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SupportVideoInImageMode_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>* CameraServerService::Stub::PrepareAsyncSupportVideoInImageModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse, ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_SupportVideoInImageMode_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>* CameraServerService::Stub::AsyncSupportVideoInImageModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncSupportVideoInImageModeRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
 CameraServerService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       CameraServerService_method_names[0],
@@ -1282,6 +1332,26 @@ CameraServerService::Service::Service() {
              ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse* resp) {
                return service->RespondTrackingOffCommand(ctx, req, resp);
              }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[39],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest* req,
+             ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse* resp) {
+               return service->SupportImageInVideoMode(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[40],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest* req,
+             ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse* resp) {
+               return service->SupportVideoInImageMode(ctx, req, resp);
+             }, this)));
 }
 
 CameraServerService::Service::~Service() {
@@ -1554,6 +1624,20 @@ CameraServerService::Service::~Service() {
 }
 
 ::grpc::Status CameraServerService::Service::RespondTrackingOffCommand(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::SupportImageInVideoMode(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest* request, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::SupportVideoInImageMode(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest* request, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/src/mavsdk_server/src/generated/camera_server/camera_server.grpc.pb.h
+++ b/src/mavsdk_server/src/generated/camera_server/camera_server.grpc.pb.h
@@ -384,6 +384,22 @@ class CameraServerService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>> PrepareAsyncRespondTrackingOffCommand(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>>(PrepareAsyncRespondTrackingOffCommandRaw(context, request, cq));
     }
+    // Set support for capturing images while in video mode. Affects CAMERA_CAP_FLAGS flags sent in CAMERA_INFORMATION.
+    virtual ::grpc::Status SupportImageInVideoMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest& request, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>> AsyncSupportImageInVideoMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>>(AsyncSupportImageInVideoModeRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>> PrepareAsyncSupportImageInVideoMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>>(PrepareAsyncSupportImageInVideoModeRaw(context, request, cq));
+    }
+    // Set support for capturing video while in image mode. Affects CAMERA_CAP_FLAGS flags sent in CAMERA_INFORMATION.
+    virtual ::grpc::Status SupportVideoInImageMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest& request, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>> AsyncSupportVideoInImageMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>>(AsyncSupportVideoInImageModeRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>> PrepareAsyncSupportVideoInImageMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>>(PrepareAsyncSupportVideoInImageModeRaw(context, request, cq));
+    }
     class async_interface {
      public:
       virtual ~async_interface() {}
@@ -487,6 +503,12 @@ class CameraServerService final {
       // Respond to an incoming tracking off command.
       virtual void RespondTrackingOffCommand(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void RespondTrackingOffCommand(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Set support for capturing images while in video mode. Affects CAMERA_CAP_FLAGS flags sent in CAMERA_INFORMATION.
+      virtual void SupportImageInVideoMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest* request, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void SupportImageInVideoMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest* request, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Set support for capturing video while in image mode. Affects CAMERA_CAP_FLAGS flags sent in CAMERA_INFORMATION.
+      virtual void SupportVideoInImageMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest* request, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void SupportVideoInImageMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest* request, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
     };
     typedef class async_interface experimental_async_interface;
     virtual class async_interface* async() { return nullptr; }
@@ -587,6 +609,10 @@ class CameraServerService final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse>* PrepareAsyncRespondTrackingRectangleCommandRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>* AsyncRespondTrackingOffCommandRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>* PrepareAsyncRespondTrackingOffCommandRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>* AsyncSupportImageInVideoModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>* PrepareAsyncSupportImageInVideoModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>* AsyncSupportVideoInImageModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>* PrepareAsyncSupportVideoInImageModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest& request, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
@@ -898,6 +924,20 @@ class CameraServerService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>> PrepareAsyncRespondTrackingOffCommand(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>>(PrepareAsyncRespondTrackingOffCommandRaw(context, request, cq));
     }
+    ::grpc::Status SupportImageInVideoMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest& request, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>> AsyncSupportImageInVideoMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>>(AsyncSupportImageInVideoModeRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>> PrepareAsyncSupportImageInVideoMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>>(PrepareAsyncSupportImageInVideoModeRaw(context, request, cq));
+    }
+    ::grpc::Status SupportVideoInImageMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest& request, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>> AsyncSupportVideoInImageMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>>(AsyncSupportVideoInImageModeRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>> PrepareAsyncSupportVideoInImageMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>>(PrepareAsyncSupportVideoInImageModeRaw(context, request, cq));
+    }
     class async final :
       public StubInterface::async_interface {
      public:
@@ -962,6 +1002,10 @@ class CameraServerService final {
       void RespondTrackingRectangleCommand(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void RespondTrackingOffCommand(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse* response, std::function<void(::grpc::Status)>) override;
       void RespondTrackingOffCommand(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SupportImageInVideoMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest* request, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse* response, std::function<void(::grpc::Status)>) override;
+      void SupportImageInVideoMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest* request, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SupportVideoInImageMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest* request, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse* response, std::function<void(::grpc::Status)>) override;
+      void SupportVideoInImageMode(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest* request, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
      private:
       friend class Stub;
       explicit async(Stub* stub): stub_(stub) { }
@@ -1068,6 +1112,10 @@ class CameraServerService final {
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse>* PrepareAsyncRespondTrackingRectangleCommandRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>* AsyncRespondTrackingOffCommandRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>* PrepareAsyncRespondTrackingOffCommandRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>* AsyncSupportImageInVideoModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>* PrepareAsyncSupportImageInVideoModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>* AsyncSupportVideoInImageModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>* PrepareAsyncSupportVideoInImageModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_SetInformation_;
     const ::grpc::internal::RpcMethod rpcmethod_SetVideoStreaming_;
     const ::grpc::internal::RpcMethod rpcmethod_SetInProgress_;
@@ -1107,6 +1155,8 @@ class CameraServerService final {
     const ::grpc::internal::RpcMethod rpcmethod_RespondTrackingPointCommand_;
     const ::grpc::internal::RpcMethod rpcmethod_RespondTrackingRectangleCommand_;
     const ::grpc::internal::RpcMethod rpcmethod_RespondTrackingOffCommand_;
+    const ::grpc::internal::RpcMethod rpcmethod_SupportImageInVideoMode_;
+    const ::grpc::internal::RpcMethod rpcmethod_SupportVideoInImageMode_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
 
@@ -1192,6 +1242,10 @@ class CameraServerService final {
     virtual ::grpc::Status RespondTrackingRectangleCommand(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse* response);
     // Respond to an incoming tracking off command.
     virtual ::grpc::Status RespondTrackingOffCommand(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse* response);
+    // Set support for capturing images while in video mode. Affects CAMERA_CAP_FLAGS flags sent in CAMERA_INFORMATION.
+    virtual ::grpc::Status SupportImageInVideoMode(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest* request, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse* response);
+    // Set support for capturing video while in image mode. Affects CAMERA_CAP_FLAGS flags sent in CAMERA_INFORMATION.
+    virtual ::grpc::Status SupportVideoInImageMode(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest* request, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse* response);
   };
   template <class BaseClass>
   class WithAsyncMethod_SetInformation : public BaseClass {
@@ -1973,7 +2027,47 @@ class CameraServerService final {
       ::grpc::Service::RequestAsyncUnary(38, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_SetInformation<WithAsyncMethod_SetVideoStreaming<WithAsyncMethod_SetInProgress<WithAsyncMethod_SubscribeTakePhoto<WithAsyncMethod_RespondTakePhoto<WithAsyncMethod_SubscribeStartVideo<WithAsyncMethod_RespondStartVideo<WithAsyncMethod_SubscribeStopVideo<WithAsyncMethod_RespondStopVideo<WithAsyncMethod_SubscribeStartVideoStreaming<WithAsyncMethod_RespondStartVideoStreaming<WithAsyncMethod_SubscribeStopVideoStreaming<WithAsyncMethod_RespondStopVideoStreaming<WithAsyncMethod_SubscribeSetMode<WithAsyncMethod_RespondSetMode<WithAsyncMethod_SubscribeStorageInformation<WithAsyncMethod_RespondStorageInformation<WithAsyncMethod_SubscribeCaptureStatus<WithAsyncMethod_RespondCaptureStatus<WithAsyncMethod_SubscribeFormatStorage<WithAsyncMethod_RespondFormatStorage<WithAsyncMethod_SubscribeResetSettings<WithAsyncMethod_RespondResetSettings<WithAsyncMethod_SubscribeZoomInStart<WithAsyncMethod_RespondZoomInStart<WithAsyncMethod_SubscribeZoomOutStart<WithAsyncMethod_RespondZoomOutStart<WithAsyncMethod_SubscribeZoomStop<WithAsyncMethod_RespondZoomStop<WithAsyncMethod_SubscribeZoomRange<WithAsyncMethod_RespondZoomRange<WithAsyncMethod_SetTrackingRectangleStatus<WithAsyncMethod_SetTrackingOffStatus<WithAsyncMethod_SubscribeTrackingPointCommand<WithAsyncMethod_SubscribeTrackingRectangleCommand<WithAsyncMethod_SubscribeTrackingOffCommand<WithAsyncMethod_RespondTrackingPointCommand<WithAsyncMethod_RespondTrackingRectangleCommand<WithAsyncMethod_RespondTrackingOffCommand<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
+  template <class BaseClass>
+  class WithAsyncMethod_SupportImageInVideoMode : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SupportImageInVideoMode() {
+      ::grpc::Service::MarkMethodAsync(39);
+    }
+    ~WithAsyncMethod_SupportImageInVideoMode() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SupportImageInVideoMode(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest* /*request*/, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSupportImageInVideoMode(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(39, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_SupportVideoInImageMode : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SupportVideoInImageMode() {
+      ::grpc::Service::MarkMethodAsync(40);
+    }
+    ~WithAsyncMethod_SupportVideoInImageMode() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SupportVideoInImageMode(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest* /*request*/, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSupportVideoInImageMode(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(40, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  typedef WithAsyncMethod_SetInformation<WithAsyncMethod_SetVideoStreaming<WithAsyncMethod_SetInProgress<WithAsyncMethod_SubscribeTakePhoto<WithAsyncMethod_RespondTakePhoto<WithAsyncMethod_SubscribeStartVideo<WithAsyncMethod_RespondStartVideo<WithAsyncMethod_SubscribeStopVideo<WithAsyncMethod_RespondStopVideo<WithAsyncMethod_SubscribeStartVideoStreaming<WithAsyncMethod_RespondStartVideoStreaming<WithAsyncMethod_SubscribeStopVideoStreaming<WithAsyncMethod_RespondStopVideoStreaming<WithAsyncMethod_SubscribeSetMode<WithAsyncMethod_RespondSetMode<WithAsyncMethod_SubscribeStorageInformation<WithAsyncMethod_RespondStorageInformation<WithAsyncMethod_SubscribeCaptureStatus<WithAsyncMethod_RespondCaptureStatus<WithAsyncMethod_SubscribeFormatStorage<WithAsyncMethod_RespondFormatStorage<WithAsyncMethod_SubscribeResetSettings<WithAsyncMethod_RespondResetSettings<WithAsyncMethod_SubscribeZoomInStart<WithAsyncMethod_RespondZoomInStart<WithAsyncMethod_SubscribeZoomOutStart<WithAsyncMethod_RespondZoomOutStart<WithAsyncMethod_SubscribeZoomStop<WithAsyncMethod_RespondZoomStop<WithAsyncMethod_SubscribeZoomRange<WithAsyncMethod_RespondZoomRange<WithAsyncMethod_SetTrackingRectangleStatus<WithAsyncMethod_SetTrackingOffStatus<WithAsyncMethod_SubscribeTrackingPointCommand<WithAsyncMethod_SubscribeTrackingRectangleCommand<WithAsyncMethod_SubscribeTrackingOffCommand<WithAsyncMethod_RespondTrackingPointCommand<WithAsyncMethod_RespondTrackingRectangleCommand<WithAsyncMethod_RespondTrackingOffCommand<WithAsyncMethod_SupportImageInVideoMode<WithAsyncMethod_SupportVideoInImageMode<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_SetInformation : public BaseClass {
    private:
@@ -2942,7 +3036,61 @@ class CameraServerService final {
     virtual ::grpc::ServerUnaryReactor* RespondTrackingOffCommand(
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_SetInformation<WithCallbackMethod_SetVideoStreaming<WithCallbackMethod_SetInProgress<WithCallbackMethod_SubscribeTakePhoto<WithCallbackMethod_RespondTakePhoto<WithCallbackMethod_SubscribeStartVideo<WithCallbackMethod_RespondStartVideo<WithCallbackMethod_SubscribeStopVideo<WithCallbackMethod_RespondStopVideo<WithCallbackMethod_SubscribeStartVideoStreaming<WithCallbackMethod_RespondStartVideoStreaming<WithCallbackMethod_SubscribeStopVideoStreaming<WithCallbackMethod_RespondStopVideoStreaming<WithCallbackMethod_SubscribeSetMode<WithCallbackMethod_RespondSetMode<WithCallbackMethod_SubscribeStorageInformation<WithCallbackMethod_RespondStorageInformation<WithCallbackMethod_SubscribeCaptureStatus<WithCallbackMethod_RespondCaptureStatus<WithCallbackMethod_SubscribeFormatStorage<WithCallbackMethod_RespondFormatStorage<WithCallbackMethod_SubscribeResetSettings<WithCallbackMethod_RespondResetSettings<WithCallbackMethod_SubscribeZoomInStart<WithCallbackMethod_RespondZoomInStart<WithCallbackMethod_SubscribeZoomOutStart<WithCallbackMethod_RespondZoomOutStart<WithCallbackMethod_SubscribeZoomStop<WithCallbackMethod_RespondZoomStop<WithCallbackMethod_SubscribeZoomRange<WithCallbackMethod_RespondZoomRange<WithCallbackMethod_SetTrackingRectangleStatus<WithCallbackMethod_SetTrackingOffStatus<WithCallbackMethod_SubscribeTrackingPointCommand<WithCallbackMethod_SubscribeTrackingRectangleCommand<WithCallbackMethod_SubscribeTrackingOffCommand<WithCallbackMethod_RespondTrackingPointCommand<WithCallbackMethod_RespondTrackingRectangleCommand<WithCallbackMethod_RespondTrackingOffCommand<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
+  template <class BaseClass>
+  class WithCallbackMethod_SupportImageInVideoMode : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SupportImageInVideoMode() {
+      ::grpc::Service::MarkMethodCallback(39,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest* request, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse* response) { return this->SupportImageInVideoMode(context, request, response); }));}
+    void SetMessageAllocatorFor_SupportImageInVideoMode(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(39);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_SupportImageInVideoMode() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SupportImageInVideoMode(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest* /*request*/, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* SupportImageInVideoMode(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest* /*request*/, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_SupportVideoInImageMode : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SupportVideoInImageMode() {
+      ::grpc::Service::MarkMethodCallback(40,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest* request, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse* response) { return this->SupportVideoInImageMode(context, request, response); }));}
+    void SetMessageAllocatorFor_SupportVideoInImageMode(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(40);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_SupportVideoInImageMode() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SupportVideoInImageMode(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest* /*request*/, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* SupportVideoInImageMode(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest* /*request*/, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse* /*response*/)  { return nullptr; }
+  };
+  typedef WithCallbackMethod_SetInformation<WithCallbackMethod_SetVideoStreaming<WithCallbackMethod_SetInProgress<WithCallbackMethod_SubscribeTakePhoto<WithCallbackMethod_RespondTakePhoto<WithCallbackMethod_SubscribeStartVideo<WithCallbackMethod_RespondStartVideo<WithCallbackMethod_SubscribeStopVideo<WithCallbackMethod_RespondStopVideo<WithCallbackMethod_SubscribeStartVideoStreaming<WithCallbackMethod_RespondStartVideoStreaming<WithCallbackMethod_SubscribeStopVideoStreaming<WithCallbackMethod_RespondStopVideoStreaming<WithCallbackMethod_SubscribeSetMode<WithCallbackMethod_RespondSetMode<WithCallbackMethod_SubscribeStorageInformation<WithCallbackMethod_RespondStorageInformation<WithCallbackMethod_SubscribeCaptureStatus<WithCallbackMethod_RespondCaptureStatus<WithCallbackMethod_SubscribeFormatStorage<WithCallbackMethod_RespondFormatStorage<WithCallbackMethod_SubscribeResetSettings<WithCallbackMethod_RespondResetSettings<WithCallbackMethod_SubscribeZoomInStart<WithCallbackMethod_RespondZoomInStart<WithCallbackMethod_SubscribeZoomOutStart<WithCallbackMethod_RespondZoomOutStart<WithCallbackMethod_SubscribeZoomStop<WithCallbackMethod_RespondZoomStop<WithCallbackMethod_SubscribeZoomRange<WithCallbackMethod_RespondZoomRange<WithCallbackMethod_SetTrackingRectangleStatus<WithCallbackMethod_SetTrackingOffStatus<WithCallbackMethod_SubscribeTrackingPointCommand<WithCallbackMethod_SubscribeTrackingRectangleCommand<WithCallbackMethod_SubscribeTrackingOffCommand<WithCallbackMethod_RespondTrackingPointCommand<WithCallbackMethod_RespondTrackingRectangleCommand<WithCallbackMethod_RespondTrackingOffCommand<WithCallbackMethod_SupportImageInVideoMode<WithCallbackMethod_SupportVideoInImageMode<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_SetInformation : public BaseClass {
@@ -3603,6 +3751,40 @@ class CameraServerService final {
     }
     // disable synchronous version of this method
     ::grpc::Status RespondTrackingOffCommand(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_SupportImageInVideoMode : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SupportImageInVideoMode() {
+      ::grpc::Service::MarkMethodGeneric(39);
+    }
+    ~WithGenericMethod_SupportImageInVideoMode() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SupportImageInVideoMode(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest* /*request*/, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_SupportVideoInImageMode : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SupportVideoInImageMode() {
+      ::grpc::Service::MarkMethodGeneric(40);
+    }
+    ~WithGenericMethod_SupportVideoInImageMode() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SupportVideoInImageMode(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest* /*request*/, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -4385,6 +4567,46 @@ class CameraServerService final {
     }
     void RequestRespondTrackingOffCommand(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(38, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_SupportImageInVideoMode : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SupportImageInVideoMode() {
+      ::grpc::Service::MarkMethodRaw(39);
+    }
+    ~WithRawMethod_SupportImageInVideoMode() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SupportImageInVideoMode(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest* /*request*/, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSupportImageInVideoMode(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(39, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_SupportVideoInImageMode : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SupportVideoInImageMode() {
+      ::grpc::Service::MarkMethodRaw(40);
+    }
+    ~WithRawMethod_SupportVideoInImageMode() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SupportVideoInImageMode(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest* /*request*/, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSupportVideoInImageMode(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(40, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -5246,6 +5468,50 @@ class CameraServerService final {
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithRawCallbackMethod_SupportImageInVideoMode : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SupportImageInVideoMode() {
+      ::grpc::Service::MarkMethodRawCallback(39,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SupportImageInVideoMode(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_SupportImageInVideoMode() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SupportImageInVideoMode(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest* /*request*/, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* SupportImageInVideoMode(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_SupportVideoInImageMode : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SupportVideoInImageMode() {
+      ::grpc::Service::MarkMethodRawCallback(40,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SupportVideoInImageMode(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_SupportVideoInImageMode() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SupportVideoInImageMode(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest* /*request*/, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* SupportVideoInImageMode(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_SetInformation : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
@@ -5839,7 +6105,61 @@ class CameraServerService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedRespondTrackingOffCommand(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest,::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_SetInformation<WithStreamedUnaryMethod_SetVideoStreaming<WithStreamedUnaryMethod_SetInProgress<WithStreamedUnaryMethod_RespondTakePhoto<WithStreamedUnaryMethod_RespondStartVideo<WithStreamedUnaryMethod_RespondStopVideo<WithStreamedUnaryMethod_RespondStartVideoStreaming<WithStreamedUnaryMethod_RespondStopVideoStreaming<WithStreamedUnaryMethod_RespondSetMode<WithStreamedUnaryMethod_RespondStorageInformation<WithStreamedUnaryMethod_RespondCaptureStatus<WithStreamedUnaryMethod_RespondFormatStorage<WithStreamedUnaryMethod_RespondResetSettings<WithStreamedUnaryMethod_RespondZoomInStart<WithStreamedUnaryMethod_RespondZoomOutStart<WithStreamedUnaryMethod_RespondZoomStop<WithStreamedUnaryMethod_RespondZoomRange<WithStreamedUnaryMethod_SetTrackingRectangleStatus<WithStreamedUnaryMethod_SetTrackingOffStatus<WithStreamedUnaryMethod_RespondTrackingPointCommand<WithStreamedUnaryMethod_RespondTrackingRectangleCommand<WithStreamedUnaryMethod_RespondTrackingOffCommand<Service > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_SupportImageInVideoMode : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_SupportImageInVideoMode() {
+      ::grpc::Service::MarkMethodStreamed(39,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>* streamer) {
+                       return this->StreamedSupportImageInVideoMode(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_SupportImageInVideoMode() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SupportImageInVideoMode(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest* /*request*/, ::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedSupportImageInVideoMode(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest,::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_SupportVideoInImageMode : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_SupportVideoInImageMode() {
+      ::grpc::Service::MarkMethodStreamed(40,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>* streamer) {
+                       return this->StreamedSupportVideoInImageMode(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_SupportVideoInImageMode() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SupportVideoInImageMode(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest* /*request*/, ::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedSupportVideoInImageMode(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest,::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse>* server_unary_streamer) = 0;
+  };
+  typedef WithStreamedUnaryMethod_SetInformation<WithStreamedUnaryMethod_SetVideoStreaming<WithStreamedUnaryMethod_SetInProgress<WithStreamedUnaryMethod_RespondTakePhoto<WithStreamedUnaryMethod_RespondStartVideo<WithStreamedUnaryMethod_RespondStopVideo<WithStreamedUnaryMethod_RespondStartVideoStreaming<WithStreamedUnaryMethod_RespondStopVideoStreaming<WithStreamedUnaryMethod_RespondSetMode<WithStreamedUnaryMethod_RespondStorageInformation<WithStreamedUnaryMethod_RespondCaptureStatus<WithStreamedUnaryMethod_RespondFormatStorage<WithStreamedUnaryMethod_RespondResetSettings<WithStreamedUnaryMethod_RespondZoomInStart<WithStreamedUnaryMethod_RespondZoomOutStart<WithStreamedUnaryMethod_RespondZoomStop<WithStreamedUnaryMethod_RespondZoomRange<WithStreamedUnaryMethod_SetTrackingRectangleStatus<WithStreamedUnaryMethod_SetTrackingOffStatus<WithStreamedUnaryMethod_RespondTrackingPointCommand<WithStreamedUnaryMethod_RespondTrackingRectangleCommand<WithStreamedUnaryMethod_RespondTrackingOffCommand<WithStreamedUnaryMethod_SupportImageInVideoMode<WithStreamedUnaryMethod_SupportVideoInImageMode<Service > > > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
   template <class BaseClass>
   class WithSplitStreamingMethod_SubscribeTakePhoto : public BaseClass {
    private:
@@ -6300,7 +6620,7 @@ class CameraServerService final {
     virtual ::grpc::Status StreamedSubscribeTrackingOffCommand(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::camera_server::SubscribeTrackingOffCommandRequest,::mavsdk::rpc::camera_server::TrackingOffCommandResponse>* server_split_streamer) = 0;
   };
   typedef WithSplitStreamingMethod_SubscribeTakePhoto<WithSplitStreamingMethod_SubscribeStartVideo<WithSplitStreamingMethod_SubscribeStopVideo<WithSplitStreamingMethod_SubscribeStartVideoStreaming<WithSplitStreamingMethod_SubscribeStopVideoStreaming<WithSplitStreamingMethod_SubscribeSetMode<WithSplitStreamingMethod_SubscribeStorageInformation<WithSplitStreamingMethod_SubscribeCaptureStatus<WithSplitStreamingMethod_SubscribeFormatStorage<WithSplitStreamingMethod_SubscribeResetSettings<WithSplitStreamingMethod_SubscribeZoomInStart<WithSplitStreamingMethod_SubscribeZoomOutStart<WithSplitStreamingMethod_SubscribeZoomStop<WithSplitStreamingMethod_SubscribeZoomRange<WithSplitStreamingMethod_SubscribeTrackingPointCommand<WithSplitStreamingMethod_SubscribeTrackingRectangleCommand<WithSplitStreamingMethod_SubscribeTrackingOffCommand<Service > > > > > > > > > > > > > > > > > SplitStreamedService;
-  typedef WithStreamedUnaryMethod_SetInformation<WithStreamedUnaryMethod_SetVideoStreaming<WithStreamedUnaryMethod_SetInProgress<WithSplitStreamingMethod_SubscribeTakePhoto<WithStreamedUnaryMethod_RespondTakePhoto<WithSplitStreamingMethod_SubscribeStartVideo<WithStreamedUnaryMethod_RespondStartVideo<WithSplitStreamingMethod_SubscribeStopVideo<WithStreamedUnaryMethod_RespondStopVideo<WithSplitStreamingMethod_SubscribeStartVideoStreaming<WithStreamedUnaryMethod_RespondStartVideoStreaming<WithSplitStreamingMethod_SubscribeStopVideoStreaming<WithStreamedUnaryMethod_RespondStopVideoStreaming<WithSplitStreamingMethod_SubscribeSetMode<WithStreamedUnaryMethod_RespondSetMode<WithSplitStreamingMethod_SubscribeStorageInformation<WithStreamedUnaryMethod_RespondStorageInformation<WithSplitStreamingMethod_SubscribeCaptureStatus<WithStreamedUnaryMethod_RespondCaptureStatus<WithSplitStreamingMethod_SubscribeFormatStorage<WithStreamedUnaryMethod_RespondFormatStorage<WithSplitStreamingMethod_SubscribeResetSettings<WithStreamedUnaryMethod_RespondResetSettings<WithSplitStreamingMethod_SubscribeZoomInStart<WithStreamedUnaryMethod_RespondZoomInStart<WithSplitStreamingMethod_SubscribeZoomOutStart<WithStreamedUnaryMethod_RespondZoomOutStart<WithSplitStreamingMethod_SubscribeZoomStop<WithStreamedUnaryMethod_RespondZoomStop<WithSplitStreamingMethod_SubscribeZoomRange<WithStreamedUnaryMethod_RespondZoomRange<WithStreamedUnaryMethod_SetTrackingRectangleStatus<WithStreamedUnaryMethod_SetTrackingOffStatus<WithSplitStreamingMethod_SubscribeTrackingPointCommand<WithSplitStreamingMethod_SubscribeTrackingRectangleCommand<WithSplitStreamingMethod_SubscribeTrackingOffCommand<WithStreamedUnaryMethod_RespondTrackingPointCommand<WithStreamedUnaryMethod_RespondTrackingRectangleCommand<WithStreamedUnaryMethod_RespondTrackingOffCommand<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_SetInformation<WithStreamedUnaryMethod_SetVideoStreaming<WithStreamedUnaryMethod_SetInProgress<WithSplitStreamingMethod_SubscribeTakePhoto<WithStreamedUnaryMethod_RespondTakePhoto<WithSplitStreamingMethod_SubscribeStartVideo<WithStreamedUnaryMethod_RespondStartVideo<WithSplitStreamingMethod_SubscribeStopVideo<WithStreamedUnaryMethod_RespondStopVideo<WithSplitStreamingMethod_SubscribeStartVideoStreaming<WithStreamedUnaryMethod_RespondStartVideoStreaming<WithSplitStreamingMethod_SubscribeStopVideoStreaming<WithStreamedUnaryMethod_RespondStopVideoStreaming<WithSplitStreamingMethod_SubscribeSetMode<WithStreamedUnaryMethod_RespondSetMode<WithSplitStreamingMethod_SubscribeStorageInformation<WithStreamedUnaryMethod_RespondStorageInformation<WithSplitStreamingMethod_SubscribeCaptureStatus<WithStreamedUnaryMethod_RespondCaptureStatus<WithSplitStreamingMethod_SubscribeFormatStorage<WithStreamedUnaryMethod_RespondFormatStorage<WithSplitStreamingMethod_SubscribeResetSettings<WithStreamedUnaryMethod_RespondResetSettings<WithSplitStreamingMethod_SubscribeZoomInStart<WithStreamedUnaryMethod_RespondZoomInStart<WithSplitStreamingMethod_SubscribeZoomOutStart<WithStreamedUnaryMethod_RespondZoomOutStart<WithSplitStreamingMethod_SubscribeZoomStop<WithStreamedUnaryMethod_RespondZoomStop<WithSplitStreamingMethod_SubscribeZoomRange<WithStreamedUnaryMethod_RespondZoomRange<WithStreamedUnaryMethod_SetTrackingRectangleStatus<WithStreamedUnaryMethod_SetTrackingOffStatus<WithSplitStreamingMethod_SubscribeTrackingPointCommand<WithSplitStreamingMethod_SubscribeTrackingRectangleCommand<WithSplitStreamingMethod_SubscribeTrackingOffCommand<WithStreamedUnaryMethod_RespondTrackingPointCommand<WithStreamedUnaryMethod_RespondTrackingRectangleCommand<WithStreamedUnaryMethod_RespondTrackingOffCommand<WithStreamedUnaryMethod_SupportImageInVideoMode<WithStreamedUnaryMethod_SupportVideoInImageMode<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace camera_server

--- a/src/mavsdk_server/src/generated/camera_server/camera_server.pb.cc
+++ b/src/mavsdk_server/src/generated/camera_server/camera_server.pb.cc
@@ -202,6 +202,44 @@ struct TakePhotoResponseDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 TakePhotoResponseDefaultTypeInternal _TakePhotoResponse_default_instance_;
+
+inline constexpr SupportVideoInImageModeRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : support_{false},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR SupportVideoInImageModeRequest::SupportVideoInImageModeRequest(::_pbi::ConstantInitialized)
+    : _impl_(::_pbi::ConstantInitialized()) {}
+struct SupportVideoInImageModeRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SupportVideoInImageModeRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SupportVideoInImageModeRequestDefaultTypeInternal() {}
+  union {
+    SupportVideoInImageModeRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SupportVideoInImageModeRequestDefaultTypeInternal _SupportVideoInImageModeRequest_default_instance_;
+
+inline constexpr SupportImageInVideoModeRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : support_{false},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR SupportImageInVideoModeRequest::SupportImageInVideoModeRequest(::_pbi::ConstantInitialized)
+    : _impl_(::_pbi::ConstantInitialized()) {}
+struct SupportImageInVideoModeRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SupportImageInVideoModeRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SupportImageInVideoModeRequestDefaultTypeInternal() {}
+  union {
+    SupportImageInVideoModeRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SupportImageInVideoModeRequestDefaultTypeInternal _SupportImageInVideoModeRequest_default_instance_;
       template <typename>
 PROTOBUF_CONSTEXPR SubscribeZoomStopRequest::SubscribeZoomStopRequest(::_pbi::ConstantInitialized) {}
 struct SubscribeZoomStopRequestDefaultTypeInternal {
@@ -1102,6 +1140,44 @@ struct TrackingPointCommandResponseDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 TrackingPointCommandResponseDefaultTypeInternal _TrackingPointCommandResponse_default_instance_;
 
+inline constexpr SupportVideoInImageModeResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_server_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR SupportVideoInImageModeResponse::SupportVideoInImageModeResponse(::_pbi::ConstantInitialized)
+    : _impl_(::_pbi::ConstantInitialized()) {}
+struct SupportVideoInImageModeResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SupportVideoInImageModeResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SupportVideoInImageModeResponseDefaultTypeInternal() {}
+  union {
+    SupportVideoInImageModeResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SupportVideoInImageModeResponseDefaultTypeInternal _SupportVideoInImageModeResponse_default_instance_;
+
+inline constexpr SupportImageInVideoModeResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_server_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR SupportImageInVideoModeResponse::SupportImageInVideoModeResponse(::_pbi::ConstantInitialized)
+    : _impl_(::_pbi::ConstantInitialized()) {}
+struct SupportImageInVideoModeResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SupportImageInVideoModeResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SupportImageInVideoModeResponseDefaultTypeInternal() {}
+  union {
+    SupportImageInVideoModeResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SupportImageInVideoModeResponseDefaultTypeInternal _SupportImageInVideoModeResponse_default_instance_;
+
 inline constexpr SetVideoStreamingResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : _cached_size_{0},
@@ -1646,7 +1722,7 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
 }  // namespace camera_server
 }  // namespace rpc
 }  // namespace mavsdk
-static ::_pb::Metadata file_level_metadata_camera_5fserver_2fcamera_5fserver_2eproto[90];
+static ::_pb::Metadata file_level_metadata_camera_5fserver_2fcamera_5fserver_2eproto[94];
 static const ::_pb::EnumDescriptor* file_level_enum_descriptors_camera_5fserver_2fcamera_5fserver_2eproto[7];
 static constexpr const ::_pb::ServiceDescriptor**
     file_level_service_descriptors_camera_5fserver_2fcamera_5fserver_2eproto = nullptr;
@@ -2500,6 +2576,44 @@ const ::uint32_t TableStruct_camera_5fserver_2fcamera_5fserver_2eproto::offsets[
     PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse, _impl_.camera_server_result_),
     0,
     ~0u,  // no _has_bits_
+    PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest, _internal_metadata_),
+    ~0u,  // no _extensions_
+    ~0u,  // no _oneof_case_
+    ~0u,  // no _weak_field_map_
+    ~0u,  // no _inlined_string_donated_
+    ~0u,  // no _split_
+    ~0u,  // no sizeof(Split)
+    PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest, _impl_.support_),
+    PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse, _impl_._has_bits_),
+    PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse, _internal_metadata_),
+    ~0u,  // no _extensions_
+    ~0u,  // no _oneof_case_
+    ~0u,  // no _weak_field_map_
+    ~0u,  // no _inlined_string_donated_
+    ~0u,  // no _split_
+    ~0u,  // no sizeof(Split)
+    PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse, _impl_.camera_server_result_),
+    0,
+    ~0u,  // no _has_bits_
+    PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest, _internal_metadata_),
+    ~0u,  // no _extensions_
+    ~0u,  // no _oneof_case_
+    ~0u,  // no _weak_field_map_
+    ~0u,  // no _inlined_string_donated_
+    ~0u,  // no _split_
+    ~0u,  // no sizeof(Split)
+    PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest, _impl_.support_),
+    PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse, _impl_._has_bits_),
+    PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse, _internal_metadata_),
+    ~0u,  // no _extensions_
+    ~0u,  // no _oneof_case_
+    ~0u,  // no _weak_field_map_
+    ~0u,  // no _inlined_string_donated_
+    ~0u,  // no _split_
+    ~0u,  // no sizeof(Split)
+    PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse, _impl_.camera_server_result_),
+    0,
+    ~0u,  // no _has_bits_
     PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::TrackPoint, _internal_metadata_),
     ~0u,  // no _extensions_
     ~0u,  // no _oneof_case_
@@ -2614,8 +2728,12 @@ static const ::_pbi::MigrationSchema
         {818, 827, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse)},
         {828, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest)},
         {837, 846, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse)},
-        {847, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackPoint)},
-        {858, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackRectangle)},
+        {847, -1, -1, sizeof(::mavsdk::rpc::camera_server::SupportImageInVideoModeRequest)},
+        {856, 865, -1, sizeof(::mavsdk::rpc::camera_server::SupportImageInVideoModeResponse)},
+        {866, -1, -1, sizeof(::mavsdk::rpc::camera_server::SupportVideoInImageModeRequest)},
+        {875, 884, -1, sizeof(::mavsdk::rpc::camera_server::SupportVideoInImageModeResponse)},
+        {885, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackPoint)},
+        {896, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackRectangle)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
@@ -2707,6 +2825,10 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::camera_server::_RespondTrackingRectangleCommandResponse_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_RespondTrackingOffCommandRequest_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_RespondTrackingOffCommandResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SupportImageInVideoModeRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SupportImageInVideoModeResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SupportVideoInImageModeRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SupportVideoInImageModeResponse_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_TrackPoint_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_TrackRectangle_default_instance_._instance,
 };
@@ -2922,157 +3044,172 @@ const char descriptor_table_protodef_camera_5fserver_2fcamera_5fserver_2eproto[]
     "er.CameraFeedback\"o\n!RespondTrackingOffC"
     "ommandResponse\022J\n\024camera_server_result\030\001"
     " \001(\0132,.mavsdk.rpc.camera_server.CameraSe"
-    "rverResult\">\n\nTrackPoint\022\017\n\007point_x\030\001 \001("
-    "\002\022\017\n\007point_y\030\002 \001(\002\022\016\n\006radius\030\003 \001(\002\"\204\001\n\016T"
-    "rackRectangle\022\031\n\021top_left_corner_x\030\001 \001(\002"
-    "\022\031\n\021top_left_corner_y\030\002 \001(\002\022\035\n\025bottom_ri"
-    "ght_corner_x\030\003 \001(\002\022\035\n\025bottom_right_corne"
-    "r_y\030\004 \001(\002*{\n\016CameraFeedback\022\033\n\027CAMERA_FE"
-    "EDBACK_UNKNOWN\020\000\022\026\n\022CAMERA_FEEDBACK_OK\020\001"
-    "\022\030\n\024CAMERA_FEEDBACK_BUSY\020\002\022\032\n\026CAMERA_FEE"
-    "DBACK_FAILED\020\003*8\n\004Mode\022\020\n\014MODE_UNKNOWN\020\000"
-    "\022\016\n\nMODE_PHOTO\020\001\022\016\n\nMODE_VIDEO\020\0022\270+\n\023Cam"
-    "eraServerService\022y\n\016SetInformation\022/.mav"
-    "sdk.rpc.camera_server.SetInformationRequ"
-    "est\0320.mavsdk.rpc.camera_server.SetInform"
-    "ationResponse\"\004\200\265\030\001\022\202\001\n\021SetVideoStreamin"
-    "g\0222.mavsdk.rpc.camera_server.SetVideoStr"
-    "eamingRequest\0323.mavsdk.rpc.camera_server"
-    ".SetVideoStreamingResponse\"\004\200\265\030\001\022v\n\rSetI"
-    "nProgress\022..mavsdk.rpc.camera_server.Set"
-    "InProgressRequest\032/.mavsdk.rpc.camera_se"
-    "rver.SetInProgressResponse\"\004\200\265\030\001\022~\n\022Subs"
-    "cribeTakePhoto\0223.mavsdk.rpc.camera_serve"
-    "r.SubscribeTakePhotoRequest\032+.mavsdk.rpc"
-    ".camera_server.TakePhotoResponse\"\004\200\265\030\0000\001"
-    "\022\177\n\020RespondTakePhoto\0221.mavsdk.rpc.camera"
-    "_server.RespondTakePhotoRequest\0322.mavsdk"
-    ".rpc.camera_server.RespondTakePhotoRespo"
-    "nse\"\004\200\265\030\001\022\201\001\n\023SubscribeStartVideo\0224.mavs"
-    "dk.rpc.camera_server.SubscribeStartVideo"
-    "Request\032,.mavsdk.rpc.camera_server.Start"
-    "VideoResponse\"\004\200\265\030\0000\001\022\202\001\n\021RespondStartVi"
-    "deo\0222.mavsdk.rpc.camera_server.RespondSt"
-    "artVideoRequest\0323.mavsdk.rpc.camera_serv"
-    "er.RespondStartVideoResponse\"\004\200\265\030\001\022~\n\022Su"
-    "bscribeStopVideo\0223.mavsdk.rpc.camera_ser"
-    "ver.SubscribeStopVideoRequest\032+.mavsdk.r"
-    "pc.camera_server.StopVideoResponse\"\004\200\265\030\000"
-    "0\001\022\177\n\020RespondStopVideo\0221.mavsdk.rpc.came"
-    "ra_server.RespondStopVideoRequest\0322.mavs"
-    "dk.rpc.camera_server.RespondStopVideoRes"
-    "ponse\"\004\200\265\030\001\022\234\001\n\034SubscribeStartVideoStrea"
-    "ming\022=.mavsdk.rpc.camera_server.Subscrib"
-    "eStartVideoStreamingRequest\0325.mavsdk.rpc"
-    ".camera_server.StartVideoStreamingRespon"
-    "se\"\004\200\265\030\0000\001\022\235\001\n\032RespondStartVideoStreamin"
-    "g\022;.mavsdk.rpc.camera_server.RespondStar"
-    "tVideoStreamingRequest\032<.mavsdk.rpc.came"
-    "ra_server.RespondStartVideoStreamingResp"
-    "onse\"\004\200\265\030\001\022\231\001\n\033SubscribeStopVideoStreami"
-    "ng\022<.mavsdk.rpc.camera_server.SubscribeS"
-    "topVideoStreamingRequest\0324.mavsdk.rpc.ca"
-    "mera_server.StopVideoStreamingResponse\"\004"
-    "\200\265\030\0000\001\022\232\001\n\031RespondStopVideoStreaming\022:.m"
-    "avsdk.rpc.camera_server.RespondStopVideo"
-    "StreamingRequest\032;.mavsdk.rpc.camera_ser"
-    "ver.RespondStopVideoStreamingResponse\"\004\200"
-    "\265\030\001\022x\n\020SubscribeSetMode\0221.mavsdk.rpc.cam"
-    "era_server.SubscribeSetModeRequest\032).mav"
-    "sdk.rpc.camera_server.SetModeResponse\"\004\200"
-    "\265\030\0000\001\022y\n\016RespondSetMode\022/.mavsdk.rpc.cam"
-    "era_server.RespondSetModeRequest\0320.mavsd"
-    "k.rpc.camera_server.RespondSetModeRespon"
-    "se\"\004\200\265\030\001\022\231\001\n\033SubscribeStorageInformation"
-    "\022<.mavsdk.rpc.camera_server.SubscribeSto"
-    "rageInformationRequest\0324.mavsdk.rpc.came"
-    "ra_server.StorageInformationResponse\"\004\200\265"
-    "\030\0000\001\022\232\001\n\031RespondStorageInformation\022:.mav"
-    "sdk.rpc.camera_server.RespondStorageInfo"
-    "rmationRequest\032;.mavsdk.rpc.camera_serve"
-    "r.RespondStorageInformationResponse\"\004\200\265\030"
-    "\001\022\212\001\n\026SubscribeCaptureStatus\0227.mavsdk.rp"
-    "c.camera_server.SubscribeCaptureStatusRe"
-    "quest\032/.mavsdk.rpc.camera_server.Capture"
-    "StatusResponse\"\004\200\265\030\0000\001\022\213\001\n\024RespondCaptur"
-    "eStatus\0225.mavsdk.rpc.camera_server.Respo"
-    "ndCaptureStatusRequest\0326.mavsdk.rpc.came"
-    "ra_server.RespondCaptureStatusResponse\"\004"
-    "\200\265\030\001\022\212\001\n\026SubscribeFormatStorage\0227.mavsdk"
-    ".rpc.camera_server.SubscribeFormatStorag"
-    "eRequest\032/.mavsdk.rpc.camera_server.Form"
-    "atStorageResponse\"\004\200\265\030\0000\001\022\213\001\n\024RespondFor"
-    "matStorage\0225.mavsdk.rpc.camera_server.Re"
-    "spondFormatStorageRequest\0326.mavsdk.rpc.c"
-    "amera_server.RespondFormatStorageRespons"
-    "e\"\004\200\265\030\001\022\212\001\n\026SubscribeResetSettings\0227.mav"
-    "sdk.rpc.camera_server.SubscribeResetSett"
-    "ingsRequest\032/.mavsdk.rpc.camera_server.R"
-    "esetSettingsResponse\"\004\200\265\030\0000\001\022\213\001\n\024Respond"
-    "ResetSettings\0225.mavsdk.rpc.camera_server"
-    ".RespondResetSettingsRequest\0326.mavsdk.rp"
-    "c.camera_server.RespondResetSettingsResp"
-    "onse\"\004\200\265\030\001\022\204\001\n\024SubscribeZoomInStart\0225.ma"
-    "vsdk.rpc.camera_server.SubscribeZoomInSt"
-    "artRequest\032-.mavsdk.rpc.camera_server.Zo"
-    "omInStartResponse\"\004\200\265\030\0000\001\022\205\001\n\022RespondZoo"
-    "mInStart\0223.mavsdk.rpc.camera_server.Resp"
-    "ondZoomInStartRequest\0324.mavsdk.rpc.camer"
-    "a_server.RespondZoomInStartResponse\"\004\200\265\030"
-    "\001\022\207\001\n\025SubscribeZoomOutStart\0226.mavsdk.rpc"
-    ".camera_server.SubscribeZoomOutStartRequ"
-    "est\032..mavsdk.rpc.camera_server.ZoomOutSt"
-    "artResponse\"\004\200\265\030\0000\001\022\210\001\n\023RespondZoomOutSt"
-    "art\0224.mavsdk.rpc.camera_server.RespondZo"
-    "omOutStartRequest\0325.mavsdk.rpc.camera_se"
-    "rver.RespondZoomOutStartResponse\"\004\200\265\030\001\022{"
-    "\n\021SubscribeZoomStop\0222.mavsdk.rpc.camera_"
-    "server.SubscribeZoomStopRequest\032*.mavsdk"
-    ".rpc.camera_server.ZoomStopResponse\"\004\200\265\030"
-    "\0000\001\022|\n\017RespondZoomStop\0220.mavsdk.rpc.came"
-    "ra_server.RespondZoomStopRequest\0321.mavsd"
-    "k.rpc.camera_server.RespondZoomStopRespo"
-    "nse\"\004\200\265\030\001\022~\n\022SubscribeZoomRange\0223.mavsdk"
-    ".rpc.camera_server.SubscribeZoomRangeReq"
-    "uest\032+.mavsdk.rpc.camera_server.ZoomRang"
-    "eResponse\"\004\200\265\030\0000\001\022\177\n\020RespondZoomRange\0221."
-    "mavsdk.rpc.camera_server.RespondZoomRang"
-    "eRequest\0322.mavsdk.rpc.camera_server.Resp"
-    "ondZoomRangeResponse\"\004\200\265\030\001\022\235\001\n\032SetTracki"
-    "ngRectangleStatus\022;.mavsdk.rpc.camera_se"
-    "rver.SetTrackingRectangleStatusRequest\032<"
-    ".mavsdk.rpc.camera_server.SetTrackingRec"
-    "tangleStatusResponse\"\004\200\265\030\001\022\213\001\n\024SetTracki"
-    "ngOffStatus\0225.mavsdk.rpc.camera_server.S"
-    "etTrackingOffStatusRequest\0326.mavsdk.rpc."
-    "camera_server.SetTrackingOffStatusRespon"
-    "se\"\004\200\265\030\001\022\237\001\n\035SubscribeTrackingPointComma"
-    "nd\022>.mavsdk.rpc.camera_server.SubscribeT"
-    "rackingPointCommandRequest\0326.mavsdk.rpc."
-    "camera_server.TrackingPointCommandRespon"
-    "se\"\004\200\265\030\0000\001\022\253\001\n!SubscribeTrackingRectangl"
-    "eCommand\022B.mavsdk.rpc.camera_server.Subs"
-    "cribeTrackingRectangleCommandRequest\032:.m"
-    "avsdk.rpc.camera_server.TrackingRectangl"
-    "eCommandResponse\"\004\200\265\030\0000\001\022\231\001\n\033SubscribeTr"
-    "ackingOffCommand\022<.mavsdk.rpc.camera_ser"
-    "ver.SubscribeTrackingOffCommandRequest\0324"
-    ".mavsdk.rpc.camera_server.TrackingOffCom"
-    "mandResponse\"\004\200\265\030\0000\001\022\240\001\n\033RespondTracking"
-    "PointCommand\022<.mavsdk.rpc.camera_server."
-    "RespondTrackingPointCommandRequest\032=.mav"
-    "sdk.rpc.camera_server.RespondTrackingPoi"
-    "ntCommandResponse\"\004\200\265\030\001\022\254\001\n\037RespondTrack"
-    "ingRectangleCommand\022@.mavsdk.rpc.camera_"
-    "server.RespondTrackingRectangleCommandRe"
-    "quest\032A.mavsdk.rpc.camera_server.Respond"
-    "TrackingRectangleCommandResponse\"\004\200\265\030\001\022\232"
-    "\001\n\031RespondTrackingOffCommand\022:.mavsdk.rp"
-    "c.camera_server.RespondTrackingOffComman"
-    "dRequest\032;.mavsdk.rpc.camera_server.Resp"
-    "ondTrackingOffCommandResponse\"\004\200\265\030\001B,\n\027i"
-    "o.mavsdk.camera_serverB\021CameraServerProt"
-    "ob\006proto3"
+    "rverResult\"1\n\036SupportImageInVideoModeReq"
+    "uest\022\017\n\007support\030\001 \001(\010\"m\n\037SupportImageInV"
+    "ideoModeResponse\022J\n\024camera_server_result"
+    "\030\001 \001(\0132,.mavsdk.rpc.camera_server.Camera"
+    "ServerResult\"1\n\036SupportVideoInImageModeR"
+    "equest\022\017\n\007support\030\001 \001(\010\"m\n\037SupportVideoI"
+    "nImageModeResponse\022J\n\024camera_server_resu"
+    "lt\030\001 \001(\0132,.mavsdk.rpc.camera_server.Came"
+    "raServerResult\">\n\nTrackPoint\022\017\n\007point_x\030"
+    "\001 \001(\002\022\017\n\007point_y\030\002 \001(\002\022\016\n\006radius\030\003 \001(\002\"\204"
+    "\001\n\016TrackRectangle\022\031\n\021top_left_corner_x\030\001"
+    " \001(\002\022\031\n\021top_left_corner_y\030\002 \001(\002\022\035\n\025botto"
+    "m_right_corner_x\030\003 \001(\002\022\035\n\025bottom_right_c"
+    "orner_y\030\004 \001(\002*{\n\016CameraFeedback\022\033\n\027CAMER"
+    "A_FEEDBACK_UNKNOWN\020\000\022\026\n\022CAMERA_FEEDBACK_"
+    "OK\020\001\022\030\n\024CAMERA_FEEDBACK_BUSY\020\002\022\032\n\026CAMERA"
+    "_FEEDBACK_FAILED\020\003*8\n\004Mode\022\020\n\014MODE_UNKNO"
+    "WN\020\000\022\016\n\nMODE_PHOTO\020\001\022\016\n\nMODE_VIDEO\020\0022\346-\n"
+    "\023CameraServerService\022y\n\016SetInformation\022/"
+    ".mavsdk.rpc.camera_server.SetInformation"
+    "Request\0320.mavsdk.rpc.camera_server.SetIn"
+    "formationResponse\"\004\200\265\030\001\022\202\001\n\021SetVideoStre"
+    "aming\0222.mavsdk.rpc.camera_server.SetVide"
+    "oStreamingRequest\0323.mavsdk.rpc.camera_se"
+    "rver.SetVideoStreamingResponse\"\004\200\265\030\001\022v\n\r"
+    "SetInProgress\022..mavsdk.rpc.camera_server"
+    ".SetInProgressRequest\032/.mavsdk.rpc.camer"
+    "a_server.SetInProgressResponse\"\004\200\265\030\001\022~\n\022"
+    "SubscribeTakePhoto\0223.mavsdk.rpc.camera_s"
+    "erver.SubscribeTakePhotoRequest\032+.mavsdk"
+    ".rpc.camera_server.TakePhotoResponse\"\004\200\265"
+    "\030\0000\001\022\177\n\020RespondTakePhoto\0221.mavsdk.rpc.ca"
+    "mera_server.RespondTakePhotoRequest\0322.ma"
+    "vsdk.rpc.camera_server.RespondTakePhotoR"
+    "esponse\"\004\200\265\030\001\022\201\001\n\023SubscribeStartVideo\0224."
+    "mavsdk.rpc.camera_server.SubscribeStartV"
+    "ideoRequest\032,.mavsdk.rpc.camera_server.S"
+    "tartVideoResponse\"\004\200\265\030\0000\001\022\202\001\n\021RespondSta"
+    "rtVideo\0222.mavsdk.rpc.camera_server.Respo"
+    "ndStartVideoRequest\0323.mavsdk.rpc.camera_"
+    "server.RespondStartVideoResponse\"\004\200\265\030\001\022~"
+    "\n\022SubscribeStopVideo\0223.mavsdk.rpc.camera"
+    "_server.SubscribeStopVideoRequest\032+.mavs"
+    "dk.rpc.camera_server.StopVideoResponse\"\004"
+    "\200\265\030\0000\001\022\177\n\020RespondStopVideo\0221.mavsdk.rpc."
+    "camera_server.RespondStopVideoRequest\0322."
+    "mavsdk.rpc.camera_server.RespondStopVide"
+    "oResponse\"\004\200\265\030\001\022\234\001\n\034SubscribeStartVideoS"
+    "treaming\022=.mavsdk.rpc.camera_server.Subs"
+    "cribeStartVideoStreamingRequest\0325.mavsdk"
+    ".rpc.camera_server.StartVideoStreamingRe"
+    "sponse\"\004\200\265\030\0000\001\022\235\001\n\032RespondStartVideoStre"
+    "aming\022;.mavsdk.rpc.camera_server.Respond"
+    "StartVideoStreamingRequest\032<.mavsdk.rpc."
+    "camera_server.RespondStartVideoStreaming"
+    "Response\"\004\200\265\030\001\022\231\001\n\033SubscribeStopVideoStr"
+    "eaming\022<.mavsdk.rpc.camera_server.Subscr"
+    "ibeStopVideoStreamingRequest\0324.mavsdk.rp"
+    "c.camera_server.StopVideoStreamingRespon"
+    "se\"\004\200\265\030\0000\001\022\232\001\n\031RespondStopVideoStreaming"
+    "\022:.mavsdk.rpc.camera_server.RespondStopV"
+    "ideoStreamingRequest\032;.mavsdk.rpc.camera"
+    "_server.RespondStopVideoStreamingRespons"
+    "e\"\004\200\265\030\001\022x\n\020SubscribeSetMode\0221.mavsdk.rpc"
+    ".camera_server.SubscribeSetModeRequest\032)"
+    ".mavsdk.rpc.camera_server.SetModeRespons"
+    "e\"\004\200\265\030\0000\001\022y\n\016RespondSetMode\022/.mavsdk.rpc"
+    ".camera_server.RespondSetModeRequest\0320.m"
+    "avsdk.rpc.camera_server.RespondSetModeRe"
+    "sponse\"\004\200\265\030\001\022\231\001\n\033SubscribeStorageInforma"
+    "tion\022<.mavsdk.rpc.camera_server.Subscrib"
+    "eStorageInformationRequest\0324.mavsdk.rpc."
+    "camera_server.StorageInformationResponse"
+    "\"\004\200\265\030\0000\001\022\232\001\n\031RespondStorageInformation\022:"
+    ".mavsdk.rpc.camera_server.RespondStorage"
+    "InformationRequest\032;.mavsdk.rpc.camera_s"
+    "erver.RespondStorageInformationResponse\""
+    "\004\200\265\030\001\022\212\001\n\026SubscribeCaptureStatus\0227.mavsd"
+    "k.rpc.camera_server.SubscribeCaptureStat"
+    "usRequest\032/.mavsdk.rpc.camera_server.Cap"
+    "tureStatusResponse\"\004\200\265\030\0000\001\022\213\001\n\024RespondCa"
+    "ptureStatus\0225.mavsdk.rpc.camera_server.R"
+    "espondCaptureStatusRequest\0326.mavsdk.rpc."
+    "camera_server.RespondCaptureStatusRespon"
+    "se\"\004\200\265\030\001\022\212\001\n\026SubscribeFormatStorage\0227.ma"
+    "vsdk.rpc.camera_server.SubscribeFormatSt"
+    "orageRequest\032/.mavsdk.rpc.camera_server."
+    "FormatStorageResponse\"\004\200\265\030\0000\001\022\213\001\n\024Respon"
+    "dFormatStorage\0225.mavsdk.rpc.camera_serve"
+    "r.RespondFormatStorageRequest\0326.mavsdk.r"
+    "pc.camera_server.RespondFormatStorageRes"
+    "ponse\"\004\200\265\030\001\022\212\001\n\026SubscribeResetSettings\0227"
+    ".mavsdk.rpc.camera_server.SubscribeReset"
+    "SettingsRequest\032/.mavsdk.rpc.camera_serv"
+    "er.ResetSettingsResponse\"\004\200\265\030\0000\001\022\213\001\n\024Res"
+    "pondResetSettings\0225.mavsdk.rpc.camera_se"
+    "rver.RespondResetSettingsRequest\0326.mavsd"
+    "k.rpc.camera_server.RespondResetSettings"
+    "Response\"\004\200\265\030\001\022\204\001\n\024SubscribeZoomInStart\022"
+    "5.mavsdk.rpc.camera_server.SubscribeZoom"
+    "InStartRequest\032-.mavsdk.rpc.camera_serve"
+    "r.ZoomInStartResponse\"\004\200\265\030\0000\001\022\205\001\n\022Respon"
+    "dZoomInStart\0223.mavsdk.rpc.camera_server."
+    "RespondZoomInStartRequest\0324.mavsdk.rpc.c"
+    "amera_server.RespondZoomInStartResponse\""
+    "\004\200\265\030\001\022\207\001\n\025SubscribeZoomOutStart\0226.mavsdk"
+    ".rpc.camera_server.SubscribeZoomOutStart"
+    "Request\032..mavsdk.rpc.camera_server.ZoomO"
+    "utStartResponse\"\004\200\265\030\0000\001\022\210\001\n\023RespondZoomO"
+    "utStart\0224.mavsdk.rpc.camera_server.Respo"
+    "ndZoomOutStartRequest\0325.mavsdk.rpc.camer"
+    "a_server.RespondZoomOutStartResponse\"\004\200\265"
+    "\030\001\022{\n\021SubscribeZoomStop\0222.mavsdk.rpc.cam"
+    "era_server.SubscribeZoomStopRequest\032*.ma"
+    "vsdk.rpc.camera_server.ZoomStopResponse\""
+    "\004\200\265\030\0000\001\022|\n\017RespondZoomStop\0220.mavsdk.rpc."
+    "camera_server.RespondZoomStopRequest\0321.m"
+    "avsdk.rpc.camera_server.RespondZoomStopR"
+    "esponse\"\004\200\265\030\001\022~\n\022SubscribeZoomRange\0223.ma"
+    "vsdk.rpc.camera_server.SubscribeZoomRang"
+    "eRequest\032+.mavsdk.rpc.camera_server.Zoom"
+    "RangeResponse\"\004\200\265\030\0000\001\022\177\n\020RespondZoomRang"
+    "e\0221.mavsdk.rpc.camera_server.RespondZoom"
+    "RangeRequest\0322.mavsdk.rpc.camera_server."
+    "RespondZoomRangeResponse\"\004\200\265\030\001\022\235\001\n\032SetTr"
+    "ackingRectangleStatus\022;.mavsdk.rpc.camer"
+    "a_server.SetTrackingRectangleStatusReque"
+    "st\032<.mavsdk.rpc.camera_server.SetTrackin"
+    "gRectangleStatusResponse\"\004\200\265\030\001\022\213\001\n\024SetTr"
+    "ackingOffStatus\0225.mavsdk.rpc.camera_serv"
+    "er.SetTrackingOffStatusRequest\0326.mavsdk."
+    "rpc.camera_server.SetTrackingOffStatusRe"
+    "sponse\"\004\200\265\030\001\022\237\001\n\035SubscribeTrackingPointC"
+    "ommand\022>.mavsdk.rpc.camera_server.Subscr"
+    "ibeTrackingPointCommandRequest\0326.mavsdk."
+    "rpc.camera_server.TrackingPointCommandRe"
+    "sponse\"\004\200\265\030\0000\001\022\253\001\n!SubscribeTrackingRect"
+    "angleCommand\022B.mavsdk.rpc.camera_server."
+    "SubscribeTrackingRectangleCommandRequest"
+    "\032:.mavsdk.rpc.camera_server.TrackingRect"
+    "angleCommandResponse\"\004\200\265\030\0000\001\022\231\001\n\033Subscri"
+    "beTrackingOffCommand\022<.mavsdk.rpc.camera"
+    "_server.SubscribeTrackingOffCommandReque"
+    "st\0324.mavsdk.rpc.camera_server.TrackingOf"
+    "fCommandResponse\"\004\200\265\030\0000\001\022\240\001\n\033RespondTrac"
+    "kingPointCommand\022<.mavsdk.rpc.camera_ser"
+    "ver.RespondTrackingPointCommandRequest\032="
+    ".mavsdk.rpc.camera_server.RespondTrackin"
+    "gPointCommandResponse\"\004\200\265\030\001\022\254\001\n\037RespondT"
+    "rackingRectangleCommand\022@.mavsdk.rpc.cam"
+    "era_server.RespondTrackingRectangleComma"
+    "ndRequest\032A.mavsdk.rpc.camera_server.Res"
+    "pondTrackingRectangleCommandResponse\"\004\200\265"
+    "\030\001\022\232\001\n\031RespondTrackingOffCommand\022:.mavsd"
+    "k.rpc.camera_server.RespondTrackingOffCo"
+    "mmandRequest\032;.mavsdk.rpc.camera_server."
+    "RespondTrackingOffCommandResponse\"\004\200\265\030\001\022"
+    "\224\001\n\027SupportImageInVideoMode\0228.mavsdk.rpc"
+    ".camera_server.SupportImageInVideoModeRe"
+    "quest\0329.mavsdk.rpc.camera_server.Support"
+    "ImageInVideoModeResponse\"\004\200\265\030\001\022\224\001\n\027Suppo"
+    "rtVideoInImageMode\0228.mavsdk.rpc.camera_s"
+    "erver.SupportVideoInImageModeRequest\0329.m"
+    "avsdk.rpc.camera_server.SupportVideoInIm"
+    "ageModeResponse\"\004\200\265\030\001B,\n\027io.mavsdk.camer"
+    "a_serverB\021CameraServerProtob\006proto3"
 };
 static const ::_pbi::DescriptorTable* const descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_deps[1] =
     {
@@ -3082,13 +3219,13 @@ static ::absl::once_flag descriptor_table_camera_5fserver_2fcamera_5fserver_2epr
 const ::_pbi::DescriptorTable descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto = {
     false,
     false,
-    14449,
+    15075,
     descriptor_table_protodef_camera_5fserver_2fcamera_5fserver_2eproto,
     "camera_server/camera_server.proto",
     &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_once,
     descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_deps,
     1,
-    90,
+    94,
     schemas,
     file_default_instances,
     TableStruct_camera_5fserver_2fcamera_5fserver_2eproto::offsets,
@@ -17859,6 +17996,758 @@ void RespondTrackingOffCommandResponse::InternalSwap(RespondTrackingOffCommandRe
 }
 // ===================================================================
 
+class SupportImageInVideoModeRequest::_Internal {
+ public:
+};
+
+SupportImageInVideoModeRequest::SupportImageInVideoModeRequest(::google::protobuf::Arena* arena)
+    : ::google::protobuf::Message(arena) {
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SupportImageInVideoModeRequest)
+}
+SupportImageInVideoModeRequest::SupportImageInVideoModeRequest(
+    ::google::protobuf::Arena* arena, const SupportImageInVideoModeRequest& from)
+    : SupportImageInVideoModeRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE SupportImageInVideoModeRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void SupportImageInVideoModeRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.support_ = {};
+}
+SupportImageInVideoModeRequest::~SupportImageInVideoModeRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.SupportImageInVideoModeRequest)
+  _internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  SharedDtor();
+}
+inline void SupportImageInVideoModeRequest::SharedDtor() {
+  ABSL_DCHECK(GetArena() == nullptr);
+  _impl_.~Impl_();
+}
+
+PROTOBUF_NOINLINE void SupportImageInVideoModeRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.SupportImageInVideoModeRequest)
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.support_ = false;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+const char* SupportImageInVideoModeRequest::_InternalParse(
+    const char* ptr, ::_pbi::ParseContext* ctx) {
+  ptr = ::_pbi::TcParser::ParseLoop(this, ptr, ctx, &_table_.header);
+  return ptr;
+}
+
+
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> SupportImageInVideoModeRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    &_SupportImageInVideoModeRequest_default_instance_._instance,
+    ::_pbi::TcParser::GenericFallback,  // fallback
+  }, {{
+    // bool support = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(SupportImageInVideoModeRequest, _impl_.support_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(SupportImageInVideoModeRequest, _impl_.support_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // bool support = 1;
+    {PROTOBUF_FIELD_OFFSET(SupportImageInVideoModeRequest, _impl_.support_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kBool)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+::uint8_t* SupportImageInVideoModeRequest::_InternalSerialize(
+    ::uint8_t* target,
+    ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.SupportImageInVideoModeRequest)
+  ::uint32_t cached_has_bits = 0;
+  (void)cached_has_bits;
+
+  // bool support = 1;
+  if (this->_internal_support() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteBoolToArray(
+        1, this->_internal_support(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target =
+        ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+            _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.SupportImageInVideoModeRequest)
+  return target;
+}
+
+::size_t SupportImageInVideoModeRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.SupportImageInVideoModeRequest)
+  ::size_t total_size = 0;
+
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // bool support = 1;
+  if (this->_internal_support() != 0) {
+    total_size += 2;
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::google::protobuf::Message::ClassData SupportImageInVideoModeRequest::_class_data_ = {
+    SupportImageInVideoModeRequest::MergeImpl,
+    nullptr,  // OnDemandRegisterArenaDtor
+};
+const ::google::protobuf::Message::ClassData* SupportImageInVideoModeRequest::GetClassData() const {
+  return &_class_data_;
+}
+
+void SupportImageInVideoModeRequest::MergeImpl(::google::protobuf::Message& to_msg, const ::google::protobuf::Message& from_msg) {
+  auto* const _this = static_cast<SupportImageInVideoModeRequest*>(&to_msg);
+  auto& from = static_cast<const SupportImageInVideoModeRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.SupportImageInVideoModeRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_support() != 0) {
+    _this->_internal_set_support(from._internal_support());
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SupportImageInVideoModeRequest::CopyFrom(const SupportImageInVideoModeRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.SupportImageInVideoModeRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+PROTOBUF_NOINLINE bool SupportImageInVideoModeRequest::IsInitialized() const {
+  return true;
+}
+
+::_pbi::CachedSize* SupportImageInVideoModeRequest::AccessCachedSize() const {
+  return &_impl_._cached_size_;
+}
+void SupportImageInVideoModeRequest::InternalSwap(SupportImageInVideoModeRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.support_, other->_impl_.support_);
+}
+
+::google::protobuf::Metadata SupportImageInVideoModeRequest::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_getter, &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_once,
+      file_level_metadata_camera_5fserver_2fcamera_5fserver_2eproto[88]);
+}
+// ===================================================================
+
+class SupportImageInVideoModeResponse::_Internal {
+ public:
+  using HasBits = decltype(std::declval<SupportImageInVideoModeResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+    8 * PROTOBUF_FIELD_OFFSET(SupportImageInVideoModeResponse, _impl_._has_bits_);
+  static const ::mavsdk::rpc::camera_server::CameraServerResult& camera_server_result(const SupportImageInVideoModeResponse* msg);
+  static void set_has_camera_server_result(HasBits* has_bits) {
+    (*has_bits)[0] |= 1u;
+  }
+};
+
+const ::mavsdk::rpc::camera_server::CameraServerResult& SupportImageInVideoModeResponse::_Internal::camera_server_result(const SupportImageInVideoModeResponse* msg) {
+  return *msg->_impl_.camera_server_result_;
+}
+SupportImageInVideoModeResponse::SupportImageInVideoModeResponse(::google::protobuf::Arena* arena)
+    : ::google::protobuf::Message(arena) {
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SupportImageInVideoModeResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE SupportImageInVideoModeResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+SupportImageInVideoModeResponse::SupportImageInVideoModeResponse(
+    ::google::protobuf::Arena* arena,
+    const SupportImageInVideoModeResponse& from)
+    : ::google::protobuf::Message(arena) {
+  SupportImageInVideoModeResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_server_result_ = (cached_has_bits & 0x00000001u)
+                ? CreateMaybeMessage<::mavsdk::rpc::camera_server::CameraServerResult>(arena, *from._impl_.camera_server_result_)
+                : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.SupportImageInVideoModeResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE SupportImageInVideoModeResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void SupportImageInVideoModeResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_server_result_ = {};
+}
+SupportImageInVideoModeResponse::~SupportImageInVideoModeResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.SupportImageInVideoModeResponse)
+  _internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  SharedDtor();
+}
+inline void SupportImageInVideoModeResponse::SharedDtor() {
+  ABSL_DCHECK(GetArena() == nullptr);
+  delete _impl_.camera_server_result_;
+  _impl_.~Impl_();
+}
+
+PROTOBUF_NOINLINE void SupportImageInVideoModeResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.SupportImageInVideoModeResponse)
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_server_result_ != nullptr);
+    _impl_.camera_server_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+const char* SupportImageInVideoModeResponse::_InternalParse(
+    const char* ptr, ::_pbi::ParseContext* ctx) {
+  ptr = ::_pbi::TcParser::ParseLoop(this, ptr, ctx, &_table_.header);
+  return ptr;
+}
+
+
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> SupportImageInVideoModeResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(SupportImageInVideoModeResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    &_SupportImageInVideoModeResponse_default_instance_._instance,
+    ::_pbi::TcParser::GenericFallback,  // fallback
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(SupportImageInVideoModeResponse, _impl_.camera_server_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {PROTOBUF_FIELD_OFFSET(SupportImageInVideoModeResponse, _impl_.camera_server_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::CameraServerResult>()},
+  }}, {{
+  }},
+};
+
+::uint8_t* SupportImageInVideoModeResponse::_InternalSerialize(
+    ::uint8_t* target,
+    ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.SupportImageInVideoModeResponse)
+  ::uint32_t cached_has_bits = 0;
+  (void)cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+  if (cached_has_bits & 0x00000001u) {
+    target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+        1, _Internal::camera_server_result(this),
+        _Internal::camera_server_result(this).GetCachedSize(), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target =
+        ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+            _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.SupportImageInVideoModeResponse)
+  return target;
+}
+
+::size_t SupportImageInVideoModeResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.SupportImageInVideoModeResponse)
+  ::size_t total_size = 0;
+
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    total_size +=
+        1 + ::google::protobuf::internal::WireFormatLite::MessageSize(*_impl_.camera_server_result_);
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::google::protobuf::Message::ClassData SupportImageInVideoModeResponse::_class_data_ = {
+    SupportImageInVideoModeResponse::MergeImpl,
+    nullptr,  // OnDemandRegisterArenaDtor
+};
+const ::google::protobuf::Message::ClassData* SupportImageInVideoModeResponse::GetClassData() const {
+  return &_class_data_;
+}
+
+void SupportImageInVideoModeResponse::MergeImpl(::google::protobuf::Message& to_msg, const ::google::protobuf::Message& from_msg) {
+  auto* const _this = static_cast<SupportImageInVideoModeResponse*>(&to_msg);
+  auto& from = static_cast<const SupportImageInVideoModeResponse&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.SupportImageInVideoModeResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if ((from._impl_._has_bits_[0] & 0x00000001u) != 0) {
+    _this->_internal_mutable_camera_server_result()->::mavsdk::rpc::camera_server::CameraServerResult::MergeFrom(
+        from._internal_camera_server_result());
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SupportImageInVideoModeResponse::CopyFrom(const SupportImageInVideoModeResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.SupportImageInVideoModeResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+PROTOBUF_NOINLINE bool SupportImageInVideoModeResponse::IsInitialized() const {
+  return true;
+}
+
+::_pbi::CachedSize* SupportImageInVideoModeResponse::AccessCachedSize() const {
+  return &_impl_._cached_size_;
+}
+void SupportImageInVideoModeResponse::InternalSwap(SupportImageInVideoModeResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_server_result_, other->_impl_.camera_server_result_);
+}
+
+::google::protobuf::Metadata SupportImageInVideoModeResponse::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_getter, &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_once,
+      file_level_metadata_camera_5fserver_2fcamera_5fserver_2eproto[89]);
+}
+// ===================================================================
+
+class SupportVideoInImageModeRequest::_Internal {
+ public:
+};
+
+SupportVideoInImageModeRequest::SupportVideoInImageModeRequest(::google::protobuf::Arena* arena)
+    : ::google::protobuf::Message(arena) {
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SupportVideoInImageModeRequest)
+}
+SupportVideoInImageModeRequest::SupportVideoInImageModeRequest(
+    ::google::protobuf::Arena* arena, const SupportVideoInImageModeRequest& from)
+    : SupportVideoInImageModeRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE SupportVideoInImageModeRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void SupportVideoInImageModeRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.support_ = {};
+}
+SupportVideoInImageModeRequest::~SupportVideoInImageModeRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.SupportVideoInImageModeRequest)
+  _internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  SharedDtor();
+}
+inline void SupportVideoInImageModeRequest::SharedDtor() {
+  ABSL_DCHECK(GetArena() == nullptr);
+  _impl_.~Impl_();
+}
+
+PROTOBUF_NOINLINE void SupportVideoInImageModeRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.SupportVideoInImageModeRequest)
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.support_ = false;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+const char* SupportVideoInImageModeRequest::_InternalParse(
+    const char* ptr, ::_pbi::ParseContext* ctx) {
+  ptr = ::_pbi::TcParser::ParseLoop(this, ptr, ctx, &_table_.header);
+  return ptr;
+}
+
+
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> SupportVideoInImageModeRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    &_SupportVideoInImageModeRequest_default_instance_._instance,
+    ::_pbi::TcParser::GenericFallback,  // fallback
+  }, {{
+    // bool support = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(SupportVideoInImageModeRequest, _impl_.support_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(SupportVideoInImageModeRequest, _impl_.support_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // bool support = 1;
+    {PROTOBUF_FIELD_OFFSET(SupportVideoInImageModeRequest, _impl_.support_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kBool)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+::uint8_t* SupportVideoInImageModeRequest::_InternalSerialize(
+    ::uint8_t* target,
+    ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.SupportVideoInImageModeRequest)
+  ::uint32_t cached_has_bits = 0;
+  (void)cached_has_bits;
+
+  // bool support = 1;
+  if (this->_internal_support() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteBoolToArray(
+        1, this->_internal_support(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target =
+        ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+            _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.SupportVideoInImageModeRequest)
+  return target;
+}
+
+::size_t SupportVideoInImageModeRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.SupportVideoInImageModeRequest)
+  ::size_t total_size = 0;
+
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // bool support = 1;
+  if (this->_internal_support() != 0) {
+    total_size += 2;
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::google::protobuf::Message::ClassData SupportVideoInImageModeRequest::_class_data_ = {
+    SupportVideoInImageModeRequest::MergeImpl,
+    nullptr,  // OnDemandRegisterArenaDtor
+};
+const ::google::protobuf::Message::ClassData* SupportVideoInImageModeRequest::GetClassData() const {
+  return &_class_data_;
+}
+
+void SupportVideoInImageModeRequest::MergeImpl(::google::protobuf::Message& to_msg, const ::google::protobuf::Message& from_msg) {
+  auto* const _this = static_cast<SupportVideoInImageModeRequest*>(&to_msg);
+  auto& from = static_cast<const SupportVideoInImageModeRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.SupportVideoInImageModeRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_support() != 0) {
+    _this->_internal_set_support(from._internal_support());
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SupportVideoInImageModeRequest::CopyFrom(const SupportVideoInImageModeRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.SupportVideoInImageModeRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+PROTOBUF_NOINLINE bool SupportVideoInImageModeRequest::IsInitialized() const {
+  return true;
+}
+
+::_pbi::CachedSize* SupportVideoInImageModeRequest::AccessCachedSize() const {
+  return &_impl_._cached_size_;
+}
+void SupportVideoInImageModeRequest::InternalSwap(SupportVideoInImageModeRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.support_, other->_impl_.support_);
+}
+
+::google::protobuf::Metadata SupportVideoInImageModeRequest::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_getter, &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_once,
+      file_level_metadata_camera_5fserver_2fcamera_5fserver_2eproto[90]);
+}
+// ===================================================================
+
+class SupportVideoInImageModeResponse::_Internal {
+ public:
+  using HasBits = decltype(std::declval<SupportVideoInImageModeResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+    8 * PROTOBUF_FIELD_OFFSET(SupportVideoInImageModeResponse, _impl_._has_bits_);
+  static const ::mavsdk::rpc::camera_server::CameraServerResult& camera_server_result(const SupportVideoInImageModeResponse* msg);
+  static void set_has_camera_server_result(HasBits* has_bits) {
+    (*has_bits)[0] |= 1u;
+  }
+};
+
+const ::mavsdk::rpc::camera_server::CameraServerResult& SupportVideoInImageModeResponse::_Internal::camera_server_result(const SupportVideoInImageModeResponse* msg) {
+  return *msg->_impl_.camera_server_result_;
+}
+SupportVideoInImageModeResponse::SupportVideoInImageModeResponse(::google::protobuf::Arena* arena)
+    : ::google::protobuf::Message(arena) {
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SupportVideoInImageModeResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE SupportVideoInImageModeResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+SupportVideoInImageModeResponse::SupportVideoInImageModeResponse(
+    ::google::protobuf::Arena* arena,
+    const SupportVideoInImageModeResponse& from)
+    : ::google::protobuf::Message(arena) {
+  SupportVideoInImageModeResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_server_result_ = (cached_has_bits & 0x00000001u)
+                ? CreateMaybeMessage<::mavsdk::rpc::camera_server::CameraServerResult>(arena, *from._impl_.camera_server_result_)
+                : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.SupportVideoInImageModeResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE SupportVideoInImageModeResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void SupportVideoInImageModeResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_server_result_ = {};
+}
+SupportVideoInImageModeResponse::~SupportVideoInImageModeResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.SupportVideoInImageModeResponse)
+  _internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  SharedDtor();
+}
+inline void SupportVideoInImageModeResponse::SharedDtor() {
+  ABSL_DCHECK(GetArena() == nullptr);
+  delete _impl_.camera_server_result_;
+  _impl_.~Impl_();
+}
+
+PROTOBUF_NOINLINE void SupportVideoInImageModeResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.SupportVideoInImageModeResponse)
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_server_result_ != nullptr);
+    _impl_.camera_server_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+const char* SupportVideoInImageModeResponse::_InternalParse(
+    const char* ptr, ::_pbi::ParseContext* ctx) {
+  ptr = ::_pbi::TcParser::ParseLoop(this, ptr, ctx, &_table_.header);
+  return ptr;
+}
+
+
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> SupportVideoInImageModeResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(SupportVideoInImageModeResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    &_SupportVideoInImageModeResponse_default_instance_._instance,
+    ::_pbi::TcParser::GenericFallback,  // fallback
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(SupportVideoInImageModeResponse, _impl_.camera_server_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {PROTOBUF_FIELD_OFFSET(SupportVideoInImageModeResponse, _impl_.camera_server_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::CameraServerResult>()},
+  }}, {{
+  }},
+};
+
+::uint8_t* SupportVideoInImageModeResponse::_InternalSerialize(
+    ::uint8_t* target,
+    ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.SupportVideoInImageModeResponse)
+  ::uint32_t cached_has_bits = 0;
+  (void)cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+  if (cached_has_bits & 0x00000001u) {
+    target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+        1, _Internal::camera_server_result(this),
+        _Internal::camera_server_result(this).GetCachedSize(), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target =
+        ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+            _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.SupportVideoInImageModeResponse)
+  return target;
+}
+
+::size_t SupportVideoInImageModeResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.SupportVideoInImageModeResponse)
+  ::size_t total_size = 0;
+
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    total_size +=
+        1 + ::google::protobuf::internal::WireFormatLite::MessageSize(*_impl_.camera_server_result_);
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::google::protobuf::Message::ClassData SupportVideoInImageModeResponse::_class_data_ = {
+    SupportVideoInImageModeResponse::MergeImpl,
+    nullptr,  // OnDemandRegisterArenaDtor
+};
+const ::google::protobuf::Message::ClassData* SupportVideoInImageModeResponse::GetClassData() const {
+  return &_class_data_;
+}
+
+void SupportVideoInImageModeResponse::MergeImpl(::google::protobuf::Message& to_msg, const ::google::protobuf::Message& from_msg) {
+  auto* const _this = static_cast<SupportVideoInImageModeResponse*>(&to_msg);
+  auto& from = static_cast<const SupportVideoInImageModeResponse&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.SupportVideoInImageModeResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if ((from._impl_._has_bits_[0] & 0x00000001u) != 0) {
+    _this->_internal_mutable_camera_server_result()->::mavsdk::rpc::camera_server::CameraServerResult::MergeFrom(
+        from._internal_camera_server_result());
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SupportVideoInImageModeResponse::CopyFrom(const SupportVideoInImageModeResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.SupportVideoInImageModeResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+PROTOBUF_NOINLINE bool SupportVideoInImageModeResponse::IsInitialized() const {
+  return true;
+}
+
+::_pbi::CachedSize* SupportVideoInImageModeResponse::AccessCachedSize() const {
+  return &_impl_._cached_size_;
+}
+void SupportVideoInImageModeResponse::InternalSwap(SupportVideoInImageModeResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_server_result_, other->_impl_.camera_server_result_);
+}
+
+::google::protobuf::Metadata SupportVideoInImageModeResponse::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_getter, &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_once,
+      file_level_metadata_camera_5fserver_2fcamera_5fserver_2eproto[91]);
+}
+// ===================================================================
+
 class TrackPoint::_Internal {
  public:
 };
@@ -18124,7 +19013,7 @@ void TrackPoint::InternalSwap(TrackPoint* PROTOBUF_RESTRICT other) {
 ::google::protobuf::Metadata TrackPoint::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_getter, &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_once,
-      file_level_metadata_camera_5fserver_2fcamera_5fserver_2eproto[88]);
+      file_level_metadata_camera_5fserver_2fcamera_5fserver_2eproto[92]);
 }
 // ===================================================================
 
@@ -18428,7 +19317,7 @@ void TrackRectangle::InternalSwap(TrackRectangle* PROTOBUF_RESTRICT other) {
 ::google::protobuf::Metadata TrackRectangle::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_getter, &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_once,
-      file_level_metadata_camera_5fserver_2fcamera_5fserver_2eproto[89]);
+      file_level_metadata_camera_5fserver_2fcamera_5fserver_2eproto[93]);
 }
 // @@protoc_insertion_point(namespace_scope)
 }  // namespace camera_server

--- a/src/mavsdk_server/src/generated/camera_server/camera_server.pb.h
+++ b/src/mavsdk_server/src/generated/camera_server/camera_server.pb.h
@@ -298,6 +298,18 @@ extern SubscribeZoomRangeRequestDefaultTypeInternal _SubscribeZoomRangeRequest_d
 class SubscribeZoomStopRequest;
 struct SubscribeZoomStopRequestDefaultTypeInternal;
 extern SubscribeZoomStopRequestDefaultTypeInternal _SubscribeZoomStopRequest_default_instance_;
+class SupportImageInVideoModeRequest;
+struct SupportImageInVideoModeRequestDefaultTypeInternal;
+extern SupportImageInVideoModeRequestDefaultTypeInternal _SupportImageInVideoModeRequest_default_instance_;
+class SupportImageInVideoModeResponse;
+struct SupportImageInVideoModeResponseDefaultTypeInternal;
+extern SupportImageInVideoModeResponseDefaultTypeInternal _SupportImageInVideoModeResponse_default_instance_;
+class SupportVideoInImageModeRequest;
+struct SupportVideoInImageModeRequestDefaultTypeInternal;
+extern SupportVideoInImageModeRequestDefaultTypeInternal _SupportVideoInImageModeRequest_default_instance_;
+class SupportVideoInImageModeResponse;
+struct SupportVideoInImageModeResponseDefaultTypeInternal;
+extern SupportVideoInImageModeResponseDefaultTypeInternal _SupportVideoInImageModeResponse_default_instance_;
 class TakePhotoResponse;
 struct TakePhotoResponseDefaultTypeInternal;
 extern TakePhotoResponseDefaultTypeInternal _TakePhotoResponse_default_instance_;
@@ -1718,7 +1730,7 @@ class TrackRectangle final :
                &_TrackRectangle_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    89;
+    93;
 
   friend void swap(TrackRectangle& a, TrackRectangle& b) {
     a.Swap(&b);
@@ -1929,7 +1941,7 @@ class TrackPoint final :
                &_TrackPoint_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    88;
+    92;
 
   friend void swap(TrackPoint& a, TrackPoint& b) {
     a.Swap(&b);
@@ -2237,6 +2249,356 @@ class TakePhotoResponse final :
         inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
                               ::google::protobuf::Arena* arena, const Impl_& from);
     ::int32_t index_;
+    mutable ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};// -------------------------------------------------------------------
+
+class SupportVideoInImageModeRequest final :
+    public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SupportVideoInImageModeRequest) */ {
+ public:
+  inline SupportVideoInImageModeRequest() : SupportVideoInImageModeRequest(nullptr) {}
+  ~SupportVideoInImageModeRequest() override;
+  template<typename = void>
+  explicit PROTOBUF_CONSTEXPR SupportVideoInImageModeRequest(::google::protobuf::internal::ConstantInitialized);
+
+  inline SupportVideoInImageModeRequest(const SupportVideoInImageModeRequest& from)
+      : SupportVideoInImageModeRequest(nullptr, from) {}
+  SupportVideoInImageModeRequest(SupportVideoInImageModeRequest&& from) noexcept
+    : SupportVideoInImageModeRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline SupportVideoInImageModeRequest& operator=(const SupportVideoInImageModeRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SupportVideoInImageModeRequest& operator=(SupportVideoInImageModeRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetArena() == from.GetArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SupportVideoInImageModeRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SupportVideoInImageModeRequest* internal_default_instance() {
+    return reinterpret_cast<const SupportVideoInImageModeRequest*>(
+               &_SupportVideoInImageModeRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    90;
+
+  friend void swap(SupportVideoInImageModeRequest& a, SupportVideoInImageModeRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(SupportVideoInImageModeRequest* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetArena() != nullptr &&
+        GetArena() == other->GetArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetArena() == other->GetArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SupportVideoInImageModeRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SupportVideoInImageModeRequest* New(::google::protobuf::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<SupportVideoInImageModeRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const SupportVideoInImageModeRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom( const SupportVideoInImageModeRequest& from) {
+    SupportVideoInImageModeRequest::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::google::protobuf::Message& to_msg, const ::google::protobuf::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  ::size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::google::protobuf::internal::ParseContext* ctx) final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target, ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  ::google::protobuf::internal::CachedSize* AccessCachedSize() const final;
+  void SharedCtor(::google::protobuf::Arena* arena);
+  void SharedDtor();
+  void InternalSwap(SupportVideoInImageModeRequest* other);
+
+  private:
+  friend class ::google::protobuf::internal::AnyMetadata;
+  static ::absl::string_view FullMessageName() {
+    return "mavsdk.rpc.camera_server.SupportVideoInImageModeRequest";
+  }
+  protected:
+  explicit SupportVideoInImageModeRequest(::google::protobuf::Arena* arena);
+  SupportVideoInImageModeRequest(::google::protobuf::Arena* arena, const SupportVideoInImageModeRequest& from);
+  public:
+
+  static const ClassData _class_data_;
+  const ::google::protobuf::Message::ClassData*GetClassData() const final;
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kSupportFieldNumber = 1,
+  };
+  // bool support = 1;
+  void clear_support() ;
+  bool support() const;
+  void set_support(bool value);
+
+  private:
+  bool _internal_support() const;
+  void _internal_set_support(bool value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SupportVideoInImageModeRequest)
+ private:
+  class _Internal;
+
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+
+        inline explicit constexpr Impl_(
+            ::google::protobuf::internal::ConstantInitialized) noexcept;
+        inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                              ::google::protobuf::Arena* arena);
+        inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                              ::google::protobuf::Arena* arena, const Impl_& from);
+    bool support_;
+    mutable ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};// -------------------------------------------------------------------
+
+class SupportImageInVideoModeRequest final :
+    public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SupportImageInVideoModeRequest) */ {
+ public:
+  inline SupportImageInVideoModeRequest() : SupportImageInVideoModeRequest(nullptr) {}
+  ~SupportImageInVideoModeRequest() override;
+  template<typename = void>
+  explicit PROTOBUF_CONSTEXPR SupportImageInVideoModeRequest(::google::protobuf::internal::ConstantInitialized);
+
+  inline SupportImageInVideoModeRequest(const SupportImageInVideoModeRequest& from)
+      : SupportImageInVideoModeRequest(nullptr, from) {}
+  SupportImageInVideoModeRequest(SupportImageInVideoModeRequest&& from) noexcept
+    : SupportImageInVideoModeRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline SupportImageInVideoModeRequest& operator=(const SupportImageInVideoModeRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SupportImageInVideoModeRequest& operator=(SupportImageInVideoModeRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetArena() == from.GetArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SupportImageInVideoModeRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SupportImageInVideoModeRequest* internal_default_instance() {
+    return reinterpret_cast<const SupportImageInVideoModeRequest*>(
+               &_SupportImageInVideoModeRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    88;
+
+  friend void swap(SupportImageInVideoModeRequest& a, SupportImageInVideoModeRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(SupportImageInVideoModeRequest* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetArena() != nullptr &&
+        GetArena() == other->GetArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetArena() == other->GetArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SupportImageInVideoModeRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SupportImageInVideoModeRequest* New(::google::protobuf::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<SupportImageInVideoModeRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const SupportImageInVideoModeRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom( const SupportImageInVideoModeRequest& from) {
+    SupportImageInVideoModeRequest::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::google::protobuf::Message& to_msg, const ::google::protobuf::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  ::size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::google::protobuf::internal::ParseContext* ctx) final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target, ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  ::google::protobuf::internal::CachedSize* AccessCachedSize() const final;
+  void SharedCtor(::google::protobuf::Arena* arena);
+  void SharedDtor();
+  void InternalSwap(SupportImageInVideoModeRequest* other);
+
+  private:
+  friend class ::google::protobuf::internal::AnyMetadata;
+  static ::absl::string_view FullMessageName() {
+    return "mavsdk.rpc.camera_server.SupportImageInVideoModeRequest";
+  }
+  protected:
+  explicit SupportImageInVideoModeRequest(::google::protobuf::Arena* arena);
+  SupportImageInVideoModeRequest(::google::protobuf::Arena* arena, const SupportImageInVideoModeRequest& from);
+  public:
+
+  static const ClassData _class_data_;
+  const ::google::protobuf::Message::ClassData*GetClassData() const final;
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kSupportFieldNumber = 1,
+  };
+  // bool support = 1;
+  void clear_support() ;
+  bool support() const;
+  void set_support(bool value);
+
+  private:
+  bool _internal_support() const;
+  void _internal_set_support(bool value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SupportImageInVideoModeRequest)
+ private:
+  class _Internal;
+
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+
+        inline explicit constexpr Impl_(
+            ::google::protobuf::internal::ConstantInitialized) noexcept;
+        inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                              ::google::protobuf::Arena* arena);
+        inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                              ::google::protobuf::Arena* arena, const Impl_& from);
+    bool support_;
     mutable ::google::protobuf::internal::CachedSize _cached_size_;
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
@@ -11199,6 +11561,368 @@ class TrackingPointCommandResponse final :
     ::google::protobuf::internal::HasBits<1> _has_bits_;
     mutable ::google::protobuf::internal::CachedSize _cached_size_;
     ::mavsdk::rpc::camera_server::TrackPoint* track_point_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};// -------------------------------------------------------------------
+
+class SupportVideoInImageModeResponse final :
+    public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SupportVideoInImageModeResponse) */ {
+ public:
+  inline SupportVideoInImageModeResponse() : SupportVideoInImageModeResponse(nullptr) {}
+  ~SupportVideoInImageModeResponse() override;
+  template<typename = void>
+  explicit PROTOBUF_CONSTEXPR SupportVideoInImageModeResponse(::google::protobuf::internal::ConstantInitialized);
+
+  inline SupportVideoInImageModeResponse(const SupportVideoInImageModeResponse& from)
+      : SupportVideoInImageModeResponse(nullptr, from) {}
+  SupportVideoInImageModeResponse(SupportVideoInImageModeResponse&& from) noexcept
+    : SupportVideoInImageModeResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline SupportVideoInImageModeResponse& operator=(const SupportVideoInImageModeResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SupportVideoInImageModeResponse& operator=(SupportVideoInImageModeResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetArena() == from.GetArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SupportVideoInImageModeResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SupportVideoInImageModeResponse* internal_default_instance() {
+    return reinterpret_cast<const SupportVideoInImageModeResponse*>(
+               &_SupportVideoInImageModeResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    91;
+
+  friend void swap(SupportVideoInImageModeResponse& a, SupportVideoInImageModeResponse& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(SupportVideoInImageModeResponse* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetArena() != nullptr &&
+        GetArena() == other->GetArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetArena() == other->GetArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SupportVideoInImageModeResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SupportVideoInImageModeResponse* New(::google::protobuf::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<SupportVideoInImageModeResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const SupportVideoInImageModeResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom( const SupportVideoInImageModeResponse& from) {
+    SupportVideoInImageModeResponse::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::google::protobuf::Message& to_msg, const ::google::protobuf::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  ::size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::google::protobuf::internal::ParseContext* ctx) final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target, ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  ::google::protobuf::internal::CachedSize* AccessCachedSize() const final;
+  void SharedCtor(::google::protobuf::Arena* arena);
+  void SharedDtor();
+  void InternalSwap(SupportVideoInImageModeResponse* other);
+
+  private:
+  friend class ::google::protobuf::internal::AnyMetadata;
+  static ::absl::string_view FullMessageName() {
+    return "mavsdk.rpc.camera_server.SupportVideoInImageModeResponse";
+  }
+  protected:
+  explicit SupportVideoInImageModeResponse(::google::protobuf::Arena* arena);
+  SupportVideoInImageModeResponse(::google::protobuf::Arena* arena, const SupportVideoInImageModeResponse& from);
+  public:
+
+  static const ClassData _class_data_;
+  const ::google::protobuf::Message::ClassData*GetClassData() const final;
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kCameraServerResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+  bool has_camera_server_result() const;
+  void clear_camera_server_result() ;
+  const ::mavsdk::rpc::camera_server::CameraServerResult& camera_server_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera_server::CameraServerResult* release_camera_server_result();
+  ::mavsdk::rpc::camera_server::CameraServerResult* mutable_camera_server_result();
+  void set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  void unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  ::mavsdk::rpc::camera_server::CameraServerResult* unsafe_arena_release_camera_server_result();
+
+  private:
+  const ::mavsdk::rpc::camera_server::CameraServerResult& _internal_camera_server_result() const;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _internal_mutable_camera_server_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SupportVideoInImageModeResponse)
+ private:
+  class _Internal;
+
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+
+        inline explicit constexpr Impl_(
+            ::google::protobuf::internal::ConstantInitialized) noexcept;
+        inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                              ::google::protobuf::Arena* arena);
+        inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                              ::google::protobuf::Arena* arena, const Impl_& from);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    mutable ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera_server::CameraServerResult* camera_server_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};// -------------------------------------------------------------------
+
+class SupportImageInVideoModeResponse final :
+    public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SupportImageInVideoModeResponse) */ {
+ public:
+  inline SupportImageInVideoModeResponse() : SupportImageInVideoModeResponse(nullptr) {}
+  ~SupportImageInVideoModeResponse() override;
+  template<typename = void>
+  explicit PROTOBUF_CONSTEXPR SupportImageInVideoModeResponse(::google::protobuf::internal::ConstantInitialized);
+
+  inline SupportImageInVideoModeResponse(const SupportImageInVideoModeResponse& from)
+      : SupportImageInVideoModeResponse(nullptr, from) {}
+  SupportImageInVideoModeResponse(SupportImageInVideoModeResponse&& from) noexcept
+    : SupportImageInVideoModeResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline SupportImageInVideoModeResponse& operator=(const SupportImageInVideoModeResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SupportImageInVideoModeResponse& operator=(SupportImageInVideoModeResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetArena() == from.GetArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SupportImageInVideoModeResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SupportImageInVideoModeResponse* internal_default_instance() {
+    return reinterpret_cast<const SupportImageInVideoModeResponse*>(
+               &_SupportImageInVideoModeResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    89;
+
+  friend void swap(SupportImageInVideoModeResponse& a, SupportImageInVideoModeResponse& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(SupportImageInVideoModeResponse* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetArena() != nullptr &&
+        GetArena() == other->GetArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetArena() == other->GetArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SupportImageInVideoModeResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SupportImageInVideoModeResponse* New(::google::protobuf::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<SupportImageInVideoModeResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const SupportImageInVideoModeResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom( const SupportImageInVideoModeResponse& from) {
+    SupportImageInVideoModeResponse::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::google::protobuf::Message& to_msg, const ::google::protobuf::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  ::size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::google::protobuf::internal::ParseContext* ctx) final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target, ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  ::google::protobuf::internal::CachedSize* AccessCachedSize() const final;
+  void SharedCtor(::google::protobuf::Arena* arena);
+  void SharedDtor();
+  void InternalSwap(SupportImageInVideoModeResponse* other);
+
+  private:
+  friend class ::google::protobuf::internal::AnyMetadata;
+  static ::absl::string_view FullMessageName() {
+    return "mavsdk.rpc.camera_server.SupportImageInVideoModeResponse";
+  }
+  protected:
+  explicit SupportImageInVideoModeResponse(::google::protobuf::Arena* arena);
+  SupportImageInVideoModeResponse(::google::protobuf::Arena* arena, const SupportImageInVideoModeResponse& from);
+  public:
+
+  static const ClassData _class_data_;
+  const ::google::protobuf::Message::ClassData*GetClassData() const final;
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kCameraServerResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+  bool has_camera_server_result() const;
+  void clear_camera_server_result() ;
+  const ::mavsdk::rpc::camera_server::CameraServerResult& camera_server_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera_server::CameraServerResult* release_camera_server_result();
+  ::mavsdk::rpc::camera_server::CameraServerResult* mutable_camera_server_result();
+  void set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  void unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  ::mavsdk::rpc::camera_server::CameraServerResult* unsafe_arena_release_camera_server_result();
+
+  private:
+  const ::mavsdk::rpc::camera_server::CameraServerResult& _internal_camera_server_result() const;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _internal_mutable_camera_server_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SupportImageInVideoModeResponse)
+ private:
+  class _Internal;
+
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+
+        inline explicit constexpr Impl_(
+            ::google::protobuf::internal::ConstantInitialized) noexcept;
+        inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                              ::google::protobuf::Arena* arena);
+        inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                              ::google::protobuf::Arena* arena, const Impl_& from);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    mutable ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera_server::CameraServerResult* camera_server_result_;
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
   union { Impl_ _impl_; };
@@ -21630,6 +22354,260 @@ inline void RespondTrackingOffCommandResponse::set_allocated_camera_server_resul
 
   _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
   // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.RespondTrackingOffCommandResponse.camera_server_result)
+}
+
+// -------------------------------------------------------------------
+
+// SupportImageInVideoModeRequest
+
+// bool support = 1;
+inline void SupportImageInVideoModeRequest::clear_support() {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  _impl_.support_ = false;
+}
+inline bool SupportImageInVideoModeRequest::support() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.SupportImageInVideoModeRequest.support)
+  return _internal_support();
+}
+inline void SupportImageInVideoModeRequest::set_support(bool value) {
+  _internal_set_support(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.SupportImageInVideoModeRequest.support)
+}
+inline bool SupportImageInVideoModeRequest::_internal_support() const {
+  PROTOBUF_TSAN_READ(&_impl_._tsan_detect_race);
+  return _impl_.support_;
+}
+inline void SupportImageInVideoModeRequest::_internal_set_support(bool value) {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  ;
+  _impl_.support_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// SupportImageInVideoModeResponse
+
+// .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+inline bool SupportImageInVideoModeResponse::has_camera_server_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_server_result_ != nullptr);
+  return value;
+}
+inline void SupportImageInVideoModeResponse::clear_camera_server_result() {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  if (_impl_.camera_server_result_ != nullptr) _impl_.camera_server_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& SupportImageInVideoModeResponse::_internal_camera_server_result() const {
+  PROTOBUF_TSAN_READ(&_impl_._tsan_detect_race);
+  const ::mavsdk::rpc::camera_server::CameraServerResult* p = _impl_.camera_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera_server::CameraServerResult&>(::mavsdk::rpc::camera_server::_CameraServerResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& SupportImageInVideoModeResponse::camera_server_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.SupportImageInVideoModeResponse.camera_server_result)
+  return _internal_camera_server_result();
+}
+inline void SupportImageInVideoModeResponse::unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_server_result_);
+  }
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera_server.SupportImageInVideoModeResponse.camera_server_result)
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SupportImageInVideoModeResponse::release_camera_server_result() {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* released = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+  released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+  if (GetArena() == nullptr) {
+    delete old;
+  }
+#else   // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArena() != nullptr) {
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+  }
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return released;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SupportImageInVideoModeResponse::unsafe_arena_release_camera_server_result() {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera_server.SupportImageInVideoModeResponse.camera_server_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* temp = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SupportImageInVideoModeResponse::_internal_mutable_camera_server_result() {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  _impl_._has_bits_[0] |= 0x00000001u;
+  if (_impl_.camera_server_result_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::camera_server::CameraServerResult>(GetArena());
+    _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(p);
+  }
+  return _impl_.camera_server_result_;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SupportImageInVideoModeResponse::mutable_camera_server_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::mavsdk::rpc::camera_server::CameraServerResult* _msg = _internal_mutable_camera_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera_server.SupportImageInVideoModeResponse.camera_server_result)
+  return _msg;
+}
+inline void SupportImageInVideoModeResponse::set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  if (message_arena == nullptr) {
+    delete reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(_impl_.camera_server_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.SupportImageInVideoModeResponse.camera_server_result)
+}
+
+// -------------------------------------------------------------------
+
+// SupportVideoInImageModeRequest
+
+// bool support = 1;
+inline void SupportVideoInImageModeRequest::clear_support() {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  _impl_.support_ = false;
+}
+inline bool SupportVideoInImageModeRequest::support() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.SupportVideoInImageModeRequest.support)
+  return _internal_support();
+}
+inline void SupportVideoInImageModeRequest::set_support(bool value) {
+  _internal_set_support(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.SupportVideoInImageModeRequest.support)
+}
+inline bool SupportVideoInImageModeRequest::_internal_support() const {
+  PROTOBUF_TSAN_READ(&_impl_._tsan_detect_race);
+  return _impl_.support_;
+}
+inline void SupportVideoInImageModeRequest::_internal_set_support(bool value) {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  ;
+  _impl_.support_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// SupportVideoInImageModeResponse
+
+// .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+inline bool SupportVideoInImageModeResponse::has_camera_server_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_server_result_ != nullptr);
+  return value;
+}
+inline void SupportVideoInImageModeResponse::clear_camera_server_result() {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  if (_impl_.camera_server_result_ != nullptr) _impl_.camera_server_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& SupportVideoInImageModeResponse::_internal_camera_server_result() const {
+  PROTOBUF_TSAN_READ(&_impl_._tsan_detect_race);
+  const ::mavsdk::rpc::camera_server::CameraServerResult* p = _impl_.camera_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera_server::CameraServerResult&>(::mavsdk::rpc::camera_server::_CameraServerResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& SupportVideoInImageModeResponse::camera_server_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.SupportVideoInImageModeResponse.camera_server_result)
+  return _internal_camera_server_result();
+}
+inline void SupportVideoInImageModeResponse::unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_server_result_);
+  }
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera_server.SupportVideoInImageModeResponse.camera_server_result)
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SupportVideoInImageModeResponse::release_camera_server_result() {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* released = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+  released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+  if (GetArena() == nullptr) {
+    delete old;
+  }
+#else   // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArena() != nullptr) {
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+  }
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return released;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SupportVideoInImageModeResponse::unsafe_arena_release_camera_server_result() {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera_server.SupportVideoInImageModeResponse.camera_server_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* temp = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SupportVideoInImageModeResponse::_internal_mutable_camera_server_result() {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  _impl_._has_bits_[0] |= 0x00000001u;
+  if (_impl_.camera_server_result_ == nullptr) {
+    auto* p = CreateMaybeMessage<::mavsdk::rpc::camera_server::CameraServerResult>(GetArena());
+    _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(p);
+  }
+  return _impl_.camera_server_result_;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SupportVideoInImageModeResponse::mutable_camera_server_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::mavsdk::rpc::camera_server::CameraServerResult* _msg = _internal_mutable_camera_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera_server.SupportVideoInImageModeResponse.camera_server_result)
+  return _msg;
+}
+inline void SupportVideoInImageModeResponse::set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  if (message_arena == nullptr) {
+    delete reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(_impl_.camera_server_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.SupportVideoInImageModeResponse.camera_server_result)
 }
 
 // -------------------------------------------------------------------

--- a/src/mavsdk_server/src/plugins/camera_server/camera_server_service_impl.h
+++ b/src/mavsdk_server/src/plugins/camera_server/camera_server_service_impl.h
@@ -2015,6 +2015,66 @@ public:
         return grpc::Status::OK;
     }
 
+    grpc::Status SupportImageInVideoMode(
+        grpc::ServerContext* /* context */,
+        const rpc::camera_server::SupportImageInVideoModeRequest* request,
+        rpc::camera_server::SupportImageInVideoModeResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            if (response != nullptr) {
+                // For server plugins, this should never happen, they should always be
+                // constructible.
+                auto result = mavsdk::CameraServer::Result::Unknown;
+                fillResponseWithResult(response, result);
+            }
+
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn() << "SupportImageInVideoMode sent with a null request! Ignoring...";
+            return grpc::Status::OK;
+        }
+
+        auto result = _lazy_plugin.maybe_plugin()->support_image_in_video_mode(request->support());
+
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status SupportVideoInImageMode(
+        grpc::ServerContext* /* context */,
+        const rpc::camera_server::SupportVideoInImageModeRequest* request,
+        rpc::camera_server::SupportVideoInImageModeResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            if (response != nullptr) {
+                // For server plugins, this should never happen, they should always be
+                // constructible.
+                auto result = mavsdk::CameraServer::Result::Unknown;
+                fillResponseWithResult(response, result);
+            }
+
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn() << "SupportVideoInImageMode sent with a null request! Ignoring...";
+            return grpc::Status::OK;
+        }
+
+        auto result = _lazy_plugin.maybe_plugin()->support_video_in_image_mode(request->support());
+
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+
+        return grpc::Status::OK;
+    }
+
     void stop()
     {
         _stopped.store(true);


### PR DESCRIPTION
One limitation I ran into with camera-server was the inability to be able to set the capability flags for [CAMERA_CAP_FLAGS_CAN_CAPTURE_IMAGE_IN_VIDEO_MODE](https://mavlink.io/en/messages/common.html#CAMERA_CAP_FLAGS_CAN_CAPTURE_IMAGE_IN_VIDEO_MODE) and [CAMERA_CAP_FLAGS_CAN_CAPTURE_VIDEO_IN_IMAGE_MODE](https://mavlink.io/en/messages/common.html#CAMERA_CAP_FLAGS_CAN_CAPTURE_VIDEO_IN_IMAGE_MODE). However, there are situations where a user may want to support this functionality. In an application I was working on, I wanted to be able to send these flags since the camera likely supported it.

This PR adds two new functions, support_image_in_video_mode and support_video_in_image_mode. A user can use these to enable the associated capability flags.

Please let me know if this is a good approach, or if there is a better way to support this functionality. Thank you!