### PR TITLE
Update dockcross

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -395,7 +395,7 @@ jobs:
         with:
           submodules: recursive
       - name: setup dockcross
-        run: docker run --rm dockcross/${{ matrix.arch_name }}:20250225-b7f8ddd > ./dockcross-${{ matrix.arch_name }}; chmod +x ./dockcross-${{ matrix.arch_name }}
+        run: docker run --rm dockcross/${{ matrix.arch_name }}:20250311-4bd0eec > ./dockcross-${{ matrix.arch_name }}; chmod +x ./dockcross-${{ matrix.arch_name }}
       - uses: actions/cache@v4
         id: cache
         with:
@@ -438,7 +438,7 @@ jobs:
         with:
           submodules: recursive
       - name: setup dockcross
-        run: docker run --rm dockcross/${{ matrix.name }}:20250225-b7f8ddd > ./dockcross-${{ matrix.name }}; chmod +x ./dockcross-${{ matrix.name }}
+        run: docker run --rm dockcross/${{ matrix.name }}:20250311-4bd0eec > ./dockcross-${{ matrix.name }}; chmod +x ./dockcross-${{ matrix.name }}
       - uses: actions/cache@v4
         id: cache
         with:


### PR DESCRIPTION
This contains a fix that should prevent cmake from finding system libraries (e.g. finding openssl on the system instead of the cross-compiled one).