### PR TITLE
Support Mission Download In Mission Raw Server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mavsdk-proto"]
 	path = proto
-	url = https://github.com/jonathanreeves/MAVSDK-Proto.git
+	url = https://github.com/mavlink/MAVSDK-Proto.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mavsdk-proto"]
 	path = proto
-	url = https://github.com/mavlink/MAVSDK-Proto.git
+	url = https://github.com/jonathanreeves/MAVSDK-Proto.git

--- a/src/mavsdk/core/mavlink_mission_transfer_server.cpp
+++ b/src/mavsdk/core/mavlink_mission_transfer_server.cpp
@@ -31,14 +31,6 @@ MavlinkMissionTransferServer::receive_incoming_items_async(
     uint8_t target_component,
     ResultAndItemsCallback callback)
 {
-    if (!_int_messages_supported) {
-        if (callback) {
-            LogErr() << "Int messages are not supported.";
-            callback(Result::IntMessagesNotSupported, {});
-        }
-        return {};
-    }
-
     auto ptr = std::make_shared<ReceiveIncomingMission>(
         _sender,
         _message_handler,
@@ -47,6 +39,31 @@ MavlinkMissionTransferServer::receive_incoming_items_async(
         _timeout_s_callback(),
         callback,
         mission_count,
+        target_system,
+        target_component,
+        _debugging);
+
+    _work_queue.push_back(ptr);
+
+    return std::weak_ptr<WorkItem>(ptr);
+}
+
+std::weak_ptr<MavlinkMissionTransferServer::WorkItem>
+MavlinkMissionTransferServer::send_outgoing_items_async(
+    uint8_t type,
+    const std::vector<ItemInt>& items,
+    uint8_t target_system,
+    uint8_t target_component,
+    ResultCallback callback)
+{
+    auto ptr = std::make_shared<SendOutgoingMission>(
+        _sender,
+        _message_handler,
+        _timeout_handler,
+        type,
+        items,
+        _timeout_s_callback(),
+        callback,
         target_system,
         target_component,
         _debugging);
@@ -238,7 +255,6 @@ void MavlinkMissionTransferServer::ReceiveIncomingMission::process_mission_count
 
     _timeout_handler.refresh(_cookie);
     _next_sequence = 0;
-    _step = Step::RequestItem;
     _retries_done = 0;
     _expected_count = _mission_count;
     request_item();
@@ -296,6 +312,338 @@ void MavlinkMissionTransferServer::ReceiveIncomingMission::callback_and_reset(Re
 {
     if (_callback) {
         _callback(result, _items);
+    }
+    _callback = nullptr;
+    _done = true;
+}
+
+MavlinkMissionTransferServer::SendOutgoingMission::SendOutgoingMission(
+    Sender& sender,
+    MavlinkMessageHandler& message_handler,
+    TimeoutHandler& timeout_handler,
+    uint8_t type,
+    const std::vector<ItemInt>& items,
+    double timeout_s,
+    ResultCallback callback,
+    uint8_t target_system_id,
+    uint8_t target_component_id,
+    bool debugging) :
+    WorkItem(sender, message_handler, timeout_handler, type, timeout_s, debugging),
+    _items(items),
+    _callback(callback),
+    _target_system_id(target_system_id),
+    _target_component_id(target_component_id)
+{
+    _message_handler.register_one(
+        MAVLINK_MSG_ID_MISSION_REQUEST,
+        [this](const mavlink_message_t& message) { process_mission_request(message); },
+        this);
+
+    _message_handler.register_one(
+        MAVLINK_MSG_ID_MISSION_REQUEST_INT,
+        [this](const mavlink_message_t& message) { process_mission_request_int(message); },
+        this);
+
+    _message_handler.register_one(
+        MAVLINK_MSG_ID_MISSION_ACK,
+        [this](const mavlink_message_t& message) { process_mission_ack(message); },
+        this);
+}
+
+MavlinkMissionTransferServer::SendOutgoingMission::~SendOutgoingMission()
+{
+    _message_handler.unregister_all(this);
+    _timeout_handler.remove(_cookie);
+}
+
+void MavlinkMissionTransferServer::SendOutgoingMission::start()
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    _started = true;
+    _retries_done = 0;
+    _step = Step::SendCount;
+    _cookie = _timeout_handler.add([this]() { process_timeout(); }, _timeout_s);
+
+    _next_sequence = 0;
+
+    send_count();
+}
+
+void MavlinkMissionTransferServer::SendOutgoingMission::cancel()
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    _timeout_handler.remove(_cookie);
+    send_cancel_and_finish();
+}
+
+void MavlinkMissionTransferServer::SendOutgoingMission::send_count()
+{
+    if (!_sender.queue_message([&](MavlinkAddress mavlink_address, uint8_t channel) {
+            mavlink_message_t message;
+            mavlink_msg_mission_count_pack_chan(
+                mavlink_address.system_id,
+                mavlink_address.component_id,
+                channel,
+                &message,
+                _target_system_id,
+                _target_component_id,
+                _items.size(),
+                _type,
+                0);
+            return message;
+        })) {
+        _timeout_handler.remove(_cookie);
+        callback_and_reset(Result::ConnectionError);
+        return;
+    }
+
+    if (_debugging) {
+        LogDebug() << "Sending send_count, count: " << _items.size()
+                   << ", retries: " << _retries_done;
+    }
+
+    ++_retries_done;
+}
+
+void MavlinkMissionTransferServer::SendOutgoingMission::send_cancel_and_finish()
+{
+    if (!_sender.queue_message([&](MavlinkAddress mavlink_address, uint8_t channel) {
+            mavlink_message_t message;
+            mavlink_msg_mission_ack_pack_chan(
+                mavlink_address.system_id,
+                mavlink_address.component_id,
+                channel,
+                &message,
+                _target_system_id,
+                _target_component_id,
+                MAV_MISSION_OPERATION_CANCELLED,
+                _type,
+                0);
+            return message;
+        })) {
+        callback_and_reset(Result::ConnectionError);
+        return;
+    }
+
+    // We do not wait on anything coming back after this.
+    callback_and_reset(Result::Cancelled);
+}
+
+void MavlinkMissionTransferServer::SendOutgoingMission::process_mission_request(
+    const mavlink_message_t& request_message)
+{
+    mavlink_mission_request_t request;
+    mavlink_msg_mission_request_decode(&request_message, &request);
+
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    // We only support int, so we nack this and thus tell the autopilot to use int.
+    if (!_sender.queue_message([&](MavlinkAddress mavlink_address, uint8_t channel) {
+            mavlink_message_t message;
+            mavlink_msg_mission_ack_pack_chan(
+                mavlink_address.system_id,
+                mavlink_address.component_id,
+                channel,
+                &message,
+                request_message.sysid,
+                request_message.compid,
+                MAV_MISSION_UNSUPPORTED,
+                _type,
+                0);
+            return message;
+        })) {
+        _timeout_handler.remove(_cookie);
+        callback_and_reset(Result::ConnectionError);
+        return;
+    }
+    _timeout_handler.refresh(_cookie);
+}
+
+void MavlinkMissionTransferServer::SendOutgoingMission::process_mission_request_int(
+    const mavlink_message_t& message)
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    mavlink_mission_request_int_t request_int;
+    mavlink_msg_mission_request_int_decode(&message, &request_int);
+
+    _step = Step::SendItems;
+
+    if (_debugging) {
+        LogDebug() << "Process mission_request_int, seq: " << request_int.seq
+                   << ", next expected sequence: " << _next_sequence;
+    }
+
+    if (_next_sequence < request_int.seq) {
+        // We should not go back to a previous one.
+        // TODO: figure out if we should error here.
+        LogWarn() << "mission_request_int: sequence incorrect";
+        return;
+
+    } else if (_next_sequence > request_int.seq) {
+        // We have already sent that one before.
+        if (_retries_done >= retries) {
+            LogWarn() << "mission_request_int: retries exceeded";
+            _timeout_handler.remove(_cookie);
+            callback_and_reset(Result::Timeout);
+            return;
+        }
+
+    } else {
+        // Correct one, sending it the first time.
+        _retries_done = 0;
+    }
+
+    _timeout_handler.refresh(_cookie);
+
+    _next_sequence = request_int.seq;
+
+    send_mission_item();
+}
+
+void MavlinkMissionTransferServer::SendOutgoingMission::send_mission_item()
+{
+    if (_next_sequence >= _items.size()) {
+        LogErr() << "send_mission_item: sequence out of bounds";
+        return;
+    }
+
+    if (_debugging) {
+        LogDebug() << "Sending mission_item_int seq: " << _next_sequence
+                   << ", retry: " << _retries_done;
+    }
+
+    if (!_sender.queue_message([&](MavlinkAddress mavlink_address, uint8_t channel) {
+            mavlink_message_t message;
+            mavlink_msg_mission_item_int_pack_chan(
+                mavlink_address.system_id,
+                mavlink_address.component_id,
+                channel,
+                &message,
+                _target_system_id,
+                _target_component_id,
+                _next_sequence,
+                _items[_next_sequence].frame,
+                _items[_next_sequence].command,
+                _items[_next_sequence].current,
+                _items[_next_sequence].autocontinue,
+                _items[_next_sequence].param1,
+                _items[_next_sequence].param2,
+                _items[_next_sequence].param3,
+                _items[_next_sequence].param4,
+                _items[_next_sequence].x,
+                _items[_next_sequence].y,
+                _items[_next_sequence].z,
+                _type);
+            return message;
+        })) {
+        _timeout_handler.remove(_cookie);
+        callback_and_reset(Result::ConnectionError);
+        return;
+    }
+
+    ++_next_sequence;
+
+    ++_retries_done;
+}
+
+void MavlinkMissionTransferServer::SendOutgoingMission::process_mission_ack(
+    const mavlink_message_t& message)
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    mavlink_mission_ack_t mission_ack;
+    mavlink_msg_mission_ack_decode(&message, &mission_ack);
+
+    if (_debugging) {
+        LogDebug() << "Received mission_ack type: " << static_cast<int>(mission_ack.type);
+    }
+
+    _timeout_handler.remove(_cookie);
+
+    switch (mission_ack.type) {
+        case MAV_MISSION_ERROR:
+            callback_and_reset(Result::ProtocolError);
+            return;
+        case MAV_MISSION_UNSUPPORTED_FRAME:
+            callback_and_reset(Result::UnsupportedFrame);
+            return;
+        case MAV_MISSION_UNSUPPORTED:
+            callback_and_reset(Result::Unsupported);
+            return;
+        case MAV_MISSION_NO_SPACE:
+            callback_and_reset(Result::TooManyMissionItems);
+            return;
+        case MAV_MISSION_INVALID:
+            // FALLTHROUGH
+        case MAV_MISSION_INVALID_PARAM1:
+            // FALLTHROUGH
+        case MAV_MISSION_INVALID_PARAM2:
+            // FALLTHROUGH
+        case MAV_MISSION_INVALID_PARAM3:
+            // FALLTHROUGH
+        case MAV_MISSION_INVALID_PARAM4:
+            // FALLTHROUGH
+        case MAV_MISSION_INVALID_PARAM5_X:
+            // FALLTHROUGH
+        case MAV_MISSION_INVALID_PARAM6_Y:
+            // FALLTHROUGH
+        case MAV_MISSION_INVALID_PARAM7:
+            callback_and_reset(Result::InvalidParam);
+            return;
+        case MAV_MISSION_INVALID_SEQUENCE:
+            callback_and_reset(Result::InvalidSequence);
+            return;
+        case MAV_MISSION_DENIED:
+            callback_and_reset(Result::Denied);
+            return;
+        case MAV_MISSION_OPERATION_CANCELLED:
+            callback_and_reset(Result::Cancelled);
+            return;
+    }
+
+    if (_next_sequence == _items.size()) {
+        callback_and_reset(Result::Success);
+    } else {
+        callback_and_reset(Result::ProtocolError);
+    }
+}
+
+void MavlinkMissionTransferServer::SendOutgoingMission::process_timeout()
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    if (_debugging) {
+        LogDebug() << "Timeout triggered, retries: " << _retries_done;
+    }
+
+    if (_retries_done >= retries) {
+        LogWarn() << "timeout: retries exceeded";
+        callback_and_reset(Result::Timeout);
+        return;
+    }
+
+    switch (_step) {
+        case Step::SendCount:
+            _cookie = _timeout_handler.add([this]() { process_timeout(); }, _timeout_s);
+            send_count();
+            break;
+
+        case Step::SendItems:
+            // When waiting for items requested we should wait longer than
+            // just our timeout, otherwise we give up too quickly.
+            ++_retries_done;
+            _cookie = _timeout_handler.add([this]() { process_timeout(); }, _timeout_s);
+            break;
+    }
+}
+
+void MavlinkMissionTransferServer::SendOutgoingMission::callback_and_reset(Result result)
+{
+    if (_callback) {
+        _callback(result);
     }
     _callback = nullptr;
     _done = true;

--- a/src/mavsdk/core/mavlink_mission_transfer_server.h
+++ b/src/mavsdk/core/mavlink_mission_transfer_server.h
@@ -186,7 +186,6 @@ public:
         ResultCallback _callback{nullptr};
         TimeoutHandler::Cookie _cookie{};
         std::size_t _next_sequence{0};
-        std::size_t _expected_count{0};
         unsigned _retries_done{0};
         uint8_t _target_system_id{0};
         uint8_t _target_component_id{0};

--- a/src/mavsdk/core/mavlink_mission_transfer_server.h
+++ b/src/mavsdk/core/mavlink_mission_transfer_server.h
@@ -130,11 +130,6 @@ public:
         void process_timeout();
         void callback_and_reset(Result result);
 
-        enum class Step {
-            RequestList,
-            RequestItem,
-        } _step{Step::RequestList};
-
         std::vector<ItemInt> _items{};
         ResultAndItemsCallback _callback{nullptr};
         TimeoutHandler::Cookie _cookie{};
@@ -146,6 +141,56 @@ public:
         uint8_t _target_component_id{0};
     };
     static constexpr unsigned retries = 5;
