### PR TITLE
telemetry: fix Imu units

### DIFF
--- a/docs/en/cpp/api_reference/classmavsdk_1_1_telemetry.md
+++ b/docs/en/cpp/api_reference/classmavsdk_1_1_telemetry.md
@@ -237,7 +237,7 @@ void | [unsubscribe_imu](#classmavsdk_1_1_telemetry_1a2af03957c69efd9b5cbb7537de
 [ScaledImuHandle](classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a4968d9d418d48a4368f2915023ca0014) | [subscribe_scaled_imu](#classmavsdk_1_1_telemetry_1a61bd540f505a3a6acd858ca169e868b3) (const [ScaledImuCallback](classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a26159a775adcfbc42302234b7108d94f) & callback) | Subscribe to 'Scaled IMU' updates.
 void | [unsubscribe_scaled_imu](#classmavsdk_1_1_telemetry_1a69acf5d201425f0a318a36ad6230fb46) ([ScaledImuHandle](classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a4968d9d418d48a4368f2915023ca0014) handle) | Unsubscribe from subscribe_scaled_imu.
 [Imu](structmavsdk_1_1_telemetry_1_1_imu.md) | [scaled_imu](#classmavsdk_1_1_telemetry_1ab6a515ba85a67bc80e6e1c9a05d1f94d) () const | Poll for '[Imu](structmavsdk_1_1_telemetry_1_1_imu.md)' (blocking).
-[RawImuHandle](classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a416f5b4dc6c51d78d05572d5cc18f3fb) | [subscribe_raw_imu](#classmavsdk_1_1_telemetry_1a98db826585b84957478a6195d46f0491) (const [RawImuCallback](classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a92711da85d343cb58b73561e6b730c76) & callback) | Subscribe to 'Raw IMU' updates.
+[RawImuHandle](classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a416f5b4dc6c51d78d05572d5cc18f3fb) | [subscribe_raw_imu](#classmavsdk_1_1_telemetry_1a98db826585b84957478a6195d46f0491) (const [RawImuCallback](classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a92711da85d343cb58b73561e6b730c76) & callback) | Subscribe to 'Raw IMU' updates (note that units are are incorrect and "raw" as provided by the sensor)
 void | [unsubscribe_raw_imu](#classmavsdk_1_1_telemetry_1aec5b5fbbb37654bb6dae9607451929d7) ([RawImuHandle](classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a416f5b4dc6c51d78d05572d5cc18f3fb) handle) | Unsubscribe from subscribe_raw_imu.
 [Imu](structmavsdk_1_1_telemetry_1_1_imu.md) | [raw_imu](#classmavsdk_1_1_telemetry_1a691464f001ddf8d02b97bcf137f5cf8a) () const | Poll for '[Imu](structmavsdk_1_1_telemetry_1_1_imu.md)' (blocking).
 [HealthAllOkHandle](classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1aa882d4938eb491cce5b7ca6aead2384c) | [subscribe_health_all_ok](#classmavsdk_1_1_telemetry_1acc64edfa8230926024cdefe93ab10c7f) (const [HealthAllOkCallback](classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a71cdcadfaa988dc14029e0b9fdbe742d) & callback) | Subscribe to 'HealthAllOk' updates.
@@ -2262,7 +2262,7 @@ RawImuHandle mavsdk::Telemetry::subscribe_raw_imu(const RawImuCallback &callback
 ```
 
 
-Subscribe to 'Raw IMU' updates.
+Subscribe to 'Raw IMU' updates (note that units are are incorrect and "raw" as provided by the sensor)
 
 
 **Parameters**

--- a/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -1772,7 +1772,8 @@ public:
     using RawImuHandle = Handle<Imu>;
 
     /**
-     * @brief Subscribe to 'Raw IMU' updates.
+     * @brief Subscribe to 'Raw IMU' updates (note that units are are incorrect and "raw" as
+     * provided by the sensor)
      */
     RawImuHandle subscribe_raw_imu(const RawImuCallback& callback);
 

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -877,15 +877,18 @@ void TelemetryImpl::process_scaled_imu(const mavlink_message_t& message)
     mavlink_scaled_imu_t scaled_imu_reading;
     mavlink_msg_scaled_imu_decode(&message, &scaled_imu_reading);
     Telemetry::Imu new_imu;
-    new_imu.acceleration_frd.forward_m_s2 = scaled_imu_reading.xacc;
-    new_imu.acceleration_frd.right_m_s2 = scaled_imu_reading.yacc;
-    new_imu.acceleration_frd.down_m_s2 = scaled_imu_reading.zacc;
-    new_imu.angular_velocity_frd.forward_rad_s = scaled_imu_reading.xgyro;
-    new_imu.angular_velocity_frd.right_rad_s = scaled_imu_reading.ygyro;
-    new_imu.angular_velocity_frd.down_rad_s = scaled_imu_reading.zgyro;
-    new_imu.magnetic_field_frd.forward_gauss = scaled_imu_reading.xmag;
-    new_imu.magnetic_field_frd.right_gauss = scaled_imu_reading.ymag;
-    new_imu.magnetic_field_frd.down_gauss = scaled_imu_reading.zmag;
+    // From mG to m/s^2
+    new_imu.acceleration_frd.forward_m_s2 = scaled_imu_reading.xacc / 1000.f * 9.81f;
+    new_imu.acceleration_frd.right_m_s2 = scaled_imu_reading.yacc / 1000.f * 9.81f;
+    new_imu.acceleration_frd.down_m_s2 = scaled_imu_reading.zacc / 1000.f * 9.81f;
+    // From mrad to rad
+    new_imu.angular_velocity_frd.forward_rad_s = scaled_imu_reading.xgyro / 1000.f;
+    new_imu.angular_velocity_frd.right_rad_s = scaled_imu_reading.ygyro / 1000.f;
+    new_imu.angular_velocity_frd.down_rad_s = scaled_imu_reading.zgyro / 1000.f;
+    // From milliGauss to Gauss
+    new_imu.magnetic_field_frd.forward_gauss = scaled_imu_reading.xmag / 1000.f;
+    new_imu.magnetic_field_frd.right_gauss = scaled_imu_reading.ymag / 1000.f;
+    new_imu.magnetic_field_frd.down_gauss = scaled_imu_reading.zmag / 1000.f;
     new_imu.temperature_degc = static_cast<float>(scaled_imu_reading.temperature) * 1e-2f;
     new_imu.timestamp_us = static_cast<uint64_t>(scaled_imu_reading.time_boot_ms) * 1000;
 

--- a/src/mavsdk_server/src/generated/telemetry/telemetry.grpc.pb.h
+++ b/src/mavsdk_server/src/generated/telemetry/telemetry.grpc.pb.h
@@ -290,7 +290,7 @@ class TelemetryService final {
     std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::telemetry::ScaledImuResponse>> PrepareAsyncSubscribeScaledImu(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeScaledImuRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::telemetry::ScaledImuResponse>>(PrepareAsyncSubscribeScaledImuRaw(context, request, cq));
     }
-    // Subscribe to 'Raw IMU' updates.
+    // Subscribe to 'Raw IMU' updates (note that units are are incorrect and "raw" as provided by the sensor)
     std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::telemetry::RawImuResponse>> SubscribeRawImu(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeRawImuRequest& request) {
       return std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::telemetry::RawImuResponse>>(SubscribeRawImuRaw(context, request));
     }
@@ -624,7 +624,7 @@ class TelemetryService final {
       virtual void SubscribeImu(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeImuRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::telemetry::ImuResponse>* reactor) = 0;
       // Subscribe to 'Scaled IMU' updates.
       virtual void SubscribeScaledImu(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeScaledImuRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::telemetry::ScaledImuResponse>* reactor) = 0;
-      // Subscribe to 'Raw IMU' updates.
+      // Subscribe to 'Raw IMU' updates (note that units are are incorrect and "raw" as provided by the sensor)
       virtual void SubscribeRawImu(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeRawImuRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::telemetry::RawImuResponse>* reactor) = 0;
       // Subscribe to 'HealthAllOk' updates.
       virtual void SubscribeHealthAllOk(::grpc::ClientContext* context, const ::mavsdk::rpc::telemetry::SubscribeHealthAllOkRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::telemetry::HealthAllOkResponse>* reactor) = 0;
@@ -1707,7 +1707,7 @@ class TelemetryService final {
     virtual ::grpc::Status SubscribeImu(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry::SubscribeImuRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::telemetry::ImuResponse>* writer);
     // Subscribe to 'Scaled IMU' updates.
     virtual ::grpc::Status SubscribeScaledImu(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry::SubscribeScaledImuRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::telemetry::ScaledImuResponse>* writer);
-    // Subscribe to 'Raw IMU' updates.
+    // Subscribe to 'Raw IMU' updates (note that units are are incorrect and "raw" as provided by the sensor)
     virtual ::grpc::Status SubscribeRawImu(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry::SubscribeRawImuRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::telemetry::RawImuResponse>* writer);
     // Subscribe to 'HealthAllOk' updates.
     virtual ::grpc::Status SubscribeHealthAllOk(::grpc::ServerContext* context, const ::mavsdk::rpc::telemetry::SubscribeHealthAllOkRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::telemetry::HealthAllOkResponse>* writer);


### PR DESCRIPTION
- ScaledImu: this comes in milliG, milliRad, milliGauss, so we need to translate it.
- RawImu: doesn't have a unit by definition, so we need to add a comment.

Depends on https://github.com/mavlink/MAVSDK-Proto/pull/380