### PR TITLE
[core] Added ComponentType::RemoteID

### DIFF
--- a/src/mavsdk/core/include/mavsdk/component_type.h
+++ b/src/mavsdk/core/include/mavsdk/component_type.h
@@ -11,6 +11,7 @@ enum class ComponentType {
     CompanionComputer, /**< @brief SDK is used as a companion computer on board the MAV. */
     Camera, /** < @brief SDK is used as a camera. */
     Gimbal, /** < @brief SDK is used as a gimbal. */
+    RemoteId, /** < @brief SDK is used as a RemoteId system. */
     Custom /**< @brief the SDK is used in a custom configuration, no automatic ID will be
               provided */
 };

--- a/src/mavsdk/core/include/mavsdk/mavsdk.h
+++ b/src/mavsdk/core/include/mavsdk/mavsdk.h
@@ -357,14 +357,18 @@ public:
     void intercept_outgoing_messages_async(std::function<bool(mavlink_message_t&)> callback);
 
 private:
+    static constexpr int DEFAULT_SYSTEM_ID_AUTOPILOT = 1;
+    static constexpr int DEFAULT_COMPONENT_ID_AUTOPILOT = MAV_COMP_ID_AUTOPILOT1;
     static constexpr int DEFAULT_SYSTEM_ID_GCS = 245;
     static constexpr int DEFAULT_COMPONENT_ID_GCS = MAV_COMP_ID_MISSIONPLANNER;
     static constexpr int DEFAULT_SYSTEM_ID_CC = 1;
     static constexpr int DEFAULT_COMPONENT_ID_CC = MAV_COMP_ID_PATHPLANNER;
-    static constexpr int DEFAULT_SYSTEM_ID_AUTOPILOT = 1;
-    static constexpr int DEFAULT_COMPONENT_ID_AUTOPILOT = MAV_COMP_ID_AUTOPILOT1;
     static constexpr int DEFAULT_SYSTEM_ID_CAMERA = 1;
     static constexpr int DEFAULT_COMPONENT_ID_CAMERA = MAV_COMP_ID_CAMERA;
+    static constexpr int DEFAULT_SYSTEM_ID_GIMBAL = 1;
+    static constexpr int DEFAULT_COMPONENT_ID_GIMBAL = MAV_COMP_ID_GIMBAL;
+    static constexpr int DEFAULT_SYSTEM_ID_REMOTEID = 1;
+    static constexpr int DEFAULT_COMPONENT_ID_REMOTEID = MAV_COMP_ID_ODID_TXRX_1;
 
     /* @private. */
     std::shared_ptr<MavsdkImpl> _impl{};

