### PR TITLE
gripper: send command to autopilot by default

### DIFF
--- a/src/mavsdk/plugins/gripper/gripper_impl.cpp
+++ b/src/mavsdk/plugins/gripper/gripper_impl.cpp
@@ -33,8 +33,6 @@ void GripperImpl::grab_async(uint32_t instance, const Gripper::ResultCallback ca
     command.params.maybe_param1 = static_cast<float>(instance);
     command.params.maybe_param2 = static_cast<float>(Gripper::GripperAction::Grab);
 
-    command.target_component_id = MAV_COMPONENT::MAV_COMP_ID_WINCH; // TODO
-
     _system_impl->send_command_async(
         command, [this, callback](MavlinkCommandSender::Result result, float) {
             command_result_callback(result, callback);
@@ -58,8 +56,6 @@ void GripperImpl::release_async(uint32_t instance, const Gripper::ResultCallback
     command.command = MAV_CMD_DO_GRIPPER;
     command.params.maybe_param1 = static_cast<float>(instance);
     command.params.maybe_param2 = static_cast<float>(Gripper::GripperAction::Release);
-
-    command.target_component_id = MAV_COMPONENT::MAV_COMP_ID_WINCH; // TODO
 
     _system_impl->send_command_async(
         command, [this, callback](MavlinkCommandSender::Result result, float) {


### PR DESCRIPTION
It's not obvious that this would go to a separate winch, so I'm removing this. Hopefully, this makes it work with PX4 like it does for QGC.

Ok with this @dakejahl?