+
+    class SendOutgoingMission : public WorkItem {
+    public:
+        explicit SendOutgoingMission(
+            Sender& sender,
+            MavlinkMessageHandler& message_handler,
+            TimeoutHandler& timeout_handler,
+            uint8_t type,
+            const std::vector<ItemInt>& items,
+            double timeout_s,
+            ResultCallback callback,
+            uint8_t target_system_id,
+            uint8_t target_component_id,
+            bool debugging);
+
+        ~SendOutgoingMission() override;
+
+        void start() override;
+        void cancel() override;
+
+        SendOutgoingMission(const SendOutgoingMission&) = delete;
+        SendOutgoingMission(SendOutgoingMission&&) = delete;
+        SendOutgoingMission& operator=(const SendOutgoingMission&) = delete;
+        SendOutgoingMission& operator=(SendOutgoingMission&&) = delete;
+
+    private:
+        void send_count();
+        void send_mission_item();
+        void send_cancel_and_finish();
+
+        void process_mission_request(const mavlink_message_t& message);
+        void process_mission_request_int(const mavlink_message_t& message);
+        void process_mission_ack(const mavlink_message_t& message);
+        void process_timeout();
+        void callback_and_reset(Result result);
+
+        enum class Step {
+            SendCount,
+            SendItems,
+        } _step{Step::SendCount};
+
+        std::vector<ItemInt> _items{};
+        ResultCallback _callback{nullptr};
+        TimeoutHandler::Cookie _cookie{};
+        std::size_t _next_sequence{0};
+        std::size_t _expected_count{0};
+        unsigned _retries_done{0};
+        uint8_t _target_system_id{0};
+        uint8_t _target_component_id{0};
+    };
 
     explicit MavlinkMissionTransferServer(
         Sender& sender,
@@ -162,10 +207,15 @@ public:
         uint8_t target_component,
         ResultAndItemsCallback callback);
 
