### PR TITLE
Add incoming and outgoing message queue, fixing threading/locking issues

### DIFF
--- a/src/mavsdk/core/mavsdk_impl.cpp
+++ b/src/mavsdk/core/mavsdk_impl.cpp
@@ -347,12 +347,10 @@ void MavsdkImpl::receive_message(mavlink_message_t& message, Connection* connect
 
 void MavsdkImpl::process_messages()
 {
-    std::unique_lock lock(_received_messages_mutex);
+    std::lock_guard lock(_received_messages_mutex);
     while (!_received_messages.empty()) {
         auto message_copied = _received_messages.front();
-        lock.unlock();
         process_message(message_copied.message, message_copied.connection_ptr);
-        lock.lock();
         _received_messages.pop();
     }
 }

--- a/src/mavsdk/core/mavsdk_impl.h
+++ b/src/mavsdk/core/mavsdk_impl.h
@@ -181,6 +181,7 @@ private:
     bool _callback_debugging{false};
     bool _system_debugging{false};
 
+    mutable std::mutex _intercept_callbacks_mutex{};
     std::function<bool(mavlink_message_t&)> _intercept_incoming_messages_callback{nullptr};
     std::function<bool(mavlink_message_t&)> _intercept_outgoing_messages_callback{nullptr};
 
@@ -197,6 +198,7 @@ private:
     std::queue<mavlink_message_t> _messages_to_send;
 
     static constexpr double HEARTBEAT_SEND_INTERVAL_S = 1.0;
+    std::mutex _heartbeat_mutex{};
     CallEveryHandler::Cookie _heartbeat_send_cookie{};
 
     std::atomic<bool> _should_exit = {false};

--- a/src/mavsdk/core/mavsdk_impl.h
+++ b/src/mavsdk/core/mavsdk_impl.h
@@ -193,6 +193,7 @@ private:
     };
     mutable std::mutex _received_messages_mutex{};
     std::queue<ReceivedMessage> _received_messages;
+    std::condition_variable _received_messages_cv{};
 
     mutable std::mutex _messages_to_send_mutex{};
     std::queue<mavlink_message_t> _messages_to_send;
@@ -201,7 +202,7 @@ private:
     std::mutex _heartbeat_mutex{};
     CallEveryHandler::Cookie _heartbeat_send_cookie{};
 
-    std::atomic<bool> _should_exit = {false};
+    std::atomic<bool> _should_exit{false};
 };
 
 } // namespace mavsdk

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -142,7 +142,6 @@ void SystemImpl::enable_timesync()
 System::IsConnectedHandle
 SystemImpl::subscribe_is_connected(const System::IsConnectedCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_connection_mutex);
     return _is_connected_callbacks.subscribe(callback);
 }
 
