### PR TITLE
Telemetry and TelemetryServer improvements

### DIFF
--- a/src/integration_tests/telemetry_async.cpp
+++ b/src/integration_tests/telemetry_async.cpp
@@ -264,7 +264,10 @@ void print_angular_velocity_body(Telemetry::AngularVelocityBody angular_velocity
 void print_fixedwing_metrics(Telemetry::FixedwingMetrics fixedwing_metrics)
 {
     std::cout << "async Airspeed: " << fixedwing_metrics.airspeed_m_s << " m/s, "
+              << "Groundspeed: " << fixedwing_metrics.groundspeed_m_s << " m/s, "
+              << "Heading: " << fixedwing_metrics.heading_deg << " deg, "
               << "Throttle: " << fixedwing_metrics.throttle_percentage << " %, "
+              << "Altitude: " << fixedwing_metrics.altitude_msl << " m (MSL), "
               << "Climb: " << fixedwing_metrics.climb_rate_m_s << " m/s" << '\n';
     _received_fixedwing_metrics = true;
 }

--- a/src/integration_tests/telemetry_async.cpp
+++ b/src/integration_tests/telemetry_async.cpp
@@ -267,7 +267,7 @@ void print_fixedwing_metrics(Telemetry::FixedwingMetrics fixedwing_metrics)
               << "Groundspeed: " << fixedwing_metrics.groundspeed_m_s << " m/s, "
               << "Heading: " << fixedwing_metrics.heading_deg << " deg, "
               << "Throttle: " << fixedwing_metrics.throttle_percentage << " %, "
-              << "Altitude: " << fixedwing_metrics.altitude_msl << " m (MSL), "
+              << "Altitude: " << fixedwing_metrics.absolute_altitude_m << " m (MSL), "
               << "Climb: " << fixedwing_metrics.climb_rate_m_s << " m/s" << '\n';
     _received_fixedwing_metrics = true;
 }

--- a/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -811,7 +811,11 @@ public:
     struct FixedwingMetrics {
         float airspeed_m_s{
             float(NAN)}; /**< @brief Current indicated airspeed (IAS) in metres per second */
+        float groundspeed_m_s{float(NAN)}; /**< @brief Current groundspeed metres per second */
+        float heading_deg{
+            float(NAN)}; /**< @brief Current heading in compass units (0-360, 0=north) */
         float throttle_percentage{float(NAN)}; /**< @brief Current throttle setting (0 to 100) */
+        float altitude_msl{float(NAN)}; /**< @brief Current altitude in metres (MSL) */
         float climb_rate_m_s{float(NAN)}; /**< @brief Current climb rate in metres per second */
     };
 

--- a/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -811,12 +811,12 @@ public:
     struct FixedwingMetrics {
         float airspeed_m_s{
             float(NAN)}; /**< @brief Current indicated airspeed (IAS) in metres per second */
+        float throttle_percentage{float(NAN)}; /**< @brief Current throttle setting (0 to 100) */
+        float climb_rate_m_s{float(NAN)}; /**< @brief Current climb rate in metres per second */
         float groundspeed_m_s{float(NAN)}; /**< @brief Current groundspeed metres per second */
         float heading_deg{
             float(NAN)}; /**< @brief Current heading in compass units (0-360, 0=north) */
-        float throttle_percentage{float(NAN)}; /**< @brief Current throttle setting (0 to 100) */
         float altitude_msl{float(NAN)}; /**< @brief Current altitude in metres (MSL) */
-        float climb_rate_m_s{float(NAN)}; /**< @brief Current climb rate in metres per second */
     };
 
     /**

--- a/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -816,7 +816,7 @@ public:
         float groundspeed_m_s{float(NAN)}; /**< @brief Current groundspeed metres per second */
         float heading_deg{
             float(NAN)}; /**< @brief Current heading in compass units (0-360, 0=north) */
-        float altitude_msl{float(NAN)}; /**< @brief Current altitude in metres (MSL) */
+        float absolute_altitude_m{float(NAN)}; /**< @brief Current altitude in metres (MSL) */
     };
 
     /**

--- a/src/mavsdk/plugins/telemetry/telemetry.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry.cpp
@@ -1319,16 +1319,16 @@ bool operator==(const Telemetry::FixedwingMetrics& lhs, const Telemetry::Fixedwi
 {
     return ((std::isnan(rhs.airspeed_m_s) && std::isnan(lhs.airspeed_m_s)) ||
             rhs.airspeed_m_s == lhs.airspeed_m_s) &&
+           ((std::isnan(rhs.throttle_percentage) && std::isnan(lhs.throttle_percentage)) ||
+            rhs.throttle_percentage == lhs.throttle_percentage) &&
+           ((std::isnan(rhs.climb_rate_m_s) && std::isnan(lhs.climb_rate_m_s)) ||
+            rhs.climb_rate_m_s == lhs.climb_rate_m_s) &&
            ((std::isnan(rhs.groundspeed_m_s) && std::isnan(lhs.groundspeed_m_s)) ||
             rhs.groundspeed_m_s == lhs.groundspeed_m_s) &&
            ((std::isnan(rhs.heading_deg) && std::isnan(lhs.heading_deg)) ||
             rhs.heading_deg == lhs.heading_deg) &&
-           ((std::isnan(rhs.throttle_percentage) && std::isnan(lhs.throttle_percentage)) ||
-            rhs.throttle_percentage == lhs.throttle_percentage) &&
            ((std::isnan(rhs.altitude_msl) && std::isnan(lhs.altitude_msl)) ||
-            rhs.altitude_msl == lhs.altitude_msl) &&
-           ((std::isnan(rhs.climb_rate_m_s) && std::isnan(lhs.climb_rate_m_s)) ||
-            rhs.climb_rate_m_s == lhs.climb_rate_m_s);
+            rhs.altitude_msl == lhs.altitude_msl);
 }
 
 std::ostream& operator<<(std::ostream& str, Telemetry::FixedwingMetrics const& fixedwing_metrics)
@@ -1336,11 +1336,11 @@ std::ostream& operator<<(std::ostream& str, Telemetry::FixedwingMetrics const& f
     str << std::setprecision(15);
     str << "fixedwing_metrics:" << '\n' << "{\n";
     str << "    airspeed_m_s: " << fixedwing_metrics.airspeed_m_s << '\n';
+    str << "    throttle_percentage: " << fixedwing_metrics.throttle_percentage << '\n';
+    str << "    climb_rate_m_s: " << fixedwing_metrics.climb_rate_m_s << '\n';
     str << "    groundspeed_m_s: " << fixedwing_metrics.groundspeed_m_s << '\n';
     str << "    heading_deg: " << fixedwing_metrics.heading_deg << '\n';
-    str << "    throttle_percentage: " << fixedwing_metrics.throttle_percentage << '\n';
     str << "    altitude_msl: " << fixedwing_metrics.altitude_msl << '\n';
-    str << "    climb_rate_m_s: " << fixedwing_metrics.climb_rate_m_s << '\n';
     str << '}';
     return str;
 }

--- a/src/mavsdk/plugins/telemetry/telemetry.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry.cpp
@@ -1319,8 +1319,14 @@ bool operator==(const Telemetry::FixedwingMetrics& lhs, const Telemetry::Fixedwi
 {
     return ((std::isnan(rhs.airspeed_m_s) && std::isnan(lhs.airspeed_m_s)) ||
             rhs.airspeed_m_s == lhs.airspeed_m_s) &&
+           ((std::isnan(rhs.groundspeed_m_s) && std::isnan(lhs.groundspeed_m_s)) ||
+            rhs.groundspeed_m_s == lhs.groundspeed_m_s) &&
+           ((std::isnan(rhs.heading_deg) && std::isnan(lhs.heading_deg)) ||
+            rhs.heading_deg == lhs.heading_deg) &&
            ((std::isnan(rhs.throttle_percentage) && std::isnan(lhs.throttle_percentage)) ||
             rhs.throttle_percentage == lhs.throttle_percentage) &&
+           ((std::isnan(rhs.altitude_msl) && std::isnan(lhs.altitude_msl)) ||
+            rhs.altitude_msl == lhs.altitude_msl) &&
            ((std::isnan(rhs.climb_rate_m_s) && std::isnan(lhs.climb_rate_m_s)) ||
             rhs.climb_rate_m_s == lhs.climb_rate_m_s);
 }
@@ -1330,7 +1336,10 @@ std::ostream& operator<<(std::ostream& str, Telemetry::FixedwingMetrics const& f
     str << std::setprecision(15);
     str << "fixedwing_metrics:" << '\n' << "{\n";
     str << "    airspeed_m_s: " << fixedwing_metrics.airspeed_m_s << '\n';
+    str << "    groundspeed_m_s: " << fixedwing_metrics.groundspeed_m_s << '\n';
+    str << "    heading_deg: " << fixedwing_metrics.heading_deg << '\n';
     str << "    throttle_percentage: " << fixedwing_metrics.throttle_percentage << '\n';
+    str << "    altitude_msl: " << fixedwing_metrics.altitude_msl << '\n';
     str << "    climb_rate_m_s: " << fixedwing_metrics.climb_rate_m_s << '\n';
     str << '}';
     return str;

--- a/src/mavsdk/plugins/telemetry/telemetry.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry.cpp
@@ -1327,8 +1327,8 @@ bool operator==(const Telemetry::FixedwingMetrics& lhs, const Telemetry::Fixedwi
             rhs.groundspeed_m_s == lhs.groundspeed_m_s) &&
            ((std::isnan(rhs.heading_deg) && std::isnan(lhs.heading_deg)) ||
             rhs.heading_deg == lhs.heading_deg) &&
-           ((std::isnan(rhs.altitude_msl) && std::isnan(lhs.altitude_msl)) ||
-            rhs.altitude_msl == lhs.altitude_msl);
+           ((std::isnan(rhs.absolute_altitude_m) && std::isnan(lhs.absolute_altitude_m)) ||
+            rhs.absolute_altitude_m == lhs.absolute_altitude_m);
 }
 
 std::ostream& operator<<(std::ostream& str, Telemetry::FixedwingMetrics const& fixedwing_metrics)
@@ -1340,7 +1340,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::FixedwingMetrics const& f
     str << "    climb_rate_m_s: " << fixedwing_metrics.climb_rate_m_s << '\n';
     str << "    groundspeed_m_s: " << fixedwing_metrics.groundspeed_m_s << '\n';
     str << "    heading_deg: " << fixedwing_metrics.heading_deg << '\n';
-    str << "    altitude_msl: " << fixedwing_metrics.altitude_msl << '\n';
+    str << "    absolute_altitude_m: " << fixedwing_metrics.absolute_altitude_m << '\n';
     str << '}';
     return str;
 }

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -994,7 +994,10 @@ void TelemetryImpl::process_fixedwing_metrics(const mavlink_message_t& message)
 
     Telemetry::FixedwingMetrics new_fixedwing_metrics;
     new_fixedwing_metrics.airspeed_m_s = vfr_hud.airspeed;
+    new_fixedwing_metrics.groundspeed_m_s = vfr_hud.groundspeed;
+    new_fixedwing_metrics.heading_deg = vfr_hud.heading;
     new_fixedwing_metrics.throttle_percentage = vfr_hud.throttle * 1e-2f;
+    new_fixedwing_metrics.altitude_msl = vfr_hud.alt;
     new_fixedwing_metrics.climb_rate_m_s = vfr_hud.climb;
 
     set_fixedwing_metrics(new_fixedwing_metrics);

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -997,7 +997,7 @@ void TelemetryImpl::process_fixedwing_metrics(const mavlink_message_t& message)
     new_fixedwing_metrics.groundspeed_m_s = vfr_hud.groundspeed;
     new_fixedwing_metrics.heading_deg = vfr_hud.heading;
     new_fixedwing_metrics.throttle_percentage = vfr_hud.throttle * 1e-2f;
-    new_fixedwing_metrics.altitude_msl = vfr_hud.alt;
+    new_fixedwing_metrics.absolute_altitude_m = vfr_hud.alt;
     new_fixedwing_metrics.climb_rate_m_s = vfr_hud.climb;
 
     set_fixedwing_metrics(new_fixedwing_metrics);

--- a/src/mavsdk/plugins/telemetry_server/include/plugins/telemetry_server/telemetry_server.h
+++ b/src/mavsdk/plugins/telemetry_server/include/plugins/telemetry_server/telemetry_server.h
@@ -760,7 +760,7 @@ public:
         float groundspeed_m_s{float(NAN)}; /**< @brief Current groundspeed metres per second */
         float heading_deg{
             float(NAN)}; /**< @brief Current heading in compass units (0-360, 0=north) */
-        float altitude_msl{float(NAN)}; /**< @brief Current altitude in metres (MSL) */
+        float absolute_altitude_m{float(NAN)}; /**< @brief Current altitude in metres (MSL) */
     };
 
     /**

--- a/src/mavsdk/plugins/telemetry_server/include/plugins/telemetry_server/telemetry_server.h
+++ b/src/mavsdk/plugins/telemetry_server/include/plugins/telemetry_server/telemetry_server.h
@@ -755,7 +755,11 @@ public:
     struct FixedwingMetrics {
         float airspeed_m_s{
             float(NAN)}; /**< @brief Current indicated airspeed (IAS) in metres per second */
+        float groundspeed_m_s{float(NAN)}; /**< @brief Current groundspeed metres per second */
+        float heading_deg{
+            float(NAN)}; /**< @brief Current heading in compass units (0-360, 0=north) */
         float throttle_percentage{float(NAN)}; /**< @brief Current throttle setting (0 to 100) */
+        float altitude_msl{float(NAN)}; /**< @brief Current altitude in metres (MSL) */
         float climb_rate_m_s{float(NAN)}; /**< @brief Current climb rate in metres per second */
     };
 
@@ -1051,6 +1055,24 @@ public:
      * @return Result of request.
      */
     Result publish_distance_sensor(DistanceSensor distance_sensor) const;
+
+    /**
+     * @brief Publish to "attitude" updates.
+     *
+     * This function is blocking.
+     *
+     * @return Result of request.
+     */
+    Result publish_attitude(EulerAngle angle, AngularVelocityBody angular_velocity) const;
+
+    /**
+     * @brief Publish to "Visual Flight Rules HUD" updates.
+     *
+     * This function is blocking.
+     *
+     * @return Result of request.
+     */
+    Result publish_visual_flight_rules_hud(FixedwingMetrics fixed_wing_metrics) const;
 
     /**
      * @brief Copy constructor.

--- a/src/mavsdk/plugins/telemetry_server/include/plugins/telemetry_server/telemetry_server.h
+++ b/src/mavsdk/plugins/telemetry_server/include/plugins/telemetry_server/telemetry_server.h
@@ -755,12 +755,12 @@ public:
     struct FixedwingMetrics {
         float airspeed_m_s{
             float(NAN)}; /**< @brief Current indicated airspeed (IAS) in metres per second */
+        float throttle_percentage{float(NAN)}; /**< @brief Current throttle setting (0 to 100) */
+        float climb_rate_m_s{float(NAN)}; /**< @brief Current climb rate in metres per second */
         float groundspeed_m_s{float(NAN)}; /**< @brief Current groundspeed metres per second */
         float heading_deg{
             float(NAN)}; /**< @brief Current heading in compass units (0-360, 0=north) */
-        float throttle_percentage{float(NAN)}; /**< @brief Current throttle setting (0 to 100) */
         float altitude_msl{float(NAN)}; /**< @brief Current altitude in metres (MSL) */
-        float climb_rate_m_s{float(NAN)}; /**< @brief Current climb rate in metres per second */
     };
 
     /**

--- a/src/mavsdk/plugins/telemetry_server/telemetry_server.cpp
+++ b/src/mavsdk/plugins/telemetry_server/telemetry_server.cpp
@@ -656,8 +656,8 @@ bool operator==(
             rhs.groundspeed_m_s == lhs.groundspeed_m_s) &&
            ((std::isnan(rhs.heading_deg) && std::isnan(lhs.heading_deg)) ||
             rhs.heading_deg == lhs.heading_deg) &&
-           ((std::isnan(rhs.altitude_msl) && std::isnan(lhs.altitude_msl)) ||
-            rhs.altitude_msl == lhs.altitude_msl);
+           ((std::isnan(rhs.absolute_altitude_m) && std::isnan(lhs.absolute_altitude_m)) ||
+            rhs.absolute_altitude_m == lhs.absolute_altitude_m);
 }
 
 std::ostream&
@@ -670,7 +670,7 @@ operator<<(std::ostream& str, TelemetryServer::FixedwingMetrics const& fixedwing
     str << "    climb_rate_m_s: " << fixedwing_metrics.climb_rate_m_s << '\n';
     str << "    groundspeed_m_s: " << fixedwing_metrics.groundspeed_m_s << '\n';
     str << "    heading_deg: " << fixedwing_metrics.heading_deg << '\n';
-    str << "    altitude_msl: " << fixedwing_metrics.altitude_msl << '\n';
+    str << "    absolute_altitude_m: " << fixedwing_metrics.absolute_altitude_m << '\n';
     str << '}';
     return str;
 }

--- a/src/mavsdk/plugins/telemetry_server/telemetry_server.cpp
+++ b/src/mavsdk/plugins/telemetry_server/telemetry_server.cpp
@@ -131,6 +131,18 @@ TelemetryServer::publish_distance_sensor(DistanceSensor distance_sensor) const
     return _impl->publish_distance_sensor(distance_sensor);
 }
 
+TelemetryServer::Result
+TelemetryServer::publish_attitude(EulerAngle angle, AngularVelocityBody angular_velocity) const
+{
+    return _impl->publish_attitude(angle, angular_velocity);
+}
+
+TelemetryServer::Result
+TelemetryServer::publish_visual_flight_rules_hud(FixedwingMetrics fixed_wing_metrics) const
+{
+    return _impl->publish_visual_flight_rules_hud(fixed_wing_metrics);
+}
+
 bool operator==(const TelemetryServer::Position& lhs, const TelemetryServer::Position& rhs)
 {
     return ((std::isnan(rhs.latitude_deg) && std::isnan(lhs.latitude_deg)) ||
@@ -636,8 +648,14 @@ bool operator==(
 {
     return ((std::isnan(rhs.airspeed_m_s) && std::isnan(lhs.airspeed_m_s)) ||
             rhs.airspeed_m_s == lhs.airspeed_m_s) &&
+           ((std::isnan(rhs.groundspeed_m_s) && std::isnan(lhs.groundspeed_m_s)) ||
+            rhs.groundspeed_m_s == lhs.groundspeed_m_s) &&
+           ((std::isnan(rhs.heading_deg) && std::isnan(lhs.heading_deg)) ||
+            rhs.heading_deg == lhs.heading_deg) &&
            ((std::isnan(rhs.throttle_percentage) && std::isnan(lhs.throttle_percentage)) ||
             rhs.throttle_percentage == lhs.throttle_percentage) &&
+           ((std::isnan(rhs.altitude_msl) && std::isnan(lhs.altitude_msl)) ||
+            rhs.altitude_msl == lhs.altitude_msl) &&
            ((std::isnan(rhs.climb_rate_m_s) && std::isnan(lhs.climb_rate_m_s)) ||
             rhs.climb_rate_m_s == lhs.climb_rate_m_s);
 }
@@ -648,7 +666,10 @@ operator<<(std::ostream& str, TelemetryServer::FixedwingMetrics const& fixedwing
     str << std::setprecision(15);
     str << "fixedwing_metrics:" << '\n' << "{\n";
     str << "    airspeed_m_s: " << fixedwing_metrics.airspeed_m_s << '\n';
+    str << "    groundspeed_m_s: " << fixedwing_metrics.groundspeed_m_s << '\n';
+    str << "    heading_deg: " << fixedwing_metrics.heading_deg << '\n';
     str << "    throttle_percentage: " << fixedwing_metrics.throttle_percentage << '\n';
+    str << "    altitude_msl: " << fixedwing_metrics.altitude_msl << '\n';
     str << "    climb_rate_m_s: " << fixedwing_metrics.climb_rate_m_s << '\n';
     str << '}';
     return str;

--- a/src/mavsdk/plugins/telemetry_server/telemetry_server.cpp
+++ b/src/mavsdk/plugins/telemetry_server/telemetry_server.cpp
@@ -648,16 +648,16 @@ bool operator==(
 {
     return ((std::isnan(rhs.airspeed_m_s) && std::isnan(lhs.airspeed_m_s)) ||
             rhs.airspeed_m_s == lhs.airspeed_m_s) &&
+           ((std::isnan(rhs.throttle_percentage) && std::isnan(lhs.throttle_percentage)) ||
+            rhs.throttle_percentage == lhs.throttle_percentage) &&
+           ((std::isnan(rhs.climb_rate_m_s) && std::isnan(lhs.climb_rate_m_s)) ||
+            rhs.climb_rate_m_s == lhs.climb_rate_m_s) &&
            ((std::isnan(rhs.groundspeed_m_s) && std::isnan(lhs.groundspeed_m_s)) ||
             rhs.groundspeed_m_s == lhs.groundspeed_m_s) &&
            ((std::isnan(rhs.heading_deg) && std::isnan(lhs.heading_deg)) ||
             rhs.heading_deg == lhs.heading_deg) &&
-           ((std::isnan(rhs.throttle_percentage) && std::isnan(lhs.throttle_percentage)) ||
-            rhs.throttle_percentage == lhs.throttle_percentage) &&
            ((std::isnan(rhs.altitude_msl) && std::isnan(lhs.altitude_msl)) ||
-            rhs.altitude_msl == lhs.altitude_msl) &&
-           ((std::isnan(rhs.climb_rate_m_s) && std::isnan(lhs.climb_rate_m_s)) ||
-            rhs.climb_rate_m_s == lhs.climb_rate_m_s);
+            rhs.altitude_msl == lhs.altitude_msl);
 }
 
 std::ostream&
@@ -666,11 +666,11 @@ operator<<(std::ostream& str, TelemetryServer::FixedwingMetrics const& fixedwing
     str << std::setprecision(15);
     str << "fixedwing_metrics:" << '\n' << "{\n";
     str << "    airspeed_m_s: " << fixedwing_metrics.airspeed_m_s << '\n';
+    str << "    throttle_percentage: " << fixedwing_metrics.throttle_percentage << '\n';
+    str << "    climb_rate_m_s: " << fixedwing_metrics.climb_rate_m_s << '\n';
     str << "    groundspeed_m_s: " << fixedwing_metrics.groundspeed_m_s << '\n';
     str << "    heading_deg: " << fixedwing_metrics.heading_deg << '\n';
-    str << "    throttle_percentage: " << fixedwing_metrics.throttle_percentage << '\n';
     str << "    altitude_msl: " << fixedwing_metrics.altitude_msl << '\n';
-    str << "    climb_rate_m_s: " << fixedwing_metrics.climb_rate_m_s << '\n';
     str << '}';
     return str;
 }

--- a/src/mavsdk/plugins/telemetry_server/telemetry_server_impl.cpp
+++ b/src/mavsdk/plugins/telemetry_server/telemetry_server_impl.cpp
@@ -536,9 +536,9 @@ TelemetryServer::Result TelemetryServerImpl::publish_attitude(
                        channel,
                        &message,
                        static_cast<uint32_t>(attitude.timestamp_us / 1000.F),
-                       attitude.roll_deg,
-                       attitude.pitch_deg,
-                       attitude.yaw_deg,
+                       attitude.roll_deg * M_PI / 180.F,
+                       attitude.pitch_deg * M_PI / 180.F,
+                       attitude.yaw_deg * M_PI / 180.F,
                        angular_velocity.roll_rad_s,
                        angular_velocity.pitch_rad_s,
                        angular_velocity.yaw_rad_s);
@@ -561,8 +561,8 @@ TelemetryServer::Result TelemetryServerImpl::publish_visual_flight_rules_hud(
                        &message,
                        fixed_wing_metrics.airspeed_m_s,
                        fixed_wing_metrics.groundspeed_m_s,
-                       fixed_wing_metrics.heading_deg,
-                       fixed_wing_metrics.throttle_percentage,
+                       static_cast<uint16_t>(std::round(fixed_wing_metrics.heading_deg)),
+                       static_cast<uint16_t>(std::round(fixed_wing_metrics.throttle_percentage)),
                        fixed_wing_metrics.altitude_msl,
                        fixed_wing_metrics.climb_rate_m_s);
                    return message;

--- a/src/mavsdk/plugins/telemetry_server/telemetry_server_impl.cpp
+++ b/src/mavsdk/plugins/telemetry_server/telemetry_server_impl.cpp
@@ -524,4 +524,51 @@ TelemetryServer::Result TelemetryServerImpl::publish_extended_sys_state(
                TelemetryServer::Result::Unsupported;
 }
 
+TelemetryServer::Result TelemetryServerImpl::publish_attitude(
+    TelemetryServer::EulerAngle attitude, TelemetryServer::AngularVelocityBody angular_velocity)
+{
+    return _server_component_impl->queue_message(
+               [&](MavlinkAddress mavlink_address, uint8_t channel) {
+                   mavlink_message_t message;
+                   mavlink_msg_attitude_pack_chan(
+                       mavlink_address.system_id,
+                       mavlink_address.component_id,
+                       channel,
+                       &message,
+                       static_cast<uint32_t>(attitude.timestamp_us / 1000.F),
+                       attitude.roll_deg,
+                       attitude.pitch_deg,
+                       attitude.yaw_deg,
+                       angular_velocity.roll_rad_s,
+                       angular_velocity.pitch_rad_s,
+                       angular_velocity.yaw_rad_s);
+                   return message;
+               }) ?
+               TelemetryServer::Result::Success :
+               TelemetryServer::Result::Unsupported;
+}
+
+TelemetryServer::Result TelemetryServerImpl::publish_visual_flight_rules_hud(
+    TelemetryServer::FixedwingMetrics fixed_wing_metrics)
+{
+    return _server_component_impl->queue_message(
+               [&](MavlinkAddress mavlink_address, uint8_t channel) {
+                   mavlink_message_t message;
+                   mavlink_msg_vfr_hud_pack_chan(
+                       mavlink_address.system_id,
+                       mavlink_address.component_id,
+                       channel,
+                       &message,
+                       fixed_wing_metrics.airspeed_m_s,
+                       fixed_wing_metrics.groundspeed_m_s,
+                       fixed_wing_metrics.heading_deg,
+                       fixed_wing_metrics.throttle_percentage,
+                       fixed_wing_metrics.altitude_msl,
+                       fixed_wing_metrics.climb_rate_m_s);
+                   return message;
+               }) ?
+               TelemetryServer::Result::Success :
+               TelemetryServer::Result::Unsupported;
+}
+
 } // namespace mavsdk

--- a/src/mavsdk/plugins/telemetry_server/telemetry_server_impl.cpp
+++ b/src/mavsdk/plugins/telemetry_server/telemetry_server_impl.cpp
@@ -563,7 +563,7 @@ TelemetryServer::Result TelemetryServerImpl::publish_visual_flight_rules_hud(
                        fixed_wing_metrics.groundspeed_m_s,
                        static_cast<uint16_t>(std::round(fixed_wing_metrics.heading_deg)),
                        static_cast<uint16_t>(std::round(fixed_wing_metrics.throttle_percentage)),
-                       fixed_wing_metrics.altitude_msl,
+                       fixed_wing_metrics.absolute_altitude_m,
                        fixed_wing_metrics.climb_rate_m_s);
                    return message;
                }) ?

--- a/src/mavsdk/plugins/telemetry_server/telemetry_server_impl.h
+++ b/src/mavsdk/plugins/telemetry_server/telemetry_server_impl.h
@@ -76,6 +76,13 @@ public:
     TelemetryServer::Result publish_extended_sys_state(
         TelemetryServer::VtolState vtol_state, TelemetryServer::LandedState landed_state);
 
+    TelemetryServer::Result publish_attitude(
+        TelemetryServer::EulerAngle attitude,
+        TelemetryServer::AngularVelocityBody angular_velocity);
+
+    TelemetryServer::Result
+    publish_visual_flight_rules_hud(TelemetryServer::FixedwingMetrics fixed_wing_metrics);
+
 private:
     bool _send_home();
 

--- a/src/mavsdk_server/src/generated/telemetry/telemetry.pb.cc
+++ b/src/mavsdk_server/src/generated/telemetry/telemetry.pb.cc
@@ -1878,11 +1878,11 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
 inline constexpr FixedwingMetrics::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : airspeed_m_s_{0},
+        throttle_percentage_{0},
+        climb_rate_m_s_{0},
         groundspeed_m_s_{0},
         heading_deg_{0},
-        throttle_percentage_{0},
         altitude_msl_{0},
-        climb_rate_m_s_{0},
         _cached_size_{0} {}
 
 template <typename>
@@ -4904,11 +4904,11 @@ const ::uint32_t
         ~0u,  // no _split_
         ~0u,  // no sizeof(Split)
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::FixedwingMetrics, _impl_.airspeed_m_s_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::FixedwingMetrics, _impl_.throttle_percentage_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::FixedwingMetrics, _impl_.climb_rate_m_s_),
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::FixedwingMetrics, _impl_.groundspeed_m_s_),
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::FixedwingMetrics, _impl_.heading_deg_),
-        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::FixedwingMetrics, _impl_.throttle_percentage_),
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::FixedwingMetrics, _impl_.altitude_msl_),
-        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::FixedwingMetrics, _impl_.climb_rate_m_s_),
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::AccelerationFrd, _internal_metadata_),
         ~0u,  // no _extensions_
@@ -5558,11 +5558,11 @@ const char descriptor_table_protodef_telemetry_2ftelemetry_2eproto[] ABSL_ATTRIB
     "\022\035\n\014latitude_deg\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlongi"
     "tude_deg\030\002 \001(\001B\007\202\265\030\003NaN\022$\n\023absolute_alti"
     "tude_m\030\003 \001(\002B\007\202\265\030\003NaN\"\327\001\n\020FixedwingMetri"
-    "cs\022\035\n\014airspeed_m_s\030\001 \001(\002B\007\202\265\030\003NaN\022 \n\017gro"
-    "undspeed_m_s\030\002 \001(\002B\007\202\265\030\003NaN\022\034\n\013heading_d"
-    "eg\030\003 \001(\002B\007\202\265\030\003NaN\022$\n\023throttle_percentage"
-    "\030\004 \001(\002B\007\202\265\030\003NaN\022\035\n\014altitude_msl\030\005 \001(\002B\007\202"
-    "\265\030\003NaN\022\037\n\016climb_rate_m_s\030\006 \001(\002B\007\202\265\030\003NaN\""
+    "cs\022\035\n\014airspeed_m_s\030\001 \001(\002B\007\202\265\030\003NaN\022$\n\023thr"
+    "ottle_percentage\030\002 \001(\002B\007\202\265\030\003NaN\022\037\n\016climb"
+    "_rate_m_s\030\003 \001(\002B\007\202\265\030\003NaN\022 \n\017groundspeed_"
+    "m_s\030\004 \001(\002B\007\202\265\030\003NaN\022\034\n\013heading_deg\030\005 \001(\002B"
+    "\007\202\265\030\003NaN\022\035\n\014altitude_msl\030\006 \001(\002B\007\202\265\030\003NaN\""
     "i\n\017AccelerationFrd\022\035\n\014forward_m_s2\030\001 \001(\002"
     "B\007\202\265\030\003NaN\022\033\n\nright_m_s2\030\002 \001(\002B\007\202\265\030\003NaN\022\032"
     "\n\tdown_m_s2\030\003 \001(\002B\007\202\265\030\003NaN\"o\n\022AngularVel"
@@ -35251,9 +35251,9 @@ inline void FixedwingMetrics::SharedCtor(::_pb::Arena* arena) {
   ::memset(reinterpret_cast<char *>(&_impl_) +
                offsetof(Impl_, airspeed_m_s_),
            0,
-           offsetof(Impl_, climb_rate_m_s_) -
+           offsetof(Impl_, altitude_msl_) -
                offsetof(Impl_, airspeed_m_s_) +
-               sizeof(Impl_::climb_rate_m_s_));
+               sizeof(Impl_::altitude_msl_));
 }
 FixedwingMetrics::~FixedwingMetrics() {
   // @@protoc_insertion_point(destructor:mavsdk.rpc.telemetry.FixedwingMetrics)
@@ -35324,21 +35324,21 @@ const ::_pbi::TcParseTable<3, 6, 0, 0, 2> FixedwingMetrics::_table_ = {
     // float airspeed_m_s = 1 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
      {13, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.airspeed_m_s_)}},
-    // float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
+    // float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
-     {21, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.groundspeed_m_s_)}},
-    // float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
+     {21, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.throttle_percentage_)}},
+    // float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
-     {29, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.heading_deg_)}},
-    // float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
+     {29, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.climb_rate_m_s_)}},
+    // float groundspeed_m_s = 4 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
-     {37, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.throttle_percentage_)}},
-    // float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
+     {37, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.groundspeed_m_s_)}},
+    // float heading_deg = 5 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
-     {45, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.altitude_msl_)}},
-    // float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
+     {45, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.heading_deg_)}},
+    // float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
-     {53, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.climb_rate_m_s_)}},
+     {53, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.altitude_msl_)}},
     {::_pbi::TcParser::MiniParse, {}},
   }}, {{
     65535, 65535
@@ -35346,20 +35346,20 @@ const ::_pbi::TcParseTable<3, 6, 0, 0, 2> FixedwingMetrics::_table_ = {
     // float airspeed_m_s = 1 [(.mavsdk.options.default_value) = "NaN"];
     {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.airspeed_m_s_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
-    // float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
-    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.groundspeed_m_s_), 0, 0,
-    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
-    // float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
-    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.heading_deg_), 0, 0,
-    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
-    // float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
+    // float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
     {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.throttle_percentage_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
-    // float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
-    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.altitude_msl_), 0, 0,
-    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
-    // float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
+    // float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
     {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.climb_rate_m_s_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+    // float groundspeed_m_s = 4 [(.mavsdk.options.default_value) = "NaN"];
+    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.groundspeed_m_s_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+    // float heading_deg = 5 [(.mavsdk.options.default_value) = "NaN"];
+    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.heading_deg_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+    // float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
+    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.altitude_msl_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
   }},
   // no aux_entries
@@ -35375,8 +35375,8 @@ PROTOBUF_NOINLINE void FixedwingMetrics::Clear() {
   (void) cached_has_bits;
 
   ::memset(&_impl_.airspeed_m_s_, 0, static_cast<::size_t>(
-      reinterpret_cast<char*>(&_impl_.climb_rate_m_s_) -
-      reinterpret_cast<char*>(&_impl_.airspeed_m_s_)) + sizeof(_impl_.climb_rate_m_s_));
+      reinterpret_cast<char*>(&_impl_.altitude_msl_) -
+      reinterpret_cast<char*>(&_impl_.airspeed_m_s_)) + sizeof(_impl_.altitude_msl_));
   _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
 }
 
@@ -35402,39 +35402,39 @@ PROTOBUF_NOINLINE void FixedwingMetrics::Clear() {
                 1, this_._internal_airspeed_m_s(), target);
           }
 
-          // float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
-          if (::absl::bit_cast<::uint32_t>(this_._internal_groundspeed_m_s()) != 0) {
-            target = stream->EnsureSpace(target);
-            target = ::_pbi::WireFormatLite::WriteFloatToArray(
-                2, this_._internal_groundspeed_m_s(), target);
-          }
-
-          // float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
-          if (::absl::bit_cast<::uint32_t>(this_._internal_heading_deg()) != 0) {
-            target = stream->EnsureSpace(target);
-            target = ::_pbi::WireFormatLite::WriteFloatToArray(
-                3, this_._internal_heading_deg(), target);
-          }
-
-          // float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
+          // float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
           if (::absl::bit_cast<::uint32_t>(this_._internal_throttle_percentage()) != 0) {
             target = stream->EnsureSpace(target);
             target = ::_pbi::WireFormatLite::WriteFloatToArray(
-                4, this_._internal_throttle_percentage(), target);
+                2, this_._internal_throttle_percentage(), target);
           }
 
-          // float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
-          if (::absl::bit_cast<::uint32_t>(this_._internal_altitude_msl()) != 0) {
-            target = stream->EnsureSpace(target);
-            target = ::_pbi::WireFormatLite::WriteFloatToArray(
-                5, this_._internal_altitude_msl(), target);
-          }
-
-          // float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
+          // float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
           if (::absl::bit_cast<::uint32_t>(this_._internal_climb_rate_m_s()) != 0) {
             target = stream->EnsureSpace(target);
             target = ::_pbi::WireFormatLite::WriteFloatToArray(
-                6, this_._internal_climb_rate_m_s(), target);
+                3, this_._internal_climb_rate_m_s(), target);
+          }
+
+          // float groundspeed_m_s = 4 [(.mavsdk.options.default_value) = "NaN"];
+          if (::absl::bit_cast<::uint32_t>(this_._internal_groundspeed_m_s()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                4, this_._internal_groundspeed_m_s(), target);
+          }
+
+          // float heading_deg = 5 [(.mavsdk.options.default_value) = "NaN"];
+          if (::absl::bit_cast<::uint32_t>(this_._internal_heading_deg()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                5, this_._internal_heading_deg(), target);
+          }
+
+          // float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
+          if (::absl::bit_cast<::uint32_t>(this_._internal_altitude_msl()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                6, this_._internal_altitude_msl(), target);
           }
 
           if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
@@ -35466,24 +35466,24 @@ PROTOBUF_NOINLINE void FixedwingMetrics::Clear() {
             if (::absl::bit_cast<::uint32_t>(this_._internal_airspeed_m_s()) != 0) {
               total_size += 5;
             }
-            // float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
-            if (::absl::bit_cast<::uint32_t>(this_._internal_groundspeed_m_s()) != 0) {
-              total_size += 5;
-            }
-            // float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
-            if (::absl::bit_cast<::uint32_t>(this_._internal_heading_deg()) != 0) {
-              total_size += 5;
-            }
-            // float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
+            // float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
             if (::absl::bit_cast<::uint32_t>(this_._internal_throttle_percentage()) != 0) {
               total_size += 5;
             }
-            // float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
-            if (::absl::bit_cast<::uint32_t>(this_._internal_altitude_msl()) != 0) {
+            // float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
+            if (::absl::bit_cast<::uint32_t>(this_._internal_climb_rate_m_s()) != 0) {
               total_size += 5;
             }
-            // float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
-            if (::absl::bit_cast<::uint32_t>(this_._internal_climb_rate_m_s()) != 0) {
+            // float groundspeed_m_s = 4 [(.mavsdk.options.default_value) = "NaN"];
+            if (::absl::bit_cast<::uint32_t>(this_._internal_groundspeed_m_s()) != 0) {
+              total_size += 5;
+            }
+            // float heading_deg = 5 [(.mavsdk.options.default_value) = "NaN"];
+            if (::absl::bit_cast<::uint32_t>(this_._internal_heading_deg()) != 0) {
+              total_size += 5;
+            }
+            // float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
+            if (::absl::bit_cast<::uint32_t>(this_._internal_altitude_msl()) != 0) {
               total_size += 5;
             }
           }
@@ -35502,20 +35502,20 @@ void FixedwingMetrics::MergeImpl(::google::protobuf::MessageLite& to_msg, const 
   if (::absl::bit_cast<::uint32_t>(from._internal_airspeed_m_s()) != 0) {
     _this->_impl_.airspeed_m_s_ = from._impl_.airspeed_m_s_;
   }
+  if (::absl::bit_cast<::uint32_t>(from._internal_throttle_percentage()) != 0) {
+    _this->_impl_.throttle_percentage_ = from._impl_.throttle_percentage_;
+  }
+  if (::absl::bit_cast<::uint32_t>(from._internal_climb_rate_m_s()) != 0) {
+    _this->_impl_.climb_rate_m_s_ = from._impl_.climb_rate_m_s_;
+  }
   if (::absl::bit_cast<::uint32_t>(from._internal_groundspeed_m_s()) != 0) {
     _this->_impl_.groundspeed_m_s_ = from._impl_.groundspeed_m_s_;
   }
   if (::absl::bit_cast<::uint32_t>(from._internal_heading_deg()) != 0) {
     _this->_impl_.heading_deg_ = from._impl_.heading_deg_;
   }
-  if (::absl::bit_cast<::uint32_t>(from._internal_throttle_percentage()) != 0) {
-    _this->_impl_.throttle_percentage_ = from._impl_.throttle_percentage_;
-  }
   if (::absl::bit_cast<::uint32_t>(from._internal_altitude_msl()) != 0) {
     _this->_impl_.altitude_msl_ = from._impl_.altitude_msl_;
-  }
-  if (::absl::bit_cast<::uint32_t>(from._internal_climb_rate_m_s()) != 0) {
-    _this->_impl_.climb_rate_m_s_ = from._impl_.climb_rate_m_s_;
   }
   _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
 }
@@ -35532,8 +35532,8 @@ void FixedwingMetrics::InternalSwap(FixedwingMetrics* PROTOBUF_RESTRICT other) {
   using std::swap;
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
   ::google::protobuf::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.climb_rate_m_s_)
-      + sizeof(FixedwingMetrics::_impl_.climb_rate_m_s_)
+      PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.altitude_msl_)
+      + sizeof(FixedwingMetrics::_impl_.altitude_msl_)
       - PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.airspeed_m_s_)>(
           reinterpret_cast<char*>(&_impl_.airspeed_m_s_),
           reinterpret_cast<char*>(&other->_impl_.airspeed_m_s_));

--- a/src/mavsdk_server/src/generated/telemetry/telemetry.pb.cc
+++ b/src/mavsdk_server/src/generated/telemetry/telemetry.pb.cc
@@ -1882,7 +1882,7 @@ inline constexpr FixedwingMetrics::Impl_::Impl_(
         climb_rate_m_s_{0},
         groundspeed_m_s_{0},
         heading_deg_{0},
-        altitude_msl_{0},
+        absolute_altitude_m_{0},
         _cached_size_{0} {}
 
 template <typename>
@@ -4908,7 +4908,7 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::FixedwingMetrics, _impl_.climb_rate_m_s_),
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::FixedwingMetrics, _impl_.groundspeed_m_s_),
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::FixedwingMetrics, _impl_.heading_deg_),
-        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::FixedwingMetrics, _impl_.altitude_msl_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::FixedwingMetrics, _impl_.absolute_altitude_m_),
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::AccelerationFrd, _internal_metadata_),
         ~0u,  // no _extensions_
@@ -5557,244 +5557,244 @@ const char descriptor_table_protodef_telemetry_2ftelemetry_2eproto[] ABSL_ATTRIB
     "rpc.telemetry.VelocityNed\"r\n\013GroundTruth"
     "\022\035\n\014latitude_deg\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlongi"
     "tude_deg\030\002 \001(\001B\007\202\265\030\003NaN\022$\n\023absolute_alti"
-    "tude_m\030\003 \001(\002B\007\202\265\030\003NaN\"\327\001\n\020FixedwingMetri"
+    "tude_m\030\003 \001(\002B\007\202\265\030\003NaN\"\336\001\n\020FixedwingMetri"
     "cs\022\035\n\014airspeed_m_s\030\001 \001(\002B\007\202\265\030\003NaN\022$\n\023thr"
     "ottle_percentage\030\002 \001(\002B\007\202\265\030\003NaN\022\037\n\016climb"
     "_rate_m_s\030\003 \001(\002B\007\202\265\030\003NaN\022 \n\017groundspeed_"
     "m_s\030\004 \001(\002B\007\202\265\030\003NaN\022\034\n\013heading_deg\030\005 \001(\002B"
-    "\007\202\265\030\003NaN\022\035\n\014altitude_msl\030\006 \001(\002B\007\202\265\030\003NaN\""
-    "i\n\017AccelerationFrd\022\035\n\014forward_m_s2\030\001 \001(\002"
-    "B\007\202\265\030\003NaN\022\033\n\nright_m_s2\030\002 \001(\002B\007\202\265\030\003NaN\022\032"
-    "\n\tdown_m_s2\030\003 \001(\002B\007\202\265\030\003NaN\"o\n\022AngularVel"
-    "ocityFrd\022\036\n\rforward_rad_s\030\001 \001(\002B\007\202\265\030\003NaN"
-    "\022\034\n\013right_rad_s\030\002 \001(\002B\007\202\265\030\003NaN\022\033\n\ndown_r"
-    "ad_s\030\003 \001(\002B\007\202\265\030\003NaN\"m\n\020MagneticFieldFrd\022"
-    "\036\n\rforward_gauss\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right"
-    "_gauss\030\002 \001(\002B\007\202\265\030\003NaN\022\033\n\ndown_gauss\030\003 \001("
-    "\002B\007\202\265\030\003NaN\"\213\002\n\003Imu\022\?\n\020acceleration_frd\030\001"
-    " \001(\0132%.mavsdk.rpc.telemetry.Acceleration"
-    "Frd\022F\n\024angular_velocity_frd\030\002 \001(\0132(.mavs"
-    "dk.rpc.telemetry.AngularVelocityFrd\022B\n\022m"
-    "agnetic_field_frd\030\003 \001(\0132&.mavsdk.rpc.tel"
-    "emetry.MagneticFieldFrd\022!\n\020temperature_d"
-    "egc\030\004 \001(\002B\007\202\265\030\003NaN\022\024\n\014timestamp_us\030\005 \001(\004"
-    "\"m\n\017GpsGlobalOrigin\022\035\n\014latitude_deg\030\001 \001("
-    "\001B\007\202\265\030\003NaN\022\036\n\rlongitude_deg\030\002 \001(\001B\007\202\265\030\003N"
-    "aN\022\033\n\naltitude_m\030\003 \001(\002B\007\202\265\030\003NaN\"\346\001\n\010Alti"
-    "tude\022%\n\024altitude_monotonic_m\030\001 \001(\002B\007\202\265\030\003"
-    "NaN\022 \n\017altitude_amsl_m\030\002 \001(\002B\007\202\265\030\003NaN\022!\n"
-    "\020altitude_local_m\030\003 \001(\002B\007\202\265\030\003NaN\022$\n\023alti"
-    "tude_relative_m\030\004 \001(\002B\007\202\265\030\003NaN\022#\n\022altitu"
-    "de_terrain_m\030\005 \001(\002B\007\202\265\030\003NaN\022#\n\022bottom_cl"
-    "earance_m\030\006 \001(\002B\007\202\265\030\003NaN\"\241\002\n\017TelemetryRe"
-    "sult\022<\n\006result\030\001 \001(\0162,.mavsdk.rpc.teleme"
-    "try.TelemetryResult.Result\022\022\n\nresult_str"
-    "\030\002 \001(\t\"\273\001\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n"
-    "\016RESULT_SUCCESS\020\001\022\024\n\020RESULT_NO_SYSTEM\020\002\022"
-    "\033\n\027RESULT_CONNECTION_ERROR\020\003\022\017\n\013RESULT_B"
-    "USY\020\004\022\031\n\025RESULT_COMMAND_DENIED\020\005\022\022\n\016RESU"
-    "LT_TIMEOUT\020\006\022\026\n\022RESULT_UNSUPPORTED\020\007*\244\001\n"
-    "\007FixType\022\023\n\017FIX_TYPE_NO_GPS\020\000\022\023\n\017FIX_TYP"
-    "E_NO_FIX\020\001\022\023\n\017FIX_TYPE_FIX_2D\020\002\022\023\n\017FIX_T"
-    "YPE_FIX_3D\020\003\022\025\n\021FIX_TYPE_FIX_DGPS\020\004\022\026\n\022F"
-    "IX_TYPE_RTK_FLOAT\020\005\022\026\n\022FIX_TYPE_RTK_FIXE"
-    "D\020\006*\206\003\n\nFlightMode\022\027\n\023FLIGHT_MODE_UNKNOW"
-    "N\020\000\022\025\n\021FLIGHT_MODE_READY\020\001\022\027\n\023FLIGHT_MOD"
-    "E_TAKEOFF\020\002\022\024\n\020FLIGHT_MODE_HOLD\020\003\022\027\n\023FLI"
-    "GHT_MODE_MISSION\020\004\022 \n\034FLIGHT_MODE_RETURN"
-    "_TO_LAUNCH\020\005\022\024\n\020FLIGHT_MODE_LAND\020\006\022\030\n\024FL"
-    "IGHT_MODE_OFFBOARD\020\007\022\031\n\025FLIGHT_MODE_FOLL"
-    "OW_ME\020\010\022\026\n\022FLIGHT_MODE_MANUAL\020\t\022\026\n\022FLIGH"
-    "T_MODE_ALTCTL\020\n\022\026\n\022FLIGHT_MODE_POSCTL\020\013\022"
-    "\024\n\020FLIGHT_MODE_ACRO\020\014\022\032\n\026FLIGHT_MODE_STA"
-    "BILIZED\020\r\022\031\n\025FLIGHT_MODE_RATTITUDE\020\016*\371\001\n"
-    "\016StatusTextType\022\032\n\026STATUS_TEXT_TYPE_DEBU"
-    "G\020\000\022\031\n\025STATUS_TEXT_TYPE_INFO\020\001\022\033\n\027STATUS"
-    "_TEXT_TYPE_NOTICE\020\002\022\034\n\030STATUS_TEXT_TYPE_"
-    "WARNING\020\003\022\032\n\026STATUS_TEXT_TYPE_ERROR\020\004\022\035\n"
-    "\031STATUS_TEXT_TYPE_CRITICAL\020\005\022\032\n\026STATUS_T"
-    "EXT_TYPE_ALERT\020\006\022\036\n\032STATUS_TEXT_TYPE_EME"
-    "RGENCY\020\007*\223\001\n\013LandedState\022\030\n\024LANDED_STATE"
-    "_UNKNOWN\020\000\022\032\n\026LANDED_STATE_ON_GROUND\020\001\022\027"
-    "\n\023LANDED_STATE_IN_AIR\020\002\022\033\n\027LANDED_STATE_"
-    "TAKING_OFF\020\003\022\030\n\024LANDED_STATE_LANDING\020\004*\215"
-    "\001\n\tVtolState\022\030\n\024VTOL_STATE_UNDEFINED\020\000\022\037"
-    "\n\033VTOL_STATE_TRANSITION_TO_FW\020\001\022\037\n\033VTOL_"
-    "STATE_TRANSITION_TO_MC\020\002\022\021\n\rVTOL_STATE_M"
-    "C\020\003\022\021\n\rVTOL_STATE_FW\020\0042\3075\n\020TelemetryServ"
-    "ice\022o\n\021SubscribePosition\022..mavsdk.rpc.te"
-    "lemetry.SubscribePositionRequest\032&.mavsd"
-    "k.rpc.telemetry.PositionResponse\"\0000\001\022c\n\r"
-    "SubscribeHome\022*.mavsdk.rpc.telemetry.Sub"
-    "scribeHomeRequest\032\".mavsdk.rpc.telemetry"
-    ".HomeResponse\"\0000\001\022f\n\016SubscribeInAir\022+.ma"
-    "vsdk.rpc.telemetry.SubscribeInAirRequest"
-    "\032#.mavsdk.rpc.telemetry.InAirResponse\"\0000"
-    "\001\022x\n\024SubscribeLandedState\0221.mavsdk.rpc.t"
-    "elemetry.SubscribeLandedStateRequest\032).m"
-    "avsdk.rpc.telemetry.LandedStateResponse\""
-    "\0000\001\022f\n\016SubscribeArmed\022+.mavsdk.rpc.telem"
-    "etry.SubscribeArmedRequest\032#.mavsdk.rpc."
-    "telemetry.ArmedResponse\"\0000\001\022r\n\022Subscribe"
-    "VtolState\022/.mavsdk.rpc.telemetry.Subscri"
-    "beVtolStateRequest\032\'.mavsdk.rpc.telemetr"
-    "y.VtolStateResponse\"\0000\001\022\215\001\n\033SubscribeAtt"
-    "itudeQuaternion\0228.mavsdk.rpc.telemetry.S"
-    "ubscribeAttitudeQuaternionRequest\0320.mavs"
-    "dk.rpc.telemetry.AttitudeQuaternionRespo"
-    "nse\"\0000\001\022~\n\026SubscribeAttitudeEuler\0223.mavs"
-    "dk.rpc.telemetry.SubscribeAttitudeEulerR"
-    "equest\032+.mavsdk.rpc.telemetry.AttitudeEu"
-    "lerResponse\"\0000\001\022\250\001\n$SubscribeAttitudeAng"
-    "ularVelocityBody\022A.mavsdk.rpc.telemetry."
-    "SubscribeAttitudeAngularVelocityBodyRequ"
-    "est\0329.mavsdk.rpc.telemetry.AttitudeAngul"
-    "arVelocityBodyResponse\"\0000\001\022x\n\024SubscribeV"
-    "elocityNed\0221.mavsdk.rpc.telemetry.Subscr"
-    "ibeVelocityNedRequest\032).mavsdk.rpc.telem"
-    "etry.VelocityNedResponse\"\0000\001\022l\n\020Subscrib"
-    "eGpsInfo\022-.mavsdk.rpc.telemetry.Subscrib"
-    "eGpsInfoRequest\032%.mavsdk.rpc.telemetry.G"
-    "psInfoResponse\"\0000\001\022i\n\017SubscribeRawGps\022,."
-    "mavsdk.rpc.telemetry.SubscribeRawGpsRequ"
-    "est\032$.mavsdk.rpc.telemetry.RawGpsRespons"
-    "e\"\0000\001\022l\n\020SubscribeBattery\022-.mavsdk.rpc.t"
-    "elemetry.SubscribeBatteryRequest\032%.mavsd"
-    "k.rpc.telemetry.BatteryResponse\"\0000\001\022u\n\023S"
-    "ubscribeFlightMode\0220.mavsdk.rpc.telemetr"
-    "y.SubscribeFlightModeRequest\032(.mavsdk.rp"
-    "c.telemetry.FlightModeResponse\"\0000\001\022i\n\017Su"
-    "bscribeHealth\022,.mavsdk.rpc.telemetry.Sub"
-    "scribeHealthRequest\032$.mavsdk.rpc.telemet"
-    "ry.HealthResponse\"\0000\001\022o\n\021SubscribeRcStat"
-    "us\022..mavsdk.rpc.telemetry.SubscribeRcSta"
-    "tusRequest\032&.mavsdk.rpc.telemetry.RcStat"
-    "usResponse\"\0000\001\022u\n\023SubscribeStatusText\0220."
-    "mavsdk.rpc.telemetry.SubscribeStatusText"
-    "Request\032(.mavsdk.rpc.telemetry.StatusTex"
-    "tResponse\"\0000\001\022\226\001\n\036SubscribeActuatorContr"
-    "olTarget\022;.mavsdk.rpc.telemetry.Subscrib"
-    "eActuatorControlTargetRequest\0323.mavsdk.r"
-    "pc.telemetry.ActuatorControlTargetRespon"
-    "se\"\0000\001\022\223\001\n\035SubscribeActuatorOutputStatus"
-    "\022:.mavsdk.rpc.telemetry.SubscribeActuato"
-    "rOutputStatusRequest\0322.mavsdk.rpc.teleme"
-    "try.ActuatorOutputStatusResponse\"\0000\001\022o\n\021"
-    "SubscribeOdometry\022..mavsdk.rpc.telemetry"
-    ".SubscribeOdometryRequest\032&.mavsdk.rpc.t"
-    "elemetry.OdometryResponse\"\0000\001\022\220\001\n\034Subscr"
-    "ibePositionVelocityNed\0229.mavsdk.rpc.tele"
-    "metry.SubscribePositionVelocityNedReques"
-    "t\0321.mavsdk.rpc.telemetry.PositionVelocit"
-    "yNedResponse\"\0000\001\022x\n\024SubscribeGroundTruth"
-    "\0221.mavsdk.rpc.telemetry.SubscribeGroundT"
-    "ruthRequest\032).mavsdk.rpc.telemetry.Groun"
-    "dTruthResponse\"\0000\001\022\207\001\n\031SubscribeFixedwin"
-    "gMetrics\0226.mavsdk.rpc.telemetry.Subscrib"
-    "eFixedwingMetricsRequest\032..mavsdk.rpc.te"
-    "lemetry.FixedwingMetricsResponse\"\0000\001\022`\n\014"
-    "SubscribeImu\022).mavsdk.rpc.telemetry.Subs"
-    "cribeImuRequest\032!.mavsdk.rpc.telemetry.I"
-    "muResponse\"\0000\001\022r\n\022SubscribeScaledImu\022/.m"
-    "avsdk.rpc.telemetry.SubscribeScaledImuRe"
-    "quest\032\'.mavsdk.rpc.telemetry.ScaledImuRe"
-    "sponse\"\0000\001\022i\n\017SubscribeRawImu\022,.mavsdk.r"
-    "pc.telemetry.SubscribeRawImuRequest\032$.ma"
-    "vsdk.rpc.telemetry.RawImuResponse\"\0000\001\022x\n"
-    "\024SubscribeHealthAllOk\0221.mavsdk.rpc.telem"
-    "etry.SubscribeHealthAllOkRequest\032).mavsd"
-    "k.rpc.telemetry.HealthAllOkResponse\"\0000\001\022"
-    "~\n\026SubscribeUnixEpochTime\0223.mavsdk.rpc.t"
-    "elemetry.SubscribeUnixEpochTimeRequest\032+"
-    ".mavsdk.rpc.telemetry.UnixEpochTimeRespo"
-    "nse\"\0000\001\022\201\001\n\027SubscribeDistanceSensor\0224.ma"
-    "vsdk.rpc.telemetry.SubscribeDistanceSens"
-    "orRequest\032,.mavsdk.rpc.telemetry.Distanc"
-    "eSensorResponse\"\0000\001\022\201\001\n\027SubscribeScaledP"
-    "ressure\0224.mavsdk.rpc.telemetry.Subscribe"
-    "ScaledPressureRequest\032,.mavsdk.rpc.telem"
-    "etry.ScaledPressureResponse\"\0000\001\022l\n\020Subsc"
-    "ribeHeading\022-.mavsdk.rpc.telemetry.Subsc"
-    "ribeHeadingRequest\032%.mavsdk.rpc.telemetr"
-    "y.HeadingResponse\"\0000\001\022o\n\021SubscribeAltitu"
-    "de\022..mavsdk.rpc.telemetry.SubscribeAltit"
-    "udeRequest\032&.mavsdk.rpc.telemetry.Altitu"
-    "deResponse\"\0000\001\022p\n\017SetRatePosition\022,.mavs"
-    "dk.rpc.telemetry.SetRatePositionRequest\032"
-    "-.mavsdk.rpc.telemetry.SetRatePositionRe"
-    "sponse\"\000\022d\n\013SetRateHome\022(.mavsdk.rpc.tel"
-    "emetry.SetRateHomeRequest\032).mavsdk.rpc.t"
-    "elemetry.SetRateHomeResponse\"\000\022g\n\014SetRat"
-    "eInAir\022).mavsdk.rpc.telemetry.SetRateInA"
-    "irRequest\032*.mavsdk.rpc.telemetry.SetRate"
-    "InAirResponse\"\000\022y\n\022SetRateLandedState\022/."
-    "mavsdk.rpc.telemetry.SetRateLandedStateR"
-    "equest\0320.mavsdk.rpc.telemetry.SetRateLan"
-    "dedStateResponse\"\000\022s\n\020SetRateVtolState\022-"
-    ".mavsdk.rpc.telemetry.SetRateVtolStateRe"
-    "quest\032..mavsdk.rpc.telemetry.SetRateVtol"
-    "StateResponse\"\000\022\216\001\n\031SetRateAttitudeQuate"
-    "rnion\0226.mavsdk.rpc.telemetry.SetRateAtti"
-    "tudeQuaternionRequest\0327.mavsdk.rpc.telem"
-    "etry.SetRateAttitudeQuaternionResponse\"\000"
-    "\022\177\n\024SetRateAttitudeEuler\0221.mavsdk.rpc.te"
-    "lemetry.SetRateAttitudeEulerRequest\0322.ma"
-    "vsdk.rpc.telemetry.SetRateAttitudeEulerR"
-    "esponse\"\000\022y\n\022SetRateVelocityNed\022/.mavsdk"
-    ".rpc.telemetry.SetRateVelocityNedRequest"
-    "\0320.mavsdk.rpc.telemetry.SetRateVelocityN"
-    "edResponse\"\000\022m\n\016SetRateGpsInfo\022+.mavsdk."
-    "rpc.telemetry.SetRateGpsInfoRequest\032,.ma"
-    "vsdk.rpc.telemetry.SetRateGpsInfoRespons"
-    "e\"\000\022m\n\016SetRateBattery\022+.mavsdk.rpc.telem"
-    "etry.SetRateBatteryRequest\032,.mavsdk.rpc."
-    "telemetry.SetRateBatteryResponse\"\000\022p\n\017Se"
-    "tRateRcStatus\022,.mavsdk.rpc.telemetry.Set"
-    "RateRcStatusRequest\032-.mavsdk.rpc.telemet"
-    "ry.SetRateRcStatusResponse\"\000\022\227\001\n\034SetRate"
-    "ActuatorControlTarget\0229.mavsdk.rpc.telem"
-    "etry.SetRateActuatorControlTargetRequest"
-    "\032:.mavsdk.rpc.telemetry.SetRateActuatorC"
-    "ontrolTargetResponse\"\000\022\224\001\n\033SetRateActuat"
-    "orOutputStatus\0228.mavsdk.rpc.telemetry.Se"
-    "tRateActuatorOutputStatusRequest\0329.mavsd"
-    "k.rpc.telemetry.SetRateActuatorOutputSta"
-    "tusResponse\"\000\022p\n\017SetRateOdometry\022,.mavsd"
-    "k.rpc.telemetry.SetRateOdometryRequest\032-"
-    ".mavsdk.rpc.telemetry.SetRateOdometryRes"
-    "ponse\"\000\022\221\001\n\032SetRatePositionVelocityNed\0227"
-    ".mavsdk.rpc.telemetry.SetRatePositionVel"
-    "ocityNedRequest\0328.mavsdk.rpc.telemetry.S"
-    "etRatePositionVelocityNedResponse\"\000\022y\n\022S"
-    "etRateGroundTruth\022/.mavsdk.rpc.telemetry"
-    ".SetRateGroundTruthRequest\0320.mavsdk.rpc."
-    "telemetry.SetRateGroundTruthResponse\"\000\022\210"
-    "\001\n\027SetRateFixedwingMetrics\0224.mavsdk.rpc."
-    "telemetry.SetRateFixedwingMetricsRequest"
-    "\0325.mavsdk.rpc.telemetry.SetRateFixedwing"
-    "MetricsResponse\"\000\022a\n\nSetRateImu\022\'.mavsdk"
-    ".rpc.telemetry.SetRateImuRequest\032(.mavsd"
-    "k.rpc.telemetry.SetRateImuResponse\"\000\022s\n\020"
-    "SetRateScaledImu\022-.mavsdk.rpc.telemetry."
-    "SetRateScaledImuRequest\032..mavsdk.rpc.tel"
-    "emetry.SetRateScaledImuResponse\"\000\022j\n\rSet"
-    "RateRawImu\022*.mavsdk.rpc.telemetry.SetRat"
-    "eRawImuRequest\032+.mavsdk.rpc.telemetry.Se"
-    "tRateRawImuResponse\"\000\022\177\n\024SetRateUnixEpoc"
-    "hTime\0221.mavsdk.rpc.telemetry.SetRateUnix"
-    "EpochTimeRequest\0322.mavsdk.rpc.telemetry."
-    "SetRateUnixEpochTimeResponse\"\000\022\202\001\n\025SetRa"
-    "teDistanceSensor\0222.mavsdk.rpc.telemetry."
-    "SetRateDistanceSensorRequest\0323.mavsdk.rp"
-    "c.telemetry.SetRateDistanceSensorRespons"
-    "e\"\000\022p\n\017SetRateAltitude\022,.mavsdk.rpc.tele"
-    "metry.SetRateAltitudeRequest\032-.mavsdk.rp"
-    "c.telemetry.SetRateAltitudeResponse\"\000\022y\n"
-    "\022GetGpsGlobalOrigin\022/.mavsdk.rpc.telemet"
-    "ry.GetGpsGlobalOriginRequest\0320.mavsdk.rp"
-    "c.telemetry.GetGpsGlobalOriginResponse\"\000"
-    "B%\n\023io.mavsdk.telemetryB\016TelemetryProtob"
-    "\006proto3"
+    "\007\202\265\030\003NaN\022$\n\023absolute_altitude_m\030\006 \001(\002B\007\202"
+    "\265\030\003NaN\"i\n\017AccelerationFrd\022\035\n\014forward_m_s"
+    "2\030\001 \001(\002B\007\202\265\030\003NaN\022\033\n\nright_m_s2\030\002 \001(\002B\007\202\265"
+    "\030\003NaN\022\032\n\tdown_m_s2\030\003 \001(\002B\007\202\265\030\003NaN\"o\n\022Ang"
+    "ularVelocityFrd\022\036\n\rforward_rad_s\030\001 \001(\002B\007"
+    "\202\265\030\003NaN\022\034\n\013right_rad_s\030\002 \001(\002B\007\202\265\030\003NaN\022\033\n"
+    "\ndown_rad_s\030\003 \001(\002B\007\202\265\030\003NaN\"m\n\020MagneticFi"
+    "eldFrd\022\036\n\rforward_gauss\030\001 \001(\002B\007\202\265\030\003NaN\022\034"
+    "\n\013right_gauss\030\002 \001(\002B\007\202\265\030\003NaN\022\033\n\ndown_gau"
+    "ss\030\003 \001(\002B\007\202\265\030\003NaN\"\213\002\n\003Imu\022\?\n\020acceleratio"
+    "n_frd\030\001 \001(\0132%.mavsdk.rpc.telemetry.Accel"
+    "erationFrd\022F\n\024angular_velocity_frd\030\002 \001(\013"
+    "2(.mavsdk.rpc.telemetry.AngularVelocityF"
+    "rd\022B\n\022magnetic_field_frd\030\003 \001(\0132&.mavsdk."
+    "rpc.telemetry.MagneticFieldFrd\022!\n\020temper"
+    "ature_degc\030\004 \001(\002B\007\202\265\030\003NaN\022\024\n\014timestamp_u"
+    "s\030\005 \001(\004\"m\n\017GpsGlobalOrigin\022\035\n\014latitude_d"
+    "eg\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlongitude_deg\030\002 \001(\001"
+    "B\007\202\265\030\003NaN\022\033\n\naltitude_m\030\003 \001(\002B\007\202\265\030\003NaN\"\346"
+    "\001\n\010Altitude\022%\n\024altitude_monotonic_m\030\001 \001("
+    "\002B\007\202\265\030\003NaN\022 \n\017altitude_amsl_m\030\002 \001(\002B\007\202\265\030"
+    "\003NaN\022!\n\020altitude_local_m\030\003 \001(\002B\007\202\265\030\003NaN\022"
+    "$\n\023altitude_relative_m\030\004 \001(\002B\007\202\265\030\003NaN\022#\n"
+    "\022altitude_terrain_m\030\005 \001(\002B\007\202\265\030\003NaN\022#\n\022bo"
+    "ttom_clearance_m\030\006 \001(\002B\007\202\265\030\003NaN\"\241\002\n\017Tele"
+    "metryResult\022<\n\006result\030\001 \001(\0162,.mavsdk.rpc"
+    ".telemetry.TelemetryResult.Result\022\022\n\nres"
+    "ult_str\030\002 \001(\t\"\273\001\n\006Result\022\022\n\016RESULT_UNKNO"
+    "WN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\024\n\020RESULT_NO_SY"
+    "STEM\020\002\022\033\n\027RESULT_CONNECTION_ERROR\020\003\022\017\n\013R"
+    "ESULT_BUSY\020\004\022\031\n\025RESULT_COMMAND_DENIED\020\005\022"
+    "\022\n\016RESULT_TIMEOUT\020\006\022\026\n\022RESULT_UNSUPPORTE"
+    "D\020\007*\244\001\n\007FixType\022\023\n\017FIX_TYPE_NO_GPS\020\000\022\023\n\017"
+    "FIX_TYPE_NO_FIX\020\001\022\023\n\017FIX_TYPE_FIX_2D\020\002\022\023"
+    "\n\017FIX_TYPE_FIX_3D\020\003\022\025\n\021FIX_TYPE_FIX_DGPS"
+    "\020\004\022\026\n\022FIX_TYPE_RTK_FLOAT\020\005\022\026\n\022FIX_TYPE_R"
+    "TK_FIXED\020\006*\206\003\n\nFlightMode\022\027\n\023FLIGHT_MODE"
+    "_UNKNOWN\020\000\022\025\n\021FLIGHT_MODE_READY\020\001\022\027\n\023FLI"
+    "GHT_MODE_TAKEOFF\020\002\022\024\n\020FLIGHT_MODE_HOLD\020\003"
+    "\022\027\n\023FLIGHT_MODE_MISSION\020\004\022 \n\034FLIGHT_MODE"
+    "_RETURN_TO_LAUNCH\020\005\022\024\n\020FLIGHT_MODE_LAND\020"
+    "\006\022\030\n\024FLIGHT_MODE_OFFBOARD\020\007\022\031\n\025FLIGHT_MO"
+    "DE_FOLLOW_ME\020\010\022\026\n\022FLIGHT_MODE_MANUAL\020\t\022\026"
+    "\n\022FLIGHT_MODE_ALTCTL\020\n\022\026\n\022FLIGHT_MODE_PO"
+    "SCTL\020\013\022\024\n\020FLIGHT_MODE_ACRO\020\014\022\032\n\026FLIGHT_M"
+    "ODE_STABILIZED\020\r\022\031\n\025FLIGHT_MODE_RATTITUD"
+    "E\020\016*\371\001\n\016StatusTextType\022\032\n\026STATUS_TEXT_TY"
+    "PE_DEBUG\020\000\022\031\n\025STATUS_TEXT_TYPE_INFO\020\001\022\033\n"
+    "\027STATUS_TEXT_TYPE_NOTICE\020\002\022\034\n\030STATUS_TEX"
+    "T_TYPE_WARNING\020\003\022\032\n\026STATUS_TEXT_TYPE_ERR"
+    "OR\020\004\022\035\n\031STATUS_TEXT_TYPE_CRITICAL\020\005\022\032\n\026S"
+    "TATUS_TEXT_TYPE_ALERT\020\006\022\036\n\032STATUS_TEXT_T"
+    "YPE_EMERGENCY\020\007*\223\001\n\013LandedState\022\030\n\024LANDE"
+    "D_STATE_UNKNOWN\020\000\022\032\n\026LANDED_STATE_ON_GRO"
+    "UND\020\001\022\027\n\023LANDED_STATE_IN_AIR\020\002\022\033\n\027LANDED"
+    "_STATE_TAKING_OFF\020\003\022\030\n\024LANDED_STATE_LAND"
+    "ING\020\004*\215\001\n\tVtolState\022\030\n\024VTOL_STATE_UNDEFI"
+    "NED\020\000\022\037\n\033VTOL_STATE_TRANSITION_TO_FW\020\001\022\037"
+    "\n\033VTOL_STATE_TRANSITION_TO_MC\020\002\022\021\n\rVTOL_"
+    "STATE_MC\020\003\022\021\n\rVTOL_STATE_FW\020\0042\3075\n\020Teleme"
+    "tryService\022o\n\021SubscribePosition\022..mavsdk"
+    ".rpc.telemetry.SubscribePositionRequest\032"
+    "&.mavsdk.rpc.telemetry.PositionResponse\""
+    "\0000\001\022c\n\rSubscribeHome\022*.mavsdk.rpc.teleme"
+    "try.SubscribeHomeRequest\032\".mavsdk.rpc.te"
+    "lemetry.HomeResponse\"\0000\001\022f\n\016SubscribeInA"
+    "ir\022+.mavsdk.rpc.telemetry.SubscribeInAir"
+    "Request\032#.mavsdk.rpc.telemetry.InAirResp"
+    "onse\"\0000\001\022x\n\024SubscribeLandedState\0221.mavsd"
+    "k.rpc.telemetry.SubscribeLandedStateRequ"
+    "est\032).mavsdk.rpc.telemetry.LandedStateRe"
+    "sponse\"\0000\001\022f\n\016SubscribeArmed\022+.mavsdk.rp"
+    "c.telemetry.SubscribeArmedRequest\032#.mavs"
+    "dk.rpc.telemetry.ArmedResponse\"\0000\001\022r\n\022Su"
+    "bscribeVtolState\022/.mavsdk.rpc.telemetry."
+    "SubscribeVtolStateRequest\032\'.mavsdk.rpc.t"
+    "elemetry.VtolStateResponse\"\0000\001\022\215\001\n\033Subsc"
+    "ribeAttitudeQuaternion\0228.mavsdk.rpc.tele"
+    "metry.SubscribeAttitudeQuaternionRequest"
+    "\0320.mavsdk.rpc.telemetry.AttitudeQuaterni"
+    "onResponse\"\0000\001\022~\n\026SubscribeAttitudeEuler"
+    "\0223.mavsdk.rpc.telemetry.SubscribeAttitud"
+    "eEulerRequest\032+.mavsdk.rpc.telemetry.Att"
+    "itudeEulerResponse\"\0000\001\022\250\001\n$SubscribeAtti"
+    "tudeAngularVelocityBody\022A.mavsdk.rpc.tel"
+    "emetry.SubscribeAttitudeAngularVelocityB"
+    "odyRequest\0329.mavsdk.rpc.telemetry.Attitu"
+    "deAngularVelocityBodyResponse\"\0000\001\022x\n\024Sub"
+    "scribeVelocityNed\0221.mavsdk.rpc.telemetry"
+    ".SubscribeVelocityNedRequest\032).mavsdk.rp"
+    "c.telemetry.VelocityNedResponse\"\0000\001\022l\n\020S"
+    "ubscribeGpsInfo\022-.mavsdk.rpc.telemetry.S"
+    "ubscribeGpsInfoRequest\032%.mavsdk.rpc.tele"
+    "metry.GpsInfoResponse\"\0000\001\022i\n\017SubscribeRa"
+    "wGps\022,.mavsdk.rpc.telemetry.SubscribeRaw"
+    "GpsRequest\032$.mavsdk.rpc.telemetry.RawGps"
+    "Response\"\0000\001\022l\n\020SubscribeBattery\022-.mavsd"
+    "k.rpc.telemetry.SubscribeBatteryRequest\032"
+    "%.mavsdk.rpc.telemetry.BatteryResponse\"\000"
+    "0\001\022u\n\023SubscribeFlightMode\0220.mavsdk.rpc.t"
+    "elemetry.SubscribeFlightModeRequest\032(.ma"
+    "vsdk.rpc.telemetry.FlightModeResponse\"\0000"
+    "\001\022i\n\017SubscribeHealth\022,.mavsdk.rpc.teleme"
+    "try.SubscribeHealthRequest\032$.mavsdk.rpc."
+    "telemetry.HealthResponse\"\0000\001\022o\n\021Subscrib"
+    "eRcStatus\022..mavsdk.rpc.telemetry.Subscri"
+    "beRcStatusRequest\032&.mavsdk.rpc.telemetry"
+    ".RcStatusResponse\"\0000\001\022u\n\023SubscribeStatus"
+    "Text\0220.mavsdk.rpc.telemetry.SubscribeSta"
+    "tusTextRequest\032(.mavsdk.rpc.telemetry.St"
+    "atusTextResponse\"\0000\001\022\226\001\n\036SubscribeActuat"
+    "orControlTarget\022;.mavsdk.rpc.telemetry.S"
+    "ubscribeActuatorControlTargetRequest\0323.m"
+    "avsdk.rpc.telemetry.ActuatorControlTarge"
+    "tResponse\"\0000\001\022\223\001\n\035SubscribeActuatorOutpu"
+    "tStatus\022:.mavsdk.rpc.telemetry.Subscribe"
+    "ActuatorOutputStatusRequest\0322.mavsdk.rpc"
+    ".telemetry.ActuatorOutputStatusResponse\""
+    "\0000\001\022o\n\021SubscribeOdometry\022..mavsdk.rpc.te"
+    "lemetry.SubscribeOdometryRequest\032&.mavsd"
+    "k.rpc.telemetry.OdometryResponse\"\0000\001\022\220\001\n"
+    "\034SubscribePositionVelocityNed\0229.mavsdk.r"
+    "pc.telemetry.SubscribePositionVelocityNe"
+    "dRequest\0321.mavsdk.rpc.telemetry.Position"
+    "VelocityNedResponse\"\0000\001\022x\n\024SubscribeGrou"
+    "ndTruth\0221.mavsdk.rpc.telemetry.Subscribe"
+    "GroundTruthRequest\032).mavsdk.rpc.telemetr"
+    "y.GroundTruthResponse\"\0000\001\022\207\001\n\031SubscribeF"
+    "ixedwingMetrics\0226.mavsdk.rpc.telemetry.S"
+    "ubscribeFixedwingMetricsRequest\032..mavsdk"
+    ".rpc.telemetry.FixedwingMetricsResponse\""
+    "\0000\001\022`\n\014SubscribeImu\022).mavsdk.rpc.telemet"
+    "ry.SubscribeImuRequest\032!.mavsdk.rpc.tele"
+    "metry.ImuResponse\"\0000\001\022r\n\022SubscribeScaled"
+    "Imu\022/.mavsdk.rpc.telemetry.SubscribeScal"
+    "edImuRequest\032\'.mavsdk.rpc.telemetry.Scal"
+    "edImuResponse\"\0000\001\022i\n\017SubscribeRawImu\022,.m"
+    "avsdk.rpc.telemetry.SubscribeRawImuReque"
+    "st\032$.mavsdk.rpc.telemetry.RawImuResponse"
+    "\"\0000\001\022x\n\024SubscribeHealthAllOk\0221.mavsdk.rp"
+    "c.telemetry.SubscribeHealthAllOkRequest\032"
+    ").mavsdk.rpc.telemetry.HealthAllOkRespon"
+    "se\"\0000\001\022~\n\026SubscribeUnixEpochTime\0223.mavsd"
+    "k.rpc.telemetry.SubscribeUnixEpochTimeRe"
+    "quest\032+.mavsdk.rpc.telemetry.UnixEpochTi"
+    "meResponse\"\0000\001\022\201\001\n\027SubscribeDistanceSens"
+    "or\0224.mavsdk.rpc.telemetry.SubscribeDista"
+    "nceSensorRequest\032,.mavsdk.rpc.telemetry."
+    "DistanceSensorResponse\"\0000\001\022\201\001\n\027Subscribe"
+    "ScaledPressure\0224.mavsdk.rpc.telemetry.Su"
+    "bscribeScaledPressureRequest\032,.mavsdk.rp"
+    "c.telemetry.ScaledPressureResponse\"\0000\001\022l"
+    "\n\020SubscribeHeading\022-.mavsdk.rpc.telemetr"
+    "y.SubscribeHeadingRequest\032%.mavsdk.rpc.t"
+    "elemetry.HeadingResponse\"\0000\001\022o\n\021Subscrib"
+    "eAltitude\022..mavsdk.rpc.telemetry.Subscri"
+    "beAltitudeRequest\032&.mavsdk.rpc.telemetry"
+    ".AltitudeResponse\"\0000\001\022p\n\017SetRatePosition"
+    "\022,.mavsdk.rpc.telemetry.SetRatePositionR"
+    "equest\032-.mavsdk.rpc.telemetry.SetRatePos"
+    "itionResponse\"\000\022d\n\013SetRateHome\022(.mavsdk."
+    "rpc.telemetry.SetRateHomeRequest\032).mavsd"
+    "k.rpc.telemetry.SetRateHomeResponse\"\000\022g\n"
+    "\014SetRateInAir\022).mavsdk.rpc.telemetry.Set"
+    "RateInAirRequest\032*.mavsdk.rpc.telemetry."
+    "SetRateInAirResponse\"\000\022y\n\022SetRateLandedS"
+    "tate\022/.mavsdk.rpc.telemetry.SetRateLande"
+    "dStateRequest\0320.mavsdk.rpc.telemetry.Set"
+    "RateLandedStateResponse\"\000\022s\n\020SetRateVtol"
+    "State\022-.mavsdk.rpc.telemetry.SetRateVtol"
+    "StateRequest\032..mavsdk.rpc.telemetry.SetR"
+    "ateVtolStateResponse\"\000\022\216\001\n\031SetRateAttitu"
+    "deQuaternion\0226.mavsdk.rpc.telemetry.SetR"
+    "ateAttitudeQuaternionRequest\0327.mavsdk.rp"
+    "c.telemetry.SetRateAttitudeQuaternionRes"
+    "ponse\"\000\022\177\n\024SetRateAttitudeEuler\0221.mavsdk"
+    ".rpc.telemetry.SetRateAttitudeEulerReque"
+    "st\0322.mavsdk.rpc.telemetry.SetRateAttitud"
+    "eEulerResponse\"\000\022y\n\022SetRateVelocityNed\022/"
+    ".mavsdk.rpc.telemetry.SetRateVelocityNed"
+    "Request\0320.mavsdk.rpc.telemetry.SetRateVe"
+    "locityNedResponse\"\000\022m\n\016SetRateGpsInfo\022+."
+    "mavsdk.rpc.telemetry.SetRateGpsInfoReque"
+    "st\032,.mavsdk.rpc.telemetry.SetRateGpsInfo"
+    "Response\"\000\022m\n\016SetRateBattery\022+.mavsdk.rp"
+    "c.telemetry.SetRateBatteryRequest\032,.mavs"
+    "dk.rpc.telemetry.SetRateBatteryResponse\""
+    "\000\022p\n\017SetRateRcStatus\022,.mavsdk.rpc.teleme"
+    "try.SetRateRcStatusRequest\032-.mavsdk.rpc."
+    "telemetry.SetRateRcStatusResponse\"\000\022\227\001\n\034"
+    "SetRateActuatorControlTarget\0229.mavsdk.rp"
+    "c.telemetry.SetRateActuatorControlTarget"
+    "Request\032:.mavsdk.rpc.telemetry.SetRateAc"
+    "tuatorControlTargetResponse\"\000\022\224\001\n\033SetRat"
+    "eActuatorOutputStatus\0228.mavsdk.rpc.telem"
+    "etry.SetRateActuatorOutputStatusRequest\032"
+    "9.mavsdk.rpc.telemetry.SetRateActuatorOu"
+    "tputStatusResponse\"\000\022p\n\017SetRateOdometry\022"
+    ",.mavsdk.rpc.telemetry.SetRateOdometryRe"
+    "quest\032-.mavsdk.rpc.telemetry.SetRateOdom"
+    "etryResponse\"\000\022\221\001\n\032SetRatePositionVeloci"
+    "tyNed\0227.mavsdk.rpc.telemetry.SetRatePosi"
+    "tionVelocityNedRequest\0328.mavsdk.rpc.tele"
+    "metry.SetRatePositionVelocityNedResponse"
+    "\"\000\022y\n\022SetRateGroundTruth\022/.mavsdk.rpc.te"
+    "lemetry.SetRateGroundTruthRequest\0320.mavs"
+    "dk.rpc.telemetry.SetRateGroundTruthRespo"
+    "nse\"\000\022\210\001\n\027SetRateFixedwingMetrics\0224.mavs"
+    "dk.rpc.telemetry.SetRateFixedwingMetrics"
+    "Request\0325.mavsdk.rpc.telemetry.SetRateFi"
+    "xedwingMetricsResponse\"\000\022a\n\nSetRateImu\022\'"
+    ".mavsdk.rpc.telemetry.SetRateImuRequest\032"
+    "(.mavsdk.rpc.telemetry.SetRateImuRespons"
+    "e\"\000\022s\n\020SetRateScaledImu\022-.mavsdk.rpc.tel"
+    "emetry.SetRateScaledImuRequest\032..mavsdk."
+    "rpc.telemetry.SetRateScaledImuResponse\"\000"
+    "\022j\n\rSetRateRawImu\022*.mavsdk.rpc.telemetry"
+    ".SetRateRawImuRequest\032+.mavsdk.rpc.telem"
+    "etry.SetRateRawImuResponse\"\000\022\177\n\024SetRateU"
+    "nixEpochTime\0221.mavsdk.rpc.telemetry.SetR"
+    "ateUnixEpochTimeRequest\0322.mavsdk.rpc.tel"
+    "emetry.SetRateUnixEpochTimeResponse\"\000\022\202\001"
+    "\n\025SetRateDistanceSensor\0222.mavsdk.rpc.tel"
+    "emetry.SetRateDistanceSensorRequest\0323.ma"
+    "vsdk.rpc.telemetry.SetRateDistanceSensor"
+    "Response\"\000\022p\n\017SetRateAltitude\022,.mavsdk.r"
+    "pc.telemetry.SetRateAltitudeRequest\032-.ma"
+    "vsdk.rpc.telemetry.SetRateAltitudeRespon"
+    "se\"\000\022y\n\022GetGpsGlobalOrigin\022/.mavsdk.rpc."
+    "telemetry.GetGpsGlobalOriginRequest\0320.ma"
+    "vsdk.rpc.telemetry.GetGpsGlobalOriginRes"
+    "ponse\"\000B%\n\023io.mavsdk.telemetryB\016Telemetr"
+    "yProtob\006proto3"
 };
 static const ::_pbi::DescriptorTable* const descriptor_table_telemetry_2ftelemetry_2eproto_deps[1] =
     {
@@ -5804,7 +5804,7 @@ static ::absl::once_flag descriptor_table_telemetry_2ftelemetry_2eproto_once;
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_telemetry_2ftelemetry_2eproto = {
     false,
     false,
-    19927,
+    19934,
     descriptor_table_protodef_telemetry_2ftelemetry_2eproto,
     "telemetry/telemetry.proto",
     &descriptor_table_telemetry_2ftelemetry_2eproto_once,
@@ -35251,9 +35251,9 @@ inline void FixedwingMetrics::SharedCtor(::_pb::Arena* arena) {
   ::memset(reinterpret_cast<char *>(&_impl_) +
                offsetof(Impl_, airspeed_m_s_),
            0,
-           offsetof(Impl_, altitude_msl_) -
+           offsetof(Impl_, absolute_altitude_m_) -
                offsetof(Impl_, airspeed_m_s_) +
-               sizeof(Impl_::altitude_msl_));
+               sizeof(Impl_::absolute_altitude_m_));
 }
 FixedwingMetrics::~FixedwingMetrics() {
   // @@protoc_insertion_point(destructor:mavsdk.rpc.telemetry.FixedwingMetrics)
@@ -35336,9 +35336,9 @@ const ::_pbi::TcParseTable<3, 6, 0, 0, 2> FixedwingMetrics::_table_ = {
     // float heading_deg = 5 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
      {45, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.heading_deg_)}},
-    // float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
+    // float absolute_altitude_m = 6 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
-     {53, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.altitude_msl_)}},
+     {53, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.absolute_altitude_m_)}},
     {::_pbi::TcParser::MiniParse, {}},
   }}, {{
     65535, 65535
@@ -35358,8 +35358,8 @@ const ::_pbi::TcParseTable<3, 6, 0, 0, 2> FixedwingMetrics::_table_ = {
     // float heading_deg = 5 [(.mavsdk.options.default_value) = "NaN"];
     {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.heading_deg_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
-    // float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
-    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.altitude_msl_), 0, 0,
+    // float absolute_altitude_m = 6 [(.mavsdk.options.default_value) = "NaN"];
+    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.absolute_altitude_m_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
   }},
   // no aux_entries
@@ -35375,8 +35375,8 @@ PROTOBUF_NOINLINE void FixedwingMetrics::Clear() {
   (void) cached_has_bits;
 
   ::memset(&_impl_.airspeed_m_s_, 0, static_cast<::size_t>(
-      reinterpret_cast<char*>(&_impl_.altitude_msl_) -
-      reinterpret_cast<char*>(&_impl_.airspeed_m_s_)) + sizeof(_impl_.altitude_msl_));
+      reinterpret_cast<char*>(&_impl_.absolute_altitude_m_) -
+      reinterpret_cast<char*>(&_impl_.airspeed_m_s_)) + sizeof(_impl_.absolute_altitude_m_));
   _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
 }
 
@@ -35430,11 +35430,11 @@ PROTOBUF_NOINLINE void FixedwingMetrics::Clear() {
                 5, this_._internal_heading_deg(), target);
           }
 
-          // float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
-          if (::absl::bit_cast<::uint32_t>(this_._internal_altitude_msl()) != 0) {
+          // float absolute_altitude_m = 6 [(.mavsdk.options.default_value) = "NaN"];
+          if (::absl::bit_cast<::uint32_t>(this_._internal_absolute_altitude_m()) != 0) {
             target = stream->EnsureSpace(target);
             target = ::_pbi::WireFormatLite::WriteFloatToArray(
-                6, this_._internal_altitude_msl(), target);
+                6, this_._internal_absolute_altitude_m(), target);
           }
 
           if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
@@ -35482,8 +35482,8 @@ PROTOBUF_NOINLINE void FixedwingMetrics::Clear() {
             if (::absl::bit_cast<::uint32_t>(this_._internal_heading_deg()) != 0) {
               total_size += 5;
             }
-            // float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
-            if (::absl::bit_cast<::uint32_t>(this_._internal_altitude_msl()) != 0) {
+            // float absolute_altitude_m = 6 [(.mavsdk.options.default_value) = "NaN"];
+            if (::absl::bit_cast<::uint32_t>(this_._internal_absolute_altitude_m()) != 0) {
               total_size += 5;
             }
           }
@@ -35514,8 +35514,8 @@ void FixedwingMetrics::MergeImpl(::google::protobuf::MessageLite& to_msg, const 
   if (::absl::bit_cast<::uint32_t>(from._internal_heading_deg()) != 0) {
     _this->_impl_.heading_deg_ = from._impl_.heading_deg_;
   }
-  if (::absl::bit_cast<::uint32_t>(from._internal_altitude_msl()) != 0) {
-    _this->_impl_.altitude_msl_ = from._impl_.altitude_msl_;
+  if (::absl::bit_cast<::uint32_t>(from._internal_absolute_altitude_m()) != 0) {
+    _this->_impl_.absolute_altitude_m_ = from._impl_.absolute_altitude_m_;
   }
   _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
 }
@@ -35532,8 +35532,8 @@ void FixedwingMetrics::InternalSwap(FixedwingMetrics* PROTOBUF_RESTRICT other) {
   using std::swap;
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
   ::google::protobuf::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.altitude_msl_)
-      + sizeof(FixedwingMetrics::_impl_.altitude_msl_)
+      PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.absolute_altitude_m_)
+      + sizeof(FixedwingMetrics::_impl_.absolute_altitude_m_)
       - PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.airspeed_m_s_)>(
           reinterpret_cast<char*>(&_impl_.airspeed_m_s_),
           reinterpret_cast<char*>(&other->_impl_.airspeed_m_s_));

--- a/src/mavsdk_server/src/generated/telemetry/telemetry.pb.cc
+++ b/src/mavsdk_server/src/generated/telemetry/telemetry.pb.cc
@@ -1878,7 +1878,10 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
 inline constexpr FixedwingMetrics::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : airspeed_m_s_{0},
+        groundspeed_m_s_{0},
+        heading_deg_{0},
         throttle_percentage_{0},
+        altitude_msl_{0},
         climb_rate_m_s_{0},
         _cached_size_{0} {}
 
@@ -4901,7 +4904,10 @@ const ::uint32_t
         ~0u,  // no _split_
         ~0u,  // no sizeof(Split)
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::FixedwingMetrics, _impl_.airspeed_m_s_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::FixedwingMetrics, _impl_.groundspeed_m_s_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::FixedwingMetrics, _impl_.heading_deg_),
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::FixedwingMetrics, _impl_.throttle_percentage_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::FixedwingMetrics, _impl_.altitude_msl_),
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::FixedwingMetrics, _impl_.climb_rate_m_s_),
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::AccelerationFrd, _internal_metadata_),
@@ -5132,13 +5138,13 @@ static const ::_pbi::MigrationSchema
         {1321, 1331, -1, sizeof(::mavsdk::rpc::telemetry::PositionVelocityNed)},
         {1333, -1, -1, sizeof(::mavsdk::rpc::telemetry::GroundTruth)},
         {1344, -1, -1, sizeof(::mavsdk::rpc::telemetry::FixedwingMetrics)},
-        {1355, -1, -1, sizeof(::mavsdk::rpc::telemetry::AccelerationFrd)},
-        {1366, -1, -1, sizeof(::mavsdk::rpc::telemetry::AngularVelocityFrd)},
-        {1377, -1, -1, sizeof(::mavsdk::rpc::telemetry::MagneticFieldFrd)},
-        {1388, 1401, -1, sizeof(::mavsdk::rpc::telemetry::Imu)},
-        {1406, -1, -1, sizeof(::mavsdk::rpc::telemetry::GpsGlobalOrigin)},
-        {1417, -1, -1, sizeof(::mavsdk::rpc::telemetry::Altitude)},
-        {1431, -1, -1, sizeof(::mavsdk::rpc::telemetry::TelemetryResult)},
+        {1358, -1, -1, sizeof(::mavsdk::rpc::telemetry::AccelerationFrd)},
+        {1369, -1, -1, sizeof(::mavsdk::rpc::telemetry::AngularVelocityFrd)},
+        {1380, -1, -1, sizeof(::mavsdk::rpc::telemetry::MagneticFieldFrd)},
+        {1391, 1404, -1, sizeof(::mavsdk::rpc::telemetry::Imu)},
+        {1409, -1, -1, sizeof(::mavsdk::rpc::telemetry::GpsGlobalOrigin)},
+        {1420, -1, -1, sizeof(::mavsdk::rpc::telemetry::Altitude)},
+        {1434, -1, -1, sizeof(::mavsdk::rpc::telemetry::TelemetryResult)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::telemetry::_SubscribePositionRequest_default_instance_._instance,
@@ -5551,241 +5557,244 @@ const char descriptor_table_protodef_telemetry_2ftelemetry_2eproto[] ABSL_ATTRIB
     "rpc.telemetry.VelocityNed\"r\n\013GroundTruth"
     "\022\035\n\014latitude_deg\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlongi"
     "tude_deg\030\002 \001(\001B\007\202\265\030\003NaN\022$\n\023absolute_alti"
-    "tude_m\030\003 \001(\002B\007\202\265\030\003NaN\"x\n\020FixedwingMetric"
-    "s\022\035\n\014airspeed_m_s\030\001 \001(\002B\007\202\265\030\003NaN\022$\n\023thro"
-    "ttle_percentage\030\002 \001(\002B\007\202\265\030\003NaN\022\037\n\016climb_"
-    "rate_m_s\030\003 \001(\002B\007\202\265\030\003NaN\"i\n\017AccelerationF"
-    "rd\022\035\n\014forward_m_s2\030\001 \001(\002B\007\202\265\030\003NaN\022\033\n\nrig"
-    "ht_m_s2\030\002 \001(\002B\007\202\265\030\003NaN\022\032\n\tdown_m_s2\030\003 \001("
-    "\002B\007\202\265\030\003NaN\"o\n\022AngularVelocityFrd\022\036\n\rforw"
-    "ard_rad_s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right_rad_s\030"
-    "\002 \001(\002B\007\202\265\030\003NaN\022\033\n\ndown_rad_s\030\003 \001(\002B\007\202\265\030\003"
-    "NaN\"m\n\020MagneticFieldFrd\022\036\n\rforward_gauss"
-    "\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right_gauss\030\002 \001(\002B\007\202\265"
-    "\030\003NaN\022\033\n\ndown_gauss\030\003 \001(\002B\007\202\265\030\003NaN\"\213\002\n\003I"
-    "mu\022\?\n\020acceleration_frd\030\001 \001(\0132%.mavsdk.rp"
-    "c.telemetry.AccelerationFrd\022F\n\024angular_v"
-    "elocity_frd\030\002 \001(\0132(.mavsdk.rpc.telemetry"
-    ".AngularVelocityFrd\022B\n\022magnetic_field_fr"
-    "d\030\003 \001(\0132&.mavsdk.rpc.telemetry.MagneticF"
-    "ieldFrd\022!\n\020temperature_degc\030\004 \001(\002B\007\202\265\030\003N"
-    "aN\022\024\n\014timestamp_us\030\005 \001(\004\"m\n\017GpsGlobalOri"
-    "gin\022\035\n\014latitude_deg\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlo"
-    "ngitude_deg\030\002 \001(\001B\007\202\265\030\003NaN\022\033\n\naltitude_m"
-    "\030\003 \001(\002B\007\202\265\030\003NaN\"\346\001\n\010Altitude\022%\n\024altitude"
-    "_monotonic_m\030\001 \001(\002B\007\202\265\030\003NaN\022 \n\017altitude_"
-    "amsl_m\030\002 \001(\002B\007\202\265\030\003NaN\022!\n\020altitude_local_"
-    "m\030\003 \001(\002B\007\202\265\030\003NaN\022$\n\023altitude_relative_m\030"
-    "\004 \001(\002B\007\202\265\030\003NaN\022#\n\022altitude_terrain_m\030\005 \001"
-    "(\002B\007\202\265\030\003NaN\022#\n\022bottom_clearance_m\030\006 \001(\002B"
-    "\007\202\265\030\003NaN\"\241\002\n\017TelemetryResult\022<\n\006result\030\001"
-    " \001(\0162,.mavsdk.rpc.telemetry.TelemetryRes"
-    "ult.Result\022\022\n\nresult_str\030\002 \001(\t\"\273\001\n\006Resul"
-    "t\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCCESS\020"
-    "\001\022\024\n\020RESULT_NO_SYSTEM\020\002\022\033\n\027RESULT_CONNEC"
-    "TION_ERROR\020\003\022\017\n\013RESULT_BUSY\020\004\022\031\n\025RESULT_"
-    "COMMAND_DENIED\020\005\022\022\n\016RESULT_TIMEOUT\020\006\022\026\n\022"
-    "RESULT_UNSUPPORTED\020\007*\244\001\n\007FixType\022\023\n\017FIX_"
-    "TYPE_NO_GPS\020\000\022\023\n\017FIX_TYPE_NO_FIX\020\001\022\023\n\017FI"
-    "X_TYPE_FIX_2D\020\002\022\023\n\017FIX_TYPE_FIX_3D\020\003\022\025\n\021"
-    "FIX_TYPE_FIX_DGPS\020\004\022\026\n\022FIX_TYPE_RTK_FLOA"
-    "T\020\005\022\026\n\022FIX_TYPE_RTK_FIXED\020\006*\206\003\n\nFlightMo"
-    "de\022\027\n\023FLIGHT_MODE_UNKNOWN\020\000\022\025\n\021FLIGHT_MO"
-    "DE_READY\020\001\022\027\n\023FLIGHT_MODE_TAKEOFF\020\002\022\024\n\020F"
-    "LIGHT_MODE_HOLD\020\003\022\027\n\023FLIGHT_MODE_MISSION"
-    "\020\004\022 \n\034FLIGHT_MODE_RETURN_TO_LAUNCH\020\005\022\024\n\020"
-    "FLIGHT_MODE_LAND\020\006\022\030\n\024FLIGHT_MODE_OFFBOA"
-    "RD\020\007\022\031\n\025FLIGHT_MODE_FOLLOW_ME\020\010\022\026\n\022FLIGH"
-    "T_MODE_MANUAL\020\t\022\026\n\022FLIGHT_MODE_ALTCTL\020\n\022"
-    "\026\n\022FLIGHT_MODE_POSCTL\020\013\022\024\n\020FLIGHT_MODE_A"
-    "CRO\020\014\022\032\n\026FLIGHT_MODE_STABILIZED\020\r\022\031\n\025FLI"
-    "GHT_MODE_RATTITUDE\020\016*\371\001\n\016StatusTextType\022"
-    "\032\n\026STATUS_TEXT_TYPE_DEBUG\020\000\022\031\n\025STATUS_TE"
-    "XT_TYPE_INFO\020\001\022\033\n\027STATUS_TEXT_TYPE_NOTIC"
-    "E\020\002\022\034\n\030STATUS_TEXT_TYPE_WARNING\020\003\022\032\n\026STA"
-    "TUS_TEXT_TYPE_ERROR\020\004\022\035\n\031STATUS_TEXT_TYP"
-    "E_CRITICAL\020\005\022\032\n\026STATUS_TEXT_TYPE_ALERT\020\006"
-    "\022\036\n\032STATUS_TEXT_TYPE_EMERGENCY\020\007*\223\001\n\013Lan"
-    "dedState\022\030\n\024LANDED_STATE_UNKNOWN\020\000\022\032\n\026LA"
-    "NDED_STATE_ON_GROUND\020\001\022\027\n\023LANDED_STATE_I"
-    "N_AIR\020\002\022\033\n\027LANDED_STATE_TAKING_OFF\020\003\022\030\n\024"
-    "LANDED_STATE_LANDING\020\004*\215\001\n\tVtolState\022\030\n\024"
-    "VTOL_STATE_UNDEFINED\020\000\022\037\n\033VTOL_STATE_TRA"
-    "NSITION_TO_FW\020\001\022\037\n\033VTOL_STATE_TRANSITION"
-    "_TO_MC\020\002\022\021\n\rVTOL_STATE_MC\020\003\022\021\n\rVTOL_STAT"
-    "E_FW\020\0042\3075\n\020TelemetryService\022o\n\021Subscribe"
-    "Position\022..mavsdk.rpc.telemetry.Subscrib"
-    "ePositionRequest\032&.mavsdk.rpc.telemetry."
-    "PositionResponse\"\0000\001\022c\n\rSubscribeHome\022*."
-    "mavsdk.rpc.telemetry.SubscribeHomeReques"
-    "t\032\".mavsdk.rpc.telemetry.HomeResponse\"\0000"
-    "\001\022f\n\016SubscribeInAir\022+.mavsdk.rpc.telemet"
-    "ry.SubscribeInAirRequest\032#.mavsdk.rpc.te"
-    "lemetry.InAirResponse\"\0000\001\022x\n\024SubscribeLa"
-    "ndedState\0221.mavsdk.rpc.telemetry.Subscri"
-    "beLandedStateRequest\032).mavsdk.rpc.teleme"
-    "try.LandedStateResponse\"\0000\001\022f\n\016Subscribe"
-    "Armed\022+.mavsdk.rpc.telemetry.SubscribeAr"
-    "medRequest\032#.mavsdk.rpc.telemetry.ArmedR"
-    "esponse\"\0000\001\022r\n\022SubscribeVtolState\022/.mavs"
-    "dk.rpc.telemetry.SubscribeVtolStateReque"
-    "st\032\'.mavsdk.rpc.telemetry.VtolStateRespo"
-    "nse\"\0000\001\022\215\001\n\033SubscribeAttitudeQuaternion\022"
-    "8.mavsdk.rpc.telemetry.SubscribeAttitude"
-    "QuaternionRequest\0320.mavsdk.rpc.telemetry"
-    ".AttitudeQuaternionResponse\"\0000\001\022~\n\026Subsc"
-    "ribeAttitudeEuler\0223.mavsdk.rpc.telemetry"
-    ".SubscribeAttitudeEulerRequest\032+.mavsdk."
-    "rpc.telemetry.AttitudeEulerResponse\"\0000\001\022"
-    "\250\001\n$SubscribeAttitudeAngularVelocityBody"
-    "\022A.mavsdk.rpc.telemetry.SubscribeAttitud"
-    "eAngularVelocityBodyRequest\0329.mavsdk.rpc"
-    ".telemetry.AttitudeAngularVelocityBodyRe"
-    "sponse\"\0000\001\022x\n\024SubscribeVelocityNed\0221.mav"
-    "sdk.rpc.telemetry.SubscribeVelocityNedRe"
-    "quest\032).mavsdk.rpc.telemetry.VelocityNed"
-    "Response\"\0000\001\022l\n\020SubscribeGpsInfo\022-.mavsd"
-    "k.rpc.telemetry.SubscribeGpsInfoRequest\032"
-    "%.mavsdk.rpc.telemetry.GpsInfoResponse\"\000"
-    "0\001\022i\n\017SubscribeRawGps\022,.mavsdk.rpc.telem"
-    "etry.SubscribeRawGpsRequest\032$.mavsdk.rpc"
-    ".telemetry.RawGpsResponse\"\0000\001\022l\n\020Subscri"
-    "beBattery\022-.mavsdk.rpc.telemetry.Subscri"
-    "beBatteryRequest\032%.mavsdk.rpc.telemetry."
-    "BatteryResponse\"\0000\001\022u\n\023SubscribeFlightMo"
-    "de\0220.mavsdk.rpc.telemetry.SubscribeFligh"
-    "tModeRequest\032(.mavsdk.rpc.telemetry.Flig"
-    "htModeResponse\"\0000\001\022i\n\017SubscribeHealth\022,."
-    "mavsdk.rpc.telemetry.SubscribeHealthRequ"
-    "est\032$.mavsdk.rpc.telemetry.HealthRespons"
-    "e\"\0000\001\022o\n\021SubscribeRcStatus\022..mavsdk.rpc."
-    "telemetry.SubscribeRcStatusRequest\032&.mav"
-    "sdk.rpc.telemetry.RcStatusResponse\"\0000\001\022u"
-    "\n\023SubscribeStatusText\0220.mavsdk.rpc.telem"
-    "etry.SubscribeStatusTextRequest\032(.mavsdk"
-    ".rpc.telemetry.StatusTextResponse\"\0000\001\022\226\001"
-    "\n\036SubscribeActuatorControlTarget\022;.mavsd"
-    "k.rpc.telemetry.SubscribeActuatorControl"
-    "TargetRequest\0323.mavsdk.rpc.telemetry.Act"
-    "uatorControlTargetResponse\"\0000\001\022\223\001\n\035Subsc"
-    "ribeActuatorOutputStatus\022:.mavsdk.rpc.te"
-    "lemetry.SubscribeActuatorOutputStatusReq"
-    "uest\0322.mavsdk.rpc.telemetry.ActuatorOutp"
-    "utStatusResponse\"\0000\001\022o\n\021SubscribeOdometr"
-    "y\022..mavsdk.rpc.telemetry.SubscribeOdomet"
-    "ryRequest\032&.mavsdk.rpc.telemetry.Odometr"
-    "yResponse\"\0000\001\022\220\001\n\034SubscribePositionVeloc"
-    "ityNed\0229.mavsdk.rpc.telemetry.SubscribeP"
-    "ositionVelocityNedRequest\0321.mavsdk.rpc.t"
-    "elemetry.PositionVelocityNedResponse\"\0000\001"
-    "\022x\n\024SubscribeGroundTruth\0221.mavsdk.rpc.te"
-    "lemetry.SubscribeGroundTruthRequest\032).ma"
-    "vsdk.rpc.telemetry.GroundTruthResponse\"\000"
-    "0\001\022\207\001\n\031SubscribeFixedwingMetrics\0226.mavsd"
-    "k.rpc.telemetry.SubscribeFixedwingMetric"
-    "sRequest\032..mavsdk.rpc.telemetry.Fixedwin"
-    "gMetricsResponse\"\0000\001\022`\n\014SubscribeImu\022).m"
-    "avsdk.rpc.telemetry.SubscribeImuRequest\032"
-    "!.mavsdk.rpc.telemetry.ImuResponse\"\0000\001\022r"
-    "\n\022SubscribeScaledImu\022/.mavsdk.rpc.teleme"
-    "try.SubscribeScaledImuRequest\032\'.mavsdk.r"
-    "pc.telemetry.ScaledImuResponse\"\0000\001\022i\n\017Su"
-    "bscribeRawImu\022,.mavsdk.rpc.telemetry.Sub"
-    "scribeRawImuRequest\032$.mavsdk.rpc.telemet"
-    "ry.RawImuResponse\"\0000\001\022x\n\024SubscribeHealth"
-    "AllOk\0221.mavsdk.rpc.telemetry.SubscribeHe"
-    "althAllOkRequest\032).mavsdk.rpc.telemetry."
-    "HealthAllOkResponse\"\0000\001\022~\n\026SubscribeUnix"
-    "EpochTime\0223.mavsdk.rpc.telemetry.Subscri"
-    "beUnixEpochTimeRequest\032+.mavsdk.rpc.tele"
-    "metry.UnixEpochTimeResponse\"\0000\001\022\201\001\n\027Subs"
-    "cribeDistanceSensor\0224.mavsdk.rpc.telemet"
-    "ry.SubscribeDistanceSensorRequest\032,.mavs"
-    "dk.rpc.telemetry.DistanceSensorResponse\""
-    "\0000\001\022\201\001\n\027SubscribeScaledPressure\0224.mavsdk"
-    ".rpc.telemetry.SubscribeScaledPressureRe"
-    "quest\032,.mavsdk.rpc.telemetry.ScaledPress"
-    "ureResponse\"\0000\001\022l\n\020SubscribeHeading\022-.ma"
-    "vsdk.rpc.telemetry.SubscribeHeadingReque"
-    "st\032%.mavsdk.rpc.telemetry.HeadingRespons"
-    "e\"\0000\001\022o\n\021SubscribeAltitude\022..mavsdk.rpc."
-    "telemetry.SubscribeAltitudeRequest\032&.mav"
-    "sdk.rpc.telemetry.AltitudeResponse\"\0000\001\022p"
-    "\n\017SetRatePosition\022,.mavsdk.rpc.telemetry"
-    ".SetRatePositionRequest\032-.mavsdk.rpc.tel"
-    "emetry.SetRatePositionResponse\"\000\022d\n\013SetR"
-    "ateHome\022(.mavsdk.rpc.telemetry.SetRateHo"
-    "meRequest\032).mavsdk.rpc.telemetry.SetRate"
-    "HomeResponse\"\000\022g\n\014SetRateInAir\022).mavsdk."
-    "rpc.telemetry.SetRateInAirRequest\032*.mavs"
-    "dk.rpc.telemetry.SetRateInAirResponse\"\000\022"
-    "y\n\022SetRateLandedState\022/.mavsdk.rpc.telem"
-    "etry.SetRateLandedStateRequest\0320.mavsdk."
-    "rpc.telemetry.SetRateLandedStateResponse"
-    "\"\000\022s\n\020SetRateVtolState\022-.mavsdk.rpc.tele"
-    "metry.SetRateVtolStateRequest\032..mavsdk.r"
-    "pc.telemetry.SetRateVtolStateResponse\"\000\022"
-    "\216\001\n\031SetRateAttitudeQuaternion\0226.mavsdk.r"
-    "pc.telemetry.SetRateAttitudeQuaternionRe"
-    "quest\0327.mavsdk.rpc.telemetry.SetRateAtti"
-    "tudeQuaternionResponse\"\000\022\177\n\024SetRateAttit"
-    "udeEuler\0221.mavsdk.rpc.telemetry.SetRateA"
-    "ttitudeEulerRequest\0322.mavsdk.rpc.telemet"
-    "ry.SetRateAttitudeEulerResponse\"\000\022y\n\022Set"
-    "RateVelocityNed\022/.mavsdk.rpc.telemetry.S"
-    "etRateVelocityNedRequest\0320.mavsdk.rpc.te"
-    "lemetry.SetRateVelocityNedResponse\"\000\022m\n\016"
-    "SetRateGpsInfo\022+.mavsdk.rpc.telemetry.Se"
-    "tRateGpsInfoRequest\032,.mavsdk.rpc.telemet"
-    "ry.SetRateGpsInfoResponse\"\000\022m\n\016SetRateBa"
-    "ttery\022+.mavsdk.rpc.telemetry.SetRateBatt"
-    "eryRequest\032,.mavsdk.rpc.telemetry.SetRat"
-    "eBatteryResponse\"\000\022p\n\017SetRateRcStatus\022,."
-    "mavsdk.rpc.telemetry.SetRateRcStatusRequ"
-    "est\032-.mavsdk.rpc.telemetry.SetRateRcStat"
-    "usResponse\"\000\022\227\001\n\034SetRateActuatorControlT"
-    "arget\0229.mavsdk.rpc.telemetry.SetRateActu"
-    "atorControlTargetRequest\032:.mavsdk.rpc.te"
-    "lemetry.SetRateActuatorControlTargetResp"
-    "onse\"\000\022\224\001\n\033SetRateActuatorOutputStatus\0228"
-    ".mavsdk.rpc.telemetry.SetRateActuatorOut"
-    "putStatusRequest\0329.mavsdk.rpc.telemetry."
-    "SetRateActuatorOutputStatusResponse\"\000\022p\n"
-    "\017SetRateOdometry\022,.mavsdk.rpc.telemetry."
-    "SetRateOdometryRequest\032-.mavsdk.rpc.tele"
-    "metry.SetRateOdometryResponse\"\000\022\221\001\n\032SetR"
-    "atePositionVelocityNed\0227.mavsdk.rpc.tele"
-    "metry.SetRatePositionVelocityNedRequest\032"
-    "8.mavsdk.rpc.telemetry.SetRatePositionVe"
-    "locityNedResponse\"\000\022y\n\022SetRateGroundTrut"
-    "h\022/.mavsdk.rpc.telemetry.SetRateGroundTr"
-    "uthRequest\0320.mavsdk.rpc.telemetry.SetRat"
-    "eGroundTruthResponse\"\000\022\210\001\n\027SetRateFixedw"
-    "ingMetrics\0224.mavsdk.rpc.telemetry.SetRat"
-    "eFixedwingMetricsRequest\0325.mavsdk.rpc.te"
-    "lemetry.SetRateFixedwingMetricsResponse\""
-    "\000\022a\n\nSetRateImu\022\'.mavsdk.rpc.telemetry.S"
-    "etRateImuRequest\032(.mavsdk.rpc.telemetry."
-    "SetRateImuResponse\"\000\022s\n\020SetRateScaledImu"
-    "\022-.mavsdk.rpc.telemetry.SetRateScaledImu"
-    "Request\032..mavsdk.rpc.telemetry.SetRateSc"
-    "aledImuResponse\"\000\022j\n\rSetRateRawImu\022*.mav"
-    "sdk.rpc.telemetry.SetRateRawImuRequest\032+"
-    ".mavsdk.rpc.telemetry.SetRateRawImuRespo"
-    "nse\"\000\022\177\n\024SetRateUnixEpochTime\0221.mavsdk.r"
-    "pc.telemetry.SetRateUnixEpochTimeRequest"
-    "\0322.mavsdk.rpc.telemetry.SetRateUnixEpoch"
-    "TimeResponse\"\000\022\202\001\n\025SetRateDistanceSensor"
-    "\0222.mavsdk.rpc.telemetry.SetRateDistanceS"
-    "ensorRequest\0323.mavsdk.rpc.telemetry.SetR"
-    "ateDistanceSensorResponse\"\000\022p\n\017SetRateAl"
-    "titude\022,.mavsdk.rpc.telemetry.SetRateAlt"
-    "itudeRequest\032-.mavsdk.rpc.telemetry.SetR"
-    "ateAltitudeResponse\"\000\022y\n\022GetGpsGlobalOri"
-    "gin\022/.mavsdk.rpc.telemetry.GetGpsGlobalO"
-    "riginRequest\0320.mavsdk.rpc.telemetry.GetG"
-    "psGlobalOriginResponse\"\000B%\n\023io.mavsdk.te"
-    "lemetryB\016TelemetryProtob\006proto3"
+    "tude_m\030\003 \001(\002B\007\202\265\030\003NaN\"\327\001\n\020FixedwingMetri"
+    "cs\022\035\n\014airspeed_m_s\030\001 \001(\002B\007\202\265\030\003NaN\022 \n\017gro"
+    "undspeed_m_s\030\002 \001(\002B\007\202\265\030\003NaN\022\034\n\013heading_d"
+    "eg\030\003 \001(\002B\007\202\265\030\003NaN\022$\n\023throttle_percentage"
+    "\030\004 \001(\002B\007\202\265\030\003NaN\022\035\n\014altitude_msl\030\005 \001(\002B\007\202"
+    "\265\030\003NaN\022\037\n\016climb_rate_m_s\030\006 \001(\002B\007\202\265\030\003NaN\""
+    "i\n\017AccelerationFrd\022\035\n\014forward_m_s2\030\001 \001(\002"
+    "B\007\202\265\030\003NaN\022\033\n\nright_m_s2\030\002 \001(\002B\007\202\265\030\003NaN\022\032"
+    "\n\tdown_m_s2\030\003 \001(\002B\007\202\265\030\003NaN\"o\n\022AngularVel"
+    "ocityFrd\022\036\n\rforward_rad_s\030\001 \001(\002B\007\202\265\030\003NaN"
+    "\022\034\n\013right_rad_s\030\002 \001(\002B\007\202\265\030\003NaN\022\033\n\ndown_r"
+    "ad_s\030\003 \001(\002B\007\202\265\030\003NaN\"m\n\020MagneticFieldFrd\022"
+    "\036\n\rforward_gauss\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right"
+    "_gauss\030\002 \001(\002B\007\202\265\030\003NaN\022\033\n\ndown_gauss\030\003 \001("
+    "\002B\007\202\265\030\003NaN\"\213\002\n\003Imu\022\?\n\020acceleration_frd\030\001"
+    " \001(\0132%.mavsdk.rpc.telemetry.Acceleration"
+    "Frd\022F\n\024angular_velocity_frd\030\002 \001(\0132(.mavs"
+    "dk.rpc.telemetry.AngularVelocityFrd\022B\n\022m"
+    "agnetic_field_frd\030\003 \001(\0132&.mavsdk.rpc.tel"
+    "emetry.MagneticFieldFrd\022!\n\020temperature_d"
+    "egc\030\004 \001(\002B\007\202\265\030\003NaN\022\024\n\014timestamp_us\030\005 \001(\004"
+    "\"m\n\017GpsGlobalOrigin\022\035\n\014latitude_deg\030\001 \001("
+    "\001B\007\202\265\030\003NaN\022\036\n\rlongitude_deg\030\002 \001(\001B\007\202\265\030\003N"
+    "aN\022\033\n\naltitude_m\030\003 \001(\002B\007\202\265\030\003NaN\"\346\001\n\010Alti"
+    "tude\022%\n\024altitude_monotonic_m\030\001 \001(\002B\007\202\265\030\003"
+    "NaN\022 \n\017altitude_amsl_m\030\002 \001(\002B\007\202\265\030\003NaN\022!\n"
+    "\020altitude_local_m\030\003 \001(\002B\007\202\265\030\003NaN\022$\n\023alti"
+    "tude_relative_m\030\004 \001(\002B\007\202\265\030\003NaN\022#\n\022altitu"
+    "de_terrain_m\030\005 \001(\002B\007\202\265\030\003NaN\022#\n\022bottom_cl"
+    "earance_m\030\006 \001(\002B\007\202\265\030\003NaN\"\241\002\n\017TelemetryRe"
+    "sult\022<\n\006result\030\001 \001(\0162,.mavsdk.rpc.teleme"
+    "try.TelemetryResult.Result\022\022\n\nresult_str"
+    "\030\002 \001(\t\"\273\001\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n"
+    "\016RESULT_SUCCESS\020\001\022\024\n\020RESULT_NO_SYSTEM\020\002\022"
+    "\033\n\027RESULT_CONNECTION_ERROR\020\003\022\017\n\013RESULT_B"
+    "USY\020\004\022\031\n\025RESULT_COMMAND_DENIED\020\005\022\022\n\016RESU"
+    "LT_TIMEOUT\020\006\022\026\n\022RESULT_UNSUPPORTED\020\007*\244\001\n"
+    "\007FixType\022\023\n\017FIX_TYPE_NO_GPS\020\000\022\023\n\017FIX_TYP"
+    "E_NO_FIX\020\001\022\023\n\017FIX_TYPE_FIX_2D\020\002\022\023\n\017FIX_T"
+    "YPE_FIX_3D\020\003\022\025\n\021FIX_TYPE_FIX_DGPS\020\004\022\026\n\022F"
+    "IX_TYPE_RTK_FLOAT\020\005\022\026\n\022FIX_TYPE_RTK_FIXE"
+    "D\020\006*\206\003\n\nFlightMode\022\027\n\023FLIGHT_MODE_UNKNOW"
+    "N\020\000\022\025\n\021FLIGHT_MODE_READY\020\001\022\027\n\023FLIGHT_MOD"
+    "E_TAKEOFF\020\002\022\024\n\020FLIGHT_MODE_HOLD\020\003\022\027\n\023FLI"
+    "GHT_MODE_MISSION\020\004\022 \n\034FLIGHT_MODE_RETURN"
+    "_TO_LAUNCH\020\005\022\024\n\020FLIGHT_MODE_LAND\020\006\022\030\n\024FL"
+    "IGHT_MODE_OFFBOARD\020\007\022\031\n\025FLIGHT_MODE_FOLL"
+    "OW_ME\020\010\022\026\n\022FLIGHT_MODE_MANUAL\020\t\022\026\n\022FLIGH"
+    "T_MODE_ALTCTL\020\n\022\026\n\022FLIGHT_MODE_POSCTL\020\013\022"
+    "\024\n\020FLIGHT_MODE_ACRO\020\014\022\032\n\026FLIGHT_MODE_STA"
+    "BILIZED\020\r\022\031\n\025FLIGHT_MODE_RATTITUDE\020\016*\371\001\n"
+    "\016StatusTextType\022\032\n\026STATUS_TEXT_TYPE_DEBU"
+    "G\020\000\022\031\n\025STATUS_TEXT_TYPE_INFO\020\001\022\033\n\027STATUS"
+    "_TEXT_TYPE_NOTICE\020\002\022\034\n\030STATUS_TEXT_TYPE_"
+    "WARNING\020\003\022\032\n\026STATUS_TEXT_TYPE_ERROR\020\004\022\035\n"
+    "\031STATUS_TEXT_TYPE_CRITICAL\020\005\022\032\n\026STATUS_T"
+    "EXT_TYPE_ALERT\020\006\022\036\n\032STATUS_TEXT_TYPE_EME"
+    "RGENCY\020\007*\223\001\n\013LandedState\022\030\n\024LANDED_STATE"
+    "_UNKNOWN\020\000\022\032\n\026LANDED_STATE_ON_GROUND\020\001\022\027"
+    "\n\023LANDED_STATE_IN_AIR\020\002\022\033\n\027LANDED_STATE_"
+    "TAKING_OFF\020\003\022\030\n\024LANDED_STATE_LANDING\020\004*\215"
+    "\001\n\tVtolState\022\030\n\024VTOL_STATE_UNDEFINED\020\000\022\037"
+    "\n\033VTOL_STATE_TRANSITION_TO_FW\020\001\022\037\n\033VTOL_"
+    "STATE_TRANSITION_TO_MC\020\002\022\021\n\rVTOL_STATE_M"
+    "C\020\003\022\021\n\rVTOL_STATE_FW\020\0042\3075\n\020TelemetryServ"
+    "ice\022o\n\021SubscribePosition\022..mavsdk.rpc.te"
+    "lemetry.SubscribePositionRequest\032&.mavsd"
+    "k.rpc.telemetry.PositionResponse\"\0000\001\022c\n\r"
+    "SubscribeHome\022*.mavsdk.rpc.telemetry.Sub"
+    "scribeHomeRequest\032\".mavsdk.rpc.telemetry"
+    ".HomeResponse\"\0000\001\022f\n\016SubscribeInAir\022+.ma"
+    "vsdk.rpc.telemetry.SubscribeInAirRequest"
+    "\032#.mavsdk.rpc.telemetry.InAirResponse\"\0000"
+    "\001\022x\n\024SubscribeLandedState\0221.mavsdk.rpc.t"
+    "elemetry.SubscribeLandedStateRequest\032).m"
+    "avsdk.rpc.telemetry.LandedStateResponse\""
+    "\0000\001\022f\n\016SubscribeArmed\022+.mavsdk.rpc.telem"
+    "etry.SubscribeArmedRequest\032#.mavsdk.rpc."
+    "telemetry.ArmedResponse\"\0000\001\022r\n\022Subscribe"
+    "VtolState\022/.mavsdk.rpc.telemetry.Subscri"
+    "beVtolStateRequest\032\'.mavsdk.rpc.telemetr"
+    "y.VtolStateResponse\"\0000\001\022\215\001\n\033SubscribeAtt"
+    "itudeQuaternion\0228.mavsdk.rpc.telemetry.S"
+    "ubscribeAttitudeQuaternionRequest\0320.mavs"
+    "dk.rpc.telemetry.AttitudeQuaternionRespo"
+    "nse\"\0000\001\022~\n\026SubscribeAttitudeEuler\0223.mavs"
+    "dk.rpc.telemetry.SubscribeAttitudeEulerR"
+    "equest\032+.mavsdk.rpc.telemetry.AttitudeEu"
+    "lerResponse\"\0000\001\022\250\001\n$SubscribeAttitudeAng"
+    "ularVelocityBody\022A.mavsdk.rpc.telemetry."
+    "SubscribeAttitudeAngularVelocityBodyRequ"
+    "est\0329.mavsdk.rpc.telemetry.AttitudeAngul"
+    "arVelocityBodyResponse\"\0000\001\022x\n\024SubscribeV"
+    "elocityNed\0221.mavsdk.rpc.telemetry.Subscr"
+    "ibeVelocityNedRequest\032).mavsdk.rpc.telem"
+    "etry.VelocityNedResponse\"\0000\001\022l\n\020Subscrib"
+    "eGpsInfo\022-.mavsdk.rpc.telemetry.Subscrib"
+    "eGpsInfoRequest\032%.mavsdk.rpc.telemetry.G"
+    "psInfoResponse\"\0000\001\022i\n\017SubscribeRawGps\022,."
+    "mavsdk.rpc.telemetry.SubscribeRawGpsRequ"
+    "est\032$.mavsdk.rpc.telemetry.RawGpsRespons"
+    "e\"\0000\001\022l\n\020SubscribeBattery\022-.mavsdk.rpc.t"
+    "elemetry.SubscribeBatteryRequest\032%.mavsd"
+    "k.rpc.telemetry.BatteryResponse\"\0000\001\022u\n\023S"
+    "ubscribeFlightMode\0220.mavsdk.rpc.telemetr"
+    "y.SubscribeFlightModeRequest\032(.mavsdk.rp"
+    "c.telemetry.FlightModeResponse\"\0000\001\022i\n\017Su"
+    "bscribeHealth\022,.mavsdk.rpc.telemetry.Sub"
+    "scribeHealthRequest\032$.mavsdk.rpc.telemet"
+    "ry.HealthResponse\"\0000\001\022o\n\021SubscribeRcStat"
+    "us\022..mavsdk.rpc.telemetry.SubscribeRcSta"
+    "tusRequest\032&.mavsdk.rpc.telemetry.RcStat"
+    "usResponse\"\0000\001\022u\n\023SubscribeStatusText\0220."
+    "mavsdk.rpc.telemetry.SubscribeStatusText"
+    "Request\032(.mavsdk.rpc.telemetry.StatusTex"
+    "tResponse\"\0000\001\022\226\001\n\036SubscribeActuatorContr"
+    "olTarget\022;.mavsdk.rpc.telemetry.Subscrib"
+    "eActuatorControlTargetRequest\0323.mavsdk.r"
+    "pc.telemetry.ActuatorControlTargetRespon"
+    "se\"\0000\001\022\223\001\n\035SubscribeActuatorOutputStatus"
+    "\022:.mavsdk.rpc.telemetry.SubscribeActuato"
+    "rOutputStatusRequest\0322.mavsdk.rpc.teleme"
+    "try.ActuatorOutputStatusResponse\"\0000\001\022o\n\021"
+    "SubscribeOdometry\022..mavsdk.rpc.telemetry"
+    ".SubscribeOdometryRequest\032&.mavsdk.rpc.t"
+    "elemetry.OdometryResponse\"\0000\001\022\220\001\n\034Subscr"
+    "ibePositionVelocityNed\0229.mavsdk.rpc.tele"
+    "metry.SubscribePositionVelocityNedReques"
+    "t\0321.mavsdk.rpc.telemetry.PositionVelocit"
+    "yNedResponse\"\0000\001\022x\n\024SubscribeGroundTruth"
+    "\0221.mavsdk.rpc.telemetry.SubscribeGroundT"
+    "ruthRequest\032).mavsdk.rpc.telemetry.Groun"
+    "dTruthResponse\"\0000\001\022\207\001\n\031SubscribeFixedwin"
+    "gMetrics\0226.mavsdk.rpc.telemetry.Subscrib"
+    "eFixedwingMetricsRequest\032..mavsdk.rpc.te"
+    "lemetry.FixedwingMetricsResponse\"\0000\001\022`\n\014"
+    "SubscribeImu\022).mavsdk.rpc.telemetry.Subs"
+    "cribeImuRequest\032!.mavsdk.rpc.telemetry.I"
+    "muResponse\"\0000\001\022r\n\022SubscribeScaledImu\022/.m"
+    "avsdk.rpc.telemetry.SubscribeScaledImuRe"
+    "quest\032\'.mavsdk.rpc.telemetry.ScaledImuRe"
+    "sponse\"\0000\001\022i\n\017SubscribeRawImu\022,.mavsdk.r"
+    "pc.telemetry.SubscribeRawImuRequest\032$.ma"
+    "vsdk.rpc.telemetry.RawImuResponse\"\0000\001\022x\n"
+    "\024SubscribeHealthAllOk\0221.mavsdk.rpc.telem"
+    "etry.SubscribeHealthAllOkRequest\032).mavsd"
+    "k.rpc.telemetry.HealthAllOkResponse\"\0000\001\022"
+    "~\n\026SubscribeUnixEpochTime\0223.mavsdk.rpc.t"
+    "elemetry.SubscribeUnixEpochTimeRequest\032+"
+    ".mavsdk.rpc.telemetry.UnixEpochTimeRespo"
+    "nse\"\0000\001\022\201\001\n\027SubscribeDistanceSensor\0224.ma"
+    "vsdk.rpc.telemetry.SubscribeDistanceSens"
+    "orRequest\032,.mavsdk.rpc.telemetry.Distanc"
+    "eSensorResponse\"\0000\001\022\201\001\n\027SubscribeScaledP"
+    "ressure\0224.mavsdk.rpc.telemetry.Subscribe"
+    "ScaledPressureRequest\032,.mavsdk.rpc.telem"
+    "etry.ScaledPressureResponse\"\0000\001\022l\n\020Subsc"
+    "ribeHeading\022-.mavsdk.rpc.telemetry.Subsc"
+    "ribeHeadingRequest\032%.mavsdk.rpc.telemetr"
+    "y.HeadingResponse\"\0000\001\022o\n\021SubscribeAltitu"
+    "de\022..mavsdk.rpc.telemetry.SubscribeAltit"
+    "udeRequest\032&.mavsdk.rpc.telemetry.Altitu"
+    "deResponse\"\0000\001\022p\n\017SetRatePosition\022,.mavs"
+    "dk.rpc.telemetry.SetRatePositionRequest\032"
+    "-.mavsdk.rpc.telemetry.SetRatePositionRe"
+    "sponse\"\000\022d\n\013SetRateHome\022(.mavsdk.rpc.tel"
+    "emetry.SetRateHomeRequest\032).mavsdk.rpc.t"
+    "elemetry.SetRateHomeResponse\"\000\022g\n\014SetRat"
+    "eInAir\022).mavsdk.rpc.telemetry.SetRateInA"
+    "irRequest\032*.mavsdk.rpc.telemetry.SetRate"
+    "InAirResponse\"\000\022y\n\022SetRateLandedState\022/."
+    "mavsdk.rpc.telemetry.SetRateLandedStateR"
+    "equest\0320.mavsdk.rpc.telemetry.SetRateLan"
+    "dedStateResponse\"\000\022s\n\020SetRateVtolState\022-"
+    ".mavsdk.rpc.telemetry.SetRateVtolStateRe"
+    "quest\032..mavsdk.rpc.telemetry.SetRateVtol"
+    "StateResponse\"\000\022\216\001\n\031SetRateAttitudeQuate"
+    "rnion\0226.mavsdk.rpc.telemetry.SetRateAtti"
+    "tudeQuaternionRequest\0327.mavsdk.rpc.telem"
+    "etry.SetRateAttitudeQuaternionResponse\"\000"
+    "\022\177\n\024SetRateAttitudeEuler\0221.mavsdk.rpc.te"
+    "lemetry.SetRateAttitudeEulerRequest\0322.ma"
+    "vsdk.rpc.telemetry.SetRateAttitudeEulerR"
+    "esponse\"\000\022y\n\022SetRateVelocityNed\022/.mavsdk"
+    ".rpc.telemetry.SetRateVelocityNedRequest"
+    "\0320.mavsdk.rpc.telemetry.SetRateVelocityN"
+    "edResponse\"\000\022m\n\016SetRateGpsInfo\022+.mavsdk."
+    "rpc.telemetry.SetRateGpsInfoRequest\032,.ma"
+    "vsdk.rpc.telemetry.SetRateGpsInfoRespons"
+    "e\"\000\022m\n\016SetRateBattery\022+.mavsdk.rpc.telem"
+    "etry.SetRateBatteryRequest\032,.mavsdk.rpc."
+    "telemetry.SetRateBatteryResponse\"\000\022p\n\017Se"
+    "tRateRcStatus\022,.mavsdk.rpc.telemetry.Set"
+    "RateRcStatusRequest\032-.mavsdk.rpc.telemet"
+    "ry.SetRateRcStatusResponse\"\000\022\227\001\n\034SetRate"
+    "ActuatorControlTarget\0229.mavsdk.rpc.telem"
+    "etry.SetRateActuatorControlTargetRequest"
+    "\032:.mavsdk.rpc.telemetry.SetRateActuatorC"
+    "ontrolTargetResponse\"\000\022\224\001\n\033SetRateActuat"
+    "orOutputStatus\0228.mavsdk.rpc.telemetry.Se"
+    "tRateActuatorOutputStatusRequest\0329.mavsd"
+    "k.rpc.telemetry.SetRateActuatorOutputSta"
+    "tusResponse\"\000\022p\n\017SetRateOdometry\022,.mavsd"
+    "k.rpc.telemetry.SetRateOdometryRequest\032-"
+    ".mavsdk.rpc.telemetry.SetRateOdometryRes"
+    "ponse\"\000\022\221\001\n\032SetRatePositionVelocityNed\0227"
+    ".mavsdk.rpc.telemetry.SetRatePositionVel"
+    "ocityNedRequest\0328.mavsdk.rpc.telemetry.S"
+    "etRatePositionVelocityNedResponse\"\000\022y\n\022S"
+    "etRateGroundTruth\022/.mavsdk.rpc.telemetry"
+    ".SetRateGroundTruthRequest\0320.mavsdk.rpc."
+    "telemetry.SetRateGroundTruthResponse\"\000\022\210"
+    "\001\n\027SetRateFixedwingMetrics\0224.mavsdk.rpc."
+    "telemetry.SetRateFixedwingMetricsRequest"
+    "\0325.mavsdk.rpc.telemetry.SetRateFixedwing"
+    "MetricsResponse\"\000\022a\n\nSetRateImu\022\'.mavsdk"
+    ".rpc.telemetry.SetRateImuRequest\032(.mavsd"
+    "k.rpc.telemetry.SetRateImuResponse\"\000\022s\n\020"
+    "SetRateScaledImu\022-.mavsdk.rpc.telemetry."
+    "SetRateScaledImuRequest\032..mavsdk.rpc.tel"
+    "emetry.SetRateScaledImuResponse\"\000\022j\n\rSet"
+    "RateRawImu\022*.mavsdk.rpc.telemetry.SetRat"
+    "eRawImuRequest\032+.mavsdk.rpc.telemetry.Se"
+    "tRateRawImuResponse\"\000\022\177\n\024SetRateUnixEpoc"
+    "hTime\0221.mavsdk.rpc.telemetry.SetRateUnix"
+    "EpochTimeRequest\0322.mavsdk.rpc.telemetry."
+    "SetRateUnixEpochTimeResponse\"\000\022\202\001\n\025SetRa"
+    "teDistanceSensor\0222.mavsdk.rpc.telemetry."
+    "SetRateDistanceSensorRequest\0323.mavsdk.rp"
+    "c.telemetry.SetRateDistanceSensorRespons"
+    "e\"\000\022p\n\017SetRateAltitude\022,.mavsdk.rpc.tele"
+    "metry.SetRateAltitudeRequest\032-.mavsdk.rp"
+    "c.telemetry.SetRateAltitudeResponse\"\000\022y\n"
+    "\022GetGpsGlobalOrigin\022/.mavsdk.rpc.telemet"
+    "ry.GetGpsGlobalOriginRequest\0320.mavsdk.rp"
+    "c.telemetry.GetGpsGlobalOriginResponse\"\000"
+    "B%\n\023io.mavsdk.telemetryB\016TelemetryProtob"
+    "\006proto3"
 };
 static const ::_pbi::DescriptorTable* const descriptor_table_telemetry_2ftelemetry_2eproto_deps[1] =
     {
@@ -5795,7 +5804,7 @@ static ::absl::once_flag descriptor_table_telemetry_2ftelemetry_2eproto_once;
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_telemetry_2ftelemetry_2eproto = {
     false,
     false,
-    19831,
+    19927,
     descriptor_table_protodef_telemetry_2ftelemetry_2eproto,
     "telemetry/telemetry.proto",
     &descriptor_table_telemetry_2ftelemetry_2eproto_once,
@@ -35293,15 +35302,15 @@ const ::google::protobuf::internal::ClassData* FixedwingMetrics::GetClassData() 
   return _class_data_.base();
 }
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<2, 3, 0, 0, 2> FixedwingMetrics::_table_ = {
+const ::_pbi::TcParseTable<3, 6, 0, 0, 2> FixedwingMetrics::_table_ = {
   {
     0,  // no _has_bits_
     0, // no _extensions_
-    3, 24,  // max_field_number, fast_idx_mask
+    6, 56,  // max_field_number, fast_idx_mask
     offsetof(decltype(_table_), field_lookup_table),
-    4294967288,  // skipmap
+    4294967232,  // skipmap
     offsetof(decltype(_table_), field_entries),
-    3,  // num_field_entries
+    6,  // num_field_entries
     0,  // num_aux_entries
     offsetof(decltype(_table_), field_names),  // no aux_entries
     _class_data_.base(),
@@ -35315,22 +35324,41 @@ const ::_pbi::TcParseTable<2, 3, 0, 0, 2> FixedwingMetrics::_table_ = {
     // float airspeed_m_s = 1 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
      {13, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.airspeed_m_s_)}},
-    // float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
+    // float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
-     {21, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.throttle_percentage_)}},
-    // float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
+     {21, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.groundspeed_m_s_)}},
+    // float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
-     {29, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.climb_rate_m_s_)}},
+     {29, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.heading_deg_)}},
+    // float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
+    {::_pbi::TcParser::FastF32S1,
+     {37, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.throttle_percentage_)}},
+    // float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
+    {::_pbi::TcParser::FastF32S1,
+     {45, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.altitude_msl_)}},
+    // float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
+    {::_pbi::TcParser::FastF32S1,
+     {53, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.climb_rate_m_s_)}},
+    {::_pbi::TcParser::MiniParse, {}},
   }}, {{
     65535, 65535
   }}, {{
     // float airspeed_m_s = 1 [(.mavsdk.options.default_value) = "NaN"];
     {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.airspeed_m_s_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
-    // float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
+    // float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
+    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.groundspeed_m_s_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+    // float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
+    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.heading_deg_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+    // float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
     {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.throttle_percentage_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
-    // float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
+    // float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
+    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.altitude_msl_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+    // float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
     {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.climb_rate_m_s_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
   }},
@@ -35374,18 +35402,39 @@ PROTOBUF_NOINLINE void FixedwingMetrics::Clear() {
                 1, this_._internal_airspeed_m_s(), target);
           }
 
-          // float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
+          // float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
+          if (::absl::bit_cast<::uint32_t>(this_._internal_groundspeed_m_s()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                2, this_._internal_groundspeed_m_s(), target);
+          }
+
+          // float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
+          if (::absl::bit_cast<::uint32_t>(this_._internal_heading_deg()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                3, this_._internal_heading_deg(), target);
+          }
+
+          // float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
           if (::absl::bit_cast<::uint32_t>(this_._internal_throttle_percentage()) != 0) {
             target = stream->EnsureSpace(target);
             target = ::_pbi::WireFormatLite::WriteFloatToArray(
-                2, this_._internal_throttle_percentage(), target);
+                4, this_._internal_throttle_percentage(), target);
           }
 
-          // float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
+          // float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
+          if (::absl::bit_cast<::uint32_t>(this_._internal_altitude_msl()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                5, this_._internal_altitude_msl(), target);
+          }
+
+          // float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
           if (::absl::bit_cast<::uint32_t>(this_._internal_climb_rate_m_s()) != 0) {
             target = stream->EnsureSpace(target);
             target = ::_pbi::WireFormatLite::WriteFloatToArray(
-                3, this_._internal_climb_rate_m_s(), target);
+                6, this_._internal_climb_rate_m_s(), target);
           }
 
           if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
@@ -35417,11 +35466,23 @@ PROTOBUF_NOINLINE void FixedwingMetrics::Clear() {
             if (::absl::bit_cast<::uint32_t>(this_._internal_airspeed_m_s()) != 0) {
               total_size += 5;
             }
-            // float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
+            // float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
+            if (::absl::bit_cast<::uint32_t>(this_._internal_groundspeed_m_s()) != 0) {
+              total_size += 5;
+            }
+            // float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
+            if (::absl::bit_cast<::uint32_t>(this_._internal_heading_deg()) != 0) {
+              total_size += 5;
+            }
+            // float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
             if (::absl::bit_cast<::uint32_t>(this_._internal_throttle_percentage()) != 0) {
               total_size += 5;
             }
-            // float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
+            // float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
+            if (::absl::bit_cast<::uint32_t>(this_._internal_altitude_msl()) != 0) {
+              total_size += 5;
+            }
+            // float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
             if (::absl::bit_cast<::uint32_t>(this_._internal_climb_rate_m_s()) != 0) {
               total_size += 5;
             }
@@ -35441,8 +35502,17 @@ void FixedwingMetrics::MergeImpl(::google::protobuf::MessageLite& to_msg, const 
   if (::absl::bit_cast<::uint32_t>(from._internal_airspeed_m_s()) != 0) {
     _this->_impl_.airspeed_m_s_ = from._impl_.airspeed_m_s_;
   }
+  if (::absl::bit_cast<::uint32_t>(from._internal_groundspeed_m_s()) != 0) {
+    _this->_impl_.groundspeed_m_s_ = from._impl_.groundspeed_m_s_;
+  }
+  if (::absl::bit_cast<::uint32_t>(from._internal_heading_deg()) != 0) {
+    _this->_impl_.heading_deg_ = from._impl_.heading_deg_;
+  }
   if (::absl::bit_cast<::uint32_t>(from._internal_throttle_percentage()) != 0) {
     _this->_impl_.throttle_percentage_ = from._impl_.throttle_percentage_;
+  }
+  if (::absl::bit_cast<::uint32_t>(from._internal_altitude_msl()) != 0) {
+    _this->_impl_.altitude_msl_ = from._impl_.altitude_msl_;
   }
   if (::absl::bit_cast<::uint32_t>(from._internal_climb_rate_m_s()) != 0) {
     _this->_impl_.climb_rate_m_s_ = from._impl_.climb_rate_m_s_;

--- a/src/mavsdk_server/src/generated/telemetry/telemetry.pb.h
+++ b/src/mavsdk_server/src/generated/telemetry/telemetry.pb.h
@@ -15534,8 +15534,11 @@ class FixedwingMetrics final
   // accessors -------------------------------------------------------
   enum : int {
     kAirspeedMSFieldNumber = 1,
-    kThrottlePercentageFieldNumber = 2,
-    kClimbRateMSFieldNumber = 3,
+    kGroundspeedMSFieldNumber = 2,
+    kHeadingDegFieldNumber = 3,
+    kThrottlePercentageFieldNumber = 4,
+    kAltitudeMslFieldNumber = 5,
+    kClimbRateMSFieldNumber = 6,
   };
   // float airspeed_m_s = 1 [(.mavsdk.options.default_value) = "NaN"];
   void clear_airspeed_m_s() ;
@@ -15547,7 +15550,27 @@ class FixedwingMetrics final
   void _internal_set_airspeed_m_s(float value);
 
   public:
-  // float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
+  // float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_groundspeed_m_s() ;
+  float groundspeed_m_s() const;
+  void set_groundspeed_m_s(float value);
+
+  private:
+  float _internal_groundspeed_m_s() const;
+  void _internal_set_groundspeed_m_s(float value);
+
+  public:
+  // float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_heading_deg() ;
+  float heading_deg() const;
+  void set_heading_deg(float value);
+
+  private:
+  float _internal_heading_deg() const;
+  void _internal_set_heading_deg(float value);
+
+  public:
+  // float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
   void clear_throttle_percentage() ;
   float throttle_percentage() const;
   void set_throttle_percentage(float value);
@@ -15557,7 +15580,17 @@ class FixedwingMetrics final
   void _internal_set_throttle_percentage(float value);
 
   public:
-  // float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
+  // float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_altitude_msl() ;
+  float altitude_msl() const;
+  void set_altitude_msl(float value);
+
+  private:
+  float _internal_altitude_msl() const;
+  void _internal_set_altitude_msl(float value);
+
+  public:
+  // float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
   void clear_climb_rate_m_s() ;
   float climb_rate_m_s() const;
   void set_climb_rate_m_s(float value);
@@ -15572,7 +15605,7 @@ class FixedwingMetrics final
   class _Internal;
   friend class ::google::protobuf::internal::TcParser;
   static const ::google::protobuf::internal::TcParseTable<
-      2, 3, 0,
+      3, 6, 0,
       0, 2>
       _table_;
 
@@ -15591,7 +15624,10 @@ class FixedwingMetrics final
                           ::google::protobuf::Arena* arena, const Impl_& from,
                           const FixedwingMetrics& from_msg);
     float airspeed_m_s_;
+    float groundspeed_m_s_;
+    float heading_deg_;
     float throttle_percentage_;
+    float altitude_msl_;
     float climb_rate_m_s_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     PROTOBUF_TSAN_DECLARE_MEMBER
@@ -37647,7 +37683,51 @@ inline void FixedwingMetrics::_internal_set_airspeed_m_s(float value) {
   _impl_.airspeed_m_s_ = value;
 }
 
-// float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
+// float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
+inline void FixedwingMetrics::clear_groundspeed_m_s() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.groundspeed_m_s_ = 0;
+}
+inline float FixedwingMetrics::groundspeed_m_s() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry.FixedwingMetrics.groundspeed_m_s)
+  return _internal_groundspeed_m_s();
+}
+inline void FixedwingMetrics::set_groundspeed_m_s(float value) {
+  _internal_set_groundspeed_m_s(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry.FixedwingMetrics.groundspeed_m_s)
+}
+inline float FixedwingMetrics::_internal_groundspeed_m_s() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.groundspeed_m_s_;
+}
+inline void FixedwingMetrics::_internal_set_groundspeed_m_s(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.groundspeed_m_s_ = value;
+}
+
+// float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
+inline void FixedwingMetrics::clear_heading_deg() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.heading_deg_ = 0;
+}
+inline float FixedwingMetrics::heading_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry.FixedwingMetrics.heading_deg)
+  return _internal_heading_deg();
+}
+inline void FixedwingMetrics::set_heading_deg(float value) {
+  _internal_set_heading_deg(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry.FixedwingMetrics.heading_deg)
+}
+inline float FixedwingMetrics::_internal_heading_deg() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.heading_deg_;
+}
+inline void FixedwingMetrics::_internal_set_heading_deg(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.heading_deg_ = value;
+}
+
+// float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
 inline void FixedwingMetrics::clear_throttle_percentage() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.throttle_percentage_ = 0;
@@ -37669,7 +37749,29 @@ inline void FixedwingMetrics::_internal_set_throttle_percentage(float value) {
   _impl_.throttle_percentage_ = value;
 }
 
-// float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
+// float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
+inline void FixedwingMetrics::clear_altitude_msl() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.altitude_msl_ = 0;
+}
+inline float FixedwingMetrics::altitude_msl() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry.FixedwingMetrics.altitude_msl)
+  return _internal_altitude_msl();
+}
+inline void FixedwingMetrics::set_altitude_msl(float value) {
+  _internal_set_altitude_msl(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry.FixedwingMetrics.altitude_msl)
+}
+inline float FixedwingMetrics::_internal_altitude_msl() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.altitude_msl_;
+}
+inline void FixedwingMetrics::_internal_set_altitude_msl(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.altitude_msl_ = value;
+}
+
+// float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
 inline void FixedwingMetrics::clear_climb_rate_m_s() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.climb_rate_m_s_ = 0;

--- a/src/mavsdk_server/src/generated/telemetry/telemetry.pb.h
+++ b/src/mavsdk_server/src/generated/telemetry/telemetry.pb.h
@@ -15534,11 +15534,11 @@ class FixedwingMetrics final
   // accessors -------------------------------------------------------
   enum : int {
     kAirspeedMSFieldNumber = 1,
-    kGroundspeedMSFieldNumber = 2,
-    kHeadingDegFieldNumber = 3,
-    kThrottlePercentageFieldNumber = 4,
-    kAltitudeMslFieldNumber = 5,
-    kClimbRateMSFieldNumber = 6,
+    kThrottlePercentageFieldNumber = 2,
+    kClimbRateMSFieldNumber = 3,
+    kGroundspeedMSFieldNumber = 4,
+    kHeadingDegFieldNumber = 5,
+    kAltitudeMslFieldNumber = 6,
   };
   // float airspeed_m_s = 1 [(.mavsdk.options.default_value) = "NaN"];
   void clear_airspeed_m_s() ;
@@ -15550,27 +15550,7 @@ class FixedwingMetrics final
   void _internal_set_airspeed_m_s(float value);
 
   public:
-  // float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
-  void clear_groundspeed_m_s() ;
-  float groundspeed_m_s() const;
-  void set_groundspeed_m_s(float value);
-
-  private:
-  float _internal_groundspeed_m_s() const;
-  void _internal_set_groundspeed_m_s(float value);
-
-  public:
-  // float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
-  void clear_heading_deg() ;
-  float heading_deg() const;
-  void set_heading_deg(float value);
-
-  private:
-  float _internal_heading_deg() const;
-  void _internal_set_heading_deg(float value);
-
-  public:
-  // float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
+  // float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
   void clear_throttle_percentage() ;
   float throttle_percentage() const;
   void set_throttle_percentage(float value);
@@ -15580,17 +15560,7 @@ class FixedwingMetrics final
   void _internal_set_throttle_percentage(float value);
 
   public:
-  // float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
-  void clear_altitude_msl() ;
-  float altitude_msl() const;
-  void set_altitude_msl(float value);
-
-  private:
-  float _internal_altitude_msl() const;
-  void _internal_set_altitude_msl(float value);
-
-  public:
-  // float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
+  // float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
   void clear_climb_rate_m_s() ;
   float climb_rate_m_s() const;
   void set_climb_rate_m_s(float value);
@@ -15598,6 +15568,36 @@ class FixedwingMetrics final
   private:
   float _internal_climb_rate_m_s() const;
   void _internal_set_climb_rate_m_s(float value);
+
+  public:
+  // float groundspeed_m_s = 4 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_groundspeed_m_s() ;
+  float groundspeed_m_s() const;
+  void set_groundspeed_m_s(float value);
+
+  private:
+  float _internal_groundspeed_m_s() const;
+  void _internal_set_groundspeed_m_s(float value);
+
+  public:
+  // float heading_deg = 5 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_heading_deg() ;
+  float heading_deg() const;
+  void set_heading_deg(float value);
+
+  private:
+  float _internal_heading_deg() const;
+  void _internal_set_heading_deg(float value);
+
+  public:
+  // float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_altitude_msl() ;
+  float altitude_msl() const;
+  void set_altitude_msl(float value);
+
+  private:
+  float _internal_altitude_msl() const;
+  void _internal_set_altitude_msl(float value);
 
   public:
   // @@protoc_insertion_point(class_scope:mavsdk.rpc.telemetry.FixedwingMetrics)
@@ -15624,11 +15624,11 @@ class FixedwingMetrics final
                           ::google::protobuf::Arena* arena, const Impl_& from,
                           const FixedwingMetrics& from_msg);
     float airspeed_m_s_;
+    float throttle_percentage_;
+    float climb_rate_m_s_;
     float groundspeed_m_s_;
     float heading_deg_;
-    float throttle_percentage_;
     float altitude_msl_;
-    float climb_rate_m_s_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
@@ -37683,51 +37683,7 @@ inline void FixedwingMetrics::_internal_set_airspeed_m_s(float value) {
   _impl_.airspeed_m_s_ = value;
 }
 
-// float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
-inline void FixedwingMetrics::clear_groundspeed_m_s() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.groundspeed_m_s_ = 0;
-}
-inline float FixedwingMetrics::groundspeed_m_s() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry.FixedwingMetrics.groundspeed_m_s)
-  return _internal_groundspeed_m_s();
-}
-inline void FixedwingMetrics::set_groundspeed_m_s(float value) {
-  _internal_set_groundspeed_m_s(value);
-  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry.FixedwingMetrics.groundspeed_m_s)
-}
-inline float FixedwingMetrics::_internal_groundspeed_m_s() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.groundspeed_m_s_;
-}
-inline void FixedwingMetrics::_internal_set_groundspeed_m_s(float value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.groundspeed_m_s_ = value;
-}
-
-// float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
-inline void FixedwingMetrics::clear_heading_deg() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.heading_deg_ = 0;
-}
-inline float FixedwingMetrics::heading_deg() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry.FixedwingMetrics.heading_deg)
-  return _internal_heading_deg();
-}
-inline void FixedwingMetrics::set_heading_deg(float value) {
-  _internal_set_heading_deg(value);
-  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry.FixedwingMetrics.heading_deg)
-}
-inline float FixedwingMetrics::_internal_heading_deg() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.heading_deg_;
-}
-inline void FixedwingMetrics::_internal_set_heading_deg(float value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.heading_deg_ = value;
-}
-
-// float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
+// float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
 inline void FixedwingMetrics::clear_throttle_percentage() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.throttle_percentage_ = 0;
@@ -37749,29 +37705,7 @@ inline void FixedwingMetrics::_internal_set_throttle_percentage(float value) {
   _impl_.throttle_percentage_ = value;
 }
 
-// float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
-inline void FixedwingMetrics::clear_altitude_msl() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.altitude_msl_ = 0;
-}
-inline float FixedwingMetrics::altitude_msl() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry.FixedwingMetrics.altitude_msl)
-  return _internal_altitude_msl();
-}
-inline void FixedwingMetrics::set_altitude_msl(float value) {
-  _internal_set_altitude_msl(value);
-  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry.FixedwingMetrics.altitude_msl)
-}
-inline float FixedwingMetrics::_internal_altitude_msl() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.altitude_msl_;
-}
-inline void FixedwingMetrics::_internal_set_altitude_msl(float value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.altitude_msl_ = value;
-}
-
-// float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
+// float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
 inline void FixedwingMetrics::clear_climb_rate_m_s() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.climb_rate_m_s_ = 0;
@@ -37791,6 +37725,72 @@ inline float FixedwingMetrics::_internal_climb_rate_m_s() const {
 inline void FixedwingMetrics::_internal_set_climb_rate_m_s(float value) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.climb_rate_m_s_ = value;
+}
+
+// float groundspeed_m_s = 4 [(.mavsdk.options.default_value) = "NaN"];
+inline void FixedwingMetrics::clear_groundspeed_m_s() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.groundspeed_m_s_ = 0;
+}
+inline float FixedwingMetrics::groundspeed_m_s() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry.FixedwingMetrics.groundspeed_m_s)
+  return _internal_groundspeed_m_s();
+}
+inline void FixedwingMetrics::set_groundspeed_m_s(float value) {
+  _internal_set_groundspeed_m_s(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry.FixedwingMetrics.groundspeed_m_s)
+}
+inline float FixedwingMetrics::_internal_groundspeed_m_s() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.groundspeed_m_s_;
+}
+inline void FixedwingMetrics::_internal_set_groundspeed_m_s(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.groundspeed_m_s_ = value;
+}
+
+// float heading_deg = 5 [(.mavsdk.options.default_value) = "NaN"];
+inline void FixedwingMetrics::clear_heading_deg() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.heading_deg_ = 0;
+}
+inline float FixedwingMetrics::heading_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry.FixedwingMetrics.heading_deg)
+  return _internal_heading_deg();
+}
+inline void FixedwingMetrics::set_heading_deg(float value) {
+  _internal_set_heading_deg(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry.FixedwingMetrics.heading_deg)
+}
+inline float FixedwingMetrics::_internal_heading_deg() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.heading_deg_;
+}
+inline void FixedwingMetrics::_internal_set_heading_deg(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.heading_deg_ = value;
+}
+
+// float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
+inline void FixedwingMetrics::clear_altitude_msl() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.altitude_msl_ = 0;
+}
+inline float FixedwingMetrics::altitude_msl() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry.FixedwingMetrics.altitude_msl)
+  return _internal_altitude_msl();
+}
+inline void FixedwingMetrics::set_altitude_msl(float value) {
+  _internal_set_altitude_msl(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry.FixedwingMetrics.altitude_msl)
+}
+inline float FixedwingMetrics::_internal_altitude_msl() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.altitude_msl_;
+}
+inline void FixedwingMetrics::_internal_set_altitude_msl(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.altitude_msl_ = value;
 }
 
 // -------------------------------------------------------------------

--- a/src/mavsdk_server/src/generated/telemetry/telemetry.pb.h
+++ b/src/mavsdk_server/src/generated/telemetry/telemetry.pb.h
@@ -15538,7 +15538,7 @@ class FixedwingMetrics final
     kClimbRateMSFieldNumber = 3,
     kGroundspeedMSFieldNumber = 4,
     kHeadingDegFieldNumber = 5,
-    kAltitudeMslFieldNumber = 6,
+    kAbsoluteAltitudeMFieldNumber = 6,
   };
   // float airspeed_m_s = 1 [(.mavsdk.options.default_value) = "NaN"];
   void clear_airspeed_m_s() ;
@@ -15590,14 +15590,14 @@ class FixedwingMetrics final
   void _internal_set_heading_deg(float value);
 
   public:
-  // float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
-  void clear_altitude_msl() ;
-  float altitude_msl() const;
-  void set_altitude_msl(float value);
+  // float absolute_altitude_m = 6 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_absolute_altitude_m() ;
+  float absolute_altitude_m() const;
+  void set_absolute_altitude_m(float value);
 
   private:
-  float _internal_altitude_msl() const;
-  void _internal_set_altitude_msl(float value);
+  float _internal_absolute_altitude_m() const;
+  void _internal_set_absolute_altitude_m(float value);
 
   public:
   // @@protoc_insertion_point(class_scope:mavsdk.rpc.telemetry.FixedwingMetrics)
@@ -15628,7 +15628,7 @@ class FixedwingMetrics final
     float climb_rate_m_s_;
     float groundspeed_m_s_;
     float heading_deg_;
-    float altitude_msl_;
+    float absolute_altitude_m_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
@@ -37771,26 +37771,26 @@ inline void FixedwingMetrics::_internal_set_heading_deg(float value) {
   _impl_.heading_deg_ = value;
 }
 
-// float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
-inline void FixedwingMetrics::clear_altitude_msl() {
+// float absolute_altitude_m = 6 [(.mavsdk.options.default_value) = "NaN"];
+inline void FixedwingMetrics::clear_absolute_altitude_m() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.altitude_msl_ = 0;
+  _impl_.absolute_altitude_m_ = 0;
 }
-inline float FixedwingMetrics::altitude_msl() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry.FixedwingMetrics.altitude_msl)
-  return _internal_altitude_msl();
+inline float FixedwingMetrics::absolute_altitude_m() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry.FixedwingMetrics.absolute_altitude_m)
+  return _internal_absolute_altitude_m();
 }
-inline void FixedwingMetrics::set_altitude_msl(float value) {
-  _internal_set_altitude_msl(value);
-  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry.FixedwingMetrics.altitude_msl)
+inline void FixedwingMetrics::set_absolute_altitude_m(float value) {
+  _internal_set_absolute_altitude_m(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry.FixedwingMetrics.absolute_altitude_m)
 }
-inline float FixedwingMetrics::_internal_altitude_msl() const {
+inline float FixedwingMetrics::_internal_absolute_altitude_m() const {
   ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.altitude_msl_;
+  return _impl_.absolute_altitude_m_;
 }
-inline void FixedwingMetrics::_internal_set_altitude_msl(float value) {
+inline void FixedwingMetrics::_internal_set_absolute_altitude_m(float value) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.altitude_msl_ = value;
+  _impl_.absolute_altitude_m_ = value;
 }
 
 // -------------------------------------------------------------------

--- a/src/mavsdk_server/src/generated/telemetry_server/telemetry_server.grpc.pb.cc
+++ b/src/mavsdk_server/src/generated/telemetry_server/telemetry_server.grpc.pb.cc
@@ -39,6 +39,8 @@ static const char* TelemetryServerService_method_names[] = {
   "/mavsdk.rpc.telemetry_server.TelemetryServerService/PublishRawImu",
   "/mavsdk.rpc.telemetry_server.TelemetryServerService/PublishUnixEpochTime",
   "/mavsdk.rpc.telemetry_server.TelemetryServerService/PublishDistanceSensor",
+  "/mavsdk.rpc.telemetry_server.TelemetryServerService/PublishAttitude",
+  "/mavsdk.rpc.telemetry_server.TelemetryServerService/PublishVisualFlightRulesHud",
 };
 
 std::unique_ptr< TelemetryServerService::Stub> TelemetryServerService::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
@@ -63,6 +65,8 @@ TelemetryServerService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterfa
   , rpcmethod_PublishRawImu_(TelemetryServerService_method_names[12], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_PublishUnixEpochTime_(TelemetryServerService_method_names[13], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_PublishDistanceSensor_(TelemetryServerService_method_names[14], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_PublishAttitude_(TelemetryServerService_method_names[15], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_PublishVisualFlightRulesHud_(TelemetryServerService_method_names[16], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status TelemetryServerService::Stub::PublishPosition(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishPositionRequest& request, ::mavsdk::rpc::telemetry_server::PublishPositionResponse* response) {
@@ -410,6 +414,52 @@ void TelemetryServerService::Stub::async::PublishDistanceSensor(::grpc::ClientCo
   return result;
 }
 
+::grpc::Status TelemetryServerService::Stub::PublishAttitude(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest& request, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_PublishAttitude_, context, request, response);
+}
+
+void TelemetryServerService::Stub::async::PublishAttitude(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest* request, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_PublishAttitude_, context, request, response, std::move(f));
+}
+
+void TelemetryServerService::Stub::async::PublishAttitude(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest* request, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_PublishAttitude_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>* TelemetryServerService::Stub::PrepareAsyncPublishAttitudeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse, ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_PublishAttitude_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>* TelemetryServerService::Stub::AsyncPublishAttitudeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncPublishAttitudeRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::Status TelemetryServerService::Stub::PublishVisualFlightRulesHud(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest& request, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_PublishVisualFlightRulesHud_, context, request, response);
+}
+
+void TelemetryServerService::Stub::async::PublishVisualFlightRulesHud(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest* request, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_PublishVisualFlightRulesHud_, context, request, response, std::move(f));
+}
+
+void TelemetryServerService::Stub::async::PublishVisualFlightRulesHud(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest* request, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_PublishVisualFlightRulesHud_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>* TelemetryServerService::Stub::PrepareAsyncPublishVisualFlightRulesHudRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_PublishVisualFlightRulesHud_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>* TelemetryServerService::Stub::AsyncPublishVisualFlightRulesHudRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncPublishVisualFlightRulesHudRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
 TelemetryServerService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       TelemetryServerService_method_names[0],
@@ -561,6 +611,26 @@ TelemetryServerService::Service::Service() {
              ::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse* resp) {
                return service->PublishDistanceSensor(ctx, req, resp);
              }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      TelemetryServerService_method_names[15],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< TelemetryServerService::Service, ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](TelemetryServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest* req,
+             ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse* resp) {
+               return service->PublishAttitude(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      TelemetryServerService_method_names[16],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< TelemetryServerService::Service, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](TelemetryServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest* req,
+             ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse* resp) {
+               return service->PublishVisualFlightRulesHud(ctx, req, resp);
+             }, this)));
 }
 
 TelemetryServerService::Service::~Service() {
@@ -665,6 +735,20 @@ TelemetryServerService::Service::~Service() {
 }
 
 ::grpc::Status TelemetryServerService::Service::PublishDistanceSensor(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry_server::PublishDistanceSensorRequest* request, ::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status TelemetryServerService::Service::PublishAttitude(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest* request, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status TelemetryServerService::Service::PublishVisualFlightRulesHud(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest* request, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/src/mavsdk_server/src/generated/telemetry_server/telemetry_server.grpc.pb.h
+++ b/src/mavsdk_server/src/generated/telemetry_server/telemetry_server.grpc.pb.h
@@ -160,6 +160,22 @@ class TelemetryServerService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse>> PrepareAsyncPublishDistanceSensor(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishDistanceSensorRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse>>(PrepareAsyncPublishDistanceSensorRaw(context, request, cq));
     }
+    // Publish to "attitude" updates.
+    virtual ::grpc::Status PublishAttitude(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest& request, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>> AsyncPublishAttitude(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>>(AsyncPublishAttitudeRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>> PrepareAsyncPublishAttitude(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>>(PrepareAsyncPublishAttitudeRaw(context, request, cq));
+    }
+    // Publish to "Visual Flight Rules HUD" updates.
+    virtual ::grpc::Status PublishVisualFlightRulesHud(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest& request, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>> AsyncPublishVisualFlightRulesHud(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>>(AsyncPublishVisualFlightRulesHudRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>> PrepareAsyncPublishVisualFlightRulesHud(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>>(PrepareAsyncPublishVisualFlightRulesHudRaw(context, request, cq));
+    }
     class async_interface {
      public:
       virtual ~async_interface() {}
@@ -208,6 +224,12 @@ class TelemetryServerService final {
       // Publish to "distance sensor" updates.
       virtual void PublishDistanceSensor(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishDistanceSensorRequest* request, ::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void PublishDistanceSensor(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishDistanceSensorRequest* request, ::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Publish to "attitude" updates.
+      virtual void PublishAttitude(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest* request, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void PublishAttitude(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest* request, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Publish to "Visual Flight Rules HUD" updates.
+      virtual void PublishVisualFlightRulesHud(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest* request, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void PublishVisualFlightRulesHud(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest* request, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
     };
     typedef class async_interface experimental_async_interface;
     virtual class async_interface* async() { return nullptr; }
@@ -243,6 +265,10 @@ class TelemetryServerService final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry_server::PublishUnixEpochTimeResponse>* PrepareAsyncPublishUnixEpochTimeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishUnixEpochTimeRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse>* AsyncPublishDistanceSensorRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishDistanceSensorRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse>* PrepareAsyncPublishDistanceSensorRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishDistanceSensorRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>* AsyncPublishAttitudeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>* PrepareAsyncPublishAttitudeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>* AsyncPublishVisualFlightRulesHudRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>* PrepareAsyncPublishVisualFlightRulesHudRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest& request, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
@@ -352,6 +378,20 @@ class TelemetryServerService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse>> PrepareAsyncPublishDistanceSensor(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishDistanceSensorRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse>>(PrepareAsyncPublishDistanceSensorRaw(context, request, cq));
     }
+    ::grpc::Status PublishAttitude(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest& request, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>> AsyncPublishAttitude(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>>(AsyncPublishAttitudeRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>> PrepareAsyncPublishAttitude(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>>(PrepareAsyncPublishAttitudeRaw(context, request, cq));
+    }
+    ::grpc::Status PublishVisualFlightRulesHud(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest& request, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>> AsyncPublishVisualFlightRulesHud(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>>(AsyncPublishVisualFlightRulesHudRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>> PrepareAsyncPublishVisualFlightRulesHud(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>>(PrepareAsyncPublishVisualFlightRulesHudRaw(context, request, cq));
+    }
     class async final :
       public StubInterface::async_interface {
      public:
@@ -385,6 +425,10 @@ class TelemetryServerService final {
       void PublishUnixEpochTime(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishUnixEpochTimeRequest* request, ::mavsdk::rpc::telemetry_server::PublishUnixEpochTimeResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void PublishDistanceSensor(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishDistanceSensorRequest* request, ::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse* response, std::function<void(::grpc::Status)>) override;
       void PublishDistanceSensor(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishDistanceSensorRequest* request, ::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void PublishAttitude(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest* request, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse* response, std::function<void(::grpc::Status)>) override;
+      void PublishAttitude(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest* request, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void PublishVisualFlightRulesHud(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest* request, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse* response, std::function<void(::grpc::Status)>) override;
+      void PublishVisualFlightRulesHud(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest* request, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
      private:
       friend class Stub;
       explicit async(Stub* stub): stub_(stub) { }
@@ -426,6 +470,10 @@ class TelemetryServerService final {
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishUnixEpochTimeResponse>* PrepareAsyncPublishUnixEpochTimeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishUnixEpochTimeRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse>* AsyncPublishDistanceSensorRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishDistanceSensorRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse>* PrepareAsyncPublishDistanceSensorRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishDistanceSensorRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>* AsyncPublishAttitudeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>* PrepareAsyncPublishAttitudeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>* AsyncPublishVisualFlightRulesHudRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>* PrepareAsyncPublishVisualFlightRulesHudRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_PublishPosition_;
     const ::grpc::internal::RpcMethod rpcmethod_PublishHome_;
     const ::grpc::internal::RpcMethod rpcmethod_PublishSysStatus_;
@@ -441,6 +489,8 @@ class TelemetryServerService final {
     const ::grpc::internal::RpcMethod rpcmethod_PublishRawImu_;
     const ::grpc::internal::RpcMethod rpcmethod_PublishUnixEpochTime_;
     const ::grpc::internal::RpcMethod rpcmethod_PublishDistanceSensor_;
+    const ::grpc::internal::RpcMethod rpcmethod_PublishAttitude_;
+    const ::grpc::internal::RpcMethod rpcmethod_PublishVisualFlightRulesHud_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
 
@@ -478,6 +528,10 @@ class TelemetryServerService final {
     virtual ::grpc::Status PublishUnixEpochTime(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry_server::PublishUnixEpochTimeRequest* request, ::mavsdk::rpc::telemetry_server::PublishUnixEpochTimeResponse* response);
     // Publish to "distance sensor" updates.
     virtual ::grpc::Status PublishDistanceSensor(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry_server::PublishDistanceSensorRequest* request, ::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse* response);
+    // Publish to "attitude" updates.
+    virtual ::grpc::Status PublishAttitude(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest* request, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse* response);
+    // Publish to "Visual Flight Rules HUD" updates.
+    virtual ::grpc::Status PublishVisualFlightRulesHud(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest* request, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse* response);
   };
   template <class BaseClass>
   class WithAsyncMethod_PublishPosition : public BaseClass {
@@ -779,7 +833,47 @@ class TelemetryServerService final {
       ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_PublishPosition<WithAsyncMethod_PublishHome<WithAsyncMethod_PublishSysStatus<WithAsyncMethod_PublishExtendedSysState<WithAsyncMethod_PublishRawGps<WithAsyncMethod_PublishBattery<WithAsyncMethod_PublishStatusText<WithAsyncMethod_PublishOdometry<WithAsyncMethod_PublishPositionVelocityNed<WithAsyncMethod_PublishGroundTruth<WithAsyncMethod_PublishImu<WithAsyncMethod_PublishScaledImu<WithAsyncMethod_PublishRawImu<WithAsyncMethod_PublishUnixEpochTime<WithAsyncMethod_PublishDistanceSensor<Service > > > > > > > > > > > > > > > AsyncService;
+  template <class BaseClass>
+  class WithAsyncMethod_PublishAttitude : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_PublishAttitude() {
+      ::grpc::Service::MarkMethodAsync(15);
+    }
+    ~WithAsyncMethod_PublishAttitude() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status PublishAttitude(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest* /*request*/, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestPublishAttitude(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_PublishVisualFlightRulesHud : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_PublishVisualFlightRulesHud() {
+      ::grpc::Service::MarkMethodAsync(16);
+    }
+    ~WithAsyncMethod_PublishVisualFlightRulesHud() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status PublishVisualFlightRulesHud(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest* /*request*/, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestPublishVisualFlightRulesHud(::grpc::ServerContext* context, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  typedef WithAsyncMethod_PublishPosition<WithAsyncMethod_PublishHome<WithAsyncMethod_PublishSysStatus<WithAsyncMethod_PublishExtendedSysState<WithAsyncMethod_PublishRawGps<WithAsyncMethod_PublishBattery<WithAsyncMethod_PublishStatusText<WithAsyncMethod_PublishOdometry<WithAsyncMethod_PublishPositionVelocityNed<WithAsyncMethod_PublishGroundTruth<WithAsyncMethod_PublishImu<WithAsyncMethod_PublishScaledImu<WithAsyncMethod_PublishRawImu<WithAsyncMethod_PublishUnixEpochTime<WithAsyncMethod_PublishDistanceSensor<WithAsyncMethod_PublishAttitude<WithAsyncMethod_PublishVisualFlightRulesHud<Service > > > > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_PublishPosition : public BaseClass {
    private:
@@ -1185,7 +1279,61 @@ class TelemetryServerService final {
     virtual ::grpc::ServerUnaryReactor* PublishDistanceSensor(
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::telemetry_server::PublishDistanceSensorRequest* /*request*/, ::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_PublishPosition<WithCallbackMethod_PublishHome<WithCallbackMethod_PublishSysStatus<WithCallbackMethod_PublishExtendedSysState<WithCallbackMethod_PublishRawGps<WithCallbackMethod_PublishBattery<WithCallbackMethod_PublishStatusText<WithCallbackMethod_PublishOdometry<WithCallbackMethod_PublishPositionVelocityNed<WithCallbackMethod_PublishGroundTruth<WithCallbackMethod_PublishImu<WithCallbackMethod_PublishScaledImu<WithCallbackMethod_PublishRawImu<WithCallbackMethod_PublishUnixEpochTime<WithCallbackMethod_PublishDistanceSensor<Service > > > > > > > > > > > > > > > CallbackService;
+  template <class BaseClass>
+  class WithCallbackMethod_PublishAttitude : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_PublishAttitude() {
+      ::grpc::Service::MarkMethodCallback(15,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest* request, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse* response) { return this->PublishAttitude(context, request, response); }));}
+    void SetMessageAllocatorFor_PublishAttitude(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(15);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_PublishAttitude() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status PublishAttitude(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest* /*request*/, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* PublishAttitude(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest* /*request*/, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_PublishVisualFlightRulesHud : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_PublishVisualFlightRulesHud() {
+      ::grpc::Service::MarkMethodCallback(16,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest* request, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse* response) { return this->PublishVisualFlightRulesHud(context, request, response); }));}
+    void SetMessageAllocatorFor_PublishVisualFlightRulesHud(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(16);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_PublishVisualFlightRulesHud() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status PublishVisualFlightRulesHud(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest* /*request*/, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* PublishVisualFlightRulesHud(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest* /*request*/, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse* /*response*/)  { return nullptr; }
+  };
+  typedef WithCallbackMethod_PublishPosition<WithCallbackMethod_PublishHome<WithCallbackMethod_PublishSysStatus<WithCallbackMethod_PublishExtendedSysState<WithCallbackMethod_PublishRawGps<WithCallbackMethod_PublishBattery<WithCallbackMethod_PublishStatusText<WithCallbackMethod_PublishOdometry<WithCallbackMethod_PublishPositionVelocityNed<WithCallbackMethod_PublishGroundTruth<WithCallbackMethod_PublishImu<WithCallbackMethod_PublishScaledImu<WithCallbackMethod_PublishRawImu<WithCallbackMethod_PublishUnixEpochTime<WithCallbackMethod_PublishDistanceSensor<WithCallbackMethod_PublishAttitude<WithCallbackMethod_PublishVisualFlightRulesHud<Service > > > > > > > > > > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_PublishPosition : public BaseClass {
@@ -1438,6 +1586,40 @@ class TelemetryServerService final {
     }
     // disable synchronous version of this method
     ::grpc::Status PublishDistanceSensor(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry_server::PublishDistanceSensorRequest* /*request*/, ::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_PublishAttitude : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_PublishAttitude() {
+      ::grpc::Service::MarkMethodGeneric(15);
+    }
+    ~WithGenericMethod_PublishAttitude() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status PublishAttitude(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest* /*request*/, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_PublishVisualFlightRulesHud : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_PublishVisualFlightRulesHud() {
+      ::grpc::Service::MarkMethodGeneric(16);
+    }
+    ~WithGenericMethod_PublishVisualFlightRulesHud() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status PublishVisualFlightRulesHud(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest* /*request*/, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -1740,6 +1922,46 @@ class TelemetryServerService final {
     }
     void RequestPublishDistanceSensor(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_PublishAttitude : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_PublishAttitude() {
+      ::grpc::Service::MarkMethodRaw(15);
+    }
+    ~WithRawMethod_PublishAttitude() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status PublishAttitude(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest* /*request*/, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestPublishAttitude(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_PublishVisualFlightRulesHud : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_PublishVisualFlightRulesHud() {
+      ::grpc::Service::MarkMethodRaw(16);
+    }
+    ~WithRawMethod_PublishVisualFlightRulesHud() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status PublishVisualFlightRulesHud(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest* /*request*/, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestPublishVisualFlightRulesHud(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2070,6 +2292,50 @@ class TelemetryServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     virtual ::grpc::ServerUnaryReactor* PublishDistanceSensor(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_PublishAttitude : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_PublishAttitude() {
+      ::grpc::Service::MarkMethodRawCallback(15,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->PublishAttitude(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_PublishAttitude() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status PublishAttitude(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest* /*request*/, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* PublishAttitude(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_PublishVisualFlightRulesHud : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_PublishVisualFlightRulesHud() {
+      ::grpc::Service::MarkMethodRawCallback(16,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->PublishVisualFlightRulesHud(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_PublishVisualFlightRulesHud() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status PublishVisualFlightRulesHud(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest* /*request*/, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* PublishVisualFlightRulesHud(
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
@@ -2477,9 +2743,63 @@ class TelemetryServerService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedPublishDistanceSensor(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::telemetry_server::PublishDistanceSensorRequest,::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_PublishPosition<WithStreamedUnaryMethod_PublishHome<WithStreamedUnaryMethod_PublishSysStatus<WithStreamedUnaryMethod_PublishExtendedSysState<WithStreamedUnaryMethod_PublishRawGps<WithStreamedUnaryMethod_PublishBattery<WithStreamedUnaryMethod_PublishStatusText<WithStreamedUnaryMethod_PublishOdometry<WithStreamedUnaryMethod_PublishPositionVelocityNed<WithStreamedUnaryMethod_PublishGroundTruth<WithStreamedUnaryMethod_PublishImu<WithStreamedUnaryMethod_PublishScaledImu<WithStreamedUnaryMethod_PublishRawImu<WithStreamedUnaryMethod_PublishUnixEpochTime<WithStreamedUnaryMethod_PublishDistanceSensor<Service > > > > > > > > > > > > > > > StreamedUnaryService;
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_PublishAttitude : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_PublishAttitude() {
+      ::grpc::Service::MarkMethodStreamed(15,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>* streamer) {
+                       return this->StreamedPublishAttitude(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_PublishAttitude() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status PublishAttitude(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest* /*request*/, ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedPublishAttitude(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest,::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_PublishVisualFlightRulesHud : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_PublishVisualFlightRulesHud() {
+      ::grpc::Service::MarkMethodStreamed(16,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>* streamer) {
+                       return this->StreamedPublishVisualFlightRulesHud(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_PublishVisualFlightRulesHud() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status PublishVisualFlightRulesHud(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest* /*request*/, ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedPublishVisualFlightRulesHud(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest,::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>* server_unary_streamer) = 0;
+  };
+  typedef WithStreamedUnaryMethod_PublishPosition<WithStreamedUnaryMethod_PublishHome<WithStreamedUnaryMethod_PublishSysStatus<WithStreamedUnaryMethod_PublishExtendedSysState<WithStreamedUnaryMethod_PublishRawGps<WithStreamedUnaryMethod_PublishBattery<WithStreamedUnaryMethod_PublishStatusText<WithStreamedUnaryMethod_PublishOdometry<WithStreamedUnaryMethod_PublishPositionVelocityNed<WithStreamedUnaryMethod_PublishGroundTruth<WithStreamedUnaryMethod_PublishImu<WithStreamedUnaryMethod_PublishScaledImu<WithStreamedUnaryMethod_PublishRawImu<WithStreamedUnaryMethod_PublishUnixEpochTime<WithStreamedUnaryMethod_PublishDistanceSensor<WithStreamedUnaryMethod_PublishAttitude<WithStreamedUnaryMethod_PublishVisualFlightRulesHud<Service > > > > > > > > > > > > > > > > > StreamedUnaryService;
   typedef Service SplitStreamedService;
-  typedef WithStreamedUnaryMethod_PublishPosition<WithStreamedUnaryMethod_PublishHome<WithStreamedUnaryMethod_PublishSysStatus<WithStreamedUnaryMethod_PublishExtendedSysState<WithStreamedUnaryMethod_PublishRawGps<WithStreamedUnaryMethod_PublishBattery<WithStreamedUnaryMethod_PublishStatusText<WithStreamedUnaryMethod_PublishOdometry<WithStreamedUnaryMethod_PublishPositionVelocityNed<WithStreamedUnaryMethod_PublishGroundTruth<WithStreamedUnaryMethod_PublishImu<WithStreamedUnaryMethod_PublishScaledImu<WithStreamedUnaryMethod_PublishRawImu<WithStreamedUnaryMethod_PublishUnixEpochTime<WithStreamedUnaryMethod_PublishDistanceSensor<Service > > > > > > > > > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_PublishPosition<WithStreamedUnaryMethod_PublishHome<WithStreamedUnaryMethod_PublishSysStatus<WithStreamedUnaryMethod_PublishExtendedSysState<WithStreamedUnaryMethod_PublishRawGps<WithStreamedUnaryMethod_PublishBattery<WithStreamedUnaryMethod_PublishStatusText<WithStreamedUnaryMethod_PublishOdometry<WithStreamedUnaryMethod_PublishPositionVelocityNed<WithStreamedUnaryMethod_PublishGroundTruth<WithStreamedUnaryMethod_PublishImu<WithStreamedUnaryMethod_PublishScaledImu<WithStreamedUnaryMethod_PublishRawImu<WithStreamedUnaryMethod_PublishUnixEpochTime<WithStreamedUnaryMethod_PublishDistanceSensor<WithStreamedUnaryMethod_PublishAttitude<WithStreamedUnaryMethod_PublishVisualFlightRulesHud<Service > > > > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace telemetry_server

--- a/src/mavsdk_server/src/generated/telemetry_server/telemetry_server.pb.cc
+++ b/src/mavsdk_server/src/generated/telemetry_server/telemetry_server.pb.cc
@@ -552,11 +552,11 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
 inline constexpr FixedwingMetrics::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : airspeed_m_s_{0},
+        throttle_percentage_{0},
+        climb_rate_m_s_{0},
         groundspeed_m_s_{0},
         heading_deg_{0},
-        throttle_percentage_{0},
         altitude_msl_{0},
-        climb_rate_m_s_{0},
         _cached_size_{0} {}
 
 template <typename>
@@ -2408,11 +2408,11 @@ const ::uint32_t
         ~0u,  // no _split_
         ~0u,  // no sizeof(Split)
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::FixedwingMetrics, _impl_.airspeed_m_s_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::FixedwingMetrics, _impl_.throttle_percentage_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::FixedwingMetrics, _impl_.climb_rate_m_s_),
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::FixedwingMetrics, _impl_.groundspeed_m_s_),
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::FixedwingMetrics, _impl_.heading_deg_),
-        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::FixedwingMetrics, _impl_.throttle_percentage_),
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::FixedwingMetrics, _impl_.altitude_msl_),
-        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::FixedwingMetrics, _impl_.climb_rate_m_s_),
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::AccelerationFrd, _internal_metadata_),
         ~0u,  // no _extensions_
@@ -2791,11 +2791,11 @@ const char descriptor_table_protodef_telemetry_5fserver_2ftelemetry_5fserver_2ep
     "g\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlongitude_deg\030\002 \001(\001B"
     "\007\202\265\030\003NaN\022$\n\023absolute_altitude_m\030\003 \001(\002B\007\202"
     "\265\030\003NaN\"\327\001\n\020FixedwingMetrics\022\035\n\014airspeed_"
-    "m_s\030\001 \001(\002B\007\202\265\030\003NaN\022 \n\017groundspeed_m_s\030\002 "
-    "\001(\002B\007\202\265\030\003NaN\022\034\n\013heading_deg\030\003 \001(\002B\007\202\265\030\003N"
-    "aN\022$\n\023throttle_percentage\030\004 \001(\002B\007\202\265\030\003NaN"
-    "\022\035\n\014altitude_msl\030\005 \001(\002B\007\202\265\030\003NaN\022\037\n\016climb"
-    "_rate_m_s\030\006 \001(\002B\007\202\265\030\003NaN\"i\n\017Acceleration"
+    "m_s\030\001 \001(\002B\007\202\265\030\003NaN\022$\n\023throttle_percentag"
+    "e\030\002 \001(\002B\007\202\265\030\003NaN\022\037\n\016climb_rate_m_s\030\003 \001(\002"
+    "B\007\202\265\030\003NaN\022 \n\017groundspeed_m_s\030\004 \001(\002B\007\202\265\030\003"
+    "NaN\022\034\n\013heading_deg\030\005 \001(\002B\007\202\265\030\003NaN\022\035\n\014alt"
+    "itude_msl\030\006 \001(\002B\007\202\265\030\003NaN\"i\n\017Acceleration"
     "Frd\022\035\n\014forward_m_s2\030\001 \001(\002B\007\202\265\030\003NaN\022\033\n\nri"
     "ght_m_s2\030\002 \001(\002B\007\202\265\030\003NaN\022\032\n\tdown_m_s2\030\003 \001"
     "(\002B\007\202\265\030\003NaN\"o\n\022AngularVelocityFrd\022\036\n\rfor"
@@ -18729,9 +18729,9 @@ inline void FixedwingMetrics::SharedCtor(::_pb::Arena* arena) {
   ::memset(reinterpret_cast<char *>(&_impl_) +
                offsetof(Impl_, airspeed_m_s_),
            0,
-           offsetof(Impl_, climb_rate_m_s_) -
+           offsetof(Impl_, altitude_msl_) -
                offsetof(Impl_, airspeed_m_s_) +
-               sizeof(Impl_::climb_rate_m_s_));
+               sizeof(Impl_::altitude_msl_));
 }
 FixedwingMetrics::~FixedwingMetrics() {
   // @@protoc_insertion_point(destructor:mavsdk.rpc.telemetry_server.FixedwingMetrics)
@@ -18802,21 +18802,21 @@ const ::_pbi::TcParseTable<3, 6, 0, 0, 2> FixedwingMetrics::_table_ = {
     // float airspeed_m_s = 1 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
      {13, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.airspeed_m_s_)}},
-    // float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
+    // float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
-     {21, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.groundspeed_m_s_)}},
-    // float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
+     {21, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.throttle_percentage_)}},
+    // float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
-     {29, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.heading_deg_)}},
-    // float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
+     {29, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.climb_rate_m_s_)}},
+    // float groundspeed_m_s = 4 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
-     {37, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.throttle_percentage_)}},
-    // float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
+     {37, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.groundspeed_m_s_)}},
+    // float heading_deg = 5 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
-     {45, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.altitude_msl_)}},
-    // float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
+     {45, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.heading_deg_)}},
+    // float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
-     {53, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.climb_rate_m_s_)}},
+     {53, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.altitude_msl_)}},
     {::_pbi::TcParser::MiniParse, {}},
   }}, {{
     65535, 65535
@@ -18824,20 +18824,20 @@ const ::_pbi::TcParseTable<3, 6, 0, 0, 2> FixedwingMetrics::_table_ = {
     // float airspeed_m_s = 1 [(.mavsdk.options.default_value) = "NaN"];
     {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.airspeed_m_s_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
-    // float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
-    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.groundspeed_m_s_), 0, 0,
-    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
-    // float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
-    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.heading_deg_), 0, 0,
-    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
-    // float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
+    // float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
     {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.throttle_percentage_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
-    // float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
-    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.altitude_msl_), 0, 0,
-    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
-    // float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
+    // float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
     {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.climb_rate_m_s_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+    // float groundspeed_m_s = 4 [(.mavsdk.options.default_value) = "NaN"];
+    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.groundspeed_m_s_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+    // float heading_deg = 5 [(.mavsdk.options.default_value) = "NaN"];
+    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.heading_deg_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+    // float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
+    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.altitude_msl_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
   }},
   // no aux_entries
@@ -18853,8 +18853,8 @@ PROTOBUF_NOINLINE void FixedwingMetrics::Clear() {
   (void) cached_has_bits;
 
   ::memset(&_impl_.airspeed_m_s_, 0, static_cast<::size_t>(
-      reinterpret_cast<char*>(&_impl_.climb_rate_m_s_) -
-      reinterpret_cast<char*>(&_impl_.airspeed_m_s_)) + sizeof(_impl_.climb_rate_m_s_));
+      reinterpret_cast<char*>(&_impl_.altitude_msl_) -
+      reinterpret_cast<char*>(&_impl_.airspeed_m_s_)) + sizeof(_impl_.altitude_msl_));
   _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
 }
 
@@ -18880,39 +18880,39 @@ PROTOBUF_NOINLINE void FixedwingMetrics::Clear() {
                 1, this_._internal_airspeed_m_s(), target);
           }
 
-          // float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
-          if (::absl::bit_cast<::uint32_t>(this_._internal_groundspeed_m_s()) != 0) {
-            target = stream->EnsureSpace(target);
-            target = ::_pbi::WireFormatLite::WriteFloatToArray(
-                2, this_._internal_groundspeed_m_s(), target);
-          }
-
-          // float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
-          if (::absl::bit_cast<::uint32_t>(this_._internal_heading_deg()) != 0) {
-            target = stream->EnsureSpace(target);
-            target = ::_pbi::WireFormatLite::WriteFloatToArray(
-                3, this_._internal_heading_deg(), target);
-          }
-
-          // float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
+          // float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
           if (::absl::bit_cast<::uint32_t>(this_._internal_throttle_percentage()) != 0) {
             target = stream->EnsureSpace(target);
             target = ::_pbi::WireFormatLite::WriteFloatToArray(
-                4, this_._internal_throttle_percentage(), target);
+                2, this_._internal_throttle_percentage(), target);
           }
 
-          // float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
-          if (::absl::bit_cast<::uint32_t>(this_._internal_altitude_msl()) != 0) {
-            target = stream->EnsureSpace(target);
-            target = ::_pbi::WireFormatLite::WriteFloatToArray(
-                5, this_._internal_altitude_msl(), target);
-          }
-
-          // float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
+          // float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
           if (::absl::bit_cast<::uint32_t>(this_._internal_climb_rate_m_s()) != 0) {
             target = stream->EnsureSpace(target);
             target = ::_pbi::WireFormatLite::WriteFloatToArray(
-                6, this_._internal_climb_rate_m_s(), target);
+                3, this_._internal_climb_rate_m_s(), target);
+          }
+
+          // float groundspeed_m_s = 4 [(.mavsdk.options.default_value) = "NaN"];
+          if (::absl::bit_cast<::uint32_t>(this_._internal_groundspeed_m_s()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                4, this_._internal_groundspeed_m_s(), target);
+          }
+
+          // float heading_deg = 5 [(.mavsdk.options.default_value) = "NaN"];
+          if (::absl::bit_cast<::uint32_t>(this_._internal_heading_deg()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                5, this_._internal_heading_deg(), target);
+          }
+
+          // float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
+          if (::absl::bit_cast<::uint32_t>(this_._internal_altitude_msl()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                6, this_._internal_altitude_msl(), target);
           }
 
           if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
@@ -18944,24 +18944,24 @@ PROTOBUF_NOINLINE void FixedwingMetrics::Clear() {
             if (::absl::bit_cast<::uint32_t>(this_._internal_airspeed_m_s()) != 0) {
               total_size += 5;
             }
-            // float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
-            if (::absl::bit_cast<::uint32_t>(this_._internal_groundspeed_m_s()) != 0) {
-              total_size += 5;
-            }
-            // float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
-            if (::absl::bit_cast<::uint32_t>(this_._internal_heading_deg()) != 0) {
-              total_size += 5;
-            }
-            // float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
+            // float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
             if (::absl::bit_cast<::uint32_t>(this_._internal_throttle_percentage()) != 0) {
               total_size += 5;
             }
-            // float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
-            if (::absl::bit_cast<::uint32_t>(this_._internal_altitude_msl()) != 0) {
+            // float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
+            if (::absl::bit_cast<::uint32_t>(this_._internal_climb_rate_m_s()) != 0) {
               total_size += 5;
             }
-            // float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
-            if (::absl::bit_cast<::uint32_t>(this_._internal_climb_rate_m_s()) != 0) {
+            // float groundspeed_m_s = 4 [(.mavsdk.options.default_value) = "NaN"];
+            if (::absl::bit_cast<::uint32_t>(this_._internal_groundspeed_m_s()) != 0) {
+              total_size += 5;
+            }
+            // float heading_deg = 5 [(.mavsdk.options.default_value) = "NaN"];
+            if (::absl::bit_cast<::uint32_t>(this_._internal_heading_deg()) != 0) {
+              total_size += 5;
+            }
+            // float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
+            if (::absl::bit_cast<::uint32_t>(this_._internal_altitude_msl()) != 0) {
               total_size += 5;
             }
           }
@@ -18980,20 +18980,20 @@ void FixedwingMetrics::MergeImpl(::google::protobuf::MessageLite& to_msg, const 
   if (::absl::bit_cast<::uint32_t>(from._internal_airspeed_m_s()) != 0) {
     _this->_impl_.airspeed_m_s_ = from._impl_.airspeed_m_s_;
   }
+  if (::absl::bit_cast<::uint32_t>(from._internal_throttle_percentage()) != 0) {
+    _this->_impl_.throttle_percentage_ = from._impl_.throttle_percentage_;
+  }
+  if (::absl::bit_cast<::uint32_t>(from._internal_climb_rate_m_s()) != 0) {
+    _this->_impl_.climb_rate_m_s_ = from._impl_.climb_rate_m_s_;
+  }
   if (::absl::bit_cast<::uint32_t>(from._internal_groundspeed_m_s()) != 0) {
     _this->_impl_.groundspeed_m_s_ = from._impl_.groundspeed_m_s_;
   }
   if (::absl::bit_cast<::uint32_t>(from._internal_heading_deg()) != 0) {
     _this->_impl_.heading_deg_ = from._impl_.heading_deg_;
   }
-  if (::absl::bit_cast<::uint32_t>(from._internal_throttle_percentage()) != 0) {
-    _this->_impl_.throttle_percentage_ = from._impl_.throttle_percentage_;
-  }
   if (::absl::bit_cast<::uint32_t>(from._internal_altitude_msl()) != 0) {
     _this->_impl_.altitude_msl_ = from._impl_.altitude_msl_;
-  }
-  if (::absl::bit_cast<::uint32_t>(from._internal_climb_rate_m_s()) != 0) {
-    _this->_impl_.climb_rate_m_s_ = from._impl_.climb_rate_m_s_;
   }
   _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
 }
@@ -19010,8 +19010,8 @@ void FixedwingMetrics::InternalSwap(FixedwingMetrics* PROTOBUF_RESTRICT other) {
   using std::swap;
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
   ::google::protobuf::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.climb_rate_m_s_)
-      + sizeof(FixedwingMetrics::_impl_.climb_rate_m_s_)
+      PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.altitude_msl_)
+      + sizeof(FixedwingMetrics::_impl_.altitude_msl_)
       - PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.airspeed_m_s_)>(
           reinterpret_cast<char*>(&_impl_.airspeed_m_s_),
           reinterpret_cast<char*>(&other->_impl_.airspeed_m_s_));

--- a/src/mavsdk_server/src/generated/telemetry_server/telemetry_server.pb.cc
+++ b/src/mavsdk_server/src/generated/telemetry_server/telemetry_server.pb.cc
@@ -556,7 +556,7 @@ inline constexpr FixedwingMetrics::Impl_::Impl_(
         climb_rate_m_s_{0},
         groundspeed_m_s_{0},
         heading_deg_{0},
-        altitude_msl_{0},
+        absolute_altitude_m_{0},
         _cached_size_{0} {}
 
 template <typename>
@@ -2412,7 +2412,7 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::FixedwingMetrics, _impl_.climb_rate_m_s_),
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::FixedwingMetrics, _impl_.groundspeed_m_s_),
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::FixedwingMetrics, _impl_.heading_deg_),
-        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::FixedwingMetrics, _impl_.altitude_msl_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::FixedwingMetrics, _impl_.absolute_altitude_m_),
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::AccelerationFrd, _internal_metadata_),
         ~0u,  // no _extensions_
@@ -2790,114 +2790,115 @@ const char descriptor_table_protodef_telemetry_5fserver_2ftelemetry_5fserver_2ep
     "elocityNed\"r\n\013GroundTruth\022\035\n\014latitude_de"
     "g\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlongitude_deg\030\002 \001(\001B"
     "\007\202\265\030\003NaN\022$\n\023absolute_altitude_m\030\003 \001(\002B\007\202"
-    "\265\030\003NaN\"\327\001\n\020FixedwingMetrics\022\035\n\014airspeed_"
+    "\265\030\003NaN\"\336\001\n\020FixedwingMetrics\022\035\n\014airspeed_"
     "m_s\030\001 \001(\002B\007\202\265\030\003NaN\022$\n\023throttle_percentag"
     "e\030\002 \001(\002B\007\202\265\030\003NaN\022\037\n\016climb_rate_m_s\030\003 \001(\002"
     "B\007\202\265\030\003NaN\022 \n\017groundspeed_m_s\030\004 \001(\002B\007\202\265\030\003"
-    "NaN\022\034\n\013heading_deg\030\005 \001(\002B\007\202\265\030\003NaN\022\035\n\014alt"
-    "itude_msl\030\006 \001(\002B\007\202\265\030\003NaN\"i\n\017Acceleration"
-    "Frd\022\035\n\014forward_m_s2\030\001 \001(\002B\007\202\265\030\003NaN\022\033\n\nri"
-    "ght_m_s2\030\002 \001(\002B\007\202\265\030\003NaN\022\032\n\tdown_m_s2\030\003 \001"
-    "(\002B\007\202\265\030\003NaN\"o\n\022AngularVelocityFrd\022\036\n\rfor"
-    "ward_rad_s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right_rad_s"
-    "\030\002 \001(\002B\007\202\265\030\003NaN\022\033\n\ndown_rad_s\030\003 \001(\002B\007\202\265\030"
-    "\003NaN\"m\n\020MagneticFieldFrd\022\036\n\rforward_gaus"
-    "s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right_gauss\030\002 \001(\002B\007\202"
-    "\265\030\003NaN\022\033\n\ndown_gauss\030\003 \001(\002B\007\202\265\030\003NaN\"\240\002\n\003"
-    "Imu\022F\n\020acceleration_frd\030\001 \001(\0132,.mavsdk.r"
-    "pc.telemetry_server.AccelerationFrd\022M\n\024a"
-    "ngular_velocity_frd\030\002 \001(\0132/.mavsdk.rpc.t"
-    "elemetry_server.AngularVelocityFrd\022I\n\022ma"
-    "gnetic_field_frd\030\003 \001(\0132-.mavsdk.rpc.tele"
-    "metry_server.MagneticFieldFrd\022!\n\020tempera"
-    "ture_degc\030\004 \001(\002B\007\202\265\030\003NaN\022\024\n\014timestamp_us"
-    "\030\005 \001(\004\"\264\002\n\025TelemetryServerResult\022I\n\006resu"
-    "lt\030\001 \001(\01629.mavsdk.rpc.telemetry_server.T"
-    "elemetryServerResult.Result\022\022\n\nresult_st"
-    "r\030\002 \001(\t\"\273\001\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022"
-    "\n\016RESULT_SUCCESS\020\001\022\024\n\020RESULT_NO_SYSTEM\020\002"
-    "\022\033\n\027RESULT_CONNECTION_ERROR\020\003\022\017\n\013RESULT_"
-    "BUSY\020\004\022\031\n\025RESULT_COMMAND_DENIED\020\005\022\022\n\016RES"
-    "ULT_TIMEOUT\020\006\022\026\n\022RESULT_UNSUPPORTED\020\007*\244\001"
-    "\n\007FixType\022\023\n\017FIX_TYPE_NO_GPS\020\000\022\023\n\017FIX_TY"
-    "PE_NO_FIX\020\001\022\023\n\017FIX_TYPE_FIX_2D\020\002\022\023\n\017FIX_"
-    "TYPE_FIX_3D\020\003\022\025\n\021FIX_TYPE_FIX_DGPS\020\004\022\026\n\022"
-    "FIX_TYPE_RTK_FLOAT\020\005\022\026\n\022FIX_TYPE_RTK_FIX"
-    "ED\020\006*\215\001\n\tVtolState\022\030\n\024VTOL_STATE_UNDEFIN"
-    "ED\020\000\022\037\n\033VTOL_STATE_TRANSITION_TO_FW\020\001\022\037\n"
-    "\033VTOL_STATE_TRANSITION_TO_MC\020\002\022\021\n\rVTOL_S"
-    "TATE_MC\020\003\022\021\n\rVTOL_STATE_FW\020\004*\371\001\n\016StatusT"
-    "extType\022\032\n\026STATUS_TEXT_TYPE_DEBUG\020\000\022\031\n\025S"
-    "TATUS_TEXT_TYPE_INFO\020\001\022\033\n\027STATUS_TEXT_TY"
-    "PE_NOTICE\020\002\022\034\n\030STATUS_TEXT_TYPE_WARNING\020"
-    "\003\022\032\n\026STATUS_TEXT_TYPE_ERROR\020\004\022\035\n\031STATUS_"
-    "TEXT_TYPE_CRITICAL\020\005\022\032\n\026STATUS_TEXT_TYPE"
-    "_ALERT\020\006\022\036\n\032STATUS_TEXT_TYPE_EMERGENCY\020\007"
-    "*\223\001\n\013LandedState\022\030\n\024LANDED_STATE_UNKNOWN"
-    "\020\000\022\032\n\026LANDED_STATE_ON_GROUND\020\001\022\027\n\023LANDED"
-    "_STATE_IN_AIR\020\002\022\033\n\027LANDED_STATE_TAKING_O"
-    "FF\020\003\022\030\n\024LANDED_STATE_LANDING\020\0042\321\022\n\026Telem"
-    "etryServerService\022\202\001\n\017PublishPosition\0223."
-    "mavsdk.rpc.telemetry_server.PublishPosit"
-    "ionRequest\0324.mavsdk.rpc.telemetry_server"
-    ".PublishPositionResponse\"\004\200\265\030\001\022v\n\013Publis"
-    "hHome\022/.mavsdk.rpc.telemetry_server.Publ"
-    "ishHomeRequest\0320.mavsdk.rpc.telemetry_se"
-    "rver.PublishHomeResponse\"\004\200\265\030\001\022\205\001\n\020Publi"
-    "shSysStatus\0224.mavsdk.rpc.telemetry_serve"
-    "r.PublishSysStatusRequest\0325.mavsdk.rpc.t"
-    "elemetry_server.PublishSysStatusResponse"
-    "\"\004\200\265\030\001\022\232\001\n\027PublishExtendedSysState\022;.mav"
-    "sdk.rpc.telemetry_server.PublishExtended"
-    "SysStateRequest\032<.mavsdk.rpc.telemetry_s"
-    "erver.PublishExtendedSysStateResponse\"\004\200"
-    "\265\030\001\022|\n\rPublishRawGps\0221.mavsdk.rpc.teleme"
-    "try_server.PublishRawGpsRequest\0322.mavsdk"
-    ".rpc.telemetry_server.PublishRawGpsRespo"
-    "nse\"\004\200\265\030\001\022\177\n\016PublishBattery\0222.mavsdk.rpc"
-    ".telemetry_server.PublishBatteryRequest\032"
-    "3.mavsdk.rpc.telemetry_server.PublishBat"
-    "teryResponse\"\004\200\265\030\001\022\210\001\n\021PublishStatusText"
-    "\0225.mavsdk.rpc.telemetry_server.PublishSt"
-    "atusTextRequest\0326.mavsdk.rpc.telemetry_s"
-    "erver.PublishStatusTextResponse\"\004\200\265\030\001\022\202\001"
-    "\n\017PublishOdometry\0223.mavsdk.rpc.telemetry"
-    "_server.PublishOdometryRequest\0324.mavsdk."
-    "rpc.telemetry_server.PublishOdometryResp"
-    "onse\"\004\200\265\030\001\022\243\001\n\032PublishPositionVelocityNe"
-    "d\022>.mavsdk.rpc.telemetry_server.PublishP"
-    "ositionVelocityNedRequest\032\?.mavsdk.rpc.t"
-    "elemetry_server.PublishPositionVelocityN"
-    "edResponse\"\004\200\265\030\001\022\213\001\n\022PublishGroundTruth\022"
-    "6.mavsdk.rpc.telemetry_server.PublishGro"
-    "undTruthRequest\0327.mavsdk.rpc.telemetry_s"
-    "erver.PublishGroundTruthResponse\"\004\200\265\030\001\022s"
-    "\n\nPublishImu\022..mavsdk.rpc.telemetry_serv"
-    "er.PublishImuRequest\032/.mavsdk.rpc.teleme"
-    "try_server.PublishImuResponse\"\004\200\265\030\001\022\205\001\n\020"
-    "PublishScaledImu\0224.mavsdk.rpc.telemetry_"
-    "server.PublishScaledImuRequest\0325.mavsdk."
-    "rpc.telemetry_server.PublishScaledImuRes"
-    "ponse\"\004\200\265\030\001\022|\n\rPublishRawImu\0221.mavsdk.rp"
-    "c.telemetry_server.PublishRawImuRequest\032"
-    "2.mavsdk.rpc.telemetry_server.PublishRaw"
-    "ImuResponse\"\004\200\265\030\001\022\221\001\n\024PublishUnixEpochTi"
-    "me\0228.mavsdk.rpc.telemetry_server.Publish"
-    "UnixEpochTimeRequest\0329.mavsdk.rpc.teleme"
-    "try_server.PublishUnixEpochTimeResponse\""
-    "\004\200\265\030\001\022\224\001\n\025PublishDistanceSensor\0229.mavsdk"
-    ".rpc.telemetry_server.PublishDistanceSen"
-    "sorRequest\032:.mavsdk.rpc.telemetry_server"
-    ".PublishDistanceSensorResponse\"\004\200\265\030\001\022\202\001\n"
-    "\017PublishAttitude\0223.mavsdk.rpc.telemetry_"
-    "server.PublishAttitudeRequest\0324.mavsdk.r"
-    "pc.telemetry_server.PublishAttitudeRespo"
-    "nse\"\004\200\265\030\001\022\246\001\n\033PublishVisualFlightRulesHu"
-    "d\022\?.mavsdk.rpc.telemetry_server.PublishV"
-    "isualFlightRulesHudRequest\032@.mavsdk.rpc."
-    "telemetry_server.PublishVisualFlightRule"
-    "sHudResponse\"\004\200\265\030\001B2\n\032io.mavsdk.telemetr"
-    "y_serverB\024TelemetryServerProtob\006proto3"
+    "NaN\022\034\n\013heading_deg\030\005 \001(\002B\007\202\265\030\003NaN\022$\n\023abs"
+    "olute_altitude_m\030\006 \001(\002B\007\202\265\030\003NaN\"i\n\017Accel"
+    "erationFrd\022\035\n\014forward_m_s2\030\001 \001(\002B\007\202\265\030\003Na"
+    "N\022\033\n\nright_m_s2\030\002 \001(\002B\007\202\265\030\003NaN\022\032\n\tdown_m"
+    "_s2\030\003 \001(\002B\007\202\265\030\003NaN\"o\n\022AngularVelocityFrd"
+    "\022\036\n\rforward_rad_s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013righ"
+    "t_rad_s\030\002 \001(\002B\007\202\265\030\003NaN\022\033\n\ndown_rad_s\030\003 \001"
+    "(\002B\007\202\265\030\003NaN\"m\n\020MagneticFieldFrd\022\036\n\rforwa"
+    "rd_gauss\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right_gauss\030\002"
+    " \001(\002B\007\202\265\030\003NaN\022\033\n\ndown_gauss\030\003 \001(\002B\007\202\265\030\003N"
+    "aN\"\240\002\n\003Imu\022F\n\020acceleration_frd\030\001 \001(\0132,.m"
+    "avsdk.rpc.telemetry_server.AccelerationF"
+    "rd\022M\n\024angular_velocity_frd\030\002 \001(\0132/.mavsd"
+    "k.rpc.telemetry_server.AngularVelocityFr"
+    "d\022I\n\022magnetic_field_frd\030\003 \001(\0132-.mavsdk.r"
+    "pc.telemetry_server.MagneticFieldFrd\022!\n\020"
+    "temperature_degc\030\004 \001(\002B\007\202\265\030\003NaN\022\024\n\014times"
+    "tamp_us\030\005 \001(\004\"\264\002\n\025TelemetryServerResult\022"
+    "I\n\006result\030\001 \001(\01629.mavsdk.rpc.telemetry_s"
+    "erver.TelemetryServerResult.Result\022\022\n\nre"
+    "sult_str\030\002 \001(\t\"\273\001\n\006Result\022\022\n\016RESULT_UNKN"
+    "OWN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\024\n\020RESULT_NO_S"
+    "YSTEM\020\002\022\033\n\027RESULT_CONNECTION_ERROR\020\003\022\017\n\013"
+    "RESULT_BUSY\020\004\022\031\n\025RESULT_COMMAND_DENIED\020\005"
+    "\022\022\n\016RESULT_TIMEOUT\020\006\022\026\n\022RESULT_UNSUPPORT"
+    "ED\020\007*\244\001\n\007FixType\022\023\n\017FIX_TYPE_NO_GPS\020\000\022\023\n"
+    "\017FIX_TYPE_NO_FIX\020\001\022\023\n\017FIX_TYPE_FIX_2D\020\002\022"
+    "\023\n\017FIX_TYPE_FIX_3D\020\003\022\025\n\021FIX_TYPE_FIX_DGP"
+    "S\020\004\022\026\n\022FIX_TYPE_RTK_FLOAT\020\005\022\026\n\022FIX_TYPE_"
+    "RTK_FIXED\020\006*\215\001\n\tVtolState\022\030\n\024VTOL_STATE_"
+    "UNDEFINED\020\000\022\037\n\033VTOL_STATE_TRANSITION_TO_"
+    "FW\020\001\022\037\n\033VTOL_STATE_TRANSITION_TO_MC\020\002\022\021\n"
+    "\rVTOL_STATE_MC\020\003\022\021\n\rVTOL_STATE_FW\020\004*\371\001\n\016"
+    "StatusTextType\022\032\n\026STATUS_TEXT_TYPE_DEBUG"
+    "\020\000\022\031\n\025STATUS_TEXT_TYPE_INFO\020\001\022\033\n\027STATUS_"
+    "TEXT_TYPE_NOTICE\020\002\022\034\n\030STATUS_TEXT_TYPE_W"
+    "ARNING\020\003\022\032\n\026STATUS_TEXT_TYPE_ERROR\020\004\022\035\n\031"
+    "STATUS_TEXT_TYPE_CRITICAL\020\005\022\032\n\026STATUS_TE"
+    "XT_TYPE_ALERT\020\006\022\036\n\032STATUS_TEXT_TYPE_EMER"
+    "GENCY\020\007*\223\001\n\013LandedState\022\030\n\024LANDED_STATE_"
+    "UNKNOWN\020\000\022\032\n\026LANDED_STATE_ON_GROUND\020\001\022\027\n"
+    "\023LANDED_STATE_IN_AIR\020\002\022\033\n\027LANDED_STATE_T"
+    "AKING_OFF\020\003\022\030\n\024LANDED_STATE_LANDING\020\0042\321\022"
+    "\n\026TelemetryServerService\022\202\001\n\017PublishPosi"
+    "tion\0223.mavsdk.rpc.telemetry_server.Publi"
+    "shPositionRequest\0324.mavsdk.rpc.telemetry"
+    "_server.PublishPositionResponse\"\004\200\265\030\001\022v\n"
+    "\013PublishHome\022/.mavsdk.rpc.telemetry_serv"
+    "er.PublishHomeRequest\0320.mavsdk.rpc.telem"
+    "etry_server.PublishHomeResponse\"\004\200\265\030\001\022\205\001"
+    "\n\020PublishSysStatus\0224.mavsdk.rpc.telemetr"
+    "y_server.PublishSysStatusRequest\0325.mavsd"
+    "k.rpc.telemetry_server.PublishSysStatusR"
+    "esponse\"\004\200\265\030\001\022\232\001\n\027PublishExtendedSysStat"
+    "e\022;.mavsdk.rpc.telemetry_server.PublishE"
+    "xtendedSysStateRequest\032<.mavsdk.rpc.tele"
+    "metry_server.PublishExtendedSysStateResp"
+    "onse\"\004\200\265\030\001\022|\n\rPublishRawGps\0221.mavsdk.rpc"
+    ".telemetry_server.PublishRawGpsRequest\0322"
+    ".mavsdk.rpc.telemetry_server.PublishRawG"
+    "psResponse\"\004\200\265\030\001\022\177\n\016PublishBattery\0222.mav"
+    "sdk.rpc.telemetry_server.PublishBatteryR"
+    "equest\0323.mavsdk.rpc.telemetry_server.Pub"
+    "lishBatteryResponse\"\004\200\265\030\001\022\210\001\n\021PublishSta"
+    "tusText\0225.mavsdk.rpc.telemetry_server.Pu"
+    "blishStatusTextRequest\0326.mavsdk.rpc.tele"
+    "metry_server.PublishStatusTextResponse\"\004"
+    "\200\265\030\001\022\202\001\n\017PublishOdometry\0223.mavsdk.rpc.te"
+    "lemetry_server.PublishOdometryRequest\0324."
+    "mavsdk.rpc.telemetry_server.PublishOdome"
+    "tryResponse\"\004\200\265\030\001\022\243\001\n\032PublishPositionVel"
+    "ocityNed\022>.mavsdk.rpc.telemetry_server.P"
+    "ublishPositionVelocityNedRequest\032\?.mavsd"
+    "k.rpc.telemetry_server.PublishPositionVe"
+    "locityNedResponse\"\004\200\265\030\001\022\213\001\n\022PublishGroun"
+    "dTruth\0226.mavsdk.rpc.telemetry_server.Pub"
+    "lishGroundTruthRequest\0327.mavsdk.rpc.tele"
+    "metry_server.PublishGroundTruthResponse\""
+    "\004\200\265\030\001\022s\n\nPublishImu\022..mavsdk.rpc.telemet"
+    "ry_server.PublishImuRequest\032/.mavsdk.rpc"
+    ".telemetry_server.PublishImuResponse\"\004\200\265"
+    "\030\001\022\205\001\n\020PublishScaledImu\0224.mavsdk.rpc.tel"
+    "emetry_server.PublishScaledImuRequest\0325."
+    "mavsdk.rpc.telemetry_server.PublishScale"
+    "dImuResponse\"\004\200\265\030\001\022|\n\rPublishRawImu\0221.ma"
+    "vsdk.rpc.telemetry_server.PublishRawImuR"
+    "equest\0322.mavsdk.rpc.telemetry_server.Pub"
+    "lishRawImuResponse\"\004\200\265\030\001\022\221\001\n\024PublishUnix"
+    "EpochTime\0228.mavsdk.rpc.telemetry_server."
+    "PublishUnixEpochTimeRequest\0329.mavsdk.rpc"
+    ".telemetry_server.PublishUnixEpochTimeRe"
+    "sponse\"\004\200\265\030\001\022\224\001\n\025PublishDistanceSensor\0229"
+    ".mavsdk.rpc.telemetry_server.PublishDist"
+    "anceSensorRequest\032:.mavsdk.rpc.telemetry"
+    "_server.PublishDistanceSensorResponse\"\004\200"
+    "\265\030\001\022\202\001\n\017PublishAttitude\0223.mavsdk.rpc.tel"
+    "emetry_server.PublishAttitudeRequest\0324.m"
+    "avsdk.rpc.telemetry_server.PublishAttitu"
+    "deResponse\"\004\200\265\030\001\022\246\001\n\033PublishVisualFlight"
+    "RulesHud\022\?.mavsdk.rpc.telemetry_server.P"
+    "ublishVisualFlightRulesHudRequest\032@.mavs"
+    "dk.rpc.telemetry_server.PublishVisualFli"
+    "ghtRulesHudResponse\"\004\200\265\030\001B2\n\032io.mavsdk.t"
+    "elemetry_serverB\024TelemetryServerProtob\006p"
+    "roto3"
 };
 static const ::_pbi::DescriptorTable* const descriptor_table_telemetry_5fserver_2ftelemetry_5fserver_2eproto_deps[1] =
     {
@@ -2907,7 +2908,7 @@ static ::absl::once_flag descriptor_table_telemetry_5fserver_2ftelemetry_5fserve
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_telemetry_5fserver_2ftelemetry_5fserver_2eproto = {
     false,
     false,
-    11398,
+    11405,
     descriptor_table_protodef_telemetry_5fserver_2ftelemetry_5fserver_2eproto,
     "telemetry_server/telemetry_server.proto",
     &descriptor_table_telemetry_5fserver_2ftelemetry_5fserver_2eproto_once,
@@ -18729,9 +18730,9 @@ inline void FixedwingMetrics::SharedCtor(::_pb::Arena* arena) {
   ::memset(reinterpret_cast<char *>(&_impl_) +
                offsetof(Impl_, airspeed_m_s_),
            0,
-           offsetof(Impl_, altitude_msl_) -
+           offsetof(Impl_, absolute_altitude_m_) -
                offsetof(Impl_, airspeed_m_s_) +
-               sizeof(Impl_::altitude_msl_));
+               sizeof(Impl_::absolute_altitude_m_));
 }
 FixedwingMetrics::~FixedwingMetrics() {
   // @@protoc_insertion_point(destructor:mavsdk.rpc.telemetry_server.FixedwingMetrics)
@@ -18814,9 +18815,9 @@ const ::_pbi::TcParseTable<3, 6, 0, 0, 2> FixedwingMetrics::_table_ = {
     // float heading_deg = 5 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
      {45, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.heading_deg_)}},
-    // float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
+    // float absolute_altitude_m = 6 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
-     {53, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.altitude_msl_)}},
+     {53, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.absolute_altitude_m_)}},
     {::_pbi::TcParser::MiniParse, {}},
   }}, {{
     65535, 65535
@@ -18836,8 +18837,8 @@ const ::_pbi::TcParseTable<3, 6, 0, 0, 2> FixedwingMetrics::_table_ = {
     // float heading_deg = 5 [(.mavsdk.options.default_value) = "NaN"];
     {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.heading_deg_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
-    // float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
-    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.altitude_msl_), 0, 0,
+    // float absolute_altitude_m = 6 [(.mavsdk.options.default_value) = "NaN"];
+    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.absolute_altitude_m_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
   }},
   // no aux_entries
@@ -18853,8 +18854,8 @@ PROTOBUF_NOINLINE void FixedwingMetrics::Clear() {
   (void) cached_has_bits;
 
   ::memset(&_impl_.airspeed_m_s_, 0, static_cast<::size_t>(
-      reinterpret_cast<char*>(&_impl_.altitude_msl_) -
-      reinterpret_cast<char*>(&_impl_.airspeed_m_s_)) + sizeof(_impl_.altitude_msl_));
+      reinterpret_cast<char*>(&_impl_.absolute_altitude_m_) -
+      reinterpret_cast<char*>(&_impl_.airspeed_m_s_)) + sizeof(_impl_.absolute_altitude_m_));
   _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
 }
 
@@ -18908,11 +18909,11 @@ PROTOBUF_NOINLINE void FixedwingMetrics::Clear() {
                 5, this_._internal_heading_deg(), target);
           }
 
-          // float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
-          if (::absl::bit_cast<::uint32_t>(this_._internal_altitude_msl()) != 0) {
+          // float absolute_altitude_m = 6 [(.mavsdk.options.default_value) = "NaN"];
+          if (::absl::bit_cast<::uint32_t>(this_._internal_absolute_altitude_m()) != 0) {
             target = stream->EnsureSpace(target);
             target = ::_pbi::WireFormatLite::WriteFloatToArray(
-                6, this_._internal_altitude_msl(), target);
+                6, this_._internal_absolute_altitude_m(), target);
           }
 
           if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
@@ -18960,8 +18961,8 @@ PROTOBUF_NOINLINE void FixedwingMetrics::Clear() {
             if (::absl::bit_cast<::uint32_t>(this_._internal_heading_deg()) != 0) {
               total_size += 5;
             }
-            // float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
-            if (::absl::bit_cast<::uint32_t>(this_._internal_altitude_msl()) != 0) {
+            // float absolute_altitude_m = 6 [(.mavsdk.options.default_value) = "NaN"];
+            if (::absl::bit_cast<::uint32_t>(this_._internal_absolute_altitude_m()) != 0) {
               total_size += 5;
             }
           }
@@ -18992,8 +18993,8 @@ void FixedwingMetrics::MergeImpl(::google::protobuf::MessageLite& to_msg, const 
   if (::absl::bit_cast<::uint32_t>(from._internal_heading_deg()) != 0) {
     _this->_impl_.heading_deg_ = from._impl_.heading_deg_;
   }
-  if (::absl::bit_cast<::uint32_t>(from._internal_altitude_msl()) != 0) {
-    _this->_impl_.altitude_msl_ = from._impl_.altitude_msl_;
+  if (::absl::bit_cast<::uint32_t>(from._internal_absolute_altitude_m()) != 0) {
+    _this->_impl_.absolute_altitude_m_ = from._impl_.absolute_altitude_m_;
   }
   _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
 }
@@ -19010,8 +19011,8 @@ void FixedwingMetrics::InternalSwap(FixedwingMetrics* PROTOBUF_RESTRICT other) {
   using std::swap;
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
   ::google::protobuf::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.altitude_msl_)
-      + sizeof(FixedwingMetrics::_impl_.altitude_msl_)
+      PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.absolute_altitude_m_)
+      + sizeof(FixedwingMetrics::_impl_.absolute_altitude_m_)
       - PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.airspeed_m_s_)>(
           reinterpret_cast<char*>(&_impl_.airspeed_m_s_),
           reinterpret_cast<char*>(&other->_impl_.airspeed_m_s_));

--- a/src/mavsdk_server/src/generated/telemetry_server/telemetry_server.pb.cc
+++ b/src/mavsdk_server/src/generated/telemetry_server/telemetry_server.pb.cc
@@ -552,7 +552,10 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
 inline constexpr FixedwingMetrics::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : airspeed_m_s_{0},
+        groundspeed_m_s_{0},
+        heading_deg_{0},
         throttle_percentage_{0},
+        altitude_msl_{0},
         climb_rate_m_s_{0},
         _cached_size_{0} {}
 
@@ -814,6 +817,56 @@ struct AccelerationFrdDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 AccelerationFrdDefaultTypeInternal _AccelerationFrd_default_instance_;
+
+inline constexpr PublishVisualFlightRulesHudResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        telemetry_server_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR PublishVisualFlightRulesHudResponse::PublishVisualFlightRulesHudResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct PublishVisualFlightRulesHudResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR PublishVisualFlightRulesHudResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~PublishVisualFlightRulesHudResponseDefaultTypeInternal() {}
+  union {
+    PublishVisualFlightRulesHudResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 PublishVisualFlightRulesHudResponseDefaultTypeInternal _PublishVisualFlightRulesHudResponse_default_instance_;
+
+inline constexpr PublishVisualFlightRulesHudRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        fixed_wing_metrics_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR PublishVisualFlightRulesHudRequest::PublishVisualFlightRulesHudRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct PublishVisualFlightRulesHudRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR PublishVisualFlightRulesHudRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~PublishVisualFlightRulesHudRequestDefaultTypeInternal() {}
+  union {
+    PublishVisualFlightRulesHudRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 PublishVisualFlightRulesHudRequestDefaultTypeInternal _PublishVisualFlightRulesHudRequest_default_instance_;
 
 inline constexpr PublishUnixEpochTimeResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -1423,6 +1476,57 @@ struct PublishBatteryRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 PublishBatteryRequestDefaultTypeInternal _PublishBatteryRequest_default_instance_;
 
+inline constexpr PublishAttitudeResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        telemetry_server_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR PublishAttitudeResponse::PublishAttitudeResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct PublishAttitudeResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR PublishAttitudeResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~PublishAttitudeResponseDefaultTypeInternal() {}
+  union {
+    PublishAttitudeResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 PublishAttitudeResponseDefaultTypeInternal _PublishAttitudeResponse_default_instance_;
+
+inline constexpr PublishAttitudeRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        angle_{nullptr},
+        angular_velocity_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR PublishAttitudeRequest::PublishAttitudeRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct PublishAttitudeRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR PublishAttitudeRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~PublishAttitudeRequestDefaultTypeInternal() {}
+  union {
+    PublishAttitudeRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 PublishAttitudeRequestDefaultTypeInternal _PublishAttitudeRequest_default_instance_;
+
 inline constexpr PositionVelocityNed::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : _cached_size_{0},
@@ -1837,6 +1941,28 @@ const ::uint32_t
         ~0u,  // no sizeof(Split)
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishDistanceSensorRequest, _impl_.distance_sensor_),
         0,
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishAttitudeRequest, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishAttitudeRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishAttitudeRequest, _impl_.angle_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishAttitudeRequest, _impl_.angular_velocity_),
+        0,
+        1,
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest, _impl_.fixed_wing_metrics_),
+        0,
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishPositionResponse, _impl_._has_bits_),
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishPositionResponse, _internal_metadata_),
         ~0u,  // no _extensions_
@@ -1986,6 +2112,26 @@ const ::uint32_t
         ~0u,  // no _split_
         ~0u,  // no sizeof(Split)
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse, _impl_.telemetry_server_result_),
+        0,
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishAttitudeResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishAttitudeResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishAttitudeResponse, _impl_.telemetry_server_result_),
+        0,
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse, _impl_.telemetry_server_result_),
         0,
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::Position, _internal_metadata_),
@@ -2262,7 +2408,10 @@ const ::uint32_t
         ~0u,  // no _split_
         ~0u,  // no sizeof(Split)
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::FixedwingMetrics, _impl_.airspeed_m_s_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::FixedwingMetrics, _impl_.groundspeed_m_s_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::FixedwingMetrics, _impl_.heading_deg_),
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::FixedwingMetrics, _impl_.throttle_percentage_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::FixedwingMetrics, _impl_.altitude_msl_),
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::FixedwingMetrics, _impl_.climb_rate_m_s_),
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry_server::AccelerationFrd, _internal_metadata_),
@@ -2347,49 +2496,53 @@ static const ::_pbi::MigrationSchema
         {164, 173, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishRawImuRequest)},
         {174, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishUnixEpochTimeRequest)},
         {183, 192, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishDistanceSensorRequest)},
-        {193, 202, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishPositionResponse)},
-        {203, 212, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishHomeResponse)},
-        {213, 222, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishSysStatusResponse)},
-        {223, 232, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishExtendedSysStateResponse)},
-        {233, 242, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishRawGpsResponse)},
-        {243, 252, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishBatteryResponse)},
-        {253, 262, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishStatusTextResponse)},
-        {263, 272, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishOdometryResponse)},
-        {273, 282, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishPositionVelocityNedResponse)},
-        {283, 292, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishGroundTruthResponse)},
-        {293, 302, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishImuResponse)},
-        {303, 312, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishScaledImuResponse)},
-        {313, 322, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishRawImuResponse)},
-        {323, 332, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishUnixEpochTimeResponse)},
-        {333, 342, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse)},
-        {343, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::Position)},
-        {355, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::Heading)},
-        {364, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::Quaternion)},
-        {377, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::EulerAngle)},
-        {389, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::AngularVelocityBody)},
-        {400, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::GpsInfo)},
-        {410, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::RawGps)},
-        {432, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::Battery)},
-        {442, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::RcStatus)},
-        {453, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::StatusText)},
-        {463, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::ActuatorControlTarget)},
-        {473, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::ActuatorOutputStatus)},
-        {483, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::Covariance)},
-        {492, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::VelocityBody)},
-        {503, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::PositionBody)},
-        {514, 531, -1, sizeof(::mavsdk::rpc::telemetry_server::Odometry)},
-        {540, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::DistanceSensor)},
-        {551, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::ScaledPressure)},
-        {564, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::PositionNed)},
-        {575, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::VelocityNed)},
-        {586, 596, -1, sizeof(::mavsdk::rpc::telemetry_server::PositionVelocityNed)},
-        {598, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::GroundTruth)},
-        {609, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::FixedwingMetrics)},
-        {620, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::AccelerationFrd)},
-        {631, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::AngularVelocityFrd)},
-        {642, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::MagneticFieldFrd)},
-        {653, 666, -1, sizeof(::mavsdk::rpc::telemetry_server::Imu)},
-        {671, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::TelemetryServerResult)},
+        {193, 203, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishAttitudeRequest)},
+        {205, 214, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest)},
+        {215, 224, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishPositionResponse)},
+        {225, 234, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishHomeResponse)},
+        {235, 244, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishSysStatusResponse)},
+        {245, 254, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishExtendedSysStateResponse)},
+        {255, 264, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishRawGpsResponse)},
+        {265, 274, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishBatteryResponse)},
+        {275, 284, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishStatusTextResponse)},
+        {285, 294, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishOdometryResponse)},
+        {295, 304, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishPositionVelocityNedResponse)},
+        {305, 314, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishGroundTruthResponse)},
+        {315, 324, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishImuResponse)},
+        {325, 334, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishScaledImuResponse)},
+        {335, 344, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishRawImuResponse)},
+        {345, 354, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishUnixEpochTimeResponse)},
+        {355, 364, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishDistanceSensorResponse)},
+        {365, 374, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishAttitudeResponse)},
+        {375, 384, -1, sizeof(::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse)},
+        {385, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::Position)},
+        {397, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::Heading)},
+        {406, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::Quaternion)},
+        {419, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::EulerAngle)},
+        {431, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::AngularVelocityBody)},
+        {442, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::GpsInfo)},
+        {452, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::RawGps)},
+        {474, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::Battery)},
+        {484, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::RcStatus)},
+        {495, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::StatusText)},
+        {505, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::ActuatorControlTarget)},
+        {515, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::ActuatorOutputStatus)},
+        {525, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::Covariance)},
+        {534, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::VelocityBody)},
+        {545, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::PositionBody)},
+        {556, 573, -1, sizeof(::mavsdk::rpc::telemetry_server::Odometry)},
+        {582, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::DistanceSensor)},
+        {593, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::ScaledPressure)},
+        {606, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::PositionNed)},
+        {617, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::VelocityNed)},
+        {628, 638, -1, sizeof(::mavsdk::rpc::telemetry_server::PositionVelocityNed)},
+        {640, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::GroundTruth)},
+        {651, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::FixedwingMetrics)},
+        {665, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::AccelerationFrd)},
+        {676, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::AngularVelocityFrd)},
+        {687, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::MagneticFieldFrd)},
+        {698, 711, -1, sizeof(::mavsdk::rpc::telemetry_server::Imu)},
+        {716, -1, -1, sizeof(::mavsdk::rpc::telemetry_server::TelemetryServerResult)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::telemetry_server::_PublishPositionRequest_default_instance_._instance,
@@ -2410,6 +2563,8 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::telemetry_server::_PublishRawImuRequest_default_instance_._instance,
     &::mavsdk::rpc::telemetry_server::_PublishUnixEpochTimeRequest_default_instance_._instance,
     &::mavsdk::rpc::telemetry_server::_PublishDistanceSensorRequest_default_instance_._instance,
+    &::mavsdk::rpc::telemetry_server::_PublishAttitudeRequest_default_instance_._instance,
+    &::mavsdk::rpc::telemetry_server::_PublishVisualFlightRulesHudRequest_default_instance_._instance,
     &::mavsdk::rpc::telemetry_server::_PublishPositionResponse_default_instance_._instance,
     &::mavsdk::rpc::telemetry_server::_PublishHomeResponse_default_instance_._instance,
     &::mavsdk::rpc::telemetry_server::_PublishSysStatusResponse_default_instance_._instance,
@@ -2425,6 +2580,8 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::telemetry_server::_PublishRawImuResponse_default_instance_._instance,
     &::mavsdk::rpc::telemetry_server::_PublishUnixEpochTimeResponse_default_instance_._instance,
     &::mavsdk::rpc::telemetry_server::_PublishDistanceSensorResponse_default_instance_._instance,
+    &::mavsdk::rpc::telemetry_server::_PublishAttitudeResponse_default_instance_._instance,
+    &::mavsdk::rpc::telemetry_server::_PublishVisualFlightRulesHudResponse_default_instance_._instance,
     &::mavsdk::rpc::telemetry_server::_Position_default_instance_._instance,
     &::mavsdk::rpc::telemetry_server::_Heading_default_instance_._instance,
     &::mavsdk::rpc::telemetry_server::_Quaternion_default_instance_._instance,
@@ -2503,222 +2660,244 @@ const char descriptor_table_protodef_telemetry_5fserver_2ftelemetry_5fserver_2ep
     "blishUnixEpochTimeRequest\022\017\n\007time_us\030\001 \001"
     "(\004\"d\n\034PublishDistanceSensorRequest\022D\n\017di"
     "stance_sensor\030\001 \001(\0132+.mavsdk.rpc.telemet"
-    "ry_server.DistanceSensor\"n\n\027PublishPosit"
-    "ionResponse\022S\n\027telemetry_server_result\030\001"
-    " \001(\01322.mavsdk.rpc.telemetry_server.Telem"
-    "etryServerResult\"j\n\023PublishHomeResponse\022"
-    "S\n\027telemetry_server_result\030\001 \001(\01322.mavsd"
-    "k.rpc.telemetry_server.TelemetryServerRe"
-    "sult\"o\n\030PublishSysStatusResponse\022S\n\027tele"
-    "metry_server_result\030\001 \001(\01322.mavsdk.rpc.t"
-    "elemetry_server.TelemetryServerResult\"v\n"
-    "\037PublishExtendedSysStateResponse\022S\n\027tele"
-    "metry_server_result\030\001 \001(\01322.mavsdk.rpc.t"
-    "elemetry_server.TelemetryServerResult\"l\n"
-    "\025PublishRawGpsResponse\022S\n\027telemetry_serv"
-    "er_result\030\001 \001(\01322.mavsdk.rpc.telemetry_s"
-    "erver.TelemetryServerResult\"m\n\026PublishBa"
-    "tteryResponse\022S\n\027telemetry_server_result"
-    "\030\001 \001(\01322.mavsdk.rpc.telemetry_server.Tel"
-    "emetryServerResult\"p\n\031PublishStatusTextR"
-    "esponse\022S\n\027telemetry_server_result\030\001 \001(\013"
-    "22.mavsdk.rpc.telemetry_server.Telemetry"
-    "ServerResult\"n\n\027PublishOdometryResponse\022"
-    "S\n\027telemetry_server_result\030\001 \001(\01322.mavsd"
-    "k.rpc.telemetry_server.TelemetryServerRe"
-    "sult\"y\n\"PublishPositionVelocityNedRespon"
-    "se\022S\n\027telemetry_server_result\030\001 \001(\01322.ma"
-    "vsdk.rpc.telemetry_server.TelemetryServe"
-    "rResult\"q\n\032PublishGroundTruthResponse\022S\n"
-    "\027telemetry_server_result\030\001 \001(\01322.mavsdk."
-    "rpc.telemetry_server.TelemetryServerResu"
-    "lt\"i\n\022PublishImuResponse\022S\n\027telemetry_se"
+    "ry_server.DistanceSensor\"\234\001\n\026PublishAtti"
+    "tudeRequest\0226\n\005angle\030\001 \001(\0132\'.mavsdk.rpc."
+    "telemetry_server.EulerAngle\022J\n\020angular_v"
+    "elocity\030\002 \001(\01320.mavsdk.rpc.telemetry_ser"
+    "ver.AngularVelocityBody\"o\n\"PublishVisual"
+    "FlightRulesHudRequest\022I\n\022fixed_wing_metr"
+    "ics\030\001 \001(\0132-.mavsdk.rpc.telemetry_server."
+    "FixedwingMetrics\"n\n\027PublishPositionRespo"
+    "nse\022S\n\027telemetry_server_result\030\001 \001(\01322.m"
+    "avsdk.rpc.telemetry_server.TelemetryServ"
+    "erResult\"j\n\023PublishHomeResponse\022S\n\027telem"
+    "etry_server_result\030\001 \001(\01322.mavsdk.rpc.te"
+    "lemetry_server.TelemetryServerResult\"o\n\030"
+    "PublishSysStatusResponse\022S\n\027telemetry_se"
     "rver_result\030\001 \001(\01322.mavsdk.rpc.telemetry"
-    "_server.TelemetryServerResult\"o\n\030Publish"
-    "ScaledImuResponse\022S\n\027telemetry_server_re"
-    "sult\030\001 \001(\01322.mavsdk.rpc.telemetry_server"
-    ".TelemetryServerResult\"l\n\025PublishRawImuR"
-    "esponse\022S\n\027telemetry_server_result\030\001 \001(\013"
-    "22.mavsdk.rpc.telemetry_server.Telemetry"
-    "ServerResult\"s\n\034PublishUnixEpochTimeResp"
-    "onse\022S\n\027telemetry_server_result\030\001 \001(\01322."
-    "mavsdk.rpc.telemetry_server.TelemetrySer"
-    "verResult\"t\n\035PublishDistanceSensorRespon"
-    "se\022S\n\027telemetry_server_result\030\001 \001(\01322.ma"
-    "vsdk.rpc.telemetry_server.TelemetryServe"
-    "rResult\"\225\001\n\010Position\022\035\n\014latitude_deg\030\001 \001"
-    "(\001B\007\202\265\030\003NaN\022\036\n\rlongitude_deg\030\002 \001(\001B\007\202\265\030\003"
-    "NaN\022$\n\023absolute_altitude_m\030\003 \001(\002B\007\202\265\030\003Na"
-    "N\022$\n\023relative_altitude_m\030\004 \001(\002B\007\202\265\030\003NaN\""
-    "\'\n\007Heading\022\034\n\013heading_deg\030\001 \001(\001B\007\202\265\030\003NaN"
-    "\"r\n\nQuaternion\022\022\n\001w\030\001 \001(\002B\007\202\265\030\003NaN\022\022\n\001x\030"
-    "\002 \001(\002B\007\202\265\030\003NaN\022\022\n\001y\030\003 \001(\002B\007\202\265\030\003NaN\022\022\n\001z\030"
-    "\004 \001(\002B\007\202\265\030\003NaN\022\024\n\014timestamp_us\030\005 \001(\004\"s\n\n"
-    "EulerAngle\022\031\n\010roll_deg\030\001 \001(\002B\007\202\265\030\003NaN\022\032\n"
-    "\tpitch_deg\030\002 \001(\002B\007\202\265\030\003NaN\022\030\n\007yaw_deg\030\003 \001"
-    "(\002B\007\202\265\030\003NaN\022\024\n\014timestamp_us\030\004 \001(\004\"l\n\023Ang"
-    "ularVelocityBody\022\033\n\nroll_rad_s\030\001 \001(\002B\007\202\265"
-    "\030\003NaN\022\034\n\013pitch_rad_s\030\002 \001(\002B\007\202\265\030\003NaN\022\032\n\ty"
-    "aw_rad_s\030\003 \001(\002B\007\202\265\030\003NaN\"`\n\007GpsInfo\022\035\n\016nu"
-    "m_satellites\030\001 \001(\005B\005\202\265\030\0010\0226\n\010fix_type\030\002 "
-    "\001(\0162$.mavsdk.rpc.telemetry_server.FixTyp"
-    "e\"\337\002\n\006RawGps\022\024\n\014timestamp_us\030\001 \001(\004\022\024\n\014la"
-    "titude_deg\030\002 \001(\001\022\025\n\rlongitude_deg\030\003 \001(\001\022"
-    "\033\n\023absolute_altitude_m\030\004 \001(\002\022\014\n\004hdop\030\005 \001"
-    "(\002\022\014\n\004vdop\030\006 \001(\002\022\024\n\014velocity_m_s\030\007 \001(\002\022\017"
-    "\n\007cog_deg\030\010 \001(\002\022\034\n\024altitude_ellipsoid_m\030"
-    "\t \001(\002\022 \n\030horizontal_uncertainty_m\030\n \001(\002\022"
-    "\036\n\026vertical_uncertainty_m\030\013 \001(\002\022 \n\030veloc"
-    "ity_uncertainty_m_s\030\014 \001(\002\022\037\n\027heading_unc"
-    "ertainty_deg\030\r \001(\002\022\017\n\007yaw_deg\030\016 \001(\002\"I\n\007B"
-    "attery\022\032\n\tvoltage_v\030\001 \001(\002B\007\202\265\030\003NaN\022\"\n\021re"
-    "maining_percent\030\002 \001(\002B\007\202\265\030\003NaN\"|\n\010RcStat"
-    "us\022%\n\022was_available_once\030\001 \001(\010B\t\202\265\030\005fals"
-    "e\022\037\n\014is_available\030\002 \001(\010B\t\202\265\030\005false\022(\n\027si"
-    "gnal_strength_percent\030\003 \001(\002B\007\202\265\030\003NaN\"U\n\n"
-    "StatusText\0229\n\004type\030\001 \001(\0162+.mavsdk.rpc.te"
-    "lemetry_server.StatusTextType\022\014\n\004text\030\002 "
-    "\001(\t\"\?\n\025ActuatorControlTarget\022\024\n\005group\030\001 "
-    "\001(\005B\005\202\265\030\0010\022\020\n\010controls\030\002 \003(\002\"\?\n\024Actuator"
-    "OutputStatus\022\025\n\006active\030\001 \001(\rB\005\202\265\030\0010\022\020\n\010a"
-    "ctuator\030\002 \003(\002\"\'\n\nCovariance\022\031\n\021covarianc"
-    "e_matrix\030\001 \003(\002\";\n\014VelocityBody\022\r\n\005x_m_s\030"
-    "\001 \001(\002\022\r\n\005y_m_s\030\002 \001(\002\022\r\n\005z_m_s\030\003 \001(\002\"5\n\014P"
-    "ositionBody\022\013\n\003x_m\030\001 \001(\002\022\013\n\003y_m\030\002 \001(\002\022\013\n"
-    "\003z_m\030\003 \001(\002\"\244\005\n\010Odometry\022\021\n\ttime_usec\030\001 \001"
-    "(\004\022@\n\010frame_id\030\002 \001(\0162..mavsdk.rpc.teleme"
-    "try_server.Odometry.MavFrame\022F\n\016child_fr"
-    "ame_id\030\003 \001(\0162..mavsdk.rpc.telemetry_serv"
-    "er.Odometry.MavFrame\022@\n\rposition_body\030\004 "
-    "\001(\0132).mavsdk.rpc.telemetry_server.Positi"
-    "onBody\0222\n\001q\030\005 \001(\0132\'.mavsdk.rpc.telemetry"
-    "_server.Quaternion\022@\n\rvelocity_body\030\006 \001("
-    "\0132).mavsdk.rpc.telemetry_server.Velocity"
-    "Body\022O\n\025angular_velocity_body\030\007 \001(\01320.ma"
-    "vsdk.rpc.telemetry_server.AngularVelocit"
-    "yBody\022@\n\017pose_covariance\030\010 \001(\0132\'.mavsdk."
-    "rpc.telemetry_server.Covariance\022D\n\023veloc"
-    "ity_covariance\030\t \001(\0132\'.mavsdk.rpc.teleme"
-    "try_server.Covariance\"j\n\010MavFrame\022\023\n\017MAV"
-    "_FRAME_UNDEF\020\000\022\026\n\022MAV_FRAME_BODY_NED\020\010\022\030"
-    "\n\024MAV_FRAME_VISION_NED\020\020\022\027\n\023MAV_FRAME_ES"
-    "TIM_NED\020\022\"\177\n\016DistanceSensor\022#\n\022minimum_d"
-    "istance_m\030\001 \001(\002B\007\202\265\030\003NaN\022#\n\022maximum_dist"
-    "ance_m\030\002 \001(\002B\007\202\265\030\003NaN\022#\n\022current_distanc"
-    "e_m\030\003 \001(\002B\007\202\265\030\003NaN\"\260\001\n\016ScaledPressure\022\024\n"
-    "\014timestamp_us\030\001 \001(\004\022\035\n\025absolute_pressure"
-    "_hpa\030\002 \001(\002\022!\n\031differential_pressure_hpa\030"
-    "\003 \001(\002\022\027\n\017temperature_deg\030\004 \001(\002\022-\n%differ"
-    "ential_pressure_temperature_deg\030\005 \001(\002\"Y\n"
-    "\013PositionNed\022\030\n\007north_m\030\001 \001(\002B\007\202\265\030\003NaN\022\027"
-    "\n\006east_m\030\002 \001(\002B\007\202\265\030\003NaN\022\027\n\006down_m\030\003 \001(\002B"
-    "\007\202\265\030\003NaN\"D\n\013VelocityNed\022\021\n\tnorth_m_s\030\001 \001"
-    "(\002\022\020\n\010east_m_s\030\002 \001(\002\022\020\n\010down_m_s\030\003 \001(\002\"\215"
-    "\001\n\023PositionVelocityNed\022:\n\010position\030\001 \001(\013"
-    "2(.mavsdk.rpc.telemetry_server.PositionN"
-    "ed\022:\n\010velocity\030\002 \001(\0132(.mavsdk.rpc.teleme"
-    "try_server.VelocityNed\"r\n\013GroundTruth\022\035\n"
-    "\014latitude_deg\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlongitud"
-    "e_deg\030\002 \001(\001B\007\202\265\030\003NaN\022$\n\023absolute_altitud"
-    "e_m\030\003 \001(\002B\007\202\265\030\003NaN\"x\n\020FixedwingMetrics\022\035"
-    "\n\014airspeed_m_s\030\001 \001(\002B\007\202\265\030\003NaN\022$\n\023throttl"
-    "e_percentage\030\002 \001(\002B\007\202\265\030\003NaN\022\037\n\016climb_rat"
-    "e_m_s\030\003 \001(\002B\007\202\265\030\003NaN\"i\n\017AccelerationFrd\022"
-    "\035\n\014forward_m_s2\030\001 \001(\002B\007\202\265\030\003NaN\022\033\n\nright_"
-    "m_s2\030\002 \001(\002B\007\202\265\030\003NaN\022\032\n\tdown_m_s2\030\003 \001(\002B\007"
-    "\202\265\030\003NaN\"o\n\022AngularVelocityFrd\022\036\n\rforward"
-    "_rad_s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right_rad_s\030\002 \001"
-    "(\002B\007\202\265\030\003NaN\022\033\n\ndown_rad_s\030\003 \001(\002B\007\202\265\030\003NaN"
-    "\"m\n\020MagneticFieldFrd\022\036\n\rforward_gauss\030\001 "
-    "\001(\002B\007\202\265\030\003NaN\022\034\n\013right_gauss\030\002 \001(\002B\007\202\265\030\003N"
-    "aN\022\033\n\ndown_gauss\030\003 \001(\002B\007\202\265\030\003NaN\"\240\002\n\003Imu\022"
-    "F\n\020acceleration_frd\030\001 \001(\0132,.mavsdk.rpc.t"
-    "elemetry_server.AccelerationFrd\022M\n\024angul"
-    "ar_velocity_frd\030\002 \001(\0132/.mavsdk.rpc.telem"
-    "etry_server.AngularVelocityFrd\022I\n\022magnet"
-    "ic_field_frd\030\003 \001(\0132-.mavsdk.rpc.telemetr"
-    "y_server.MagneticFieldFrd\022!\n\020temperature"
-    "_degc\030\004 \001(\002B\007\202\265\030\003NaN\022\024\n\014timestamp_us\030\005 \001"
-    "(\004\"\264\002\n\025TelemetryServerResult\022I\n\006result\030\001"
-    " \001(\01629.mavsdk.rpc.telemetry_server.Telem"
-    "etryServerResult.Result\022\022\n\nresult_str\030\002 "
-    "\001(\t\"\273\001\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RE"
-    "SULT_SUCCESS\020\001\022\024\n\020RESULT_NO_SYSTEM\020\002\022\033\n\027"
-    "RESULT_CONNECTION_ERROR\020\003\022\017\n\013RESULT_BUSY"
-    "\020\004\022\031\n\025RESULT_COMMAND_DENIED\020\005\022\022\n\016RESULT_"
-    "TIMEOUT\020\006\022\026\n\022RESULT_UNSUPPORTED\020\007*\244\001\n\007Fi"
-    "xType\022\023\n\017FIX_TYPE_NO_GPS\020\000\022\023\n\017FIX_TYPE_N"
-    "O_FIX\020\001\022\023\n\017FIX_TYPE_FIX_2D\020\002\022\023\n\017FIX_TYPE"
-    "_FIX_3D\020\003\022\025\n\021FIX_TYPE_FIX_DGPS\020\004\022\026\n\022FIX_"
-    "TYPE_RTK_FLOAT\020\005\022\026\n\022FIX_TYPE_RTK_FIXED\020\006"
-    "*\215\001\n\tVtolState\022\030\n\024VTOL_STATE_UNDEFINED\020\000"
-    "\022\037\n\033VTOL_STATE_TRANSITION_TO_FW\020\001\022\037\n\033VTO"
-    "L_STATE_TRANSITION_TO_MC\020\002\022\021\n\rVTOL_STATE"
-    "_MC\020\003\022\021\n\rVTOL_STATE_FW\020\004*\371\001\n\016StatusTextT"
-    "ype\022\032\n\026STATUS_TEXT_TYPE_DEBUG\020\000\022\031\n\025STATU"
-    "S_TEXT_TYPE_INFO\020\001\022\033\n\027STATUS_TEXT_TYPE_N"
-    "OTICE\020\002\022\034\n\030STATUS_TEXT_TYPE_WARNING\020\003\022\032\n"
-    "\026STATUS_TEXT_TYPE_ERROR\020\004\022\035\n\031STATUS_TEXT"
-    "_TYPE_CRITICAL\020\005\022\032\n\026STATUS_TEXT_TYPE_ALE"
-    "RT\020\006\022\036\n\032STATUS_TEXT_TYPE_EMERGENCY\020\007*\223\001\n"
-    "\013LandedState\022\030\n\024LANDED_STATE_UNKNOWN\020\000\022\032"
-    "\n\026LANDED_STATE_ON_GROUND\020\001\022\027\n\023LANDED_STA"
-    "TE_IN_AIR\020\002\022\033\n\027LANDED_STATE_TAKING_OFF\020\003"
-    "\022\030\n\024LANDED_STATE_LANDING\020\0042\243\020\n\026Telemetry"
-    "ServerService\022\202\001\n\017PublishPosition\0223.mavs"
-    "dk.rpc.telemetry_server.PublishPositionR"
-    "equest\0324.mavsdk.rpc.telemetry_server.Pub"
-    "lishPositionResponse\"\004\200\265\030\001\022v\n\013PublishHom"
-    "e\022/.mavsdk.rpc.telemetry_server.PublishH"
-    "omeRequest\0320.mavsdk.rpc.telemetry_server"
-    ".PublishHomeResponse\"\004\200\265\030\001\022\205\001\n\020PublishSy"
-    "sStatus\0224.mavsdk.rpc.telemetry_server.Pu"
-    "blishSysStatusRequest\0325.mavsdk.rpc.telem"
-    "etry_server.PublishSysStatusResponse\"\004\200\265"
-    "\030\001\022\232\001\n\027PublishExtendedSysState\022;.mavsdk."
-    "rpc.telemetry_server.PublishExtendedSysS"
-    "tateRequest\032<.mavsdk.rpc.telemetry_serve"
-    "r.PublishExtendedSysStateResponse\"\004\200\265\030\001\022"
-    "|\n\rPublishRawGps\0221.mavsdk.rpc.telemetry_"
-    "server.PublishRawGpsRequest\0322.mavsdk.rpc"
-    ".telemetry_server.PublishRawGpsResponse\""
-    "\004\200\265\030\001\022\177\n\016PublishBattery\0222.mavsdk.rpc.tel"
-    "emetry_server.PublishBatteryRequest\0323.ma"
-    "vsdk.rpc.telemetry_server.PublishBattery"
-    "Response\"\004\200\265\030\001\022\210\001\n\021PublishStatusText\0225.m"
-    "avsdk.rpc.telemetry_server.PublishStatus"
-    "TextRequest\0326.mavsdk.rpc.telemetry_serve"
-    "r.PublishStatusTextResponse\"\004\200\265\030\001\022\202\001\n\017Pu"
-    "blishOdometry\0223.mavsdk.rpc.telemetry_ser"
-    "ver.PublishOdometryRequest\0324.mavsdk.rpc."
-    "telemetry_server.PublishOdometryResponse"
-    "\"\004\200\265\030\001\022\243\001\n\032PublishPositionVelocityNed\022>."
+    "_server.TelemetryServerResult\"v\n\037Publish"
+    "ExtendedSysStateResponse\022S\n\027telemetry_se"
+    "rver_result\030\001 \001(\01322.mavsdk.rpc.telemetry"
+    "_server.TelemetryServerResult\"l\n\025Publish"
+    "RawGpsResponse\022S\n\027telemetry_server_resul"
+    "t\030\001 \001(\01322.mavsdk.rpc.telemetry_server.Te"
+    "lemetryServerResult\"m\n\026PublishBatteryRes"
+    "ponse\022S\n\027telemetry_server_result\030\001 \001(\01322"
+    ".mavsdk.rpc.telemetry_server.TelemetrySe"
+    "rverResult\"p\n\031PublishStatusTextResponse\022"
+    "S\n\027telemetry_server_result\030\001 \001(\01322.mavsd"
+    "k.rpc.telemetry_server.TelemetryServerRe"
+    "sult\"n\n\027PublishOdometryResponse\022S\n\027telem"
+    "etry_server_result\030\001 \001(\01322.mavsdk.rpc.te"
+    "lemetry_server.TelemetryServerResult\"y\n\""
+    "PublishPositionVelocityNedResponse\022S\n\027te"
+    "lemetry_server_result\030\001 \001(\01322.mavsdk.rpc"
+    ".telemetry_server.TelemetryServerResult\""
+    "q\n\032PublishGroundTruthResponse\022S\n\027telemet"
+    "ry_server_result\030\001 \001(\01322.mavsdk.rpc.tele"
+    "metry_server.TelemetryServerResult\"i\n\022Pu"
+    "blishImuResponse\022S\n\027telemetry_server_res"
+    "ult\030\001 \001(\01322.mavsdk.rpc.telemetry_server."
+    "TelemetryServerResult\"o\n\030PublishScaledIm"
+    "uResponse\022S\n\027telemetry_server_result\030\001 \001"
+    "(\01322.mavsdk.rpc.telemetry_server.Telemet"
+    "ryServerResult\"l\n\025PublishRawImuResponse\022"
+    "S\n\027telemetry_server_result\030\001 \001(\01322.mavsd"
+    "k.rpc.telemetry_server.TelemetryServerRe"
+    "sult\"s\n\034PublishUnixEpochTimeResponse\022S\n\027"
+    "telemetry_server_result\030\001 \001(\01322.mavsdk.r"
+    "pc.telemetry_server.TelemetryServerResul"
+    "t\"t\n\035PublishDistanceSensorResponse\022S\n\027te"
+    "lemetry_server_result\030\001 \001(\01322.mavsdk.rpc"
+    ".telemetry_server.TelemetryServerResult\""
+    "n\n\027PublishAttitudeResponse\022S\n\027telemetry_"
+    "server_result\030\001 \001(\01322.mavsdk.rpc.telemet"
+    "ry_server.TelemetryServerResult\"z\n#Publi"
+    "shVisualFlightRulesHudResponse\022S\n\027teleme"
+    "try_server_result\030\001 \001(\01322.mavsdk.rpc.tel"
+    "emetry_server.TelemetryServerResult\"\225\001\n\010"
+    "Position\022\035\n\014latitude_deg\030\001 \001(\001B\007\202\265\030\003NaN\022"
+    "\036\n\rlongitude_deg\030\002 \001(\001B\007\202\265\030\003NaN\022$\n\023absol"
+    "ute_altitude_m\030\003 \001(\002B\007\202\265\030\003NaN\022$\n\023relativ"
+    "e_altitude_m\030\004 \001(\002B\007\202\265\030\003NaN\"\'\n\007Heading\022\034"
+    "\n\013heading_deg\030\001 \001(\001B\007\202\265\030\003NaN\"r\n\nQuaterni"
+    "on\022\022\n\001w\030\001 \001(\002B\007\202\265\030\003NaN\022\022\n\001x\030\002 \001(\002B\007\202\265\030\003N"
+    "aN\022\022\n\001y\030\003 \001(\002B\007\202\265\030\003NaN\022\022\n\001z\030\004 \001(\002B\007\202\265\030\003N"
+    "aN\022\024\n\014timestamp_us\030\005 \001(\004\"s\n\nEulerAngle\022\031"
+    "\n\010roll_deg\030\001 \001(\002B\007\202\265\030\003NaN\022\032\n\tpitch_deg\030\002"
+    " \001(\002B\007\202\265\030\003NaN\022\030\n\007yaw_deg\030\003 \001(\002B\007\202\265\030\003NaN\022"
+    "\024\n\014timestamp_us\030\004 \001(\004\"l\n\023AngularVelocity"
+    "Body\022\033\n\nroll_rad_s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013pit"
+    "ch_rad_s\030\002 \001(\002B\007\202\265\030\003NaN\022\032\n\tyaw_rad_s\030\003 \001"
+    "(\002B\007\202\265\030\003NaN\"`\n\007GpsInfo\022\035\n\016num_satellites"
+    "\030\001 \001(\005B\005\202\265\030\0010\0226\n\010fix_type\030\002 \001(\0162$.mavsdk"
+    ".rpc.telemetry_server.FixType\"\337\002\n\006RawGps"
+    "\022\024\n\014timestamp_us\030\001 \001(\004\022\024\n\014latitude_deg\030\002"
+    " \001(\001\022\025\n\rlongitude_deg\030\003 \001(\001\022\033\n\023absolute_"
+    "altitude_m\030\004 \001(\002\022\014\n\004hdop\030\005 \001(\002\022\014\n\004vdop\030\006"
+    " \001(\002\022\024\n\014velocity_m_s\030\007 \001(\002\022\017\n\007cog_deg\030\010 "
+    "\001(\002\022\034\n\024altitude_ellipsoid_m\030\t \001(\002\022 \n\030hor"
+    "izontal_uncertainty_m\030\n \001(\002\022\036\n\026vertical_"
+    "uncertainty_m\030\013 \001(\002\022 \n\030velocity_uncertai"
+    "nty_m_s\030\014 \001(\002\022\037\n\027heading_uncertainty_deg"
+    "\030\r \001(\002\022\017\n\007yaw_deg\030\016 \001(\002\"I\n\007Battery\022\032\n\tvo"
+    "ltage_v\030\001 \001(\002B\007\202\265\030\003NaN\022\"\n\021remaining_perc"
+    "ent\030\002 \001(\002B\007\202\265\030\003NaN\"|\n\010RcStatus\022%\n\022was_av"
+    "ailable_once\030\001 \001(\010B\t\202\265\030\005false\022\037\n\014is_avai"
+    "lable\030\002 \001(\010B\t\202\265\030\005false\022(\n\027signal_strengt"
+    "h_percent\030\003 \001(\002B\007\202\265\030\003NaN\"U\n\nStatusText\0229"
+    "\n\004type\030\001 \001(\0162+.mavsdk.rpc.telemetry_serv"
+    "er.StatusTextType\022\014\n\004text\030\002 \001(\t\"\?\n\025Actua"
+    "torControlTarget\022\024\n\005group\030\001 \001(\005B\005\202\265\030\0010\022\020"
+    "\n\010controls\030\002 \003(\002\"\?\n\024ActuatorOutputStatus"
+    "\022\025\n\006active\030\001 \001(\rB\005\202\265\030\0010\022\020\n\010actuator\030\002 \003("
+    "\002\"\'\n\nCovariance\022\031\n\021covariance_matrix\030\001 \003"
+    "(\002\";\n\014VelocityBody\022\r\n\005x_m_s\030\001 \001(\002\022\r\n\005y_m"
+    "_s\030\002 \001(\002\022\r\n\005z_m_s\030\003 \001(\002\"5\n\014PositionBody\022"
+    "\013\n\003x_m\030\001 \001(\002\022\013\n\003y_m\030\002 \001(\002\022\013\n\003z_m\030\003 \001(\002\"\244"
+    "\005\n\010Odometry\022\021\n\ttime_usec\030\001 \001(\004\022@\n\010frame_"
+    "id\030\002 \001(\0162..mavsdk.rpc.telemetry_server.O"
+    "dometry.MavFrame\022F\n\016child_frame_id\030\003 \001(\016"
+    "2..mavsdk.rpc.telemetry_server.Odometry."
+    "MavFrame\022@\n\rposition_body\030\004 \001(\0132).mavsdk"
+    ".rpc.telemetry_server.PositionBody\0222\n\001q\030"
+    "\005 \001(\0132\'.mavsdk.rpc.telemetry_server.Quat"
+    "ernion\022@\n\rvelocity_body\030\006 \001(\0132).mavsdk.r"
+    "pc.telemetry_server.VelocityBody\022O\n\025angu"
+    "lar_velocity_body\030\007 \001(\01320.mavsdk.rpc.tel"
+    "emetry_server.AngularVelocityBody\022@\n\017pos"
+    "e_covariance\030\010 \001(\0132\'.mavsdk.rpc.telemetr"
+    "y_server.Covariance\022D\n\023velocity_covarian"
+    "ce\030\t \001(\0132\'.mavsdk.rpc.telemetry_server.C"
+    "ovariance\"j\n\010MavFrame\022\023\n\017MAV_FRAME_UNDEF"
+    "\020\000\022\026\n\022MAV_FRAME_BODY_NED\020\010\022\030\n\024MAV_FRAME_"
+    "VISION_NED\020\020\022\027\n\023MAV_FRAME_ESTIM_NED\020\022\"\177\n"
+    "\016DistanceSensor\022#\n\022minimum_distance_m\030\001 "
+    "\001(\002B\007\202\265\030\003NaN\022#\n\022maximum_distance_m\030\002 \001(\002"
+    "B\007\202\265\030\003NaN\022#\n\022current_distance_m\030\003 \001(\002B\007\202"
+    "\265\030\003NaN\"\260\001\n\016ScaledPressure\022\024\n\014timestamp_u"
+    "s\030\001 \001(\004\022\035\n\025absolute_pressure_hpa\030\002 \001(\002\022!"
+    "\n\031differential_pressure_hpa\030\003 \001(\002\022\027\n\017tem"
+    "perature_deg\030\004 \001(\002\022-\n%differential_press"
+    "ure_temperature_deg\030\005 \001(\002\"Y\n\013PositionNed"
+    "\022\030\n\007north_m\030\001 \001(\002B\007\202\265\030\003NaN\022\027\n\006east_m\030\002 \001"
+    "(\002B\007\202\265\030\003NaN\022\027\n\006down_m\030\003 \001(\002B\007\202\265\030\003NaN\"D\n\013"
+    "VelocityNed\022\021\n\tnorth_m_s\030\001 \001(\002\022\020\n\010east_m"
+    "_s\030\002 \001(\002\022\020\n\010down_m_s\030\003 \001(\002\"\215\001\n\023PositionV"
+    "elocityNed\022:\n\010position\030\001 \001(\0132(.mavsdk.rp"
+    "c.telemetry_server.PositionNed\022:\n\010veloci"
+    "ty\030\002 \001(\0132(.mavsdk.rpc.telemetry_server.V"
+    "elocityNed\"r\n\013GroundTruth\022\035\n\014latitude_de"
+    "g\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlongitude_deg\030\002 \001(\001B"
+    "\007\202\265\030\003NaN\022$\n\023absolute_altitude_m\030\003 \001(\002B\007\202"
+    "\265\030\003NaN\"\327\001\n\020FixedwingMetrics\022\035\n\014airspeed_"
+    "m_s\030\001 \001(\002B\007\202\265\030\003NaN\022 \n\017groundspeed_m_s\030\002 "
+    "\001(\002B\007\202\265\030\003NaN\022\034\n\013heading_deg\030\003 \001(\002B\007\202\265\030\003N"
+    "aN\022$\n\023throttle_percentage\030\004 \001(\002B\007\202\265\030\003NaN"
+    "\022\035\n\014altitude_msl\030\005 \001(\002B\007\202\265\030\003NaN\022\037\n\016climb"
+    "_rate_m_s\030\006 \001(\002B\007\202\265\030\003NaN\"i\n\017Acceleration"
+    "Frd\022\035\n\014forward_m_s2\030\001 \001(\002B\007\202\265\030\003NaN\022\033\n\nri"
+    "ght_m_s2\030\002 \001(\002B\007\202\265\030\003NaN\022\032\n\tdown_m_s2\030\003 \001"
+    "(\002B\007\202\265\030\003NaN\"o\n\022AngularVelocityFrd\022\036\n\rfor"
+    "ward_rad_s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right_rad_s"
+    "\030\002 \001(\002B\007\202\265\030\003NaN\022\033\n\ndown_rad_s\030\003 \001(\002B\007\202\265\030"
+    "\003NaN\"m\n\020MagneticFieldFrd\022\036\n\rforward_gaus"
+    "s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right_gauss\030\002 \001(\002B\007\202"
+    "\265\030\003NaN\022\033\n\ndown_gauss\030\003 \001(\002B\007\202\265\030\003NaN\"\240\002\n\003"
+    "Imu\022F\n\020acceleration_frd\030\001 \001(\0132,.mavsdk.r"
+    "pc.telemetry_server.AccelerationFrd\022M\n\024a"
+    "ngular_velocity_frd\030\002 \001(\0132/.mavsdk.rpc.t"
+    "elemetry_server.AngularVelocityFrd\022I\n\022ma"
+    "gnetic_field_frd\030\003 \001(\0132-.mavsdk.rpc.tele"
+    "metry_server.MagneticFieldFrd\022!\n\020tempera"
+    "ture_degc\030\004 \001(\002B\007\202\265\030\003NaN\022\024\n\014timestamp_us"
+    "\030\005 \001(\004\"\264\002\n\025TelemetryServerResult\022I\n\006resu"
+    "lt\030\001 \001(\01629.mavsdk.rpc.telemetry_server.T"
+    "elemetryServerResult.Result\022\022\n\nresult_st"
+    "r\030\002 \001(\t\"\273\001\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022"
+    "\n\016RESULT_SUCCESS\020\001\022\024\n\020RESULT_NO_SYSTEM\020\002"
+    "\022\033\n\027RESULT_CONNECTION_ERROR\020\003\022\017\n\013RESULT_"
+    "BUSY\020\004\022\031\n\025RESULT_COMMAND_DENIED\020\005\022\022\n\016RES"
+    "ULT_TIMEOUT\020\006\022\026\n\022RESULT_UNSUPPORTED\020\007*\244\001"
+    "\n\007FixType\022\023\n\017FIX_TYPE_NO_GPS\020\000\022\023\n\017FIX_TY"
+    "PE_NO_FIX\020\001\022\023\n\017FIX_TYPE_FIX_2D\020\002\022\023\n\017FIX_"
+    "TYPE_FIX_3D\020\003\022\025\n\021FIX_TYPE_FIX_DGPS\020\004\022\026\n\022"
+    "FIX_TYPE_RTK_FLOAT\020\005\022\026\n\022FIX_TYPE_RTK_FIX"
+    "ED\020\006*\215\001\n\tVtolState\022\030\n\024VTOL_STATE_UNDEFIN"
+    "ED\020\000\022\037\n\033VTOL_STATE_TRANSITION_TO_FW\020\001\022\037\n"
+    "\033VTOL_STATE_TRANSITION_TO_MC\020\002\022\021\n\rVTOL_S"
+    "TATE_MC\020\003\022\021\n\rVTOL_STATE_FW\020\004*\371\001\n\016StatusT"
+    "extType\022\032\n\026STATUS_TEXT_TYPE_DEBUG\020\000\022\031\n\025S"
+    "TATUS_TEXT_TYPE_INFO\020\001\022\033\n\027STATUS_TEXT_TY"
+    "PE_NOTICE\020\002\022\034\n\030STATUS_TEXT_TYPE_WARNING\020"
+    "\003\022\032\n\026STATUS_TEXT_TYPE_ERROR\020\004\022\035\n\031STATUS_"
+    "TEXT_TYPE_CRITICAL\020\005\022\032\n\026STATUS_TEXT_TYPE"
+    "_ALERT\020\006\022\036\n\032STATUS_TEXT_TYPE_EMERGENCY\020\007"
+    "*\223\001\n\013LandedState\022\030\n\024LANDED_STATE_UNKNOWN"
+    "\020\000\022\032\n\026LANDED_STATE_ON_GROUND\020\001\022\027\n\023LANDED"
+    "_STATE_IN_AIR\020\002\022\033\n\027LANDED_STATE_TAKING_O"
+    "FF\020\003\022\030\n\024LANDED_STATE_LANDING\020\0042\321\022\n\026Telem"
+    "etryServerService\022\202\001\n\017PublishPosition\0223."
     "mavsdk.rpc.telemetry_server.PublishPosit"
-    "ionVelocityNedRequest\032\?.mavsdk.rpc.telem"
-    "etry_server.PublishPositionVelocityNedRe"
-    "sponse\"\004\200\265\030\001\022\213\001\n\022PublishGroundTruth\0226.ma"
-    "vsdk.rpc.telemetry_server.PublishGroundT"
-    "ruthRequest\0327.mavsdk.rpc.telemetry_serve"
-    "r.PublishGroundTruthResponse\"\004\200\265\030\001\022s\n\nPu"
-    "blishImu\022..mavsdk.rpc.telemetry_server.P"
-    "ublishImuRequest\032/.mavsdk.rpc.telemetry_"
-    "server.PublishImuResponse\"\004\200\265\030\001\022\205\001\n\020Publ"
-    "ishScaledImu\0224.mavsdk.rpc.telemetry_serv"
-    "er.PublishScaledImuRequest\0325.mavsdk.rpc."
-    "telemetry_server.PublishScaledImuRespons"
-    "e\"\004\200\265\030\001\022|\n\rPublishRawImu\0221.mavsdk.rpc.te"
-    "lemetry_server.PublishRawImuRequest\0322.ma"
-    "vsdk.rpc.telemetry_server.PublishRawImuR"
-    "esponse\"\004\200\265\030\001\022\221\001\n\024PublishUnixEpochTime\0228"
-    ".mavsdk.rpc.telemetry_server.PublishUnix"
-    "EpochTimeRequest\0329.mavsdk.rpc.telemetry_"
-    "server.PublishUnixEpochTimeResponse\"\004\200\265\030"
-    "\001\022\224\001\n\025PublishDistanceSensor\0229.mavsdk.rpc"
-    ".telemetry_server.PublishDistanceSensorR"
-    "equest\032:.mavsdk.rpc.telemetry_server.Pub"
-    "lishDistanceSensorResponse\"\004\200\265\030\001B2\n\032io.m"
-    "avsdk.telemetry_serverB\024TelemetryServerP"
-    "rotob\006proto3"
+    "ionRequest\0324.mavsdk.rpc.telemetry_server"
+    ".PublishPositionResponse\"\004\200\265\030\001\022v\n\013Publis"
+    "hHome\022/.mavsdk.rpc.telemetry_server.Publ"
+    "ishHomeRequest\0320.mavsdk.rpc.telemetry_se"
+    "rver.PublishHomeResponse\"\004\200\265\030\001\022\205\001\n\020Publi"
+    "shSysStatus\0224.mavsdk.rpc.telemetry_serve"
+    "r.PublishSysStatusRequest\0325.mavsdk.rpc.t"
+    "elemetry_server.PublishSysStatusResponse"
+    "\"\004\200\265\030\001\022\232\001\n\027PublishExtendedSysState\022;.mav"
+    "sdk.rpc.telemetry_server.PublishExtended"
+    "SysStateRequest\032<.mavsdk.rpc.telemetry_s"
+    "erver.PublishExtendedSysStateResponse\"\004\200"
+    "\265\030\001\022|\n\rPublishRawGps\0221.mavsdk.rpc.teleme"
+    "try_server.PublishRawGpsRequest\0322.mavsdk"
+    ".rpc.telemetry_server.PublishRawGpsRespo"
+    "nse\"\004\200\265\030\001\022\177\n\016PublishBattery\0222.mavsdk.rpc"
+    ".telemetry_server.PublishBatteryRequest\032"
+    "3.mavsdk.rpc.telemetry_server.PublishBat"
+    "teryResponse\"\004\200\265\030\001\022\210\001\n\021PublishStatusText"
+    "\0225.mavsdk.rpc.telemetry_server.PublishSt"
+    "atusTextRequest\0326.mavsdk.rpc.telemetry_s"
+    "erver.PublishStatusTextResponse\"\004\200\265\030\001\022\202\001"
+    "\n\017PublishOdometry\0223.mavsdk.rpc.telemetry"
+    "_server.PublishOdometryRequest\0324.mavsdk."
+    "rpc.telemetry_server.PublishOdometryResp"
+    "onse\"\004\200\265\030\001\022\243\001\n\032PublishPositionVelocityNe"
+    "d\022>.mavsdk.rpc.telemetry_server.PublishP"
+    "ositionVelocityNedRequest\032\?.mavsdk.rpc.t"
+    "elemetry_server.PublishPositionVelocityN"
+    "edResponse\"\004\200\265\030\001\022\213\001\n\022PublishGroundTruth\022"
+    "6.mavsdk.rpc.telemetry_server.PublishGro"
+    "undTruthRequest\0327.mavsdk.rpc.telemetry_s"
+    "erver.PublishGroundTruthResponse\"\004\200\265\030\001\022s"
+    "\n\nPublishImu\022..mavsdk.rpc.telemetry_serv"
+    "er.PublishImuRequest\032/.mavsdk.rpc.teleme"
+    "try_server.PublishImuResponse\"\004\200\265\030\001\022\205\001\n\020"
+    "PublishScaledImu\0224.mavsdk.rpc.telemetry_"
+    "server.PublishScaledImuRequest\0325.mavsdk."
+    "rpc.telemetry_server.PublishScaledImuRes"
+    "ponse\"\004\200\265\030\001\022|\n\rPublishRawImu\0221.mavsdk.rp"
+    "c.telemetry_server.PublishRawImuRequest\032"
+    "2.mavsdk.rpc.telemetry_server.PublishRaw"
+    "ImuResponse\"\004\200\265\030\001\022\221\001\n\024PublishUnixEpochTi"
+    "me\0228.mavsdk.rpc.telemetry_server.Publish"
+    "UnixEpochTimeRequest\0329.mavsdk.rpc.teleme"
+    "try_server.PublishUnixEpochTimeResponse\""
+    "\004\200\265\030\001\022\224\001\n\025PublishDistanceSensor\0229.mavsdk"
+    ".rpc.telemetry_server.PublishDistanceSen"
+    "sorRequest\032:.mavsdk.rpc.telemetry_server"
+    ".PublishDistanceSensorResponse\"\004\200\265\030\001\022\202\001\n"
+    "\017PublishAttitude\0223.mavsdk.rpc.telemetry_"
+    "server.PublishAttitudeRequest\0324.mavsdk.r"
+    "pc.telemetry_server.PublishAttitudeRespo"
+    "nse\"\004\200\265\030\001\022\246\001\n\033PublishVisualFlightRulesHu"
+    "d\022\?.mavsdk.rpc.telemetry_server.PublishV"
+    "isualFlightRulesHudRequest\032@.mavsdk.rpc."
+    "telemetry_server.PublishVisualFlightRule"
+    "sHudResponse\"\004\200\265\030\001B2\n\032io.mavsdk.telemetr"
+    "y_serverB\024TelemetryServerProtob\006proto3"
 };
 static const ::_pbi::DescriptorTable* const descriptor_table_telemetry_5fserver_2ftelemetry_5fserver_2eproto_deps[1] =
     {
@@ -2728,13 +2907,13 @@ static ::absl::once_flag descriptor_table_telemetry_5fserver_2ftelemetry_5fserve
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_telemetry_5fserver_2ftelemetry_5fserver_2eproto = {
     false,
     false,
-    10492,
+    11398,
     descriptor_table_protodef_telemetry_5fserver_2ftelemetry_5fserver_2eproto,
     "telemetry_server/telemetry_server.proto",
     &descriptor_table_telemetry_5fserver_2ftelemetry_5fserver_2eproto_once,
     descriptor_table_telemetry_5fserver_2ftelemetry_5fserver_2eproto_deps,
     1,
-    61,
+    65,
     schemas,
     file_default_instances,
     TableStruct_telemetry_5fserver_2ftelemetry_5fserver_2eproto::offsets,
@@ -7455,6 +7634,557 @@ void PublishDistanceSensorRequest::InternalSwap(PublishDistanceSensorRequest* PR
 }
 // ===================================================================
 
+class PublishAttitudeRequest::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<PublishAttitudeRequest>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(PublishAttitudeRequest, _impl_._has_bits_);
+};
+
+PublishAttitudeRequest::PublishAttitudeRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.telemetry_server.PublishAttitudeRequest)
+}
+inline PROTOBUF_NDEBUG_INLINE PublishAttitudeRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::telemetry_server::PublishAttitudeRequest& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+PublishAttitudeRequest::PublishAttitudeRequest(
+    ::google::protobuf::Arena* arena,
+    const PublishAttitudeRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  PublishAttitudeRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.angle_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::telemetry_server::EulerAngle>(
+                              arena, *from._impl_.angle_)
+                        : nullptr;
+  _impl_.angular_velocity_ = (cached_has_bits & 0x00000002u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::telemetry_server::AngularVelocityBody>(
+                              arena, *from._impl_.angular_velocity_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.telemetry_server.PublishAttitudeRequest)
+}
+inline PROTOBUF_NDEBUG_INLINE PublishAttitudeRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void PublishAttitudeRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  ::memset(reinterpret_cast<char *>(&_impl_) +
+               offsetof(Impl_, angle_),
+           0,
+           offsetof(Impl_, angular_velocity_) -
+               offsetof(Impl_, angle_) +
+               sizeof(Impl_::angular_velocity_));
+}
+PublishAttitudeRequest::~PublishAttitudeRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.telemetry_server.PublishAttitudeRequest)
+  SharedDtor(*this);
+}
+inline void PublishAttitudeRequest::SharedDtor(MessageLite& self) {
+  PublishAttitudeRequest& this_ = static_cast<PublishAttitudeRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.angle_;
+  delete this_._impl_.angular_velocity_;
+  this_._impl_.~Impl_();
+}
+
+inline void* PublishAttitudeRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) PublishAttitudeRequest(arena);
+}
+constexpr auto PublishAttitudeRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(PublishAttitudeRequest),
+                                            alignof(PublishAttitudeRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull PublishAttitudeRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_PublishAttitudeRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &PublishAttitudeRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<PublishAttitudeRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &PublishAttitudeRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<PublishAttitudeRequest>(), &PublishAttitudeRequest::ByteSizeLong,
+            &PublishAttitudeRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(PublishAttitudeRequest, _impl_._cached_size_),
+        false,
+    },
+    &PublishAttitudeRequest::kDescriptorMethods,
+    &descriptor_table_telemetry_5fserver_2ftelemetry_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* PublishAttitudeRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<1, 2, 2, 0, 2> PublishAttitudeRequest::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(PublishAttitudeRequest, _impl_._has_bits_),
+    0, // no _extensions_
+    2, 8,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967292,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    2,  // num_field_entries
+    2,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::telemetry_server::PublishAttitudeRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.telemetry_server.AngularVelocityBody angular_velocity = 2;
+    {::_pbi::TcParser::FastMtS1,
+     {18, 1, 1, PROTOBUF_FIELD_OFFSET(PublishAttitudeRequest, _impl_.angular_velocity_)}},
+    // .mavsdk.rpc.telemetry_server.EulerAngle angle = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(PublishAttitudeRequest, _impl_.angle_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.telemetry_server.EulerAngle angle = 1;
+    {PROTOBUF_FIELD_OFFSET(PublishAttitudeRequest, _impl_.angle_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .mavsdk.rpc.telemetry_server.AngularVelocityBody angular_velocity = 2;
+    {PROTOBUF_FIELD_OFFSET(PublishAttitudeRequest, _impl_.angular_velocity_), _Internal::kHasBitsOffset + 1, 1,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::telemetry_server::EulerAngle>()},
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::telemetry_server::AngularVelocityBody>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void PublishAttitudeRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.telemetry_server.PublishAttitudeRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    if (cached_has_bits & 0x00000001u) {
+      ABSL_DCHECK(_impl_.angle_ != nullptr);
+      _impl_.angle_->Clear();
+    }
+    if (cached_has_bits & 0x00000002u) {
+      ABSL_DCHECK(_impl_.angular_velocity_ != nullptr);
+      _impl_.angular_velocity_->Clear();
+    }
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* PublishAttitudeRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const PublishAttitudeRequest& this_ = static_cast<const PublishAttitudeRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* PublishAttitudeRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const PublishAttitudeRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.telemetry_server.PublishAttitudeRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.telemetry_server.EulerAngle angle = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.angle_, this_._impl_.angle_->GetCachedSize(), target,
+                stream);
+          }
+
+          // .mavsdk.rpc.telemetry_server.AngularVelocityBody angular_velocity = 2;
+          if (cached_has_bits & 0x00000002u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                2, *this_._impl_.angular_velocity_, this_._impl_.angular_velocity_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.telemetry_server.PublishAttitudeRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t PublishAttitudeRequest::ByteSizeLong(const MessageLite& base) {
+          const PublishAttitudeRequest& this_ = static_cast<const PublishAttitudeRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t PublishAttitudeRequest::ByteSizeLong() const {
+          const PublishAttitudeRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.telemetry_server.PublishAttitudeRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+          ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+          cached_has_bits = this_._impl_._has_bits_[0];
+          if (cached_has_bits & 0x00000003u) {
+            // .mavsdk.rpc.telemetry_server.EulerAngle angle = 1;
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.angle_);
+            }
+            // .mavsdk.rpc.telemetry_server.AngularVelocityBody angular_velocity = 2;
+            if (cached_has_bits & 0x00000002u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.angular_velocity_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void PublishAttitudeRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<PublishAttitudeRequest*>(&to_msg);
+  auto& from = static_cast<const PublishAttitudeRequest&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.telemetry_server.PublishAttitudeRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    if (cached_has_bits & 0x00000001u) {
+      ABSL_DCHECK(from._impl_.angle_ != nullptr);
+      if (_this->_impl_.angle_ == nullptr) {
+        _this->_impl_.angle_ =
+            ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::telemetry_server::EulerAngle>(arena, *from._impl_.angle_);
+      } else {
+        _this->_impl_.angle_->MergeFrom(*from._impl_.angle_);
+      }
+    }
+    if (cached_has_bits & 0x00000002u) {
+      ABSL_DCHECK(from._impl_.angular_velocity_ != nullptr);
+      if (_this->_impl_.angular_velocity_ == nullptr) {
+        _this->_impl_.angular_velocity_ =
+            ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::telemetry_server::AngularVelocityBody>(arena, *from._impl_.angular_velocity_);
+      } else {
+        _this->_impl_.angular_velocity_->MergeFrom(*from._impl_.angular_velocity_);
+      }
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void PublishAttitudeRequest::CopyFrom(const PublishAttitudeRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.telemetry_server.PublishAttitudeRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void PublishAttitudeRequest::InternalSwap(PublishAttitudeRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  ::google::protobuf::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(PublishAttitudeRequest, _impl_.angular_velocity_)
+      + sizeof(PublishAttitudeRequest::_impl_.angular_velocity_)
+      - PROTOBUF_FIELD_OFFSET(PublishAttitudeRequest, _impl_.angle_)>(
+          reinterpret_cast<char*>(&_impl_.angle_),
+          reinterpret_cast<char*>(&other->_impl_.angle_));
+}
+
+::google::protobuf::Metadata PublishAttitudeRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class PublishVisualFlightRulesHudRequest::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<PublishVisualFlightRulesHudRequest>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(PublishVisualFlightRulesHudRequest, _impl_._has_bits_);
+};
+
+PublishVisualFlightRulesHudRequest::PublishVisualFlightRulesHudRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudRequest)
+}
+inline PROTOBUF_NDEBUG_INLINE PublishVisualFlightRulesHudRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+PublishVisualFlightRulesHudRequest::PublishVisualFlightRulesHudRequest(
+    ::google::protobuf::Arena* arena,
+    const PublishVisualFlightRulesHudRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  PublishVisualFlightRulesHudRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.fixed_wing_metrics_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::telemetry_server::FixedwingMetrics>(
+                              arena, *from._impl_.fixed_wing_metrics_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudRequest)
+}
+inline PROTOBUF_NDEBUG_INLINE PublishVisualFlightRulesHudRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void PublishVisualFlightRulesHudRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.fixed_wing_metrics_ = {};
+}
+PublishVisualFlightRulesHudRequest::~PublishVisualFlightRulesHudRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudRequest)
+  SharedDtor(*this);
+}
+inline void PublishVisualFlightRulesHudRequest::SharedDtor(MessageLite& self) {
+  PublishVisualFlightRulesHudRequest& this_ = static_cast<PublishVisualFlightRulesHudRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.fixed_wing_metrics_;
+  this_._impl_.~Impl_();
+}
+
+inline void* PublishVisualFlightRulesHudRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) PublishVisualFlightRulesHudRequest(arena);
+}
+constexpr auto PublishVisualFlightRulesHudRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(PublishVisualFlightRulesHudRequest),
+                                            alignof(PublishVisualFlightRulesHudRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull PublishVisualFlightRulesHudRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_PublishVisualFlightRulesHudRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &PublishVisualFlightRulesHudRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<PublishVisualFlightRulesHudRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &PublishVisualFlightRulesHudRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<PublishVisualFlightRulesHudRequest>(), &PublishVisualFlightRulesHudRequest::ByteSizeLong,
+            &PublishVisualFlightRulesHudRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(PublishVisualFlightRulesHudRequest, _impl_._cached_size_),
+        false,
+    },
+    &PublishVisualFlightRulesHudRequest::kDescriptorMethods,
+    &descriptor_table_telemetry_5fserver_2ftelemetry_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* PublishVisualFlightRulesHudRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> PublishVisualFlightRulesHudRequest::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(PublishVisualFlightRulesHudRequest, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.telemetry_server.FixedwingMetrics fixed_wing_metrics = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(PublishVisualFlightRulesHudRequest, _impl_.fixed_wing_metrics_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.telemetry_server.FixedwingMetrics fixed_wing_metrics = 1;
+    {PROTOBUF_FIELD_OFFSET(PublishVisualFlightRulesHudRequest, _impl_.fixed_wing_metrics_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::telemetry_server::FixedwingMetrics>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void PublishVisualFlightRulesHudRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.fixed_wing_metrics_ != nullptr);
+    _impl_.fixed_wing_metrics_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* PublishVisualFlightRulesHudRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const PublishVisualFlightRulesHudRequest& this_ = static_cast<const PublishVisualFlightRulesHudRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* PublishVisualFlightRulesHudRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const PublishVisualFlightRulesHudRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.telemetry_server.FixedwingMetrics fixed_wing_metrics = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.fixed_wing_metrics_, this_._impl_.fixed_wing_metrics_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t PublishVisualFlightRulesHudRequest::ByteSizeLong(const MessageLite& base) {
+          const PublishVisualFlightRulesHudRequest& this_ = static_cast<const PublishVisualFlightRulesHudRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t PublishVisualFlightRulesHudRequest::ByteSizeLong() const {
+          const PublishVisualFlightRulesHudRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.telemetry_server.FixedwingMetrics fixed_wing_metrics = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.fixed_wing_metrics_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void PublishVisualFlightRulesHudRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<PublishVisualFlightRulesHudRequest*>(&to_msg);
+  auto& from = static_cast<const PublishVisualFlightRulesHudRequest&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.fixed_wing_metrics_ != nullptr);
+    if (_this->_impl_.fixed_wing_metrics_ == nullptr) {
+      _this->_impl_.fixed_wing_metrics_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::telemetry_server::FixedwingMetrics>(arena, *from._impl_.fixed_wing_metrics_);
+    } else {
+      _this->_impl_.fixed_wing_metrics_->MergeFrom(*from._impl_.fixed_wing_metrics_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void PublishVisualFlightRulesHudRequest::CopyFrom(const PublishVisualFlightRulesHudRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void PublishVisualFlightRulesHudRequest::InternalSwap(PublishVisualFlightRulesHudRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.fixed_wing_metrics_, other->_impl_.fixed_wing_metrics_);
+}
+
+::google::protobuf::Metadata PublishVisualFlightRulesHudRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
 class PublishPositionResponse::_Internal {
  public:
   using HasBits =
@@ -11201,6 +11931,506 @@ void PublishDistanceSensorResponse::InternalSwap(PublishDistanceSensorResponse* 
 }
 
 ::google::protobuf::Metadata PublishDistanceSensorResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class PublishAttitudeResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<PublishAttitudeResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(PublishAttitudeResponse, _impl_._has_bits_);
+};
+
+PublishAttitudeResponse::PublishAttitudeResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.telemetry_server.PublishAttitudeResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE PublishAttitudeResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::telemetry_server::PublishAttitudeResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+PublishAttitudeResponse::PublishAttitudeResponse(
+    ::google::protobuf::Arena* arena,
+    const PublishAttitudeResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  PublishAttitudeResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.telemetry_server_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::telemetry_server::TelemetryServerResult>(
+                              arena, *from._impl_.telemetry_server_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.telemetry_server.PublishAttitudeResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE PublishAttitudeResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void PublishAttitudeResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.telemetry_server_result_ = {};
+}
+PublishAttitudeResponse::~PublishAttitudeResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.telemetry_server.PublishAttitudeResponse)
+  SharedDtor(*this);
+}
+inline void PublishAttitudeResponse::SharedDtor(MessageLite& self) {
+  PublishAttitudeResponse& this_ = static_cast<PublishAttitudeResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.telemetry_server_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* PublishAttitudeResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) PublishAttitudeResponse(arena);
+}
+constexpr auto PublishAttitudeResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(PublishAttitudeResponse),
+                                            alignof(PublishAttitudeResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull PublishAttitudeResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_PublishAttitudeResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &PublishAttitudeResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<PublishAttitudeResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &PublishAttitudeResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<PublishAttitudeResponse>(), &PublishAttitudeResponse::ByteSizeLong,
+            &PublishAttitudeResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(PublishAttitudeResponse, _impl_._cached_size_),
+        false,
+    },
+    &PublishAttitudeResponse::kDescriptorMethods,
+    &descriptor_table_telemetry_5fserver_2ftelemetry_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* PublishAttitudeResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> PublishAttitudeResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(PublishAttitudeResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::telemetry_server::PublishAttitudeResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.telemetry_server.TelemetryServerResult telemetry_server_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(PublishAttitudeResponse, _impl_.telemetry_server_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.telemetry_server.TelemetryServerResult telemetry_server_result = 1;
+    {PROTOBUF_FIELD_OFFSET(PublishAttitudeResponse, _impl_.telemetry_server_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::telemetry_server::TelemetryServerResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void PublishAttitudeResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.telemetry_server.PublishAttitudeResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.telemetry_server_result_ != nullptr);
+    _impl_.telemetry_server_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* PublishAttitudeResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const PublishAttitudeResponse& this_ = static_cast<const PublishAttitudeResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* PublishAttitudeResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const PublishAttitudeResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.telemetry_server.PublishAttitudeResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.telemetry_server.TelemetryServerResult telemetry_server_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.telemetry_server_result_, this_._impl_.telemetry_server_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.telemetry_server.PublishAttitudeResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t PublishAttitudeResponse::ByteSizeLong(const MessageLite& base) {
+          const PublishAttitudeResponse& this_ = static_cast<const PublishAttitudeResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t PublishAttitudeResponse::ByteSizeLong() const {
+          const PublishAttitudeResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.telemetry_server.PublishAttitudeResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.telemetry_server.TelemetryServerResult telemetry_server_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.telemetry_server_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void PublishAttitudeResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<PublishAttitudeResponse*>(&to_msg);
+  auto& from = static_cast<const PublishAttitudeResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.telemetry_server.PublishAttitudeResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.telemetry_server_result_ != nullptr);
+    if (_this->_impl_.telemetry_server_result_ == nullptr) {
+      _this->_impl_.telemetry_server_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::telemetry_server::TelemetryServerResult>(arena, *from._impl_.telemetry_server_result_);
+    } else {
+      _this->_impl_.telemetry_server_result_->MergeFrom(*from._impl_.telemetry_server_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void PublishAttitudeResponse::CopyFrom(const PublishAttitudeResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.telemetry_server.PublishAttitudeResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void PublishAttitudeResponse::InternalSwap(PublishAttitudeResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.telemetry_server_result_, other->_impl_.telemetry_server_result_);
+}
+
+::google::protobuf::Metadata PublishAttitudeResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class PublishVisualFlightRulesHudResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<PublishVisualFlightRulesHudResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(PublishVisualFlightRulesHudResponse, _impl_._has_bits_);
+};
+
+PublishVisualFlightRulesHudResponse::PublishVisualFlightRulesHudResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE PublishVisualFlightRulesHudResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+PublishVisualFlightRulesHudResponse::PublishVisualFlightRulesHudResponse(
+    ::google::protobuf::Arena* arena,
+    const PublishVisualFlightRulesHudResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  PublishVisualFlightRulesHudResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.telemetry_server_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::telemetry_server::TelemetryServerResult>(
+                              arena, *from._impl_.telemetry_server_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE PublishVisualFlightRulesHudResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void PublishVisualFlightRulesHudResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.telemetry_server_result_ = {};
+}
+PublishVisualFlightRulesHudResponse::~PublishVisualFlightRulesHudResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudResponse)
+  SharedDtor(*this);
+}
+inline void PublishVisualFlightRulesHudResponse::SharedDtor(MessageLite& self) {
+  PublishVisualFlightRulesHudResponse& this_ = static_cast<PublishVisualFlightRulesHudResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.telemetry_server_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* PublishVisualFlightRulesHudResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) PublishVisualFlightRulesHudResponse(arena);
+}
+constexpr auto PublishVisualFlightRulesHudResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(PublishVisualFlightRulesHudResponse),
+                                            alignof(PublishVisualFlightRulesHudResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull PublishVisualFlightRulesHudResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_PublishVisualFlightRulesHudResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &PublishVisualFlightRulesHudResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<PublishVisualFlightRulesHudResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &PublishVisualFlightRulesHudResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<PublishVisualFlightRulesHudResponse>(), &PublishVisualFlightRulesHudResponse::ByteSizeLong,
+            &PublishVisualFlightRulesHudResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(PublishVisualFlightRulesHudResponse, _impl_._cached_size_),
+        false,
+    },
+    &PublishVisualFlightRulesHudResponse::kDescriptorMethods,
+    &descriptor_table_telemetry_5fserver_2ftelemetry_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* PublishVisualFlightRulesHudResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> PublishVisualFlightRulesHudResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(PublishVisualFlightRulesHudResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::telemetry_server::PublishVisualFlightRulesHudResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.telemetry_server.TelemetryServerResult telemetry_server_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(PublishVisualFlightRulesHudResponse, _impl_.telemetry_server_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.telemetry_server.TelemetryServerResult telemetry_server_result = 1;
+    {PROTOBUF_FIELD_OFFSET(PublishVisualFlightRulesHudResponse, _impl_.telemetry_server_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::telemetry_server::TelemetryServerResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void PublishVisualFlightRulesHudResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.telemetry_server_result_ != nullptr);
+    _impl_.telemetry_server_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* PublishVisualFlightRulesHudResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const PublishVisualFlightRulesHudResponse& this_ = static_cast<const PublishVisualFlightRulesHudResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* PublishVisualFlightRulesHudResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const PublishVisualFlightRulesHudResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.telemetry_server.TelemetryServerResult telemetry_server_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.telemetry_server_result_, this_._impl_.telemetry_server_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t PublishVisualFlightRulesHudResponse::ByteSizeLong(const MessageLite& base) {
+          const PublishVisualFlightRulesHudResponse& this_ = static_cast<const PublishVisualFlightRulesHudResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t PublishVisualFlightRulesHudResponse::ByteSizeLong() const {
+          const PublishVisualFlightRulesHudResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.telemetry_server.TelemetryServerResult telemetry_server_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.telemetry_server_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void PublishVisualFlightRulesHudResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<PublishVisualFlightRulesHudResponse*>(&to_msg);
+  auto& from = static_cast<const PublishVisualFlightRulesHudResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.telemetry_server_result_ != nullptr);
+    if (_this->_impl_.telemetry_server_result_ == nullptr) {
+      _this->_impl_.telemetry_server_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::telemetry_server::TelemetryServerResult>(arena, *from._impl_.telemetry_server_result_);
+    } else {
+      _this->_impl_.telemetry_server_result_->MergeFrom(*from._impl_.telemetry_server_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void PublishVisualFlightRulesHudResponse::CopyFrom(const PublishVisualFlightRulesHudResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void PublishVisualFlightRulesHudResponse::InternalSwap(PublishVisualFlightRulesHudResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.telemetry_server_result_, other->_impl_.telemetry_server_result_);
+}
+
+::google::protobuf::Metadata PublishVisualFlightRulesHudResponse::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================
@@ -17550,15 +18780,15 @@ const ::google::protobuf::internal::ClassData* FixedwingMetrics::GetClassData() 
   return _class_data_.base();
 }
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<2, 3, 0, 0, 2> FixedwingMetrics::_table_ = {
+const ::_pbi::TcParseTable<3, 6, 0, 0, 2> FixedwingMetrics::_table_ = {
   {
     0,  // no _has_bits_
     0, // no _extensions_
-    3, 24,  // max_field_number, fast_idx_mask
+    6, 56,  // max_field_number, fast_idx_mask
     offsetof(decltype(_table_), field_lookup_table),
-    4294967288,  // skipmap
+    4294967232,  // skipmap
     offsetof(decltype(_table_), field_entries),
-    3,  // num_field_entries
+    6,  // num_field_entries
     0,  // num_aux_entries
     offsetof(decltype(_table_), field_names),  // no aux_entries
     _class_data_.base(),
@@ -17572,22 +18802,41 @@ const ::_pbi::TcParseTable<2, 3, 0, 0, 2> FixedwingMetrics::_table_ = {
     // float airspeed_m_s = 1 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
      {13, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.airspeed_m_s_)}},
-    // float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
+    // float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
-     {21, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.throttle_percentage_)}},
-    // float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
+     {21, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.groundspeed_m_s_)}},
+    // float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
-     {29, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.climb_rate_m_s_)}},
+     {29, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.heading_deg_)}},
+    // float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
+    {::_pbi::TcParser::FastF32S1,
+     {37, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.throttle_percentage_)}},
+    // float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
+    {::_pbi::TcParser::FastF32S1,
+     {45, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.altitude_msl_)}},
+    // float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
+    {::_pbi::TcParser::FastF32S1,
+     {53, 63, 0, PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.climb_rate_m_s_)}},
+    {::_pbi::TcParser::MiniParse, {}},
   }}, {{
     65535, 65535
   }}, {{
     // float airspeed_m_s = 1 [(.mavsdk.options.default_value) = "NaN"];
     {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.airspeed_m_s_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
-    // float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
+    // float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
+    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.groundspeed_m_s_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+    // float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
+    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.heading_deg_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+    // float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
     {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.throttle_percentage_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
-    // float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
+    // float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
+    {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.altitude_msl_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+    // float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
     {PROTOBUF_FIELD_OFFSET(FixedwingMetrics, _impl_.climb_rate_m_s_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
   }},
@@ -17631,18 +18880,39 @@ PROTOBUF_NOINLINE void FixedwingMetrics::Clear() {
                 1, this_._internal_airspeed_m_s(), target);
           }
 
-          // float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
+          // float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
+          if (::absl::bit_cast<::uint32_t>(this_._internal_groundspeed_m_s()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                2, this_._internal_groundspeed_m_s(), target);
+          }
+
+          // float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
+          if (::absl::bit_cast<::uint32_t>(this_._internal_heading_deg()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                3, this_._internal_heading_deg(), target);
+          }
+
+          // float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
           if (::absl::bit_cast<::uint32_t>(this_._internal_throttle_percentage()) != 0) {
             target = stream->EnsureSpace(target);
             target = ::_pbi::WireFormatLite::WriteFloatToArray(
-                2, this_._internal_throttle_percentage(), target);
+                4, this_._internal_throttle_percentage(), target);
           }
 
-          // float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
+          // float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
+          if (::absl::bit_cast<::uint32_t>(this_._internal_altitude_msl()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                5, this_._internal_altitude_msl(), target);
+          }
+
+          // float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
           if (::absl::bit_cast<::uint32_t>(this_._internal_climb_rate_m_s()) != 0) {
             target = stream->EnsureSpace(target);
             target = ::_pbi::WireFormatLite::WriteFloatToArray(
-                3, this_._internal_climb_rate_m_s(), target);
+                6, this_._internal_climb_rate_m_s(), target);
           }
 
           if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
@@ -17674,11 +18944,23 @@ PROTOBUF_NOINLINE void FixedwingMetrics::Clear() {
             if (::absl::bit_cast<::uint32_t>(this_._internal_airspeed_m_s()) != 0) {
               total_size += 5;
             }
-            // float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
+            // float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
+            if (::absl::bit_cast<::uint32_t>(this_._internal_groundspeed_m_s()) != 0) {
+              total_size += 5;
+            }
+            // float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
+            if (::absl::bit_cast<::uint32_t>(this_._internal_heading_deg()) != 0) {
+              total_size += 5;
+            }
+            // float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
             if (::absl::bit_cast<::uint32_t>(this_._internal_throttle_percentage()) != 0) {
               total_size += 5;
             }
-            // float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
+            // float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
+            if (::absl::bit_cast<::uint32_t>(this_._internal_altitude_msl()) != 0) {
+              total_size += 5;
+            }
+            // float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
             if (::absl::bit_cast<::uint32_t>(this_._internal_climb_rate_m_s()) != 0) {
               total_size += 5;
             }
@@ -17698,8 +18980,17 @@ void FixedwingMetrics::MergeImpl(::google::protobuf::MessageLite& to_msg, const 
   if (::absl::bit_cast<::uint32_t>(from._internal_airspeed_m_s()) != 0) {
     _this->_impl_.airspeed_m_s_ = from._impl_.airspeed_m_s_;
   }
+  if (::absl::bit_cast<::uint32_t>(from._internal_groundspeed_m_s()) != 0) {
+    _this->_impl_.groundspeed_m_s_ = from._impl_.groundspeed_m_s_;
+  }
+  if (::absl::bit_cast<::uint32_t>(from._internal_heading_deg()) != 0) {
+    _this->_impl_.heading_deg_ = from._impl_.heading_deg_;
+  }
   if (::absl::bit_cast<::uint32_t>(from._internal_throttle_percentage()) != 0) {
     _this->_impl_.throttle_percentage_ = from._impl_.throttle_percentage_;
+  }
+  if (::absl::bit_cast<::uint32_t>(from._internal_altitude_msl()) != 0) {
+    _this->_impl_.altitude_msl_ = from._impl_.altitude_msl_;
   }
   if (::absl::bit_cast<::uint32_t>(from._internal_climb_rate_m_s()) != 0) {
     _this->_impl_.climb_rate_m_s_ = from._impl_.climb_rate_m_s_;

--- a/src/mavsdk_server/src/generated/telemetry_server/telemetry_server.pb.h
+++ b/src/mavsdk_server/src/generated/telemetry_server/telemetry_server.pb.h
@@ -4803,11 +4803,11 @@ class FixedwingMetrics final
   // accessors -------------------------------------------------------
   enum : int {
     kAirspeedMSFieldNumber = 1,
-    kGroundspeedMSFieldNumber = 2,
-    kHeadingDegFieldNumber = 3,
-    kThrottlePercentageFieldNumber = 4,
-    kAltitudeMslFieldNumber = 5,
-    kClimbRateMSFieldNumber = 6,
+    kThrottlePercentageFieldNumber = 2,
+    kClimbRateMSFieldNumber = 3,
+    kGroundspeedMSFieldNumber = 4,
+    kHeadingDegFieldNumber = 5,
+    kAltitudeMslFieldNumber = 6,
   };
   // float airspeed_m_s = 1 [(.mavsdk.options.default_value) = "NaN"];
   void clear_airspeed_m_s() ;
@@ -4819,27 +4819,7 @@ class FixedwingMetrics final
   void _internal_set_airspeed_m_s(float value);
 
   public:
-  // float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
-  void clear_groundspeed_m_s() ;
-  float groundspeed_m_s() const;
-  void set_groundspeed_m_s(float value);
-
-  private:
-  float _internal_groundspeed_m_s() const;
-  void _internal_set_groundspeed_m_s(float value);
-
-  public:
-  // float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
-  void clear_heading_deg() ;
-  float heading_deg() const;
-  void set_heading_deg(float value);
-
-  private:
-  float _internal_heading_deg() const;
-  void _internal_set_heading_deg(float value);
-
-  public:
-  // float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
+  // float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
   void clear_throttle_percentage() ;
   float throttle_percentage() const;
   void set_throttle_percentage(float value);
@@ -4849,17 +4829,7 @@ class FixedwingMetrics final
   void _internal_set_throttle_percentage(float value);
 
   public:
-  // float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
-  void clear_altitude_msl() ;
-  float altitude_msl() const;
-  void set_altitude_msl(float value);
-
-  private:
-  float _internal_altitude_msl() const;
-  void _internal_set_altitude_msl(float value);
-
-  public:
-  // float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
+  // float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
   void clear_climb_rate_m_s() ;
   float climb_rate_m_s() const;
   void set_climb_rate_m_s(float value);
@@ -4867,6 +4837,36 @@ class FixedwingMetrics final
   private:
   float _internal_climb_rate_m_s() const;
   void _internal_set_climb_rate_m_s(float value);
+
+  public:
+  // float groundspeed_m_s = 4 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_groundspeed_m_s() ;
+  float groundspeed_m_s() const;
+  void set_groundspeed_m_s(float value);
+
+  private:
+  float _internal_groundspeed_m_s() const;
+  void _internal_set_groundspeed_m_s(float value);
+
+  public:
+  // float heading_deg = 5 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_heading_deg() ;
+  float heading_deg() const;
+  void set_heading_deg(float value);
+
+  private:
+  float _internal_heading_deg() const;
+  void _internal_set_heading_deg(float value);
+
+  public:
+  // float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_altitude_msl() ;
+  float altitude_msl() const;
+  void set_altitude_msl(float value);
+
+  private:
+  float _internal_altitude_msl() const;
+  void _internal_set_altitude_msl(float value);
 
   public:
   // @@protoc_insertion_point(class_scope:mavsdk.rpc.telemetry_server.FixedwingMetrics)
@@ -4893,11 +4893,11 @@ class FixedwingMetrics final
                           ::google::protobuf::Arena* arena, const Impl_& from,
                           const FixedwingMetrics& from_msg);
     float airspeed_m_s_;
+    float throttle_percentage_;
+    float climb_rate_m_s_;
     float groundspeed_m_s_;
     float heading_deg_;
-    float throttle_percentage_;
     float altitude_msl_;
-    float climb_rate_m_s_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
@@ -20724,51 +20724,7 @@ inline void FixedwingMetrics::_internal_set_airspeed_m_s(float value) {
   _impl_.airspeed_m_s_ = value;
 }
 
-// float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
-inline void FixedwingMetrics::clear_groundspeed_m_s() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.groundspeed_m_s_ = 0;
-}
-inline float FixedwingMetrics::groundspeed_m_s() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry_server.FixedwingMetrics.groundspeed_m_s)
-  return _internal_groundspeed_m_s();
-}
-inline void FixedwingMetrics::set_groundspeed_m_s(float value) {
-  _internal_set_groundspeed_m_s(value);
-  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry_server.FixedwingMetrics.groundspeed_m_s)
-}
-inline float FixedwingMetrics::_internal_groundspeed_m_s() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.groundspeed_m_s_;
-}
-inline void FixedwingMetrics::_internal_set_groundspeed_m_s(float value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.groundspeed_m_s_ = value;
-}
-
-// float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
-inline void FixedwingMetrics::clear_heading_deg() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.heading_deg_ = 0;
-}
-inline float FixedwingMetrics::heading_deg() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry_server.FixedwingMetrics.heading_deg)
-  return _internal_heading_deg();
-}
-inline void FixedwingMetrics::set_heading_deg(float value) {
-  _internal_set_heading_deg(value);
-  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry_server.FixedwingMetrics.heading_deg)
-}
-inline float FixedwingMetrics::_internal_heading_deg() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.heading_deg_;
-}
-inline void FixedwingMetrics::_internal_set_heading_deg(float value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.heading_deg_ = value;
-}
-
-// float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
+// float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
 inline void FixedwingMetrics::clear_throttle_percentage() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.throttle_percentage_ = 0;
@@ -20790,29 +20746,7 @@ inline void FixedwingMetrics::_internal_set_throttle_percentage(float value) {
   _impl_.throttle_percentage_ = value;
 }
 
-// float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
-inline void FixedwingMetrics::clear_altitude_msl() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.altitude_msl_ = 0;
-}
-inline float FixedwingMetrics::altitude_msl() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry_server.FixedwingMetrics.altitude_msl)
-  return _internal_altitude_msl();
-}
-inline void FixedwingMetrics::set_altitude_msl(float value) {
-  _internal_set_altitude_msl(value);
-  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry_server.FixedwingMetrics.altitude_msl)
-}
-inline float FixedwingMetrics::_internal_altitude_msl() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.altitude_msl_;
-}
-inline void FixedwingMetrics::_internal_set_altitude_msl(float value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.altitude_msl_ = value;
-}
-
-// float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
+// float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
 inline void FixedwingMetrics::clear_climb_rate_m_s() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.climb_rate_m_s_ = 0;
@@ -20832,6 +20766,72 @@ inline float FixedwingMetrics::_internal_climb_rate_m_s() const {
 inline void FixedwingMetrics::_internal_set_climb_rate_m_s(float value) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.climb_rate_m_s_ = value;
+}
+
+// float groundspeed_m_s = 4 [(.mavsdk.options.default_value) = "NaN"];
+inline void FixedwingMetrics::clear_groundspeed_m_s() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.groundspeed_m_s_ = 0;
+}
+inline float FixedwingMetrics::groundspeed_m_s() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry_server.FixedwingMetrics.groundspeed_m_s)
+  return _internal_groundspeed_m_s();
+}
+inline void FixedwingMetrics::set_groundspeed_m_s(float value) {
+  _internal_set_groundspeed_m_s(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry_server.FixedwingMetrics.groundspeed_m_s)
+}
+inline float FixedwingMetrics::_internal_groundspeed_m_s() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.groundspeed_m_s_;
+}
+inline void FixedwingMetrics::_internal_set_groundspeed_m_s(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.groundspeed_m_s_ = value;
+}
+
+// float heading_deg = 5 [(.mavsdk.options.default_value) = "NaN"];
+inline void FixedwingMetrics::clear_heading_deg() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.heading_deg_ = 0;
+}
+inline float FixedwingMetrics::heading_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry_server.FixedwingMetrics.heading_deg)
+  return _internal_heading_deg();
+}
+inline void FixedwingMetrics::set_heading_deg(float value) {
+  _internal_set_heading_deg(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry_server.FixedwingMetrics.heading_deg)
+}
+inline float FixedwingMetrics::_internal_heading_deg() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.heading_deg_;
+}
+inline void FixedwingMetrics::_internal_set_heading_deg(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.heading_deg_ = value;
+}
+
+// float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
+inline void FixedwingMetrics::clear_altitude_msl() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.altitude_msl_ = 0;
+}
+inline float FixedwingMetrics::altitude_msl() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry_server.FixedwingMetrics.altitude_msl)
+  return _internal_altitude_msl();
+}
+inline void FixedwingMetrics::set_altitude_msl(float value) {
+  _internal_set_altitude_msl(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry_server.FixedwingMetrics.altitude_msl)
+}
+inline float FixedwingMetrics::_internal_altitude_msl() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.altitude_msl_;
+}
+inline void FixedwingMetrics::_internal_set_altitude_msl(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.altitude_msl_ = value;
 }
 
 // -------------------------------------------------------------------

--- a/src/mavsdk_server/src/generated/telemetry_server/telemetry_server.pb.h
+++ b/src/mavsdk_server/src/generated/telemetry_server/telemetry_server.pb.h
@@ -4807,7 +4807,7 @@ class FixedwingMetrics final
     kClimbRateMSFieldNumber = 3,
     kGroundspeedMSFieldNumber = 4,
     kHeadingDegFieldNumber = 5,
-    kAltitudeMslFieldNumber = 6,
+    kAbsoluteAltitudeMFieldNumber = 6,
   };
   // float airspeed_m_s = 1 [(.mavsdk.options.default_value) = "NaN"];
   void clear_airspeed_m_s() ;
@@ -4859,14 +4859,14 @@ class FixedwingMetrics final
   void _internal_set_heading_deg(float value);
 
   public:
-  // float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
-  void clear_altitude_msl() ;
-  float altitude_msl() const;
-  void set_altitude_msl(float value);
+  // float absolute_altitude_m = 6 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_absolute_altitude_m() ;
+  float absolute_altitude_m() const;
+  void set_absolute_altitude_m(float value);
 
   private:
-  float _internal_altitude_msl() const;
-  void _internal_set_altitude_msl(float value);
+  float _internal_absolute_altitude_m() const;
+  void _internal_set_absolute_altitude_m(float value);
 
   public:
   // @@protoc_insertion_point(class_scope:mavsdk.rpc.telemetry_server.FixedwingMetrics)
@@ -4897,7 +4897,7 @@ class FixedwingMetrics final
     float climb_rate_m_s_;
     float groundspeed_m_s_;
     float heading_deg_;
-    float altitude_msl_;
+    float absolute_altitude_m_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
@@ -20812,26 +20812,26 @@ inline void FixedwingMetrics::_internal_set_heading_deg(float value) {
   _impl_.heading_deg_ = value;
 }
 
-// float altitude_msl = 6 [(.mavsdk.options.default_value) = "NaN"];
-inline void FixedwingMetrics::clear_altitude_msl() {
+// float absolute_altitude_m = 6 [(.mavsdk.options.default_value) = "NaN"];
+inline void FixedwingMetrics::clear_absolute_altitude_m() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.altitude_msl_ = 0;
+  _impl_.absolute_altitude_m_ = 0;
 }
-inline float FixedwingMetrics::altitude_msl() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry_server.FixedwingMetrics.altitude_msl)
-  return _internal_altitude_msl();
+inline float FixedwingMetrics::absolute_altitude_m() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry_server.FixedwingMetrics.absolute_altitude_m)
+  return _internal_absolute_altitude_m();
 }
-inline void FixedwingMetrics::set_altitude_msl(float value) {
-  _internal_set_altitude_msl(value);
-  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry_server.FixedwingMetrics.altitude_msl)
+inline void FixedwingMetrics::set_absolute_altitude_m(float value) {
+  _internal_set_absolute_altitude_m(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry_server.FixedwingMetrics.absolute_altitude_m)
 }
-inline float FixedwingMetrics::_internal_altitude_msl() const {
+inline float FixedwingMetrics::_internal_absolute_altitude_m() const {
   ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.altitude_msl_;
+  return _impl_.absolute_altitude_m_;
 }
-inline void FixedwingMetrics::_internal_set_altitude_msl(float value) {
+inline void FixedwingMetrics::_internal_set_absolute_altitude_m(float value) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.altitude_msl_ = value;
+  _impl_.absolute_altitude_m_ = value;
 }
 
 // -------------------------------------------------------------------

--- a/src/mavsdk_server/src/generated/telemetry_server/telemetry_server.pb.h
+++ b/src/mavsdk_server/src/generated/telemetry_server/telemetry_server.pb.h
@@ -116,6 +116,12 @@ extern PositionNedDefaultTypeInternal _PositionNed_default_instance_;
 class PositionVelocityNed;
 struct PositionVelocityNedDefaultTypeInternal;
 extern PositionVelocityNedDefaultTypeInternal _PositionVelocityNed_default_instance_;
+class PublishAttitudeRequest;
+struct PublishAttitudeRequestDefaultTypeInternal;
+extern PublishAttitudeRequestDefaultTypeInternal _PublishAttitudeRequest_default_instance_;
+class PublishAttitudeResponse;
+struct PublishAttitudeResponseDefaultTypeInternal;
+extern PublishAttitudeResponseDefaultTypeInternal _PublishAttitudeResponse_default_instance_;
 class PublishBatteryRequest;
 struct PublishBatteryRequestDefaultTypeInternal;
 extern PublishBatteryRequestDefaultTypeInternal _PublishBatteryRequest_default_instance_;
@@ -215,6 +221,12 @@ extern PublishUnixEpochTimeRequestDefaultTypeInternal _PublishUnixEpochTimeReque
 class PublishUnixEpochTimeResponse;
 struct PublishUnixEpochTimeResponseDefaultTypeInternal;
 extern PublishUnixEpochTimeResponseDefaultTypeInternal _PublishUnixEpochTimeResponse_default_instance_;
+class PublishVisualFlightRulesHudRequest;
+struct PublishVisualFlightRulesHudRequestDefaultTypeInternal;
+extern PublishVisualFlightRulesHudRequestDefaultTypeInternal _PublishVisualFlightRulesHudRequest_default_instance_;
+class PublishVisualFlightRulesHudResponse;
+struct PublishVisualFlightRulesHudResponseDefaultTypeInternal;
+extern PublishVisualFlightRulesHudResponseDefaultTypeInternal _PublishVisualFlightRulesHudResponse_default_instance_;
 class Quaternion;
 struct QuaternionDefaultTypeInternal;
 extern QuaternionDefaultTypeInternal _Quaternion_default_instance_;
@@ -533,7 +545,7 @@ class VelocityNed final
     return reinterpret_cast<const VelocityNed*>(
         &_VelocityNed_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 52;
+  static constexpr int kIndexInFileMessages = 56;
   friend void swap(VelocityNed& a, VelocityNed& b) { a.Swap(&b); }
   inline void Swap(VelocityNed* other) {
     if (other == this) return;
@@ -748,7 +760,7 @@ class VelocityBody final
     return reinterpret_cast<const VelocityBody*>(
         &_VelocityBody_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 46;
+  static constexpr int kIndexInFileMessages = 50;
   friend void swap(VelocityBody& a, VelocityBody& b) { a.Swap(&b); }
   inline void Swap(VelocityBody* other) {
     if (other == this) return;
@@ -963,7 +975,7 @@ class TelemetryServerResult final
     return reinterpret_cast<const TelemetryServerResult*>(
         &_TelemetryServerResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 60;
+  static constexpr int kIndexInFileMessages = 64;
   friend void swap(TelemetryServerResult& a, TelemetryServerResult& b) { a.Swap(&b); }
   inline void Swap(TelemetryServerResult* other) {
     if (other == this) return;
@@ -1197,7 +1209,7 @@ class StatusText final
     return reinterpret_cast<const StatusText*>(
         &_StatusText_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 42;
+  static constexpr int kIndexInFileMessages = 46;
   friend void swap(StatusText& a, StatusText& b) { a.Swap(&b); }
   inline void Swap(StatusText* other) {
     if (other == this) return;
@@ -1406,7 +1418,7 @@ class ScaledPressure final
     return reinterpret_cast<const ScaledPressure*>(
         &_ScaledPressure_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 50;
+  static constexpr int kIndexInFileMessages = 54;
   friend void swap(ScaledPressure& a, ScaledPressure& b) { a.Swap(&b); }
   inline void Swap(ScaledPressure* other) {
     if (other == this) return;
@@ -1645,7 +1657,7 @@ class RcStatus final
     return reinterpret_cast<const RcStatus*>(
         &_RcStatus_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 41;
+  static constexpr int kIndexInFileMessages = 45;
   friend void swap(RcStatus& a, RcStatus& b) { a.Swap(&b); }
   inline void Swap(RcStatus* other) {
     if (other == this) return;
@@ -1860,7 +1872,7 @@ class RawGps final
     return reinterpret_cast<const RawGps*>(
         &_RawGps_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 39;
+  static constexpr int kIndexInFileMessages = 43;
   friend void swap(RawGps& a, RawGps& b) { a.Swap(&b); }
   inline void Swap(RawGps* other) {
     if (other == this) return;
@@ -2207,7 +2219,7 @@ class Quaternion final
     return reinterpret_cast<const Quaternion*>(
         &_Quaternion_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 35;
+  static constexpr int kIndexInFileMessages = 39;
   friend void swap(Quaternion& a, Quaternion& b) { a.Swap(&b); }
   inline void Swap(Quaternion* other) {
     if (other == this) return;
@@ -3222,7 +3234,7 @@ class PositionNed final
     return reinterpret_cast<const PositionNed*>(
         &_PositionNed_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 51;
+  static constexpr int kIndexInFileMessages = 55;
   friend void swap(PositionNed& a, PositionNed& b) { a.Swap(&b); }
   inline void Swap(PositionNed* other) {
     if (other == this) return;
@@ -3437,7 +3449,7 @@ class PositionBody final
     return reinterpret_cast<const PositionBody*>(
         &_PositionBody_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 47;
+  static constexpr int kIndexInFileMessages = 51;
   friend void swap(PositionBody& a, PositionBody& b) { a.Swap(&b); }
   inline void Swap(PositionBody* other) {
     if (other == this) return;
@@ -3652,7 +3664,7 @@ class Position final
     return reinterpret_cast<const Position*>(
         &_Position_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 33;
+  static constexpr int kIndexInFileMessages = 37;
   friend void swap(Position& a, Position& b) { a.Swap(&b); }
   inline void Swap(Position* other) {
     if (other == this) return;
@@ -3879,7 +3891,7 @@ class MagneticFieldFrd final
     return reinterpret_cast<const MagneticFieldFrd*>(
         &_MagneticFieldFrd_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 58;
+  static constexpr int kIndexInFileMessages = 62;
   friend void swap(MagneticFieldFrd& a, MagneticFieldFrd& b) { a.Swap(&b); }
   inline void Swap(MagneticFieldFrd* other) {
     if (other == this) return;
@@ -4094,7 +4106,7 @@ class Heading final
     return reinterpret_cast<const Heading*>(
         &_Heading_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 34;
+  static constexpr int kIndexInFileMessages = 38;
   friend void swap(Heading& a, Heading& b) { a.Swap(&b); }
   inline void Swap(Heading* other) {
     if (other == this) return;
@@ -4285,7 +4297,7 @@ class GroundTruth final
     return reinterpret_cast<const GroundTruth*>(
         &_GroundTruth_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 54;
+  static constexpr int kIndexInFileMessages = 58;
   friend void swap(GroundTruth& a, GroundTruth& b) { a.Swap(&b); }
   inline void Swap(GroundTruth* other) {
     if (other == this) return;
@@ -4500,7 +4512,7 @@ class GpsInfo final
     return reinterpret_cast<const GpsInfo*>(
         &_GpsInfo_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 38;
+  static constexpr int kIndexInFileMessages = 42;
   friend void swap(GpsInfo& a, GpsInfo& b) { a.Swap(&b); }
   inline void Swap(GpsInfo* other) {
     if (other == this) return;
@@ -4703,7 +4715,7 @@ class FixedwingMetrics final
     return reinterpret_cast<const FixedwingMetrics*>(
         &_FixedwingMetrics_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 55;
+  static constexpr int kIndexInFileMessages = 59;
   friend void swap(FixedwingMetrics& a, FixedwingMetrics& b) { a.Swap(&b); }
   inline void Swap(FixedwingMetrics* other) {
     if (other == this) return;
@@ -4791,8 +4803,11 @@ class FixedwingMetrics final
   // accessors -------------------------------------------------------
   enum : int {
     kAirspeedMSFieldNumber = 1,
-    kThrottlePercentageFieldNumber = 2,
-    kClimbRateMSFieldNumber = 3,
+    kGroundspeedMSFieldNumber = 2,
+    kHeadingDegFieldNumber = 3,
+    kThrottlePercentageFieldNumber = 4,
+    kAltitudeMslFieldNumber = 5,
+    kClimbRateMSFieldNumber = 6,
   };
   // float airspeed_m_s = 1 [(.mavsdk.options.default_value) = "NaN"];
   void clear_airspeed_m_s() ;
@@ -4804,7 +4819,27 @@ class FixedwingMetrics final
   void _internal_set_airspeed_m_s(float value);
 
   public:
-  // float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
+  // float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_groundspeed_m_s() ;
+  float groundspeed_m_s() const;
+  void set_groundspeed_m_s(float value);
+
+  private:
+  float _internal_groundspeed_m_s() const;
+  void _internal_set_groundspeed_m_s(float value);
+
+  public:
+  // float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_heading_deg() ;
+  float heading_deg() const;
+  void set_heading_deg(float value);
+
+  private:
+  float _internal_heading_deg() const;
+  void _internal_set_heading_deg(float value);
+
+  public:
+  // float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
   void clear_throttle_percentage() ;
   float throttle_percentage() const;
   void set_throttle_percentage(float value);
@@ -4814,7 +4849,17 @@ class FixedwingMetrics final
   void _internal_set_throttle_percentage(float value);
 
   public:
-  // float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
+  // float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
+  void clear_altitude_msl() ;
+  float altitude_msl() const;
+  void set_altitude_msl(float value);
+
+  private:
+  float _internal_altitude_msl() const;
+  void _internal_set_altitude_msl(float value);
+
+  public:
+  // float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
   void clear_climb_rate_m_s() ;
   float climb_rate_m_s() const;
   void set_climb_rate_m_s(float value);
@@ -4829,7 +4874,7 @@ class FixedwingMetrics final
   class _Internal;
   friend class ::google::protobuf::internal::TcParser;
   static const ::google::protobuf::internal::TcParseTable<
-      2, 3, 0,
+      3, 6, 0,
       0, 2>
       _table_;
 
@@ -4848,7 +4893,10 @@ class FixedwingMetrics final
                           ::google::protobuf::Arena* arena, const Impl_& from,
                           const FixedwingMetrics& from_msg);
     float airspeed_m_s_;
+    float groundspeed_m_s_;
+    float heading_deg_;
     float throttle_percentage_;
+    float altitude_msl_;
     float climb_rate_m_s_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     PROTOBUF_TSAN_DECLARE_MEMBER
@@ -4918,7 +4966,7 @@ class EulerAngle final
     return reinterpret_cast<const EulerAngle*>(
         &_EulerAngle_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 36;
+  static constexpr int kIndexInFileMessages = 40;
   friend void swap(EulerAngle& a, EulerAngle& b) { a.Swap(&b); }
   inline void Swap(EulerAngle* other) {
     if (other == this) return;
@@ -5145,7 +5193,7 @@ class DistanceSensor final
     return reinterpret_cast<const DistanceSensor*>(
         &_DistanceSensor_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 49;
+  static constexpr int kIndexInFileMessages = 53;
   friend void swap(DistanceSensor& a, DistanceSensor& b) { a.Swap(&b); }
   inline void Swap(DistanceSensor* other) {
     if (other == this) return;
@@ -5360,7 +5408,7 @@ class Covariance final
     return reinterpret_cast<const Covariance*>(
         &_Covariance_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 45;
+  static constexpr int kIndexInFileMessages = 49;
   friend void swap(Covariance& a, Covariance& b) { a.Swap(&b); }
   inline void Swap(Covariance* other) {
     if (other == this) return;
@@ -5559,7 +5607,7 @@ class Battery final
     return reinterpret_cast<const Battery*>(
         &_Battery_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 40;
+  static constexpr int kIndexInFileMessages = 44;
   friend void swap(Battery& a, Battery& b) { a.Swap(&b); }
   inline void Swap(Battery* other) {
     if (other == this) return;
@@ -5762,7 +5810,7 @@ class AngularVelocityFrd final
     return reinterpret_cast<const AngularVelocityFrd*>(
         &_AngularVelocityFrd_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 57;
+  static constexpr int kIndexInFileMessages = 61;
   friend void swap(AngularVelocityFrd& a, AngularVelocityFrd& b) { a.Swap(&b); }
   inline void Swap(AngularVelocityFrd* other) {
     if (other == this) return;
@@ -5977,7 +6025,7 @@ class AngularVelocityBody final
     return reinterpret_cast<const AngularVelocityBody*>(
         &_AngularVelocityBody_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 37;
+  static constexpr int kIndexInFileMessages = 41;
   friend void swap(AngularVelocityBody& a, AngularVelocityBody& b) { a.Swap(&b); }
   inline void Swap(AngularVelocityBody* other) {
     if (other == this) return;
@@ -6192,7 +6240,7 @@ class ActuatorOutputStatus final
     return reinterpret_cast<const ActuatorOutputStatus*>(
         &_ActuatorOutputStatus_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 44;
+  static constexpr int kIndexInFileMessages = 48;
   friend void swap(ActuatorOutputStatus& a, ActuatorOutputStatus& b) { a.Swap(&b); }
   inline void Swap(ActuatorOutputStatus* other) {
     if (other == this) return;
@@ -6403,7 +6451,7 @@ class ActuatorControlTarget final
     return reinterpret_cast<const ActuatorControlTarget*>(
         &_ActuatorControlTarget_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 43;
+  static constexpr int kIndexInFileMessages = 47;
   friend void swap(ActuatorControlTarget& a, ActuatorControlTarget& b) { a.Swap(&b); }
   inline void Swap(ActuatorControlTarget* other) {
     if (other == this) return;
@@ -6614,7 +6662,7 @@ class AccelerationFrd final
     return reinterpret_cast<const AccelerationFrd*>(
         &_AccelerationFrd_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 56;
+  static constexpr int kIndexInFileMessages = 60;
   friend void swap(AccelerationFrd& a, AccelerationFrd& b) { a.Swap(&b); }
   inline void Swap(AccelerationFrd* other) {
     if (other == this) return;
@@ -6769,6 +6817,400 @@ class AccelerationFrd final
 };
 // -------------------------------------------------------------------
 
+class PublishVisualFlightRulesHudResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudResponse) */ {
+ public:
+  inline PublishVisualFlightRulesHudResponse() : PublishVisualFlightRulesHudResponse(nullptr) {}
+  ~PublishVisualFlightRulesHudResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(PublishVisualFlightRulesHudResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(PublishVisualFlightRulesHudResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR PublishVisualFlightRulesHudResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline PublishVisualFlightRulesHudResponse(const PublishVisualFlightRulesHudResponse& from) : PublishVisualFlightRulesHudResponse(nullptr, from) {}
+  inline PublishVisualFlightRulesHudResponse(PublishVisualFlightRulesHudResponse&& from) noexcept
+      : PublishVisualFlightRulesHudResponse(nullptr, std::move(from)) {}
+  inline PublishVisualFlightRulesHudResponse& operator=(const PublishVisualFlightRulesHudResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline PublishVisualFlightRulesHudResponse& operator=(PublishVisualFlightRulesHudResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const PublishVisualFlightRulesHudResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const PublishVisualFlightRulesHudResponse* internal_default_instance() {
+    return reinterpret_cast<const PublishVisualFlightRulesHudResponse*>(
+        &_PublishVisualFlightRulesHudResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 36;
+  friend void swap(PublishVisualFlightRulesHudResponse& a, PublishVisualFlightRulesHudResponse& b) { a.Swap(&b); }
+  inline void Swap(PublishVisualFlightRulesHudResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(PublishVisualFlightRulesHudResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  PublishVisualFlightRulesHudResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<PublishVisualFlightRulesHudResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const PublishVisualFlightRulesHudResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const PublishVisualFlightRulesHudResponse& from) { PublishVisualFlightRulesHudResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(PublishVisualFlightRulesHudResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudResponse"; }
+
+ protected:
+  explicit PublishVisualFlightRulesHudResponse(::google::protobuf::Arena* arena);
+  PublishVisualFlightRulesHudResponse(::google::protobuf::Arena* arena, const PublishVisualFlightRulesHudResponse& from);
+  PublishVisualFlightRulesHudResponse(::google::protobuf::Arena* arena, PublishVisualFlightRulesHudResponse&& from) noexcept
+      : PublishVisualFlightRulesHudResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kTelemetryServerResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.telemetry_server.TelemetryServerResult telemetry_server_result = 1;
+  bool has_telemetry_server_result() const;
+  void clear_telemetry_server_result() ;
+  const ::mavsdk::rpc::telemetry_server::TelemetryServerResult& telemetry_server_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::telemetry_server::TelemetryServerResult* release_telemetry_server_result();
+  ::mavsdk::rpc::telemetry_server::TelemetryServerResult* mutable_telemetry_server_result();
+  void set_allocated_telemetry_server_result(::mavsdk::rpc::telemetry_server::TelemetryServerResult* value);
+  void unsafe_arena_set_allocated_telemetry_server_result(::mavsdk::rpc::telemetry_server::TelemetryServerResult* value);
+  ::mavsdk::rpc::telemetry_server::TelemetryServerResult* unsafe_arena_release_telemetry_server_result();
+
+  private:
+  const ::mavsdk::rpc::telemetry_server::TelemetryServerResult& _internal_telemetry_server_result() const;
+  ::mavsdk::rpc::telemetry_server::TelemetryServerResult* _internal_mutable_telemetry_server_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const PublishVisualFlightRulesHudResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::telemetry_server::TelemetryServerResult* telemetry_server_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_telemetry_5fserver_2ftelemetry_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class PublishVisualFlightRulesHudRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudRequest) */ {
+ public:
+  inline PublishVisualFlightRulesHudRequest() : PublishVisualFlightRulesHudRequest(nullptr) {}
+  ~PublishVisualFlightRulesHudRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(PublishVisualFlightRulesHudRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(PublishVisualFlightRulesHudRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR PublishVisualFlightRulesHudRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline PublishVisualFlightRulesHudRequest(const PublishVisualFlightRulesHudRequest& from) : PublishVisualFlightRulesHudRequest(nullptr, from) {}
+  inline PublishVisualFlightRulesHudRequest(PublishVisualFlightRulesHudRequest&& from) noexcept
+      : PublishVisualFlightRulesHudRequest(nullptr, std::move(from)) {}
+  inline PublishVisualFlightRulesHudRequest& operator=(const PublishVisualFlightRulesHudRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline PublishVisualFlightRulesHudRequest& operator=(PublishVisualFlightRulesHudRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const PublishVisualFlightRulesHudRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const PublishVisualFlightRulesHudRequest* internal_default_instance() {
+    return reinterpret_cast<const PublishVisualFlightRulesHudRequest*>(
+        &_PublishVisualFlightRulesHudRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 19;
+  friend void swap(PublishVisualFlightRulesHudRequest& a, PublishVisualFlightRulesHudRequest& b) { a.Swap(&b); }
+  inline void Swap(PublishVisualFlightRulesHudRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(PublishVisualFlightRulesHudRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  PublishVisualFlightRulesHudRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<PublishVisualFlightRulesHudRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const PublishVisualFlightRulesHudRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const PublishVisualFlightRulesHudRequest& from) { PublishVisualFlightRulesHudRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(PublishVisualFlightRulesHudRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudRequest"; }
+
+ protected:
+  explicit PublishVisualFlightRulesHudRequest(::google::protobuf::Arena* arena);
+  PublishVisualFlightRulesHudRequest(::google::protobuf::Arena* arena, const PublishVisualFlightRulesHudRequest& from);
+  PublishVisualFlightRulesHudRequest(::google::protobuf::Arena* arena, PublishVisualFlightRulesHudRequest&& from) noexcept
+      : PublishVisualFlightRulesHudRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kFixedWingMetricsFieldNumber = 1,
+  };
+  // .mavsdk.rpc.telemetry_server.FixedwingMetrics fixed_wing_metrics = 1;
+  bool has_fixed_wing_metrics() const;
+  void clear_fixed_wing_metrics() ;
+  const ::mavsdk::rpc::telemetry_server::FixedwingMetrics& fixed_wing_metrics() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::telemetry_server::FixedwingMetrics* release_fixed_wing_metrics();
+  ::mavsdk::rpc::telemetry_server::FixedwingMetrics* mutable_fixed_wing_metrics();
+  void set_allocated_fixed_wing_metrics(::mavsdk::rpc::telemetry_server::FixedwingMetrics* value);
+  void unsafe_arena_set_allocated_fixed_wing_metrics(::mavsdk::rpc::telemetry_server::FixedwingMetrics* value);
+  ::mavsdk::rpc::telemetry_server::FixedwingMetrics* unsafe_arena_release_fixed_wing_metrics();
+
+  private:
+  const ::mavsdk::rpc::telemetry_server::FixedwingMetrics& _internal_fixed_wing_metrics() const;
+  ::mavsdk::rpc::telemetry_server::FixedwingMetrics* _internal_mutable_fixed_wing_metrics();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const PublishVisualFlightRulesHudRequest& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::telemetry_server::FixedwingMetrics* fixed_wing_metrics_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_telemetry_5fserver_2ftelemetry_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
 class PublishUnixEpochTimeResponse final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.telemetry_server.PublishUnixEpochTimeResponse) */ {
@@ -6829,7 +7271,7 @@ class PublishUnixEpochTimeResponse final
     return reinterpret_cast<const PublishUnixEpochTimeResponse*>(
         &_PublishUnixEpochTimeResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 31;
+  static constexpr int kIndexInFileMessages = 33;
   friend void swap(PublishUnixEpochTimeResponse& a, PublishUnixEpochTimeResponse& b) { a.Swap(&b); }
   inline void Swap(PublishUnixEpochTimeResponse* other) {
     if (other == this) return;
@@ -7026,7 +7468,7 @@ class PublishSysStatusResponse final
     return reinterpret_cast<const PublishSysStatusResponse*>(
         &_PublishSysStatusResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 20;
+  static constexpr int kIndexInFileMessages = 22;
   friend void swap(PublishSysStatusResponse& a, PublishSysStatusResponse& b) { a.Swap(&b); }
   inline void Swap(PublishSysStatusResponse* other) {
     if (other == this) return;
@@ -7480,7 +7922,7 @@ class PublishStatusTextResponse final
     return reinterpret_cast<const PublishStatusTextResponse*>(
         &_PublishStatusTextResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 24;
+  static constexpr int kIndexInFileMessages = 26;
   friend void swap(PublishStatusTextResponse& a, PublishStatusTextResponse& b) { a.Swap(&b); }
   inline void Swap(PublishStatusTextResponse* other) {
     if (other == this) return;
@@ -7874,7 +8316,7 @@ class PublishScaledImuResponse final
     return reinterpret_cast<const PublishScaledImuResponse*>(
         &_PublishScaledImuResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 29;
+  static constexpr int kIndexInFileMessages = 31;
   friend void swap(PublishScaledImuResponse& a, PublishScaledImuResponse& b) { a.Swap(&b); }
   inline void Swap(PublishScaledImuResponse* other) {
     if (other == this) return;
@@ -8268,7 +8710,7 @@ class PublishRawImuResponse final
     return reinterpret_cast<const PublishRawImuResponse*>(
         &_PublishRawImuResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 30;
+  static constexpr int kIndexInFileMessages = 32;
   friend void swap(PublishRawImuResponse& a, PublishRawImuResponse& b) { a.Swap(&b); }
   inline void Swap(PublishRawImuResponse* other) {
     if (other == this) return;
@@ -8465,7 +8907,7 @@ class PublishRawGpsResponse final
     return reinterpret_cast<const PublishRawGpsResponse*>(
         &_PublishRawGpsResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 22;
+  static constexpr int kIndexInFileMessages = 24;
   friend void swap(PublishRawGpsResponse& a, PublishRawGpsResponse& b) { a.Swap(&b); }
   inline void Swap(PublishRawGpsResponse* other) {
     if (other == this) return;
@@ -8876,7 +9318,7 @@ class PublishPositionVelocityNedResponse final
     return reinterpret_cast<const PublishPositionVelocityNedResponse*>(
         &_PublishPositionVelocityNedResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 26;
+  static constexpr int kIndexInFileMessages = 28;
   friend void swap(PublishPositionVelocityNedResponse& a, PublishPositionVelocityNedResponse& b) { a.Swap(&b); }
   inline void Swap(PublishPositionVelocityNedResponse* other) {
     if (other == this) return;
@@ -9073,7 +9515,7 @@ class PublishPositionResponse final
     return reinterpret_cast<const PublishPositionResponse*>(
         &_PublishPositionResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 18;
+  static constexpr int kIndexInFileMessages = 20;
   friend void swap(PublishPositionResponse& a, PublishPositionResponse& b) { a.Swap(&b); }
   inline void Swap(PublishPositionResponse* other) {
     if (other == this) return;
@@ -9501,7 +9943,7 @@ class PublishOdometryResponse final
     return reinterpret_cast<const PublishOdometryResponse*>(
         &_PublishOdometryResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 25;
+  static constexpr int kIndexInFileMessages = 27;
   friend void swap(PublishOdometryResponse& a, PublishOdometryResponse& b) { a.Swap(&b); }
   inline void Swap(PublishOdometryResponse* other) {
     if (other == this) return;
@@ -9698,7 +10140,7 @@ class PublishImuResponse final
     return reinterpret_cast<const PublishImuResponse*>(
         &_PublishImuResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 28;
+  static constexpr int kIndexInFileMessages = 30;
   friend void swap(PublishImuResponse& a, PublishImuResponse& b) { a.Swap(&b); }
   inline void Swap(PublishImuResponse* other) {
     if (other == this) return;
@@ -9895,7 +10337,7 @@ class PublishHomeResponse final
     return reinterpret_cast<const PublishHomeResponse*>(
         &_PublishHomeResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 19;
+  static constexpr int kIndexInFileMessages = 21;
   friend void swap(PublishHomeResponse& a, PublishHomeResponse& b) { a.Swap(&b); }
   inline void Swap(PublishHomeResponse* other) {
     if (other == this) return;
@@ -10289,7 +10731,7 @@ class PublishGroundTruthResponse final
     return reinterpret_cast<const PublishGroundTruthResponse*>(
         &_PublishGroundTruthResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 27;
+  static constexpr int kIndexInFileMessages = 29;
   friend void swap(PublishGroundTruthResponse& a, PublishGroundTruthResponse& b) { a.Swap(&b); }
   inline void Swap(PublishGroundTruthResponse* other) {
     if (other == this) return;
@@ -10683,7 +11125,7 @@ class PublishExtendedSysStateResponse final
     return reinterpret_cast<const PublishExtendedSysStateResponse*>(
         &_PublishExtendedSysStateResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 21;
+  static constexpr int kIndexInFileMessages = 23;
   friend void swap(PublishExtendedSysStateResponse& a, PublishExtendedSysStateResponse& b) { a.Swap(&b); }
   inline void Swap(PublishExtendedSysStateResponse* other) {
     if (other == this) return;
@@ -10880,7 +11322,7 @@ class PublishDistanceSensorResponse final
     return reinterpret_cast<const PublishDistanceSensorResponse*>(
         &_PublishDistanceSensorResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 32;
+  static constexpr int kIndexInFileMessages = 34;
   friend void swap(PublishDistanceSensorResponse& a, PublishDistanceSensorResponse& b) { a.Swap(&b); }
   inline void Swap(PublishDistanceSensorResponse* other) {
     if (other == this) return;
@@ -11274,7 +11716,7 @@ class PublishBatteryResponse final
     return reinterpret_cast<const PublishBatteryResponse*>(
         &_PublishBatteryResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 23;
+  static constexpr int kIndexInFileMessages = 25;
   friend void swap(PublishBatteryResponse& a, PublishBatteryResponse& b) { a.Swap(&b); }
   inline void Swap(PublishBatteryResponse* other) {
     if (other == this) return;
@@ -11608,6 +12050,417 @@ class PublishBatteryRequest final
 };
 // -------------------------------------------------------------------
 
+class PublishAttitudeResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.telemetry_server.PublishAttitudeResponse) */ {
+ public:
+  inline PublishAttitudeResponse() : PublishAttitudeResponse(nullptr) {}
+  ~PublishAttitudeResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(PublishAttitudeResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(PublishAttitudeResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR PublishAttitudeResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline PublishAttitudeResponse(const PublishAttitudeResponse& from) : PublishAttitudeResponse(nullptr, from) {}
+  inline PublishAttitudeResponse(PublishAttitudeResponse&& from) noexcept
+      : PublishAttitudeResponse(nullptr, std::move(from)) {}
+  inline PublishAttitudeResponse& operator=(const PublishAttitudeResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline PublishAttitudeResponse& operator=(PublishAttitudeResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const PublishAttitudeResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const PublishAttitudeResponse* internal_default_instance() {
+    return reinterpret_cast<const PublishAttitudeResponse*>(
+        &_PublishAttitudeResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 35;
+  friend void swap(PublishAttitudeResponse& a, PublishAttitudeResponse& b) { a.Swap(&b); }
+  inline void Swap(PublishAttitudeResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(PublishAttitudeResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  PublishAttitudeResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<PublishAttitudeResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const PublishAttitudeResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const PublishAttitudeResponse& from) { PublishAttitudeResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(PublishAttitudeResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.telemetry_server.PublishAttitudeResponse"; }
+
+ protected:
+  explicit PublishAttitudeResponse(::google::protobuf::Arena* arena);
+  PublishAttitudeResponse(::google::protobuf::Arena* arena, const PublishAttitudeResponse& from);
+  PublishAttitudeResponse(::google::protobuf::Arena* arena, PublishAttitudeResponse&& from) noexcept
+      : PublishAttitudeResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kTelemetryServerResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.telemetry_server.TelemetryServerResult telemetry_server_result = 1;
+  bool has_telemetry_server_result() const;
+  void clear_telemetry_server_result() ;
+  const ::mavsdk::rpc::telemetry_server::TelemetryServerResult& telemetry_server_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::telemetry_server::TelemetryServerResult* release_telemetry_server_result();
+  ::mavsdk::rpc::telemetry_server::TelemetryServerResult* mutable_telemetry_server_result();
+  void set_allocated_telemetry_server_result(::mavsdk::rpc::telemetry_server::TelemetryServerResult* value);
+  void unsafe_arena_set_allocated_telemetry_server_result(::mavsdk::rpc::telemetry_server::TelemetryServerResult* value);
+  ::mavsdk::rpc::telemetry_server::TelemetryServerResult* unsafe_arena_release_telemetry_server_result();
+
+  private:
+  const ::mavsdk::rpc::telemetry_server::TelemetryServerResult& _internal_telemetry_server_result() const;
+  ::mavsdk::rpc::telemetry_server::TelemetryServerResult* _internal_mutable_telemetry_server_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.telemetry_server.PublishAttitudeResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const PublishAttitudeResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::telemetry_server::TelemetryServerResult* telemetry_server_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_telemetry_5fserver_2ftelemetry_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class PublishAttitudeRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.telemetry_server.PublishAttitudeRequest) */ {
+ public:
+  inline PublishAttitudeRequest() : PublishAttitudeRequest(nullptr) {}
+  ~PublishAttitudeRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(PublishAttitudeRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(PublishAttitudeRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR PublishAttitudeRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline PublishAttitudeRequest(const PublishAttitudeRequest& from) : PublishAttitudeRequest(nullptr, from) {}
+  inline PublishAttitudeRequest(PublishAttitudeRequest&& from) noexcept
+      : PublishAttitudeRequest(nullptr, std::move(from)) {}
+  inline PublishAttitudeRequest& operator=(const PublishAttitudeRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline PublishAttitudeRequest& operator=(PublishAttitudeRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const PublishAttitudeRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const PublishAttitudeRequest* internal_default_instance() {
+    return reinterpret_cast<const PublishAttitudeRequest*>(
+        &_PublishAttitudeRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 18;
+  friend void swap(PublishAttitudeRequest& a, PublishAttitudeRequest& b) { a.Swap(&b); }
+  inline void Swap(PublishAttitudeRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(PublishAttitudeRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  PublishAttitudeRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<PublishAttitudeRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const PublishAttitudeRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const PublishAttitudeRequest& from) { PublishAttitudeRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(PublishAttitudeRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.telemetry_server.PublishAttitudeRequest"; }
+
+ protected:
+  explicit PublishAttitudeRequest(::google::protobuf::Arena* arena);
+  PublishAttitudeRequest(::google::protobuf::Arena* arena, const PublishAttitudeRequest& from);
+  PublishAttitudeRequest(::google::protobuf::Arena* arena, PublishAttitudeRequest&& from) noexcept
+      : PublishAttitudeRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kAngleFieldNumber = 1,
+    kAngularVelocityFieldNumber = 2,
+  };
+  // .mavsdk.rpc.telemetry_server.EulerAngle angle = 1;
+  bool has_angle() const;
+  void clear_angle() ;
+  const ::mavsdk::rpc::telemetry_server::EulerAngle& angle() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::telemetry_server::EulerAngle* release_angle();
+  ::mavsdk::rpc::telemetry_server::EulerAngle* mutable_angle();
+  void set_allocated_angle(::mavsdk::rpc::telemetry_server::EulerAngle* value);
+  void unsafe_arena_set_allocated_angle(::mavsdk::rpc::telemetry_server::EulerAngle* value);
+  ::mavsdk::rpc::telemetry_server::EulerAngle* unsafe_arena_release_angle();
+
+  private:
+  const ::mavsdk::rpc::telemetry_server::EulerAngle& _internal_angle() const;
+  ::mavsdk::rpc::telemetry_server::EulerAngle* _internal_mutable_angle();
+
+  public:
+  // .mavsdk.rpc.telemetry_server.AngularVelocityBody angular_velocity = 2;
+  bool has_angular_velocity() const;
+  void clear_angular_velocity() ;
+  const ::mavsdk::rpc::telemetry_server::AngularVelocityBody& angular_velocity() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::telemetry_server::AngularVelocityBody* release_angular_velocity();
+  ::mavsdk::rpc::telemetry_server::AngularVelocityBody* mutable_angular_velocity();
+  void set_allocated_angular_velocity(::mavsdk::rpc::telemetry_server::AngularVelocityBody* value);
+  void unsafe_arena_set_allocated_angular_velocity(::mavsdk::rpc::telemetry_server::AngularVelocityBody* value);
+  ::mavsdk::rpc::telemetry_server::AngularVelocityBody* unsafe_arena_release_angular_velocity();
+
+  private:
+  const ::mavsdk::rpc::telemetry_server::AngularVelocityBody& _internal_angular_velocity() const;
+  ::mavsdk::rpc::telemetry_server::AngularVelocityBody* _internal_mutable_angular_velocity();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.telemetry_server.PublishAttitudeRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      1, 2, 2,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const PublishAttitudeRequest& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::telemetry_server::EulerAngle* angle_;
+    ::mavsdk::rpc::telemetry_server::AngularVelocityBody* angular_velocity_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_telemetry_5fserver_2ftelemetry_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
 class PositionVelocityNed final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.telemetry_server.PositionVelocityNed) */ {
@@ -11668,7 +12521,7 @@ class PositionVelocityNed final
     return reinterpret_cast<const PositionVelocityNed*>(
         &_PositionVelocityNed_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 53;
+  static constexpr int kIndexInFileMessages = 57;
   friend void swap(PositionVelocityNed& a, PositionVelocityNed& b) { a.Swap(&b); }
   inline void Swap(PositionVelocityNed* other) {
     if (other == this) return;
@@ -11882,7 +12735,7 @@ class Odometry final
     return reinterpret_cast<const Odometry*>(
         &_Odometry_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 48;
+  static constexpr int kIndexInFileMessages = 52;
   friend void swap(Odometry& a, Odometry& b) { a.Swap(&b); }
   inline void Swap(Odometry* other) {
     if (other == this) return;
@@ -12221,7 +13074,7 @@ class Imu final
     return reinterpret_cast<const Imu*>(
         &_Imu_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 59;
+  static constexpr int kIndexInFileMessages = 63;
   friend void swap(Imu& a, Imu& b) { a.Swap(&b); }
   inline void Swap(Imu* other) {
     if (other == this) return;
@@ -15338,6 +16191,302 @@ inline void PublishDistanceSensorRequest::set_allocated_distance_sensor(::mavsdk
 
 // -------------------------------------------------------------------
 
+// PublishAttitudeRequest
+
+// .mavsdk.rpc.telemetry_server.EulerAngle angle = 1;
+inline bool PublishAttitudeRequest::has_angle() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.angle_ != nullptr);
+  return value;
+}
+inline void PublishAttitudeRequest::clear_angle() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.angle_ != nullptr) _impl_.angle_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::telemetry_server::EulerAngle& PublishAttitudeRequest::_internal_angle() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::telemetry_server::EulerAngle* p = _impl_.angle_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::telemetry_server::EulerAngle&>(::mavsdk::rpc::telemetry_server::_EulerAngle_default_instance_);
+}
+inline const ::mavsdk::rpc::telemetry_server::EulerAngle& PublishAttitudeRequest::angle() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry_server.PublishAttitudeRequest.angle)
+  return _internal_angle();
+}
+inline void PublishAttitudeRequest::unsafe_arena_set_allocated_angle(::mavsdk::rpc::telemetry_server::EulerAngle* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.angle_);
+  }
+  _impl_.angle_ = reinterpret_cast<::mavsdk::rpc::telemetry_server::EulerAngle*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.telemetry_server.PublishAttitudeRequest.angle)
+}
+inline ::mavsdk::rpc::telemetry_server::EulerAngle* PublishAttitudeRequest::release_angle() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::telemetry_server::EulerAngle* released = _impl_.angle_;
+  _impl_.angle_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::telemetry_server::EulerAngle* PublishAttitudeRequest::unsafe_arena_release_angle() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.telemetry_server.PublishAttitudeRequest.angle)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::telemetry_server::EulerAngle* temp = _impl_.angle_;
+  _impl_.angle_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::telemetry_server::EulerAngle* PublishAttitudeRequest::_internal_mutable_angle() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.angle_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::telemetry_server::EulerAngle>(GetArena());
+    _impl_.angle_ = reinterpret_cast<::mavsdk::rpc::telemetry_server::EulerAngle*>(p);
+  }
+  return _impl_.angle_;
+}
+inline ::mavsdk::rpc::telemetry_server::EulerAngle* PublishAttitudeRequest::mutable_angle() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::telemetry_server::EulerAngle* _msg = _internal_mutable_angle();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.telemetry_server.PublishAttitudeRequest.angle)
+  return _msg;
+}
+inline void PublishAttitudeRequest::set_allocated_angle(::mavsdk::rpc::telemetry_server::EulerAngle* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.angle_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.angle_ = reinterpret_cast<::mavsdk::rpc::telemetry_server::EulerAngle*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.telemetry_server.PublishAttitudeRequest.angle)
+}
+
+// .mavsdk.rpc.telemetry_server.AngularVelocityBody angular_velocity = 2;
+inline bool PublishAttitudeRequest::has_angular_velocity() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000002u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.angular_velocity_ != nullptr);
+  return value;
+}
+inline void PublishAttitudeRequest::clear_angular_velocity() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.angular_velocity_ != nullptr) _impl_.angular_velocity_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000002u;
+}
+inline const ::mavsdk::rpc::telemetry_server::AngularVelocityBody& PublishAttitudeRequest::_internal_angular_velocity() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::telemetry_server::AngularVelocityBody* p = _impl_.angular_velocity_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::telemetry_server::AngularVelocityBody&>(::mavsdk::rpc::telemetry_server::_AngularVelocityBody_default_instance_);
+}
+inline const ::mavsdk::rpc::telemetry_server::AngularVelocityBody& PublishAttitudeRequest::angular_velocity() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry_server.PublishAttitudeRequest.angular_velocity)
+  return _internal_angular_velocity();
+}
+inline void PublishAttitudeRequest::unsafe_arena_set_allocated_angular_velocity(::mavsdk::rpc::telemetry_server::AngularVelocityBody* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.angular_velocity_);
+  }
+  _impl_.angular_velocity_ = reinterpret_cast<::mavsdk::rpc::telemetry_server::AngularVelocityBody*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000002u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000002u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.telemetry_server.PublishAttitudeRequest.angular_velocity)
+}
+inline ::mavsdk::rpc::telemetry_server::AngularVelocityBody* PublishAttitudeRequest::release_angular_velocity() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000002u;
+  ::mavsdk::rpc::telemetry_server::AngularVelocityBody* released = _impl_.angular_velocity_;
+  _impl_.angular_velocity_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::telemetry_server::AngularVelocityBody* PublishAttitudeRequest::unsafe_arena_release_angular_velocity() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.telemetry_server.PublishAttitudeRequest.angular_velocity)
+
+  _impl_._has_bits_[0] &= ~0x00000002u;
+  ::mavsdk::rpc::telemetry_server::AngularVelocityBody* temp = _impl_.angular_velocity_;
+  _impl_.angular_velocity_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::telemetry_server::AngularVelocityBody* PublishAttitudeRequest::_internal_mutable_angular_velocity() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.angular_velocity_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::telemetry_server::AngularVelocityBody>(GetArena());
+    _impl_.angular_velocity_ = reinterpret_cast<::mavsdk::rpc::telemetry_server::AngularVelocityBody*>(p);
+  }
+  return _impl_.angular_velocity_;
+}
+inline ::mavsdk::rpc::telemetry_server::AngularVelocityBody* PublishAttitudeRequest::mutable_angular_velocity() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000002u;
+  ::mavsdk::rpc::telemetry_server::AngularVelocityBody* _msg = _internal_mutable_angular_velocity();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.telemetry_server.PublishAttitudeRequest.angular_velocity)
+  return _msg;
+}
+inline void PublishAttitudeRequest::set_allocated_angular_velocity(::mavsdk::rpc::telemetry_server::AngularVelocityBody* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.angular_velocity_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000002u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000002u;
+  }
+
+  _impl_.angular_velocity_ = reinterpret_cast<::mavsdk::rpc::telemetry_server::AngularVelocityBody*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.telemetry_server.PublishAttitudeRequest.angular_velocity)
+}
+
+// -------------------------------------------------------------------
+
+// PublishVisualFlightRulesHudRequest
+
+// .mavsdk.rpc.telemetry_server.FixedwingMetrics fixed_wing_metrics = 1;
+inline bool PublishVisualFlightRulesHudRequest::has_fixed_wing_metrics() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.fixed_wing_metrics_ != nullptr);
+  return value;
+}
+inline void PublishVisualFlightRulesHudRequest::clear_fixed_wing_metrics() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.fixed_wing_metrics_ != nullptr) _impl_.fixed_wing_metrics_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::telemetry_server::FixedwingMetrics& PublishVisualFlightRulesHudRequest::_internal_fixed_wing_metrics() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::telemetry_server::FixedwingMetrics* p = _impl_.fixed_wing_metrics_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::telemetry_server::FixedwingMetrics&>(::mavsdk::rpc::telemetry_server::_FixedwingMetrics_default_instance_);
+}
+inline const ::mavsdk::rpc::telemetry_server::FixedwingMetrics& PublishVisualFlightRulesHudRequest::fixed_wing_metrics() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudRequest.fixed_wing_metrics)
+  return _internal_fixed_wing_metrics();
+}
+inline void PublishVisualFlightRulesHudRequest::unsafe_arena_set_allocated_fixed_wing_metrics(::mavsdk::rpc::telemetry_server::FixedwingMetrics* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.fixed_wing_metrics_);
+  }
+  _impl_.fixed_wing_metrics_ = reinterpret_cast<::mavsdk::rpc::telemetry_server::FixedwingMetrics*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudRequest.fixed_wing_metrics)
+}
+inline ::mavsdk::rpc::telemetry_server::FixedwingMetrics* PublishVisualFlightRulesHudRequest::release_fixed_wing_metrics() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::telemetry_server::FixedwingMetrics* released = _impl_.fixed_wing_metrics_;
+  _impl_.fixed_wing_metrics_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::telemetry_server::FixedwingMetrics* PublishVisualFlightRulesHudRequest::unsafe_arena_release_fixed_wing_metrics() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudRequest.fixed_wing_metrics)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::telemetry_server::FixedwingMetrics* temp = _impl_.fixed_wing_metrics_;
+  _impl_.fixed_wing_metrics_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::telemetry_server::FixedwingMetrics* PublishVisualFlightRulesHudRequest::_internal_mutable_fixed_wing_metrics() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.fixed_wing_metrics_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::telemetry_server::FixedwingMetrics>(GetArena());
+    _impl_.fixed_wing_metrics_ = reinterpret_cast<::mavsdk::rpc::telemetry_server::FixedwingMetrics*>(p);
+  }
+  return _impl_.fixed_wing_metrics_;
+}
+inline ::mavsdk::rpc::telemetry_server::FixedwingMetrics* PublishVisualFlightRulesHudRequest::mutable_fixed_wing_metrics() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::telemetry_server::FixedwingMetrics* _msg = _internal_mutable_fixed_wing_metrics();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudRequest.fixed_wing_metrics)
+  return _msg;
+}
+inline void PublishVisualFlightRulesHudRequest::set_allocated_fixed_wing_metrics(::mavsdk::rpc::telemetry_server::FixedwingMetrics* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.fixed_wing_metrics_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.fixed_wing_metrics_ = reinterpret_cast<::mavsdk::rpc::telemetry_server::FixedwingMetrics*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudRequest.fixed_wing_metrics)
+}
+
+// -------------------------------------------------------------------
+
 // PublishPositionResponse
 
 // .mavsdk.rpc.telemetry_server.TelemetryServerResult telemetry_server_result = 1;
@@ -16834,6 +17983,206 @@ inline void PublishDistanceSensorResponse::set_allocated_telemetry_server_result
 
   _impl_.telemetry_server_result_ = reinterpret_cast<::mavsdk::rpc::telemetry_server::TelemetryServerResult*>(value);
   // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.telemetry_server.PublishDistanceSensorResponse.telemetry_server_result)
+}
+
+// -------------------------------------------------------------------
+
+// PublishAttitudeResponse
+
+// .mavsdk.rpc.telemetry_server.TelemetryServerResult telemetry_server_result = 1;
+inline bool PublishAttitudeResponse::has_telemetry_server_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.telemetry_server_result_ != nullptr);
+  return value;
+}
+inline void PublishAttitudeResponse::clear_telemetry_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.telemetry_server_result_ != nullptr) _impl_.telemetry_server_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::telemetry_server::TelemetryServerResult& PublishAttitudeResponse::_internal_telemetry_server_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::telemetry_server::TelemetryServerResult* p = _impl_.telemetry_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::telemetry_server::TelemetryServerResult&>(::mavsdk::rpc::telemetry_server::_TelemetryServerResult_default_instance_);
+}
+inline const ::mavsdk::rpc::telemetry_server::TelemetryServerResult& PublishAttitudeResponse::telemetry_server_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry_server.PublishAttitudeResponse.telemetry_server_result)
+  return _internal_telemetry_server_result();
+}
+inline void PublishAttitudeResponse::unsafe_arena_set_allocated_telemetry_server_result(::mavsdk::rpc::telemetry_server::TelemetryServerResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.telemetry_server_result_);
+  }
+  _impl_.telemetry_server_result_ = reinterpret_cast<::mavsdk::rpc::telemetry_server::TelemetryServerResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.telemetry_server.PublishAttitudeResponse.telemetry_server_result)
+}
+inline ::mavsdk::rpc::telemetry_server::TelemetryServerResult* PublishAttitudeResponse::release_telemetry_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::telemetry_server::TelemetryServerResult* released = _impl_.telemetry_server_result_;
+  _impl_.telemetry_server_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::telemetry_server::TelemetryServerResult* PublishAttitudeResponse::unsafe_arena_release_telemetry_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.telemetry_server.PublishAttitudeResponse.telemetry_server_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::telemetry_server::TelemetryServerResult* temp = _impl_.telemetry_server_result_;
+  _impl_.telemetry_server_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::telemetry_server::TelemetryServerResult* PublishAttitudeResponse::_internal_mutable_telemetry_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.telemetry_server_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::telemetry_server::TelemetryServerResult>(GetArena());
+    _impl_.telemetry_server_result_ = reinterpret_cast<::mavsdk::rpc::telemetry_server::TelemetryServerResult*>(p);
+  }
+  return _impl_.telemetry_server_result_;
+}
+inline ::mavsdk::rpc::telemetry_server::TelemetryServerResult* PublishAttitudeResponse::mutable_telemetry_server_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::telemetry_server::TelemetryServerResult* _msg = _internal_mutable_telemetry_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.telemetry_server.PublishAttitudeResponse.telemetry_server_result)
+  return _msg;
+}
+inline void PublishAttitudeResponse::set_allocated_telemetry_server_result(::mavsdk::rpc::telemetry_server::TelemetryServerResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.telemetry_server_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.telemetry_server_result_ = reinterpret_cast<::mavsdk::rpc::telemetry_server::TelemetryServerResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.telemetry_server.PublishAttitudeResponse.telemetry_server_result)
+}
+
+// -------------------------------------------------------------------
+
+// PublishVisualFlightRulesHudResponse
+
+// .mavsdk.rpc.telemetry_server.TelemetryServerResult telemetry_server_result = 1;
+inline bool PublishVisualFlightRulesHudResponse::has_telemetry_server_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.telemetry_server_result_ != nullptr);
+  return value;
+}
+inline void PublishVisualFlightRulesHudResponse::clear_telemetry_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.telemetry_server_result_ != nullptr) _impl_.telemetry_server_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::telemetry_server::TelemetryServerResult& PublishVisualFlightRulesHudResponse::_internal_telemetry_server_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::telemetry_server::TelemetryServerResult* p = _impl_.telemetry_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::telemetry_server::TelemetryServerResult&>(::mavsdk::rpc::telemetry_server::_TelemetryServerResult_default_instance_);
+}
+inline const ::mavsdk::rpc::telemetry_server::TelemetryServerResult& PublishVisualFlightRulesHudResponse::telemetry_server_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudResponse.telemetry_server_result)
+  return _internal_telemetry_server_result();
+}
+inline void PublishVisualFlightRulesHudResponse::unsafe_arena_set_allocated_telemetry_server_result(::mavsdk::rpc::telemetry_server::TelemetryServerResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.telemetry_server_result_);
+  }
+  _impl_.telemetry_server_result_ = reinterpret_cast<::mavsdk::rpc::telemetry_server::TelemetryServerResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudResponse.telemetry_server_result)
+}
+inline ::mavsdk::rpc::telemetry_server::TelemetryServerResult* PublishVisualFlightRulesHudResponse::release_telemetry_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::telemetry_server::TelemetryServerResult* released = _impl_.telemetry_server_result_;
+  _impl_.telemetry_server_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::telemetry_server::TelemetryServerResult* PublishVisualFlightRulesHudResponse::unsafe_arena_release_telemetry_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudResponse.telemetry_server_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::telemetry_server::TelemetryServerResult* temp = _impl_.telemetry_server_result_;
+  _impl_.telemetry_server_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::telemetry_server::TelemetryServerResult* PublishVisualFlightRulesHudResponse::_internal_mutable_telemetry_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.telemetry_server_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::telemetry_server::TelemetryServerResult>(GetArena());
+    _impl_.telemetry_server_result_ = reinterpret_cast<::mavsdk::rpc::telemetry_server::TelemetryServerResult*>(p);
+  }
+  return _impl_.telemetry_server_result_;
+}
+inline ::mavsdk::rpc::telemetry_server::TelemetryServerResult* PublishVisualFlightRulesHudResponse::mutable_telemetry_server_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::telemetry_server::TelemetryServerResult* _msg = _internal_mutable_telemetry_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudResponse.telemetry_server_result)
+  return _msg;
+}
+inline void PublishVisualFlightRulesHudResponse::set_allocated_telemetry_server_result(::mavsdk::rpc::telemetry_server::TelemetryServerResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.telemetry_server_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.telemetry_server_result_ = reinterpret_cast<::mavsdk::rpc::telemetry_server::TelemetryServerResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.telemetry_server.PublishVisualFlightRulesHudResponse.telemetry_server_result)
 }
 
 // -------------------------------------------------------------------
@@ -19375,7 +20724,51 @@ inline void FixedwingMetrics::_internal_set_airspeed_m_s(float value) {
   _impl_.airspeed_m_s_ = value;
 }
 
-// float throttle_percentage = 2 [(.mavsdk.options.default_value) = "NaN"];
+// float groundspeed_m_s = 2 [(.mavsdk.options.default_value) = "NaN"];
+inline void FixedwingMetrics::clear_groundspeed_m_s() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.groundspeed_m_s_ = 0;
+}
+inline float FixedwingMetrics::groundspeed_m_s() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry_server.FixedwingMetrics.groundspeed_m_s)
+  return _internal_groundspeed_m_s();
+}
+inline void FixedwingMetrics::set_groundspeed_m_s(float value) {
+  _internal_set_groundspeed_m_s(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry_server.FixedwingMetrics.groundspeed_m_s)
+}
+inline float FixedwingMetrics::_internal_groundspeed_m_s() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.groundspeed_m_s_;
+}
+inline void FixedwingMetrics::_internal_set_groundspeed_m_s(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.groundspeed_m_s_ = value;
+}
+
+// float heading_deg = 3 [(.mavsdk.options.default_value) = "NaN"];
+inline void FixedwingMetrics::clear_heading_deg() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.heading_deg_ = 0;
+}
+inline float FixedwingMetrics::heading_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry_server.FixedwingMetrics.heading_deg)
+  return _internal_heading_deg();
+}
+inline void FixedwingMetrics::set_heading_deg(float value) {
+  _internal_set_heading_deg(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry_server.FixedwingMetrics.heading_deg)
+}
+inline float FixedwingMetrics::_internal_heading_deg() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.heading_deg_;
+}
+inline void FixedwingMetrics::_internal_set_heading_deg(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.heading_deg_ = value;
+}
+
+// float throttle_percentage = 4 [(.mavsdk.options.default_value) = "NaN"];
 inline void FixedwingMetrics::clear_throttle_percentage() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.throttle_percentage_ = 0;
@@ -19397,7 +20790,29 @@ inline void FixedwingMetrics::_internal_set_throttle_percentage(float value) {
   _impl_.throttle_percentage_ = value;
 }
 
-// float climb_rate_m_s = 3 [(.mavsdk.options.default_value) = "NaN"];
+// float altitude_msl = 5 [(.mavsdk.options.default_value) = "NaN"];
+inline void FixedwingMetrics::clear_altitude_msl() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.altitude_msl_ = 0;
+}
+inline float FixedwingMetrics::altitude_msl() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry_server.FixedwingMetrics.altitude_msl)
+  return _internal_altitude_msl();
+}
+inline void FixedwingMetrics::set_altitude_msl(float value) {
+  _internal_set_altitude_msl(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry_server.FixedwingMetrics.altitude_msl)
+}
+inline float FixedwingMetrics::_internal_altitude_msl() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.altitude_msl_;
+}
+inline void FixedwingMetrics::_internal_set_altitude_msl(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.altitude_msl_ = value;
+}
+
+// float climb_rate_m_s = 6 [(.mavsdk.options.default_value) = "NaN"];
 inline void FixedwingMetrics::clear_climb_rate_m_s() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.climb_rate_m_s_ = 0;

--- a/src/mavsdk_server/src/plugins/telemetry/telemetry_service_impl.h
+++ b/src/mavsdk_server/src/plugins/telemetry/telemetry_service_impl.h
@@ -1108,7 +1108,7 @@ public:
 
         rpc_obj->set_heading_deg(fixedwing_metrics.heading_deg);
 
-        rpc_obj->set_altitude_msl(fixedwing_metrics.altitude_msl);
+        rpc_obj->set_absolute_altitude_m(fixedwing_metrics.absolute_altitude_m);
 
         return rpc_obj;
     }
@@ -1128,7 +1128,7 @@ public:
 
         obj.heading_deg = fixedwing_metrics.heading_deg();
 
-        obj.altitude_msl = fixedwing_metrics.altitude_msl();
+        obj.absolute_altitude_m = fixedwing_metrics.absolute_altitude_m();
 
         return obj;
     }

--- a/src/mavsdk_server/src/plugins/telemetry/telemetry_service_impl.h
+++ b/src/mavsdk_server/src/plugins/telemetry/telemetry_service_impl.h
@@ -1100,7 +1100,13 @@ public:
 
         rpc_obj->set_airspeed_m_s(fixedwing_metrics.airspeed_m_s);
 
+        rpc_obj->set_groundspeed_m_s(fixedwing_metrics.groundspeed_m_s);
+
+        rpc_obj->set_heading_deg(fixedwing_metrics.heading_deg);
+
         rpc_obj->set_throttle_percentage(fixedwing_metrics.throttle_percentage);
+
+        rpc_obj->set_altitude_msl(fixedwing_metrics.altitude_msl);
 
         rpc_obj->set_climb_rate_m_s(fixedwing_metrics.climb_rate_m_s);
 
@@ -1114,7 +1120,13 @@ public:
 
         obj.airspeed_m_s = fixedwing_metrics.airspeed_m_s();
 
+        obj.groundspeed_m_s = fixedwing_metrics.groundspeed_m_s();
+
+        obj.heading_deg = fixedwing_metrics.heading_deg();
+
         obj.throttle_percentage = fixedwing_metrics.throttle_percentage();
+
+        obj.altitude_msl = fixedwing_metrics.altitude_msl();
 
         obj.climb_rate_m_s = fixedwing_metrics.climb_rate_m_s();
 

--- a/src/mavsdk_server/src/plugins/telemetry/telemetry_service_impl.h
+++ b/src/mavsdk_server/src/plugins/telemetry/telemetry_service_impl.h
@@ -1100,15 +1100,15 @@ public:
 
         rpc_obj->set_airspeed_m_s(fixedwing_metrics.airspeed_m_s);
 
+        rpc_obj->set_throttle_percentage(fixedwing_metrics.throttle_percentage);
+
+        rpc_obj->set_climb_rate_m_s(fixedwing_metrics.climb_rate_m_s);
+
         rpc_obj->set_groundspeed_m_s(fixedwing_metrics.groundspeed_m_s);
 
         rpc_obj->set_heading_deg(fixedwing_metrics.heading_deg);
 
-        rpc_obj->set_throttle_percentage(fixedwing_metrics.throttle_percentage);
-
         rpc_obj->set_altitude_msl(fixedwing_metrics.altitude_msl);
-
-        rpc_obj->set_climb_rate_m_s(fixedwing_metrics.climb_rate_m_s);
 
         return rpc_obj;
     }
@@ -1120,15 +1120,15 @@ public:
 
         obj.airspeed_m_s = fixedwing_metrics.airspeed_m_s();
 
+        obj.throttle_percentage = fixedwing_metrics.throttle_percentage();
+
+        obj.climb_rate_m_s = fixedwing_metrics.climb_rate_m_s();
+
         obj.groundspeed_m_s = fixedwing_metrics.groundspeed_m_s();
 
         obj.heading_deg = fixedwing_metrics.heading_deg();
 
-        obj.throttle_percentage = fixedwing_metrics.throttle_percentage();
-
         obj.altitude_msl = fixedwing_metrics.altitude_msl();
-
-        obj.climb_rate_m_s = fixedwing_metrics.climb_rate_m_s();
 
         return obj;
     }

--- a/src/mavsdk_server/src/plugins/telemetry_server/telemetry_server_service_impl.h
+++ b/src/mavsdk_server/src/plugins/telemetry_server/telemetry_server_service_impl.h
@@ -974,7 +974,7 @@ public:
 
         rpc_obj->set_heading_deg(fixedwing_metrics.heading_deg);
 
-        rpc_obj->set_altitude_msl(fixedwing_metrics.altitude_msl);
+        rpc_obj->set_absolute_altitude_m(fixedwing_metrics.absolute_altitude_m);
 
         return rpc_obj;
     }
@@ -994,7 +994,7 @@ public:
 
         obj.heading_deg = fixedwing_metrics.heading_deg();
 
-        obj.altitude_msl = fixedwing_metrics.altitude_msl();
+        obj.absolute_altitude_m = fixedwing_metrics.absolute_altitude_m();
 
         return obj;
     }

--- a/src/mavsdk_server/src/plugins/telemetry_server/telemetry_server_service_impl.h
+++ b/src/mavsdk_server/src/plugins/telemetry_server/telemetry_server_service_impl.h
@@ -966,7 +966,13 @@ public:
 
         rpc_obj->set_airspeed_m_s(fixedwing_metrics.airspeed_m_s);
 
+        rpc_obj->set_groundspeed_m_s(fixedwing_metrics.groundspeed_m_s);
+
+        rpc_obj->set_heading_deg(fixedwing_metrics.heading_deg);
+
         rpc_obj->set_throttle_percentage(fixedwing_metrics.throttle_percentage);
+
+        rpc_obj->set_altitude_msl(fixedwing_metrics.altitude_msl);
 
         rpc_obj->set_climb_rate_m_s(fixedwing_metrics.climb_rate_m_s);
 
@@ -980,7 +986,13 @@ public:
 
         obj.airspeed_m_s = fixedwing_metrics.airspeed_m_s();
 
+        obj.groundspeed_m_s = fixedwing_metrics.groundspeed_m_s();
+
+        obj.heading_deg = fixedwing_metrics.heading_deg();
+
         obj.throttle_percentage = fixedwing_metrics.throttle_percentage();
+
+        obj.altitude_msl = fixedwing_metrics.altitude_msl();
 
         obj.climb_rate_m_s = fixedwing_metrics.climb_rate_m_s();
 
@@ -1626,6 +1638,69 @@ public:
 
         auto result = _lazy_plugin.maybe_plugin()->publish_distance_sensor(
             translateFromRpcDistanceSensor(request->distance_sensor()));
+
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status PublishAttitude(
+        grpc::ServerContext* /* context */,
+        const rpc::telemetry_server::PublishAttitudeRequest* request,
+        rpc::telemetry_server::PublishAttitudeResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            if (response != nullptr) {
+                // For server plugins, this should never happen, they should always be
+                // constructible.
+                auto result = mavsdk::TelemetryServer::Result::Unknown;
+                fillResponseWithResult(response, result);
+            }
+
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn() << "PublishAttitude sent with a null request! Ignoring...";
+            return grpc::Status::OK;
+        }
+
+        auto result = _lazy_plugin.maybe_plugin()->publish_attitude(
+            translateFromRpcEulerAngle(request->angle()),
+            translateFromRpcAngularVelocityBody(request->angular_velocity()));
+
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status PublishVisualFlightRulesHud(
+        grpc::ServerContext* /* context */,
+        const rpc::telemetry_server::PublishVisualFlightRulesHudRequest* request,
+        rpc::telemetry_server::PublishVisualFlightRulesHudResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            if (response != nullptr) {
+                // For server plugins, this should never happen, they should always be
+                // constructible.
+                auto result = mavsdk::TelemetryServer::Result::Unknown;
+                fillResponseWithResult(response, result);
+            }
+
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn() << "PublishVisualFlightRulesHud sent with a null request! Ignoring...";
+            return grpc::Status::OK;
+        }
+
+        auto result = _lazy_plugin.maybe_plugin()->publish_visual_flight_rules_hud(
+            translateFromRpcFixedwingMetrics(request->fixed_wing_metrics()));
 
         if (response != nullptr) {
             fillResponseWithResult(response, result);

--- a/src/mavsdk_server/src/plugins/telemetry_server/telemetry_server_service_impl.h
+++ b/src/mavsdk_server/src/plugins/telemetry_server/telemetry_server_service_impl.h
@@ -966,15 +966,15 @@ public:
 
         rpc_obj->set_airspeed_m_s(fixedwing_metrics.airspeed_m_s);
 
+        rpc_obj->set_throttle_percentage(fixedwing_metrics.throttle_percentage);
+
+        rpc_obj->set_climb_rate_m_s(fixedwing_metrics.climb_rate_m_s);
+
         rpc_obj->set_groundspeed_m_s(fixedwing_metrics.groundspeed_m_s);
 
         rpc_obj->set_heading_deg(fixedwing_metrics.heading_deg);
 
-        rpc_obj->set_throttle_percentage(fixedwing_metrics.throttle_percentage);
-
         rpc_obj->set_altitude_msl(fixedwing_metrics.altitude_msl);
-
-        rpc_obj->set_climb_rate_m_s(fixedwing_metrics.climb_rate_m_s);
 
         return rpc_obj;
     }
@@ -986,15 +986,15 @@ public:
 
         obj.airspeed_m_s = fixedwing_metrics.airspeed_m_s();
 
+        obj.throttle_percentage = fixedwing_metrics.throttle_percentage();
+
+        obj.climb_rate_m_s = fixedwing_metrics.climb_rate_m_s();
+
         obj.groundspeed_m_s = fixedwing_metrics.groundspeed_m_s();
 
         obj.heading_deg = fixedwing_metrics.heading_deg();
 
-        obj.throttle_percentage = fixedwing_metrics.throttle_percentage();
-
         obj.altitude_msl = fixedwing_metrics.altitude_msl();
-
-        obj.climb_rate_m_s = fixedwing_metrics.climb_rate_m_s();
 
         return obj;
     }


### PR DESCRIPTION
# Overview
This PR does 3 things:

1. Expands the `FixedwingMetrics` telemetry object to include all fields that show up in the MAVLINK VFR_HUD message. The telemetry client handles the VFR_HUD message currently, translating it to a `FixedwingMetrics` struct, but it only takes half the fields. This PR fills out the rest of the fields so the full message is available.
2. Adds an endpoint for sending the VFR_HUD message via `TelemetryServer`
3. Adds an endpoint for sending the MAVLINK ATTITUDE message via `TelemetryServer`. Note that the client already supports handling this message.

# Testing Done
Tested with a VTOL aircraft using MAVSDK as an autopilot, sending telemetry to QGroundControl. VFR and attitude messages are used to update the instrument panels and virtual horizon display. Hover taxi video here:

https://github.com/user-attachments/assets/5e35afd2-0b63-49e8-b1c7-ab4d941f9d6a

# Notes and Caveats
There is a corresponding Proto PR based on Proto:main here: https://github.com/mavlink/MAVSDK-Proto/pull/364

Unfortunately I am unable to get proto main to build against MAVSDK main, and I haven't had a chance to look into it. MAVSDK `main` is pinned to the proto submodule revision `9a871c7b4ec53a753e9fc46e950c4433dc2d6bf7`, which works fine, so I branched proto from this revision for my own testing. That is the branch that is being used in this PR currently.
