### PR TITLE
core: Fixed unnecessary repeated invocations of `notify_on_discover`

### DIFF
--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -534,7 +534,7 @@ void SystemImpl::set_connected()
 
     if (enable_needed) {
         _mavsdk_impl.notify_on_discover();
-        
+
         if (has_autopilot()) {
             send_autopilot_version_request();
         }

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -532,9 +532,9 @@ void SystemImpl::set_connected()
         // If not yet connected there is nothing to do/
     }
 
-    _mavsdk_impl.notify_on_discover();
-
     if (enable_needed) {
+        _mavsdk_impl.notify_on_discover();
+        
         if (has_autopilot()) {
             send_autopilot_version_request();
         }


### PR DESCRIPTION
This problem introduced in v2.10.1

Now it works only if there was a change in the connection status

closes: #2354