--- a/src/mavsdk/core/mavsdk.cpp
+++ b/src/mavsdk/core/mavsdk.cpp
@@ -90,14 +90,18 @@ Mavsdk::Configuration::Configuration(
 ComponentType Mavsdk::Configuration::component_type_for_component_id(uint8_t component_id)
 {
     switch (component_id) {
+        case Mavsdk::DEFAULT_COMPONENT_ID_AUTOPILOT:
+            return ComponentType::Autopilot;
         case Mavsdk::DEFAULT_COMPONENT_ID_GCS:
             return ComponentType::GroundStation;
         case Mavsdk::DEFAULT_COMPONENT_ID_CC:
             return ComponentType::CompanionComputer;
-        case Mavsdk::DEFAULT_COMPONENT_ID_AUTOPILOT:
-            return ComponentType::Autopilot;
         case Mavsdk::DEFAULT_COMPONENT_ID_CAMERA:
             return ComponentType::Camera;
+        case Mavsdk::DEFAULT_COMPONENT_ID_GIMBAL:
+            return ComponentType::Gimbal;
+        case Mavsdk::DEFAULT_COMPONENT_ID_REMOTEID:
+            return ComponentType::RemoteId;
         default:
             return ComponentType::Custom;
     }
@@ -129,6 +133,16 @@ Mavsdk::Configuration::Configuration(ComponentType component_type) :
         case ComponentType::Camera:
             _system_id = Mavsdk::DEFAULT_SYSTEM_ID_CAMERA;
             _component_id = Mavsdk::DEFAULT_COMPONENT_ID_CAMERA;
+            _always_send_heartbeats = true;
+            break;
+        case ComponentType::Gimbal:
+            _system_id = Mavsdk::DEFAULT_SYSTEM_ID_GIMBAL;
+            _component_id = Mavsdk::DEFAULT_COMPONENT_ID_GIMBAL;
+            _always_send_heartbeats = true;
+            break;
+        case ComponentType::RemoteId:
+            _system_id = Mavsdk::DEFAULT_SYSTEM_ID_REMOTEID;
+            _component_id = Mavsdk::DEFAULT_COMPONENT_ID_REMOTEID;
             _always_send_heartbeats = true;
             break;
         default:

--- a/src/mavsdk/core/mavsdk_impl.cpp
+++ b/src/mavsdk/core/mavsdk_impl.cpp
@@ -185,6 +185,8 @@ std::shared_ptr<ServerComponent> MavsdkImpl::server_component(unsigned instance)
         case ComponentType::GroundStation:
         case ComponentType::CompanionComputer:
         case ComponentType::Camera:
+        case ComponentType::Gimbal:
+        case ComponentType::RemoteId:
         case ComponentType::Custom:
             return server_component_by_type(component_type, instance);
         default:
@@ -703,6 +705,12 @@ uint8_t MavsdkImpl::get_mav_type() const
 
         case ComponentType::Camera:
             return MAV_TYPE_CAMERA;
+
+        case ComponentType::Gimbal:
+            return MAV_TYPE_GIMBAL;
+
+        case ComponentType::RemoteId:
+            return MAV_TYPE_ODID;
 
         case ComponentType::Custom:
             return MAV_TYPE_GENERIC;

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -334,6 +334,13 @@ ComponentType SystemImpl::component_type(uint8_t component_id)
     switch (component_id) {
         case MAV_COMP_ID_AUTOPILOT1:
             return ComponentType::Autopilot;
+        case MAV_COMP_ID_MISSIONPLANNER:
+            return ComponentType::GroundStation;
+        case MAV_COMP_ID_ONBOARD_COMPUTER:
+        case MAV_COMP_ID_ONBOARD_COMPUTER2:
+        case MAV_COMP_ID_ONBOARD_COMPUTER3:
+        case MAV_COMP_ID_ONBOARD_COMPUTER4:
+            return ComponentType::CompanionComputer;
         case MAV_COMP_ID_CAMERA:
         case MAV_COMP_ID_CAMERA2:
         case MAV_COMP_ID_CAMERA3:
@@ -343,13 +350,10 @@ ComponentType SystemImpl::component_type(uint8_t component_id)
             return ComponentType::Camera;
         case MAV_COMP_ID_GIMBAL:
             return ComponentType::Gimbal;
-        case MAV_COMP_ID_ONBOARD_COMPUTER:
-        case MAV_COMP_ID_ONBOARD_COMPUTER2:
-        case MAV_COMP_ID_ONBOARD_COMPUTER3:
-        case MAV_COMP_ID_ONBOARD_COMPUTER4:
-            return ComponentType::CompanionComputer;
-        case MAV_COMP_ID_MISSIONPLANNER:
-            return ComponentType::GroundStation;
+        case MAV_COMP_ID_ODID_TXRX_1:
+        case MAV_COMP_ID_ODID_TXRX_2:
+        case MAV_COMP_ID_ODID_TXRX_3:
+            return ComponentType::RemoteId;
         default:
             return ComponentType::Custom;
     }


### PR DESCRIPTION
- ~Removed unused duplicate enum class in system.h~ Can we consolidate `System::ComponentType` with `Mavsdk::ComponentType`?
- Added `ComponentType::RemoteID` -- I'm transitioning [RemoteIDTransmitter](https://github.com/ARK-Electronics/RemoteIDTransmitter) to MAVSDK
- Removed `ComponentType::Custom` to reduce confusion since it was defaulting to MAV_TYPE_GENERIC
- Added `Mavsdk::Configuration` constructor for `ComponentType::RemoteId`