### PR TITLE
Win CI fixes

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   Windows-mavsdk_server:
     name: Windows mavsdk_server build
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
         with:
@@ -71,7 +71,7 @@ jobs:
 
   Windows-mavsdk-library:
     name: Windows mavsdk library build
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: 'install/bin/mavsdk_server_bin.exe'
-          asset_name: 'mavsdk_server_win32.exe'
+          asset_name: 'mavsdk_server_win_x64.exe'
           tag: ${{ github.ref }}
           overwrite: true
 


### PR DESCRIPTION
- Rename exe to `mavsdk_server_win_x64.exe`.
- Pin GitHub runners.