### PR TITLE
core: ignore no known remotes

### DIFF
--- a/src/mavsdk/core/udp_connection.cpp
+++ b/src/mavsdk/core/udp_connection.cpp
@@ -116,7 +116,6 @@ bool UdpConnection::send_message(const mavlink_message_t& message)
     std::lock_guard<std::mutex> lock(_remote_mutex);
 
     if (_remotes.size() == 0) {
-        LogErr() << "No known remotes";
         return false;
     }
 


### PR DESCRIPTION
There is no point spamming the user about no known remotes. It's just confusing and noisy until the remotes appear.