### PR TITLE
Revert library packaging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -285,7 +285,7 @@ jobs:
           sudo apt-get install -y ruby-dev
           sudo gem install --no-document fpm
       - name: configure
-        run: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_MAVSDK_SERVER=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr/ -DWERROR=ON -Bbuild/release -H.
+        run: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_MAVSDK_SERVER=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=install -DWERROR=ON -Bbuild/release -H.
       - name: build
         run: cmake --build build/release -- -j2
       - name: install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -292,7 +292,7 @@ jobs:
         run: sudo cmake --build build/release --target install
       - name: Package
         if: startsWith(github.ref, 'refs/tags/v')
-        run: tools/create_packages.sh /usr/ . amd64 libmavsdk-dev
+        run: tools/create_packages.sh ./install . amd64 libmavsdk-dev
       - name: Publish artefacts
         if: startsWith(github.ref, 'refs/tags/v')
         uses: svenstaro/upload-release-action@v1-release


### PR DESCRIPTION
https://github.com/mavlink/MAVSDK/pull/2482 broke the .deb library generation.

See:
- 3.1.0: https://github.com/mavlink/MAVSDK/actions/runs/13861584250/job/38791176950: ./install is wrong
- 3.2.0: https://github.com/mavlink/MAVSDK/actions/runs/13934248046/job/40004713611: /usr/ runs out of disk space because it wants to package everything

I'm reverting these until we have a proper fix that doesn't want to package the whole system.