### PR TITLE
core: only use http redirects

### DIFF
--- a/src/mavsdk/core/curl_wrapper.cpp
+++ b/src/mavsdk/core/curl_wrapper.cpp
@@ -29,6 +29,7 @@ bool CurlWrapper::download_text(const std::string& url, std::string& content)
         curl_easy_setopt(curl.get(), CURLOPT_URL, url.c_str());
         curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION, write_callback);
         curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, &readBuffer);
+        curl_easy_setopt(curl.get(), CURLOPT_REDIR_PROTOCOLS_STR, "http");
         res = curl_easy_perform(curl.get());
         content = readBuffer;
 
@@ -108,6 +109,7 @@ bool CurlWrapper::download_file_to_path(
         curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION, NULL);
         curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, fp);
         curl_easy_setopt(curl.get(), CURLOPT_NOPROGRESS, 0L);
+        curl_easy_setopt(curl.get(), CURLOPT_REDIR_PROTOCOLS_STR, "http");
         res = curl_easy_perform(curl.get());
         fclose(fp);
 


### PR DESCRIPTION
This is an attempt to prevent cURL from being redirected from http to https since we ship without SSL in MAVSDK v2.