### PR TITLE
cmake: bump to 3.5

### DIFF
--- a/third_party/absl/CMakeLists.txt
+++ b/third_party/absl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(external-absl)
 include(ExternalProject)

--- a/third_party/cares/CMakeLists.txt
+++ b/third_party/cares/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(external-cares)
 include(ExternalProject)

--- a/third_party/cpptrace/CMakeLists.txt
+++ b/third_party/cpptrace/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(external-cpptrace)
 include(ExternalProject)

--- a/third_party/curl/CMakeLists.txt
+++ b/third_party/curl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(external-curl)
 include(ExternalProject)

--- a/third_party/grpc/CMakeLists.txt
+++ b/third_party/grpc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(external-grpc)
 include(ExternalProject)

--- a/third_party/gtest/CMakeLists.txt
+++ b/third_party/gtest/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(external-gtest)
 include(ExternalProject)

--- a/third_party/jsoncpp/CMakeLists.txt
+++ b/third_party/jsoncpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(external-jsoncpp)
 include(ExternalProject)

--- a/third_party/liblzma/CMakeLists.txt
+++ b/third_party/liblzma/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(external-liblzma)
 include(ExternalProject)

--- a/third_party/openssl/CMakeLists.txt
+++ b/third_party/openssl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(external-openssl)
 include(ExternalProject)

--- a/third_party/protobuf/CMakeLists.txt
+++ b/third_party/protobuf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(external-protobuf)
 include(ExternalProject)

--- a/third_party/re2/CMakeLists.txt
+++ b/third_party/re2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(external-re2)
 include(ExternalProject)

--- a/third_party/tinyxml2/CMakeLists.txt
+++ b/third_party/tinyxml2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(external-tinyxml2)
 include(ExternalProject)

--- a/third_party/zlib-ng/CMakeLists.txt
+++ b/third_party/zlib-ng/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(external-zlib-ng)
 include(ExternalProject)

--- a/third_party/zlib/CMakeLists.txt
+++ b/third_party/zlib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(external-zlib)
 include(ExternalProject)


### PR DESCRIPTION
With CMake 4 compatibility with versions <3.5 has been removed. Fixes this error: 

> Compatibility with CMake < 3.5 has been removed from CMake