### PR TITLE
Add a BUILD_TESTING option to superbuild

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
         id: cache
         with:
           path: ./build/release/third_party/install
-          key: ${{ github.job }}-${{ matrix.ubuntu_image }}-${{ hashFiles('./third_party/**') }}
+          key: ${{ github.job }}-${{ matrix.ubuntu_image }}-${{ hashFiles('./third_party/**') }}-1
       - name: disable superbuild on cache hit
         if: steps.cache.outputs.cache-hit == 'true'
         run: echo "superbuild=-DSUPERBUILD=OFF" >> $GITHUB_ENV && echo "cmake_prefix_path=-DCMAKE_PREFIX_PATH=$(pwd)/build/release/third_party/install" >> $GITHUB_ENV

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ option(BUILD_MAVSDK_SERVER "Build mavsdk_server" OFF)
 option(BUILD_WITH_PROTO_REFLECTION "Build mavsdk_server with proto reflection" OFF)
 option(BUILD_SHARED_LIBS "Build core as shared libraries instead of static ones" ON)
 option(MAVLINK_DIALECT "MAVLink dialect. Default: common" "common")
+option(BUILD_TESTING "Build tests" ON)
 
 if (SUPERBUILD AND HUNTER_ENABLED)
     message(FATAL_ERROR "Cannot SUPERBUILD while HUNTER_ENABLED. Set -DSUPERBUILD=OFF when using Hunter")

--- a/debian/rules
+++ b/debian/rules
@@ -10,6 +10,6 @@ override_dh_auto_configure:
 	dh_auto_configure -O--buildsystem=cmake -O--builddirectory=build -- \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DBUILD_SHARED_LIBS=ON \
-		-DBUILD_TESTS=OFF \
+		-DBUILD_TESTING=OFF \
 		-DSUPERBUILD=OFF \
 		-DCMAKE_INSTALL_PREFIX=/usr

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,7 @@ if(CCACHE AND CCACHE_PROGRAM AND NOT DEFINED ENV{CCACHE_DISABLE})
     endif()
 endif()
 
-option(BUILD_TESTS "Build tests" ON)
+option(BUILD_TESTING "Build tests" ON)
 option(CMAKE_POSITION_INDEPENDENT_CODE "Position independent code" ON)
 
 include(cmake/compiler_flags.cmake)
@@ -43,9 +43,9 @@ hunter_add_package(lzma)
 find_package(CURL REQUIRED)
 find_package(LibLZMA REQUIRED)
 
-if(BUILD_TESTS AND (IOS OR ANDROID))
-    message(STATUS "Building for iOS or Android: forcing BUILD_TESTS to FALSE...")
-    set(BUILD_TESTS OFF)
+if(BUILD_TESTING AND (IOS OR ANDROID))
+    message(STATUS "Building for iOS or Android: forcing BUILD_TESTING to FALSE...")
+    set(BUILD_TESTING OFF)
 endif()
 
 if(ANDROID)
@@ -70,7 +70,7 @@ add_subdirectory(mavsdk)
 
 include(cmake/static_analyzers.cmake)
 
-if(BUILD_TESTS)
+if(BUILD_TESTING)
     enable_testing()
 
     add_subdirectory(integration_tests)

--- a/src/mavsdk_server/CMakeLists.txt
+++ b/src/mavsdk_server/CMakeLists.txt
@@ -6,6 +6,6 @@ find_package(gRPC REQUIRED)
 
 add_subdirectory(src)
 
-if(BUILD_TESTS)
+if(BUILD_TESTING)
     add_subdirectory(test)
 endif()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -7,7 +7,7 @@ include(cmake/build_target.cmake)
 list(APPEND CMAKE_PREFIX_PATH "${DEPS_INSTALL_PATH}")
 set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} PARENT_SCOPE)
 
-if (SUPERBUILD)
+if(SUPERBUILD)
     build_target(mavlink)
     build_target(jsoncpp)
     build_target(tinyxml2)
@@ -29,12 +29,14 @@ if (SUPERBUILD)
         build_target(grpc)
     endif()
 
-    build_target(gtest)
+    if(BUILD_TESTING)
+        build_target(gtest)
+    endif()
 
 endif()
 
 build_target(libevents)
 
-if (ENABLE_CPPTRACE)
+if(ENABLE_CPPTRACE)
     build_target(cpptrace)
 endif()


### PR DESCRIPTION
It has been a problem e.g. [here](https://github.com/mavlink/MAVSDK/issues/2374#issuecomment-2293752977) and [here](https://discuss.px4.io/t/mavsdk-main-branch-fails-to-build-on-rpi4-blueos/40003/9). I think it makes sense to add an option for those who don't need to run the tests.

Also I renamed BUILD_TESTS to BUILD_TESTING, which is more common with CMake (that's actually the CTest way, I believe).