+    std::weak_ptr<WorkItem> send_outgoing_items_async(
+        uint8_t type,
+        const std::vector<ItemInt>& items,
+        uint8_t target_system,
+        uint8_t target_component,
+        ResultCallback callback);
+
     void do_work();
     bool is_idle();
-
-    void set_int_messages_supported(bool supported);
 
     // Non-copyable
     MavlinkMissionTransferServer(const MavlinkMissionTransferServer&) = delete;
@@ -179,7 +229,6 @@ private:
 
     LockedQueue<WorkItem> _work_queue{};
 
-    bool _int_messages_supported{true};
     bool _debugging{false};
 };
 

--- a/src/mavsdk/core/mavlink_mission_transfer_server_test.cpp
+++ b/src/mavsdk/core/mavlink_mission_transfer_server_test.cpp
@@ -45,107 +45,211 @@ protected:
         ON_CALL(mock_sender, autopilot()).WillByDefault(Return(Autopilot::Px4));
     }
 
+    static ItemInt make_item(uint8_t type, uint16_t sequence)
+    {
+        ItemInt item;
+
+        item.seq = sequence;
+        item.frame = MAV_FRAME_MISSION;
+        item.command = MAV_CMD_NAV_WAYPOINT;
+        item.current = uint8_t(sequence == 0 ? 1 : 0);
+        item.autocontinue = 1;
+        item.param1 = 1.0f;
+        item.param2 = 2.0f;
+        item.param3 = 3.0f;
+        item.param4 = 4.0f;
+        item.x = 5;
+        item.y = 6;
+        item.z = 7.0f;
+        item.mission_type = type;
+
+        return item;
+    }
+
+    static mavlink_message_t make_mission_count(unsigned count)
+    {
+        mavlink_message_t message;
+        mavlink_msg_mission_count_pack(
+            own_address.system_id,
+            own_address.component_id,
+            &message,
+            target_address.system_id,
+            target_address.component_id,
+            count,
+            MAV_MISSION_TYPE_MISSION,
+            0);
+        return message;
+    }
+
+    static bool is_correct_autopilot_mission_request_int(
+        uint8_t type, unsigned sequence, uint8_t target_component, const mavlink_message_t& message)
+    {
+        if (message.msgid != MAVLINK_MSG_ID_MISSION_REQUEST_INT) {
+            return false;
+        }
+
+        mavlink_mission_request_int_t mission_request_int;
+        mavlink_msg_mission_request_int_decode(&message, &mission_request_int);
+        return (
+            message.sysid == own_address.system_id && message.compid == own_address.component_id &&
+            mission_request_int.target_system == target_address.system_id &&
+            mission_request_int.target_component == target_component &&
+            mission_request_int.seq == sequence && mission_request_int.mission_type == type);
+    }
+
+    static bool is_correct_autopilot_mission_ack(
+        uint8_t type, uint8_t result, uint8_t target_component, const mavlink_message_t& message)
+    {
+        if (message.msgid != MAVLINK_MSG_ID_MISSION_ACK) {
+            return false;
+        }
+
+        mavlink_mission_ack_t ack;
+        mavlink_msg_mission_ack_decode(&message, &ack);
+        return (
+            message.sysid == own_address.system_id && message.compid == own_address.component_id &&
+            ack.target_system == target_address.system_id &&
+            ack.target_component == target_component && ack.type == result &&
+            ack.mission_type == type);
+    }
+
+    static bool is_the_same_mission_item_int(const ItemInt& item, const mavlink_message_t& message)
+    {
+        if (message.msgid != MAVLINK_MSG_ID_MISSION_ITEM_INT) {
+            return false;
+        }
+        mavlink_mission_item_int_t mission_item_int;
+        mavlink_msg_mission_item_int_decode(&message, &mission_item_int);
+
+        return (
+            message.sysid == own_address.system_id && //
+            message.compid == own_address.component_id && //
+            mission_item_int.target_system == target_address.system_id && //
+            mission_item_int.target_component == target_address.component_id && //
+            mission_item_int.seq == item.seq && //
+            mission_item_int.frame == item.frame && //
+            mission_item_int.command == item.command && //
+            mission_item_int.current == item.current && //
+            mission_item_int.autocontinue == item.autocontinue && //
+            mission_item_int.param1 == item.param1 && //
+            mission_item_int.param2 == item.param2 && //
+            mission_item_int.param3 == item.param3 && //
+            mission_item_int.param4 == item.param4 && //
+            mission_item_int.x == item.x && //
+            mission_item_int.y == item.y && //
+            mission_item_int.z == item.z && //
+            mission_item_int.mission_type == item.mission_type);
+    }
+
+    static mavlink_message_t
+    make_mission_item(const std::vector<ItemInt>& item_ints, std::size_t index)
+    {
+        mavlink_message_t message;
+        mavlink_msg_mission_item_int_pack(
+            own_address.system_id,
+            own_address.component_id,
+            &message,
+            target_address.system_id,
+            target_address.component_id,
+            index,
+            item_ints[index].frame,
+            item_ints[index].command,
+            item_ints[index].current,
+            item_ints[index].autocontinue,
+            item_ints[index].param1,
+            item_ints[index].param2,
+            item_ints[index].param3,
+            item_ints[index].param4,
+            item_ints[index].x,
+            item_ints[index].y,
+            item_ints[index].z,
+            item_ints[index].mission_type);
+        return message;
+    }
+
+    static bool
+    is_correct_mission_send_count(uint8_t type, unsigned count, const mavlink_message_t& message)
+    {
+        if (message.msgid != MAVLINK_MSG_ID_MISSION_COUNT) {
+            return false;
+        }
+
+        mavlink_mission_count_t mission_count;
+        mavlink_msg_mission_count_decode(&message, &mission_count);
+
+        return (
+            message.msgid == MAVLINK_MSG_ID_MISSION_COUNT &&
+            message.sysid == own_address.system_id && message.compid == own_address.component_id &&
+            mission_count.target_system == target_address.system_id &&
+            mission_count.target_component == target_address.component_id &&
+            mission_count.count == count && mission_count.mission_type == type);
+    }
+
+    static mavlink_message_t make_mission_request_int(uint8_t type, int sequence)
+    {
+        mavlink_message_t message;
+        mavlink_msg_mission_request_int_pack(
+            own_address.system_id,
+            own_address.component_id,
+            &message,
+            target_address.system_id,
+            target_address.component_id,
+            sequence,
+            type);
+        return message;
+    }
+
+    static mavlink_message_t make_mission_ack(uint8_t type, uint8_t result)
+    {
+        mavlink_message_t message;
+        mavlink_msg_mission_ack_pack(
+            own_address.system_id,
+            own_address.component_id,
+            &message,
+            target_address.system_id,
+            target_address.component_id,
+            result,
+            type,
+            0);
+        return message;
+    }
+
+    static mavlink_message_t make_mission_request(uint8_t type, int sequence)
+    {
+        mavlink_message_t message;
+        mavlink_msg_mission_request_pack(
+            target_address.system_id,
+            target_address.component_id,
+            &message,
+            own_address.system_id,
+            own_address.component_id,
+            sequence,
+            type);
+        return message;
+    }
+
+    static bool
+    is_correct_mission_ack(uint8_t type, uint8_t result, const mavlink_message_t& message)
+    {
+        if (message.msgid != MAVLINK_MSG_ID_MISSION_ACK) {
+            return false;
+        }
+
+        mavlink_mission_ack_t ack;
+        mavlink_msg_mission_ack_decode(&message, &ack);
+        return (
+            message.sysid == own_address.system_id && message.compid == own_address.component_id &&
+            ack.target_system == target_address.system_id &&
+            ack.target_component == target_address.component_id && ack.type == result &&
+            ack.mission_type == type);
+    }
+
     MockSender mock_sender;
     MavlinkMessageHandler message_handler;
     FakeTime time;
     TimeoutHandler timeout_handler;
     MavlinkMissionTransferServer mmt;
 };
