### PR TITLE
gimbal: try to avoid potential lockup on reconnection

### DIFF
--- a/src/mavsdk/plugins/gimbal/gimbal_impl.h
+++ b/src/mavsdk/plugins/gimbal/gimbal_impl.h
@@ -83,6 +83,8 @@ private:
     std::unique_ptr<GimbalProtocolBase> _gimbal_protocol{nullptr};
     CallbackList<Gimbal::ControlStatus> _control_subscriptions{};
     CallbackList<Gimbal::Attitude> _attitude_subscriptions{};
+
+    CallEveryHandler::Cookie _request_gimbal_information_cookie{};
 };
 
 } // namespace mavsdk


### PR DESCRIPTION
This will be fixed properly with v3 but it's worth trying to avoid the deadlock anyway.