### PR TITLE
fix `rpath` issue for `mavsdk_server` macos build

### DIFF
--- a/src/mavsdk_server/src/CMakeLists.txt
+++ b/src/mavsdk_server/src/CMakeLists.txt
@@ -112,14 +112,24 @@ if(NOT IOS AND NOT ANDROID)
     )
 
     if (BUILD_SHARED_LIBS)
-        set_target_properties(mavsdk_server_bin PROPERTIES
-            INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}"
+        if (APPLE)
+            set_target_properties(mavsdk_server PROPERTIES
+                BUILD_WITH_INSTALL_RPATH ON
+                INSTALL_NAME_DIR "@rpath"
+                INSTALL_RPATH "@loader_path/../lib"
             )
-
-        set_target_properties(mavsdk_server
-            PROPERTIES
-            INSTALL_RPATH "$ORIGIN"
-        )
+            set_target_properties(mavsdk_server_bin PROPERTIES
+                BUILD_WITH_INSTALL_RPATH ON
+                INSTALL_RPATH "@loader_path/../lib"
+            )
+        else()
+            set_target_properties(mavsdk_server PROPERTIES
+                INSTALL_RPATH "$ORIGIN"
+            )
+            set_target_properties(mavsdk_server_bin PROPERTIES
+                INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}"
+            )
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
seeing some rpath issue with `mavsdk_server` macos build 

```
  ==> /opt/homebrew/Cellar/mavsdk/3.0.0/bin/mavsdk_server --help
  dyld[21093]: Library not loaded: @rpath/libmavsdk_server.3.dylib
    Referenced from: <3175EB8C-F78F-3F99-AC24-F073CB8A7838> /opt/homebrew/Cellar/mavsdk/3.0.0/bin/mavsdk_server
    Reason: tried: 'lib/libmavsdk_server.3.dylib' (no such file), 'lib/libmavsdk_server.3.dylib' (no such file)
```

relates to https://github.com/Homebrew/homebrew-core/pull/204677