### PR TITLE
Fixes MAVSDK-Java#155 camera::possibleSettingOptions crashes as a result of erroneous string format

### DIFF
--- a/src/mavsdk/plugins/camera/camera_impl.cpp
+++ b/src/mavsdk/plugins/camera/camera_impl.cpp
@@ -1848,10 +1848,8 @@ bool CameraImpl::get_possible_options(
     }
 
     for (const auto& value : values) {
-        std::stringstream ss{};
-        ss << value.get_string();
         Camera::Option option{};
-        option.option_id = ss.str();
+        option.option_id = value.get_string();
         if (!is_setting_range(setting_id)) {
             get_option_str(setting_id, option.option_id, option.option_description);
         }

--- a/src/mavsdk/plugins/camera/camera_impl.cpp
+++ b/src/mavsdk/plugins/camera/camera_impl.cpp
@@ -1849,7 +1849,7 @@ bool CameraImpl::get_possible_options(
 
     for (const auto& value : values) {
         std::stringstream ss{};
-        ss << value;
+        ss << value.get_string();
         Camera::Option option{};
         option.option_id = ss.str();
         if (!is_setting_range(setting_id)) {


### PR DESCRIPTION
Corrects the conversion to numeric string representation