### PR TITLE
Fix for Invalid argument exception in camera plugin

### DIFF
--- a/src/mavsdk/plugins/camera/camera_definition.cpp
+++ b/src/mavsdk/plugins/camera/camera_definition.cpp
@@ -742,7 +742,7 @@ bool CameraDefinition::get_option_str(
     }
 
     for (const auto& option : _parameter_map[setting_name]->options) {
-        if (option->value == option_name) {
+        if (option->name == option_name) {
             description = option->name;
             return true;
         }


### PR DESCRIPTION
Fix for Issue [2495](https://github.com/mavlink/MAVSDK/issues/2496)