### PR TITLE
Remove clunky iterator_invalidated flags

### DIFF
--- a/src/mavsdk/core/call_every_handler.h
+++ b/src/mavsdk/core/call_every_handler.h
@@ -39,7 +39,6 @@ private:
 
     std::vector<Entry> _entries{};
     std::mutex _entries_mutex{};
-    bool _iterator_invalidated{false};
 
     Time& _time;
 

--- a/src/mavsdk/core/timeout_handler.h
+++ b/src/mavsdk/core/timeout_handler.h
@@ -39,7 +39,6 @@ private:
 
     std::vector<Timeout> _timeouts{};
     std::mutex _timeouts_mutex{};
-    bool _iterator_invalidated{false};
 
     Time& _time;
 


### PR DESCRIPTION
This is an improvement to avoid having to invalidate the iterator. Instead we copy out all callbacks, release the lock, and then call them.