### PR TITLE
Update UDP client connection syntax to use udpin://

### DIFF
--- a/examples/autopilot_server/autopilot_server.cpp
+++ b/examples/autopilot_server/autopilot_server.cpp
@@ -154,7 +154,7 @@ int main(int argc, char** argv)
     // to communicate with the autopilot server plugins.
     mavsdk::Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
-    auto result = mavsdk.add_any_connection("udp://:14551");
+    auto result = mavsdk.add_any_connection("udpin://:14551");
     if (result == mavsdk::ConnectionResult::Success) {
         std::cout << "Connected!" << std::endl;
     }

--- a/examples/autopilot_server/autopilot_server.cpp
+++ b/examples/autopilot_server/autopilot_server.cpp
@@ -154,7 +154,7 @@ int main(int argc, char** argv)
     // to communicate with the autopilot server plugins.
     mavsdk::Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 
-    auto result = mavsdk.add_any_connection("udpin://:14551");
+    auto result = mavsdk.add_any_connection("udpin://0.0.0.0:14551");
     if (result == mavsdk::ConnectionResult::Success) {
         std::cout << "Connected!" << std::endl;
     }

--- a/examples/battery/battery.cpp
+++ b/examples/battery/battery.cpp
@@ -26,7 +26,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/battery/battery.cpp
+++ b/examples/battery/battery.cpp
@@ -26,7 +26,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/calibrate/calibrate.cpp
+++ b/examples/calibrate/calibrate.cpp
@@ -27,7 +27,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/calibrate/calibrate.cpp
+++ b/examples/calibrate/calibrate.cpp
@@ -27,7 +27,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/camera/camera.cpp
+++ b/examples/camera/camera.cpp
@@ -23,7 +23,7 @@ void usage(std::string bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/camera/camera.cpp
+++ b/examples/camera/camera.cpp
@@ -23,7 +23,7 @@ void usage(std::string bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/camera_settings/camera_settings.cpp
+++ b/examples/camera_settings/camera_settings.cpp
@@ -25,7 +25,7 @@ void usage(std::string bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 struct CurrentSettings {

--- a/examples/camera_settings/camera_settings.cpp
+++ b/examples/camera_settings/camera_settings.cpp
@@ -25,7 +25,7 @@ void usage(std::string bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 struct CurrentSettings {

--- a/examples/camera_zoom/camera_zoom.cpp
+++ b/examples/camera_zoom/camera_zoom.cpp
@@ -22,7 +22,7 @@ void usage(std::string bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/camera_zoom/camera_zoom.cpp
+++ b/examples/camera_zoom/camera_zoom.cpp
@@ -22,7 +22,7 @@ void usage(std::string bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/component_metadata/component_metadata.cpp
+++ b/examples/component_metadata/component_metadata.cpp
@@ -18,7 +18,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/component_metadata/component_metadata.cpp
+++ b/examples/component_metadata/component_metadata.cpp
@@ -18,7 +18,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/disconnect/disconnect.cpp
+++ b/examples/disconnect/disconnect.cpp
@@ -19,7 +19,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 bool connect(Mavsdk* mavsdk, std::string connection_url)

--- a/examples/disconnect/disconnect.cpp
+++ b/examples/disconnect/disconnect.cpp
@@ -19,7 +19,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 bool connect(Mavsdk* mavsdk, std::string connection_url)

--- a/examples/distance_sensor/distance_sensor.cpp
+++ b/examples/distance_sensor/distance_sensor.cpp
@@ -26,7 +26,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/distance_sensor/distance_sensor.cpp
+++ b/examples/distance_sensor/distance_sensor.cpp
@@ -26,7 +26,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/events/events.cpp
+++ b/examples/events/events.cpp
@@ -18,7 +18,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n\n"
+              << "For example, to connect to the simulator use URL: udpin://:14540\n\n"
               << " -v: enable verbose output\n"
               << " monitor: listen for events (instead of printing the arming report)\n";
 }

--- a/examples/events/events.cpp
+++ b/examples/events/events.cpp
@@ -18,7 +18,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n\n"
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n\n"
               << " -v: enable verbose output\n"
               << " monitor: listen for events (instead of printing the arming report)\n";
 }

--- a/examples/fly_mission/fly_mission.cpp
+++ b/examples/fly_mission/fly_mission.cpp
@@ -46,7 +46,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/fly_mission/fly_mission.cpp
+++ b/examples/fly_mission/fly_mission.cpp
@@ -46,7 +46,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/fly_multiple_drones/fly_multiple_drones.cpp
+++ b/examples/fly_multiple_drones/fly_multiple_drones.cpp
@@ -3,7 +3,7 @@
 // separate plan file. Also saves the telemetry information to csv files
 //
 // Run with:
-// ./fly_multiple_drones udpin://:14540 udpin://:14541 test1.plan test2.plan
+// ./fly_multiple_drones udpin://0.0.0.0:14540 udpin://0.0.0.0:14541 test1.plan test2.plan
 //
 //
 // How to Start Multiple Instances (for jMAVSim)
@@ -33,12 +33,12 @@
 // 2. Build the executable
 // 3. (a) Create a Mission in QGroundControl and save them to a file (.plan), or
 //    (b) Use a pre-created sample mission plan.
-// 4. Run the executable by passing the connection urls (ex. udpin://:14540) and
+// 4. Run the executable by passing the connection urls (ex. udpin://0.0.0.0:14540) and
 //    path of QGC mission plan as arguments Example: If you have test1.plan and
 //    test2.plan in "../../../plugins/mission/" and you are running two drones
-//    in udpin://:14540 and udpin://:14541 then you run the example as:
+//    in udpin://0.0.0.0:14540 and udpin://0.0.0.0:14541 then you run the example as:
 //
-//   ./fly_multiple_drones udpin://:14540 udpin://:14541 test1.plan test2.plan
+//   ./fly_multiple_drones udpin://0.0.0.0:14540 udpin://0.0.0.0:14541 test1.plan test2.plan
 //
 //
 // Note: The mission needs to end with RTL or land, otherwise it will get stuck

--- a/examples/fly_multiple_drones/fly_multiple_drones.cpp
+++ b/examples/fly_multiple_drones/fly_multiple_drones.cpp
@@ -3,7 +3,7 @@
 // separate plan file. Also saves the telemetry information to csv files
 //
 // Run with:
-// ./fly_multiple_drones udp://:14540 udp://:14541 test1.plan test2.plan
+// ./fly_multiple_drones udpin://:14540 udpin://:14541 test1.plan test2.plan
 //
 //
 // How to Start Multiple Instances (for jMAVSim)
@@ -33,12 +33,12 @@
 // 2. Build the executable
 // 3. (a) Create a Mission in QGroundControl and save them to a file (.plan), or
 //    (b) Use a pre-created sample mission plan.
-// 4. Run the executable by passing the connection urls (ex. udp://:14540) and
+// 4. Run the executable by passing the connection urls (ex. udpin://:14540) and
 //    path of QGC mission plan as arguments Example: If you have test1.plan and
 //    test2.plan in "../../../plugins/mission/" and you are running two drones
-//    in udp://:14540 and udp://:14541 then you run the example as:
+//    in udpin://:14540 and udpin://:14541 then you run the example as:
 //
-//   ./fly_multiple_drones udp://:14540 udp://:14541 test1.plan test2.plan
+//   ./fly_multiple_drones udpin://:14540 udpin://:14541 test1.plan test2.plan
 //
 //
 // Note: The mission needs to end with RTL or land, otherwise it will get stuck

--- a/examples/fly_qgc_mission/fly_qgc_mission.cpp
+++ b/examples/fly_qgc_mission/fly_qgc_mission.cpp
@@ -38,7 +38,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/fly_qgc_mission/fly_qgc_mission.cpp
+++ b/examples/fly_qgc_mission/fly_qgc_mission.cpp
@@ -38,7 +38,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/follow_me/follow_me.cpp
+++ b/examples/follow_me/follow_me.cpp
@@ -27,7 +27,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/follow_me/follow_me.cpp
+++ b/examples/follow_me/follow_me.cpp
@@ -27,7 +27,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/ftp_client/ftp_client.cpp
+++ b/examples/ftp_client/ftp_client.cpp
@@ -24,7 +24,7 @@ void usage(const std::string& bin_name)
         << " For TCP : tcp://[server_host][:server_port]\n"
         << " For UDP : udp://[bind_host][:bind_port]\n"
         << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-        << "For example, to connect to the simulator use URL: udpin://:14540\n"
+        << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n"
         << '\n'
         << "Server component id is for example 1 for autopilot or 195 for companion computer,\n"
         << "which is being used if you run the ftp_server example\n"

--- a/examples/ftp_client/ftp_client.cpp
+++ b/examples/ftp_client/ftp_client.cpp
@@ -24,7 +24,7 @@ void usage(const std::string& bin_name)
         << " For TCP : tcp://[server_host][:server_port]\n"
         << " For UDP : udp://[bind_host][:bind_port]\n"
         << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-        << "For example, to connect to the simulator use URL: udp://:14540\n"
+        << "For example, to connect to the simulator use URL: udpin://:14540\n"
         << '\n'
         << "Server component id is for example 1 for autopilot or 195 for companion computer,\n"
         << "which is being used if you run the ftp_server example\n"

--- a/examples/geofence/geofence.cpp
+++ b/examples/geofence/geofence.cpp
@@ -28,7 +28,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/geofence/geofence.cpp
+++ b/examples/geofence/geofence.cpp
@@ -28,7 +28,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/gimbal/gimbal.cpp
+++ b/examples/gimbal/gimbal.cpp
@@ -26,7 +26,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/gimbal/gimbal.cpp
+++ b/examples/gimbal/gimbal.cpp
@@ -26,7 +26,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/gimbal_full_control/gimbal_full_control.cpp
+++ b/examples/gimbal_full_control/gimbal_full_control.cpp
@@ -24,7 +24,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/gimbal_full_control/gimbal_full_control.cpp
+++ b/examples/gimbal_full_control/gimbal_full_control.cpp
@@ -24,7 +24,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/log_streaming/log_streaming.cpp
+++ b/examples/log_streaming/log_streaming.cpp
@@ -25,7 +25,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540" << '\n'
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540" << '\n'
               << "--drop   To drop some of the messages" << std::endl;
 }
 

--- a/examples/log_streaming/log_streaming.cpp
+++ b/examples/log_streaming/log_streaming.cpp
@@ -25,7 +25,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540" << '\n'
+              << "For example, to connect to the simulator use URL: udpin://:14540" << '\n'
               << "--drop   To drop some of the messages" << std::endl;
 }
 

--- a/examples/logfile_download/logfile_download.cpp
+++ b/examples/logfile_download/logfile_download.cpp
@@ -25,7 +25,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n"
+              << "For example, to connect to the simulator use URL: udpin://:14540\n"
               << '\n'
               << "To remove log files after all downloads completed,\n"
               << "please add the --rm argument" << std::endl;

--- a/examples/logfile_download/logfile_download.cpp
+++ b/examples/logfile_download/logfile_download.cpp
@@ -25,7 +25,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n"
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n"
               << '\n'
               << "To remove log files after all downloads completed,\n"
               << "please add the --rm argument" << std::endl;

--- a/examples/manual_control/manual_control.cpp
+++ b/examples/manual_control/manual_control.cpp
@@ -43,7 +43,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/manual_control/manual_control.cpp
+++ b/examples/manual_control/manual_control.cpp
@@ -43,7 +43,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/mavshell/mavshell.cpp
+++ b/examples/mavshell/mavshell.cpp
@@ -15,7 +15,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/mavshell/mavshell.cpp
+++ b/examples/mavshell/mavshell.cpp
@@ -15,7 +15,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/multiple_drones/multiple_drones.cpp
+++ b/examples/multiple_drones/multiple_drones.cpp
@@ -1,6 +1,6 @@
 //
 // Example to connect multiple vehicles and make them take off and land in parallel.
-//./multiple_drones udpin://:14540 udpin://:14541
+//./multiple_drones udpin://0.0.0.0:14540 udpin://0.0.0.0:14541
 //
 
 #include <mavsdk/mavsdk.h>
@@ -25,7 +25,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char* argv[])

--- a/examples/multiple_drones/multiple_drones.cpp
+++ b/examples/multiple_drones/multiple_drones.cpp
@@ -1,6 +1,6 @@
 //
 // Example to connect multiple vehicles and make them take off and land in parallel.
-//./multiple_drones udp://:14540 udp://:14541
+//./multiple_drones udpin://:14540 udpin://:14541
 //
 
 #include <mavsdk/mavsdk.h>
@@ -25,7 +25,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char* argv[])

--- a/examples/offboard/offboard.cpp
+++ b/examples/offboard/offboard.cpp
@@ -27,7 +27,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 //

--- a/examples/offboard/offboard.cpp
+++ b/examples/offboard/offboard.cpp
@@ -27,7 +27,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 //

--- a/examples/parachute/parachute.cpp
+++ b/examples/parachute/parachute.cpp
@@ -25,7 +25,7 @@ static void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 static void process_command_long(const mavlink_message_t& message, uint8_t our_sysid)

--- a/examples/parachute/parachute.cpp
+++ b/examples/parachute/parachute.cpp
@@ -25,7 +25,7 @@ static void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 static void process_command_long(const mavlink_message_t& message, uint8_t our_sysid)

--- a/examples/set_actuator/set_actuator.cpp
+++ b/examples/set_actuator/set_actuator.cpp
@@ -18,7 +18,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/set_actuator/set_actuator.cpp
+++ b/examples/set_actuator/set_actuator.cpp
@@ -18,7 +18,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/sniffer/sniffer.cpp
+++ b/examples/sniffer/sniffer.cpp
@@ -19,7 +19,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/sniffer/sniffer.cpp
+++ b/examples/sniffer/sniffer.cpp
@@ -19,7 +19,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/system_info/system_info.cpp
+++ b/examples/system_info/system_info.cpp
@@ -22,7 +22,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/system_info/system_info.cpp
+++ b/examples/system_info/system_info.cpp
@@ -22,7 +22,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/takeoff_and_land/takeoff_and_land.cpp
+++ b/examples/takeoff_and_land/takeoff_and_land.cpp
@@ -23,7 +23,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/takeoff_and_land/takeoff_and_land.cpp
+++ b/examples/takeoff_and_land/takeoff_and_land.cpp
@@ -23,7 +23,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/terminate/terminate.cpp
+++ b/examples/terminate/terminate.cpp
@@ -23,7 +23,7 @@ static void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char* argv[])

--- a/examples/terminate/terminate.cpp
+++ b/examples/terminate/terminate.cpp
@@ -23,7 +23,7 @@ static void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char* argv[])

