### PR TITLE
docker: try to fix lxml for Ubuntu 20.04

### DIFF
--- a/docker/Dockerfile-ubuntu-20.04
+++ b/docker/Dockerfile-ubuntu-20.04
@@ -26,6 +26,7 @@ RUN apt-get update \
         python3 \
         python3-pip \
         python3-future \
+        python3-lxml \
         ruby-dev \
         doxygen \
         colordiff \


### PR DESCRIPTION
The pip build for lxml doesn't work anymore, so let's try to install it via apt.