### PR TITLE
core: make udpin parsing stricter

### DIFF
--- a/src/mavsdk/core/cli_arg.cpp
+++ b/src/mavsdk/core/cli_arg.cpp
@@ -103,8 +103,11 @@ bool CliArg::parse_udpin(const std::string_view rest)
     auto& p = std::get<Udp>(protocol);
     p.host = rest.substr(0, pos);
     p.mode = Udp::Mode::In;
-    p.host = rest.substr(0, pos);
-    p.mode = Udp::Mode::In;
+
+    if (p.host.empty()) {
+        LogErr() << "No network interface (or 0.0.0.0 for all network interfaces) supplied";
+        return false;
+    }
 
     if (auto maybe_port = port_from_str(rest.substr(pos + 1))) {
         p.port = maybe_port.value();

--- a/src/mavsdk/core/cli_arg.cpp
+++ b/src/mavsdk/core/cli_arg.cpp
@@ -105,7 +105,7 @@ bool CliArg::parse_udpin(const std::string_view rest)
     p.mode = Udp::Mode::In;
 
     if (p.host.empty()) {
-        LogErr() << "No network interface (or 0.0.0.0 for all network interfaces) supplied";
+        LogErr() << "No network interface supplied (use 0.0.0.0 for all network interfaces)";
         return false;
     }
 

--- a/src/mavsdk/core/cli_arg_test.cpp
+++ b/src/mavsdk/core/cli_arg_test.cpp
@@ -128,6 +128,13 @@ TEST(CliArg, UdpInAll)
     EXPECT_EQ(udp->mode, CliArg::Udp::Mode::In);
 }
 
+TEST(CliArg, UdpInWrong)
+{
+    CliArg ca;
+
+    EXPECT_FALSE(ca.parse("udpin://:55"));
+}
+
 TEST(CliArg, UdpInSpecific)
 {
     CliArg ca;


### PR DESCRIPTION
We don't want to accept udpin://:PORT but we always need the network interface, e.g.:
- udpin://192.168.X.Y:PORT, or
- udpin://0.0.0.0:PORT for all network interfaces

Without this we got an error further down with inet_pton.