### PR TITLE
core: don't ignore radio messages and system

### DIFF
--- a/src/mavsdk/core/mavsdk_impl.cpp
+++ b/src/mavsdk/core/mavsdk_impl.cpp
@@ -383,13 +383,6 @@ void MavsdkImpl::receive_message(mavlink_message_t& message, Connection* connect
         }
     }
 
-    if (!found_system && message.compid == MAV_COMP_ID_TELEMETRY_RADIO) {
-        if (_message_logging_on) {
-            LogDebug() << "Don't create new system just for telemetry radio";
-        }
-        return;
-    }
-
     if (!found_system) {
         make_system_with_component(message.sysid, message.compid);
     }


### PR DESCRIPTION
It is confusing that we just ignore the system for the telemetry radio. We should instead treat it as a proper system. Users should be able to filter for it properly, especially given they now have the nice `wait_for_autopilot` method.

Closes #2302.