### PR TITLE
core: change Android tmp dir, make it configurable

### DIFF
--- a/src/mavsdk/core/fs_utils.cpp
+++ b/src/mavsdk/core/fs_utils.cpp
@@ -20,6 +20,13 @@
 
 namespace mavsdk {
 
+#ifdef ANDROID
+extern "C" {
+// Default Android temp path that can be overridden by JNI if needed
+char* mavsdk_temp_path = const_cast<char*>("/data/local/tmp");
+}
+#endif
+
 #ifdef WINDOWS
 static std::optional<std::filesystem::path> get_known_windows_path(REFKNOWNFOLDERID folderId)
 {
@@ -93,7 +100,11 @@ std::optional<std::filesystem::path> get_cache_directory()
 std::optional<std::filesystem::path> create_tmp_directory(const std::string& prefix)
 {
     // Inspired by https://stackoverflow.com/a/58454949/8548472
+#ifdef ANDROID
+    const auto tmp_dir = std::filesystem::path(mavsdk_temp_path);
+#else
     const auto tmp_dir = std::filesystem::temp_directory_path();
+#endif
 
     std::random_device dev;
     std::mt19937 prng(dev());

--- a/src/mavsdk/core/fs_utils.h
+++ b/src/mavsdk/core/fs_utils.h
@@ -19,4 +19,10 @@ std::optional<std::filesystem::path> create_tmp_directory(const std::string& pre
 
 std::string replace_non_ascii_and_whitespace(const std::string& input);
 
+#ifdef ANDROID
+extern "C" {
+extern char* mavsdk_temp_path;
+}
+#endif
+
 } // namespace mavsdk


### PR DESCRIPTION
When Android tries to access the default `/tmp` temporary directory it crashes due to missing permissions.

As a workaround, let's try to use `/data/local/tmp` instead, and if that doesn't work, make it configurable within JNI for the user.

Hopefully fixes https://github.com/mavlink/MAVSDK-Java/issues/206.