### PR TITLE
mission_raw: fix mission import for mission commands

### DIFF
--- a/src/mavsdk/plugins/mission_raw/mission_import.h
+++ b/src/mavsdk/plugins/mission_raw/mission_import.h
@@ -32,7 +32,7 @@ private:
     static std::vector<MissionRaw::MissionItem>
     import_circular_geofences(const Json::Value& json_item);
     static float set_float(const Json::Value& val);
-    static int32_t set_int32(const Json::Value& val);
+    static int32_t set_int32(const Json::Value& val, uint32_t frame);
 };
 
 } // namespace mavsdk

--- a/src/mavsdk/plugins/mission_raw/mission_import_test.cpp
+++ b/src/mavsdk/plugins/mission_raw/mission_import_test.cpp
@@ -441,3 +441,33 @@ TEST(MissionRaw, ImportSamplePlanWithArduPilot)
 
     EXPECT_EQ(reference_items, result_pair.second.mission_items);
 }
+
+TEST(MissionRaw, ImportSamplePlanWithDigicamControl)
+{
+    auto digicam_control_items = std::vector<MissionRaw::MissionItem>{
+        {0,
+         MAV_FRAME_MISSION,
+         MAV_CMD_DO_DIGICAM_CONTROL,
+         1, // current
+         1, // autocontinue
+         1,
+         0,
+         0,
+         0,
+         1,
+         0,
+         0,
+         MAV_MISSION_TYPE_MISSION}};
+
+    std::ifstream file{path_prefix("qgroundcontrol_sample_with_digicam_control.plan")};
+    ASSERT_TRUE(file);
+
+    std::stringstream buf;
+    buf << file.rdbuf();
+    file.close();
+
+    const auto result_pair = MissionImport::parse_json(buf.str(), Autopilot::Px4);
+    ASSERT_EQ(result_pair.first, MissionRaw::Result::Success);
+
+    EXPECT_EQ(digicam_control_items, result_pair.second.mission_items);
+}

--- a/src/mavsdk/plugins/mission_raw/test_plans/qgroundcontrol_sample_with_digicam_control.plan
+++ b/src/mavsdk/plugins/mission_raw/test_plans/qgroundcontrol_sample_with_digicam_control.plan
@@ -1,0 +1,48 @@
+{
+  "fileType": "Plan",
+  "geoFence": {
+    "circles": [],
+    "polygons": [],
+    "version": 2
+  },
+  "groundStation": "LiniaGenerator",
+  "mission": {
+    "cruiseSpeed": 10.0,
+    "firmwareType": 3,
+    "globalPlanAltitudeMode": 1,
+    "hoverSpeed": 10.0,
+    "items": [
+      {
+        "autoContinue": true,
+        "command": 203,
+        "doJumpId": 7,
+        "frame": 2,
+        "params": [
+          1,
+          0,
+          0,
+          0,
+          1,
+          0,
+          0
+        ],
+        "type": "SimpleItem",
+        "amslaltAboveTerrain": null,
+        "altitudeMode": null,
+        "altitude": null
+      }
+            ],
+    "vehicleType": 2,
+    "plannedHomePosition": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "version": 2
+  },
+  "rallyPoints": {
+    "points": [],
+    "version": 2
+  },
+  "version": 1
+}


### PR DESCRIPTION
We should only convert lat/lon values but not regular commands. We can tell by checking the mission item's frame.

Fixes #2543.