### PR TITLE
[BACKPORT v2] core: fix param get regression

### DIFF
--- a/src/mavsdk/core/mavlink_parameter_client.cpp
+++ b/src/mavsdk/core/mavlink_parameter_client.cpp
@@ -673,7 +673,8 @@ void MavlinkParameterClient::process_param_value(const mavlink_message_t& messag
                    << ", index: " << param_value.param_index;
     }
 
-    if (param_value.param_index == std::numeric_limits<uint16_t>::max()) {
+    if (param_value.param_index == std::numeric_limits<uint16_t>::max() &&
+        safe_param_id == "_HASH_CHECK") {
         // Ignore PX4's _HASH_CHECK param.
         return;
     }


### PR DESCRIPTION
It turns out single params are sent with index -1, so caught by the test for the _HASH_CHECK param.

Backport part of https://github.com/mavlink/MAVSDK/pull/2480.

Fixes #2477.