--- a/examples/transponder/transponder.cpp
+++ b/examples/transponder/transponder.cpp
@@ -22,7 +22,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/transponder/transponder.cpp
+++ b/examples/transponder/transponder.cpp
@@ -22,7 +22,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/tune/tune.cpp
+++ b/examples/tune/tune.cpp
@@ -20,7 +20,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/tune/tune.cpp
+++ b/examples/tune/tune.cpp
@@ -20,7 +20,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/vtol_transition/vtol_transition.cpp
+++ b/examples/vtol_transition/vtol_transition.cpp
@@ -24,7 +24,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/vtol_transition/vtol_transition.cpp
+++ b/examples/vtol_transition/vtol_transition.cpp
@@ -24,7 +24,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/winch/winch.cpp
+++ b/examples/winch/winch.cpp
@@ -20,7 +20,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udpin://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
 }
 
 int main(int argc, char** argv)

--- a/examples/winch/winch.cpp
+++ b/examples/winch/winch.cpp
@@ -20,7 +20,7 @@ void usage(const std::string& bin_name)
               << " For TCP : tcp://[server_host][:server_port]\n"
               << " For UDP : udp://[bind_host][:bind_port]\n"
               << " For Serial : serial:///path/to/serial/dev[:baudrate]\n"
-              << "For example, to connect to the simulator use URL: udp://:14540\n";
+              << "For example, to connect to the simulator use URL: udpin://:14540\n";
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Changed all instances of the deprecated UDP client connection syntax udp://:PORT to the recommended udpin://:PORT following the deprecation warning: Connection using udp:// is deprecated, please use udpin:// or udpout:// (cli_arg.cpp:28)