### PR TITLE
core: don't remove explicit udpout remotes

### DIFF
--- a/src/mavsdk/core/mavsdk_impl.cpp
+++ b/src/mavsdk/core/mavsdk_impl.cpp
@@ -637,7 +637,7 @@ MavsdkImpl::add_udp_connection(const CliArg::Udp& udp, ForwardingOption forwardi
             return {ConnectionResult::DestinationIpUnknown, Mavsdk::ConnectionHandle{}};
         }
 
-        new_conn->add_remote(remote_ip.value(), udp.port);
+        new_conn->add_remote_to_keep(remote_ip.value(), udp.port);
         std::lock_guard lock(_mutex);
 
         // With a UDP remote, we need to initiate the connection by sending heartbeats.

--- a/src/mavsdk/core/udp_connection.h
+++ b/src/mavsdk/core/udp_connection.h
@@ -27,7 +27,7 @@ public:
 
     std::pair<bool, std::string> send_message(const mavlink_message_t& message) override;
 
-    void add_remote(const std::string& remote_ip, int remote_port);
+    void add_remote_to_keep(const std::string& remote_ip, int remote_port);
 
     // Non-copyable
     UdpConnection(const UdpConnection&) = delete;
@@ -39,8 +39,16 @@ private:
 
     void receive();
 
-    void add_remote_with_remote_sysid(
-        const std::string& remote_ip, int remote_port, uint8_t remote_sysid);
+    enum class RemoteOption {
+        Fixed,
+        Found,
+    };
+
+    void add_remote_impl(
+        const std::string& remote_ip,
+        int remote_port,
+        uint8_t remote_sysid,
+        RemoteOption remote_option);
 
     std::string _local_ip;
     int _local_port_number;
@@ -50,6 +58,7 @@ private:
         std::string ip{};
         int port_number{0};
         std::chrono::steady_clock::time_point last_activity{std::chrono::steady_clock::now()};
+        RemoteOption remote_option;
 
         bool operator==(const UdpConnection::Remote& other) const
         {


### PR DESCRIPTION
When we add a connection with udpout:// we should not remove that remote. Otherwise, we can basically only try to connect for 10s before the remote is removed and we're left without any way to communicate.

This is a cleanup after #2557.