### PR TITLE
telem: remove periodic request HOME_POSITION

### DIFF
--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -191,35 +191,9 @@ void TelemetryImpl::deinit()
     _system_impl->unregister_all_mavlink_message_handlers(this);
 }
 
-void TelemetryImpl::enable()
-{
-    // We're going to retry until we have the Home Position.
-    _homepos_cookie =
-        _system_impl->add_call_every([this]() { request_home_position_again(); }, 2.0f);
-}
+void TelemetryImpl::enable() {}
 
-void TelemetryImpl::disable()
-{
-    _system_impl->remove_call_every(_homepos_cookie);
-    {
-        std::lock_guard<std::mutex> lock(_health_mutex);
-        _health.is_home_position_ok = false;
-    }
-}
-
-void TelemetryImpl::request_home_position_again()
-{
-    {
-        std::lock_guard<std::mutex> lock(_health_mutex);
-        if (_health.is_home_position_ok) {
-            _system_impl->remove_call_every(_homepos_cookie);
-            return;
-        }
-
-        _system_impl->mavlink_request_message().request(
-            MAVLINK_MSG_ID_HOME_POSITION, MAV_COMP_ID_AUTOPILOT1, nullptr);
-    }
-}
+void TelemetryImpl::disable() {}
 
 Telemetry::Result TelemetryImpl::set_rate_position_velocity_ned(double rate_hz)
 {

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -191,9 +191,15 @@ void TelemetryImpl::deinit()
     _system_impl->unregister_all_mavlink_message_handlers(this);
 }
 
-void TelemetryImpl::enable() {}
+void TelemetryImpl::enable()
+{
+    // Nothing to do
+}
 
-void TelemetryImpl::disable() {}
+void TelemetryImpl::disable()
+{
+    // Nothing to do
+}
 
 Telemetry::Result TelemetryImpl::set_rate_position_velocity_ned(double rate_hz)
 {

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.h
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.h
@@ -266,8 +266,6 @@ private:
 
     void receive_statustext(const MavlinkStatustextHandler::Statustext&);
 
-    void request_home_position_again();
-
     static bool sys_status_present_enabled_health(
         const mavlink_sys_status_t& sys_status, MAV_SYS_STATUS_SENSOR flag);
 
@@ -418,8 +416,6 @@ private:
     // Battery info can be extracted from SYS_STATUS or from BATTERY_STATUS.
     // If no BATTERY_STATUS messages are received, use info from SYS_STATUS.
     bool _has_bat_status{false};
-
-    CallEveryHandler::Cookie _homepos_cookie{};
 
     Telemetry::EulerAngle extractOrientation(mavlink_distance_sensor_t distance_sensor_msg);
 


### PR DESCRIPTION
PX4 already streams the HOME_POSITION message at 0.5Hz. When MAVSDK is used with a system that does not have a GPS the home position is never set, and therefore this periodic message request results in log spam.

This is basically just reverting https://github.com/mavlink/MAVSDK/pull/1816