### PR TITLE
update to working geofence

### DIFF
--- a/src/mavsdk/plugins/geofence/geofence_impl.cpp
+++ b/src/mavsdk/plugins/geofence/geofence_impl.cpp
@@ -46,7 +46,7 @@ void GeofenceImpl::upload_geofence_async(
 
     _system_impl->mission_transfer_client().upload_items_async(
         MAV_MISSION_TYPE_FENCE,
-        1,
+        _system_impl->get_system_id(),
         items,
         [this, callback](MavlinkMissionTransferClient::Result result) {
             auto converted_result = convert_result(result);


### PR DESCRIPTION
Overview

Currently there is a bug in MAVSDK server that will only allow geofence upload for UAV's with sysID of 1. This has been replaced with a function to return the sys id of the device assigned.

Tested IRL and in Gazebo with quad's assigned sys ID's from 1 - 6.