### PR TITLE
Added function to query SYS_STATUS present/enabled/health flags

### DIFF
--- a/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -432,6 +432,15 @@ public:
     friend std::ostream& operator<<(std::ostream& str, Telemetry::Health const& health);
 
     /**
+     * @brief SysStatusSensors type.
+     */
+    struct SysStatusSensors {
+        uint32_t present{0}; /**< Bitmap showing which onboard controllers and sensors are present */
+        uint32_t enabled{0}; /**< Bitmap showing which onboard controllers and sensors are enabled */
+        uint32_t health{0}; /**< Bitmap showing which onboard controllers and sensors have an error */
+    };
+
+    /**
      * @brief Remote control status type.
      */
     struct RcStatus {
@@ -1427,6 +1436,8 @@ public:
      * @return One Health update.
      */
     Health health() const;
+
+    SysStatusSensors sys_status_sensors() const;
 
     /**
      * @brief Callback type for subscribe_rc_status.

--- a/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -1440,6 +1440,11 @@ public:
      */
     Health health() const;
 
+    /**
+     * @brief Poll for 'sys_status_sensors' (blocking).
+     *
+     * @return One SysStatusSensors update.
+     */
     SysStatusSensors sys_status_sensors() const;
 
     /**

--- a/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -435,9 +435,12 @@ public:
      * @brief SysStatusSensors type.
      */
     struct SysStatusSensors {
-        uint32_t present{0}; /**< Bitmap showing which onboard controllers and sensors are present */
-        uint32_t enabled{0}; /**< Bitmap showing which onboard controllers and sensors are enabled */
-        uint32_t health{0}; /**< Bitmap showing which onboard controllers and sensors have an error */
+        uint32_t present{
+            0}; /**< Bitmap showing which onboard controllers and sensors are present */
+        uint32_t enabled{
+            0}; /**< Bitmap showing which onboard controllers and sensors are enabled */
+        uint32_t health{
+            0}; /**< Bitmap showing which onboard controllers and sensors have an error */
     };
 
     /**

--- a/src/mavsdk/plugins/telemetry/telemetry.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry.cpp
@@ -278,6 +278,11 @@ Telemetry::Health Telemetry::health() const
     return _impl->health();
 }
 
+Telemetry::SysStatusSensors Telemetry::sys_status_sensors() const
+{
+    return _impl->sys_status_sensors();
+}
+
 Telemetry::RcStatusHandle Telemetry::subscribe_rc_status(const RcStatusCallback& callback)
 {
     return _impl->subscribe_rc_status(callback);

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.h
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.h
@@ -102,6 +102,7 @@ public:
     Telemetry::FlightMode flight_mode() const;
     Telemetry::Health health() const;
     bool health_all_ok() const;
+    Telemetry::SysStatusSensors sys_status_sensors() const;
     Telemetry::RcStatus rc_status() const;
     Telemetry::ActuatorControlTarget actuator_control_target() const;
     Telemetry::ActuatorOutputStatus actuator_output_status() const;
@@ -234,6 +235,7 @@ private:
     void set_scaled_pressure(Telemetry::ScaledPressure& scaled_pressure);
     void set_heading(Telemetry::Heading heading);
     void set_altitude(Telemetry::Altitude altitude);
+    void set_sys_status_sensors(const mavlink_sys_status_t& sys_status);
 
     void process_position_velocity_ned(const mavlink_message_t& message);
     void process_global_position_int(const mavlink_message_t& message);
@@ -339,6 +341,9 @@ private:
 
     mutable std::mutex _health_mutex{};
     Telemetry::Health _health{};
+
+    mutable std::mutex _sys_status_sensors_mutex{};
+    Telemetry::SysStatusSensors _sys_status_sensors{};
 
     mutable std::mutex _vtol_state_mutex{};
     Telemetry::VtolState _vtol_state{Telemetry::VtolState::Undefined};


### PR DESCRIPTION
Added function to query SYS_STATUS present/enabled/health. This allows applications to look at specific sensor statuses, such as [logloader](https://github.com/ARK-Electronics/logloader) which looks at the [MAV_SYS_STATUS_LOGGING](https://mavlink.io/en/messages/common.html#MAV_SYS_STATUS_LOGGING) flag