### PR TITLE
Improve handling of mission finished

### DIFF
--- a/docs/en/cpp/api_reference/classmavsdk_1_1_mission_raw.md
+++ b/docs/en/cpp/api_reference/classmavsdk_1_1_mission_raw.md
@@ -69,6 +69,7 @@ void | [unsubscribe_mission_progress](#classmavsdk_1_1_mission_raw_1ac46f08b5270
 void | [unsubscribe_mission_changed](#classmavsdk_1_1_mission_raw_1ac6cd7602b2e5b46ad0ea1cf8bf602a0c) ([MissionChangedHandle](classmavsdk_1_1_mission_raw.md#classmavsdk_1_1_mission_raw_1a46da6d8a53822fd5fbd7b2a414624c5c) handle) | Unsubscribe from subscribe_mission_changed.
 std::pair< [Result](classmavsdk_1_1_mission_raw.md#classmavsdk_1_1_mission_raw_1a7ea2a624818ebb5a3e209cc275d58eaf), [MissionRaw::MissionImportData](structmavsdk_1_1_mission_raw_1_1_mission_import_data.md) > | [import_qgroundcontrol_mission](#classmavsdk_1_1_mission_raw_1a2a4ca261c37737e691c6954693d6d0a5) (std::string qgc_plan_path)const | Import a QGroundControl missions in JSON .plan format, from a file.
 std::pair< [Result](classmavsdk_1_1_mission_raw.md#classmavsdk_1_1_mission_raw_1a7ea2a624818ebb5a3e209cc275d58eaf), [MissionRaw::MissionImportData](structmavsdk_1_1_mission_raw_1_1_mission_import_data.md) > | [import_qgroundcontrol_mission_from_string](#classmavsdk_1_1_mission_raw_1a4a1b55650120d8af0ce7fa037f6b5ce9) (std::string qgc_plan)const | Import a QGroundControl missions in JSON .plan format, from a string.
+std::pair< [Result](classmavsdk_1_1_mission_raw.md#classmavsdk_1_1_mission_raw_1a7ea2a624818ebb5a3e209cc275d58eaf), bool > | [is_mission_finished](#classmavsdk_1_1_mission_raw_1a998db451c2718d9728276ca2d01ce315) () const | Check if the mission is finished.
 const [MissionRaw](classmavsdk_1_1_mission_raw.md) & | [operator=](#classmavsdk_1_1_mission_raw_1a2b8cdc1fbee72224a9ef6eb9266b2e2a) (const [MissionRaw](classmavsdk_1_1_mission_raw.md) &)=delete | Equality operator (object is not copyable).
 
 
@@ -733,6 +734,23 @@ This function is blocking.
 **Returns**
 
 &emsp;std::pair< [Result](classmavsdk_1_1_mission_raw.md#classmavsdk_1_1_mission_raw_1a7ea2a624818ebb5a3e209cc275d58eaf), [MissionRaw::MissionImportData](structmavsdk_1_1_mission_raw_1_1_mission_import_data.md) > - Result of request.
+
+### is_mission_finished() {#classmavsdk_1_1_mission_raw_1a998db451c2718d9728276ca2d01ce315}
+```cpp
+std::pair< Result, bool > mavsdk::MissionRaw::is_mission_finished() const
+```
+
+
+Check if the mission is finished.
+
+Returns true if the mission is finished, false otherwise.
+
+
+This function is blocking.
+
+**Returns**
+
+&emsp;std::pair< [Result](classmavsdk_1_1_mission_raw.md#classmavsdk_1_1_mission_raw_1a7ea2a624818ebb5a3e209cc275d58eaf), bool > - Result of request.
 
 ### operator=() {#classmavsdk_1_1_mission_raw_1a2b8cdc1fbee72224a9ef6eb9266b2e2a}
 ```cpp

--- a/src/mavsdk/plugins/mission/mission_impl.cpp
+++ b/src/mavsdk/plugins/mission/mission_impl.cpp
@@ -999,13 +999,15 @@ std::pair<Mission::Result, bool> MissionImpl::is_mission_finished_locked() const
         // It is not straightforward to look at "current" because it jumps to 0
         // once the last item has been done. Therefore we have to lo decide using
         // "reached" here.
-        // It seems that we never receive a reached when RTL is initiated after
-        // a mission, and we need to account for that.
+        // With PX4, it seems that we didn't use to receive a reached when RTL is initiated
+        // after a mission, and we needed to account for that all the way to PX4 v1.16.
         const unsigned rtl_correction = _enable_return_to_launch_after_mission ? 2 : 1;
 
+        // By accepting the current to be larger than the total, we are accepting the case
+        // where we no longer require the rtl_correction, as this is now getting fixed in PX4.
         return std::make_pair<Mission::Result, bool>(
             Mission::Result::Success,
-            unsigned(_mission_data.last_reached_mavlink_mission_item + rtl_correction) ==
+            unsigned(_mission_data.last_reached_mavlink_mission_item + rtl_correction) >=
                 _mission_data.mavlink_mission_item_to_mission_item_indices.size());
     }
 

--- a/src/mavsdk/plugins/mission/mission_impl.cpp
+++ b/src/mavsdk/plugins/mission/mission_impl.cpp
@@ -70,6 +70,7 @@ void MissionImpl::process_mission_current(const mavlink_message_t& message)
 
     std::lock_guard<std::mutex> lock(_mission_data.mutex);
     _mission_data.last_current_mavlink_mission_item = mission_current.seq;
+    _mission_data.mission_state = static_cast<MissionState>(mission_current.mission_state);
     report_progress_locked();
 }
 
@@ -993,17 +994,28 @@ std::pair<Mission::Result, bool> MissionImpl::is_mission_finished_locked() const
         return std::make_pair<Mission::Result, bool>(Mission::Result::Success, false);
     }
 
-    // It is not straightforward to look at "current" because it jumps to 0
-    // once the last item has been done. Therefore we have to lo decide using
-    // "reached" here.
-    // It seems that we never receive a reached when RTL is initiated after
-    // a mission, and we need to account for that.
-    const unsigned rtl_correction = _enable_return_to_launch_after_mission ? 2 : 1;
+    // If mission_state is Unknown, fall back to the previous behavior
+    if (_mission_data.mission_state == MissionState::Unknown) {
+        // It is not straightforward to look at "current" because it jumps to 0
+        // once the last item has been done. Therefore we have to lo decide using
+        // "reached" here.
+        // It seems that we never receive a reached when RTL is initiated after
+        // a mission, and we need to account for that.
+        const unsigned rtl_correction = _enable_return_to_launch_after_mission ? 2 : 1;
 
-    return std::make_pair<Mission::Result, bool>(
-        Mission::Result::Success,
-        unsigned(_mission_data.last_reached_mavlink_mission_item + rtl_correction) ==
-            _mission_data.mavlink_mission_item_to_mission_item_indices.size());
+        return std::make_pair<Mission::Result, bool>(
+            Mission::Result::Success,
+            unsigned(_mission_data.last_reached_mavlink_mission_item + rtl_correction) ==
+                _mission_data.mavlink_mission_item_to_mission_item_indices.size());
+    }
+
+    // If mission_state is Completed, the mission is finished
+    if (_mission_data.mission_state == MissionState::Completed) {
+        return std::make_pair<Mission::Result, bool>(Mission::Result::Success, true);
+    }
+
+    // If mission_state is NotCompleted, the mission is not finished
+    return std::make_pair<Mission::Result, bool>(Mission::Result::Success, false);
 }
 
 int MissionImpl::current_mission_item() const

--- a/src/mavsdk/plugins/mission/mission_impl.h
+++ b/src/mavsdk/plugins/mission/mission_impl.h
@@ -16,6 +16,8 @@ namespace mavsdk {
 
 class MissionImpl : public PluginImplBase {
 public:
+    enum class MissionState { Unknown = 0, NotCompleted = 1, Completed = 2 };
+
     explicit MissionImpl(System& system);
     explicit MissionImpl(std::shared_ptr<System> system);
     ~MissionImpl() override;
@@ -127,6 +129,7 @@ private:
         std::weak_ptr<MavlinkMissionTransferClient::WorkItem> last_upload{};
         std::weak_ptr<MavlinkMissionTransferClient::WorkItem> last_download{};
         bool gimbal_v2_in_control{false};
+        MissionState mission_state{MissionState::Unknown};
     } _mission_data{};
 
     TimeoutHandler::Cookie _timeout_cookie{};

--- a/src/mavsdk/plugins/mission_raw/include/plugins/mission_raw/mission_raw.h
+++ b/src/mavsdk/plugins/mission_raw/include/plugins/mission_raw/mission_raw.h
@@ -508,6 +508,17 @@ public:
     import_qgroundcontrol_mission_from_string(std::string qgc_plan) const;
 
     /**
+     * @brief Check if the mission is finished.
+     *
+     * Returns true if the mission is finished, false otherwise.
+     *
+     * This function is blocking.
+     *
+     * @return Result of request.
+     */
+    std::pair<Result, bool> is_mission_finished() const;
+
+    /**
      * @brief Copy constructor.
      */
     MissionRaw(const MissionRaw& other);

--- a/src/mavsdk/plugins/mission_raw/mission_raw.cpp
+++ b/src/mavsdk/plugins/mission_raw/mission_raw.cpp
@@ -180,6 +180,11 @@ MissionRaw::import_qgroundcontrol_mission_from_string(std::string qgc_plan) cons
     return _impl->import_qgroundcontrol_mission_from_string(qgc_plan);
 }
 
+std::pair<MissionRaw::Result, bool> MissionRaw::is_mission_finished() const
+{
+    return _impl->is_mission_finished();
+}
+
 bool operator==(const MissionRaw::MissionProgress& lhs, const MissionRaw::MissionProgress& rhs)
 {
     return (rhs.current == lhs.current) && (rhs.total == lhs.total);

--- a/src/mavsdk_server/src/generated/mission_raw/mission_raw.grpc.pb.cc
+++ b/src/mavsdk_server/src/generated/mission_raw/mission_raw.grpc.pb.cc
@@ -40,6 +40,7 @@ static const char* MissionRawService_method_names[] = {
   "/mavsdk.rpc.mission_raw.MissionRawService/SubscribeMissionChanged",
   "/mavsdk.rpc.mission_raw.MissionRawService/ImportQgroundcontrolMission",
   "/mavsdk.rpc.mission_raw.MissionRawService/ImportQgroundcontrolMissionFromString",
+  "/mavsdk.rpc.mission_raw.MissionRawService/IsMissionFinished",
 };
 
 std::unique_ptr< MissionRawService::Stub> MissionRawService::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
@@ -65,6 +66,7 @@ MissionRawService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& 
   , rpcmethod_SubscribeMissionChanged_(MissionRawService_method_names[13], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
   , rpcmethod_ImportQgroundcontrolMission_(MissionRawService_method_names[14], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_ImportQgroundcontrolMissionFromString_(MissionRawService_method_names[15], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_IsMissionFinished_(MissionRawService_method_names[16], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status MissionRawService::Stub::UploadMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::UploadMissionRequest& request, ::mavsdk::rpc::mission_raw::UploadMissionResponse* response) {
@@ -421,6 +423,29 @@ void MissionRawService::Stub::async::ImportQgroundcontrolMissionFromString(::grp
   return result;
 }
 
+::grpc::Status MissionRawService::Stub::IsMissionFinished(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest& request, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_IsMissionFinished_, context, request, response);
+}
+
+void MissionRawService::Stub::async::IsMissionFinished(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest* request, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_IsMissionFinished_, context, request, response, std::move(f));
+}
+
+void MissionRawService::Stub::async::IsMissionFinished(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest* request, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_IsMissionFinished_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>* MissionRawService::Stub::PrepareAsyncIsMissionFinishedRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse, ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_IsMissionFinished_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>* MissionRawService::Stub::AsyncIsMissionFinishedRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncIsMissionFinishedRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
 MissionRawService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       MissionRawService_method_names[0],
@@ -582,6 +607,16 @@ MissionRawService::Service::Service() {
              ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* resp) {
                return service->ImportQgroundcontrolMissionFromString(ctx, req, resp);
              }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      MissionRawService_method_names[16],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< MissionRawService::Service, ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](MissionRawService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest* req,
+             ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse* resp) {
+               return service->IsMissionFinished(ctx, req, resp);
+             }, this)));
 }
 
 MissionRawService::Service::~Service() {
@@ -693,6 +728,13 @@ MissionRawService::Service::~Service() {
 }
 
 ::grpc::Status MissionRawService::Service::ImportQgroundcontrolMissionFromString(::grpc::ServerContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status MissionRawService::Service::IsMissionFinished(::grpc::ServerContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest* request, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/src/mavsdk_server/src/generated/mission_raw/mission_raw.grpc.pb.h
+++ b/src/mavsdk_server/src/generated/mission_raw/mission_raw.grpc.pb.h
@@ -216,6 +216,17 @@ class MissionRawService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>> PrepareAsyncImportQgroundcontrolMissionFromString(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>>(PrepareAsyncImportQgroundcontrolMissionFromStringRaw(context, request, cq));
     }
+    //
+    // Check if the mission is finished.
+    //
+    // Returns true if the mission is finished, false otherwise.
+    virtual ::grpc::Status IsMissionFinished(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest& request, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>> AsyncIsMissionFinished(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>>(AsyncIsMissionFinishedRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>> PrepareAsyncIsMissionFinished(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>>(PrepareAsyncIsMissionFinishedRaw(context, request, cq));
+    }
     class async_interface {
      public:
       virtual ~async_interface() {}
@@ -311,6 +322,12 @@ class MissionRawService final {
       // - Structure Scan
       virtual void ImportQgroundcontrolMissionFromString(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void ImportQgroundcontrolMissionFromString(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      //
+      // Check if the mission is finished.
+      //
+      // Returns true if the mission is finished, false otherwise.
+      virtual void IsMissionFinished(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest* request, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void IsMissionFinished(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest* request, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
     };
     typedef class async_interface experimental_async_interface;
     virtual class async_interface* async() { return nullptr; }
@@ -350,6 +367,8 @@ class MissionRawService final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse>* PrepareAsyncImportQgroundcontrolMissionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>* AsyncImportQgroundcontrolMissionFromStringRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>* PrepareAsyncImportQgroundcontrolMissionFromStringRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>* AsyncIsMissionFinishedRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>* PrepareAsyncIsMissionFinishedRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest& request, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
@@ -470,6 +489,13 @@ class MissionRawService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>> PrepareAsyncImportQgroundcontrolMissionFromString(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>>(PrepareAsyncImportQgroundcontrolMissionFromStringRaw(context, request, cq));
     }
+    ::grpc::Status IsMissionFinished(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest& request, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>> AsyncIsMissionFinished(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>>(AsyncIsMissionFinishedRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>> PrepareAsyncIsMissionFinished(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>>(PrepareAsyncIsMissionFinishedRaw(context, request, cq));
+    }
     class async final :
       public StubInterface::async_interface {
      public:
@@ -503,6 +529,8 @@ class MissionRawService final {
       void ImportQgroundcontrolMission(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void ImportQgroundcontrolMissionFromString(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* response, std::function<void(::grpc::Status)>) override;
       void ImportQgroundcontrolMissionFromString(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void IsMissionFinished(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest* request, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse* response, std::function<void(::grpc::Status)>) override;
+      void IsMissionFinished(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest* request, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
      private:
       friend class Stub;
       explicit async(Stub* stub): stub_(stub) { }
@@ -548,6 +576,8 @@ class MissionRawService final {
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse>* PrepareAsyncImportQgroundcontrolMissionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>* AsyncImportQgroundcontrolMissionFromStringRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>* PrepareAsyncImportQgroundcontrolMissionFromStringRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>* AsyncIsMissionFinishedRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>* PrepareAsyncIsMissionFinishedRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_UploadMission_;
     const ::grpc::internal::RpcMethod rpcmethod_UploadGeofence_;
     const ::grpc::internal::RpcMethod rpcmethod_UploadRallyPoints_;
@@ -564,6 +594,7 @@ class MissionRawService final {
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeMissionChanged_;
     const ::grpc::internal::RpcMethod rpcmethod_ImportQgroundcontrolMission_;
     const ::grpc::internal::RpcMethod rpcmethod_ImportQgroundcontrolMissionFromString_;
+    const ::grpc::internal::RpcMethod rpcmethod_IsMissionFinished_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
 
@@ -649,6 +680,11 @@ class MissionRawService final {
     // Not supported:
     // - Structure Scan
     virtual ::grpc::Status ImportQgroundcontrolMissionFromString(::grpc::ServerContext* context, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* request, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* response);
+    //
+    // Check if the mission is finished.
+    //
+    // Returns true if the mission is finished, false otherwise.
+    virtual ::grpc::Status IsMissionFinished(::grpc::ServerContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest* request, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse* response);
   };
   template <class BaseClass>
   class WithAsyncMethod_UploadMission : public BaseClass {
@@ -970,7 +1006,27 @@ class MissionRawService final {
       ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_UploadMission<WithAsyncMethod_UploadGeofence<WithAsyncMethod_UploadRallyPoints<WithAsyncMethod_CancelMissionUpload<WithAsyncMethod_DownloadMission<WithAsyncMethod_DownloadGeofence<WithAsyncMethod_DownloadRallypoints<WithAsyncMethod_CancelMissionDownload<WithAsyncMethod_StartMission<WithAsyncMethod_PauseMission<WithAsyncMethod_ClearMission<WithAsyncMethod_SetCurrentMissionItem<WithAsyncMethod_SubscribeMissionProgress<WithAsyncMethod_SubscribeMissionChanged<WithAsyncMethod_ImportQgroundcontrolMission<WithAsyncMethod_ImportQgroundcontrolMissionFromString<Service > > > > > > > > > > > > > > > > AsyncService;
+  template <class BaseClass>
+  class WithAsyncMethod_IsMissionFinished : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_IsMissionFinished() {
+      ::grpc::Service::MarkMethodAsync(16);
+    }
+    ~WithAsyncMethod_IsMissionFinished() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status IsMissionFinished(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest* /*request*/, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestIsMissionFinished(::grpc::ServerContext* context, ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  typedef WithAsyncMethod_UploadMission<WithAsyncMethod_UploadGeofence<WithAsyncMethod_UploadRallyPoints<WithAsyncMethod_CancelMissionUpload<WithAsyncMethod_DownloadMission<WithAsyncMethod_DownloadGeofence<WithAsyncMethod_DownloadRallypoints<WithAsyncMethod_CancelMissionDownload<WithAsyncMethod_StartMission<WithAsyncMethod_PauseMission<WithAsyncMethod_ClearMission<WithAsyncMethod_SetCurrentMissionItem<WithAsyncMethod_SubscribeMissionProgress<WithAsyncMethod_SubscribeMissionChanged<WithAsyncMethod_ImportQgroundcontrolMission<WithAsyncMethod_ImportQgroundcontrolMissionFromString<WithAsyncMethod_IsMissionFinished<Service > > > > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_UploadMission : public BaseClass {
    private:
@@ -1393,7 +1449,34 @@ class MissionRawService final {
     virtual ::grpc::ServerUnaryReactor* ImportQgroundcontrolMissionFromString(
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* /*request*/, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_UploadMission<WithCallbackMethod_UploadGeofence<WithCallbackMethod_UploadRallyPoints<WithCallbackMethod_CancelMissionUpload<WithCallbackMethod_DownloadMission<WithCallbackMethod_DownloadGeofence<WithCallbackMethod_DownloadRallypoints<WithCallbackMethod_CancelMissionDownload<WithCallbackMethod_StartMission<WithCallbackMethod_PauseMission<WithCallbackMethod_ClearMission<WithCallbackMethod_SetCurrentMissionItem<WithCallbackMethod_SubscribeMissionProgress<WithCallbackMethod_SubscribeMissionChanged<WithCallbackMethod_ImportQgroundcontrolMission<WithCallbackMethod_ImportQgroundcontrolMissionFromString<Service > > > > > > > > > > > > > > > > CallbackService;
+  template <class BaseClass>
+  class WithCallbackMethod_IsMissionFinished : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_IsMissionFinished() {
+      ::grpc::Service::MarkMethodCallback(16,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest* request, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse* response) { return this->IsMissionFinished(context, request, response); }));}
+    void SetMessageAllocatorFor_IsMissionFinished(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(16);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_IsMissionFinished() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status IsMissionFinished(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest* /*request*/, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* IsMissionFinished(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest* /*request*/, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse* /*response*/)  { return nullptr; }
+  };
+  typedef WithCallbackMethod_UploadMission<WithCallbackMethod_UploadGeofence<WithCallbackMethod_UploadRallyPoints<WithCallbackMethod_CancelMissionUpload<WithCallbackMethod_DownloadMission<WithCallbackMethod_DownloadGeofence<WithCallbackMethod_DownloadRallypoints<WithCallbackMethod_CancelMissionDownload<WithCallbackMethod_StartMission<WithCallbackMethod_PauseMission<WithCallbackMethod_ClearMission<WithCallbackMethod_SetCurrentMissionItem<WithCallbackMethod_SubscribeMissionProgress<WithCallbackMethod_SubscribeMissionChanged<WithCallbackMethod_ImportQgroundcontrolMission<WithCallbackMethod_ImportQgroundcontrolMissionFromString<WithCallbackMethod_IsMissionFinished<Service > > > > > > > > > > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_UploadMission : public BaseClass {
@@ -1663,6 +1746,23 @@ class MissionRawService final {
     }
     // disable synchronous version of this method
     ::grpc::Status ImportQgroundcontrolMissionFromString(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest* /*request*/, ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_IsMissionFinished : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_IsMissionFinished() {
+      ::grpc::Service::MarkMethodGeneric(16);
+    }
+    ~WithGenericMethod_IsMissionFinished() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status IsMissionFinished(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest* /*request*/, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -1985,6 +2085,26 @@ class MissionRawService final {
     }
     void RequestImportQgroundcontrolMissionFromString(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_IsMissionFinished : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_IsMissionFinished() {
+      ::grpc::Service::MarkMethodRaw(16);
+    }
+    ~WithRawMethod_IsMissionFinished() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status IsMissionFinished(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest* /*request*/, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestIsMissionFinished(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2337,6 +2457,28 @@ class MissionRawService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     virtual ::grpc::ServerUnaryReactor* ImportQgroundcontrolMissionFromString(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_IsMissionFinished : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_IsMissionFinished() {
+      ::grpc::Service::MarkMethodRawCallback(16,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->IsMissionFinished(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_IsMissionFinished() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status IsMissionFinished(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest* /*request*/, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* IsMissionFinished(
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
@@ -2717,7 +2859,34 @@ class MissionRawService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedImportQgroundcontrolMissionFromString(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest,::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_UploadMission<WithStreamedUnaryMethod_UploadGeofence<WithStreamedUnaryMethod_UploadRallyPoints<WithStreamedUnaryMethod_CancelMissionUpload<WithStreamedUnaryMethod_DownloadMission<WithStreamedUnaryMethod_DownloadGeofence<WithStreamedUnaryMethod_DownloadRallypoints<WithStreamedUnaryMethod_CancelMissionDownload<WithStreamedUnaryMethod_StartMission<WithStreamedUnaryMethod_PauseMission<WithStreamedUnaryMethod_ClearMission<WithStreamedUnaryMethod_SetCurrentMissionItem<WithStreamedUnaryMethod_ImportQgroundcontrolMission<WithStreamedUnaryMethod_ImportQgroundcontrolMissionFromString<Service > > > > > > > > > > > > > > StreamedUnaryService;
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_IsMissionFinished : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_IsMissionFinished() {
+      ::grpc::Service::MarkMethodStreamed(16,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>* streamer) {
+                       return this->StreamedIsMissionFinished(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_IsMissionFinished() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status IsMissionFinished(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest* /*request*/, ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedIsMissionFinished(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::mission_raw::IsMissionFinishedRequest,::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>* server_unary_streamer) = 0;
+  };
+  typedef WithStreamedUnaryMethod_UploadMission<WithStreamedUnaryMethod_UploadGeofence<WithStreamedUnaryMethod_UploadRallyPoints<WithStreamedUnaryMethod_CancelMissionUpload<WithStreamedUnaryMethod_DownloadMission<WithStreamedUnaryMethod_DownloadGeofence<WithStreamedUnaryMethod_DownloadRallypoints<WithStreamedUnaryMethod_CancelMissionDownload<WithStreamedUnaryMethod_StartMission<WithStreamedUnaryMethod_PauseMission<WithStreamedUnaryMethod_ClearMission<WithStreamedUnaryMethod_SetCurrentMissionItem<WithStreamedUnaryMethod_ImportQgroundcontrolMission<WithStreamedUnaryMethod_ImportQgroundcontrolMissionFromString<WithStreamedUnaryMethod_IsMissionFinished<Service > > > > > > > > > > > > > > > StreamedUnaryService;
   template <class BaseClass>
   class WithSplitStreamingMethod_SubscribeMissionProgress : public BaseClass {
    private:
@@ -2773,7 +2942,7 @@ class MissionRawService final {
     virtual ::grpc::Status StreamedSubscribeMissionChanged(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::mission_raw::SubscribeMissionChangedRequest,::mavsdk::rpc::mission_raw::MissionChangedResponse>* server_split_streamer) = 0;
   };
   typedef WithSplitStreamingMethod_SubscribeMissionProgress<WithSplitStreamingMethod_SubscribeMissionChanged<Service > > SplitStreamedService;
-  typedef WithStreamedUnaryMethod_UploadMission<WithStreamedUnaryMethod_UploadGeofence<WithStreamedUnaryMethod_UploadRallyPoints<WithStreamedUnaryMethod_CancelMissionUpload<WithStreamedUnaryMethod_DownloadMission<WithStreamedUnaryMethod_DownloadGeofence<WithStreamedUnaryMethod_DownloadRallypoints<WithStreamedUnaryMethod_CancelMissionDownload<WithStreamedUnaryMethod_StartMission<WithStreamedUnaryMethod_PauseMission<WithStreamedUnaryMethod_ClearMission<WithStreamedUnaryMethod_SetCurrentMissionItem<WithSplitStreamingMethod_SubscribeMissionProgress<WithSplitStreamingMethod_SubscribeMissionChanged<WithStreamedUnaryMethod_ImportQgroundcontrolMission<WithStreamedUnaryMethod_ImportQgroundcontrolMissionFromString<Service > > > > > > > > > > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_UploadMission<WithStreamedUnaryMethod_UploadGeofence<WithStreamedUnaryMethod_UploadRallyPoints<WithStreamedUnaryMethod_CancelMissionUpload<WithStreamedUnaryMethod_DownloadMission<WithStreamedUnaryMethod_DownloadGeofence<WithStreamedUnaryMethod_DownloadRallypoints<WithStreamedUnaryMethod_CancelMissionDownload<WithStreamedUnaryMethod_StartMission<WithStreamedUnaryMethod_PauseMission<WithStreamedUnaryMethod_ClearMission<WithStreamedUnaryMethod_SetCurrentMissionItem<WithSplitStreamingMethod_SubscribeMissionProgress<WithSplitStreamingMethod_SubscribeMissionChanged<WithStreamedUnaryMethod_ImportQgroundcontrolMission<WithStreamedUnaryMethod_ImportQgroundcontrolMissionFromString<WithStreamedUnaryMethod_IsMissionFinished<Service > > > > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace mission_raw

--- a/src/mavsdk_server/src/generated/mission_raw/mission_raw.pb.cc
+++ b/src/mavsdk_server/src/generated/mission_raw/mission_raw.pb.cc
@@ -240,6 +240,24 @@ struct MissionChangedResponseDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 MissionChangedResponseDefaultTypeInternal _MissionChangedResponse_default_instance_;
+              template <typename>
+PROTOBUF_CONSTEXPR IsMissionFinishedRequest::IsMissionFinishedRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(_class_data_.base()){}
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase() {
+}
+#endif  // PROTOBUF_CUSTOM_VTABLE
+struct IsMissionFinishedRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR IsMissionFinishedRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~IsMissionFinishedRequestDefaultTypeInternal() {}
+  union {
+    IsMissionFinishedRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 IsMissionFinishedRequestDefaultTypeInternal _IsMissionFinishedRequest_default_instance_;
 
 inline constexpr ImportQgroundcontrolMissionRequest::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -679,6 +697,32 @@ struct MissionImportDataDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 MissionImportDataDefaultTypeInternal _MissionImportData_default_instance_;
+
+inline constexpr IsMissionFinishedResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        mission_raw_result_{nullptr},
+        is_finished_{false} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR IsMissionFinishedResponse::IsMissionFinishedResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct IsMissionFinishedResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR IsMissionFinishedResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~IsMissionFinishedResponseDefaultTypeInternal() {}
+  union {
+    IsMissionFinishedResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 IsMissionFinishedResponseDefaultTypeInternal _IsMissionFinishedResponse_default_instance_;
 
 inline constexpr DownloadRallypointsResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -1197,6 +1241,26 @@ const ::uint32_t
         0,
         1,
         ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw::IsMissionFinishedRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw::IsMissionFinishedResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw::IsMissionFinishedResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw::IsMissionFinishedResponse, _impl_.mission_raw_result_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw::IsMissionFinishedResponse, _impl_.is_finished_),
+        0,
+        ~0u,
+        ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mission_raw::MissionProgress, _internal_metadata_),
         ~0u,  // no _extensions_
         ~0u,  // no _oneof_case_
@@ -1284,10 +1348,12 @@ static const ::_pbi::MigrationSchema
         {270, 280, -1, sizeof(::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionResponse)},
         {282, -1, -1, sizeof(::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringRequest)},
         {291, 301, -1, sizeof(::mavsdk::rpc::mission_raw::ImportQgroundcontrolMissionFromStringResponse)},
-        {303, -1, -1, sizeof(::mavsdk::rpc::mission_raw::MissionProgress)},
-        {313, -1, -1, sizeof(::mavsdk::rpc::mission_raw::MissionItem)},
-        {334, -1, -1, sizeof(::mavsdk::rpc::mission_raw::MissionImportData)},
-        {345, -1, -1, sizeof(::mavsdk::rpc::mission_raw::MissionRawResult)},
+        {303, -1, -1, sizeof(::mavsdk::rpc::mission_raw::IsMissionFinishedRequest)},
+        {311, 321, -1, sizeof(::mavsdk::rpc::mission_raw::IsMissionFinishedResponse)},
+        {323, -1, -1, sizeof(::mavsdk::rpc::mission_raw::MissionProgress)},
+        {333, -1, -1, sizeof(::mavsdk::rpc::mission_raw::MissionItem)},
+        {354, -1, -1, sizeof(::mavsdk::rpc::mission_raw::MissionImportData)},
+        {365, -1, -1, sizeof(::mavsdk::rpc::mission_raw::MissionRawResult)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::mission_raw::_UploadMissionRequest_default_instance_._instance,
@@ -1322,6 +1388,8 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::mission_raw::_ImportQgroundcontrolMissionResponse_default_instance_._instance,
     &::mavsdk::rpc::mission_raw::_ImportQgroundcontrolMissionFromStringRequest_default_instance_._instance,
     &::mavsdk::rpc::mission_raw::_ImportQgroundcontrolMissionFromStringResponse_default_instance_._instance,
+    &::mavsdk::rpc::mission_raw::_IsMissionFinishedRequest_default_instance_._instance,
+    &::mavsdk::rpc::mission_raw::_IsMissionFinishedResponse_default_instance_._instance,
     &::mavsdk::rpc::mission_raw::_MissionProgress_default_instance_._instance,
     &::mavsdk::rpc::mission_raw::_MissionItem_default_instance_._instance,
     &::mavsdk::rpc::mission_raw::_MissionImportData_default_instance_._instance,
@@ -1395,89 +1463,96 @@ const char descriptor_table_protodef_mission_5fraw_2fmission_5fraw_2eproto[] ABS
     "ngResponse\022D\n\022mission_raw_result\030\001 \001(\0132("
     ".mavsdk.rpc.mission_raw.MissionRawResult"
     "\022F\n\023mission_import_data\030\002 \001(\0132).mavsdk.r"
-    "pc.mission_raw.MissionImportData\"1\n\017Miss"
-    "ionProgress\022\017\n\007current\030\001 \001(\005\022\r\n\005total\030\002 "
-    "\001(\005\"\330\001\n\013MissionItem\022\013\n\003seq\030\001 \001(\r\022\r\n\005fram"
-    "e\030\002 \001(\r\022\017\n\007command\030\003 \001(\r\022\017\n\007current\030\004 \001("
-    "\r\022\024\n\014autocontinue\030\005 \001(\r\022\016\n\006param1\030\006 \001(\002\022"
-    "\016\n\006param2\030\007 \001(\002\022\016\n\006param3\030\010 \001(\002\022\016\n\006param"
-    "4\030\t \001(\002\022\t\n\001x\030\n \001(\005\022\t\n\001y\030\013 \001(\005\022\t\n\001z\030\014 \001(\002"
-    "\022\024\n\014mission_type\030\r \001(\r\"\306\001\n\021MissionImport"
-    "Data\022:\n\rmission_items\030\001 \003(\0132#.mavsdk.rpc"
-    ".mission_raw.MissionItem\022;\n\016geofence_ite"
-    "ms\030\002 \003(\0132#.mavsdk.rpc.mission_raw.Missio"
-    "nItem\0228\n\013rally_items\030\003 \003(\0132#.mavsdk.rpc."
-    "mission_raw.MissionItem\"\376\004\n\020MissionRawRe"
-    "sult\022\?\n\006result\030\001 \001(\0162/.mavsdk.rpc.missio"
-    "n_raw.MissionRawResult.Result\022\022\n\nresult_"
-    "str\030\002 \001(\t\"\224\004\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000"
-    "\022\022\n\016RESULT_SUCCESS\020\001\022\020\n\014RESULT_ERROR\020\002\022!"
-    "\n\035RESULT_TOO_MANY_MISSION_ITEMS\020\003\022\017\n\013RES"
-    "ULT_BUSY\020\004\022\022\n\016RESULT_TIMEOUT\020\005\022\033\n\027RESULT"
-    "_INVALID_ARGUMENT\020\006\022\026\n\022RESULT_UNSUPPORTE"
-    "D\020\007\022\037\n\033RESULT_NO_MISSION_AVAILABLE\020\010\022\035\n\031"
-    "RESULT_TRANSFER_CANCELLED\020\t\022\"\n\036RESULT_FA"
-    "ILED_TO_OPEN_QGC_PLAN\020\n\022#\n\037RESULT_FAILED"
-    "_TO_PARSE_QGC_PLAN\020\013\022\024\n\020RESULT_NO_SYSTEM"
-    "\020\014\022\021\n\rRESULT_DENIED\020\r\022&\n\"RESULT_MISSION_"
-    "TYPE_NOT_CONSISTENT\020\016\022\033\n\027RESULT_INVALID_"
-    "SEQUENCE\020\017\022\032\n\026RESULT_CURRENT_INVALID\020\020\022\031"
-    "\n\025RESULT_PROTOCOL_ERROR\020\021\022%\n!RESULT_INT_"
-    "MESSAGES_NOT_SUPPORTED\020\0222\273\020\n\021MissionRawS"
-    "ervice\022n\n\rUploadMission\022,.mavsdk.rpc.mis"
-    "sion_raw.UploadMissionRequest\032-.mavsdk.r"
-    "pc.mission_raw.UploadMissionResponse\"\000\022q"
-    "\n\016UploadGeofence\022-.mavsdk.rpc.mission_ra"
-    "w.UploadGeofenceRequest\032..mavsdk.rpc.mis"
-    "sion_raw.UploadGeofenceResponse\"\000\022z\n\021Upl"
-    "oadRallyPoints\0220.mavsdk.rpc.mission_raw."
-    "UploadRallyPointsRequest\0321.mavsdk.rpc.mi"
-    "ssion_raw.UploadRallyPointsResponse\"\000\022\204\001"
-    "\n\023CancelMissionUpload\0222.mavsdk.rpc.missi"
-    "on_raw.CancelMissionUploadRequest\0323.mavs"
-    "dk.rpc.mission_raw.CancelMissionUploadRe"
-    "sponse\"\004\200\265\030\001\022t\n\017DownloadMission\022..mavsdk"
-    ".rpc.mission_raw.DownloadMissionRequest\032"
-    "/.mavsdk.rpc.mission_raw.DownloadMission"
-    "Response\"\000\022w\n\020DownloadGeofence\022/.mavsdk."
-    "rpc.mission_raw.DownloadGeofenceRequest\032"
-    "0.mavsdk.rpc.mission_raw.DownloadGeofenc"
-    "eResponse\"\000\022\200\001\n\023DownloadRallypoints\0222.ma"
+    "pc.mission_raw.MissionImportData\"\032\n\030IsMi"
+    "ssionFinishedRequest\"v\n\031IsMissionFinishe"
+    "dResponse\022D\n\022mission_raw_result\030\001 \001(\0132(."
+    "mavsdk.rpc.mission_raw.MissionRawResult\022"
+    "\023\n\013is_finished\030\002 \001(\010\"1\n\017MissionProgress\022"
+    "\017\n\007current\030\001 \001(\005\022\r\n\005total\030\002 \001(\005\"\330\001\n\013Miss"
+    "ionItem\022\013\n\003seq\030\001 \001(\r\022\r\n\005frame\030\002 \001(\r\022\017\n\007c"
+    "ommand\030\003 \001(\r\022\017\n\007current\030\004 \001(\r\022\024\n\014autocon"
+    "tinue\030\005 \001(\r\022\016\n\006param1\030\006 \001(\002\022\016\n\006param2\030\007 "
+    "\001(\002\022\016\n\006param3\030\010 \001(\002\022\016\n\006param4\030\t \001(\002\022\t\n\001x"
+    "\030\n \001(\005\022\t\n\001y\030\013 \001(\005\022\t\n\001z\030\014 \001(\002\022\024\n\014mission_"
+    "type\030\r \001(\r\"\306\001\n\021MissionImportData\022:\n\rmiss"
+    "ion_items\030\001 \003(\0132#.mavsdk.rpc.mission_raw"
+    ".MissionItem\022;\n\016geofence_items\030\002 \003(\0132#.m"
+    "avsdk.rpc.mission_raw.MissionItem\0228\n\013ral"
+    "ly_items\030\003 \003(\0132#.mavsdk.rpc.mission_raw."
+    "MissionItem\"\376\004\n\020MissionRawResult\022\?\n\006resu"
+    "lt\030\001 \001(\0162/.mavsdk.rpc.mission_raw.Missio"
+    "nRawResult.Result\022\022\n\nresult_str\030\002 \001(\t\"\224\004"
+    "\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESULT_S"
+    "UCCESS\020\001\022\020\n\014RESULT_ERROR\020\002\022!\n\035RESULT_TOO"
+    "_MANY_MISSION_ITEMS\020\003\022\017\n\013RESULT_BUSY\020\004\022\022"
+    "\n\016RESULT_TIMEOUT\020\005\022\033\n\027RESULT_INVALID_ARG"
+    "UMENT\020\006\022\026\n\022RESULT_UNSUPPORTED\020\007\022\037\n\033RESUL"
+    "T_NO_MISSION_AVAILABLE\020\010\022\035\n\031RESULT_TRANS"
+    "FER_CANCELLED\020\t\022\"\n\036RESULT_FAILED_TO_OPEN"
+    "_QGC_PLAN\020\n\022#\n\037RESULT_FAILED_TO_PARSE_QG"
+    "C_PLAN\020\013\022\024\n\020RESULT_NO_SYSTEM\020\014\022\021\n\rRESULT"
+    "_DENIED\020\r\022&\n\"RESULT_MISSION_TYPE_NOT_CON"
+    "SISTENT\020\016\022\033\n\027RESULT_INVALID_SEQUENCE\020\017\022\032"
+    "\n\026RESULT_CURRENT_INVALID\020\020\022\031\n\025RESULT_PRO"
+    "TOCOL_ERROR\020\021\022%\n!RESULT_INT_MESSAGES_NOT"
+    "_SUPPORTED\020\0222\273\021\n\021MissionRawService\022n\n\rUp"
+    "loadMission\022,.mavsdk.rpc.mission_raw.Upl"
+    "oadMissionRequest\032-.mavsdk.rpc.mission_r"
+    "aw.UploadMissionResponse\"\000\022q\n\016UploadGeof"
+    "ence\022-.mavsdk.rpc.mission_raw.UploadGeof"
+    "enceRequest\032..mavsdk.rpc.mission_raw.Upl"
+    "oadGeofenceResponse\"\000\022z\n\021UploadRallyPoin"
+    "ts\0220.mavsdk.rpc.mission_raw.UploadRallyP"
+    "ointsRequest\0321.mavsdk.rpc.mission_raw.Up"
+    "loadRallyPointsResponse\"\000\022\204\001\n\023CancelMiss"
+    "ionUpload\0222.mavsdk.rpc.mission_raw.Cance"
+    "lMissionUploadRequest\0323.mavsdk.rpc.missi"
+    "on_raw.CancelMissionUploadResponse\"\004\200\265\030\001"
+    "\022t\n\017DownloadMission\022..mavsdk.rpc.mission"
+    "_raw.DownloadMissionRequest\032/.mavsdk.rpc"
+    ".mission_raw.DownloadMissionResponse\"\000\022w"
+    "\n\020DownloadGeofence\022/.mavsdk.rpc.mission_"
+    "raw.DownloadGeofenceRequest\0320.mavsdk.rpc"
+    ".mission_raw.DownloadGeofenceResponse\"\000\022"
+    "\200\001\n\023DownloadRallypoints\0222.mavsdk.rpc.mis"
+    "sion_raw.DownloadRallypointsRequest\0323.ma"
     "vsdk.rpc.mission_raw.DownloadRallypoints"
-    "Request\0323.mavsdk.rpc.mission_raw.Downloa"
-    "dRallypointsResponse\"\000\022\212\001\n\025CancelMission"
-    "Download\0224.mavsdk.rpc.mission_raw.Cancel"
-    "MissionDownloadRequest\0325.mavsdk.rpc.miss"
-    "ion_raw.CancelMissionDownloadResponse\"\004\200"
-    "\265\030\001\022k\n\014StartMission\022+.mavsdk.rpc.mission"
-    "_raw.StartMissionRequest\032,.mavsdk.rpc.mi"
-    "ssion_raw.StartMissionResponse\"\000\022k\n\014Paus"
-    "eMission\022+.mavsdk.rpc.mission_raw.PauseM"
-    "issionRequest\032,.mavsdk.rpc.mission_raw.P"
-    "auseMissionResponse\"\000\022k\n\014ClearMission\022+."
-    "mavsdk.rpc.mission_raw.ClearMissionReque"
-    "st\032,.mavsdk.rpc.mission_raw.ClearMission"
-    "Response\"\000\022\206\001\n\025SetCurrentMissionItem\0224.m"
-    "avsdk.rpc.mission_raw.SetCurrentMissionI"
-    "temRequest\0325.mavsdk.rpc.mission_raw.SetC"
-    "urrentMissionItemResponse\"\000\022\210\001\n\030Subscrib"
-    "eMissionProgress\0227.mavsdk.rpc.mission_ra"
-    "w.SubscribeMissionProgressRequest\032/.mavs"
-    "dk.rpc.mission_raw.MissionProgressRespon"
-    "se\"\0000\001\022\211\001\n\027SubscribeMissionChanged\0226.mav"
-    "sdk.rpc.mission_raw.SubscribeMissionChan"
-    "gedRequest\032..mavsdk.rpc.mission_raw.Miss"
-    "ionChangedResponse\"\004\200\265\030\0000\001\022\234\001\n\033ImportQgr"
-    "oundcontrolMission\022:.mavsdk.rpc.mission_"
-    "raw.ImportQgroundcontrolMissionRequest\032;"
-    ".mavsdk.rpc.mission_raw.ImportQgroundcon"
-    "trolMissionResponse\"\004\200\265\030\001\022\272\001\n%ImportQgro"
-    "undcontrolMissionFromString\022D.mavsdk.rpc"
-    ".mission_raw.ImportQgroundcontrolMission"
-    "FromStringRequest\032E.mavsdk.rpc.mission_r"
-    "aw.ImportQgroundcontrolMissionFromString"
-    "Response\"\004\200\265\030\001B(\n\025io.mavsdk.mission_rawB"
-    "\017MissionRawProtob\006proto3"
+    "Response\"\000\022\212\001\n\025CancelMissionDownload\0224.m"
+    "avsdk.rpc.mission_raw.CancelMissionDownl"
+    "oadRequest\0325.mavsdk.rpc.mission_raw.Canc"
+    "elMissionDownloadResponse\"\004\200\265\030\001\022k\n\014Start"
+    "Mission\022+.mavsdk.rpc.mission_raw.StartMi"
+    "ssionRequest\032,.mavsdk.rpc.mission_raw.St"
+    "artMissionResponse\"\000\022k\n\014PauseMission\022+.m"
+    "avsdk.rpc.mission_raw.PauseMissionReques"
+    "t\032,.mavsdk.rpc.mission_raw.PauseMissionR"
+    "esponse\"\000\022k\n\014ClearMission\022+.mavsdk.rpc.m"
+    "ission_raw.ClearMissionRequest\032,.mavsdk."
+    "rpc.mission_raw.ClearMissionResponse\"\000\022\206"
+    "\001\n\025SetCurrentMissionItem\0224.mavsdk.rpc.mi"
+    "ssion_raw.SetCurrentMissionItemRequest\0325"
+    ".mavsdk.rpc.mission_raw.SetCurrentMissio"
+    "nItemResponse\"\000\022\210\001\n\030SubscribeMissionProg"
+    "ress\0227.mavsdk.rpc.mission_raw.SubscribeM"
+    "issionProgressRequest\032/.mavsdk.rpc.missi"
+    "on_raw.MissionProgressResponse\"\0000\001\022\211\001\n\027S"
+    "ubscribeMissionChanged\0226.mavsdk.rpc.miss"
+    "ion_raw.SubscribeMissionChangedRequest\032."
+    ".mavsdk.rpc.mission_raw.MissionChangedRe"
+    "sponse\"\004\200\265\030\0000\001\022\234\001\n\033ImportQgroundcontrolM"
+    "ission\022:.mavsdk.rpc.mission_raw.ImportQg"
+    "roundcontrolMissionRequest\032;.mavsdk.rpc."
+    "mission_raw.ImportQgroundcontrolMissionR"
+    "esponse\"\004\200\265\030\001\022\272\001\n%ImportQgroundcontrolMi"
+    "ssionFromString\022D.mavsdk.rpc.mission_raw"
+    ".ImportQgroundcontrolMissionFromStringRe"
+    "quest\032E.mavsdk.rpc.mission_raw.ImportQgr"
+    "oundcontrolMissionFromStringResponse\"\004\200\265"
+    "\030\001\022~\n\021IsMissionFinished\0220.mavsdk.rpc.mis"
+    "sion_raw.IsMissionFinishedRequest\0321.mavs"
+    "dk.rpc.mission_raw.IsMissionFinishedResp"
+    "onse\"\004\200\265\030\001B(\n\025io.mavsdk.mission_rawB\017Mis"
+    "sionRawProtob\006proto3"
 };
 static const ::_pbi::DescriptorTable* const descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_deps[1] =
     {
@@ -1487,13 +1562,13 @@ static ::absl::once_flag descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_mission_5fraw_2fmission_5fraw_2eproto = {
     false,
     false,
-    5944,
+    6220,
     descriptor_table_protodef_mission_5fraw_2fmission_5fraw_2eproto,
     "mission_raw/mission_raw.proto",
     &descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_once,
     descriptor_table_mission_5fraw_2fmission_5fraw_2eproto_deps,
     1,
-    36,
+    38,
     schemas,
     file_default_instances,
     TableStruct_mission_5fraw_2fmission_5fraw_2eproto::offsets,
@@ -8159,6 +8234,394 @@ void ImportQgroundcontrolMissionFromStringResponse::InternalSwap(ImportQgroundco
 }
 
 ::google::protobuf::Metadata ImportQgroundcontrolMissionFromStringResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class IsMissionFinishedRequest::_Internal {
+ public:
+};
+
+IsMissionFinishedRequest::IsMissionFinishedRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.mission_raw.IsMissionFinishedRequest)
+}
+IsMissionFinishedRequest::IsMissionFinishedRequest(
+    ::google::protobuf::Arena* arena,
+    const IsMissionFinishedRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  IsMissionFinishedRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.mission_raw.IsMissionFinishedRequest)
+}
+
+inline void* IsMissionFinishedRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) IsMissionFinishedRequest(arena);
+}
+constexpr auto IsMissionFinishedRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(IsMissionFinishedRequest),
+                                            alignof(IsMissionFinishedRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull IsMissionFinishedRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_IsMissionFinishedRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &IsMissionFinishedRequest::MergeImpl,
+        ::google::protobuf::internal::ZeroFieldsBase::GetNewImpl<IsMissionFinishedRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &IsMissionFinishedRequest::SharedDtor,
+        ::google::protobuf::internal::ZeroFieldsBase::GetClearImpl<IsMissionFinishedRequest>(), &IsMissionFinishedRequest::ByteSizeLong,
+            &IsMissionFinishedRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(IsMissionFinishedRequest, _impl_._cached_size_),
+        false,
+    },
+    &IsMissionFinishedRequest::kDescriptorMethods,
+    &descriptor_table_mission_5fraw_2fmission_5fraw_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* IsMissionFinishedRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 0, 0, 0, 2> IsMissionFinishedRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    0, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967295,  // skipmap
+    offsetof(decltype(_table_), field_names),  // no field_entries
+    0,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::mission_raw::IsMissionFinishedRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    {::_pbi::TcParser::MiniParse, {}},
+  }}, {{
+    65535, 65535
+  }},
+  // no field_entries, or aux_entries
+  {{
+  }},
+};
+
+
+
+
+
+
+
+
+::google::protobuf::Metadata IsMissionFinishedRequest::GetMetadata() const {
+  return ::google::protobuf::internal::ZeroFieldsBase::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class IsMissionFinishedResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<IsMissionFinishedResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(IsMissionFinishedResponse, _impl_._has_bits_);
+};
+
+IsMissionFinishedResponse::IsMissionFinishedResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.mission_raw.IsMissionFinishedResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE IsMissionFinishedResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::mission_raw::IsMissionFinishedResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+IsMissionFinishedResponse::IsMissionFinishedResponse(
+    ::google::protobuf::Arena* arena,
+    const IsMissionFinishedResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  IsMissionFinishedResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.mission_raw_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::mission_raw::MissionRawResult>(
+                              arena, *from._impl_.mission_raw_result_)
+                        : nullptr;
+  _impl_.is_finished_ = from._impl_.is_finished_;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.mission_raw.IsMissionFinishedResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE IsMissionFinishedResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void IsMissionFinishedResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  ::memset(reinterpret_cast<char *>(&_impl_) +
+               offsetof(Impl_, mission_raw_result_),
+           0,
+           offsetof(Impl_, is_finished_) -
+               offsetof(Impl_, mission_raw_result_) +
+               sizeof(Impl_::is_finished_));
+}
+IsMissionFinishedResponse::~IsMissionFinishedResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.mission_raw.IsMissionFinishedResponse)
+  SharedDtor(*this);
+}
+inline void IsMissionFinishedResponse::SharedDtor(MessageLite& self) {
+  IsMissionFinishedResponse& this_ = static_cast<IsMissionFinishedResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.mission_raw_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* IsMissionFinishedResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) IsMissionFinishedResponse(arena);
+}
+constexpr auto IsMissionFinishedResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(IsMissionFinishedResponse),
+                                            alignof(IsMissionFinishedResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull IsMissionFinishedResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_IsMissionFinishedResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &IsMissionFinishedResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<IsMissionFinishedResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &IsMissionFinishedResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<IsMissionFinishedResponse>(), &IsMissionFinishedResponse::ByteSizeLong,
+            &IsMissionFinishedResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(IsMissionFinishedResponse, _impl_._cached_size_),
+        false,
+    },
+    &IsMissionFinishedResponse::kDescriptorMethods,
+    &descriptor_table_mission_5fraw_2fmission_5fraw_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* IsMissionFinishedResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<1, 2, 1, 0, 2> IsMissionFinishedResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(IsMissionFinishedResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    2, 8,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967292,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    2,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::mission_raw::IsMissionFinishedResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // bool is_finished = 2;
+    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(IsMissionFinishedResponse, _impl_.is_finished_), 63>(),
+     {16, 63, 0, PROTOBUF_FIELD_OFFSET(IsMissionFinishedResponse, _impl_.is_finished_)}},
+    // .mavsdk.rpc.mission_raw.MissionRawResult mission_raw_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(IsMissionFinishedResponse, _impl_.mission_raw_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.mission_raw.MissionRawResult mission_raw_result = 1;
+    {PROTOBUF_FIELD_OFFSET(IsMissionFinishedResponse, _impl_.mission_raw_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+    // bool is_finished = 2;
+    {PROTOBUF_FIELD_OFFSET(IsMissionFinishedResponse, _impl_.is_finished_), -1, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kBool)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::mission_raw::MissionRawResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void IsMissionFinishedResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.mission_raw.IsMissionFinishedResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.mission_raw_result_ != nullptr);
+    _impl_.mission_raw_result_->Clear();
+  }
+  _impl_.is_finished_ = false;
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* IsMissionFinishedResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const IsMissionFinishedResponse& this_ = static_cast<const IsMissionFinishedResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* IsMissionFinishedResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const IsMissionFinishedResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.mission_raw.IsMissionFinishedResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.mission_raw.MissionRawResult mission_raw_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.mission_raw_result_, this_._impl_.mission_raw_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          // bool is_finished = 2;
+          if (this_._internal_is_finished() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteBoolToArray(
+                2, this_._internal_is_finished(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.mission_raw.IsMissionFinishedResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t IsMissionFinishedResponse::ByteSizeLong(const MessageLite& base) {
+          const IsMissionFinishedResponse& this_ = static_cast<const IsMissionFinishedResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t IsMissionFinishedResponse::ByteSizeLong() const {
+          const IsMissionFinishedResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.mission_raw.IsMissionFinishedResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+          ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+           {
+            // .mavsdk.rpc.mission_raw.MissionRawResult mission_raw_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.mission_raw_result_);
+            }
+          }
+           {
+            // bool is_finished = 2;
+            if (this_._internal_is_finished() != 0) {
+              total_size += 2;
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void IsMissionFinishedResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<IsMissionFinishedResponse*>(&to_msg);
+  auto& from = static_cast<const IsMissionFinishedResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.mission_raw.IsMissionFinishedResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.mission_raw_result_ != nullptr);
+    if (_this->_impl_.mission_raw_result_ == nullptr) {
+      _this->_impl_.mission_raw_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::mission_raw::MissionRawResult>(arena, *from._impl_.mission_raw_result_);
+    } else {
+      _this->_impl_.mission_raw_result_->MergeFrom(*from._impl_.mission_raw_result_);
+    }
+  }
+  if (from._internal_is_finished() != 0) {
+    _this->_impl_.is_finished_ = from._impl_.is_finished_;
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void IsMissionFinishedResponse::CopyFrom(const IsMissionFinishedResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.mission_raw.IsMissionFinishedResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void IsMissionFinishedResponse::InternalSwap(IsMissionFinishedResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  ::google::protobuf::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(IsMissionFinishedResponse, _impl_.is_finished_)
+      + sizeof(IsMissionFinishedResponse::_impl_.is_finished_)
+      - PROTOBUF_FIELD_OFFSET(IsMissionFinishedResponse, _impl_.mission_raw_result_)>(
+          reinterpret_cast<char*>(&_impl_.mission_raw_result_),
+          reinterpret_cast<char*>(&other->_impl_.mission_raw_result_));
+}
+
+::google::protobuf::Metadata IsMissionFinishedResponse::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================

--- a/src/mavsdk_server/src/generated/mission_raw/mission_raw.pb.h
+++ b/src/mavsdk_server/src/generated/mission_raw/mission_raw.pb.h
@@ -105,6 +105,12 @@ extern ImportQgroundcontrolMissionRequestDefaultTypeInternal _ImportQgroundcontr
 class ImportQgroundcontrolMissionResponse;
 struct ImportQgroundcontrolMissionResponseDefaultTypeInternal;
 extern ImportQgroundcontrolMissionResponseDefaultTypeInternal _ImportQgroundcontrolMissionResponse_default_instance_;
+class IsMissionFinishedRequest;
+struct IsMissionFinishedRequestDefaultTypeInternal;
+extern IsMissionFinishedRequestDefaultTypeInternal _IsMissionFinishedRequest_default_instance_;
+class IsMissionFinishedResponse;
+struct IsMissionFinishedResponseDefaultTypeInternal;
+extern IsMissionFinishedResponseDefaultTypeInternal _IsMissionFinishedResponse_default_instance_;
 class MissionChangedResponse;
 struct MissionChangedResponseDefaultTypeInternal;
 extern MissionChangedResponseDefaultTypeInternal _MissionChangedResponse_default_instance_;
@@ -1067,7 +1073,7 @@ class MissionRawResult final
     return reinterpret_cast<const MissionRawResult*>(
         &_MissionRawResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 35;
+  static constexpr int kIndexInFileMessages = 37;
   friend void swap(MissionRawResult& a, MissionRawResult& b) { a.Swap(&b); }
   inline void Swap(MissionRawResult* other) {
     if (other == this) return;
@@ -1312,7 +1318,7 @@ class MissionProgress final
     return reinterpret_cast<const MissionProgress*>(
         &_MissionProgress_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 32;
+  static constexpr int kIndexInFileMessages = 34;
   friend void swap(MissionProgress& a, MissionProgress& b) { a.Swap(&b); }
   inline void Swap(MissionProgress* other) {
     if (other == this) return;
@@ -1515,7 +1521,7 @@ class MissionItem final
     return reinterpret_cast<const MissionItem*>(
         &_MissionItem_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 33;
+  static constexpr int kIndexInFileMessages = 35;
   friend void swap(MissionItem& a, MissionItem& b) { a.Swap(&b); }
   inline void Swap(MissionItem* other) {
     if (other == this) return;
@@ -1977,6 +1983,152 @@ class MissionChangedResponse final
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
   union { Impl_ _impl_; };
+  friend struct ::TableStruct_mission_5fraw_2fmission_5fraw_2eproto;
+};
+// -------------------------------------------------------------------
+
+class IsMissionFinishedRequest final
+    : public ::google::protobuf::internal::ZeroFieldsBase
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.mission_raw.IsMissionFinishedRequest) */ {
+ public:
+  inline IsMissionFinishedRequest() : IsMissionFinishedRequest(nullptr) {}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(IsMissionFinishedRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(IsMissionFinishedRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR IsMissionFinishedRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline IsMissionFinishedRequest(const IsMissionFinishedRequest& from) : IsMissionFinishedRequest(nullptr, from) {}
+  inline IsMissionFinishedRequest(IsMissionFinishedRequest&& from) noexcept
+      : IsMissionFinishedRequest(nullptr, std::move(from)) {}
+  inline IsMissionFinishedRequest& operator=(const IsMissionFinishedRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline IsMissionFinishedRequest& operator=(IsMissionFinishedRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const IsMissionFinishedRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const IsMissionFinishedRequest* internal_default_instance() {
+    return reinterpret_cast<const IsMissionFinishedRequest*>(
+        &_IsMissionFinishedRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 32;
+  friend void swap(IsMissionFinishedRequest& a, IsMissionFinishedRequest& b) { a.Swap(&b); }
+  inline void Swap(IsMissionFinishedRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(IsMissionFinishedRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  IsMissionFinishedRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::internal::ZeroFieldsBase::DefaultConstruct<IsMissionFinishedRequest>(arena);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::CopyFrom;
+  inline void CopyFrom(const IsMissionFinishedRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::CopyImpl(*this, from);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::MergeFrom;
+  void MergeFrom(const IsMissionFinishedRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::MergeImpl(*this, from);
+  }
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.mission_raw.IsMissionFinishedRequest"; }
+
+ protected:
+  explicit IsMissionFinishedRequest(::google::protobuf::Arena* arena);
+  IsMissionFinishedRequest(::google::protobuf::Arena* arena, const IsMissionFinishedRequest& from);
+  IsMissionFinishedRequest(::google::protobuf::Arena* arena, IsMissionFinishedRequest&& from) noexcept
+      : IsMissionFinishedRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.mission_raw.IsMissionFinishedRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 0, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const IsMissionFinishedRequest& from_msg);
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
   friend struct ::TableStruct_mission_5fraw_2fmission_5fraw_2eproto;
 };
 // -------------------------------------------------------------------
@@ -5284,7 +5436,7 @@ class MissionImportData final
     return reinterpret_cast<const MissionImportData*>(
         &_MissionImportData_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 34;
+  static constexpr int kIndexInFileMessages = 36;
   friend void swap(MissionImportData& a, MissionImportData& b) { a.Swap(&b); }
   inline void Swap(MissionImportData* other) {
     if (other == this) return;
@@ -5453,6 +5605,215 @@ class MissionImportData final
     ::google::protobuf::RepeatedPtrField< ::mavsdk::rpc::mission_raw::MissionItem > geofence_items_;
     ::google::protobuf::RepeatedPtrField< ::mavsdk::rpc::mission_raw::MissionItem > rally_items_;
     ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_mission_5fraw_2fmission_5fraw_2eproto;
+};
+// -------------------------------------------------------------------
+
+class IsMissionFinishedResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.mission_raw.IsMissionFinishedResponse) */ {
+ public:
+  inline IsMissionFinishedResponse() : IsMissionFinishedResponse(nullptr) {}
+  ~IsMissionFinishedResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(IsMissionFinishedResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(IsMissionFinishedResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR IsMissionFinishedResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline IsMissionFinishedResponse(const IsMissionFinishedResponse& from) : IsMissionFinishedResponse(nullptr, from) {}
+  inline IsMissionFinishedResponse(IsMissionFinishedResponse&& from) noexcept
+      : IsMissionFinishedResponse(nullptr, std::move(from)) {}
+  inline IsMissionFinishedResponse& operator=(const IsMissionFinishedResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline IsMissionFinishedResponse& operator=(IsMissionFinishedResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const IsMissionFinishedResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const IsMissionFinishedResponse* internal_default_instance() {
+    return reinterpret_cast<const IsMissionFinishedResponse*>(
+        &_IsMissionFinishedResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 33;
+  friend void swap(IsMissionFinishedResponse& a, IsMissionFinishedResponse& b) { a.Swap(&b); }
+  inline void Swap(IsMissionFinishedResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(IsMissionFinishedResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  IsMissionFinishedResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<IsMissionFinishedResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const IsMissionFinishedResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const IsMissionFinishedResponse& from) { IsMissionFinishedResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(IsMissionFinishedResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.mission_raw.IsMissionFinishedResponse"; }
+
+ protected:
+  explicit IsMissionFinishedResponse(::google::protobuf::Arena* arena);
+  IsMissionFinishedResponse(::google::protobuf::Arena* arena, const IsMissionFinishedResponse& from);
+  IsMissionFinishedResponse(::google::protobuf::Arena* arena, IsMissionFinishedResponse&& from) noexcept
+      : IsMissionFinishedResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kMissionRawResultFieldNumber = 1,
+    kIsFinishedFieldNumber = 2,
+  };
+  // .mavsdk.rpc.mission_raw.MissionRawResult mission_raw_result = 1;
+  bool has_mission_raw_result() const;
+  void clear_mission_raw_result() ;
+  const ::mavsdk::rpc::mission_raw::MissionRawResult& mission_raw_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::mission_raw::MissionRawResult* release_mission_raw_result();
+  ::mavsdk::rpc::mission_raw::MissionRawResult* mutable_mission_raw_result();
+  void set_allocated_mission_raw_result(::mavsdk::rpc::mission_raw::MissionRawResult* value);
+  void unsafe_arena_set_allocated_mission_raw_result(::mavsdk::rpc::mission_raw::MissionRawResult* value);
+  ::mavsdk::rpc::mission_raw::MissionRawResult* unsafe_arena_release_mission_raw_result();
+
+  private:
+  const ::mavsdk::rpc::mission_raw::MissionRawResult& _internal_mission_raw_result() const;
+  ::mavsdk::rpc::mission_raw::MissionRawResult* _internal_mutable_mission_raw_result();
+
+  public:
+  // bool is_finished = 2;
+  void clear_is_finished() ;
+  bool is_finished() const;
+  void set_is_finished(bool value);
+
+  private:
+  bool _internal_is_finished() const;
+  void _internal_set_is_finished(bool value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.mission_raw.IsMissionFinishedResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      1, 2, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const IsMissionFinishedResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::mission_raw::MissionRawResult* mission_raw_result_;
+    bool is_finished_;
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
   union { Impl_ _impl_; };
@@ -9330,6 +9691,132 @@ inline void ImportQgroundcontrolMissionFromStringResponse::set_allocated_mission
 
   _impl_.mission_import_data_ = reinterpret_cast<::mavsdk::rpc::mission_raw::MissionImportData*>(value);
   // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.mission_raw.ImportQgroundcontrolMissionFromStringResponse.mission_import_data)
+}
+
+// -------------------------------------------------------------------
+
+// IsMissionFinishedRequest
+
+// -------------------------------------------------------------------
+
+// IsMissionFinishedResponse
+
+// .mavsdk.rpc.mission_raw.MissionRawResult mission_raw_result = 1;
+inline bool IsMissionFinishedResponse::has_mission_raw_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.mission_raw_result_ != nullptr);
+  return value;
+}
+inline void IsMissionFinishedResponse::clear_mission_raw_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.mission_raw_result_ != nullptr) _impl_.mission_raw_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::mission_raw::MissionRawResult& IsMissionFinishedResponse::_internal_mission_raw_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::mission_raw::MissionRawResult* p = _impl_.mission_raw_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::mission_raw::MissionRawResult&>(::mavsdk::rpc::mission_raw::_MissionRawResult_default_instance_);
+}
+inline const ::mavsdk::rpc::mission_raw::MissionRawResult& IsMissionFinishedResponse::mission_raw_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.mission_raw.IsMissionFinishedResponse.mission_raw_result)
+  return _internal_mission_raw_result();
+}
+inline void IsMissionFinishedResponse::unsafe_arena_set_allocated_mission_raw_result(::mavsdk::rpc::mission_raw::MissionRawResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.mission_raw_result_);
+  }
+  _impl_.mission_raw_result_ = reinterpret_cast<::mavsdk::rpc::mission_raw::MissionRawResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.mission_raw.IsMissionFinishedResponse.mission_raw_result)
+}
+inline ::mavsdk::rpc::mission_raw::MissionRawResult* IsMissionFinishedResponse::release_mission_raw_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::mission_raw::MissionRawResult* released = _impl_.mission_raw_result_;
+  _impl_.mission_raw_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::mission_raw::MissionRawResult* IsMissionFinishedResponse::unsafe_arena_release_mission_raw_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.mission_raw.IsMissionFinishedResponse.mission_raw_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::mission_raw::MissionRawResult* temp = _impl_.mission_raw_result_;
+  _impl_.mission_raw_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::mission_raw::MissionRawResult* IsMissionFinishedResponse::_internal_mutable_mission_raw_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.mission_raw_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::mission_raw::MissionRawResult>(GetArena());
+    _impl_.mission_raw_result_ = reinterpret_cast<::mavsdk::rpc::mission_raw::MissionRawResult*>(p);
+  }
+  return _impl_.mission_raw_result_;
+}
+inline ::mavsdk::rpc::mission_raw::MissionRawResult* IsMissionFinishedResponse::mutable_mission_raw_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::mission_raw::MissionRawResult* _msg = _internal_mutable_mission_raw_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.mission_raw.IsMissionFinishedResponse.mission_raw_result)
+  return _msg;
+}
+inline void IsMissionFinishedResponse::set_allocated_mission_raw_result(::mavsdk::rpc::mission_raw::MissionRawResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.mission_raw_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.mission_raw_result_ = reinterpret_cast<::mavsdk::rpc::mission_raw::MissionRawResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.mission_raw.IsMissionFinishedResponse.mission_raw_result)
+}
+
+// bool is_finished = 2;
+inline void IsMissionFinishedResponse::clear_is_finished() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.is_finished_ = false;
+}
+inline bool IsMissionFinishedResponse::is_finished() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.mission_raw.IsMissionFinishedResponse.is_finished)
+  return _internal_is_finished();
+}
+inline void IsMissionFinishedResponse::set_is_finished(bool value) {
+  _internal_set_is_finished(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.mission_raw.IsMissionFinishedResponse.is_finished)
+}
+inline bool IsMissionFinishedResponse::_internal_is_finished() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.is_finished_;
+}
+inline void IsMissionFinishedResponse::_internal_set_is_finished(bool value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.is_finished_ = value;
 }
 
 // -------------------------------------------------------------------

--- a/src/mavsdk_server/src/plugins/mission_raw/mission_raw_service_impl.h
+++ b/src/mavsdk_server/src/plugins/mission_raw/mission_raw_service_impl.h
@@ -750,6 +750,31 @@ public:
         return grpc::Status::OK;
     }
 
+    grpc::Status IsMissionFinished(
+        grpc::ServerContext* /* context */,
+        const rpc::mission_raw::IsMissionFinishedRequest* /* request */,
+        rpc::mission_raw::IsMissionFinishedResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            if (response != nullptr) {
+                auto result = mavsdk::MissionRaw::Result::NoSystem;
+                fillResponseWithResult(response, result);
+            }
+
+            return grpc::Status::OK;
+        }
+
+        auto result = _lazy_plugin.maybe_plugin()->is_mission_finished();
+
+        if (response != nullptr) {
+            fillResponseWithResult(response, result.first);
+
+            response->set_is_finished(result.second);
+        }
+
+        return grpc::Status::OK;
+    }
+
     void stop()
     {
         _stopped.store(true);


### PR DESCRIPTION
- Mission: If the mission state is available we should make good use of it, otherwise we can fallback on what we did previously.
- MissionRaw: Add is_mission_finished method, and copy logic of Mission.
- Mission: PX4 required us to account for RTL items as they were not reported as "reached". This is no longer required in the future, so we need to fix the comparison.

Uses https://github.com/mavlink/mavlink/pull/1869.