### PR TITLE
takeoff and land prolblem while running has solved

### DIFF
--- a/examples/takeoff_and_land/takeoff_and_land.cpp
+++ b/examples/takeoff_and_land/takeoff_and_land.cpp
@@ -66,7 +66,7 @@ int main(int argc, char** argv)
     });
 
     // Check until vehicle is ready to arm
-    while (telemetry.health_all_ok() != true) {
+    if (telemetry.health_all_ok() != true) {
         std::cout << "Vehicle is getting ready to arm\n";
         sleep_for(seconds(1));
     }


### PR DESCRIPTION
Issue:
When running the takeoff_and_land example while connected to the simulator, the code froze at line 68 and failed to issue the takeoff command. Only the message "Vehicle is getting ready to arm" was printed repeatedly.

Fix:
Replacing the while loop with an if condition resolved the issue.

Key Technical Details:
Original Problem:

The blocking while loop likely waited indefinitely for a state change that never occurred (e.g., stuck in PREFLIGHT mode).

Common causes:

Simulator (jMAVSim)

Solution Rationale:

if checks the condition once, avoiding deadlocks.

Better practice: Add a timeout or state machine for robustness.

Code Example (Before/After):

// Before (Problematic)
// Check until vehicle is ready to arm
    while (telemetry.health_all_ok() != true) {
        std::cout << "Vehicle is getting ready to arm\n";
        sleep_for(seconds(1));
    }

// After (Fixed)
// Check until vehicle is ready to arm
    if (telemetry.health_all_ok() != true) {
        std::cout << "Vehicle is getting ready to arm\n";
        sleep_for(seconds(1));
    }