### PR TITLE
Respond to MAVLINK 2 PROTOCOL_VERSION request

### DIFF
--- a/src/mavsdk/core/server_component_impl.cpp
+++ b/src/mavsdk/core/server_component_impl.cpp
@@ -396,11 +396,11 @@ void ServerComponentImpl::send_protocol_version()
             mavlink_address.component_id,
             channel,
             &message,
-            kMavlinkVersionInfo.version,
-            kMavlinkVersionInfo.min_version,
-            kMavlinkVersionInfo.max_version,
-            kMavlinkVersionInfo.spec_version_hash,
-            kMavlinkVersionInfo.library_version_hash);
+            MAVLINK_VERSION_INFO.version,
+            MAVLINK_VERSION_INFO.min_version,
+            MAVLINK_VERSION_INFO.max_version,
+            MAVLINK_VERSION_INFO.spec_version_hash,
+            MAVLINK_VERSION_INFO.library_version_hash);
         return message;
     });
 }

--- a/src/mavsdk/core/server_component_impl.h
+++ b/src/mavsdk/core/server_component_impl.h
@@ -25,6 +25,14 @@ class ServerPluginImplBase;
 
 class ServerComponentImpl {
 public:
+    static constexpr mavlink_protocol_version_t kMavlinkVersionInfo{
+        MAVLINK_VERSION * 100, // currently active mavlink version
+        100, // min supported version
+        MAVLINK_VERSION * 100, // max supported version
+        {}, // spec version hash (unused for now)
+        {}, // library version hash (unused for now)
+    };
+
     ServerComponentImpl(MavsdkImpl& mavsdk_impl, uint8_t component_id);
     ~ServerComponentImpl();
 
@@ -140,6 +148,7 @@ public:
     void set_product_id(uint16_t product_id);
     bool set_uid2(std::string uid2);
     void send_autopilot_version();
+    void send_protocol_version();
 
     MavlinkMissionTransferServer& mission_transfer_server() { return _mission_transfer_server; }
     MavlinkParameterServer& mavlink_parameter_server() { return _mavlink_parameter_server; }

--- a/src/mavsdk/core/server_component_impl.h
+++ b/src/mavsdk/core/server_component_impl.h
@@ -25,7 +25,7 @@ class ServerPluginImplBase;
 
 class ServerComponentImpl {
 public:
-    static constexpr mavlink_protocol_version_t kMavlinkVersionInfo{
+    static constexpr mavlink_protocol_version_t MAVLINK_VERSION_INFO{
         MAVLINK_VERSION * 100, // currently active mavlink version
         100, // min supported version
         MAVLINK_VERSION * 100, // max supported version


### PR DESCRIPTION
MAVSDK comfortably supports MAVLINK 2, but the server component doesn't currently respond to the MAVLINK_MSG_ID_PROTOCOL_VERSION request, and thus GCSes like QGroundControl fall back to MAVLINK 1 when establishing communication.

This change adds the MAVLINK_MSG_ID_PROTOCOL_VERSION handler with a corresponding capability to communicate to clients that MAVLINK 2 is supported.

QGroundControl log before:
```
InitialConnectStateMachineLog: Sending REQUEST_MESSAGE:PROTOCOL_VERSION
VehicleLog: _waitForMavlinkMessage msg:timeout 300 1000
...
InitialConnectStateMachineLog: REQUEST_MESSAGE PROTOCOL_VERSION command acked but message never received
InitialConnectStateMachineLog: "Setting _maxProtoVersion to 100 due to timeout on receiving PROTOCOL_VERSION message."
VehicleLog: _setMaxProtoVersionFromBothSources using protocol version message
VehicleLog: _setMaxProtoVersion before:after 200 100
```

QGroundControl log after:
```
InitialConnectStateMachineLog: Sending REQUEST_MESSAGE:PROTOCOL_VERSION
VehicleLog: _waitForMavlinkMessage msg:timeout 300 1000
VehicleLog: _sendMavCommandFromList command:tryCount "MAV_CMD_REQUEST_MESSAGE" 0
MissionControllerLog: _recalcFlightPathSegments homePositionValid false
VehicleLog: _waitForMavlinkMessageMessageReceived message received 300
VehicleLog: _waitForMavlinkMessageClear
VehicleLog: "_handleCommandAck command(MAV_CMD_REQUEST_MESSAGE) result(MAV_RESULT_ACCEPTED)"
InitialConnectStateMachineLog: PROTOCOL_VERSION received mav_version: 300
VehicleLog: _setMaxProtoVersionFromBothSources using protocol version message
```