### PR TITLE
[BACKPORT v2.12] core: Fixed unnecessary repeated invocations of `notify_on_discover`

### DIFF
--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -531,9 +531,9 @@ void SystemImpl::set_connected()
         // If not yet connected there is nothing to do/
     }
 
-    _mavsdk_impl.notify_on_discover();
-
     if (enable_needed) {
+        _mavsdk_impl.notify_on_discover();
+        
         if (has_autopilot()) {
             send_autopilot_version_request();
         }

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -533,7 +533,7 @@ void SystemImpl::set_connected()
 
     if (enable_needed) {
         _mavsdk_impl.notify_on_discover();
-        
+
         if (has_autopilot()) {
             send_autopilot_version_request();
         }


### PR DESCRIPTION
Backport of #2356.

Note: merge #2358 first.