### PR TITLE
Fix manual control inverted r (yaw) axis

### DIFF
--- a/src/mavsdk_server/src/plugins/manual_control/manual_control_service_impl.h
+++ b/src/mavsdk_server/src/plugins/manual_control/manual_control_service_impl.h
@@ -165,7 +165,7 @@ public:
         }
 
         auto result = _lazy_plugin.maybe_plugin()->set_manual_control_input(
-            request->x(), request->y(), request->z(), request->r());
+            request->x(), request->y(), request->z(), -request->r());
 
         if (response != nullptr) {
             fillResponseWithResult(response, result);


### PR DESCRIPTION
Protobuf message definition is defined as positive +CW, -CCW: https://github.com/mavlink/MAVSDK-Proto/blob/main/protos/manual_control/manual_control.proto#L50

MAVLink message is defined as +CCW, -CW: https://mavlink.io/en/messages/common.html#MANUAL_CONTROL

Therefore, to respect both specifications, sign must be reversed.