### PR TITLE
Switch to new REQUEST_MESSAGE but fall back to deprecated request message commands if required

### DIFF
--- a/src/mavsdk/core/CMakeLists.txt
+++ b/src/mavsdk/core/CMakeLists.txt
@@ -42,6 +42,7 @@ target_sources(mavsdk
     mavlink_parameter_subscription.cpp
     mavlink_parameter_helper.cpp
     mavlink_receiver.cpp
+    mavlink_request_message.cpp
     mavlink_request_message_handler.cpp
     mavlink_statustext_handler.cpp
     mavlink_message_handler.cpp
@@ -60,7 +61,6 @@ target_sources(mavsdk
     log.cpp
     cli_arg.cpp
     geometry.cpp
-    request_message.cpp
     mavsdk_time.cpp
     timesync.cpp
 )

--- a/src/mavsdk/core/mavlink_component_metadata.cpp
+++ b/src/mavsdk/core/mavlink_component_metadata.cpp
@@ -61,7 +61,7 @@ void MavlinkComponentMetadata::request_component(uint32_t compid)
     const std::lock_guard lg{_mavlink_components_mutex};
     if (_mavlink_components.find(compid) == _mavlink_components.end()) {
         _mavlink_components[compid] = MavlinkComponent{};
-        _system_impl.request_message().request(
+        _system_impl.mavlink_request_message().request(
             MAVLINK_MSG_ID_COMPONENT_METADATA, compid, [this](auto&& result, auto&& message) {
                 receive_component_metadata(result, message);
             });

--- a/src/mavsdk/core/mavlink_message_handler.h
+++ b/src/mavsdk/core/mavlink_message_handler.h
@@ -31,8 +31,30 @@ public:
     void update_component_id(uint16_t msg_id, uint8_t cmp_id, const void* cookie);
 
 private:
+    void register_one_impl(
+        uint16_t msg_id,
+        std::optional<uint8_t> maybe_component_id,
+        const Callback& callback,
+        const void* cookie);
+
+    void unregister_impl(std::optional<uint16_t> maybe_msg_id, const void* cookie);
+
+    void check_register_later();
+    void check_unregister_later();
+
     std::mutex _mutex{};
     std::vector<Entry> _table{};
+
+    std::mutex _register_later_mutex{};
+    std::vector<Entry> _register_later_table{};
+
+    struct UnregisterEntry {
+        std::optional<uint16_t> maybe_msg_id;
+        const void* cookie;
+    };
+
+    std::mutex _unregister_later_mutex{};
+    std::vector<UnregisterEntry> _unregister_later_table{};
 
     bool _debugging{false};
 };

--- a/src/mavsdk/core/mavlink_request_message.h
+++ b/src/mavsdk/core/mavlink_request_message.h
@@ -13,29 +13,29 @@ namespace mavsdk {
 
 class SystemImpl;
 
-class RequestMessage {
+class MavlinkRequestMessage {
 public:
-    RequestMessage(
+    MavlinkRequestMessage(
         SystemImpl& system_impl,
         MavlinkCommandSender& command_sender,
         MavlinkMessageHandler& message_handler,
         TimeoutHandler& timeout_handler);
-    RequestMessage() = delete;
+    MavlinkRequestMessage() = delete;
 
-    using RequestMessageCallback =
+    using MavlinkRequestMessageCallback =
         std::function<void(MavlinkCommandSender::Result, const mavlink_message_t&)>;
 
     void request(
         uint32_t message_id,
         uint8_t target_component,
-        RequestMessageCallback callback,
+        MavlinkRequestMessageCallback callback,
         uint32_t param2 = 0);
 
 private:
     struct WorkItem {
         uint32_t message_id{0};
         uint8_t target_component{0};
-        RequestMessageCallback callback{};
+        MavlinkRequestMessageCallback callback{};
         uint32_t param2{0};
         unsigned retries{0};
         TimeoutHandler::Cookie timeout_cookie{};

--- a/src/mavsdk/core/request_message.h
+++ b/src/mavsdk/core/request_message.h
@@ -37,12 +37,14 @@ private:
         uint8_t target_component{0};
         RequestMessageCallback callback{};
         uint32_t param2{0};
-        std::size_t retries{0};
+        unsigned retries{0};
         TimeoutHandler::Cookie timeout_cookie{};
         std::optional<MavlinkCommandSender::Result> maybe_result{};
     };
 
-    void send_request(uint32_t message_id, uint8_t target_component);
+    void send_request(WorkItem& item);
+    void send_request_using_new_command(WorkItem& item);
+    bool try_sending_request_using_old_command(WorkItem& item);
     void handle_any_message(const mavlink_message_t& message);
     void handle_command_result(uint32_t message_id, MavlinkCommandSender::Result result);
     void handle_timeout(uint32_t message_id, uint8_t target_component);

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -471,31 +471,8 @@ bool SystemImpl::queue_message(
 
 void SystemImpl::send_autopilot_version_request()
 {
-    MavlinkCommandSender::CommandLong command{};
-    command.target_component_id = get_autopilot_id();
-
-    if (_old_message_520_supported) {
-        // Note: This MAVLINK message is deprecated and would be removed from MAVSDK in a future
-        // release.
-        command.command = MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES;
-        command.params.maybe_param1 = 1.0f;
-    } else {
-        command.command = MAV_CMD_REQUEST_MESSAGE;
-        command.params.maybe_param1 = {static_cast<float>(MAVLINK_MSG_ID_AUTOPILOT_VERSION)};
-    }
-
-    send_command_async(command, [this](MavlinkCommandSender::Result result, float) {
-        receive_autopilot_version_request_ack(result);
-    });
-}
-
-void SystemImpl::receive_autopilot_version_request_ack(MavlinkCommandSender::Result result)
-{
-    if (result == MavlinkCommandSender::Result::Unsupported) {
-        _old_message_520_supported = false;
-        LogWarn()
-            << "Trying alternative command REQUEST_MESSAGE instead of REQUEST_AUTOPILOT_CAPABILITIES next.";
-    }
+    mavlink_request_message().request(
+        MAVLINK_MSG_ID_AUTOPILOT_VERSION, MAV_COMP_ID_AUTOPILOT1, nullptr);
 }
 
 void SystemImpl::set_connected()

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -6,7 +6,6 @@
 #include "plugin_impl_base.h"
 #include "px4_custom_mode.h"
 #include "ardupilot_custom_mode.h"
-#include "request_message.h"
 #include "callback_list.tpp"
 #include "unused.h"
 #include <cassert>
@@ -32,7 +31,7 @@ SystemImpl::SystemImpl(MavsdkImpl& mavsdk_impl) :
         _mavsdk_impl.timeout_handler,
         [this]() { return timeout_s(); },
         [this]() { return autopilot(); }),
-    _request_message(
+    _mavlink_request_message(
         *this, _command_sender, _mavlink_message_handler, _mavsdk_impl.timeout_handler),
     _mavlink_ftp_client(*this),
     _mavlink_component_metadata(*this)

--- a/src/mavsdk/core/system_impl.h
+++ b/src/mavsdk/core/system_impl.h
@@ -306,8 +306,6 @@ private:
     void set_connected();
     void set_disconnected();
 
-    void receive_autopilot_version_request_ack(MavlinkCommandSender::Result result);
-
     static std::string component_name(uint8_t component_id);
     static System::ComponentType component_type(uint8_t component_id);
 
@@ -413,8 +411,6 @@ private:
 
     std::mutex _mavlink_ftp_files_mutex{};
     std::unordered_map<std::string, std::string> _mavlink_ftp_files{};
-
-    bool _old_message_520_supported{true};
 };
 
 } // namespace mavsdk

--- a/src/mavsdk/core/system_impl.h
+++ b/src/mavsdk/core/system_impl.h
@@ -9,17 +9,14 @@
 #include "mavlink_include.h"
 #include "mavlink_parameter_client.h"
 #include "mavlink_command_sender.h"
-#include "mavlink_command_receiver.h"
 #include "mavlink_ftp_client.h"
 #include "mavlink_message_handler.h"
 #include "mavlink_mission_transfer_client.h"
-#include "mavlink_request_message_handler.h"
+#include "mavlink_request_message.h"
 #include "mavlink_statustext_handler.h"
-#include "request_message.h"
 #include "ardupilot_custom_mode.h"
 #include "ping.h"
 #include "timeout_handler.h"
-#include "safe_queue.h"
 #include "timesync.h"
 #include "system.h"
 #include <cstdint>
@@ -290,7 +287,7 @@ public:
 
     MavlinkComponentMetadata& component_metadata() { return _mavlink_component_metadata; }
 
-    RequestMessage& request_message() { return _request_message; }
+    MavlinkRequestMessage& mavlink_request_message() { return _mavlink_request_message; }
 
     // Non-copyable
     SystemImpl(const SystemImpl&) = delete;
@@ -397,7 +394,7 @@ private:
     Ping _ping;
 
     MavlinkMissionTransferClient _mission_transfer_client;
-    RequestMessage _request_message;
+    MavlinkRequestMessage _mavlink_request_message;
     MavlinkFtpClient _mavlink_ftp_client;
     MavlinkComponentMetadata _mavlink_component_metadata;
 

--- a/src/mavsdk/plugins/camera/camera_impl.h
+++ b/src/mavsdk/plugins/camera/camera_impl.h
@@ -218,21 +218,12 @@ private:
     MavlinkCommandSender::CommandLong make_command_take_photo(float interval_s, float no_of_photos);
     MavlinkCommandSender::CommandLong make_command_stop_photo();
 
-    MavlinkCommandSender::CommandLong make_command_request_camera_info();
     MavlinkCommandSender::CommandLong make_command_set_camera_mode(float mavlink_mode);
-    MavlinkCommandSender::CommandLong make_command_request_camera_settings();
-    MavlinkCommandSender::CommandLong make_command_request_camera_capture_status();
-    MavlinkCommandSender::CommandLong make_command_request_camera_image_captured(size_t photo_id);
-    MavlinkCommandSender::CommandLong make_command_request_storage_info();
-
     MavlinkCommandSender::CommandLong make_command_start_video(float capture_status_rate_hz);
     MavlinkCommandSender::CommandLong make_command_stop_video();
 
     MavlinkCommandSender::CommandLong make_command_start_video_streaming(int32_t stream_id);
     MavlinkCommandSender::CommandLong make_command_stop_video_streaming(int32_t stream_id);
-
-    MavlinkCommandSender::CommandLong make_command_request_video_stream_info();
-    MavlinkCommandSender::CommandLong make_command_request_video_stream_status();
 
     MavlinkCommandSender::CommandLong make_command_zoom_in();
     MavlinkCommandSender::CommandLong make_command_zoom_out();

--- a/src/mavsdk/plugins/gimbal/gimbal_impl.cpp
+++ b/src/mavsdk/plugins/gimbal/gimbal_impl.cpp
@@ -86,12 +86,8 @@ void GimbalImpl::request_gimbal_manager_information(uint8_t target_component_id)
                    << std::to_string(target_component_id);
     }
 
-    MavlinkCommandSender::CommandLong command{};
-    command.command = MAV_CMD_REQUEST_MESSAGE;
-    command.params.maybe_param1 = {static_cast<float>(MAVLINK_MSG_ID_GIMBAL_MANAGER_INFORMATION)};
-    command.target_system_id = _system_impl->get_system_id();
-    command.target_component_id = target_component_id;
-    _system_impl->send_command_async(command, nullptr);
+    _system_impl->mavlink_request_message().request(
+        MAVLINK_MSG_ID_GIMBAL_MANAGER_INFORMATION, target_component_id, nullptr);
 }
 
 void GimbalImpl::request_gimbal_device_information(uint8_t target_component_id) const
@@ -102,12 +98,8 @@ void GimbalImpl::request_gimbal_device_information(uint8_t target_component_id) 
                    << std::to_string(target_component_id);
     }
 
-    MavlinkCommandSender::CommandLong command{};
-    command.command = MAV_CMD_REQUEST_MESSAGE;
-    command.params.maybe_param1 = {static_cast<float>(MAVLINK_MSG_ID_GIMBAL_DEVICE_INFORMATION)};
-    command.target_system_id = _system_impl->get_system_id();
-    command.target_component_id = target_component_id;
-    _system_impl->send_command_async(command, nullptr);
+    _system_impl->mavlink_request_message().request(
+        MAVLINK_MSG_ID_GIMBAL_DEVICE_INFORMATION, target_component_id, nullptr);
 }
 
 void GimbalImpl::process_heartbeat(const mavlink_message_t& message)

--- a/src/mavsdk/plugins/info/info_impl.cpp
+++ b/src/mavsdk/plugins/info/info_impl.cpp
@@ -230,7 +230,7 @@ std::pair<Info::Result, Info::FlightInfo> InfoImpl::get_flight_information()
 {
     std::promise<std::pair<Info::Result, Info::FlightInfo>> prom;
     auto fut = prom.get_future();
-    _system_impl->request_message().request(
+    _system_impl->mavlink_request_message().request(
         MAVLINK_MSG_ID_FLIGHT_INFORMATION,
         MAV_COMP_ID_AUTOPILOT1,
         [&](MavlinkCommandSender::Result result, const mavlink_message_t& message) {

--- a/src/mavsdk/plugins/mission/mission_impl.h
+++ b/src/mavsdk/plugins/mission/mission_impl.h
@@ -80,7 +80,6 @@ private:
 
     void process_mission_current(const mavlink_message_t& message);
     void process_mission_item_reached(const mavlink_message_t& message);
-    void process_gimbal_manager_information(const mavlink_message_t& message);
     void receive_protocol_timeout();
     void wait_for_protocol();
     void wait_for_protocol_async(std::function<void()> callback);
@@ -99,18 +98,12 @@ private:
         Mission::ResultCallback callback, MavlinkCommandSender::Result result);
     static Mission::Result command_result_to_mission_result(MavlinkCommandSender::Result result);
 
-    // FIXME: make static
     std::pair<Mission::Result, Mission::MissionPlan> convert_to_result_and_mission_items(
         MavlinkMissionTransferClient::Result result,
         const std::vector<MavlinkMissionTransferClient::ItemInt>& int_items);
 
     static Mission::Result convert_result(MavlinkMissionTransferClient::Result result);
 
-    void add_gimbal_items_v1(
-        std::vector<MavlinkMissionTransferClient::ItemInt>& int_items,
-        unsigned item_i,
-        float pitch_deg,
-        float yaw_deg);
     void add_gimbal_items_v2(
         std::vector<MavlinkMissionTransferClient::ItemInt>& int_items,
         unsigned item_i,
@@ -139,14 +132,6 @@ private:
     TimeoutHandler::Cookie _timeout_cookie{};
 
     bool _enable_return_to_launch_after_mission{false};
-
-    // FIXME: This is hardcoded for now because it is urgently needed for 3DR with Yuneec H520.
-    //        Ultimate it needs a setter.
-    bool _enable_absolute_gimbal_yaw_angle{true};
-
-    TimeoutHandler::Cookie _gimbal_protocol_cookie{};
-    enum class GimbalProtocol { Unknown, V1, V2 };
-    std::atomic<GimbalProtocol> _gimbal_protocol{GimbalProtocol::Unknown};
 };
 
 } // namespace mavsdk

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -2483,7 +2483,7 @@ void TelemetryImpl::request_home_position_async()
 void TelemetryImpl::get_gps_global_origin_async(
     const Telemetry::GetGpsGlobalOriginCallback callback)
 {
-    _system_impl->request_message().request(
+    _system_impl->mavlink_request_message().request(
         MAVLINK_MSG_ID_GPS_GLOBAL_ORIGIN,
         MAV_COMP_ID_AUTOPILOT1,
         [this, callback](MavlinkCommandSender::Result result, const mavlink_message_t& message) {

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.h
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.h
@@ -261,9 +261,7 @@ private:
 
     void receive_statustext(const MavlinkStatustextHandler::Statustext&);
 
-    void request_home_position_async();
     void request_home_position_again();
-    void check_calibration();
 
     static bool sys_status_present_enabled_health(
         const mavlink_sys_status_t& sys_status, MAV_SYS_STATUS_SENSOR flag);
@@ -369,8 +367,6 @@ private:
 
     mutable std::mutex _altitude_mutex{};
     Telemetry::Altitude _altitude{};
-
-    mutable std::mutex _request_home_position_mutex{};
 
     std::mutex _subscription_mutex{};
     CallbackList<Telemetry::PositionVelocityNed> _position_velocity_ned_subscriptions{};


### PR DESCRIPTION
This implements the logic of requesting messages using the new command as well as the deprecated commands consolidated in the RequestMessage class.

Currently WIP implementing the functionality in REQUEST_MESSAGE. The next step is to use this class consistently everywhere.

Closes #1605, closes #2013.