### PR TITLE
ActionServer: allow direct setting of arm/disarm state and vehicle flight mode

### DIFF
--- a/docs/en/cpp/api_reference/classmavsdk_1_1_action_server.md
+++ b/docs/en/cpp/api_reference/classmavsdk_1_1_action_server.md
@@ -64,6 +64,8 @@ void | [unsubscribe_terminate](#classmavsdk_1_1_action_server_1a3e236694f1f0beae
 [Result](classmavsdk_1_1_action_server.md#classmavsdk_1_1_action_server_1a4a8eb4fe9d098a5b7891232fc5bf32f8) | [set_disarmable](#classmavsdk_1_1_action_server_1afae1336100d7a91a4f4521cee56a1ecb) (bool disarmable, bool force_disarmable)const | Can the vehicle disarm when requested.
 [Result](classmavsdk_1_1_action_server.md#classmavsdk_1_1_action_server_1a4a8eb4fe9d098a5b7891232fc5bf32f8) | [set_allowable_flight_modes](#classmavsdk_1_1_action_server_1a3041d1b923a3b01021433ad43ab93b3a) ([AllowableFlightModes](structmavsdk_1_1_action_server_1_1_allowable_flight_modes.md) flight_modes)const | Set which modes the vehicle can transition to (Manual always allowed)
 [ActionServer::AllowableFlightModes](structmavsdk_1_1_action_server_1_1_allowable_flight_modes.md) | [get_allowable_flight_modes](#classmavsdk_1_1_action_server_1a0960a6ec243823729a418a3c68feaf2a) () const | Get which modes the vehicle can transition to (Manual always allowed)
+[Result](classmavsdk_1_1_action_server.md#classmavsdk_1_1_action_server_1a4a8eb4fe9d098a5b7891232fc5bf32f8) | [set_armed_state](#classmavsdk_1_1_action_server_1a8830660884933029f104c49c31b7af24) (bool is_armed)const | Set/override the armed/disarmed state of the vehicle directly, and notify subscribers.
+[Result](classmavsdk_1_1_action_server.md#classmavsdk_1_1_action_server_1a4a8eb4fe9d098a5b7891232fc5bf32f8) | [set_flight_mode](#classmavsdk_1_1_action_server_1ac5ba6d26aef83881826361aa20a9bd65) ([FlightMode](classmavsdk_1_1_action_server.md#classmavsdk_1_1_action_server_1aee12027f5d9380f2c13fa7813c6ae1d8) flight_mode)const | Set/override the flight mode of the vehicle directly, and notify subscribers.
 const [ActionServer](classmavsdk_1_1_action_server.md) & | [operator=](#classmavsdk_1_1_action_server_1aa80e34dd72d2e31005085c78892bab8c) (const [ActionServer](classmavsdk_1_1_action_server.md) &)=delete | Equality operator (object is not copyable).
 
 
@@ -612,6 +614,42 @@ This function is blocking.
 **Returns**
 
 &emsp;[ActionServer::AllowableFlightModes](structmavsdk_1_1_action_server_1_1_allowable_flight_modes.md) - Result of request.
+
+### set_armed_state() {#classmavsdk_1_1_action_server_1a8830660884933029f104c49c31b7af24}
+```cpp
+Result mavsdk::ActionServer::set_armed_state(bool is_armed) const
+```
+
+
+Set/override the armed/disarmed state of the vehicle directly, and notify subscribers.
+
+This function is blocking.
+
+**Parameters**
+
+* bool **is_armed** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_action_server.md#classmavsdk_1_1_action_server_1a4a8eb4fe9d098a5b7891232fc5bf32f8) - Result of request.
+
+### set_flight_mode() {#classmavsdk_1_1_action_server_1ac5ba6d26aef83881826361aa20a9bd65}
+```cpp
+Result mavsdk::ActionServer::set_flight_mode(FlightMode flight_mode) const
+```
+
+
+Set/override the flight mode of the vehicle directly, and notify subscribers.
+
+This function is blocking.
+
+**Parameters**
+
+* [FlightMode](classmavsdk_1_1_action_server.md#classmavsdk_1_1_action_server_1aee12027f5d9380f2c13fa7813c6ae1d8) **flight_mode** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_action_server.md#classmavsdk_1_1_action_server_1a4a8eb4fe9d098a5b7891232fc5bf32f8) - Result of request.
 
 ### operator=() {#classmavsdk_1_1_action_server_1aa80e34dd72d2e31005085c78892bab8c}
 ```cpp

--- a/src/mavsdk/plugins/action_server/action_server.cpp
+++ b/src/mavsdk/plugins/action_server/action_server.cpp
@@ -117,6 +117,16 @@ ActionServer::AllowableFlightModes ActionServer::get_allowable_flight_modes() co
     return _impl->get_allowable_flight_modes();
 }
 
+ActionServer::Result ActionServer::set_armed_state(bool is_armed) const
+{
+    return _impl->set_armed_state(is_armed);
+}
+
+ActionServer::Result ActionServer::set_flight_mode(FlightMode flight_mode) const
+{
+    return _impl->set_flight_mode(flight_mode);
+}
+
 bool operator==(
     const ActionServer::AllowableFlightModes& lhs, const ActionServer::AllowableFlightModes& rhs)
 {

--- a/src/mavsdk/plugins/action_server/action_server_impl.h
+++ b/src/mavsdk/plugins/action_server/action_server_impl.h
@@ -51,7 +51,14 @@ public:
 
     ActionServer::AllowableFlightModes get_allowable_flight_modes();
 
+    ActionServer::Result set_armed_state(bool armed);
+
+    ActionServer::Result set_flight_mode(ActionServer::FlightMode flight_mode);
+
 private:
+    static ActionServer::FlightMode telemetry_flight_mode_from_flight_mode(FlightMode flight_mode);
+    static uint32_t to_px4_mode_from_flight_mode(ActionServer::FlightMode flight_mode);
+
     void set_base_mode(uint8_t base_mode);
     uint8_t get_base_mode() const;
 
@@ -74,16 +81,6 @@ private:
     std::atomic<bool> _disarmable = false;
     std::atomic<bool> _force_disarmable = false;
     std::atomic<bool> _allow_takeoff = false;
-
-    union px4_custom_mode {
-        struct {
-            uint16_t reserved;
-            uint8_t main_mode;
-            uint8_t sub_mode;
-        };
-        uint32_t data;
-        float data_float;
-    };
 
     std::mutex _flight_mode_mutex;
     ActionServer::AllowableFlightModes _allowed_flight_modes{};

--- a/src/mavsdk/plugins/action_server/include/plugins/action_server/action_server.h
+++ b/src/mavsdk/plugins/action_server/include/plugins/action_server/action_server.h
@@ -351,6 +351,28 @@ public:
     ActionServer::AllowableFlightModes get_allowable_flight_modes() const;
 
     /**
+     * @brief Set/override the armed/disarmed state of the vehicle directly, and notify subscribers
+     *
+     * This function is blocking.
+     *
+
+     * @return Result of request.
+
+     */
+    Result set_armed_state(bool is_armed) const;
+
+    /**
+     * @brief Set/override the flight mode of the vehicle directly, and notify subscribers
+     *
+     * This function is blocking.
+     *
+
+     * @return Result of request.
+
+     */
+    Result set_flight_mode(FlightMode flight_mode) const;
+
+    /**
      * @brief Copy constructor.
      */
     ActionServer(const ActionServer& other);

--- a/src/mavsdk_server/src/generated/action_server/action_server.grpc.pb.cc
+++ b/src/mavsdk_server/src/generated/action_server/action_server.grpc.pb.cc
@@ -36,6 +36,8 @@ static const char* ActionServerService_method_names[] = {
   "/mavsdk.rpc.action_server.ActionServerService/SetDisarmable",
   "/mavsdk.rpc.action_server.ActionServerService/SetAllowableFlightModes",
   "/mavsdk.rpc.action_server.ActionServerService/GetAllowableFlightModes",
+  "/mavsdk.rpc.action_server.ActionServerService/SetArmedState",
+  "/mavsdk.rpc.action_server.ActionServerService/SetFlightMode",
 };
 
 std::unique_ptr< ActionServerService::Stub> ActionServerService::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
@@ -57,6 +59,8 @@ ActionServerService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>
   , rpcmethod_SetDisarmable_(ActionServerService_method_names[9], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_SetAllowableFlightModes_(ActionServerService_method_names[10], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_GetAllowableFlightModes_(ActionServerService_method_names[11], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetArmedState_(ActionServerService_method_names[12], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetFlightMode_(ActionServerService_method_names[13], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::ClientReader< ::mavsdk::rpc::action_server::ArmDisarmResponse>* ActionServerService::Stub::SubscribeArmDisarmRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SubscribeArmDisarmRequest& request) {
@@ -286,6 +290,52 @@ void ActionServerService::Stub::async::GetAllowableFlightModes(::grpc::ClientCon
   return result;
 }
 
+::grpc::Status ActionServerService::Stub::SetArmedState(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest& request, ::mavsdk::rpc::action_server::SetArmedStateResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::action_server::SetArmedStateRequest, ::mavsdk::rpc::action_server::SetArmedStateResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_SetArmedState_, context, request, response);
+}
+
+void ActionServerService::Stub::async::SetArmedState(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest* request, ::mavsdk::rpc::action_server::SetArmedStateResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::action_server::SetArmedStateRequest, ::mavsdk::rpc::action_server::SetArmedStateResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetArmedState_, context, request, response, std::move(f));
+}
+
+void ActionServerService::Stub::async::SetArmedState(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest* request, ::mavsdk::rpc::action_server::SetArmedStateResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetArmedState_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetArmedStateResponse>* ActionServerService::Stub::PrepareAsyncSetArmedStateRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::action_server::SetArmedStateResponse, ::mavsdk::rpc::action_server::SetArmedStateRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_SetArmedState_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetArmedStateResponse>* ActionServerService::Stub::AsyncSetArmedStateRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncSetArmedStateRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::Status ActionServerService::Stub::SetFlightMode(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest& request, ::mavsdk::rpc::action_server::SetFlightModeResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::action_server::SetFlightModeRequest, ::mavsdk::rpc::action_server::SetFlightModeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_SetFlightMode_, context, request, response);
+}
+
+void ActionServerService::Stub::async::SetFlightMode(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest* request, ::mavsdk::rpc::action_server::SetFlightModeResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::action_server::SetFlightModeRequest, ::mavsdk::rpc::action_server::SetFlightModeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetFlightMode_, context, request, response, std::move(f));
+}
+
+void ActionServerService::Stub::async::SetFlightMode(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest* request, ::mavsdk::rpc::action_server::SetFlightModeResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetFlightMode_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetFlightModeResponse>* ActionServerService::Stub::PrepareAsyncSetFlightModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::action_server::SetFlightModeResponse, ::mavsdk::rpc::action_server::SetFlightModeRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_SetFlightMode_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetFlightModeResponse>* ActionServerService::Stub::AsyncSetFlightModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncSetFlightModeRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
 ActionServerService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       ActionServerService_method_names[0],
@@ -407,6 +457,26 @@ ActionServerService::Service::Service() {
              ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* resp) {
                return service->GetAllowableFlightModes(ctx, req, resp);
              }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      ActionServerService_method_names[12],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< ActionServerService::Service, ::mavsdk::rpc::action_server::SetArmedStateRequest, ::mavsdk::rpc::action_server::SetArmedStateResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](ActionServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::action_server::SetArmedStateRequest* req,
+             ::mavsdk::rpc::action_server::SetArmedStateResponse* resp) {
+               return service->SetArmedState(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      ActionServerService_method_names[13],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< ActionServerService::Service, ::mavsdk::rpc::action_server::SetFlightModeRequest, ::mavsdk::rpc::action_server::SetFlightModeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](ActionServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::action_server::SetFlightModeRequest* req,
+             ::mavsdk::rpc::action_server::SetFlightModeResponse* resp) {
+               return service->SetFlightMode(ctx, req, resp);
+             }, this)));
 }
 
 ActionServerService::Service::~Service() {
@@ -490,6 +560,20 @@ ActionServerService::Service::~Service() {
 }
 
 ::grpc::Status ActionServerService::Service::GetAllowableFlightModes(::grpc::ServerContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status ActionServerService::Service::SetArmedState(::grpc::ServerContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest* request, ::mavsdk::rpc::action_server::SetArmedStateResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status ActionServerService::Service::SetFlightMode(::grpc::ServerContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest* request, ::mavsdk::rpc::action_server::SetFlightModeResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/src/mavsdk_server/src/generated/action_server/action_server.grpc.pb.h
+++ b/src/mavsdk_server/src/generated/action_server/action_server.grpc.pb.h
@@ -148,6 +148,22 @@ class ActionServerService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>> PrepareAsyncGetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>>(PrepareAsyncGetAllowableFlightModesRaw(context, request, cq));
     }
+    // Set/override the armed/disarmed state of the vehicle directly, and notify subscribers
+    virtual ::grpc::Status SetArmedState(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest& request, ::mavsdk::rpc::action_server::SetArmedStateResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetArmedStateResponse>> AsyncSetArmedState(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetArmedStateResponse>>(AsyncSetArmedStateRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetArmedStateResponse>> PrepareAsyncSetArmedState(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetArmedStateResponse>>(PrepareAsyncSetArmedStateRaw(context, request, cq));
+    }
+    // Set/override the flight mode of the vehicle directly, and notify subscribers
+    virtual ::grpc::Status SetFlightMode(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest& request, ::mavsdk::rpc::action_server::SetFlightModeResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetFlightModeResponse>> AsyncSetFlightMode(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetFlightModeResponse>>(AsyncSetFlightModeRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetFlightModeResponse>> PrepareAsyncSetFlightMode(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetFlightModeResponse>>(PrepareAsyncSetFlightModeRaw(context, request, cq));
+    }
     class async_interface {
      public:
       virtual ~async_interface() {}
@@ -180,6 +196,12 @@ class ActionServerService final {
       // Get which modes the vehicle can transition to (Manual always allowed)
       virtual void GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Set/override the armed/disarmed state of the vehicle directly, and notify subscribers
+      virtual void SetArmedState(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest* request, ::mavsdk::rpc::action_server::SetArmedStateResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void SetArmedState(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest* request, ::mavsdk::rpc::action_server::SetArmedStateResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Set/override the flight mode of the vehicle directly, and notify subscribers
+      virtual void SetFlightMode(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest* request, ::mavsdk::rpc::action_server::SetFlightModeResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void SetFlightMode(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest* request, ::mavsdk::rpc::action_server::SetFlightModeResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
     };
     typedef class async_interface experimental_async_interface;
     virtual class async_interface* async() { return nullptr; }
@@ -216,6 +238,10 @@ class ActionServerService final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>* PrepareAsyncSetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>* AsyncGetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>* PrepareAsyncGetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetArmedStateResponse>* AsyncSetArmedStateRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetArmedStateResponse>* PrepareAsyncSetArmedStateRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetFlightModeResponse>* AsyncSetFlightModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action_server::SetFlightModeResponse>* PrepareAsyncSetFlightModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest& request, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
@@ -318,6 +344,20 @@ class ActionServerService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>> PrepareAsyncGetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>>(PrepareAsyncGetAllowableFlightModesRaw(context, request, cq));
     }
+    ::grpc::Status SetArmedState(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest& request, ::mavsdk::rpc::action_server::SetArmedStateResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetArmedStateResponse>> AsyncSetArmedState(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetArmedStateResponse>>(AsyncSetArmedStateRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetArmedStateResponse>> PrepareAsyncSetArmedState(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetArmedStateResponse>>(PrepareAsyncSetArmedStateRaw(context, request, cq));
+    }
+    ::grpc::Status SetFlightMode(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest& request, ::mavsdk::rpc::action_server::SetFlightModeResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetFlightModeResponse>> AsyncSetFlightMode(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetFlightModeResponse>>(AsyncSetFlightModeRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetFlightModeResponse>> PrepareAsyncSetFlightMode(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetFlightModeResponse>>(PrepareAsyncSetFlightModeRaw(context, request, cq));
+    }
     class async final :
       public StubInterface::async_interface {
      public:
@@ -338,6 +378,10 @@ class ActionServerService final {
       void SetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* response, std::function<void(::grpc::Status)>) override;
       void GetAllowableFlightModes(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SetArmedState(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest* request, ::mavsdk::rpc::action_server::SetArmedStateResponse* response, std::function<void(::grpc::Status)>) override;
+      void SetArmedState(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest* request, ::mavsdk::rpc::action_server::SetArmedStateResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SetFlightMode(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest* request, ::mavsdk::rpc::action_server::SetFlightModeResponse* response, std::function<void(::grpc::Status)>) override;
+      void SetFlightMode(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest* request, ::mavsdk::rpc::action_server::SetFlightModeResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
      private:
       friend class Stub;
       explicit async(Stub* stub): stub_(stub) { }
@@ -380,6 +424,10 @@ class ActionServerService final {
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse>* PrepareAsyncSetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>* AsyncGetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>* PrepareAsyncGetAllowableFlightModesRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetArmedStateResponse>* AsyncSetArmedStateRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetArmedStateResponse>* PrepareAsyncSetArmedStateRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetFlightModeResponse>* AsyncSetFlightModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action_server::SetFlightModeResponse>* PrepareAsyncSetFlightModeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeArmDisarm_;
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeFlightModeChange_;
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeTakeoff_;
@@ -392,6 +440,8 @@ class ActionServerService final {
     const ::grpc::internal::RpcMethod rpcmethod_SetDisarmable_;
     const ::grpc::internal::RpcMethod rpcmethod_SetAllowableFlightModes_;
     const ::grpc::internal::RpcMethod rpcmethod_GetAllowableFlightModes_;
+    const ::grpc::internal::RpcMethod rpcmethod_SetArmedState_;
+    const ::grpc::internal::RpcMethod rpcmethod_SetFlightMode_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
 
@@ -423,6 +473,10 @@ class ActionServerService final {
     virtual ::grpc::Status SetAllowableFlightModes(::grpc::ServerContext* context, const ::mavsdk::rpc::action_server::SetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::SetAllowableFlightModesResponse* response);
     // Get which modes the vehicle can transition to (Manual always allowed)
     virtual ::grpc::Status GetAllowableFlightModes(::grpc::ServerContext* context, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* request, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* response);
+    // Set/override the armed/disarmed state of the vehicle directly, and notify subscribers
+    virtual ::grpc::Status SetArmedState(::grpc::ServerContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest* request, ::mavsdk::rpc::action_server::SetArmedStateResponse* response);
+    // Set/override the flight mode of the vehicle directly, and notify subscribers
+    virtual ::grpc::Status SetFlightMode(::grpc::ServerContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest* request, ::mavsdk::rpc::action_server::SetFlightModeResponse* response);
   };
   template <class BaseClass>
   class WithAsyncMethod_SubscribeArmDisarm : public BaseClass {
@@ -664,7 +718,47 @@ class ActionServerService final {
       ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_SubscribeArmDisarm<WithAsyncMethod_SubscribeFlightModeChange<WithAsyncMethod_SubscribeTakeoff<WithAsyncMethod_SubscribeLand<WithAsyncMethod_SubscribeReboot<WithAsyncMethod_SubscribeShutdown<WithAsyncMethod_SubscribeTerminate<WithAsyncMethod_SetAllowTakeoff<WithAsyncMethod_SetArmable<WithAsyncMethod_SetDisarmable<WithAsyncMethod_SetAllowableFlightModes<WithAsyncMethod_GetAllowableFlightModes<Service > > > > > > > > > > > > AsyncService;
+  template <class BaseClass>
+  class WithAsyncMethod_SetArmedState : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SetArmedState() {
+      ::grpc::Service::MarkMethodAsync(12);
+    }
+    ~WithAsyncMethod_SetArmedState() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetArmedState(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetArmedStateRequest* /*request*/, ::mavsdk::rpc::action_server::SetArmedStateResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetArmedState(::grpc::ServerContext* context, ::mavsdk::rpc::action_server::SetArmedStateRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action_server::SetArmedStateResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_SetFlightMode : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SetFlightMode() {
+      ::grpc::Service::MarkMethodAsync(13);
+    }
+    ~WithAsyncMethod_SetFlightMode() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetFlightMode(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::SetFlightModeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetFlightMode(::grpc::ServerContext* context, ::mavsdk::rpc::action_server::SetFlightModeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action_server::SetFlightModeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  typedef WithAsyncMethod_SubscribeArmDisarm<WithAsyncMethod_SubscribeFlightModeChange<WithAsyncMethod_SubscribeTakeoff<WithAsyncMethod_SubscribeLand<WithAsyncMethod_SubscribeReboot<WithAsyncMethod_SubscribeShutdown<WithAsyncMethod_SubscribeTerminate<WithAsyncMethod_SetAllowTakeoff<WithAsyncMethod_SetArmable<WithAsyncMethod_SetDisarmable<WithAsyncMethod_SetAllowableFlightModes<WithAsyncMethod_GetAllowableFlightModes<WithAsyncMethod_SetArmedState<WithAsyncMethod_SetFlightMode<Service > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_SubscribeArmDisarm : public BaseClass {
    private:
@@ -954,7 +1048,61 @@ class ActionServerService final {
     virtual ::grpc::ServerUnaryReactor* GetAllowableFlightModes(
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* /*request*/, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_SubscribeArmDisarm<WithCallbackMethod_SubscribeFlightModeChange<WithCallbackMethod_SubscribeTakeoff<WithCallbackMethod_SubscribeLand<WithCallbackMethod_SubscribeReboot<WithCallbackMethod_SubscribeShutdown<WithCallbackMethod_SubscribeTerminate<WithCallbackMethod_SetAllowTakeoff<WithCallbackMethod_SetArmable<WithCallbackMethod_SetDisarmable<WithCallbackMethod_SetAllowableFlightModes<WithCallbackMethod_GetAllowableFlightModes<Service > > > > > > > > > > > > CallbackService;
+  template <class BaseClass>
+  class WithCallbackMethod_SetArmedState : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SetArmedState() {
+      ::grpc::Service::MarkMethodCallback(12,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action_server::SetArmedStateRequest, ::mavsdk::rpc::action_server::SetArmedStateResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action_server::SetArmedStateRequest* request, ::mavsdk::rpc::action_server::SetArmedStateResponse* response) { return this->SetArmedState(context, request, response); }));}
+    void SetMessageAllocatorFor_SetArmedState(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::action_server::SetArmedStateRequest, ::mavsdk::rpc::action_server::SetArmedStateResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(12);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action_server::SetArmedStateRequest, ::mavsdk::rpc::action_server::SetArmedStateResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_SetArmedState() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetArmedState(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetArmedStateRequest* /*request*/, ::mavsdk::rpc::action_server::SetArmedStateResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* SetArmedState(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetArmedStateRequest* /*request*/, ::mavsdk::rpc::action_server::SetArmedStateResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_SetFlightMode : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SetFlightMode() {
+      ::grpc::Service::MarkMethodCallback(13,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action_server::SetFlightModeRequest, ::mavsdk::rpc::action_server::SetFlightModeResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action_server::SetFlightModeRequest* request, ::mavsdk::rpc::action_server::SetFlightModeResponse* response) { return this->SetFlightMode(context, request, response); }));}
+    void SetMessageAllocatorFor_SetFlightMode(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::action_server::SetFlightModeRequest, ::mavsdk::rpc::action_server::SetFlightModeResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(13);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action_server::SetFlightModeRequest, ::mavsdk::rpc::action_server::SetFlightModeResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_SetFlightMode() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetFlightMode(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::SetFlightModeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* SetFlightMode(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::SetFlightModeResponse* /*response*/)  { return nullptr; }
+  };
+  typedef WithCallbackMethod_SubscribeArmDisarm<WithCallbackMethod_SubscribeFlightModeChange<WithCallbackMethod_SubscribeTakeoff<WithCallbackMethod_SubscribeLand<WithCallbackMethod_SubscribeReboot<WithCallbackMethod_SubscribeShutdown<WithCallbackMethod_SubscribeTerminate<WithCallbackMethod_SetAllowTakeoff<WithCallbackMethod_SetArmable<WithCallbackMethod_SetDisarmable<WithCallbackMethod_SetAllowableFlightModes<WithCallbackMethod_GetAllowableFlightModes<WithCallbackMethod_SetArmedState<WithCallbackMethod_SetFlightMode<Service > > > > > > > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_SubscribeArmDisarm : public BaseClass {
@@ -1156,6 +1304,40 @@ class ActionServerService final {
     }
     // disable synchronous version of this method
     ::grpc::Status GetAllowableFlightModes(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest* /*request*/, ::mavsdk::rpc::action_server::GetAllowableFlightModesResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_SetArmedState : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SetArmedState() {
+      ::grpc::Service::MarkMethodGeneric(12);
+    }
+    ~WithGenericMethod_SetArmedState() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetArmedState(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetArmedStateRequest* /*request*/, ::mavsdk::rpc::action_server::SetArmedStateResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_SetFlightMode : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SetFlightMode() {
+      ::grpc::Service::MarkMethodGeneric(13);
+    }
+    ~WithGenericMethod_SetFlightMode() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetFlightMode(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::SetFlightModeResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -1398,6 +1580,46 @@ class ActionServerService final {
     }
     void RequestGetAllowableFlightModes(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_SetArmedState : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SetArmedState() {
+      ::grpc::Service::MarkMethodRaw(12);
+    }
+    ~WithRawMethod_SetArmedState() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetArmedState(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetArmedStateRequest* /*request*/, ::mavsdk::rpc::action_server::SetArmedStateResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetArmedState(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_SetFlightMode : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SetFlightMode() {
+      ::grpc::Service::MarkMethodRaw(13);
+    }
+    ~WithRawMethod_SetFlightMode() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetFlightMode(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::SetFlightModeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetFlightMode(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1665,6 +1887,50 @@ class ActionServerService final {
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithRawCallbackMethod_SetArmedState : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SetArmedState() {
+      ::grpc::Service::MarkMethodRawCallback(12,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetArmedState(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_SetArmedState() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetArmedState(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetArmedStateRequest* /*request*/, ::mavsdk::rpc::action_server::SetArmedStateResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* SetArmedState(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_SetFlightMode : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SetFlightMode() {
+      ::grpc::Service::MarkMethodRawCallback(13,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetFlightMode(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_SetFlightMode() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetFlightMode(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::SetFlightModeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* SetFlightMode(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_SetAllowTakeoff : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
@@ -1799,7 +2065,61 @@ class ActionServerService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedGetAllowableFlightModes(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::action_server::GetAllowableFlightModesRequest,::mavsdk::rpc::action_server::GetAllowableFlightModesResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_SetAllowTakeoff<WithStreamedUnaryMethod_SetArmable<WithStreamedUnaryMethod_SetDisarmable<WithStreamedUnaryMethod_SetAllowableFlightModes<WithStreamedUnaryMethod_GetAllowableFlightModes<Service > > > > > StreamedUnaryService;
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_SetArmedState : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_SetArmedState() {
+      ::grpc::Service::MarkMethodStreamed(12,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::action_server::SetArmedStateRequest, ::mavsdk::rpc::action_server::SetArmedStateResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::action_server::SetArmedStateRequest, ::mavsdk::rpc::action_server::SetArmedStateResponse>* streamer) {
+                       return this->StreamedSetArmedState(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_SetArmedState() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SetArmedState(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetArmedStateRequest* /*request*/, ::mavsdk::rpc::action_server::SetArmedStateResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedSetArmedState(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::action_server::SetArmedStateRequest,::mavsdk::rpc::action_server::SetArmedStateResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_SetFlightMode : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_SetFlightMode() {
+      ::grpc::Service::MarkMethodStreamed(13,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::action_server::SetFlightModeRequest, ::mavsdk::rpc::action_server::SetFlightModeResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::action_server::SetFlightModeRequest, ::mavsdk::rpc::action_server::SetFlightModeResponse>* streamer) {
+                       return this->StreamedSetFlightMode(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_SetFlightMode() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SetFlightMode(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action_server::SetFlightModeRequest* /*request*/, ::mavsdk::rpc::action_server::SetFlightModeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedSetFlightMode(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::action_server::SetFlightModeRequest,::mavsdk::rpc::action_server::SetFlightModeResponse>* server_unary_streamer) = 0;
+  };
+  typedef WithStreamedUnaryMethod_SetAllowTakeoff<WithStreamedUnaryMethod_SetArmable<WithStreamedUnaryMethod_SetDisarmable<WithStreamedUnaryMethod_SetAllowableFlightModes<WithStreamedUnaryMethod_GetAllowableFlightModes<WithStreamedUnaryMethod_SetArmedState<WithStreamedUnaryMethod_SetFlightMode<Service > > > > > > > StreamedUnaryService;
   template <class BaseClass>
   class WithSplitStreamingMethod_SubscribeArmDisarm : public BaseClass {
    private:
@@ -1990,7 +2310,7 @@ class ActionServerService final {
     virtual ::grpc::Status StreamedSubscribeTerminate(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::action_server::SubscribeTerminateRequest,::mavsdk::rpc::action_server::TerminateResponse>* server_split_streamer) = 0;
   };
   typedef WithSplitStreamingMethod_SubscribeArmDisarm<WithSplitStreamingMethod_SubscribeFlightModeChange<WithSplitStreamingMethod_SubscribeTakeoff<WithSplitStreamingMethod_SubscribeLand<WithSplitStreamingMethod_SubscribeReboot<WithSplitStreamingMethod_SubscribeShutdown<WithSplitStreamingMethod_SubscribeTerminate<Service > > > > > > > SplitStreamedService;
-  typedef WithSplitStreamingMethod_SubscribeArmDisarm<WithSplitStreamingMethod_SubscribeFlightModeChange<WithSplitStreamingMethod_SubscribeTakeoff<WithSplitStreamingMethod_SubscribeLand<WithSplitStreamingMethod_SubscribeReboot<WithSplitStreamingMethod_SubscribeShutdown<WithSplitStreamingMethod_SubscribeTerminate<WithStreamedUnaryMethod_SetAllowTakeoff<WithStreamedUnaryMethod_SetArmable<WithStreamedUnaryMethod_SetDisarmable<WithStreamedUnaryMethod_SetAllowableFlightModes<WithStreamedUnaryMethod_GetAllowableFlightModes<Service > > > > > > > > > > > > StreamedService;
+  typedef WithSplitStreamingMethod_SubscribeArmDisarm<WithSplitStreamingMethod_SubscribeFlightModeChange<WithSplitStreamingMethod_SubscribeTakeoff<WithSplitStreamingMethod_SubscribeLand<WithSplitStreamingMethod_SubscribeReboot<WithSplitStreamingMethod_SubscribeShutdown<WithSplitStreamingMethod_SubscribeTerminate<WithStreamedUnaryMethod_SetAllowTakeoff<WithStreamedUnaryMethod_SetArmable<WithStreamedUnaryMethod_SetDisarmable<WithStreamedUnaryMethod_SetAllowableFlightModes<WithStreamedUnaryMethod_GetAllowableFlightModes<WithStreamedUnaryMethod_SetArmedState<WithStreamedUnaryMethod_SetFlightMode<Service > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace action_server

--- a/src/mavsdk_server/src/generated/action_server/action_server.pb.cc
+++ b/src/mavsdk_server/src/generated/action_server/action_server.pb.cc
@@ -154,6 +154,31 @@ struct SubscribeArmDisarmRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SubscribeArmDisarmRequestDefaultTypeInternal _SubscribeArmDisarmRequest_default_instance_;
 
+inline constexpr SetFlightModeRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : flight_mode_{static_cast< ::mavsdk::rpc::action_server::FlightMode >(0)},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR SetFlightModeRequest::SetFlightModeRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct SetFlightModeRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SetFlightModeRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SetFlightModeRequestDefaultTypeInternal() {}
+  union {
+    SetFlightModeRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetFlightModeRequestDefaultTypeInternal _SetFlightModeRequest_default_instance_;
+
 inline constexpr SetDisarmableRequest::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : disarmable_{false},
@@ -179,6 +204,31 @@ struct SetDisarmableRequestDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetDisarmableRequestDefaultTypeInternal _SetDisarmableRequest_default_instance_;
+
+inline constexpr SetArmedStateRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : is_armed_{false},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR SetArmedStateRequest::SetArmedStateRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct SetArmedStateRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SetArmedStateRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SetArmedStateRequestDefaultTypeInternal() {}
+  union {
+    SetArmedStateRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetArmedStateRequestDefaultTypeInternal _SetArmedStateRequest_default_instance_;
 
 inline constexpr SetArmableRequest::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -408,6 +458,31 @@ struct ShutdownResponseDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ShutdownResponseDefaultTypeInternal _ShutdownResponse_default_instance_;
 
+inline constexpr SetFlightModeResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        action_server_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR SetFlightModeResponse::SetFlightModeResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct SetFlightModeResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SetFlightModeResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SetFlightModeResponseDefaultTypeInternal() {}
+  union {
+    SetFlightModeResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetFlightModeResponseDefaultTypeInternal _SetFlightModeResponse_default_instance_;
+
 inline constexpr SetDisarmableResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : _cached_size_{0},
@@ -432,6 +507,31 @@ struct SetDisarmableResponseDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetDisarmableResponseDefaultTypeInternal _SetDisarmableResponse_default_instance_;
+
+inline constexpr SetArmedStateResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        action_server_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR SetArmedStateResponse::SetArmedStateResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct SetArmedStateResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SetArmedStateResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SetArmedStateResponseDefaultTypeInternal() {}
+  union {
+    SetArmedStateResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetArmedStateResponseDefaultTypeInternal _SetArmedStateResponse_default_instance_;
 
 inline constexpr SetArmableResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -710,6 +810,24 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetAllowableFlightModesRequest, _impl_.flight_modes_),
         0,
         ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetArmedStateRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetArmedStateRequest, _impl_.is_armed_),
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetFlightModeRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetFlightModeRequest, _impl_.flight_mode_),
+        ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::GetAllowableFlightModesRequest, _internal_metadata_),
         ~0u,  // no _extensions_
         ~0u,  // no _oneof_case_
@@ -907,6 +1025,26 @@ const ::uint32_t
         ~0u,  // no sizeof(Split)
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::GetAllowableFlightModesResponse, _impl_.flight_modes_),
         0,
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetArmedStateResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetArmedStateResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetArmedStateResponse, _impl_.action_server_result_),
+        0,
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetFlightModeResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetFlightModeResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::SetFlightModeResponse, _impl_.action_server_result_),
+        0,
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action_server::AllowableFlightModes, _internal_metadata_),
         ~0u,  // no _extensions_
@@ -946,35 +1084,41 @@ static const ::_pbi::MigrationSchema
         {9, -1, -1, sizeof(::mavsdk::rpc::action_server::SetArmableRequest)},
         {19, -1, -1, sizeof(::mavsdk::rpc::action_server::SetDisarmableRequest)},
         {29, 38, -1, sizeof(::mavsdk::rpc::action_server::SetAllowableFlightModesRequest)},
-        {39, -1, -1, sizeof(::mavsdk::rpc::action_server::GetAllowableFlightModesRequest)},
-        {47, -1, -1, sizeof(::mavsdk::rpc::action_server::SubscribeArmDisarmRequest)},
-        {55, -1, -1, sizeof(::mavsdk::rpc::action_server::SubscribeFlightModeChangeRequest)},
-        {63, -1, -1, sizeof(::mavsdk::rpc::action_server::SubscribeTakeoffRequest)},
-        {71, -1, -1, sizeof(::mavsdk::rpc::action_server::SubscribeLandRequest)},
-        {79, -1, -1, sizeof(::mavsdk::rpc::action_server::SubscribeRebootRequest)},
-        {87, -1, -1, sizeof(::mavsdk::rpc::action_server::SubscribeShutdownRequest)},
-        {95, -1, -1, sizeof(::mavsdk::rpc::action_server::SubscribeTerminateRequest)},
-        {103, 113, -1, sizeof(::mavsdk::rpc::action_server::ArmDisarmResponse)},
-        {115, 125, -1, sizeof(::mavsdk::rpc::action_server::FlightModeChangeResponse)},
-        {127, 137, -1, sizeof(::mavsdk::rpc::action_server::TakeoffResponse)},
-        {139, 149, -1, sizeof(::mavsdk::rpc::action_server::LandResponse)},
-        {151, 161, -1, sizeof(::mavsdk::rpc::action_server::RebootResponse)},
-        {163, 173, -1, sizeof(::mavsdk::rpc::action_server::ShutdownResponse)},
-        {175, 185, -1, sizeof(::mavsdk::rpc::action_server::TerminateResponse)},
-        {187, 196, -1, sizeof(::mavsdk::rpc::action_server::SetArmableResponse)},
-        {197, 206, -1, sizeof(::mavsdk::rpc::action_server::SetDisarmableResponse)},
-        {207, 216, -1, sizeof(::mavsdk::rpc::action_server::SetAllowableFlightModesResponse)},
-        {217, 226, -1, sizeof(::mavsdk::rpc::action_server::SetAllowTakeoffResponse)},
-        {227, 236, -1, sizeof(::mavsdk::rpc::action_server::GetAllowableFlightModesResponse)},
-        {237, -1, -1, sizeof(::mavsdk::rpc::action_server::AllowableFlightModes)},
-        {248, -1, -1, sizeof(::mavsdk::rpc::action_server::ArmDisarm)},
-        {258, -1, -1, sizeof(::mavsdk::rpc::action_server::ActionServerResult)},
+        {39, -1, -1, sizeof(::mavsdk::rpc::action_server::SetArmedStateRequest)},
+        {48, -1, -1, sizeof(::mavsdk::rpc::action_server::SetFlightModeRequest)},
+        {57, -1, -1, sizeof(::mavsdk::rpc::action_server::GetAllowableFlightModesRequest)},
+        {65, -1, -1, sizeof(::mavsdk::rpc::action_server::SubscribeArmDisarmRequest)},
+        {73, -1, -1, sizeof(::mavsdk::rpc::action_server::SubscribeFlightModeChangeRequest)},
+        {81, -1, -1, sizeof(::mavsdk::rpc::action_server::SubscribeTakeoffRequest)},
+        {89, -1, -1, sizeof(::mavsdk::rpc::action_server::SubscribeLandRequest)},
+        {97, -1, -1, sizeof(::mavsdk::rpc::action_server::SubscribeRebootRequest)},
+        {105, -1, -1, sizeof(::mavsdk::rpc::action_server::SubscribeShutdownRequest)},
+        {113, -1, -1, sizeof(::mavsdk::rpc::action_server::SubscribeTerminateRequest)},
+        {121, 131, -1, sizeof(::mavsdk::rpc::action_server::ArmDisarmResponse)},
+        {133, 143, -1, sizeof(::mavsdk::rpc::action_server::FlightModeChangeResponse)},
+        {145, 155, -1, sizeof(::mavsdk::rpc::action_server::TakeoffResponse)},
+        {157, 167, -1, sizeof(::mavsdk::rpc::action_server::LandResponse)},
+        {169, 179, -1, sizeof(::mavsdk::rpc::action_server::RebootResponse)},
+        {181, 191, -1, sizeof(::mavsdk::rpc::action_server::ShutdownResponse)},
+        {193, 203, -1, sizeof(::mavsdk::rpc::action_server::TerminateResponse)},
+        {205, 214, -1, sizeof(::mavsdk::rpc::action_server::SetArmableResponse)},
+        {215, 224, -1, sizeof(::mavsdk::rpc::action_server::SetDisarmableResponse)},
+        {225, 234, -1, sizeof(::mavsdk::rpc::action_server::SetAllowableFlightModesResponse)},
+        {235, 244, -1, sizeof(::mavsdk::rpc::action_server::SetAllowTakeoffResponse)},
+        {245, 254, -1, sizeof(::mavsdk::rpc::action_server::GetAllowableFlightModesResponse)},
+        {255, 264, -1, sizeof(::mavsdk::rpc::action_server::SetArmedStateResponse)},
+        {265, 274, -1, sizeof(::mavsdk::rpc::action_server::SetFlightModeResponse)},
+        {275, -1, -1, sizeof(::mavsdk::rpc::action_server::AllowableFlightModes)},
+        {286, -1, -1, sizeof(::mavsdk::rpc::action_server::ArmDisarm)},
+        {296, -1, -1, sizeof(::mavsdk::rpc::action_server::ActionServerResult)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::action_server::_SetAllowTakeoffRequest_default_instance_._instance,
     &::mavsdk::rpc::action_server::_SetArmableRequest_default_instance_._instance,
     &::mavsdk::rpc::action_server::_SetDisarmableRequest_default_instance_._instance,
     &::mavsdk::rpc::action_server::_SetAllowableFlightModesRequest_default_instance_._instance,
+    &::mavsdk::rpc::action_server::_SetArmedStateRequest_default_instance_._instance,
+    &::mavsdk::rpc::action_server::_SetFlightModeRequest_default_instance_._instance,
     &::mavsdk::rpc::action_server::_GetAllowableFlightModesRequest_default_instance_._instance,
     &::mavsdk::rpc::action_server::_SubscribeArmDisarmRequest_default_instance_._instance,
     &::mavsdk::rpc::action_server::_SubscribeFlightModeChangeRequest_default_instance_._instance,
@@ -995,6 +1139,8 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::action_server::_SetAllowableFlightModesResponse_default_instance_._instance,
     &::mavsdk::rpc::action_server::_SetAllowTakeoffResponse_default_instance_._instance,
     &::mavsdk::rpc::action_server::_GetAllowableFlightModesResponse_default_instance_._instance,
+    &::mavsdk::rpc::action_server::_SetArmedStateResponse_default_instance_._instance,
+    &::mavsdk::rpc::action_server::_SetFlightModeResponse_default_instance_._instance,
     &::mavsdk::rpc::action_server::_AllowableFlightModes_default_instance_._instance,
     &::mavsdk::rpc::action_server::_ArmDisarm_default_instance_._instance,
     &::mavsdk::rpc::action_server::_ActionServerResult_default_instance_._instance,
@@ -1010,113 +1156,127 @@ const char descriptor_table_protodef_action_5fserver_2faction_5fserver_2eproto[]
     "\020force_disarmable\030\002 \001(\010\"f\n\036SetAllowableF"
     "lightModesRequest\022D\n\014flight_modes\030\001 \001(\0132"
     "..mavsdk.rpc.action_server.AllowableFlig"
-    "htModes\" \n\036GetAllowableFlightModesReques"
-    "t\"\033\n\031SubscribeArmDisarmRequest\"\"\n Subscr"
-    "ibeFlightModeChangeRequest\"\031\n\027SubscribeT"
-    "akeoffRequest\"\026\n\024SubscribeLandRequest\"\030\n"
-    "\026SubscribeRebootRequest\"\032\n\030SubscribeShut"
-    "downRequest\"\033\n\031SubscribeTerminateRequest"
-    "\"\221\001\n\021ArmDisarmResponse\022J\n\024action_server_"
+    "htModes\"(\n\024SetArmedStateRequest\022\020\n\010is_ar"
+    "med\030\001 \001(\010\"Q\n\024SetFlightModeRequest\0229\n\013fli"
+    "ght_mode\030\001 \001(\0162$.mavsdk.rpc.action_serve"
+    "r.FlightMode\" \n\036GetAllowableFlightModesR"
+    "equest\"\033\n\031SubscribeArmDisarmRequest\"\"\n S"
+    "ubscribeFlightModeChangeRequest\"\031\n\027Subsc"
+    "ribeTakeoffRequest\"\026\n\024SubscribeLandReque"
+    "st\"\030\n\026SubscribeRebootRequest\"\032\n\030Subscrib"
+    "eShutdownRequest\"\033\n\031SubscribeTerminateRe"
+    "quest\"\221\001\n\021ArmDisarmResponse\022J\n\024action_se"
+    "rver_result\030\001 \001(\0132,.mavsdk.rpc.action_se"
+    "rver.ActionServerResult\0220\n\003arm\030\002 \001(\0132#.m"
+    "avsdk.rpc.action_server.ArmDisarm\"\241\001\n\030Fl"
+    "ightModeChangeResponse\022J\n\024action_server_"
     "result\030\001 \001(\0132,.mavsdk.rpc.action_server."
-    "ActionServerResult\0220\n\003arm\030\002 \001(\0132#.mavsdk"
-    ".rpc.action_server.ArmDisarm\"\241\001\n\030FlightM"
-    "odeChangeResponse\022J\n\024action_server_resul"
-    "t\030\001 \001(\0132,.mavsdk.rpc.action_server.Actio"
-    "nServerResult\0229\n\013flight_mode\030\002 \001(\0162$.mav"
-    "sdk.rpc.action_server.FlightMode\"n\n\017Take"
-    "offResponse\022J\n\024action_server_result\030\001 \001("
-    "\0132,.mavsdk.rpc.action_server.ActionServe"
-    "rResult\022\017\n\007takeoff\030\002 \001(\010\"h\n\014LandResponse"
-    "\022J\n\024action_server_result\030\001 \001(\0132,.mavsdk."
-    "rpc.action_server.ActionServerResult\022\014\n\004"
-    "land\030\002 \001(\010\"l\n\016RebootResponse\022J\n\024action_s"
-    "erver_result\030\001 \001(\0132,.mavsdk.rpc.action_s"
-    "erver.ActionServerResult\022\016\n\006reboot\030\002 \001(\010"
-    "\"p\n\020ShutdownResponse\022J\n\024action_server_re"
-    "sult\030\001 \001(\0132,.mavsdk.rpc.action_server.Ac"
-    "tionServerResult\022\020\n\010shutdown\030\002 \001(\010\"r\n\021Te"
-    "rminateResponse\022J\n\024action_server_result\030"
-    "\001 \001(\0132,.mavsdk.rpc.action_server.ActionS"
-    "erverResult\022\021\n\tterminate\030\002 \001(\010\"`\n\022SetArm"
-    "ableResponse\022J\n\024action_server_result\030\001 \001"
-    "(\0132,.mavsdk.rpc.action_server.ActionServ"
-    "erResult\"c\n\025SetDisarmableResponse\022J\n\024act"
+    "ActionServerResult\0229\n\013flight_mode\030\002 \001(\0162"
+    "$.mavsdk.rpc.action_server.FlightMode\"n\n"
+    "\017TakeoffResponse\022J\n\024action_server_result"
+    "\030\001 \001(\0132,.mavsdk.rpc.action_server.Action"
+    "ServerResult\022\017\n\007takeoff\030\002 \001(\010\"h\n\014LandRes"
+    "ponse\022J\n\024action_server_result\030\001 \001(\0132,.ma"
+    "vsdk.rpc.action_server.ActionServerResul"
+    "t\022\014\n\004land\030\002 \001(\010\"l\n\016RebootResponse\022J\n\024act"
     "ion_server_result\030\001 \001(\0132,.mavsdk.rpc.act"
-    "ion_server.ActionServerResult\"m\n\037SetAllo"
-    "wableFlightModesResponse\022J\n\024action_serve"
-    "r_result\030\001 \001(\0132,.mavsdk.rpc.action_serve"
-    "r.ActionServerResult\"e\n\027SetAllowTakeoffR"
-    "esponse\022J\n\024action_server_result\030\001 \001(\0132,."
-    "mavsdk.rpc.action_server.ActionServerRes"
-    "ult\"g\n\037GetAllowableFlightModesResponse\022D"
-    "\n\014flight_modes\030\001 \001(\0132..mavsdk.rpc.action"
-    "_server.AllowableFlightModes\"b\n\024Allowabl"
-    "eFlightModes\022\025\n\rcan_auto_mode\030\001 \001(\010\022\027\n\017c"
-    "an_guided_mode\030\002 \001(\010\022\032\n\022can_stabilize_mo"
-    "de\030\003 \001(\010\"\'\n\tArmDisarm\022\013\n\003arm\030\001 \001(\010\022\r\n\005fo"
-    "rce\030\002 \001(\010\"\351\003\n\022ActionServerResult\022C\n\006resu"
-    "lt\030\001 \001(\01623.mavsdk.rpc.action_server.Acti"
-    "onServerResult.Result\022\022\n\nresult_str\030\002 \001("
-    "\t\"\371\002\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESU"
-    "LT_SUCCESS\020\001\022\024\n\020RESULT_NO_SYSTEM\020\002\022\033\n\027RE"
-    "SULT_CONNECTION_ERROR\020\003\022\017\n\013RESULT_BUSY\020\004"
-    "\022\031\n\025RESULT_COMMAND_DENIED\020\005\022.\n*RESULT_CO"
-    "MMAND_DENIED_LANDED_STATE_UNKNOWN\020\006\022$\n R"
-    "ESULT_COMMAND_DENIED_NOT_LANDED\020\007\022\022\n\016RES"
-    "ULT_TIMEOUT\020\010\022*\n&RESULT_VTOL_TRANSITION_"
-    "SUPPORT_UNKNOWN\020\t\022%\n!RESULT_NO_VTOL_TRAN"
-    "SITION_SUPPORT\020\n\022\032\n\026RESULT_PARAMETER_ERR"
-    "OR\020\013\022\017\n\013RESULT_NEXT\020\014*\353\002\n\nFlightMode\022\027\n\023"
-    "FLIGHT_MODE_UNKNOWN\020\000\022\025\n\021FLIGHT_MODE_REA"
-    "DY\020\001\022\027\n\023FLIGHT_MODE_TAKEOFF\020\002\022\024\n\020FLIGHT_"
-    "MODE_HOLD\020\003\022\027\n\023FLIGHT_MODE_MISSION\020\004\022 \n\034"
-    "FLIGHT_MODE_RETURN_TO_LAUNCH\020\005\022\024\n\020FLIGHT"
-    "_MODE_LAND\020\006\022\030\n\024FLIGHT_MODE_OFFBOARD\020\007\022\031"
-    "\n\025FLIGHT_MODE_FOLLOW_ME\020\010\022\026\n\022FLIGHT_MODE"
-    "_MANUAL\020\t\022\026\n\022FLIGHT_MODE_ALTCTL\020\n\022\026\n\022FLI"
-    "GHT_MODE_POSCTL\020\013\022\024\n\020FLIGHT_MODE_ACRO\020\014\022"
-    "\032\n\026FLIGHT_MODE_STABILIZED\020\r2\235\014\n\023ActionSe"
-    "rverService\022~\n\022SubscribeArmDisarm\0223.mavs"
-    "dk.rpc.action_server.SubscribeArmDisarmR"
-    "equest\032+.mavsdk.rpc.action_server.ArmDis"
-    "armResponse\"\004\200\265\030\0000\001\022\223\001\n\031SubscribeFlightM"
-    "odeChange\022:.mavsdk.rpc.action_server.Sub"
-    "scribeFlightModeChangeRequest\0322.mavsdk.r"
-    "pc.action_server.FlightModeChangeRespons"
-    "e\"\004\200\265\030\0000\001\022x\n\020SubscribeTakeoff\0221.mavsdk.r"
-    "pc.action_server.SubscribeTakeoffRequest"
-    "\032).mavsdk.rpc.action_server.TakeoffRespo"
-    "nse\"\004\200\265\030\0000\001\022o\n\rSubscribeLand\022..mavsdk.rp"
-    "c.action_server.SubscribeLandRequest\032&.m"
-    "avsdk.rpc.action_server.LandResponse\"\004\200\265"
-    "\030\0000\001\022u\n\017SubscribeReboot\0220.mavsdk.rpc.act"
-    "ion_server.SubscribeRebootRequest\032(.mavs"
-    "dk.rpc.action_server.RebootResponse\"\004\200\265\030"
-    "\0000\001\022{\n\021SubscribeShutdown\0222.mavsdk.rpc.ac"
-    "tion_server.SubscribeShutdownRequest\032*.m"
-    "avsdk.rpc.action_server.ShutdownResponse"
-    "\"\004\200\265\030\0000\001\022~\n\022SubscribeTerminate\0223.mavsdk."
-    "rpc.action_server.SubscribeTerminateRequ"
-    "est\032+.mavsdk.rpc.action_server.Terminate"
-    "Response\"\004\200\265\030\0000\001\022|\n\017SetAllowTakeoff\0220.ma"
-    "vsdk.rpc.action_server.SetAllowTakeoffRe"
-    "quest\0321.mavsdk.rpc.action_server.SetAllo"
-    "wTakeoffResponse\"\004\200\265\030\001\022m\n\nSetArmable\022+.m"
-    "avsdk.rpc.action_server.SetArmableReques"
-    "t\032,.mavsdk.rpc.action_server.SetArmableR"
-    "esponse\"\004\200\265\030\001\022v\n\rSetDisarmable\022..mavsdk."
-    "rpc.action_server.SetDisarmableRequest\032/"
-    ".mavsdk.rpc.action_server.SetDisarmableR"
-    "esponse\"\004\200\265\030\001\022\224\001\n\027SetAllowableFlightMode"
-    "s\0228.mavsdk.rpc.action_server.SetAllowabl"
-    "eFlightModesRequest\0329.mavsdk.rpc.action_"
-    "server.SetAllowableFlightModesResponse\"\004"
-    "\200\265\030\001\022\224\001\n\027GetAllowableFlightModes\0228.mavsd"
-    "k.rpc.action_server.GetAllowableFlightMo"
-    "desRequest\0329.mavsdk.rpc.action_server.Ge"
-    "tAllowableFlightModesResponse\"\004\200\265\030\001B,\n\027i"
-    "o.mavsdk.action_serverB\021ActionServerProt"
-    "ob\006proto3"
+    "ion_server.ActionServerResult\022\016\n\006reboot\030"
+    "\002 \001(\010\"p\n\020ShutdownResponse\022J\n\024action_serv"
+    "er_result\030\001 \001(\0132,.mavsdk.rpc.action_serv"
+    "er.ActionServerResult\022\020\n\010shutdown\030\002 \001(\010\""
+    "r\n\021TerminateResponse\022J\n\024action_server_re"
+    "sult\030\001 \001(\0132,.mavsdk.rpc.action_server.Ac"
+    "tionServerResult\022\021\n\tterminate\030\002 \001(\010\"`\n\022S"
+    "etArmableResponse\022J\n\024action_server_resul"
+    "t\030\001 \001(\0132,.mavsdk.rpc.action_server.Actio"
+    "nServerResult\"c\n\025SetDisarmableResponse\022J"
+    "\n\024action_server_result\030\001 \001(\0132,.mavsdk.rp"
+    "c.action_server.ActionServerResult\"m\n\037Se"
+    "tAllowableFlightModesResponse\022J\n\024action_"
+    "server_result\030\001 \001(\0132,.mavsdk.rpc.action_"
+    "server.ActionServerResult\"e\n\027SetAllowTak"
+    "eoffResponse\022J\n\024action_server_result\030\001 \001"
+    "(\0132,.mavsdk.rpc.action_server.ActionServ"
+    "erResult\"g\n\037GetAllowableFlightModesRespo"
+    "nse\022D\n\014flight_modes\030\001 \001(\0132..mavsdk.rpc.a"
+    "ction_server.AllowableFlightModes\"c\n\025Set"
+    "ArmedStateResponse\022J\n\024action_server_resu"
+    "lt\030\001 \001(\0132,.mavsdk.rpc.action_server.Acti"
+    "onServerResult\"c\n\025SetFlightModeResponse\022"
+    "J\n\024action_server_result\030\001 \001(\0132,.mavsdk.r"
+    "pc.action_server.ActionServerResult\"b\n\024A"
+    "llowableFlightModes\022\025\n\rcan_auto_mode\030\001 \001"
+    "(\010\022\027\n\017can_guided_mode\030\002 \001(\010\022\032\n\022can_stabi"
+    "lize_mode\030\003 \001(\010\"\'\n\tArmDisarm\022\013\n\003arm\030\001 \001("
+    "\010\022\r\n\005force\030\002 \001(\010\"\351\003\n\022ActionServerResult\022"
+    "C\n\006result\030\001 \001(\01623.mavsdk.rpc.action_serv"
+    "er.ActionServerResult.Result\022\022\n\nresult_s"
+    "tr\030\002 \001(\t\"\371\002\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022"
+    "\022\n\016RESULT_SUCCESS\020\001\022\024\n\020RESULT_NO_SYSTEM\020"
+    "\002\022\033\n\027RESULT_CONNECTION_ERROR\020\003\022\017\n\013RESULT"
+    "_BUSY\020\004\022\031\n\025RESULT_COMMAND_DENIED\020\005\022.\n*RE"
+    "SULT_COMMAND_DENIED_LANDED_STATE_UNKNOWN"
+    "\020\006\022$\n RESULT_COMMAND_DENIED_NOT_LANDED\020\007"
+    "\022\022\n\016RESULT_TIMEOUT\020\010\022*\n&RESULT_VTOL_TRAN"
+    "SITION_SUPPORT_UNKNOWN\020\t\022%\n!RESULT_NO_VT"
+    "OL_TRANSITION_SUPPORT\020\n\022\032\n\026RESULT_PARAME"
+    "TER_ERROR\020\013\022\017\n\013RESULT_NEXT\020\014*\353\002\n\nFlightM"
+    "ode\022\027\n\023FLIGHT_MODE_UNKNOWN\020\000\022\025\n\021FLIGHT_M"
+    "ODE_READY\020\001\022\027\n\023FLIGHT_MODE_TAKEOFF\020\002\022\024\n\020"
+    "FLIGHT_MODE_HOLD\020\003\022\027\n\023FLIGHT_MODE_MISSIO"
+    "N\020\004\022 \n\034FLIGHT_MODE_RETURN_TO_LAUNCH\020\005\022\024\n"
+    "\020FLIGHT_MODE_LAND\020\006\022\030\n\024FLIGHT_MODE_OFFBO"
+    "ARD\020\007\022\031\n\025FLIGHT_MODE_FOLLOW_ME\020\010\022\026\n\022FLIG"
+    "HT_MODE_MANUAL\020\t\022\026\n\022FLIGHT_MODE_ALTCTL\020\n"
+    "\022\026\n\022FLIGHT_MODE_POSCTL\020\013\022\024\n\020FLIGHT_MODE_"
+    "ACRO\020\014\022\032\n\026FLIGHT_MODE_STABILIZED\020\r2\215\016\n\023A"
+    "ctionServerService\022~\n\022SubscribeArmDisarm"
+    "\0223.mavsdk.rpc.action_server.SubscribeArm"
+    "DisarmRequest\032+.mavsdk.rpc.action_server"
+    ".ArmDisarmResponse\"\004\200\265\030\0000\001\022\223\001\n\031Subscribe"
+    "FlightModeChange\022:.mavsdk.rpc.action_ser"
+    "ver.SubscribeFlightModeChangeRequest\0322.m"
+    "avsdk.rpc.action_server.FlightModeChange"
+    "Response\"\004\200\265\030\0000\001\022x\n\020SubscribeTakeoff\0221.m"
+    "avsdk.rpc.action_server.SubscribeTakeoff"
+    "Request\032).mavsdk.rpc.action_server.Takeo"
+    "ffResponse\"\004\200\265\030\0000\001\022o\n\rSubscribeLand\022..ma"
+    "vsdk.rpc.action_server.SubscribeLandRequ"
+    "est\032&.mavsdk.rpc.action_server.LandRespo"
+    "nse\"\004\200\265\030\0000\001\022u\n\017SubscribeReboot\0220.mavsdk."
+    "rpc.action_server.SubscribeRebootRequest"
+    "\032(.mavsdk.rpc.action_server.RebootRespon"
+    "se\"\004\200\265\030\0000\001\022{\n\021SubscribeShutdown\0222.mavsdk"
+    ".rpc.action_server.SubscribeShutdownRequ"
+    "est\032*.mavsdk.rpc.action_server.ShutdownR"
+    "esponse\"\004\200\265\030\0000\001\022~\n\022SubscribeTerminate\0223."
+    "mavsdk.rpc.action_server.SubscribeTermin"
+    "ateRequest\032+.mavsdk.rpc.action_server.Te"
+    "rminateResponse\"\004\200\265\030\0000\001\022|\n\017SetAllowTakeo"
+    "ff\0220.mavsdk.rpc.action_server.SetAllowTa"
+    "keoffRequest\0321.mavsdk.rpc.action_server."
+    "SetAllowTakeoffResponse\"\004\200\265\030\001\022m\n\nSetArma"
+    "ble\022+.mavsdk.rpc.action_server.SetArmabl"
+    "eRequest\032,.mavsdk.rpc.action_server.SetA"
+    "rmableResponse\"\004\200\265\030\001\022v\n\rSetDisarmable\022.."
+    "mavsdk.rpc.action_server.SetDisarmableRe"
+    "quest\032/.mavsdk.rpc.action_server.SetDisa"
+    "rmableResponse\"\004\200\265\030\001\022\224\001\n\027SetAllowableFli"
+    "ghtModes\0228.mavsdk.rpc.action_server.SetA"
+    "llowableFlightModesRequest\0329.mavsdk.rpc."
+    "action_server.SetAllowableFlightModesRes"
+    "ponse\"\004\200\265\030\001\022\224\001\n\027GetAllowableFlightModes\022"
+    "8.mavsdk.rpc.action_server.GetAllowableF"
+    "lightModesRequest\0329.mavsdk.rpc.action_se"
+    "rver.GetAllowableFlightModesResponse\"\004\200\265"
+    "\030\001\022v\n\rSetArmedState\022..mavsdk.rpc.action_"
+    "server.SetArmedStateRequest\032/.mavsdk.rpc"
+    ".action_server.SetArmedStateResponse\"\004\200\265"
+    "\030\001\022v\n\rSetFlightMode\022..mavsdk.rpc.action_"
+    "server.SetFlightModeRequest\032/.mavsdk.rpc"
+    ".action_server.SetFlightModeResponse\"\004\200\265"
+    "\030\001B,\n\027io.mavsdk.action_serverB\021ActionSer"
+    "verProtob\006proto3"
 };
 static const ::_pbi::DescriptorTable* const descriptor_table_action_5fserver_2faction_5fserver_2eproto_deps[1] =
     {
@@ -1126,13 +1286,13 @@ static ::absl::once_flag descriptor_table_action_5fserver_2faction_5fserver_2epr
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_action_5fserver_2faction_5fserver_2eproto = {
     false,
     false,
-    4609,
+    5176,
     descriptor_table_protodef_action_5fserver_2faction_5fserver_2eproto,
     "action_server/action_server.proto",
     &descriptor_table_action_5fserver_2faction_5fserver_2eproto_once,
     descriptor_table_action_5fserver_2faction_5fserver_2eproto_deps,
     1,
-    27,
+    31,
     schemas,
     file_default_instances,
     TableStruct_action_5fserver_2faction_5fserver_2eproto::offsets,
@@ -2114,6 +2274,419 @@ void SetAllowableFlightModesRequest::InternalSwap(SetAllowableFlightModesRequest
 }
 
 ::google::protobuf::Metadata SetAllowableFlightModesRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SetArmedStateRequest::_Internal {
+ public:
+};
+
+SetArmedStateRequest::SetArmedStateRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.action_server.SetArmedStateRequest)
+}
+SetArmedStateRequest::SetArmedStateRequest(
+    ::google::protobuf::Arena* arena, const SetArmedStateRequest& from)
+    : SetArmedStateRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE SetArmedStateRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void SetArmedStateRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.is_armed_ = {};
+}
+SetArmedStateRequest::~SetArmedStateRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.action_server.SetArmedStateRequest)
+  SharedDtor(*this);
+}
+inline void SetArmedStateRequest::SharedDtor(MessageLite& self) {
+  SetArmedStateRequest& this_ = static_cast<SetArmedStateRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* SetArmedStateRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SetArmedStateRequest(arena);
+}
+constexpr auto SetArmedStateRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SetArmedStateRequest),
+                                            alignof(SetArmedStateRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SetArmedStateRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SetArmedStateRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SetArmedStateRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<SetArmedStateRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SetArmedStateRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<SetArmedStateRequest>(), &SetArmedStateRequest::ByteSizeLong,
+            &SetArmedStateRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SetArmedStateRequest, _impl_._cached_size_),
+        false,
+    },
+    &SetArmedStateRequest::kDescriptorMethods,
+    &descriptor_table_action_5fserver_2faction_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SetArmedStateRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> SetArmedStateRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::action_server::SetArmedStateRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // bool is_armed = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(SetArmedStateRequest, _impl_.is_armed_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(SetArmedStateRequest, _impl_.is_armed_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // bool is_armed = 1;
+    {PROTOBUF_FIELD_OFFSET(SetArmedStateRequest, _impl_.is_armed_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kBool)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void SetArmedStateRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action_server.SetArmedStateRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.is_armed_ = false;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* SetArmedStateRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const SetArmedStateRequest& this_ = static_cast<const SetArmedStateRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* SetArmedStateRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const SetArmedStateRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action_server.SetArmedStateRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // bool is_armed = 1;
+          if (this_._internal_is_armed() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteBoolToArray(
+                1, this_._internal_is_armed(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action_server.SetArmedStateRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t SetArmedStateRequest::ByteSizeLong(const MessageLite& base) {
+          const SetArmedStateRequest& this_ = static_cast<const SetArmedStateRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t SetArmedStateRequest::ByteSizeLong() const {
+          const SetArmedStateRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action_server.SetArmedStateRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // bool is_armed = 1;
+            if (this_._internal_is_armed() != 0) {
+              total_size += 2;
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void SetArmedStateRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<SetArmedStateRequest*>(&to_msg);
+  auto& from = static_cast<const SetArmedStateRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action_server.SetArmedStateRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_is_armed() != 0) {
+    _this->_impl_.is_armed_ = from._impl_.is_armed_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SetArmedStateRequest::CopyFrom(const SetArmedStateRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action_server.SetArmedStateRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void SetArmedStateRequest::InternalSwap(SetArmedStateRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.is_armed_, other->_impl_.is_armed_);
+}
+
+::google::protobuf::Metadata SetArmedStateRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SetFlightModeRequest::_Internal {
+ public:
+};
+
+SetFlightModeRequest::SetFlightModeRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.action_server.SetFlightModeRequest)
+}
+SetFlightModeRequest::SetFlightModeRequest(
+    ::google::protobuf::Arena* arena, const SetFlightModeRequest& from)
+    : SetFlightModeRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE SetFlightModeRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void SetFlightModeRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.flight_mode_ = {};
+}
+SetFlightModeRequest::~SetFlightModeRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.action_server.SetFlightModeRequest)
+  SharedDtor(*this);
+}
+inline void SetFlightModeRequest::SharedDtor(MessageLite& self) {
+  SetFlightModeRequest& this_ = static_cast<SetFlightModeRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* SetFlightModeRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SetFlightModeRequest(arena);
+}
+constexpr auto SetFlightModeRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SetFlightModeRequest),
+                                            alignof(SetFlightModeRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SetFlightModeRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SetFlightModeRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SetFlightModeRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<SetFlightModeRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SetFlightModeRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<SetFlightModeRequest>(), &SetFlightModeRequest::ByteSizeLong,
+            &SetFlightModeRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SetFlightModeRequest, _impl_._cached_size_),
+        false,
+    },
+    &SetFlightModeRequest::kDescriptorMethods,
+    &descriptor_table_action_5fserver_2faction_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SetFlightModeRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> SetFlightModeRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::action_server::SetFlightModeRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.action_server.FlightMode flight_mode = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(SetFlightModeRequest, _impl_.flight_mode_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(SetFlightModeRequest, _impl_.flight_mode_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.action_server.FlightMode flight_mode = 1;
+    {PROTOBUF_FIELD_OFFSET(SetFlightModeRequest, _impl_.flight_mode_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kOpenEnum)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void SetFlightModeRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action_server.SetFlightModeRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.flight_mode_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* SetFlightModeRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const SetFlightModeRequest& this_ = static_cast<const SetFlightModeRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* SetFlightModeRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const SetFlightModeRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action_server.SetFlightModeRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // .mavsdk.rpc.action_server.FlightMode flight_mode = 1;
+          if (this_._internal_flight_mode() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteEnumToArray(
+                1, this_._internal_flight_mode(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action_server.SetFlightModeRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t SetFlightModeRequest::ByteSizeLong(const MessageLite& base) {
+          const SetFlightModeRequest& this_ = static_cast<const SetFlightModeRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t SetFlightModeRequest::ByteSizeLong() const {
+          const SetFlightModeRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action_server.SetFlightModeRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.action_server.FlightMode flight_mode = 1;
+            if (this_._internal_flight_mode() != 0) {
+              total_size += 1 +
+                            ::_pbi::WireFormatLite::EnumSize(this_._internal_flight_mode());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void SetFlightModeRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<SetFlightModeRequest*>(&to_msg);
+  auto& from = static_cast<const SetFlightModeRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action_server.SetFlightModeRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_flight_mode() != 0) {
+    _this->_impl_.flight_mode_ = from._impl_.flight_mode_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SetFlightModeRequest::CopyFrom(const SetFlightModeRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action_server.SetFlightModeRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void SetFlightModeRequest::InternalSwap(SetFlightModeRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_.flight_mode_, other->_impl_.flight_mode_);
+}
+
+::google::protobuf::Metadata SetFlightModeRequest::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================
@@ -6200,6 +6773,506 @@ void GetAllowableFlightModesResponse::InternalSwap(GetAllowableFlightModesRespon
 }
 
 ::google::protobuf::Metadata GetAllowableFlightModesResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SetArmedStateResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<SetArmedStateResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(SetArmedStateResponse, _impl_._has_bits_);
+};
+
+SetArmedStateResponse::SetArmedStateResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.action_server.SetArmedStateResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE SetArmedStateResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::action_server::SetArmedStateResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+SetArmedStateResponse::SetArmedStateResponse(
+    ::google::protobuf::Arena* arena,
+    const SetArmedStateResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SetArmedStateResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.action_server_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::action_server::ActionServerResult>(
+                              arena, *from._impl_.action_server_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.action_server.SetArmedStateResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE SetArmedStateResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void SetArmedStateResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.action_server_result_ = {};
+}
+SetArmedStateResponse::~SetArmedStateResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.action_server.SetArmedStateResponse)
+  SharedDtor(*this);
+}
+inline void SetArmedStateResponse::SharedDtor(MessageLite& self) {
+  SetArmedStateResponse& this_ = static_cast<SetArmedStateResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.action_server_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* SetArmedStateResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SetArmedStateResponse(arena);
+}
+constexpr auto SetArmedStateResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SetArmedStateResponse),
+                                            alignof(SetArmedStateResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SetArmedStateResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SetArmedStateResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SetArmedStateResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<SetArmedStateResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SetArmedStateResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<SetArmedStateResponse>(), &SetArmedStateResponse::ByteSizeLong,
+            &SetArmedStateResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SetArmedStateResponse, _impl_._cached_size_),
+        false,
+    },
+    &SetArmedStateResponse::kDescriptorMethods,
+    &descriptor_table_action_5fserver_2faction_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SetArmedStateResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> SetArmedStateResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(SetArmedStateResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::action_server::SetArmedStateResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.action_server.ActionServerResult action_server_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(SetArmedStateResponse, _impl_.action_server_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.action_server.ActionServerResult action_server_result = 1;
+    {PROTOBUF_FIELD_OFFSET(SetArmedStateResponse, _impl_.action_server_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::action_server::ActionServerResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void SetArmedStateResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action_server.SetArmedStateResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.action_server_result_ != nullptr);
+    _impl_.action_server_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* SetArmedStateResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const SetArmedStateResponse& this_ = static_cast<const SetArmedStateResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* SetArmedStateResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const SetArmedStateResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action_server.SetArmedStateResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.action_server.ActionServerResult action_server_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.action_server_result_, this_._impl_.action_server_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action_server.SetArmedStateResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t SetArmedStateResponse::ByteSizeLong(const MessageLite& base) {
+          const SetArmedStateResponse& this_ = static_cast<const SetArmedStateResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t SetArmedStateResponse::ByteSizeLong() const {
+          const SetArmedStateResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action_server.SetArmedStateResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.action_server.ActionServerResult action_server_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.action_server_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void SetArmedStateResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<SetArmedStateResponse*>(&to_msg);
+  auto& from = static_cast<const SetArmedStateResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action_server.SetArmedStateResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.action_server_result_ != nullptr);
+    if (_this->_impl_.action_server_result_ == nullptr) {
+      _this->_impl_.action_server_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::action_server::ActionServerResult>(arena, *from._impl_.action_server_result_);
+    } else {
+      _this->_impl_.action_server_result_->MergeFrom(*from._impl_.action_server_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SetArmedStateResponse::CopyFrom(const SetArmedStateResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action_server.SetArmedStateResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void SetArmedStateResponse::InternalSwap(SetArmedStateResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.action_server_result_, other->_impl_.action_server_result_);
+}
+
+::google::protobuf::Metadata SetArmedStateResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SetFlightModeResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<SetFlightModeResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(SetFlightModeResponse, _impl_._has_bits_);
+};
+
+SetFlightModeResponse::SetFlightModeResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.action_server.SetFlightModeResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE SetFlightModeResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::action_server::SetFlightModeResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+SetFlightModeResponse::SetFlightModeResponse(
+    ::google::protobuf::Arena* arena,
+    const SetFlightModeResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SetFlightModeResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.action_server_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::action_server::ActionServerResult>(
+                              arena, *from._impl_.action_server_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.action_server.SetFlightModeResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE SetFlightModeResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void SetFlightModeResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.action_server_result_ = {};
+}
+SetFlightModeResponse::~SetFlightModeResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.action_server.SetFlightModeResponse)
+  SharedDtor(*this);
+}
+inline void SetFlightModeResponse::SharedDtor(MessageLite& self) {
+  SetFlightModeResponse& this_ = static_cast<SetFlightModeResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.action_server_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* SetFlightModeResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SetFlightModeResponse(arena);
+}
+constexpr auto SetFlightModeResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SetFlightModeResponse),
+                                            alignof(SetFlightModeResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SetFlightModeResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SetFlightModeResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SetFlightModeResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<SetFlightModeResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SetFlightModeResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<SetFlightModeResponse>(), &SetFlightModeResponse::ByteSizeLong,
+            &SetFlightModeResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SetFlightModeResponse, _impl_._cached_size_),
+        false,
+    },
+    &SetFlightModeResponse::kDescriptorMethods,
+    &descriptor_table_action_5fserver_2faction_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SetFlightModeResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> SetFlightModeResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(SetFlightModeResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::action_server::SetFlightModeResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.action_server.ActionServerResult action_server_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(SetFlightModeResponse, _impl_.action_server_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.action_server.ActionServerResult action_server_result = 1;
+    {PROTOBUF_FIELD_OFFSET(SetFlightModeResponse, _impl_.action_server_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::action_server::ActionServerResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void SetFlightModeResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action_server.SetFlightModeResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.action_server_result_ != nullptr);
+    _impl_.action_server_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* SetFlightModeResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const SetFlightModeResponse& this_ = static_cast<const SetFlightModeResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* SetFlightModeResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const SetFlightModeResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action_server.SetFlightModeResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.action_server.ActionServerResult action_server_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.action_server_result_, this_._impl_.action_server_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action_server.SetFlightModeResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t SetFlightModeResponse::ByteSizeLong(const MessageLite& base) {
+          const SetFlightModeResponse& this_ = static_cast<const SetFlightModeResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t SetFlightModeResponse::ByteSizeLong() const {
+          const SetFlightModeResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action_server.SetFlightModeResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.action_server.ActionServerResult action_server_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.action_server_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void SetFlightModeResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<SetFlightModeResponse*>(&to_msg);
+  auto& from = static_cast<const SetFlightModeResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action_server.SetFlightModeResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.action_server_result_ != nullptr);
+    if (_this->_impl_.action_server_result_ == nullptr) {
+      _this->_impl_.action_server_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::action_server::ActionServerResult>(arena, *from._impl_.action_server_result_);
+    } else {
+      _this->_impl_.action_server_result_->MergeFrom(*from._impl_.action_server_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SetFlightModeResponse::CopyFrom(const SetFlightModeResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action_server.SetFlightModeResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void SetFlightModeResponse::InternalSwap(SetFlightModeResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.action_server_result_, other->_impl_.action_server_result_);
+}
+
+::google::protobuf::Metadata SetFlightModeResponse::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================

--- a/src/mavsdk_server/src/generated/action_server/action_server.pb.h
+++ b/src/mavsdk_server/src/generated/action_server/action_server.pb.h
@@ -102,12 +102,24 @@ extern SetArmableRequestDefaultTypeInternal _SetArmableRequest_default_instance_
 class SetArmableResponse;
 struct SetArmableResponseDefaultTypeInternal;
 extern SetArmableResponseDefaultTypeInternal _SetArmableResponse_default_instance_;
+class SetArmedStateRequest;
+struct SetArmedStateRequestDefaultTypeInternal;
+extern SetArmedStateRequestDefaultTypeInternal _SetArmedStateRequest_default_instance_;
+class SetArmedStateResponse;
+struct SetArmedStateResponseDefaultTypeInternal;
+extern SetArmedStateResponseDefaultTypeInternal _SetArmedStateResponse_default_instance_;
 class SetDisarmableRequest;
 struct SetDisarmableRequestDefaultTypeInternal;
 extern SetDisarmableRequestDefaultTypeInternal _SetDisarmableRequest_default_instance_;
 class SetDisarmableResponse;
 struct SetDisarmableResponseDefaultTypeInternal;
 extern SetDisarmableResponseDefaultTypeInternal _SetDisarmableResponse_default_instance_;
+class SetFlightModeRequest;
+struct SetFlightModeRequestDefaultTypeInternal;
+extern SetFlightModeRequestDefaultTypeInternal _SetFlightModeRequest_default_instance_;
+class SetFlightModeResponse;
+struct SetFlightModeResponseDefaultTypeInternal;
+extern SetFlightModeResponseDefaultTypeInternal _SetFlightModeResponse_default_instance_;
 class ShutdownResponse;
 struct ShutdownResponseDefaultTypeInternal;
 extern ShutdownResponseDefaultTypeInternal _ShutdownResponse_default_instance_;
@@ -303,7 +315,7 @@ class SubscribeTerminateRequest final
     return reinterpret_cast<const SubscribeTerminateRequest*>(
         &_SubscribeTerminateRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 11;
+  static constexpr int kIndexInFileMessages = 13;
   friend void swap(SubscribeTerminateRequest& a, SubscribeTerminateRequest& b) { a.Swap(&b); }
   inline void Swap(SubscribeTerminateRequest* other) {
     if (other == this) return;
@@ -449,7 +461,7 @@ class SubscribeTakeoffRequest final
     return reinterpret_cast<const SubscribeTakeoffRequest*>(
         &_SubscribeTakeoffRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 7;
+  static constexpr int kIndexInFileMessages = 9;
   friend void swap(SubscribeTakeoffRequest& a, SubscribeTakeoffRequest& b) { a.Swap(&b); }
   inline void Swap(SubscribeTakeoffRequest* other) {
     if (other == this) return;
@@ -595,7 +607,7 @@ class SubscribeShutdownRequest final
     return reinterpret_cast<const SubscribeShutdownRequest*>(
         &_SubscribeShutdownRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 10;
+  static constexpr int kIndexInFileMessages = 12;
   friend void swap(SubscribeShutdownRequest& a, SubscribeShutdownRequest& b) { a.Swap(&b); }
   inline void Swap(SubscribeShutdownRequest* other) {
     if (other == this) return;
@@ -741,7 +753,7 @@ class SubscribeRebootRequest final
     return reinterpret_cast<const SubscribeRebootRequest*>(
         &_SubscribeRebootRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 9;
+  static constexpr int kIndexInFileMessages = 11;
   friend void swap(SubscribeRebootRequest& a, SubscribeRebootRequest& b) { a.Swap(&b); }
   inline void Swap(SubscribeRebootRequest* other) {
     if (other == this) return;
@@ -887,7 +899,7 @@ class SubscribeLandRequest final
     return reinterpret_cast<const SubscribeLandRequest*>(
         &_SubscribeLandRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 8;
+  static constexpr int kIndexInFileMessages = 10;
   friend void swap(SubscribeLandRequest& a, SubscribeLandRequest& b) { a.Swap(&b); }
   inline void Swap(SubscribeLandRequest* other) {
     if (other == this) return;
@@ -1033,7 +1045,7 @@ class SubscribeFlightModeChangeRequest final
     return reinterpret_cast<const SubscribeFlightModeChangeRequest*>(
         &_SubscribeFlightModeChangeRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 6;
+  static constexpr int kIndexInFileMessages = 8;
   friend void swap(SubscribeFlightModeChangeRequest& a, SubscribeFlightModeChangeRequest& b) { a.Swap(&b); }
   inline void Swap(SubscribeFlightModeChangeRequest* other) {
     if (other == this) return;
@@ -1179,7 +1191,7 @@ class SubscribeArmDisarmRequest final
     return reinterpret_cast<const SubscribeArmDisarmRequest*>(
         &_SubscribeArmDisarmRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 5;
+  static constexpr int kIndexInFileMessages = 7;
   friend void swap(SubscribeArmDisarmRequest& a, SubscribeArmDisarmRequest& b) { a.Swap(&b); }
   inline void Swap(SubscribeArmDisarmRequest* other) {
     if (other == this) return;
@@ -1262,6 +1274,197 @@ class SubscribeArmDisarmRequest final
                           const SubscribeArmDisarmRequest& from_msg);
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
+  friend struct ::TableStruct_action_5fserver_2faction_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SetFlightModeRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.action_server.SetFlightModeRequest) */ {
+ public:
+  inline SetFlightModeRequest() : SetFlightModeRequest(nullptr) {}
+  ~SetFlightModeRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SetFlightModeRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SetFlightModeRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SetFlightModeRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SetFlightModeRequest(const SetFlightModeRequest& from) : SetFlightModeRequest(nullptr, from) {}
+  inline SetFlightModeRequest(SetFlightModeRequest&& from) noexcept
+      : SetFlightModeRequest(nullptr, std::move(from)) {}
+  inline SetFlightModeRequest& operator=(const SetFlightModeRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetFlightModeRequest& operator=(SetFlightModeRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SetFlightModeRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SetFlightModeRequest* internal_default_instance() {
+    return reinterpret_cast<const SetFlightModeRequest*>(
+        &_SetFlightModeRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 5;
+  friend void swap(SetFlightModeRequest& a, SetFlightModeRequest& b) { a.Swap(&b); }
+  inline void Swap(SetFlightModeRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetFlightModeRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SetFlightModeRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<SetFlightModeRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const SetFlightModeRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const SetFlightModeRequest& from) { SetFlightModeRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(SetFlightModeRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.action_server.SetFlightModeRequest"; }
+
+ protected:
+  explicit SetFlightModeRequest(::google::protobuf::Arena* arena);
+  SetFlightModeRequest(::google::protobuf::Arena* arena, const SetFlightModeRequest& from);
+  SetFlightModeRequest(::google::protobuf::Arena* arena, SetFlightModeRequest&& from) noexcept
+      : SetFlightModeRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kFlightModeFieldNumber = 1,
+  };
+  // .mavsdk.rpc.action_server.FlightMode flight_mode = 1;
+  void clear_flight_mode() ;
+  ::mavsdk::rpc::action_server::FlightMode flight_mode() const;
+  void set_flight_mode(::mavsdk::rpc::action_server::FlightMode value);
+
+  private:
+  ::mavsdk::rpc::action_server::FlightMode _internal_flight_mode() const;
+  void _internal_set_flight_mode(::mavsdk::rpc::action_server::FlightMode value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action_server.SetFlightModeRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SetFlightModeRequest& from_msg);
+    int flight_mode_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
   friend struct ::TableStruct_action_5fserver_2faction_5fserver_2eproto;
 };
 // -------------------------------------------------------------------
@@ -1461,6 +1664,197 @@ class SetDisarmableRequest final
                           const SetDisarmableRequest& from_msg);
     bool disarmable_;
     bool force_disarmable_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_action_5fserver_2faction_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SetArmedStateRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.action_server.SetArmedStateRequest) */ {
+ public:
+  inline SetArmedStateRequest() : SetArmedStateRequest(nullptr) {}
+  ~SetArmedStateRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SetArmedStateRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SetArmedStateRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SetArmedStateRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SetArmedStateRequest(const SetArmedStateRequest& from) : SetArmedStateRequest(nullptr, from) {}
+  inline SetArmedStateRequest(SetArmedStateRequest&& from) noexcept
+      : SetArmedStateRequest(nullptr, std::move(from)) {}
+  inline SetArmedStateRequest& operator=(const SetArmedStateRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetArmedStateRequest& operator=(SetArmedStateRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SetArmedStateRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SetArmedStateRequest* internal_default_instance() {
+    return reinterpret_cast<const SetArmedStateRequest*>(
+        &_SetArmedStateRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 4;
+  friend void swap(SetArmedStateRequest& a, SetArmedStateRequest& b) { a.Swap(&b); }
+  inline void Swap(SetArmedStateRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetArmedStateRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SetArmedStateRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<SetArmedStateRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const SetArmedStateRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const SetArmedStateRequest& from) { SetArmedStateRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(SetArmedStateRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.action_server.SetArmedStateRequest"; }
+
+ protected:
+  explicit SetArmedStateRequest(::google::protobuf::Arena* arena);
+  SetArmedStateRequest(::google::protobuf::Arena* arena, const SetArmedStateRequest& from);
+  SetArmedStateRequest(::google::protobuf::Arena* arena, SetArmedStateRequest&& from) noexcept
+      : SetArmedStateRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kIsArmedFieldNumber = 1,
+  };
+  // bool is_armed = 1;
+  void clear_is_armed() ;
+  bool is_armed() const;
+  void set_is_armed(bool value);
+
+  private:
+  bool _internal_is_armed() const;
+  void _internal_set_is_armed(bool value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action_server.SetArmedStateRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SetArmedStateRequest& from_msg);
+    bool is_armed_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
@@ -1922,7 +2316,7 @@ class GetAllowableFlightModesRequest final
     return reinterpret_cast<const GetAllowableFlightModesRequest*>(
         &_GetAllowableFlightModesRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 4;
+  static constexpr int kIndexInFileMessages = 6;
   friend void swap(GetAllowableFlightModesRequest& a, GetAllowableFlightModesRequest& b) { a.Swap(&b); }
   inline void Swap(GetAllowableFlightModesRequest* other) {
     if (other == this) return;
@@ -2069,7 +2463,7 @@ class ArmDisarm final
     return reinterpret_cast<const ArmDisarm*>(
         &_ArmDisarm_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 25;
+  static constexpr int kIndexInFileMessages = 29;
   friend void swap(ArmDisarm& a, ArmDisarm& b) { a.Swap(&b); }
   inline void Swap(ArmDisarm* other) {
     if (other == this) return;
@@ -2272,7 +2666,7 @@ class AllowableFlightModes final
     return reinterpret_cast<const AllowableFlightModes*>(
         &_AllowableFlightModes_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 24;
+  static constexpr int kIndexInFileMessages = 28;
   friend void swap(AllowableFlightModes& a, AllowableFlightModes& b) { a.Swap(&b); }
   inline void Swap(AllowableFlightModes* other) {
     if (other == this) return;
@@ -2487,7 +2881,7 @@ class ActionServerResult final
     return reinterpret_cast<const ActionServerResult*>(
         &_ActionServerResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 26;
+  static constexpr int kIndexInFileMessages = 30;
   friend void swap(ActionServerResult& a, ActionServerResult& b) { a.Swap(&b); }
   inline void Swap(ActionServerResult* other) {
     if (other == this) return;
@@ -2726,7 +3120,7 @@ class TerminateResponse final
     return reinterpret_cast<const TerminateResponse*>(
         &_TerminateResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 18;
+  static constexpr int kIndexInFileMessages = 20;
   friend void swap(TerminateResponse& a, TerminateResponse& b) { a.Swap(&b); }
   inline void Swap(TerminateResponse* other) {
     if (other == this) return;
@@ -2935,7 +3329,7 @@ class TakeoffResponse final
     return reinterpret_cast<const TakeoffResponse*>(
         &_TakeoffResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 14;
+  static constexpr int kIndexInFileMessages = 16;
   friend void swap(TakeoffResponse& a, TakeoffResponse& b) { a.Swap(&b); }
   inline void Swap(TakeoffResponse* other) {
     if (other == this) return;
@@ -3144,7 +3538,7 @@ class ShutdownResponse final
     return reinterpret_cast<const ShutdownResponse*>(
         &_ShutdownResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 17;
+  static constexpr int kIndexInFileMessages = 19;
   friend void swap(ShutdownResponse& a, ShutdownResponse& b) { a.Swap(&b); }
   inline void Swap(ShutdownResponse* other) {
     if (other == this) return;
@@ -3293,6 +3687,203 @@ class ShutdownResponse final
 };
 // -------------------------------------------------------------------
 
+class SetFlightModeResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.action_server.SetFlightModeResponse) */ {
+ public:
+  inline SetFlightModeResponse() : SetFlightModeResponse(nullptr) {}
+  ~SetFlightModeResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SetFlightModeResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SetFlightModeResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SetFlightModeResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SetFlightModeResponse(const SetFlightModeResponse& from) : SetFlightModeResponse(nullptr, from) {}
+  inline SetFlightModeResponse(SetFlightModeResponse&& from) noexcept
+      : SetFlightModeResponse(nullptr, std::move(from)) {}
+  inline SetFlightModeResponse& operator=(const SetFlightModeResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetFlightModeResponse& operator=(SetFlightModeResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SetFlightModeResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SetFlightModeResponse* internal_default_instance() {
+    return reinterpret_cast<const SetFlightModeResponse*>(
+        &_SetFlightModeResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 27;
+  friend void swap(SetFlightModeResponse& a, SetFlightModeResponse& b) { a.Swap(&b); }
+  inline void Swap(SetFlightModeResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetFlightModeResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SetFlightModeResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<SetFlightModeResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const SetFlightModeResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const SetFlightModeResponse& from) { SetFlightModeResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(SetFlightModeResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.action_server.SetFlightModeResponse"; }
+
+ protected:
+  explicit SetFlightModeResponse(::google::protobuf::Arena* arena);
+  SetFlightModeResponse(::google::protobuf::Arena* arena, const SetFlightModeResponse& from);
+  SetFlightModeResponse(::google::protobuf::Arena* arena, SetFlightModeResponse&& from) noexcept
+      : SetFlightModeResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kActionServerResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.action_server.ActionServerResult action_server_result = 1;
+  bool has_action_server_result() const;
+  void clear_action_server_result() ;
+  const ::mavsdk::rpc::action_server::ActionServerResult& action_server_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::action_server::ActionServerResult* release_action_server_result();
+  ::mavsdk::rpc::action_server::ActionServerResult* mutable_action_server_result();
+  void set_allocated_action_server_result(::mavsdk::rpc::action_server::ActionServerResult* value);
+  void unsafe_arena_set_allocated_action_server_result(::mavsdk::rpc::action_server::ActionServerResult* value);
+  ::mavsdk::rpc::action_server::ActionServerResult* unsafe_arena_release_action_server_result();
+
+  private:
+  const ::mavsdk::rpc::action_server::ActionServerResult& _internal_action_server_result() const;
+  ::mavsdk::rpc::action_server::ActionServerResult* _internal_mutable_action_server_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action_server.SetFlightModeResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SetFlightModeResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::action_server::ActionServerResult* action_server_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_action_5fserver_2faction_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
 class SetDisarmableResponse final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action_server.SetDisarmableResponse) */ {
@@ -3353,7 +3944,7 @@ class SetDisarmableResponse final
     return reinterpret_cast<const SetDisarmableResponse*>(
         &_SetDisarmableResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 20;
+  static constexpr int kIndexInFileMessages = 22;
   friend void swap(SetDisarmableResponse& a, SetDisarmableResponse& b) { a.Swap(&b); }
   inline void Swap(SetDisarmableResponse* other) {
     if (other == this) return;
@@ -3490,6 +4081,203 @@ class SetDisarmableResponse final
 };
 // -------------------------------------------------------------------
 
+class SetArmedStateResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.action_server.SetArmedStateResponse) */ {
+ public:
+  inline SetArmedStateResponse() : SetArmedStateResponse(nullptr) {}
+  ~SetArmedStateResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SetArmedStateResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SetArmedStateResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SetArmedStateResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SetArmedStateResponse(const SetArmedStateResponse& from) : SetArmedStateResponse(nullptr, from) {}
+  inline SetArmedStateResponse(SetArmedStateResponse&& from) noexcept
+      : SetArmedStateResponse(nullptr, std::move(from)) {}
+  inline SetArmedStateResponse& operator=(const SetArmedStateResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetArmedStateResponse& operator=(SetArmedStateResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SetArmedStateResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SetArmedStateResponse* internal_default_instance() {
+    return reinterpret_cast<const SetArmedStateResponse*>(
+        &_SetArmedStateResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 26;
+  friend void swap(SetArmedStateResponse& a, SetArmedStateResponse& b) { a.Swap(&b); }
+  inline void Swap(SetArmedStateResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetArmedStateResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SetArmedStateResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<SetArmedStateResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const SetArmedStateResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const SetArmedStateResponse& from) { SetArmedStateResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(SetArmedStateResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.action_server.SetArmedStateResponse"; }
+
+ protected:
+  explicit SetArmedStateResponse(::google::protobuf::Arena* arena);
+  SetArmedStateResponse(::google::protobuf::Arena* arena, const SetArmedStateResponse& from);
+  SetArmedStateResponse(::google::protobuf::Arena* arena, SetArmedStateResponse&& from) noexcept
+      : SetArmedStateResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kActionServerResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.action_server.ActionServerResult action_server_result = 1;
+  bool has_action_server_result() const;
+  void clear_action_server_result() ;
+  const ::mavsdk::rpc::action_server::ActionServerResult& action_server_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::action_server::ActionServerResult* release_action_server_result();
+  ::mavsdk::rpc::action_server::ActionServerResult* mutable_action_server_result();
+  void set_allocated_action_server_result(::mavsdk::rpc::action_server::ActionServerResult* value);
+  void unsafe_arena_set_allocated_action_server_result(::mavsdk::rpc::action_server::ActionServerResult* value);
+  ::mavsdk::rpc::action_server::ActionServerResult* unsafe_arena_release_action_server_result();
+
+  private:
+  const ::mavsdk::rpc::action_server::ActionServerResult& _internal_action_server_result() const;
+  ::mavsdk::rpc::action_server::ActionServerResult* _internal_mutable_action_server_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action_server.SetArmedStateResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SetArmedStateResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::action_server::ActionServerResult* action_server_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_action_5fserver_2faction_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
 class SetArmableResponse final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action_server.SetArmableResponse) */ {
@@ -3550,7 +4338,7 @@ class SetArmableResponse final
     return reinterpret_cast<const SetArmableResponse*>(
         &_SetArmableResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 19;
+  static constexpr int kIndexInFileMessages = 21;
   friend void swap(SetArmableResponse& a, SetArmableResponse& b) { a.Swap(&b); }
   inline void Swap(SetArmableResponse* other) {
     if (other == this) return;
@@ -3747,7 +4535,7 @@ class SetAllowableFlightModesResponse final
     return reinterpret_cast<const SetAllowableFlightModesResponse*>(
         &_SetAllowableFlightModesResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 21;
+  static constexpr int kIndexInFileMessages = 23;
   friend void swap(SetAllowableFlightModesResponse& a, SetAllowableFlightModesResponse& b) { a.Swap(&b); }
   inline void Swap(SetAllowableFlightModesResponse* other) {
     if (other == this) return;
@@ -4141,7 +4929,7 @@ class SetAllowTakeoffResponse final
     return reinterpret_cast<const SetAllowTakeoffResponse*>(
         &_SetAllowTakeoffResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 22;
+  static constexpr int kIndexInFileMessages = 24;
   friend void swap(SetAllowTakeoffResponse& a, SetAllowTakeoffResponse& b) { a.Swap(&b); }
   inline void Swap(SetAllowTakeoffResponse* other) {
     if (other == this) return;
@@ -4338,7 +5126,7 @@ class RebootResponse final
     return reinterpret_cast<const RebootResponse*>(
         &_RebootResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 16;
+  static constexpr int kIndexInFileMessages = 18;
   friend void swap(RebootResponse& a, RebootResponse& b) { a.Swap(&b); }
   inline void Swap(RebootResponse* other) {
     if (other == this) return;
@@ -4547,7 +5335,7 @@ class LandResponse final
     return reinterpret_cast<const LandResponse*>(
         &_LandResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 15;
+  static constexpr int kIndexInFileMessages = 17;
   friend void swap(LandResponse& a, LandResponse& b) { a.Swap(&b); }
   inline void Swap(LandResponse* other) {
     if (other == this) return;
@@ -4756,7 +5544,7 @@ class GetAllowableFlightModesResponse final
     return reinterpret_cast<const GetAllowableFlightModesResponse*>(
         &_GetAllowableFlightModesResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 23;
+  static constexpr int kIndexInFileMessages = 25;
   friend void swap(GetAllowableFlightModesResponse& a, GetAllowableFlightModesResponse& b) { a.Swap(&b); }
   inline void Swap(GetAllowableFlightModesResponse* other) {
     if (other == this) return;
@@ -4953,7 +5741,7 @@ class FlightModeChangeResponse final
     return reinterpret_cast<const FlightModeChangeResponse*>(
         &_FlightModeChangeResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 13;
+  static constexpr int kIndexInFileMessages = 15;
   friend void swap(FlightModeChangeResponse& a, FlightModeChangeResponse& b) { a.Swap(&b); }
   inline void Swap(FlightModeChangeResponse* other) {
     if (other == this) return;
@@ -5162,7 +5950,7 @@ class ArmDisarmResponse final
     return reinterpret_cast<const ArmDisarmResponse*>(
         &_ArmDisarmResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 12;
+  static constexpr int kIndexInFileMessages = 14;
   friend void swap(ArmDisarmResponse& a, ArmDisarmResponse& b) { a.Swap(&b); }
   inline void Swap(ArmDisarmResponse* other) {
     if (other == this) return;
@@ -5547,6 +6335,58 @@ inline void SetAllowableFlightModesRequest::set_allocated_flight_modes(::mavsdk:
 
   _impl_.flight_modes_ = reinterpret_cast<::mavsdk::rpc::action_server::AllowableFlightModes*>(value);
   // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.action_server.SetAllowableFlightModesRequest.flight_modes)
+}
+
+// -------------------------------------------------------------------
+
+// SetArmedStateRequest
+
+// bool is_armed = 1;
+inline void SetArmedStateRequest::clear_is_armed() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.is_armed_ = false;
+}
+inline bool SetArmedStateRequest::is_armed() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action_server.SetArmedStateRequest.is_armed)
+  return _internal_is_armed();
+}
+inline void SetArmedStateRequest::set_is_armed(bool value) {
+  _internal_set_is_armed(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.action_server.SetArmedStateRequest.is_armed)
+}
+inline bool SetArmedStateRequest::_internal_is_armed() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.is_armed_;
+}
+inline void SetArmedStateRequest::_internal_set_is_armed(bool value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.is_armed_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// SetFlightModeRequest
+
+// .mavsdk.rpc.action_server.FlightMode flight_mode = 1;
+inline void SetFlightModeRequest::clear_flight_mode() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.flight_mode_ = 0;
+}
+inline ::mavsdk::rpc::action_server::FlightMode SetFlightModeRequest::flight_mode() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action_server.SetFlightModeRequest.flight_mode)
+  return _internal_flight_mode();
+}
+inline void SetFlightModeRequest::set_flight_mode(::mavsdk::rpc::action_server::FlightMode value) {
+  _internal_set_flight_mode(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.action_server.SetFlightModeRequest.flight_mode)
+}
+inline ::mavsdk::rpc::action_server::FlightMode SetFlightModeRequest::_internal_flight_mode() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return static_cast<::mavsdk::rpc::action_server::FlightMode>(_impl_.flight_mode_);
+}
+inline void SetFlightModeRequest::_internal_set_flight_mode(::mavsdk::rpc::action_server::FlightMode value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.flight_mode_ = value;
 }
 
 // -------------------------------------------------------------------
@@ -7007,6 +7847,206 @@ inline void GetAllowableFlightModesResponse::set_allocated_flight_modes(::mavsdk
 
   _impl_.flight_modes_ = reinterpret_cast<::mavsdk::rpc::action_server::AllowableFlightModes*>(value);
   // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.action_server.GetAllowableFlightModesResponse.flight_modes)
+}
+
+// -------------------------------------------------------------------
+
+// SetArmedStateResponse
+
+// .mavsdk.rpc.action_server.ActionServerResult action_server_result = 1;
+inline bool SetArmedStateResponse::has_action_server_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.action_server_result_ != nullptr);
+  return value;
+}
+inline void SetArmedStateResponse::clear_action_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.action_server_result_ != nullptr) _impl_.action_server_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::action_server::ActionServerResult& SetArmedStateResponse::_internal_action_server_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::action_server::ActionServerResult* p = _impl_.action_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::action_server::ActionServerResult&>(::mavsdk::rpc::action_server::_ActionServerResult_default_instance_);
+}
+inline const ::mavsdk::rpc::action_server::ActionServerResult& SetArmedStateResponse::action_server_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action_server.SetArmedStateResponse.action_server_result)
+  return _internal_action_server_result();
+}
+inline void SetArmedStateResponse::unsafe_arena_set_allocated_action_server_result(::mavsdk::rpc::action_server::ActionServerResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.action_server_result_);
+  }
+  _impl_.action_server_result_ = reinterpret_cast<::mavsdk::rpc::action_server::ActionServerResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.action_server.SetArmedStateResponse.action_server_result)
+}
+inline ::mavsdk::rpc::action_server::ActionServerResult* SetArmedStateResponse::release_action_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::action_server::ActionServerResult* released = _impl_.action_server_result_;
+  _impl_.action_server_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::action_server::ActionServerResult* SetArmedStateResponse::unsafe_arena_release_action_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.action_server.SetArmedStateResponse.action_server_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::action_server::ActionServerResult* temp = _impl_.action_server_result_;
+  _impl_.action_server_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::action_server::ActionServerResult* SetArmedStateResponse::_internal_mutable_action_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.action_server_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::action_server::ActionServerResult>(GetArena());
+    _impl_.action_server_result_ = reinterpret_cast<::mavsdk::rpc::action_server::ActionServerResult*>(p);
+  }
+  return _impl_.action_server_result_;
+}
+inline ::mavsdk::rpc::action_server::ActionServerResult* SetArmedStateResponse::mutable_action_server_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::action_server::ActionServerResult* _msg = _internal_mutable_action_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.action_server.SetArmedStateResponse.action_server_result)
+  return _msg;
+}
+inline void SetArmedStateResponse::set_allocated_action_server_result(::mavsdk::rpc::action_server::ActionServerResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.action_server_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.action_server_result_ = reinterpret_cast<::mavsdk::rpc::action_server::ActionServerResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.action_server.SetArmedStateResponse.action_server_result)
+}
+
+// -------------------------------------------------------------------
+
+// SetFlightModeResponse
+
+// .mavsdk.rpc.action_server.ActionServerResult action_server_result = 1;
+inline bool SetFlightModeResponse::has_action_server_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.action_server_result_ != nullptr);
+  return value;
+}
+inline void SetFlightModeResponse::clear_action_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.action_server_result_ != nullptr) _impl_.action_server_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::action_server::ActionServerResult& SetFlightModeResponse::_internal_action_server_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::action_server::ActionServerResult* p = _impl_.action_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::action_server::ActionServerResult&>(::mavsdk::rpc::action_server::_ActionServerResult_default_instance_);
+}
+inline const ::mavsdk::rpc::action_server::ActionServerResult& SetFlightModeResponse::action_server_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action_server.SetFlightModeResponse.action_server_result)
+  return _internal_action_server_result();
+}
+inline void SetFlightModeResponse::unsafe_arena_set_allocated_action_server_result(::mavsdk::rpc::action_server::ActionServerResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.action_server_result_);
+  }
+  _impl_.action_server_result_ = reinterpret_cast<::mavsdk::rpc::action_server::ActionServerResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.action_server.SetFlightModeResponse.action_server_result)
+}
+inline ::mavsdk::rpc::action_server::ActionServerResult* SetFlightModeResponse::release_action_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::action_server::ActionServerResult* released = _impl_.action_server_result_;
+  _impl_.action_server_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::action_server::ActionServerResult* SetFlightModeResponse::unsafe_arena_release_action_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.action_server.SetFlightModeResponse.action_server_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::action_server::ActionServerResult* temp = _impl_.action_server_result_;
+  _impl_.action_server_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::action_server::ActionServerResult* SetFlightModeResponse::_internal_mutable_action_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.action_server_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::action_server::ActionServerResult>(GetArena());
+    _impl_.action_server_result_ = reinterpret_cast<::mavsdk::rpc::action_server::ActionServerResult*>(p);
+  }
+  return _impl_.action_server_result_;
+}
+inline ::mavsdk::rpc::action_server::ActionServerResult* SetFlightModeResponse::mutable_action_server_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::action_server::ActionServerResult* _msg = _internal_mutable_action_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.action_server.SetFlightModeResponse.action_server_result)
+  return _msg;
+}
+inline void SetFlightModeResponse::set_allocated_action_server_result(::mavsdk::rpc::action_server::ActionServerResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.action_server_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.action_server_result_ = reinterpret_cast<::mavsdk::rpc::action_server::ActionServerResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.action_server.SetFlightModeResponse.action_server_result)
 }
 
 // -------------------------------------------------------------------

--- a/src/mavsdk_server/src/plugins/action_server/action_server_service_impl.h
+++ b/src/mavsdk_server/src/plugins/action_server/action_server_service_impl.h
@@ -787,6 +787,67 @@ public:
         return grpc::Status::OK;
     }
 
+    grpc::Status SetArmedState(
+        grpc::ServerContext* /* context */,
+        const rpc::action_server::SetArmedStateRequest* request,
+        rpc::action_server::SetArmedStateResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            if (response != nullptr) {
+                // For server plugins, this should never happen, they should always be
+                // constructible.
+                auto result = mavsdk::ActionServer::Result::Unknown;
+                fillResponseWithResult(response, result);
+            }
+
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn() << "SetArmedState sent with a null request! Ignoring...";
+            return grpc::Status::OK;
+        }
+
+        auto result = _lazy_plugin.maybe_plugin()->set_armed_state(request->is_armed());
+
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status SetFlightMode(
+        grpc::ServerContext* /* context */,
+        const rpc::action_server::SetFlightModeRequest* request,
+        rpc::action_server::SetFlightModeResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            if (response != nullptr) {
+                // For server plugins, this should never happen, they should always be
+                // constructible.
+                auto result = mavsdk::ActionServer::Result::Unknown;
+                fillResponseWithResult(response, result);
+            }
+
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn() << "SetFlightMode sent with a null request! Ignoring...";
+            return grpc::Status::OK;
+        }
+
+        auto result = _lazy_plugin.maybe_plugin()->set_flight_mode(
+            translateFromRpcFlightMode(request->flight_mode()));
+
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+
+        return grpc::Status::OK;
+    }
+
     void stop()
     {
         _stopped.store(true);


### PR DESCRIPTION
# Summary
SDK changes to implement the interface provided in the corresponding [proto PR](https://github.com/mavlink/MAVSDK-Proto/pull/370). Testing continues to be done using QGroundControl to provide visibility into vehicle mode changes.

It's worth noting that there is probably a broad class of state changes like this that could use public APIs. I've opted to keep the scope constrained and focus only on the most essential information for now.