### PR TITLE
core: fix REQUEST_MESSAGE drops with multiple components

### DIFF
--- a/src/mavsdk/core/mavlink_request_message.cpp
+++ b/src/mavsdk/core/mavlink_request_message.cpp
@@ -41,10 +41,14 @@ void MavlinkRequestMessage::request(
 
     // Respond with 'Busy' if already in progress.
     for (auto& item : _work_items) {
-        if (item.message_id == message_id && item.param2 == param2) {
+        if (item.message_id == message_id && item.param2 == param2 &&
+            item.target_component == target_component) {
             lock.unlock();
             if (callback) {
                 callback(MavlinkCommandSender::Result::Busy, {});
+            }
+            if (_debugging) {
+                LogDebug() << "Message " << item.message_id << " already requested";
             }
             return;
         }


### PR DESCRIPTION
We often flagged REQUEST_MESSAGE commands as Busy because they were duplicate. However, when we are targetting different component IDs, they are obviously different and need to be done for this to work properly.

This came up when debugging a gimbal not being recognized as the request for GIMBAL_DEVICE_INFORMATION was swallowed.