### PR TITLE
core: always convert hostname to IP for UDP remotes

### DIFF
--- a/src/mavsdk/core/CMakeLists.txt
+++ b/src/mavsdk/core/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(mavsdk
     file_cache.cpp
     flight_mode.cpp
     fs_utils.cpp
+    hostname_to_ip.cpp
     inflate_lzma.cpp
     math_conversions.cpp
     mavsdk.cpp
@@ -85,8 +86,9 @@ if (NOT BUILD_WITHOUT_CURL)
     )
 
     list(APPEND UNIT_TEST_SOURCES
-        # TODO: add this again
         ${PROJECT_SOURCE_DIR}/mavsdk/core/curl_test.cpp
+        ${PROJECT_SOURCE_DIR}/mavsdk/core/hostname_to_ip_test.cpp
+        # TODO: add this again
         #${PROJECT_SOURCE_DIR}/mavsdk/core/http_loader_test.cpp
     )
 else()

--- a/src/mavsdk/core/hostname_to_ip.cpp
+++ b/src/mavsdk/core/hostname_to_ip.cpp
@@ -1,0 +1,60 @@
+#include "hostname_to_ip.h"
+#include "log.h"
+
+#if defined(WINDOWS)
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#pragma comment(lib, "ws2_32.lib")
+#else
+#include <netdb.h>
+#include <arpa/inet.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#endif
+
+namespace mavsdk {
+
+std::optional<std::string> resolve_hostname_to_ip(const std::string& hostname)
+{
+#if defined(WINDOWS)
+    WSADATA wsaData;
+    if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {
+        std::cerr << "WSAStartup failed" << std::endl;
+        return {};
+    }
+#endif
+
+    addrinfo hints{};
+    hints.ai_family = AF_INET; // IPv4
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;
+
+    addrinfo* result = nullptr;
+    int res = getaddrinfo(hostname.c_str(), nullptr, &hints, &result);
+    if (res != 0) {
+#if defined(WINDOWS)
+        LogErr() << "getaddrinfo failed: " << WSAGetLastError();
+        WSACleanup();
+#else
+        LogErr() << "getaddrinfo failed: " << gai_strerror(res);
+#endif
+        return {};
+    }
+
+    std::string ipAddress;
+    for (addrinfo* ptr = result; ptr != nullptr; ptr = ptr->ai_next) {
+        sockaddr_in* sockaddrIpv4 = reinterpret_cast<sockaddr_in*>(ptr->ai_addr);
+        char ipStr[INET_ADDRSTRLEN];
+        inet_ntop(AF_INET, &(sockaddrIpv4->sin_addr), ipStr, INET_ADDRSTRLEN);
+        ipAddress = ipStr;
+        break; // Take the first result
+    }
+
+    freeaddrinfo(result);
+#if defined(WINDOWS)
+    WSACleanup();
+#endif
+    return {ipAddress};
+}
+
+} // namespace mavsdk

--- a/src/mavsdk/core/hostname_to_ip.h
+++ b/src/mavsdk/core/hostname_to_ip.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+#include <optional>
+
+namespace mavsdk {
+
+std::optional<std::string> resolve_hostname_to_ip(const std::string& hostname);
+
+} // namespace mavsdk

--- a/src/mavsdk/core/hostname_to_ip_test.cpp
+++ b/src/mavsdk/core/hostname_to_ip_test.cpp
@@ -1,0 +1,34 @@
+#include "hostname_to_ip.h"
+#include <gtest/gtest.h>
+
+using namespace mavsdk;
+
+TEST(HostnameToIp, Localhost)
+{
+    auto host = "localhost";
+    auto ip = resolve_hostname_to_ip(host);
+    ASSERT_TRUE(ip);
+    EXPECT_EQ(ip.value(), "127.0.0.1");
+}
+
+TEST(HostnameToIp, Ip)
+{
+    auto host = "127.0.0.1";
+    auto ip = resolve_hostname_to_ip(host);
+    ASSERT_TRUE(ip);
+    EXPECT_EQ(ip.value(), host);
+}
+
+TEST(HostnameToIp, Empty)
+{
+    auto host = "";
+    auto ip = resolve_hostname_to_ip(host);
+    EXPECT_FALSE(ip);
+}
+
+TEST(HostnameToIp, Something)
+{
+    auto host = "something";
+    auto ip = resolve_hostname_to_ip(host);
+    EXPECT_FALSE(ip);
+}


### PR DESCRIPTION
Otherwise we end up with two connections, one for the hostname that we add and one for the IP where we receive messages from.

Fixes https://github.com/mavlink/MAVSDK-Java/issues/182.