### PR TITLE
core: flush after each Log* line (take 2)

### DIFF
--- a/src/mavsdk/core/log.h
+++ b/src/mavsdk/core/log.h
@@ -125,7 +125,7 @@ public:
         std::cout << _s.str();
         std::cout << " (" << _caller_filename << ":" << std::dec << _caller_filenumber << ")";
 
-        std::cout << '\n';
+        std::cout << std::endl;
 #endif
     }
 


### PR DESCRIPTION
While debugging debug output in MAVSDK-Python I realized that error messages like "Invalid connection" just never appear which is very confusing.

I have also seen reports in the past where MAVSDK logs wouldn't show up or show up very late in journalctl (if an application is started via systemd). Again, very confusing.

Given we don't print a lot of stuff, and flushing after each line unlikely has real performance implications, I suggest to use std::endl which includes std::flush instead of only printing a newline.

This replaces #2626. It's currently on top of #2630 for CI testing.