-
-static ItemInt make_item(uint8_t type, uint16_t sequence)
-{
-    ItemInt item;
-
-    item.seq = sequence;
-    item.frame = MAV_FRAME_MISSION;
-    item.command = MAV_CMD_NAV_WAYPOINT;
-    item.current = uint8_t(sequence == 0 ? 1 : 0);
-    item.autocontinue = 1;
-    item.param1 = 1.0f;
-    item.param2 = 2.0f;
-    item.param3 = 3.0f;
-    item.param4 = 4.0f;
-    item.x = 5;
-    item.y = 6;
-    item.z = 7.0f;
-    item.mission_type = type;
-
-    return item;
-}
-
-static mavlink_message_t make_mission_count(unsigned count)
-{
-    mavlink_message_t message;
-    mavlink_msg_mission_count_pack(
-        own_address.system_id,
-        own_address.component_id,
-        &message,
-        target_address.system_id,
-        target_address.component_id,
-        count,
-        MAV_MISSION_TYPE_MISSION,
-        0);
-    return message;
-}
-
-bool is_correct_autopilot_mission_request_int(
-    uint8_t type, unsigned sequence, uint8_t target_component, const mavlink_message_t& message)
-{
-    if (message.msgid != MAVLINK_MSG_ID_MISSION_REQUEST_INT) {
-        return false;
-    }
-
-    mavlink_mission_request_int_t mission_request_int;
-    mavlink_msg_mission_request_int_decode(&message, &mission_request_int);
-    return (
-        message.sysid == own_address.system_id && message.compid == own_address.component_id &&
-        mission_request_int.target_system == target_address.system_id &&
-        mission_request_int.target_component == target_component &&
-        mission_request_int.seq == sequence && mission_request_int.mission_type == type);
-}
-
-bool is_correct_autopilot_mission_ack(
-    uint8_t type, uint8_t result, uint8_t target_component, const mavlink_message_t& message)
-{
-    if (message.msgid != MAVLINK_MSG_ID_MISSION_ACK) {
-        return false;
-    }
-
-    mavlink_mission_ack_t ack;
-    mavlink_msg_mission_ack_decode(&message, &ack);
-    return (
-        message.sysid == own_address.system_id && message.compid == own_address.component_id &&
-        ack.target_system == target_address.system_id && ack.target_component == target_component &&
-        ack.type == result && ack.mission_type == type);
-}
-
-bool is_the_same_mission_item_int(const ItemInt& item, const mavlink_message_t& message)
-{
-    if (message.msgid != MAVLINK_MSG_ID_MISSION_ITEM_INT) {
-        return false;
-    }
-    mavlink_mission_item_int_t mission_item_int;
-    mavlink_msg_mission_item_int_decode(&message, &mission_item_int);
-
-    return (
-        message.sysid == own_address.system_id && //
-        message.compid == own_address.component_id && //
-        mission_item_int.target_system == target_address.system_id && //
-        mission_item_int.target_component == target_address.component_id && //
-        mission_item_int.seq == item.seq && //
-        mission_item_int.frame == item.frame && //
-        mission_item_int.command == item.command && //
-        mission_item_int.current == item.current && //
-        mission_item_int.autocontinue == item.autocontinue && //
-        mission_item_int.param1 == item.param1 && //
-        mission_item_int.param2 == item.param2 && //
-        mission_item_int.param3 == item.param3 && //
-        mission_item_int.param4 == item.param4 && //
-        mission_item_int.x == item.x && //
-        mission_item_int.y == item.y && //
-        mission_item_int.z == item.z && //
-        mission_item_int.mission_type == item.mission_type);
-}
 
 TEST_F(MavlinkMissionTransferServerTest, ReceiveIncomingMissionSendsMissionRequests)
 {
@@ -231,31 +335,6 @@ TEST_F(
 
     mmt.do_work();
     EXPECT_TRUE(mmt.is_idle());
-}
-
-mavlink_message_t make_mission_item(const std::vector<ItemInt>& item_ints, std::size_t index)
-{
-    mavlink_message_t message;
-    mavlink_msg_mission_item_int_pack(
-        own_address.system_id,
-        own_address.component_id,
-        &message,
-        target_address.system_id,
-        target_address.component_id,
-        index,
-        item_ints[index].frame,
-        item_ints[index].command,
-        item_ints[index].current,
-        item_ints[index].autocontinue,
-        item_ints[index].param1,
-        item_ints[index].param2,
-        item_ints[index].param3,
-        item_ints[index].param4,
-        item_ints[index].x,
-        item_ints[index].y,
-        item_ints[index].z,
-        item_ints[index].mission_type);
-    return message;
 }
 
 TEST_F(MavlinkMissionTransferServerTest, ReceiveIncomingMissionResendsRequestItemAgainForSecondItem)
@@ -409,6 +488,733 @@ TEST_F(MavlinkMissionTransferServerTest, ReceiveIncomingMissionCanBeCancelled)
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
+}
+
+TEST_F(MavlinkMissionTransferServerTest, SendOutgoingMissionEmptyMission)
+{
+    std::vector<ItemInt> items;
+
+    std::promise<void> prom;
+    auto fut = prom.get_future();
+
+    ON_CALL(mock_sender, queue_message(_)).WillByDefault(Return(true));
+
+    mmt.send_outgoing_items_async(
+        MAV_MISSION_TYPE_MISSION,
+        items,
+        target_address.system_id,
+        target_address.component_id,
+        [&prom](Result result) {
+            EXPECT_EQ(result, Result::Success);
+            ONCE_ONLY;
+            prom.set_value();
+        });
+    mmt.do_work();
+
+    // empty mission should just send a zero count and be done
+    message_handler.process_message(
+        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+
+    EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
+}
+
+TEST_F(MavlinkMissionTransferServerTest, SendOutgoingMissionDoesNotCrashIfCallbackIsNull)
+{
+    ON_CALL(mock_sender, queue_message(_)).WillByDefault(Return(false));
+
+    // Catch the empty case
+    std::vector<ItemInt> items;
+    mmt.send_outgoing_items_async(
+        MAV_MISSION_TYPE_MISSION,
+        items,
+        target_address.system_id,
+        target_address.component_id,
+        nullptr);
+    mmt.do_work();
+
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
+
+    mmt.send_outgoing_items_async(
+        MAV_MISSION_TYPE_MISSION,
+        items,
+        target_address.system_id,
+        target_address.component_id,
+        nullptr);
+    mmt.do_work();
+
+    // Catch the WrongSequence case as well.
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 3));
+    mmt.send_outgoing_items_async(
+        MAV_MISSION_TYPE_MISSION,
+        items,
+        target_address.system_id,
+        target_address.component_id,
+        nullptr);
+    mmt.do_work();
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
+}
+
+TEST_F(
+    MavlinkMissionTransferServerTest, SendOutgoingMissionReturnsConnectionErrorWhenSendMessageFails)
+{
+    ON_CALL(mock_sender, queue_message(_)).WillByDefault(Return(false));
+
+    std::vector<ItemInt> items;
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
+
+    std::promise<void> prom;
+    auto fut = prom.get_future();
+
+    mmt.send_outgoing_items_async(
+        MAV_MISSION_TYPE_MISSION,
+        items,
+        target_address.system_id,
+        target_address.component_id,
+        [&prom](Result result) {
+            EXPECT_EQ(result, Result::ConnectionError);
+            ONCE_ONLY;
+            prom.set_value();
+        });
+    mmt.do_work();
+
+    EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    // We want to be sure a timeout is not still triggered later.
+    time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
+    timeout_handler.run_once();
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
+}
+
+TEST_F(MavlinkMissionTransferServerTest, SendOutgoingMissionSendsCount)
+{
+    std::vector<ItemInt> items;
+    items.push_back(make_item(MAV_MISSION_TYPE_FENCE, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_FENCE, 1));
+
+    ON_CALL(mock_sender, queue_message(_)).WillByDefault(Return(true));
+
+    EXPECT_CALL(
+        mock_sender,
+        queue_message(Truly([&items](std::function<mavlink_message_t(
+                                         MavlinkAddress mavlink_address, uint8_t channel)> fun) {
+            return is_correct_mission_send_count(
+                MAV_MISSION_TYPE_FENCE, items.size(), fun(own_address, channel));
+        })));
+
+    mmt.send_outgoing_items_async(
+        MAV_MISSION_TYPE_FENCE,
+        items,
+        target_address.system_id,
+        target_address.component_id,
+        [](Result result) {
+            UNUSED(result);
+            EXPECT_TRUE(false);
+        });
+    mmt.do_work();
+}
+
+TEST_F(MavlinkMissionTransferServerTest, SendOutgoingMissionResendsCount)
+{
+    std::vector<ItemInt> items;
+    items.push_back(make_item(MAV_MISSION_TYPE_FENCE, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_FENCE, 1));
+
+    ON_CALL(mock_sender, queue_message(_)).WillByDefault(Return(true));
+
+    EXPECT_CALL(
+        mock_sender,
+        queue_message(Truly([&items](std::function<mavlink_message_t(
+                                         MavlinkAddress mavlink_address, uint8_t channel)> fun) {
+            return is_correct_mission_send_count(
+                MAV_MISSION_TYPE_FENCE, items.size(), fun(own_address, channel));
+        })))
+        .Times(2);
+
+    mmt.send_outgoing_items_async(
+        MAV_MISSION_TYPE_FENCE,
+        items,
+        target_address.system_id,
+        target_address.component_id,
+        [](Result result) {
+            UNUSED(result);
+            EXPECT_TRUE(false);
+        });
+    mmt.do_work();
+
+    time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
+    timeout_handler.run_once();
+}
+
+TEST_F(MavlinkMissionTransferServerTest, SendOutgoingMissionTimeoutAfterSendCount)
+{
+    std::vector<ItemInt> items;
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
+
+    ON_CALL(mock_sender, queue_message(_)).WillByDefault(Return(true));
+
+    EXPECT_CALL(
+        mock_sender,
+        queue_message(Truly([&items](std::function<mavlink_message_t(
+                                         MavlinkAddress mavlink_address, uint8_t channel)> fun) {
+            return is_correct_mission_send_count(
+                MAV_MISSION_TYPE_MISSION, items.size(), fun(own_address, channel));
+        })))
+        .Times(MavlinkMissionTransferServer::retries);
+
+    std::promise<void> prom;
+    auto fut = prom.get_future();
+
+    mmt.send_outgoing_items_async(
+        MAV_MISSION_TYPE_MISSION,
+        items,
+        target_address.system_id,
+        target_address.component_id,
+        [&prom](Result result) {
+            EXPECT_EQ(result, Result::Timeout);
+            ONCE_ONLY;
+            prom.set_value();
+        });
+    mmt.do_work();
+
+    EXPECT_EQ(fut.wait_for(std::chrono::seconds(0)), std::future_status::timeout);
+
+    // After the specified retries we should give up with a timeout.
+    for (unsigned i = 0; i < MavlinkMissionTransferServer::retries; ++i) {
+        time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
+        timeout_handler.run_once();
+    }
+
+    EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+}
+
+TEST_F(MavlinkMissionTransferServerTest, SendOutgoingMissionSendsMissionItems)
+{
+    std::vector<ItemInt> items;
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
+
+    ON_CALL(mock_sender, queue_message(_)).WillByDefault(Return(true));
+
+    std::promise<void> prom;
+    auto fut = prom.get_future();
+
+    mmt.send_outgoing_items_async(
+        MAV_MISSION_TYPE_MISSION,
+        items,
+        target_address.system_id,
+        target_address.component_id,
+        [&prom](Result result) {
+            EXPECT_EQ(result, Result::Success);
+            ONCE_ONLY;
+            prom.set_value();
+        });
+    mmt.do_work();
+
+    EXPECT_CALL(
+        mock_sender,
+        queue_message(Truly([&items](std::function<mavlink_message_t(
+                                         MavlinkAddress mavlink_address, uint8_t channel)> fun) {
+            return is_the_same_mission_item_int(items[0], fun(own_address, channel));
+        })));
+
+    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+
+    EXPECT_CALL(
+        mock_sender,
+        queue_message(Truly([&items](std::function<mavlink_message_t(
+                                         MavlinkAddress mavlink_address, uint8_t channel)> fun) {
+            return is_the_same_mission_item_int(items[1], fun(own_address, channel));
+        })));
+
+    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 1));
+
+    message_handler.process_message(
+        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+
+    // We are finished and should have received the successful result.
+    EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    // We do not expect a timeout later though.
+    time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
+    timeout_handler.run_once();
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
+}
+
+TEST_F(MavlinkMissionTransferServerTest, SendOutgoingMissionResendsMissionItems)
+{
+    std::vector<ItemInt> items;
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
+
+    ON_CALL(mock_sender, queue_message(_)).WillByDefault(Return(true));
+
+    std::promise<void> prom;
+    auto fut = prom.get_future();
+
+    mmt.send_outgoing_items_async(
+        MAV_MISSION_TYPE_MISSION,
+        items,
+        target_address.system_id,
+        target_address.component_id,
+        [&prom](Result result) {
+            EXPECT_EQ(result, Result::Success);
+            ONCE_ONLY;
+            prom.set_value();
+        });
+    mmt.do_work();
+
+    EXPECT_CALL(
+        mock_sender,
+        queue_message(Truly([&items](std::function<mavlink_message_t(
+                                         MavlinkAddress mavlink_address, uint8_t channel)> fun) {
+            return is_the_same_mission_item_int(items[0], fun(own_address, channel));
+        })));
+
+    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+
+    EXPECT_CALL(
+        mock_sender,
+        queue_message(Truly([&items](std::function<mavlink_message_t(
+                                         MavlinkAddress mavlink_address, uint8_t channel)> fun) {
+            return is_the_same_mission_item_int(items[0], fun(own_address, channel));
+        })));
+
+    // Request 0 again in case it had not arrived.
+    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+
+    EXPECT_CALL(
+        mock_sender,
+        queue_message(Truly([&items](std::function<mavlink_message_t(
+                                         MavlinkAddress mavlink_address, uint8_t channel)> fun) {
+            return is_the_same_mission_item_int(items[1], fun(own_address, channel));
+        })));
+
+    // Request 1 finally.
+    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 1));
+
+    message_handler.process_message(
+        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+
+    // We are finished and should have received the successful result.
+    EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
+}
+
+TEST_F(
+    MavlinkMissionTransferServerTest,
+    SendOutgoingMissionResendsMissionItemsButGivesUpAfterSomeRetries)
+{
+    std::vector<ItemInt> items;
+    items.push_back(make_item(MAV_MISSION_TYPE_FENCE, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_FENCE, 1));
+
+    ON_CALL(mock_sender, queue_message(_)).WillByDefault(Return(true));
+
+    std::promise<void> prom;
+    auto fut = prom.get_future();
+
+    mmt.send_outgoing_items_async(
+        MAV_MISSION_TYPE_FENCE,
+        items,
+        target_address.system_id,
+        target_address.component_id,
+        [&prom](Result result) {
+            EXPECT_EQ(result, Result::Timeout);
+            ONCE_ONLY;
+            prom.set_value();
+        });
+    mmt.do_work();
+
+    EXPECT_CALL(
+        mock_sender,
+        queue_message(Truly([&items](std::function<mavlink_message_t(
+                                         MavlinkAddress mavlink_address, uint8_t channel)> fun) {
+            return is_the_same_mission_item_int(items[0], fun(own_address, channel));
+        })))
+        .Times(MavlinkMissionTransferServer::retries);
+
+    for (unsigned i = 0; i < MavlinkMissionTransferServer::retries; ++i) {
+        message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    }
+
+    EXPECT_EQ(fut.wait_for(std::chrono::seconds(0)), std::future_status::timeout);
+
+    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+
+    // We are finished and should have received the successful result.
+    EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
+}
+
+TEST_F(MavlinkMissionTransferServerTest, SendOutgoingMissionAckArrivesTooEarly)
+{
+    std::vector<ItemInt> items;
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
+
+    ON_CALL(mock_sender, queue_message(_)).WillByDefault(Return(true));
+
+    std::promise<void> prom;
+    auto fut = prom.get_future();
+
+    mmt.send_outgoing_items_async(
+        MAV_MISSION_TYPE_MISSION,
+        items,
+        target_address.system_id,
+        target_address.component_id,
+        [&prom](Result result) {
+            EXPECT_EQ(result, Result::ProtocolError);
+            ONCE_ONLY;
+            prom.set_value();
+        });
+    mmt.do_work();
+
+    EXPECT_CALL(
+        mock_sender,
+        queue_message(Truly([&items](std::function<mavlink_message_t(
+                                         MavlinkAddress mavlink_address, uint8_t channel)> fun) {
+            return is_the_same_mission_item_int(items[0], fun(own_address, channel));
+        })));
+
+    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+
+    // Don't request item 1 but already send ack.
+    message_handler.process_message(
+        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+
+    EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
+}
+
+class MavlinkMissionTransferServerNackTests
+    : public MavlinkMissionTransferServerTest,
+      public ::testing::WithParamInterface<std::pair<uint8_t, Result>> {};
+
+TEST_P(MavlinkMissionTransferServerNackTests, SendOutgoingMissionNackAreHandled)
+{
+    uint8_t mavlink_nack = std::get<0>(GetParam());
+    Result mavsdk_nack = std::get<1>(GetParam());
+
+    std::vector<ItemInt> items;
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
+
+    ON_CALL(mock_sender, queue_message(_)).WillByDefault(Return(true));
+
+    std::promise<void> prom;
+    auto fut = prom.get_future();
+
+    mmt.send_outgoing_items_async(
+        MAV_MISSION_TYPE_MISSION,
+        items,
+        target_address.system_id,
+        target_address.component_id,
+        [&prom, &mavsdk_nack](Result result) {
+            EXPECT_EQ(result, mavsdk_nack);
+            prom.set_value();
+        });
+    mmt.do_work();
+
+    EXPECT_CALL(
+        mock_sender,
+        queue_message(Truly([&items](std::function<mavlink_message_t(
+                                         MavlinkAddress mavlink_address, uint8_t channel)> fun) {
+            return is_the_same_mission_item_int(items[0], fun(own_address, channel));
+        })));
+
+    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+
+    // Send nack now.
+    message_handler.process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, mavlink_nack));
+
+    EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MavlinkMissionTransferServerTests,
+    MavlinkMissionTransferServerNackTests,
+    ::testing::Values(
+        std::make_pair(MAV_MISSION_ERROR, Result::ProtocolError),
+        std::make_pair(MAV_MISSION_UNSUPPORTED_FRAME, Result::UnsupportedFrame),
+        std::make_pair(MAV_MISSION_UNSUPPORTED, Result::Unsupported),
+        std::make_pair(MAV_MISSION_NO_SPACE, Result::TooManyMissionItems),
+        std::make_pair(MAV_MISSION_INVALID, Result::InvalidParam),
+        std::make_pair(MAV_MISSION_INVALID_PARAM1, Result::InvalidParam),
+        std::make_pair(MAV_MISSION_INVALID_PARAM2, Result::InvalidParam),
+        std::make_pair(MAV_MISSION_INVALID_PARAM3, Result::InvalidParam),
+        std::make_pair(MAV_MISSION_INVALID_PARAM4, Result::InvalidParam),
+        std::make_pair(MAV_MISSION_INVALID_PARAM5_X, Result::InvalidParam),
+        std::make_pair(MAV_MISSION_INVALID_PARAM6_Y, Result::InvalidParam),
+        std::make_pair(MAV_MISSION_INVALID_PARAM7, Result::InvalidParam),
+        std::make_pair(MAV_MISSION_INVALID_SEQUENCE, Result::InvalidSequence),
+        std::make_pair(MAV_MISSION_DENIED, Result::Denied),
+        std::make_pair(MAV_MISSION_OPERATION_CANCELLED, Result::Cancelled)));
+
+TEST_F(MavlinkMissionTransferServerTest, SendOutgoingMissionTimeoutNotTriggeredDuringTransfer)
+{
+    std::vector<ItemInt> items;
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 2));
+
+    ON_CALL(mock_sender, queue_message(_)).WillByDefault(Return(true));
+
+    std::promise<void> prom;
+    auto fut = prom.get_future();
+
+    mmt.send_outgoing_items_async(
+        MAV_MISSION_TYPE_MISSION,
+        items,
+        target_address.system_id,
+        target_address.component_id,
+        [&prom](Result result) {
+            EXPECT_EQ(result, Result::Success);
+            ONCE_ONLY;
+            prom.set_value();
+        });
+    mmt.do_work();
+
+    EXPECT_CALL(
+        mock_sender,
+        queue_message(Truly([&items](std::function<mavlink_message_t(
+                                         MavlinkAddress mavlink_address, uint8_t channel)> fun) {
+            return is_the_same_mission_item_int(items[0], fun(own_address, channel));
+        })));
+
+    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+
+    // We almost use up the max timeout in each cycle.
+    time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 0.8 * 1000.)));
+    timeout_handler.run_once();
+
+    EXPECT_CALL(
+        mock_sender,
+        queue_message(Truly([&items](std::function<mavlink_message_t(
+                                         MavlinkAddress mavlink_address, uint8_t channel)> fun) {
+            return is_the_same_mission_item_int(items[1], fun(own_address, channel));
+        })));
+
+    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 1));
+
+    time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 0.8 * 1000.)));
+    timeout_handler.run_once();
+
+    EXPECT_CALL(
+        mock_sender,
+        queue_message(Truly([&items](std::function<mavlink_message_t(
+                                         MavlinkAddress mavlink_address, uint8_t channel)> fun) {
+            return is_the_same_mission_item_int(items[2], fun(own_address, channel));
+        })));
+
+    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 2));
+
+    time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 0.8 * 1000.)));
+    timeout_handler.run_once();
+
+    message_handler.process_message(
+        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+
+    // We are finished and should have received the successful result.
+    EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
+}
+
+TEST_F(MavlinkMissionTransferServerTest, SendOutgoingMissionTimeoutAfterSendMissionItem)
+{
+    std::vector<ItemInt> items;
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
+
+    ON_CALL(mock_sender, queue_message(_)).WillByDefault(Return(true));
+
+    std::promise<void> prom;
+    auto fut = prom.get_future();
+
+    mmt.send_outgoing_items_async(
+        MAV_MISSION_TYPE_MISSION,
+        items,
+        target_address.system_id,
+        target_address.component_id,
+        [&prom](Result result) {
+            EXPECT_EQ(result, Result::Timeout);
+            ONCE_ONLY;
+            prom.set_value();
+        });
+    mmt.do_work();
+
+    EXPECT_CALL(
+        mock_sender,
+        queue_message(Truly([&items](std::function<mavlink_message_t(
+                                         MavlinkAddress mavlink_address, uint8_t channel)> fun) {
+            return is_the_same_mission_item_int(items[0], fun(own_address, channel));
+        })));
+
+    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+
+    // Make sure single timeout does not trigger it yet.
+    time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1000. + 250)));
+    timeout_handler.run_once();
+
+    EXPECT_EQ(fut.wait_for(std::chrono::milliseconds(50)), std::future_status::timeout);
+
+    // But multiple do.
+    for (unsigned i = 0; i < (MavlinkMissionTransferServer::retries - 1); ++i) {
+        time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1000.)));
+        timeout_handler.run_once();
+    }
+
+    EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    // Ignore later (wrong) ack.
+    message_handler.process_message(
+        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
+}
+
+TEST_F(MavlinkMissionTransferServerTest, SendOutgoingMissionDoesNotCrashOnRandomMessages)
+{
+    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+
+    message_handler.process_message(
+        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+
+    time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
+    timeout_handler.run_once();
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
+}
+
+TEST_F(MavlinkMissionTransferServerTest, SendOutgoingMissionCanBeCancelled)
+{
+    std::vector<ItemInt> items;
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
+    items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
+
+    ON_CALL(mock_sender, queue_message(_)).WillByDefault(Return(true));
+
+    std::promise<void> prom;
+    auto fut = prom.get_future();
+
+    auto transfer = mmt.send_outgoing_items_async(
+        MAV_MISSION_TYPE_MISSION,
+        items,
+        target_address.system_id,
+        target_address.component_id,
+        [&prom](Result result) {
+            EXPECT_EQ(result, Result::Cancelled);
+            ONCE_ONLY;
+            prom.set_value();
+        });
+    mmt.do_work();
+
+    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+
+    EXPECT_CALL(
+        mock_sender,
+        queue_message(Truly([](std::function<mavlink_message_t(
+                                   MavlinkAddress mavlink_address, uint8_t channel)> fun) {
+            return is_correct_mission_ack(
+                MAV_MISSION_TYPE_MISSION,
+                MAV_MISSION_OPERATION_CANCELLED,
+                fun(own_address, channel));
+        })));
+
+    auto ptr = transfer.lock();
+    EXPECT_TRUE(ptr);
+    if (ptr) {
+        ptr->cancel();
+    }
+
+    // We are finished and should have received the successful result.
+    EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    // We do not expect a timeout later though.
+    time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
+    timeout_handler.run_once();
+
+    mmt.do_work();
+    EXPECT_TRUE(mmt.is_idle());
+}
+
+TEST_F(MavlinkMissionTransferServerTest, SendOutgoingMissionNacksNonIntCase)
+{
+    std::vector<ItemInt> items;
+    items.push_back(make_item(MAV_MISSION_TYPE_FENCE, 0));
+
+    ON_CALL(mock_sender, queue_message(_)).WillByDefault(Return(true));
+
+    std::promise<void> prom;
+    auto fut = prom.get_future();
+
+    mmt.send_outgoing_items_async(
+        MAV_MISSION_TYPE_FENCE,
+        items,
+        target_address.system_id,
+        target_address.component_id,
+        [&prom](Result result) {
+            EXPECT_EQ(result, Result::Success);
+            ONCE_ONLY;
+            prom.set_value();
+        });
+    mmt.do_work();
+
+    EXPECT_CALL(
+        mock_sender,
+        queue_message(Truly([](std::function<mavlink_message_t(
+                                   MavlinkAddress mavlink_address, uint8_t channel)> fun) {
+            return is_correct_mission_ack(
+                MAV_MISSION_TYPE_FENCE, MAV_MISSION_UNSUPPORTED, fun(own_address, channel));
+        })))
+        .Times(1);
+
+    // First the non-int wrong case comes in.
+    message_handler.process_message(make_mission_request(MAV_MISSION_TYPE_FENCE, 0));
+
+    EXPECT_CALL(
+        mock_sender,
+        queue_message(Truly([&items](std::function<mavlink_message_t(
+                                         MavlinkAddress mavlink_address, uint8_t channel)> fun) {
+            return is_the_same_mission_item_int(items[0], fun(own_address, channel));
+        })));
+
+    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_FENCE, 0));
+    message_handler.process_message(make_mission_ack(MAV_MISSION_TYPE_FENCE, MAV_MISSION_ACCEPTED));
+
+    // We are finished and should have received the successful result.
+    EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    // We do not expect a timeout later though.
+    time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
+    timeout_handler.run_once();
 
     mmt.do_work();
     EXPECT_TRUE(mmt.is_idle());

