### PR TITLE
get_all_params fixes

### DIFF
--- a/src/mavsdk/core/mavlink_parameter_cache.cpp
+++ b/src/mavsdk/core/mavlink_parameter_cache.cpp
@@ -138,6 +138,19 @@ bool MavlinkParameterCache::exists(uint16_t param_index) const
     return it != _all_params.end();
 }
 
+uint16_t MavlinkParameterCache::missing_count(uint16_t count) const
+{
+    uint16_t missing = 0;
+
+    for (uint16_t i = 0; i < count; ++i) {
+        if (!exists(i)) {
+            ++missing;
+        }
+    }
+
+    return missing;
+}
+
 std::optional<uint16_t> MavlinkParameterCache::next_missing_index(uint16_t count)
 {
     // Extended doesn't matter here because we use this function in the sender

--- a/src/mavsdk/core/mavlink_parameter_cache.h
+++ b/src/mavsdk/core/mavlink_parameter_cache.h
@@ -2,6 +2,7 @@
 
 #include "param_value.h"
 
+#include <cstdint>
 #include <limits>
 #include <map>
 #include <string>
@@ -45,6 +46,8 @@ public:
     [[nodiscard]] uint16_t count(bool including_extended) const;
 
     [[nodiscard]] std::optional<uint16_t> next_missing_index(uint16_t count);
+
+    [[nodiscard]] uint16_t missing_count(uint16_t count) const;
 
     void print_missing(uint16_t count);
 

--- a/src/mavsdk/core/mavlink_parameter_cache.h
+++ b/src/mavsdk/core/mavlink_parameter_cache.h
@@ -46,10 +46,13 @@ public:
 
     [[nodiscard]] std::optional<uint16_t> next_missing_index(uint16_t count);
 
+    void print_missing(uint16_t count);
+
     void clear();
 
 private:
     [[nodiscard]] bool exists(const std::string& param_id) const;
+    [[nodiscard]] bool exists(uint16_t param_index) const;
 
     std::vector<Param> _all_params;
 };

--- a/src/mavsdk/core/mavlink_parameter_cache.h
+++ b/src/mavsdk/core/mavlink_parameter_cache.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <limits>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -45,9 +46,14 @@ public:
 
     [[nodiscard]] uint16_t count(bool including_extended) const;
 
-    [[nodiscard]] std::optional<uint16_t> next_missing_index(uint16_t count);
+    [[nodiscard]] std::vector<uint16_t> next_missing_indices(uint16_t count, uint16_t chunk_size);
 
     [[nodiscard]] uint16_t missing_count(uint16_t count) const;
+
+    [[nodiscard]] std::optional<uint16_t> last_missing_requested() const
+    {
+        return _last_missing_requested;
+    }
 
     void print_missing(uint16_t count);
 
@@ -58,6 +64,8 @@ private:
     [[nodiscard]] bool exists(uint16_t param_index) const;
 
     std::vector<Param> _all_params;
+
+    std::optional<uint16_t> _last_missing_requested{};
 };
 
 } // namespace mavsdk

--- a/src/mavsdk/core/mavlink_parameter_client.cpp
+++ b/src/mavsdk/core/mavlink_parameter_client.cpp
@@ -826,6 +826,8 @@ void MavlinkParameterClient::process_param_value(const mavlink_message_t& messag
                                         assert(false);
                                     }
 
+                                    LogInfo() << "Requesting " << _param_cache.missing_count() << " parameters missed during initial burst.";
+
                                     if (_parameter_debugging) {
                                         LogDebug() << "Requesting missing parameter "
                                                    << (int)maybe_next_missing_index.value();

--- a/src/mavsdk/core/mavlink_parameter_client.cpp
+++ b/src/mavsdk/core/mavlink_parameter_client.cpp
@@ -490,8 +490,8 @@ void MavlinkParameterClient::do_work()
                 }
                 work->already_requested = true;
                 // We want to get notified if a timeout happens
-                _timeout_cookie =
-                    _timeout_handler.add([this] { receive_timeout(); }, _timeout_s_callback());
+                _timeout_cookie = _timeout_handler.add(
+                    [this] { receive_timeout(); }, _timeout_s_callback() * _get_all_timeout_factor);
             }},
         work->work_item_variant);
 }
@@ -1129,7 +1129,8 @@ void MavlinkParameterClient::receive_timeout()
 
                         // We want to get notified if a timeout happens
                         _timeout_cookie = _timeout_handler.add(
-                            [this] { receive_timeout(); }, _timeout_s_callback());
+                            [this] { receive_timeout(); },
+                            _timeout_s_callback() * _get_all_timeout_factor);
                     } else {
                         if (item.callback) {
                             auto callback = item.callback;

--- a/src/mavsdk/core/mavlink_parameter_client.cpp
+++ b/src/mavsdk/core/mavlink_parameter_client.cpp
@@ -5,6 +5,7 @@
 #include "plugin_base.h"
 #include <algorithm>
 #include <future>
+#include <limits>
 #include <utility>
 
 namespace mavsdk {
@@ -665,6 +666,10 @@ void MavlinkParameterClient::process_param_value(const mavlink_message_t& messag
 
     if (_parameter_debugging) {
         LogDebug() << "process_param_value: " << safe_param_id << " " << received_value;
+
+    if (param_value.param_index == std::numeric_limits<uint16_t>::max()) {
+        // Ignore PX4's _HASH_CHECK param.
+        return;
     }
 
     // We need to use a unique pointer here to remove the lock from the work queue manually "early"

--- a/src/mavsdk/core/mavlink_parameter_client.h
+++ b/src/mavsdk/core/mavlink_parameter_client.h
@@ -195,6 +195,8 @@ private:
         const std::array<char, PARAM_ID_LEN>& param_id_buff, int16_t param_index);
     bool send_request_list_message();
 
+    bool request_next_missing(uint16_t count);
+
     Sender& _sender;
     MavlinkMessageHandler& _message_handler;
     TimeoutHandler& _timeout_handler;

--- a/src/mavsdk/core/mavlink_parameter_client.h
+++ b/src/mavsdk/core/mavlink_parameter_client.h
@@ -152,6 +152,8 @@ public:
     friend std::ostream& operator<<(std::ostream&, const Result&);
 
 private:
+    const double _get_all_timeout_factor = 4.0;
+
     struct WorkItemSet {
         const std::string param_name;
         const ParamValue param_value;


### PR DESCRIPTION
This includes several fixes to improve/fix getting all parameters, especially using a low bandwidth radio such as an SiK radio.

The main fixes are:
- Logic fix in keeping track of which parameters have already been received. We used to re-transmit way too many parameters again unnecessarily.
- Increase timeout to start re-transmissions. Parameters sent in bursts over an SiK radio can have long periods of silence. We just need to wait these out instead of using re-transmissions too early.
- When re-requesting parameters, we should still accept any other parameters, in case they are still coming in and we started the re-transmission too early.
- During re-transmission, request missing parameters in chunks of 10 to speed things up.