### PR TITLE
Build error windows without JOM

### DIFF
--- a/docs/en/cpp/guide/build_windows.md
+++ b/docs/en/cpp/guide/build_windows.md
@@ -47,7 +47,10 @@ git submodule update --init --recursive
 ```
 
 ## Building the MAVSDK library only
-
+::: Tip
+Make sure to run this within the Visual Studio environment to access Ninja. You can either run the "x64 Native Tools Command Prompt for VS 2022" program or call the vcvarsall.bat script located in your Visual Studio 2022 installation directory:
+`C:\Program Files\Microsoft Visual Studio\2022\EDITION\VC\Auxiliary\Build\vcvarsall.bat`
+:::
 ### Debug Build
 
 For development, use the debug build:

--- a/third_party/openssl/CMakeLists.txt
+++ b/third_party/openssl/CMakeLists.txt
@@ -120,7 +120,7 @@ elseif(MSVC)
             PREFIX openssl
             CONFIGURE_COMMAND perl <SOURCE_DIR>/Configure VC-WIN64A --prefix=${NATIVE_INSTALL_PREFIX} --openssldir=${NATIVE_INSTALL_PREFIX} ${OPENSSL_BUILD_TYPE} no-shared no-asm no-tests
             BUILD_COMMAND set MAKEFLAGS= && nmake build_libs
-            INSTALL_COMMAND nmake install_dev
+            INSTALL_COMMAND set MAKEFLAGS= && nmake install_dev
         )
     endif()
 


### PR DESCRIPTION
Fixed a build error on windows when not using JOM and updated the windows build documentation.