--- a/src/mavsdk/plugins/mission_raw_server/include/plugins/mission_raw_server/mission_raw_server.h
+++ b/src/mavsdk/plugins/mission_raw_server/include/plugins/mission_raw_server/mission_raw_server.h
@@ -186,13 +186,6 @@ public:
     void unsubscribe_incoming_mission(IncomingMissionHandle handle);
 
     /**
-     * @brief Poll for 'MissionPlan' (blocking).
-     *
-     * @return One MissionPlan update.
-     */
-    MissionPlan incoming_mission() const;
-
-    /**
      * @brief Callback type for subscribe_current_item_changed.
      */
     using CurrentItemChangedCallback = std::function<void(MissionItem)>;
@@ -212,13 +205,6 @@ public:
      * @brief Unsubscribe from subscribe_current_item_changed
      */
     void unsubscribe_current_item_changed(CurrentItemChangedHandle handle);
-
-    /**
-     * @brief Poll for 'MissionItem' (blocking).
-     *
-     * @return One MissionItem update.
-     */
-    MissionItem current_item_changed() const;
 
     /**
      * @brief Set Current item as completed
@@ -248,13 +234,6 @@ public:
      * @brief Unsubscribe from subscribe_clear_all
      */
     void unsubscribe_clear_all(ClearAllHandle handle);
