### PR TITLE
core: fix get_all_params caching

### DIFF
--- a/src/mavsdk/core/mavlink_parameter_client.cpp
+++ b/src/mavsdk/core/mavlink_parameter_client.cpp
@@ -458,6 +458,8 @@ void MavlinkParameterClient::do_work()
                     _timeout_handler.add([this] { receive_timeout(); }, _timeout_s_callback());
             },
             [&](WorkItemGet& item) {
+                // We can't rely on the cache as we haven't implemented the hash check.
+                clear_cache();
                 if (!send_get_param_message(item)) {
                     LogErr() << "Send message failed";
                     work_queue_guard->pop_front();
@@ -474,6 +476,8 @@ void MavlinkParameterClient::do_work()
                     _timeout_handler.add([this] { receive_timeout(); }, _timeout_s_callback());
             },
             [&](WorkItemGetAll& item) {
+                // We can't rely on the cache as we haven't implemented the hash check.
+                clear_cache();
                 if (!send_request_list_message()) {
                     LogErr() << "Send message failed";
                     work_queue_guard->pop_front();


### PR DESCRIPTION
We don't have the hash check based on the hidden param _HASH_CHECK implemented yet, so we shouldn't use the cache to get (all) params.