### PR TITLE
Autopilot server and command server fixes

### DIFF
--- a/src/mavsdk/core/mavlink_command_receiver.cpp
+++ b/src/mavsdk/core/mavlink_command_receiver.cpp
@@ -40,14 +40,15 @@ void MavlinkCommandReceiver::receive_command_int(const mavlink_message_t& messag
     MavlinkCommandReceiver::CommandInt cmd(message);
 
     if (_debugging) {
-        LogDebug() << "Received command int " << (int)cmd.command;
+        LogDebug() << "Received command int " << std::to_string(cmd.command);
     }
 
     if (cmd.target_component_id != _server_component_impl.get_own_component_id() &&
         cmd.target_component_id != MAV_COMP_ID_ALL) {
         if (_debugging) {
-            LogDebug() << "Ignored command int to component " << (int)cmd.target_component_id
-                       << " instead of " << (int)_server_component_impl.get_own_component_id();
+            LogDebug() << "Ignored command int to component "
+                       << std::to_string(cmd.target_component_id) << " instead of "
+                       << std::to_string(_server_component_impl.get_own_component_id());
         }
         return;
     }
@@ -57,7 +58,7 @@ void MavlinkCommandReceiver::receive_command_int(const mavlink_message_t& messag
     for (auto& handler : _mavlink_command_int_handler_table) {
         if (handler.cmd_id == cmd.command) {
             if (_debugging) {
-                LogDebug() << "Handling command int " << (int)cmd.command;
+                LogDebug() << "Handling command int " << std::to_string(cmd.command);
             }
 
             // The client side can pack a COMMAND_ACK as a response to receiving the command.
@@ -76,8 +77,8 @@ void MavlinkCommandReceiver::receive_command_int(const mavlink_message_t& messag
                     });
 
                 if (_debugging) {
-                    LogDebug() << "Acked command int " << (int)cmd.command << " with "
-                               << maybe_command_ack.value().result;
+                    LogDebug() << "Acked command int " << std::to_string(cmd.command) << " with "
+                               << std::to_string(maybe_command_ack.value().result);
                 }
             }
         }
@@ -89,14 +90,15 @@ void MavlinkCommandReceiver::receive_command_long(const mavlink_message_t& messa
     MavlinkCommandReceiver::CommandLong cmd(message);
 
     if (_debugging) {
-        LogDebug() << "Received command long " << (int)cmd.command;
+        LogDebug() << "Received command long " << std::to_string(cmd.command);
     }
 
     if (cmd.target_component_id != _server_component_impl.get_own_component_id() &&
         cmd.target_component_id != MAV_COMP_ID_ALL) {
         if (_debugging) {
-            LogDebug() << "Ignored command long to component " << (int)cmd.target_component_id
-                       << " instead of " << (int)_server_component_impl.get_own_component_id();
+            LogDebug() << "Ignored command long to component "
+                       << std::to_string(cmd.target_component_id) << " instead of "
+                       << std::to_string(_server_component_impl.get_own_component_id());
         }
         return;
     }
@@ -106,7 +108,7 @@ void MavlinkCommandReceiver::receive_command_long(const mavlink_message_t& messa
     for (auto& handler : _mavlink_command_long_handler_table) {
         if (handler.cmd_id == cmd.command) {
             if (_debugging) {
-                LogDebug() << "Handling command long " << (int)cmd.command;
+                LogDebug() << "Handling command long " << std::to_string(cmd.command);
             }
 
             // The client side can pack a COMMAND_ACK as a response to receiving the command.
@@ -124,8 +126,8 @@ void MavlinkCommandReceiver::receive_command_long(const mavlink_message_t& messa
                         return response_message;
                     });
                 if (_debugging) {
-                    LogDebug() << "Acked command long " << (int)cmd.command << " with "
-                               << maybe_command_ack.value().result;
+                    LogDebug() << "Acked command long " << std::to_string(cmd.command) << " with "
+                               << std::to_string(maybe_command_ack.value().result);
                 }
             }
         }

--- a/src/mavsdk/plugins/telemetry_server/telemetry_server_impl.cpp
+++ b/src/mavsdk/plugins/telemetry_server/telemetry_server_impl.cpp
@@ -83,20 +83,25 @@ void TelemetryServerImpl::init()
                 case MAVLINK_MSG_ID_HOME_POSITION:
                     if (_maybe_home) {
                         if (_send_home()) {
-                            return _server_component_impl->make_command_ack_message(
-                                command, MAV_RESULT::MAV_RESULT_ACCEPTED);
+                            return std::optional<mavlink_command_ack_t>{
+                                _server_component_impl->make_command_ack_message(
+                                    command, MAV_RESULT::MAV_RESULT_ACCEPTED)};
                         } else {
-                            return _server_component_impl->make_command_ack_message(
-                                command, MAV_RESULT::MAV_RESULT_FAILED);
+                            return std::optional<mavlink_command_ack_t>{
+                                _server_component_impl->make_command_ack_message(
+                                    command, MAV_RESULT::MAV_RESULT_FAILED)};
                         }
                     } else {
-                        return _server_component_impl->make_command_ack_message(
-                            command, MAV_RESULT::MAV_RESULT_DENIED);
+                        return std::optional<mavlink_command_ack_t>{
+                            _server_component_impl->make_command_ack_message(
+                                command, MAV_RESULT::MAV_RESULT_DENIED)};
                     }
 
                 default:
-                    return _server_component_impl->make_command_ack_message(
-                        command, MAV_RESULT::MAV_RESULT_DENIED);
+                    // Let's hope someone else answers and keep silent. In an ideal world we would
+                    // explicitly deny all the ones that we ought to answer but haven't implemented
+                    // yet.
+                    return std::optional<mavlink_command_ack_t>{};
             }
         },
         this);


### PR DESCRIPTION
See commits.

The command fix gets rid of these confusing warnings:
```
[02:27:01|Debug] Received ack from 1/1 for not-existing command: 512! Ignoring... (mavlink_command_sender.cpp:285)
```

Finally...