-
-    /**
-     * @brief Poll for 'uint32_t' (blocking).
-     *
-     * @return One uint32_t update.
-     */
-    uint32_t clear_all() const;
 
     /**
      * @brief Copy constructor.

--- a/src/mavsdk/plugins/mission_raw_server/mission_raw_server.cpp
+++ b/src/mavsdk/plugins/mission_raw_server/mission_raw_server.cpp
@@ -32,11 +32,6 @@ void MissionRawServer::unsubscribe_incoming_mission(IncomingMissionHandle handle
     _impl->unsubscribe_incoming_mission(handle);
 }
 
-MissionRawServer::MissionPlan MissionRawServer::incoming_mission() const
-{
-    return _impl->incoming_mission();
-}
-
 MissionRawServer::CurrentItemChangedHandle
 MissionRawServer::subscribe_current_item_changed(const CurrentItemChangedCallback& callback)
 {
@@ -46,11 +41,6 @@ MissionRawServer::subscribe_current_item_changed(const CurrentItemChangedCallbac
 void MissionRawServer::unsubscribe_current_item_changed(CurrentItemChangedHandle handle)
 {
     _impl->unsubscribe_current_item_changed(handle);
-}
-
-MissionRawServer::MissionItem MissionRawServer::current_item_changed() const
-{
-    return _impl->current_item_changed();
 }
 
 void MissionRawServer::set_current_item_complete() const
@@ -67,11 +57,6 @@ MissionRawServer::subscribe_clear_all(const ClearAllCallback& callback)
 void MissionRawServer::unsubscribe_clear_all(ClearAllHandle handle)
 {
     _impl->unsubscribe_clear_all(handle);
-}
-
-uint32_t MissionRawServer::clear_all() const
-{
-    return _impl->clear_all();
 }
 
 bool operator==(const MissionRawServer::MissionItem& lhs, const MissionRawServer::MissionItem& rhs)

--- a/src/mavsdk/plugins/mission_raw_server/mission_raw_server_impl.h
+++ b/src/mavsdk/plugins/mission_raw_server/mission_raw_server_impl.h
@@ -32,17 +32,16 @@ public:
 
     void set_current_item_complete();
 
-    MissionRawServer::MissionPlan incoming_mission() const;
-    MissionRawServer::MissionItem current_item_changed() const;
-    uint32_t clear_all() const;
-
 private:
     void process_mission_count(const mavlink_message_t& message);
+    void process_mission_request_list(const mavlink_message_t& message);
     void process_mission_set_current(const mavlink_message_t& message);
     void process_mission_clear(const mavlink_message_t message);
 
     CallbackList<MissionRawServer::Result, MissionRawServer::MissionPlan>
         _incoming_mission_callbacks{};
+    CallbackList<MissionRawServer::Result, MissionRawServer::MissionPlan>
+        _outgoing_mission_callbacks{};
     CallbackList<MissionRawServer::MissionItem> _current_item_changed_callbacks{};
     CallbackList<uint32_t> _clear_all_callbacks{};
     std::atomic<int> _target_system_id;
@@ -54,6 +53,7 @@ private:
     std::size_t _current_seq;
 
     std::weak_ptr<MavlinkMissionTransferServer::WorkItem> _last_download{};
+    std::weak_ptr<MavlinkMissionTransferServer::WorkItem> _last_upload{};
 
     void set_current_seq(std::size_t seq);
 };

--- a/src/mavsdk_server/src/generated/mission_raw_server/mission_raw_server.pb.cc
+++ b/src/mavsdk_server/src/generated/mission_raw_server/mission_raw_server.pb.cc
@@ -506,25 +506,25 @@ const char descriptor_table_protodef_mission_5fraw_5fserver_2fmission_5fraw_5fse
     "ULT_UNSUPPORTED\020\007\022\037\n\033RESULT_NO_MISSION_A"
     "VAILABLE\020\010\022\"\n\036RESULT_UNSUPPORTED_MISSION"
     "_CMD\020\013\022\035\n\031RESULT_TRANSFER_CANCELLED\020\014\022\024\n"
-    "\020RESULT_NO_SYSTEM\020\r\022\017\n\013RESULT_NEXT\020\0162\366\004\n"
-    "\027MissionRawServerService\022\226\001\n\030SubscribeIn"
+    "\020RESULT_NO_SYSTEM\020\r\022\017\n\013RESULT_NEXT\020\0162\202\005\n"
+    "\027MissionRawServerService\022\232\001\n\030SubscribeIn"
     "comingMission\022>.mavsdk.rpc.mission_raw_s"
     "erver.SubscribeIncomingMissionRequest\0326."
     "mavsdk.rpc.mission_raw_server.IncomingMi"
-    "ssionResponse\"\0000\001\022\237\001\n\033SubscribeCurrentIt"
-    "emChanged\022A.mavsdk.rpc.mission_raw_serve"
-    "r.SubscribeCurrentItemChangedRequest\0329.m"
-    "avsdk.rpc.mission_raw_server.CurrentItem"
-    "ChangedResponse\"\0000\001\022\233\001\n\026SetCurrentItemCo"
-    "mplete\022<.mavsdk.rpc.mission_raw_server.S"
-    "etCurrentItemCompleteRequest\032=.mavsdk.rp"
-    "c.mission_raw_server.SetCurrentItemCompl"
-    "eteResponse\"\004\200\265\030\001\022\201\001\n\021SubscribeClearAll\022"
-    "7.mavsdk.rpc.mission_raw_server.Subscrib"
-    "eClearAllRequest\032/.mavsdk.rpc.mission_ra"
-    "w_server.ClearAllResponse\"\0000\001B5\n\034io.mavs"
-    "dk.mission_raw_serverB\025MissionRawServerP"
-    "rotob\006proto3"
+    "ssionResponse\"\004\200\265\030\0000\001\022\243\001\n\033SubscribeCurre"
+    "ntItemChanged\022A.mavsdk.rpc.mission_raw_s"
+    "erver.SubscribeCurrentItemChangedRequest"
+    "\0329.mavsdk.rpc.mission_raw_server.Current"
+    "ItemChangedResponse\"\004\200\265\030\0000\001\022\233\001\n\026SetCurre"
+    "ntItemComplete\022<.mavsdk.rpc.mission_raw_"
+    "server.SetCurrentItemCompleteRequest\032=.m"
+    "avsdk.rpc.mission_raw_server.SetCurrentI"
+    "temCompleteResponse\"\004\200\265\030\001\022\205\001\n\021SubscribeC"
+    "learAll\0227.mavsdk.rpc.mission_raw_server."
+    "SubscribeClearAllRequest\032/.mavsdk.rpc.mi"
+    "ssion_raw_server.ClearAllResponse\"\004\200\265\030\0000"
+    "\001B5\n\034io.mavsdk.mission_raw_serverB\025Missi"
+    "onRawServerProtob\006proto3"
 };
 static const ::_pbi::DescriptorTable* const descriptor_table_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto_deps[1] =
     {
@@ -534,7 +534,7 @@ static ::absl::once_flag descriptor_table_mission_5fraw_5fserver_2fmission_5fraw
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto = {
     false,
     false,
-    2092,
+    2104,
     descriptor_table_protodef_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto,
     "mission_raw_server/mission_raw_server.proto",
     &descriptor_table_mission_5fraw_5fserver_2fmission_5fraw_5fserver_2eproto_once,


### PR DESCRIPTION
# Mission Download Support

## Overview
MAVSDK has two classes for managing mission transfers:
  * `MavlinkMissionTransferClient` used for initiating mission transfers (used primarily on the ground side)
  * `MavlinkMissionTransferServer` used for handling mission transfer requests (used primarily on the air vehicle)

`MavlinkMissionTransferClient` has support both for sending missions as well as requesting missions from a server and handling the response. `MavlinkMissionTransferServer` currently only handles receiving missions, but does not respond to mission download requests (air to ground). The `MissionRawServer` service uses `MavlinkMissionTransferServer` to handle mission transfer requests, and thus `MissionRawServer` is currently "unidirectional".

This pull request implements the required functionality in `MavlinkMissionTransferServer` to handle mission download requests (air to ground), and adds the necessary hooks in `MissionRawServer`.

## Guides For Review
Files changed will be commented with relevant guides. At a high level the changes are as follows:
  * `src/mavsdk/core/mavlink_mission_transfer_server.h/.cpp`: added `SendOutgoingMission` work item class and `send_outgoing_items_async()` method for handling outgoing transfers. Added associated unit tests
  * `src/mavsdk/plugins/mission_raw_server/include/plugins/mission_raw_server/mission_raw_server.h`: added API for mission download result callback
  * `src/mavsdk/plugins/mission_raw_server/mission_raw_server_impl.h/.cpp`: Added listener for MAVLINK MISSION_REQUEST_LIST and machinery to queue an outgoing mission transfer in `MavlinkMissionTransferServer`.

## Proof of function
Before this change, running QGroundControl against the MAVSDK MissionRawServer would result in the following error on launch:
![Screenshot from 2024-12-06 16-03-43](https://github.com/user-attachments/assets/d1b87cd4-4047-4303-8ae5-a71b021a7514)

The QGC log shows the same failed queries
```
PlanManagerLog: "Retrying T:Mission REQUEST_LIST retry Count" 1
PlanManagerLog: "_requestList T:Mission _planType:_retryCount" 0 1
...
PlanManagerLog: "Retrying T:Mission REQUEST_LIST retry Count" 2
PlanManagerLog: "_requestList T:Mission _planType:_retryCount" 0 2
...
PlanManagerLog: "Retrying T:Mission REQUEST_LIST retry Count" 6
PlanManagerLog: "_requestList T:Mission _planType:_retryCount" 0 6
...
```

Here's a video showing a vehicle loaded with a valid mission, followed by closing QGC and re-launching:

https://github.com/user-attachments/assets/12801032-fc80-45ae-b367-f8d37ed54015

And here's doing the same thing after applying this change. Note that you can close QGC and re-launch, and the same mission re-populates in the UI without error

https://github.com/user-attachments/assets/5a667534-8dbc-4775-a807-9c17b1b87ded

## Opportunities For Improvement
`MavlinkMissionTransferClient` and `MavlinkMissionTransferServer` currently have a great deal of duplicated code. This was true before this change, but I haven't done anything to address opportunistic refactoring. In this future this could probably be collapsed into a single multipurpose mission transfer class.