@@ -490,8 +489,6 @@ void SystemImpl::set_connected()
 {
     bool enable_needed = false;
     {
-        std::lock_guard<std::mutex> lock(_connection_mutex);
-
         if (!_connected) {
             if (!_components.empty()) {
                 LogDebug() << "Discovered " << _components.size() << " component(s)";
@@ -510,24 +507,32 @@ void SystemImpl::set_connected()
 
             enable_needed = true;
 
+            // Queue callbacks without holding any locks to avoid deadlocks
             _is_connected_callbacks.queue(
                 true, [this](const auto& func) { _mavsdk_impl.call_user_callback(func); });
 
         } else if (_connected) {
             refresh_timeout_handler(_heartbeat_timeout_cookie);
         }
-        // If not yet connected there is nothing to do/
+        // If not yet connected there is nothing to do
     }
 
     if (enable_needed) {
+        // Notify about the new system without holding any locks
         _mavsdk_impl.notify_on_discover();
 
         if (has_autopilot()) {
             send_autopilot_version_request();
         }
 
-        std::lock_guard<std::mutex> lock(_plugin_impls_mutex);
-        for (auto plugin_impl : _plugin_impls) {
+        // Enable plugins
+        std::vector<PluginImplBase*> plugin_impls_to_enable;
+        {
+            std::lock_guard<std::mutex> lock(_plugin_impls_mutex);
+            plugin_impls_to_enable = _plugin_impls;
+        }
+
+        for (auto plugin_impl : plugin_impls_to_enable) {
             plugin_impl->enable();
         }
     }
@@ -536,8 +541,6 @@ void SystemImpl::set_connected()
 void SystemImpl::set_disconnected()
 {
     {
-        std::lock_guard<std::mutex> lock(_connection_mutex);
-
         // This might not be needed because this is probably called from the triggered
         // timeout anyway, but it should also do no harm.
         // unregister_timeout_handler(_heartbeat_timeout_cookie);

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -496,11 +496,14 @@ void SystemImpl::set_connected()
 
             _connected = true;
 
-            // We call this later to avoid deadlocks on creating the server components.
-            _mavsdk_impl.call_user_callback([this]() {
-                // Send a heartbeat back immediately.
-                _mavsdk_impl.start_sending_heartbeats();
-            });
+            // Only send heartbeats if we're not shutting down
+            if (!_should_exit) {
+                // We call this later to avoid deadlocks on creating the server components.
+                _mavsdk_impl.call_user_callback([this]() {
+                    // Send a heartbeat back immediately.
+                    _mavsdk_impl.start_sending_heartbeats();
+                });
+            }
 
             _heartbeat_timeout_cookie =
                 register_timeout_handler([this] { heartbeats_timed_out(); }, HEARTBEAT_TIMEOUT_S);

--- a/src/mavsdk/core/system_impl.h
+++ b/src/mavsdk/core/system_impl.h
@@ -372,7 +372,6 @@ private:
 
     static constexpr double HEARTBEAT_TIMEOUT_S = 3.0;
 
-    std::mutex _connection_mutex{};
     std::atomic<bool> _connected{false};
     CallbackList<bool> _is_connected_callbacks{};
     TimeoutHandler::Cookie _heartbeat_timeout_cookie{};

--- a/src/mavsdk/plugins/camera/camera_impl.cpp
+++ b/src/mavsdk/plugins/camera/camera_impl.cpp
@@ -2543,7 +2543,7 @@ CameraImpl::PotentialCamera* CameraImpl::maybe_potential_camera_for_component_id
 
     const auto it = std::find_if(
         _potential_cameras.begin(), _potential_cameras.end(), [&](auto& potential_camera) {
-            return potential_camera.component_id = component_id;
+            return potential_camera.component_id == component_id;
         });
 
     if (it == _potential_cameras.end()) {

--- a/src/system_tests/ftp_upload_file.cpp
+++ b/src/system_tests/ftp_upload_file.cpp
@@ -227,7 +227,11 @@ TEST(SystemTest, FtpUploadStopAndTryAgain)
 
     // Once we received half, we want to stop all traffic.
     bool got_half = false;
-    auto drop_at_some_point = [&got_half](mavlink_message_t&) { return !got_half; };
+    std::mutex got_half_mutex;
+    auto drop_at_some_point = [&got_half, &got_half_mutex](mavlink_message_t&) {
+        std::lock_guard<std::mutex> lock(got_half_mutex);
+        return !got_half;
+    };
 
     mavsdk_groundstation.intercept_incoming_messages_async(drop_at_some_point);
     mavsdk_groundstation.intercept_outgoing_messages_async(drop_at_some_point);
@@ -256,8 +260,10 @@ TEST(SystemTest, FtpUploadStopAndTryAgain)
         ftp.upload_async(
             (temp_dir_to_upload / temp_file).string(),
             "",
-            [&prom, &got_half](Ftp::Result result, Ftp::ProgressData progress_data) {
+            [&prom, &got_half, &got_half_mutex](
+                Ftp::Result result, Ftp::ProgressData progress_data) {
                 if (progress_data.bytes_transferred > 500) {
+                    std::lock_guard<std::mutex> lock(got_half_mutex);
                     got_half = true;
                 }
                 if (result != Ftp::Result::Next) {


### PR DESCRIPTION
This is a bigger refactor where we no longer do work from the receiver threads but instead copy messages into a queue and work on them subsequently.

This is an attempt to prevent deadlocks where locks are acquired in different orders.

Additional, there are various small fixes to make all system and unit tests pass in address sanitizer and thread sanitizer.

I need to review this with fresh eyes again tomorrow.

Follow up to #2542 