### PR TITLE
Rollback to older dockcross

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -395,7 +395,7 @@ jobs:
         with:
           submodules: recursive
       - name: setup dockcross
-        run: docker run --rm dockcross/${{ matrix.arch_name }}:20250311-4bd0eec > ./dockcross-${{ matrix.arch_name }}; chmod +x ./dockcross-${{ matrix.arch_name }}
+        run: docker run --rm dockcross/${{ matrix.arch_name }}:20250109-7bf589c > ./dockcross-${{ matrix.arch_name }}; chmod +x ./dockcross-${{ matrix.arch_name }}
       - uses: actions/cache@v4
         id: cache
         with:
@@ -438,7 +438,7 @@ jobs:
         with:
           submodules: recursive
       - name: setup dockcross
-        run: docker run --rm dockcross/${{ matrix.name }}:20250311-4bd0eec > ./dockcross-${{ matrix.name }}; chmod +x ./dockcross-${{ matrix.name }}
+        run: docker run --rm dockcross/${{ matrix.name }}:20250109-7bf589c > ./dockcross-${{ matrix.name }}; chmod +x ./dockcross-${{ matrix.name }}
       - uses: actions/cache@v4
         id: cache
         with:


### PR DESCRIPTION
Trying to understand what's happening in https://github.com/mavlink/MAVSDK/pull/2531 and https://github.com/mavlink/MAVSDK/pull/2530 :thinking: 

It seems like the recent dockcross releases have broken our builds. I thought I had fixed it, but apparently not completely. It works well with the dependencies, but it has issues when coming to the main project.

I would suggest we use a dockcross from 3 months ago until I get time to investigate and fix this.