### PR TITLE
Add new JSON based interception API

### DIFF
--- a/docs/en/cpp/api_reference/classmavsdk_1_1_mavsdk.md
+++ b/docs/en/cpp/api_reference/classmavsdk_1_1_mavsdk.md
@@ -20,6 +20,8 @@ struct [Configuration](classmavsdk_1_1_mavsdk_1_1_configuration.md)
 
 struct [ConnectionError](structmavsdk_1_1_mavsdk_1_1_connection_error.md)
 
+struct [MavlinkMessage](structmavsdk_1_1_mavsdk_1_1_mavlink_message.md)
+
 ## Public Types
 
 
@@ -30,6 +32,8 @@ std::function< void([ConnectionError](structmavsdk_1_1_mavsdk_1_1_connection_err
 [Handle](classmavsdk_1_1_handle.md)< [ConnectionError](structmavsdk_1_1_mavsdk_1_1_connection_error.md) > [ConnectionErrorHandle](#classmavsdk_1_1_mavsdk_1aeb442a462d03662e4c152509fd0c203b) | [Handle](classmavsdk_1_1_handle.md) type to remove a connection error subscription.
 std::function< void()> [NewSystemCallback](#classmavsdk_1_1_mavsdk_1a7a283c6a75e852a56be4c5862f8a3fab) | Callback type discover and timeout notifications.
 [Handle](classmavsdk_1_1_handle.md)<> [NewSystemHandle](#classmavsdk_1_1_mavsdk_1ae0727f2bed9cbf276d161ada0a432b8c) | [Handle](classmavsdk_1_1_handle.md) type to unsubscribe from subscribe_on_new_system.
+[Handle](classmavsdk_1_1_handle.md)< bool([MavlinkMessage](structmavsdk_1_1_mavsdk_1_1_mavlink_message.md))> [InterceptJsonHandle](#classmavsdk_1_1_mavsdk_1a3b40ae4fd8af4c4419b61f0ad955812f) | [Handle](classmavsdk_1_1_handle.md) for intercepting messages.
+std::function< bool([MavlinkMessage](structmavsdk_1_1_mavsdk_1_1_mavlink_message.md))> [InterceptJsonCallback](#classmavsdk_1_1_mavsdk_1a17923db3b1504e911487729114b68f48) | Callback type for intercepting messages.
 
 ## Public Member Functions
 
@@ -54,6 +58,10 @@ void | [unsubscribe_on_new_system](#classmavsdk_1_1_mavsdk_1ad7f77f1295a700ee73c
 std::shared_ptr< [ServerComponent](classmavsdk_1_1_server_component.md) > | [server_component](#classmavsdk_1_1_mavsdk_1a693a2f665c35d6b01d6144819d353280) (unsigned instance=0) | Get server component with default type of [Mavsdk](classmavsdk_1_1_mavsdk.md) instance.
 std::shared_ptr< [ServerComponent](classmavsdk_1_1_server_component.md) > | [server_component_by_type](#classmavsdk_1_1_mavsdk_1a547fc7e18434473ea3e0e51ab3305abb) ([ComponentType](namespacemavsdk.md#namespacemavsdk_1a20fe7f7c8312779a187017111bf33d12) component_type, unsigned instance=0) | Get server component by a high level type.
 std::shared_ptr< [ServerComponent](classmavsdk_1_1_server_component.md) > | [server_component_by_id](#classmavsdk_1_1_mavsdk_1adef7d0d7422bcddbda629a404fb33ae2) (uint8_t component_id) | Get server component by the low MAVLink component ID.
+[InterceptJsonHandle](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a3b40ae4fd8af4c4419b61f0ad955812f) | [subscribe_incoming_messages_json](#classmavsdk_1_1_mavsdk_1a722fce6f1abe8337721dde710b5b40d7) (const [InterceptJsonCallback](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a17923db3b1504e911487729114b68f48) & callback) | Intercept incoming messages as JSON.
+void | [unsubscribe_incoming_messages_json](#classmavsdk_1_1_mavsdk_1a4be244c38939cb517c2061baf4d43386) ([InterceptJsonHandle](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a3b40ae4fd8af4c4419b61f0ad955812f) handle) | Unsubscribe from incoming messages as JSON.
+[InterceptJsonHandle](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a3b40ae4fd8af4c4419b61f0ad955812f) | [subscribe_outgoing_messages_json](#classmavsdk_1_1_mavsdk_1a58f85b2f74a32404a8e975feefed8f47) (const [InterceptJsonCallback](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a17923db3b1504e911487729114b68f48) & callback) | Intercept outgoing messages as JSON.
+void | [unsubscribe_outgoing_messages_json](#classmavsdk_1_1_mavsdk_1aa3a490358db87cfed617cdad902bb753) ([InterceptJsonHandle](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a3b40ae4fd8af4c4419b61f0ad955812f) handle) | Unsubscribe from outgoing messages as JSON.
 void | [intercept_incoming_messages_async](#classmavsdk_1_1_mavsdk_1ac80c8909958533131cbdbc61d061794f) (std::function< bool(mavlink_message_t &)> callback) | Intercept incoming messages.
 void | [intercept_outgoing_messages_async](#classmavsdk_1_1_mavsdk_1a040ee5c1d41e71c0d63cf8f76d2db275) (std::function< bool(mavlink_message_t &)> callback) | Intercept outgoing messages.
 
@@ -146,6 +154,26 @@ using mavsdk::Mavsdk::NewSystemHandle =  Handle<>
 
 
 [Handle](classmavsdk_1_1_handle.md) type to unsubscribe from subscribe_on_new_system.
+
+
+### typedef InterceptJsonHandle {#classmavsdk_1_1_mavsdk_1a3b40ae4fd8af4c4419b61f0ad955812f}
+
+```cpp
+using mavsdk::Mavsdk::InterceptJsonHandle =  Handle<bool(MavlinkMessage)>
+```
+
+
+[Handle](classmavsdk_1_1_handle.md) for intercepting messages.
+
+
+### typedef InterceptJsonCallback {#classmavsdk_1_1_mavsdk_1a17923db3b1504e911487729114b68f48}
+
+```cpp
+using mavsdk::Mavsdk::InterceptJsonCallback =  std::function<bool(MavlinkMessage)>
+```
+
+
+Callback type for intercepting messages.
 
 
 ## Member Function Documentation
@@ -454,6 +482,71 @@ This represents a server component of the MAVSDK instance.
 **Returns**
 
 &emsp;std::shared_ptr< [ServerComponent](classmavsdk_1_1_server_component.md) > - A valid shared pointer to a server component if it was successful, an empty pointer otherwise.
+
+### subscribe_incoming_messages_json() {#classmavsdk_1_1_mavsdk_1a722fce6f1abe8337721dde710b5b40d7}
+```cpp
+InterceptJsonHandle mavsdk::Mavsdk::subscribe_incoming_messages_json(const InterceptJsonCallback &callback)
+```
+
+
+Intercept incoming messages as JSON.
+
+This is a hook that allows to read any messages arriving via the in JSON format.
+
+**Parameters**
+
+* const [InterceptJsonCallback](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a17923db3b1504e911487729114b68f48)& **callback** - Callback to be called for each incoming message. To drop a message, return 'false' from the callback.
+
+**Returns**
+
+&emsp;[InterceptJsonHandle](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a3b40ae4fd8af4c4419b61f0ad955812f) - 
+
+### unsubscribe_incoming_messages_json() {#classmavsdk_1_1_mavsdk_1a4be244c38939cb517c2061baf4d43386}
+```cpp
+void mavsdk::Mavsdk::unsubscribe_incoming_messages_json(InterceptJsonHandle handle)
+```
+
+
+Unsubscribe from incoming messages as JSON.
+
+
+**Parameters**
+
+* [InterceptJsonHandle](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a3b40ae4fd8af4c4419b61f0ad955812f) **handle** - 
+
+### subscribe_outgoing_messages_json() {#classmavsdk_1_1_mavsdk_1a58f85b2f74a32404a8e975feefed8f47}
+```cpp
+InterceptJsonHandle mavsdk::Mavsdk::subscribe_outgoing_messages_json(const InterceptJsonCallback &callback)
+```
+
+
+Intercept outgoing messages as JSON.
+
+3 
+
+
+This is a hook that allows to read any messages arriving via the in JSON format.
+
+**Parameters**
+
+* const [InterceptJsonCallback](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a17923db3b1504e911487729114b68f48)& **callback** - Callback to be called for each outgoing message. To drop a message, return 'false' from the callback.
+
+**Returns**
+
+&emsp;[InterceptJsonHandle](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a3b40ae4fd8af4c4419b61f0ad955812f) - 
+
+### unsubscribe_outgoing_messages_json() {#classmavsdk_1_1_mavsdk_1aa3a490358db87cfed617cdad902bb753}
+```cpp
+void mavsdk::Mavsdk::unsubscribe_outgoing_messages_json(InterceptJsonHandle handle)
+```
+
+
+Unsubscribe from outgoing messages as JSON.
+
+
+**Parameters**
+
+* [InterceptJsonHandle](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a3b40ae4fd8af4c4419b61f0ad955812f) **handle** - 
 
 ### intercept_incoming_messages_async() {#classmavsdk_1_1_mavsdk_1ac80c8909958533131cbdbc61d061794f}
 ```cpp

--- a/docs/en/cpp/api_reference/structmavsdk_1_1_mavlink_direct_1_1_mavlink_message.md
+++ b/docs/en/cpp/api_reference/structmavsdk_1_1_mavlink_direct_1_1_mavlink_message.md
@@ -16,9 +16,9 @@ uint32_t [system_id](#structmavsdk_1_1_mavlink_direct_1_1_mavlink_message_1a0fea
 
 uint32_t [component_id](#structmavsdk_1_1_mavlink_direct_1_1_mavlink_message_1a742b128da448bb76b80ea842dc04161e) {} - Component ID of the sender (for received messages)
 
-uint32_t [target_system](#structmavsdk_1_1_mavlink_direct_1_1_mavlink_message_1abe3432b0a8d0fdcccf57091ef8ffd674) {} - Target system ID (for sending, 0 for broadcast)
+uint32_t [target_system_id](#structmavsdk_1_1_mavlink_direct_1_1_mavlink_message_1a428079a85d1d095c9b48a9bab2109d4e) {} - Target system ID (for sending, 0 for broadcast)
 
-uint32_t [target_component](#structmavsdk_1_1_mavlink_direct_1_1_mavlink_message_1abed450709e187a3f0bedd2763680620c) {} - Target component ID (for sending, 0 for broadcast)
+uint32_t [target_component_id](#structmavsdk_1_1_mavlink_direct_1_1_mavlink_message_1a9c22c881d07fb00698bb149a99b76bdb) {} - Target component ID (for sending, 0 for broadcast)
 
 std::string [fields_json](#structmavsdk_1_1_mavlink_direct_1_1_mavlink_message_1a6f3a89236007a00cf69f2063dcbcac50) {} - All message fields as single JSON object.
 
@@ -56,20 +56,20 @@ uint32_t mavsdk::MavlinkDirect::MavlinkMessage::component_id {}
 Component ID of the sender (for received messages)
 
 
-### target_system {#structmavsdk_1_1_mavlink_direct_1_1_mavlink_message_1abe3432b0a8d0fdcccf57091ef8ffd674}
+### target_system_id {#structmavsdk_1_1_mavlink_direct_1_1_mavlink_message_1a428079a85d1d095c9b48a9bab2109d4e}
 
 ```cpp
-uint32_t mavsdk::MavlinkDirect::MavlinkMessage::target_system {}
+uint32_t mavsdk::MavlinkDirect::MavlinkMessage::target_system_id {}
 ```
 
 
 Target system ID (for sending, 0 for broadcast)
 
 
-### target_component {#structmavsdk_1_1_mavlink_direct_1_1_mavlink_message_1abed450709e187a3f0bedd2763680620c}
+### target_component_id {#structmavsdk_1_1_mavlink_direct_1_1_mavlink_message_1a9c22c881d07fb00698bb149a99b76bdb}
 
 ```cpp
-uint32_t mavsdk::MavlinkDirect::MavlinkMessage::target_component {}
+uint32_t mavsdk::MavlinkDirect::MavlinkMessage::target_component_id {}
 ```
 
 

--- a/docs/en/cpp/api_reference/structmavsdk_1_1_mavsdk_1_1_mavlink_message.md
+++ b/docs/en/cpp/api_reference/structmavsdk_1_1_mavsdk_1_1_mavlink_message.md
@@ -16,9 +16,9 @@ uint32_t [system_id](#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1ab4e295a583a8
 
 uint32_t [component_id](#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1a810d77876cacc800939d3bfb6453e2f7) {} - Component ID of the sender (for received messages)
 
-uint32_t [target_system](#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1aa30e2970d9a40c17e7bf8e02b150d310) {} - Target system ID (for sending, 0 for broadcast)
+uint32_t [target_system_id](#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1a33caacebcd27ee177372f92472cfd215) {} - Target system ID (for sending, 0 for broadcast)
 
-uint32_t [target_component](#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1a5cf69f1e41e5791da49528dfd1788865) {} - Target component ID (for sending, 0 for broadcast)
+uint32_t [target_component_id](#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1ad19da69723464182b41439325eea5014) {} - Target component ID (for sending, 0 for broadcast)
 
 std::string [fields_json](#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1a73165621a97083c143ba7c36461c9754) {} - All message fields as single JSON object.
 
@@ -56,20 +56,20 @@ uint32_t mavsdk::Mavsdk::MavlinkMessage::component_id {}
 Component ID of the sender (for received messages)
 
 
-### target_system {#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1aa30e2970d9a40c17e7bf8e02b150d310}
+### target_system_id {#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1a33caacebcd27ee177372f92472cfd215}
 
 ```cpp
-uint32_t mavsdk::Mavsdk::MavlinkMessage::target_system {}
+uint32_t mavsdk::Mavsdk::MavlinkMessage::target_system_id {}
 ```
 
 
 Target system ID (for sending, 0 for broadcast)
 
 
-### target_component {#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1a5cf69f1e41e5791da49528dfd1788865}
+### target_component_id {#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1ad19da69723464182b41439325eea5014}
 
 ```cpp
-uint32_t mavsdk::Mavsdk::MavlinkMessage::target_component {}
+uint32_t mavsdk::Mavsdk::MavlinkMessage::target_component_id {}
 ```
 
 

--- a/docs/en/cpp/api_reference/structmavsdk_1_1_mavsdk_1_1_mavlink_message.md
+++ b/docs/en/cpp/api_reference/structmavsdk_1_1_mavsdk_1_1_mavlink_message.md
@@ -1,0 +1,87 @@
+# mavsdk::Mavsdk::MavlinkMessage Struct Reference
+`#include: mavsdk.h`
+
+----
+
+
+A complete MAVLink message with all header information and fields. 
+
+
+## Data Fields
+
+
+std::string [message_name](#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1a17ddcd78e5712403ef4c1b6798698cdb) {} - MAVLink message name (e.g., "HEARTBEAT", "GLOBAL_POSITION_INT")
+
+uint32_t [system_id](#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1ab4e295a583a82deb0f1786a4d61968ce) {} - [System](classmavsdk_1_1_system.md) ID of the sender (for received messages)
+
+uint32_t [component_id](#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1a810d77876cacc800939d3bfb6453e2f7) {} - Component ID of the sender (for received messages)
+
+uint32_t [target_system](#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1aa30e2970d9a40c17e7bf8e02b150d310) {} - Target system ID (for sending, 0 for broadcast)
+
+uint32_t [target_component](#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1a5cf69f1e41e5791da49528dfd1788865) {} - Target component ID (for sending, 0 for broadcast)
+
+std::string [fields_json](#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1a73165621a97083c143ba7c36461c9754) {} - All message fields as single JSON object.
+
+
+## Field Documentation
+
+
+### message_name {#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1a17ddcd78e5712403ef4c1b6798698cdb}
+
+```cpp
+std::string mavsdk::Mavsdk::MavlinkMessage::message_name {}
+```
+
+
+MAVLink message name (e.g., "HEARTBEAT", "GLOBAL_POSITION_INT")
+
+
+### system_id {#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1ab4e295a583a82deb0f1786a4d61968ce}
+
+```cpp
+uint32_t mavsdk::Mavsdk::MavlinkMessage::system_id {}
+```
+
+
+[System](classmavsdk_1_1_system.md) ID of the sender (for received messages)
+
+
+### component_id {#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1a810d77876cacc800939d3bfb6453e2f7}
+
+```cpp
+uint32_t mavsdk::Mavsdk::MavlinkMessage::component_id {}
+```
+
+
+Component ID of the sender (for received messages)
+
+
+### target_system {#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1aa30e2970d9a40c17e7bf8e02b150d310}
+
+```cpp
+uint32_t mavsdk::Mavsdk::MavlinkMessage::target_system {}
+```
+
+
+Target system ID (for sending, 0 for broadcast)
+
+
+### target_component {#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1a5cf69f1e41e5791da49528dfd1788865}
+
+```cpp
+uint32_t mavsdk::Mavsdk::MavlinkMessage::target_component {}
+```
+
+
+Target component ID (for sending, 0 for broadcast)
+
+
+### fields_json {#structmavsdk_1_1_mavsdk_1_1_mavlink_message_1a73165621a97083c143ba7c36461c9754}
+
+```cpp
+std::string mavsdk::Mavsdk::MavlinkMessage::fields_json {}
+```
+
+
+All message fields as single JSON object.
+

--- a/examples/sniffer/sniffer.cpp
+++ b/examples/sniffer/sniffer.cpp
@@ -1,58 +1,233 @@
 //
-// Example how to print every message arriving.
+// Example how to intercept and display MAVLink messages in JSON format.
 //
 
-#include <cstdint>
-#include <future>
 #include <mavsdk/mavsdk.h>
 #include <iostream>
 #include <thread>
+#include <set>
+#include <string>
+#include <vector>
+#include <chrono>
+#include <iomanip>
+#include <map>
+#include <algorithm>
 
 using namespace mavsdk;
-using namespace std::this_thread;
-using namespace std::chrono;
+
+enum class DisplayMode {
+    List, // Show message names only
+    Stat, // Show refreshing message statistics
+    All, // Show all messages with JSON fields
+    Selective // Show only specified message types
+};
 
 void usage(const std::string& bin_name)
 {
-    std::cerr << "Usage : " << bin_name << " <connection_url>\n"
-              << "Connection URL format should be :\n"
-              << " For TCP server: tcpin://<our_ip>:<port>\n"
-              << " For TCP client: tcpout://<remote_ip>:<port>\n"
-              << " For UDP server: udp://<our_ip>:<port>\n"
-              << " For UDP client: udp://<remote_ip>:<port>\n"
-              << " For Serial : serial://</path/to/serial/dev>:<baudrate>]\n"
-              << "For example, to connect to the simulator use URL: udpin://0.0.0.0:14540\n";
+    std::cerr << "Usage:\n"
+              << "  " << bin_name << " <connection_url> list\n"
+              << "  " << bin_name << " <connection_url> stat\n"
+              << "  " << bin_name << " <connection_url> all\n"
+              << "  " << bin_name << " <connection_url> <message_name1> [message_name2] ...\n\n"
+              << "Examples:\n"
+              << "  " << bin_name << " udpin://0.0.0.0:14540 list\n"
+              << "  " << bin_name << " udpin://0.0.0.0:14540 stat\n"
+              << "  " << bin_name << " udpin://0.0.0.0:14540 all\n"
+              << "  " << bin_name << " udpin://0.0.0.0:14540 GPS_RAW_INT HEARTBEAT\n\n"
+              << "Connection URL format:\n"
+              << "  TCP server : tcpin://<our_ip>:<port>\n"
+              << "  TCP client : tcpout://<remote_ip>:<port>\n"
+              << "  UDP server : udpin://<our_ip>:<port>\n"
+              << "  UDP client : udpout://<remote_ip>:<port>\n"
+              << "  Serial     : serial://</path/to/serial/dev>:<baudrate>\n";
+}
+
+std::string get_timestamp()
+{
+    auto now = std::chrono::system_clock::now();
+    auto time_t = std::chrono::system_clock::to_time_t(now);
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
+
+    std::stringstream ss;
+    ss << std::put_time(std::localtime(&time_t), "%H:%M:%S");
+    ss << '.' << std::setfill('0') << std::setw(3) << ms.count();
+    return ss.str();
 }
 
 int main(int argc, char** argv)
 {
-    if (argc != 2) {
+    if (argc < 3) {
         usage(argv[0]);
         return 1;
     }
 
+    std::string connection_url = argv[1];
+    std::string mode_arg = argv[2];
+
+    DisplayMode mode;
+    std::set<std::string> requested_messages;
+
+    if (mode_arg == "list") {
+        mode = DisplayMode::List;
+    } else if (mode_arg == "stat") {
+        mode = DisplayMode::Stat;
+    } else if (mode_arg == "all") {
+        mode = DisplayMode::All;
+    } else {
+        mode = DisplayMode::Selective;
+        // Add all remaining arguments as message names
+        for (int i = 2; i < argc; ++i) {
+            requested_messages.insert(argv[i]);
+        }
+        if (requested_messages.empty()) {
+            std::cerr << "Error: No message names specified for selective mode\n";
+            usage(argv[0]);
+            return 1;
+        }
+    }
+
     Mavsdk mavsdk{Mavsdk::Configuration{ComponentType::GroundStation}};
-    ConnectionResult connection_result = mavsdk.add_any_connection(argv[1]);
+    ConnectionResult connection_result = mavsdk.add_any_connection(connection_url);
 
     if (connection_result != ConnectionResult::Success) {
         std::cerr << "Connection failed: " << connection_result << '\n';
         return 1;
     }
 
-    auto system = mavsdk.first_autopilot(3.0);
-    if (!system) {
-        std::cerr << "Timed out waiting for system\n";
-        return 1;
+    std::cout << "Connected, waiting for messages..." << std::endl;
+    if (mode == DisplayMode::List) {
+        std::cout << "Mode: List message names only" << std::endl;
+    } else if (mode == DisplayMode::Stat) {
+        std::cout << "Mode: Show message statistics (refreshing)" << std::endl;
+    } else if (mode == DisplayMode::All) {
+        std::cout << "Mode: Show all messages with JSON fields" << std::endl;
+    } else {
+        std::cout << "Mode: Show messages: ";
+        for (const auto& msg : requested_messages) {
+            std::cout << msg << " ";
+        }
+        std::cout << std::endl;
     }
+    std::cout << "Press Ctrl+C to exit\n" << std::endl;
 
-    mavsdk.intercept_incoming_messages_async([](mavlink_message_t& message) {
-        std::cout << "Got message " << (int)message.msgid << '\n';
-        return true;
+    // Statistics tracking for stat mode
+    std::map<std::string, size_t> message_counts;
+    std::map<std::string, std::chrono::steady_clock::time_point> last_message_time;
+    std::map<std::string, double> message_frequencies;
+    auto start_time = std::chrono::steady_clock::now();
+
+    auto handle = mavsdk.subscribe_incoming_messages_json([&](Mavsdk::MavlinkMessage message) {
+        bool should_display = false;
+
+        switch (mode) {
+            case DisplayMode::List:
+            case DisplayMode::All:
+                should_display = true;
+                break;
+            case DisplayMode::Stat:
+                // Track statistics for stat mode
+                {
+                    auto now = std::chrono::steady_clock::now();
+                    message_counts[message.message_name]++;
+
+                    // Calculate frequency (Hz) based on time since last message of this type
+                    if (last_message_time.find(message.message_name) != last_message_time.end()) {
+                        auto time_diff = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                             now - last_message_time[message.message_name])
+                                             .count();
+                        if (time_diff > 0) {
+                            message_frequencies[message.message_name] = 1000.0 / time_diff;
+                        }
+                    }
+                    last_message_time[message.message_name] = now;
+                }
+                break;
+            case DisplayMode::Selective:
+                should_display =
+                    requested_messages.find(message.message_name) != requested_messages.end();
+                break;
+        }
+
+        if (should_display) {
+            std::cout << "[" << get_timestamp() << "] ";
+            std::cout << "(" << message.system_id << ":" << message.component_id << ") ";
+            std::cout << message.message_name;
+
+            if (mode == DisplayMode::All || mode == DisplayMode::Selective) {
+                if (!message.fields_json.empty()) {
+                    std::cout << ": " << message.fields_json;
+                }
+            }
+            std::cout << std::endl;
+        }
+
+        return true; // Always let messages through
     });
 
-    while (true) {
-        std::this_thread::sleep_for(std::chrono::seconds(1));
+    if (mode == DisplayMode::Stat) {
+        // For stat mode, refresh the display every second
+        auto last_display_update = std::chrono::steady_clock::now();
+        int lines_printed = 0;
+
+        while (true) {
+            auto now = std::chrono::steady_clock::now();
+            auto elapsed =
+                std::chrono::duration_cast<std::chrono::seconds>(now - last_display_update);
+
+            if (elapsed.count() >= 1) {
+                // Clear previous output (move cursor up and clear lines)
+                if (lines_printed > 0) {
+                    std::cout << "\033[" << lines_printed << "A"; // Move cursor up
+                    for (int i = 0; i < lines_printed; i++) {
+                        std::cout << "\033[K\n"; // Clear line and move to next
+                    }
+                    std::cout << "\033[" << lines_printed << "A"; // Move cursor back up
+                }
+
+                // Create sorted vector of message statistics
+                std::vector<std::pair<std::string, size_t>> sorted_messages;
+                for (const auto& pair : message_counts) {
+                    sorted_messages.push_back(pair);
+                }
+                std::sort(
+                    sorted_messages.begin(),
+                    sorted_messages.end(),
+                    [](const auto& a, const auto& b) { return a.first < b.first; });
+
+                // Print header
+                std::cout << std::endl;
+                std::cout << std::left << std::setw(35) << "Message Type" << std::setw(10)
+                          << "Count" << std::setw(10) << "Hz" << std::endl;
+                std::cout << std::string(55, '-') << std::endl;
+                lines_printed = 3;
+
+                // Print statistics
+                for (const auto& pair : sorted_messages) {
+                    const std::string& msg_name = pair.first;
+                    size_t count = pair.second;
+                    double hz = message_frequencies.find(msg_name) != message_frequencies.end() ?
+                                    message_frequencies[msg_name] :
+                                    0.0;
+
+                    std::cout << std::left << std::setw(35) << msg_name << std::setw(10) << count
+                              << std::setw(10) << std::fixed << std::setprecision(1) << hz
+                              << std::endl;
+                    lines_printed++;
+                }
+
+                std::cout << std::flush;
+                last_display_update = now;
+            }
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+    } else {
+        // For other modes, just sleep
+        while (true) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
     }
 
+    mavsdk.unsubscribe_incoming_messages_json(handle);
     return 0;
 }

--- a/src/mavsdk/core/connection.cpp
+++ b/src/mavsdk/core/connection.cpp
@@ -70,7 +70,8 @@ void Connection::stop_libmav_receiver()
     }
 }
 
-void Connection::receive_libmav_message(const LibmavMessage& message, Connection* connection)
+void Connection::receive_libmav_message(
+    const Mavsdk::MavlinkMessage& message, Connection* connection)
 {
     // Register system ID when receiving a message from a new system.
     if (_system_ids.find(message.system_id) == _system_ids.end()) {

--- a/src/mavsdk/core/connection.h
+++ b/src/mavsdk/core/connection.h
@@ -18,7 +18,7 @@ public:
     using ReceiverCallback =
         std::function<void(mavlink_message_t& message, Connection* connection)>;
     using LibmavReceiverCallback =
-        std::function<void(const LibmavMessage& message, Connection* connection)>;
+        std::function<void(const Mavsdk::MavlinkMessage& message, Connection* connection)>;
 
     explicit Connection(
         ReceiverCallback receiver_callback,
@@ -53,7 +53,7 @@ protected:
 
     bool start_libmav_receiver();
     void stop_libmav_receiver();
-    void receive_libmav_message(const LibmavMessage& message, Connection* connection);
+    void receive_libmav_message(const Mavsdk::MavlinkMessage& message, Connection* connection);
 
     ReceiverCallback _receiver_callback{};
     LibmavReceiverCallback _libmav_receiver_callback{};

--- a/src/mavsdk/core/include/mavsdk/mavsdk.h
+++ b/src/mavsdk/core/include/mavsdk/mavsdk.h
@@ -380,6 +380,62 @@ public:
     std::shared_ptr<ServerComponent> server_component_by_id(uint8_t component_id);
 
     /**
+     * @brief A complete MAVLink message with all header information and fields
+     */
+    struct MavlinkMessage {
+        std::string message_name{}; /**< @brief MAVLink message name (e.g., "HEARTBEAT",
+                                       "GLOBAL_POSITION_INT") */
+        uint32_t system_id{}; /**< @brief System ID of the sender (for received messages) */
+        uint32_t component_id{}; /**< @brief Component ID of the sender (for received messages) */
+        uint32_t target_system{}; /**< @brief Target system ID (for sending, 0 for broadcast) */
+        uint32_t
+            target_component{}; /**< @brief Target component ID (for sending, 0 for broadcast) */
+        std::string fields_json{}; /**< @brief All message fields as single JSON object */
+    };
+
+    /**
+     * @brief Handle for intercepting messages.
+     */
+    using InterceptJsonHandle = Handle<bool(MavlinkMessage)>;
+
+    /**
+     * @brief Callback type for intercepting messages.
+     */
+    using InterceptJsonCallback = std::function<bool(MavlinkMessage)>;
+
+    /**
+     * @brief Intercept incoming messages as JSON.
+     *
+     * This is a hook that allows to read any messages arriving via the
+     * in JSON format.
+     *
+     * @param callback Callback to be called for each incoming message.
+     *        To drop a message, return 'false' from the callback.
+     */
+    InterceptJsonHandle subscribe_incoming_messages_json(const InterceptJsonCallback& callback);
+
+    /**
+     * @brief Unsubscribe from incoming messages as JSON
+     */
+    void unsubscribe_incoming_messages_json(InterceptJsonHandle handle);
+
+    /**3
+     * @brief Intercept outgoing messages as JSON.
+     *
+     * This is a hook that allows to read any messages arriving via the
+     * in JSON format.
+     *
+     * @param callback Callback to be called for each outgoing message.
+     *        To drop a message, return 'false' from the callback.
+     */
+    InterceptJsonHandle subscribe_outgoing_messages_json(const InterceptJsonCallback& callback);
+
+    /**
+     * @brief Unsubscribe from outgoing messages as JSON
+     */
+    void unsubscribe_outgoing_messages_json(InterceptJsonHandle handle);
+
+    /**
      * @brief Intercept incoming messages.
      *
      * This is a hook which allows to change or drop MAVLink messages as they

--- a/src/mavsdk/core/include/mavsdk/mavsdk.h
+++ b/src/mavsdk/core/include/mavsdk/mavsdk.h
@@ -387,9 +387,9 @@ public:
                                        "GLOBAL_POSITION_INT") */
         uint32_t system_id{}; /**< @brief System ID of the sender (for received messages) */
         uint32_t component_id{}; /**< @brief Component ID of the sender (for received messages) */
-        uint32_t target_system{}; /**< @brief Target system ID (for sending, 0 for broadcast) */
+        uint32_t target_system_id{}; /**< @brief Target system ID (for sending, 0 for broadcast) */
         uint32_t
-            target_component{}; /**< @brief Target component ID (for sending, 0 for broadcast) */
+            target_component_id{}; /**< @brief Target component ID (for sending, 0 for broadcast) */
         std::string fields_json{}; /**< @brief All message fields as single JSON object */
     };
 

--- a/src/mavsdk/core/libmav_receiver.cpp
+++ b/src/mavsdk/core/libmav_receiver.cpp
@@ -63,8 +63,8 @@ bool LibmavReceiver::parse_libmav_message_from_buffer(const uint8_t* buffer, siz
     // Generate complete JSON with all field values
     std::string json = libmav_message_to_json(message);
 
-    // Fill our LibmavMessage structure
-    _last_message.message = message;
+    // Fill our message structures
+    _last_libmav_message = message;
     _last_message.message_name = message.name();
     _last_message.system_id = header.systemId();
     _last_message.component_id = header.componentId();

--- a/src/mavsdk/core/libmav_receiver.cpp
+++ b/src/mavsdk/core/libmav_receiver.cpp
@@ -70,17 +70,17 @@ bool LibmavReceiver::parse_libmav_message_from_buffer(const uint8_t* buffer, siz
     _last_message.component_id = header.componentId();
 
     // Extract target_system and target_component if present in message fields
-    uint8_t target_system = 0;
-    uint8_t target_component = 0;
-    if (message.get("target_system", target_system) == mav::MessageResult::Success) {
-        _last_message.target_system = target_system;
+    uint8_t target_system_id = 0;
+    uint8_t target_component_id = 0;
+    if (message.get("target_system", target_system_id) == mav::MessageResult::Success) {
+        _last_message.target_system_id = target_system_id;
     } else {
-        _last_message.target_system = 0;
+        _last_message.target_system_id = 0;
     }
-    if (message.get("target_component", target_component) == mav::MessageResult::Success) {
-        _last_message.target_component = target_component;
+    if (message.get("target_component", target_component_id) == mav::MessageResult::Success) {
+        _last_message.target_component_id = target_component_id;
     } else {
-        _last_message.target_component = 0;
+        _last_message.target_component_id = 0;
     }
 
     _last_message.fields_json = json;

--- a/src/mavsdk/core/libmav_receiver.h
+++ b/src/mavsdk/core/libmav_receiver.h
@@ -54,6 +54,9 @@ public:
     // Load custom XML message definitions
     bool load_custom_xml(const std::string& xml_content);
 
+    // JSON conversion (made public for use in message interception)
+    std::string libmav_message_to_json(const mav::Message& msg) const;
+
 private:
     MavsdkImpl& _mavsdk_impl; // For thread-safe MessageSet access
     std::unique_ptr<mav::BufferParser> _buffer_parser;
@@ -65,7 +68,6 @@ private:
     bool _debugging = false;
 
     // Helper methods
-    std::string libmav_message_to_json(const mav::Message& msg) const;
     bool parse_libmav_message_from_buffer(const uint8_t* buffer, size_t buffer_len);
 };
 

--- a/src/mavsdk/core/libmav_receiver.h
+++ b/src/mavsdk/core/libmav_receiver.h
@@ -6,6 +6,7 @@
 #include <optional>
 #include <memory>
 #include "mavlink_include.h"
+#include "mavsdk.h"
 
 // Forward declarations to avoid including MessageSet.h in header
 namespace mav {
@@ -19,17 +20,6 @@ class Value;
 
 namespace mavsdk {
 
-struct LibmavMessage {
-    std::optional<mav::Message>
-        message; // The libmav message object (optional since no default constructor)
-    std::string message_name; // Message name (e.g., "HEARTBEAT")
-    uint32_t system_id; // Source system ID
-    uint32_t component_id; // Source component ID
-    uint32_t target_system_id; // Target system ID (if applicable)
-    uint32_t target_component_id; // Target component ID (if applicable)
-    std::string fields_json; // Pre-converted JSON fields
-};
-
 // Forward declaration for thread-safe MessageSet operations
 class MavsdkImpl;
 
@@ -38,7 +28,11 @@ public:
     explicit LibmavReceiver(MavsdkImpl& mavsdk_impl);
     ~LibmavReceiver(); // Need explicit destructor for unique_ptr with incomplete type
 
-    const LibmavMessage& get_last_message() const { return _last_message; }
+    const Mavsdk::MavlinkMessage& get_last_message() const { return _last_message; }
+    const std::optional<mav::Message>& get_last_libmav_message() const
+    {
+        return _last_libmav_message;
+    }
 
     void set_new_datagram(char* datagram, unsigned datagram_len);
 
@@ -60,7 +54,8 @@ public:
 private:
     MavsdkImpl& _mavsdk_impl; // For thread-safe MessageSet access
     std::unique_ptr<mav::BufferParser> _buffer_parser;
-    LibmavMessage _last_message;
+    Mavsdk::MavlinkMessage _last_message;
+    std::optional<mav::Message> _last_libmav_message; // Separate libmav message for integration
 
     char* _datagram = nullptr;
     unsigned _datagram_len = 0;

--- a/src/mavsdk/core/libmav_receiver.h
+++ b/src/mavsdk/core/libmav_receiver.h
@@ -25,8 +25,8 @@ struct LibmavMessage {
     std::string message_name; // Message name (e.g., "HEARTBEAT")
     uint32_t system_id; // Source system ID
     uint32_t component_id; // Source component ID
-    uint32_t target_system; // Target system ID (if applicable)
-    uint32_t target_component; // Target component ID (if applicable)
+    uint32_t target_system_id; // Target system ID (if applicable)
+    uint32_t target_component_id; // Target component ID (if applicable)
     std::string fields_json; // Pre-converted JSON fields
 };
 

--- a/src/mavsdk/core/mavsdk.cpp
+++ b/src/mavsdk/core/mavsdk.cpp
@@ -245,4 +245,26 @@ void Mavsdk::unsubscribe_connection_errors(ConnectionErrorHandle handle)
     return _impl->unsubscribe_connection_errors(handle);
 }
 
+Mavsdk::InterceptJsonHandle
+Mavsdk::subscribe_incoming_messages_json(const InterceptJsonCallback& callback)
+{
+    return _impl->subscribe_incoming_messages_json(callback);
+}
+
+void Mavsdk::unsubscribe_incoming_messages_json(InterceptJsonHandle handle)
+{
+    _impl->unsubscribe_incoming_messages_json(handle);
+}
+
+Mavsdk::InterceptJsonHandle
+Mavsdk::subscribe_outgoing_messages_json(const InterceptJsonCallback& callback)
+{
+    return _impl->subscribe_outgoing_messages_json(callback);
+}
+
+void Mavsdk::unsubscribe_outgoing_messages_json(InterceptJsonHandle handle)
+{
+    _impl->unsubscribe_outgoing_messages_json(handle);
+}
+
 } // namespace mavsdk

--- a/src/mavsdk/core/mavsdk_impl.cpp
+++ b/src/mavsdk/core/mavsdk_impl.cpp
@@ -403,32 +403,11 @@ void MavsdkImpl::process_message(mavlink_message_t& message, Connection* connect
     {
         std::lock_guard lock(_mutex);
 
-        // This is a low level interface where incoming messages can be tampered
-        // with or even dropped.
-        {
-            bool keep = true;
-            {
-                std::lock_guard<std::mutex> intercept_lock(_intercept_callbacks_mutex);
-                if (_intercept_incoming_messages_callback != nullptr) {
-                    keep = _intercept_incoming_messages_callback(message);
-                }
-            }
-
-            if (!keep) {
-                LogDebug() << "Dropped incoming message: " << int(message.msgid);
-                return;
-            }
-        }
-
-        if (_should_exit) {
-            // If we're meant to clean up, let's not try to acquire any more locks but bail.
-            return;
-        }
-
-        /** @note: Forward message if option is enabled and multiple interfaces are connected.
-         *  Performs message forwarding checks for every messages if message forwarding
-         *  is enabled on at least one connection, and in case of a single forwarding connection,
-         *  we check that it is not the one which received the current message.
+        /** @note: Forward message FIRST (before intercept) if option is enabled and multiple
+         * interfaces are connected. This ensures that forwarded messages are not affected by
+         * intercept modifications. Performs message forwarding checks for every messages if message
+         * forwarding is enabled on at least one connection, and in case of a single forwarding
+         * connection, we check that it is not the one which received the current message.
          *
          * Conditions:
          * 1. At least 2 connections.
@@ -445,6 +424,28 @@ void MavsdkImpl::process_message(mavlink_message_t& message, Connection* connect
                            << static_cast<int>(message.compid);
             }
             forward_message(message, connection);
+        }
+
+        if (_should_exit) {
+            // If we're meant to clean up, let's not try to acquire any more locks but bail.
+            return;
+        }
+
+        // This is a low level interface where incoming messages can be tampered
+        // with or even dropped FOR LOCAL PROCESSING ONLY (after forwarding).
+        {
+            bool keep = true;
+            {
+                std::lock_guard<std::mutex> intercept_lock(_intercept_callbacks_mutex);
+                if (_intercept_incoming_messages_callback != nullptr) {
+                    keep = _intercept_incoming_messages_callback(message);
+                }
+            }
+
+            if (!keep) {
+                LogDebug() << "Dropped incoming message: " << int(message.msgid);
+                return;
+            }
         }
 
         // Don't ever create a system with sysid 0.
@@ -1373,6 +1374,7 @@ Sender& MavsdkImpl::sender()
 
 std::vector<Connection*> MavsdkImpl::get_connections() const
 {
+    std::lock_guard lock(_mutex);
     std::vector<Connection*> connections;
     for (const auto& connection_entry : _connections) {
         connections.push_back(connection_entry.connection.get());

--- a/src/mavsdk/core/mavsdk_impl.cpp
+++ b/src/mavsdk/core/mavsdk_impl.cpp
@@ -697,19 +697,19 @@ void MavsdkImpl::deliver_message(mavlink_message_t& message)
         libmav_message.component_id = message.compid;
 
         // Extract target_system and target_component if present
-        uint8_t target_system = 0;
-        uint8_t target_component = 0;
-        if (libmav_msg_opt.value().get("target_system", target_system) ==
+        uint8_t target_system_id = 0;
+        uint8_t target_component_id = 0;
+        if (libmav_msg_opt.value().get("target_system", target_system_id) ==
             mav::MessageResult::Success) {
-            libmav_message.target_system = target_system;
+            libmav_message.target_system_id = target_system_id;
         } else {
-            libmav_message.target_system = 0;
+            libmav_message.target_system_id = 0;
         }
-        if (libmav_msg_opt.value().get("target_component", target_component) ==
+        if (libmav_msg_opt.value().get("target_component", target_component_id) ==
             mav::MessageResult::Success) {
-            libmav_message.target_component = target_component;
+            libmav_message.target_component_id = target_component_id;
         } else {
-            libmav_message.target_component = 0;
+            libmav_message.target_component_id = 0;
         }
 
         // Generate JSON using LibmavReceiver's public method
@@ -1248,8 +1248,8 @@ Mavsdk::MavlinkMessage MavsdkImpl::libmav_to_mavsdk_message(const LibmavMessage&
     json_message.message_name = libmav_message.message_name;
     json_message.system_id = libmav_message.system_id;
     json_message.component_id = libmav_message.component_id;
-    json_message.target_system = libmav_message.target_system;
-    json_message.target_component = libmav_message.target_component;
+    json_message.target_system_id = libmav_message.target_system_id;
+    json_message.target_component_id = libmav_message.target_component_id;
     json_message.fields_json = libmav_message.fields_json; // Already populated!
 
     return json_message;

--- a/src/mavsdk/core/mavsdk_impl.h
+++ b/src/mavsdk/core/mavsdk_impl.h
@@ -52,7 +52,7 @@ public:
 
     void forward_message(mavlink_message_t& message, Connection* connection);
     void receive_message(mavlink_message_t& message, Connection* connection);
-    void receive_libmav_message(const LibmavMessage& message, Connection* connection);
+    void receive_libmav_message(const Mavsdk::MavlinkMessage& message, Connection* connection);
 
     std::pair<ConnectionResult, Mavsdk::ConnectionHandle>
     add_any_connection(const std::string& connection_url, ForwardingOption forwarding_option);
@@ -164,7 +164,7 @@ private:
     void process_message(mavlink_message_t& message, Connection* connection);
 
     void process_libmav_messages();
-    void process_libmav_message(const LibmavMessage& message, Connection* connection);
+    void process_libmav_message(const Mavsdk::MavlinkMessage& message, Connection* connection);
 
     void deliver_messages();
     void deliver_message(mavlink_message_t& message);
@@ -178,7 +178,6 @@ private:
     static uint8_t get_target_component_id(const mavlink_message_t& message);
 
     // Helper methods for JSON message conversion
-    Mavsdk::MavlinkMessage libmav_to_mavsdk_message(const LibmavMessage& libmav_message);
     bool call_json_interception_callbacks(
         const Mavsdk::MavlinkMessage& json_message,
         std::vector<std::pair<Mavsdk::InterceptJsonHandle, Mavsdk::InterceptJsonCallback>>&
@@ -256,7 +255,7 @@ private:
     std::condition_variable _received_messages_cv{};
 
     struct ReceivedLibmavMessage {
-        LibmavMessage message;
+        Mavsdk::MavlinkMessage message;
         Connection* connection_ptr;
     };
     mutable std::mutex _received_libmav_messages_mutex{};

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -121,7 +121,7 @@ void SystemImpl::update_component_id_messages_handler(
     _mavlink_message_handler.update_component_id(msg_id, component_id, cookie);
 }
 
-void SystemImpl::process_libmav_message(const LibmavMessage& message)
+void SystemImpl::process_libmav_message(const Mavsdk::MavlinkMessage& message)
 {
     // Call all registered libmav message handlers
     std::lock_guard<std::mutex> lock(_libmav_message_handlers_mutex);

--- a/src/mavsdk/core/system_impl.h
+++ b/src/mavsdk/core/system_impl.h
@@ -73,9 +73,9 @@ public:
     update_component_id_messages_handler(uint16_t msg_id, uint8_t component_id, const void* cookie);
 
     // Libmav message handling
-    using LibmavMessageCallback = std::function<void(const LibmavMessage&)>;
+    using LibmavMessageCallback = std::function<void(const Mavsdk::MavlinkMessage&)>;
 
-    void process_libmav_message(const LibmavMessage& message);
+    void process_libmav_message(const Mavsdk::MavlinkMessage& message);
 
     void register_libmav_message_handler(
         const std::string& message_name, const LibmavMessageCallback& callback, const void* cookie);

--- a/src/mavsdk/core/system_impl.h
+++ b/src/mavsdk/core/system_impl.h
@@ -373,7 +373,6 @@ private:
         ParamValue value,
         const GetParamIntCallback& callback);
 
-    std::mutex _component_discovered_callback_mutex{};
     CallbackList<ComponentType> _component_discovered_callbacks{};
     CallbackList<ComponentType, uint8_t> _component_discovered_id_callbacks{};
 
@@ -401,7 +400,6 @@ private:
         std::function<void(const MavlinkStatustextHandler::Statustext&)> callback;
         void* cookie;
     };
-    std::mutex _statustext_handler_callbacks_mutex{};
     std::vector<StatustextCallback> _statustext_handler_callbacks;
 
     std::atomic<bool> _armed{false};
@@ -445,9 +443,9 @@ private:
     std::vector<PluginImplBase*> _plugin_impls{};
 
     // We used set to maintain unique component ids
+    mutable std::mutex _components_mutex{};
     std::unordered_set<uint8_t> _components{};
 
-    std::mutex _param_changed_callbacks_mutex{};
     std::unordered_map<const void*, ParamChangedCallback> _param_changed_callbacks{};
 
     MAV_TYPE _vehicle_type{MAV_TYPE::MAV_TYPE_GENERIC};

--- a/src/mavsdk/plugins/mavlink_direct/include/plugins/mavlink_direct/mavlink_direct.h
+++ b/src/mavsdk/plugins/mavlink_direct/include/plugins/mavlink_direct/mavlink_direct.h
@@ -67,9 +67,9 @@ public:
                                        "GLOBAL_POSITION_INT") */
         uint32_t system_id{}; /**< @brief System ID of the sender (for received messages) */
         uint32_t component_id{}; /**< @brief Component ID of the sender (for received messages) */
-        uint32_t target_system{}; /**< @brief Target system ID (for sending, 0 for broadcast) */
+        uint32_t target_system_id{}; /**< @brief Target system ID (for sending, 0 for broadcast) */
         uint32_t
-            target_component{}; /**< @brief Target component ID (for sending, 0 for broadcast) */
+            target_component_id{}; /**< @brief Target component ID (for sending, 0 for broadcast) */
         std::string fields_json{}; /**< @brief All message fields as single JSON object */
     };
 

--- a/src/mavsdk/plugins/mavlink_direct/mavlink_direct.cpp
+++ b/src/mavsdk/plugins/mavlink_direct/mavlink_direct.cpp
@@ -48,8 +48,10 @@ MavlinkDirect::Result MavlinkDirect::load_custom_xml(std::string xml_content) co
 bool operator==(const MavlinkDirect::MavlinkMessage& lhs, const MavlinkDirect::MavlinkMessage& rhs)
 {
     return (rhs.message_name == lhs.message_name) && (rhs.system_id == lhs.system_id) &&
-           (rhs.component_id == lhs.component_id) && (rhs.target_system == lhs.target_system) &&
-           (rhs.target_component == lhs.target_component) && (rhs.fields_json == lhs.fields_json);
+           (rhs.component_id == lhs.component_id) &&
+           (rhs.target_system_id == lhs.target_system_id) &&
+           (rhs.target_component_id == lhs.target_component_id) &&
+           (rhs.fields_json == lhs.fields_json);
 }
 
 std::ostream& operator<<(std::ostream& str, MavlinkDirect::MavlinkMessage const& mavlink_message)
@@ -59,8 +61,8 @@ std::ostream& operator<<(std::ostream& str, MavlinkDirect::MavlinkMessage const&
     str << "    message_name: " << mavlink_message.message_name << '\n';
     str << "    system_id: " << mavlink_message.system_id << '\n';
     str << "    component_id: " << mavlink_message.component_id << '\n';
-    str << "    target_system: " << mavlink_message.target_system << '\n';
-    str << "    target_component: " << mavlink_message.target_component << '\n';
+    str << "    target_system_id: " << mavlink_message.target_system_id << '\n';
+    str << "    target_component_id: " << mavlink_message.target_component_id << '\n';
     str << "    fields_json: " << mavlink_message.fields_json << '\n';
     str << '}';
     return str;

--- a/src/mavsdk/plugins/mavlink_direct/mavlink_direct_impl.cpp
+++ b/src/mavsdk/plugins/mavlink_direct/mavlink_direct_impl.cpp
@@ -87,13 +87,14 @@ MavlinkDirect::Result MavlinkDirectImpl::send_message(MavlinkDirect::MavlinkMess
     }
 
     // Set target system/component if specified
-    if (message.target_system != 0) {
+    if (message.target_system_id != 0) {
         // For messages that have target_system field, set it
-        libmav_message.set("target_system", static_cast<uint8_t>(message.target_system));
+        libmav_message.set("target_system", static_cast<uint8_t>(message.target_system_id));
     }
-    if (message.target_component != 0) {
+    if (message.target_component_id != 0) {
         // For messages that have target_component field, set it
-        libmav_message.set("target_component", static_cast<uint8_t>(message.target_component));
+        libmav_message.set(
+            "target_component_id", static_cast<uint8_t>(message.target_component_id));
     }
 
     if (_debugging) {
@@ -150,8 +151,8 @@ MavlinkDirect::MessageHandle MavlinkDirectImpl::subscribe_message(
             message.message_name = libmav_msg.message_name;
             message.system_id = libmav_msg.system_id;
             message.component_id = libmav_msg.component_id;
-            message.target_system = libmav_msg.target_system;
-            message.target_component = libmav_msg.target_component;
+            message.target_system_id = libmav_msg.target_system_id;
+            message.target_component_id = libmav_msg.target_component_id;
             message.fields_json = libmav_msg.fields_json;
 
             // Use CallbackList::queue to safely call all subscribed callbacks

--- a/src/mavsdk/plugins/telemetry_server/telemetry_server_impl.cpp
+++ b/src/mavsdk/plugins/telemetry_server/telemetry_server_impl.cpp
@@ -14,6 +14,10 @@ TelemetryServerImpl::TelemetryServerImpl(std::shared_ptr<ServerComponent> server
 
 TelemetryServerImpl::~TelemetryServerImpl()
 {
+    // Unregister command handlers BEFORE unregistering plugin to prevent use-after-free
+    _server_component_impl->unregister_mavlink_command_handler(MAV_CMD_SET_MESSAGE_INTERVAL, this);
+    _server_component_impl->unregister_mavlink_command_handler(MAV_CMD_REQUEST_MESSAGE, this);
+
     _server_component_impl->unregister_plugin(this);
     std::lock_guard<std::mutex> lock(_mutex);
     for (const auto& request : _interval_requests) {

--- a/src/mavsdk_server/src/generated/mavlink_direct/mavlink_direct.pb.cc
+++ b/src/mavsdk_server/src/generated/mavlink_direct/mavlink_direct.pb.cc
@@ -65,8 +65,8 @@ inline constexpr MavlinkMessage::Impl_::Impl_(
             ::_pbi::ConstantInitialized()),
         system_id_{0u},
         component_id_{0u},
-        target_system_{0u},
-        target_component_{0u},
+        target_system_id_{0u},
+        target_component_id_{0u},
         _cached_size_{0} {}
 
 template <typename>
@@ -321,8 +321,8 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mavlink_direct::MavlinkMessage, _impl_.message_name_),
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mavlink_direct::MavlinkMessage, _impl_.system_id_),
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mavlink_direct::MavlinkMessage, _impl_.component_id_),
-        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mavlink_direct::MavlinkMessage, _impl_.target_system_),
-        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mavlink_direct::MavlinkMessage, _impl_.target_component_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mavlink_direct::MavlinkMessage, _impl_.target_system_id_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mavlink_direct::MavlinkMessage, _impl_.target_component_id_),
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mavlink_direct::MavlinkMessage, _impl_.fields_json_),
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::mavlink_direct::MavlinkDirectResult, _internal_metadata_),
@@ -372,30 +372,30 @@ const char descriptor_table_protodef_mavlink_5fdirect_2fmavlink_5fdirect_2eproto
     "\n\024LoadCustomXmlRequest\022\023\n\013xml_content\030\001 "
     "\001(\t\"f\n\025LoadCustomXmlResponse\022M\n\025mavlink_"
     "direct_result\030\001 \001(\0132..mavsdk.rpc.mavlink"
-    "_direct.MavlinkDirectResult\"\225\001\n\016MavlinkM"
+    "_direct.MavlinkDirectResult\"\233\001\n\016MavlinkM"
     "essage\022\024\n\014message_name\030\001 \001(\t\022\021\n\tsystem_i"
-    "d\030\002 \001(\r\022\024\n\014component_id\030\003 \001(\r\022\025\n\rtarget_"
-    "system\030\004 \001(\r\022\030\n\020target_component\030\005 \001(\r\022\023"
-    "\n\013fields_json\030\006 \001(\t\"\262\002\n\023MavlinkDirectRes"
-    "ult\022E\n\006result\030\001 \001(\01625.mavsdk.rpc.mavlink"
-    "_direct.MavlinkDirectResult.Result\022\022\n\nre"
-    "sult_str\030\002 \001(\t\"\277\001\n\006Result\022\022\n\016RESULT_UNKN"
-    "OWN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\020\n\014RESULT_ERRO"
-    "R\020\002\022\032\n\026RESULT_INVALID_MESSAGE\020\003\022\030\n\024RESUL"
-    "T_INVALID_FIELD\020\004\022\033\n\027RESULT_CONNECTION_E"
-    "RROR\020\005\022\024\n\020RESULT_NO_SYSTEM\020\006\022\022\n\016RESULT_T"
-    "IMEOUT\020\0072\200\003\n\024MavlinkDirectService\022r\n\013Sen"
-    "dMessage\022-.mavsdk.rpc.mavlink_direct.Sen"
-    "dMessageRequest\032..mavsdk.rpc.mavlink_dir"
-    "ect.SendMessageResponse\"\004\200\265\030\001\022z\n\020Subscri"
-    "beMessage\0222.mavsdk.rpc.mavlink_direct.Su"
-    "bscribeMessageRequest\032*.mavsdk.rpc.mavli"
-    "nk_direct.MessageResponse\"\004\200\265\030\0000\001\022x\n\rLoa"
-    "dCustomXml\022/.mavsdk.rpc.mavlink_direct.L"
-    "oadCustomXmlRequest\0320.mavsdk.rpc.mavlink"
-    "_direct.LoadCustomXmlResponse\"\004\200\265\030\001B.\n\030i"
-    "o.mavsdk.mavlink_directB\022MavlinkDirectPr"
-    "otob\006proto3"
+    "d\030\002 \001(\r\022\024\n\014component_id\030\003 \001(\r\022\030\n\020target_"
+    "system_id\030\004 \001(\r\022\033\n\023target_component_id\030\005"
+    " \001(\r\022\023\n\013fields_json\030\006 \001(\t\"\262\002\n\023MavlinkDir"
+    "ectResult\022E\n\006result\030\001 \001(\01625.mavsdk.rpc.m"
+    "avlink_direct.MavlinkDirectResult.Result"
+    "\022\022\n\nresult_str\030\002 \001(\t\"\277\001\n\006Result\022\022\n\016RESUL"
+    "T_UNKNOWN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\020\n\014RESUL"
+    "T_ERROR\020\002\022\032\n\026RESULT_INVALID_MESSAGE\020\003\022\030\n"
+    "\024RESULT_INVALID_FIELD\020\004\022\033\n\027RESULT_CONNEC"
+    "TION_ERROR\020\005\022\024\n\020RESULT_NO_SYSTEM\020\006\022\022\n\016RE"
+    "SULT_TIMEOUT\020\0072\200\003\n\024MavlinkDirectService\022"
+    "r\n\013SendMessage\022-.mavsdk.rpc.mavlink_dire"
+    "ct.SendMessageRequest\032..mavsdk.rpc.mavli"
+    "nk_direct.SendMessageResponse\"\004\200\265\030\001\022z\n\020S"
+    "ubscribeMessage\0222.mavsdk.rpc.mavlink_dir"
+    "ect.SubscribeMessageRequest\032*.mavsdk.rpc"
+    ".mavlink_direct.MessageResponse\"\004\200\265\030\0000\001\022"
+    "x\n\rLoadCustomXml\022/.mavsdk.rpc.mavlink_di"
+    "rect.LoadCustomXmlRequest\0320.mavsdk.rpc.m"
+    "avlink_direct.LoadCustomXmlResponse\"\004\200\265\030"
+    "\001B.\n\030io.mavsdk.mavlink_directB\022MavlinkDi"
+    "rectProtob\006proto3"
 };
 static const ::_pbi::DescriptorTable* const descriptor_table_mavlink_5fdirect_2fmavlink_5fdirect_2eproto_deps[1] =
     {
@@ -405,7 +405,7 @@ static ::absl::once_flag descriptor_table_mavlink_5fdirect_2fmavlink_5fdirect_2e
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_mavlink_5fdirect_2fmavlink_5fdirect_2eproto = {
     false,
     false,
-    1451,
+    1457,
     descriptor_table_protodef_mavlink_5fdirect_2fmavlink_5fdirect_2eproto,
     "mavlink_direct/mavlink_direct.proto",
     &descriptor_table_mavlink_5fdirect_2fmavlink_5fdirect_2eproto_once,
@@ -1948,9 +1948,9 @@ MavlinkMessage::MavlinkMessage(
                offsetof(Impl_, system_id_),
            reinterpret_cast<const char *>(&from._impl_) +
                offsetof(Impl_, system_id_),
-           offsetof(Impl_, target_component_) -
+           offsetof(Impl_, target_component_id_) -
                offsetof(Impl_, system_id_) +
-               sizeof(Impl_::target_component_));
+               sizeof(Impl_::target_component_id_));
 
   // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.mavlink_direct.MavlinkMessage)
 }
@@ -1966,9 +1966,9 @@ inline void MavlinkMessage::SharedCtor(::_pb::Arena* arena) {
   ::memset(reinterpret_cast<char *>(&_impl_) +
                offsetof(Impl_, system_id_),
            0,
-           offsetof(Impl_, target_component_) -
+           offsetof(Impl_, target_component_id_) -
                offsetof(Impl_, system_id_) +
-               sizeof(Impl_::target_component_));
+               sizeof(Impl_::target_component_id_));
 }
 MavlinkMessage::~MavlinkMessage() {
   // @@protoc_insertion_point(destructor:mavsdk.rpc.mavlink_direct.MavlinkMessage)
@@ -2047,12 +2047,12 @@ const ::_pbi::TcParseTable<3, 6, 0, 72, 2> MavlinkMessage::_table_ = {
     // uint32 component_id = 3;
     {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(MavlinkMessage, _impl_.component_id_), 63>(),
      {24, 63, 0, PROTOBUF_FIELD_OFFSET(MavlinkMessage, _impl_.component_id_)}},
-    // uint32 target_system = 4;
-    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(MavlinkMessage, _impl_.target_system_), 63>(),
-     {32, 63, 0, PROTOBUF_FIELD_OFFSET(MavlinkMessage, _impl_.target_system_)}},
-    // uint32 target_component = 5;
-    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(MavlinkMessage, _impl_.target_component_), 63>(),
-     {40, 63, 0, PROTOBUF_FIELD_OFFSET(MavlinkMessage, _impl_.target_component_)}},
+    // uint32 target_system_id = 4;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(MavlinkMessage, _impl_.target_system_id_), 63>(),
+     {32, 63, 0, PROTOBUF_FIELD_OFFSET(MavlinkMessage, _impl_.target_system_id_)}},
+    // uint32 target_component_id = 5;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(MavlinkMessage, _impl_.target_component_id_), 63>(),
+     {40, 63, 0, PROTOBUF_FIELD_OFFSET(MavlinkMessage, _impl_.target_component_id_)}},
     // string fields_json = 6;
     {::_pbi::TcParser::FastUS1,
      {50, 63, 0, PROTOBUF_FIELD_OFFSET(MavlinkMessage, _impl_.fields_json_)}},
@@ -2069,11 +2069,11 @@ const ::_pbi::TcParseTable<3, 6, 0, 72, 2> MavlinkMessage::_table_ = {
     // uint32 component_id = 3;
     {PROTOBUF_FIELD_OFFSET(MavlinkMessage, _impl_.component_id_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kUInt32)},
-    // uint32 target_system = 4;
-    {PROTOBUF_FIELD_OFFSET(MavlinkMessage, _impl_.target_system_), 0, 0,
+    // uint32 target_system_id = 4;
+    {PROTOBUF_FIELD_OFFSET(MavlinkMessage, _impl_.target_system_id_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kUInt32)},
-    // uint32 target_component = 5;
-    {PROTOBUF_FIELD_OFFSET(MavlinkMessage, _impl_.target_component_), 0, 0,
+    // uint32 target_component_id = 5;
+    {PROTOBUF_FIELD_OFFSET(MavlinkMessage, _impl_.target_component_id_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kUInt32)},
     // string fields_json = 6;
     {PROTOBUF_FIELD_OFFSET(MavlinkMessage, _impl_.fields_json_), 0, 0,
@@ -2098,8 +2098,8 @@ PROTOBUF_NOINLINE void MavlinkMessage::Clear() {
   _impl_.message_name_.ClearToEmpty();
   _impl_.fields_json_.ClearToEmpty();
   ::memset(&_impl_.system_id_, 0, static_cast<::size_t>(
-      reinterpret_cast<char*>(&_impl_.target_component_) -
-      reinterpret_cast<char*>(&_impl_.system_id_)) + sizeof(_impl_.target_component_));
+      reinterpret_cast<char*>(&_impl_.target_component_id_) -
+      reinterpret_cast<char*>(&_impl_.system_id_)) + sizeof(_impl_.target_component_id_));
   _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
 }
 
@@ -2140,18 +2140,18 @@ PROTOBUF_NOINLINE void MavlinkMessage::Clear() {
                 3, this_._internal_component_id(), target);
           }
 
-          // uint32 target_system = 4;
-          if (this_._internal_target_system() != 0) {
+          // uint32 target_system_id = 4;
+          if (this_._internal_target_system_id() != 0) {
             target = stream->EnsureSpace(target);
             target = ::_pbi::WireFormatLite::WriteUInt32ToArray(
-                4, this_._internal_target_system(), target);
+                4, this_._internal_target_system_id(), target);
           }
 
-          // uint32 target_component = 5;
-          if (this_._internal_target_component() != 0) {
+          // uint32 target_component_id = 5;
+          if (this_._internal_target_component_id() != 0) {
             target = stream->EnsureSpace(target);
             target = ::_pbi::WireFormatLite::WriteUInt32ToArray(
-                5, this_._internal_target_component(), target);
+                5, this_._internal_target_component_id(), target);
           }
 
           // string fields_json = 6;
@@ -2207,15 +2207,15 @@ PROTOBUF_NOINLINE void MavlinkMessage::Clear() {
               total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(
                   this_._internal_component_id());
             }
-            // uint32 target_system = 4;
-            if (this_._internal_target_system() != 0) {
+            // uint32 target_system_id = 4;
+            if (this_._internal_target_system_id() != 0) {
               total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(
-                  this_._internal_target_system());
+                  this_._internal_target_system_id());
             }
-            // uint32 target_component = 5;
-            if (this_._internal_target_component() != 0) {
+            // uint32 target_component_id = 5;
+            if (this_._internal_target_component_id() != 0) {
               total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(
-                  this_._internal_target_component());
+                  this_._internal_target_component_id());
             }
           }
           return this_.MaybeComputeUnknownFieldsSize(total_size,
@@ -2242,11 +2242,11 @@ void MavlinkMessage::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::
   if (from._internal_component_id() != 0) {
     _this->_impl_.component_id_ = from._impl_.component_id_;
   }
-  if (from._internal_target_system() != 0) {
-    _this->_impl_.target_system_ = from._impl_.target_system_;
+  if (from._internal_target_system_id() != 0) {
+    _this->_impl_.target_system_id_ = from._impl_.target_system_id_;
   }
-  if (from._internal_target_component() != 0) {
-    _this->_impl_.target_component_ = from._impl_.target_component_;
+  if (from._internal_target_component_id() != 0) {
+    _this->_impl_.target_component_id_ = from._impl_.target_component_id_;
   }
   _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
 }
@@ -2267,8 +2267,8 @@ void MavlinkMessage::InternalSwap(MavlinkMessage* PROTOBUF_RESTRICT other) {
   ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.message_name_, &other->_impl_.message_name_, arena);
   ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.fields_json_, &other->_impl_.fields_json_, arena);
   ::google::protobuf::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(MavlinkMessage, _impl_.target_component_)
-      + sizeof(MavlinkMessage::_impl_.target_component_)
+      PROTOBUF_FIELD_OFFSET(MavlinkMessage, _impl_.target_component_id_)
+      + sizeof(MavlinkMessage::_impl_.target_component_id_)
       - PROTOBUF_FIELD_OFFSET(MavlinkMessage, _impl_.system_id_)>(
           reinterpret_cast<char*>(&_impl_.system_id_),
           reinterpret_cast<char*>(&other->_impl_.system_id_));

--- a/src/mavsdk_server/src/generated/mavlink_direct/mavlink_direct.pb.h
+++ b/src/mavsdk_server/src/generated/mavlink_direct/mavlink_direct.pb.h
@@ -484,8 +484,8 @@ class MavlinkMessage final
     kFieldsJsonFieldNumber = 6,
     kSystemIdFieldNumber = 2,
     kComponentIdFieldNumber = 3,
-    kTargetSystemFieldNumber = 4,
-    kTargetComponentFieldNumber = 5,
+    kTargetSystemIdFieldNumber = 4,
+    kTargetComponentIdFieldNumber = 5,
   };
   // string message_name = 1;
   void clear_message_name() ;
@@ -539,24 +539,24 @@ class MavlinkMessage final
   void _internal_set_component_id(::uint32_t value);
 
   public:
-  // uint32 target_system = 4;
-  void clear_target_system() ;
-  ::uint32_t target_system() const;
-  void set_target_system(::uint32_t value);
+  // uint32 target_system_id = 4;
+  void clear_target_system_id() ;
+  ::uint32_t target_system_id() const;
+  void set_target_system_id(::uint32_t value);
 
   private:
-  ::uint32_t _internal_target_system() const;
-  void _internal_set_target_system(::uint32_t value);
+  ::uint32_t _internal_target_system_id() const;
+  void _internal_set_target_system_id(::uint32_t value);
 
   public:
-  // uint32 target_component = 5;
-  void clear_target_component() ;
-  ::uint32_t target_component() const;
-  void set_target_component(::uint32_t value);
+  // uint32 target_component_id = 5;
+  void clear_target_component_id() ;
+  ::uint32_t target_component_id() const;
+  void set_target_component_id(::uint32_t value);
 
   private:
-  ::uint32_t _internal_target_component() const;
-  void _internal_set_target_component(::uint32_t value);
+  ::uint32_t _internal_target_component_id() const;
+  void _internal_set_target_component_id(::uint32_t value);
 
   public:
   // @@protoc_insertion_point(class_scope:mavsdk.rpc.mavlink_direct.MavlinkMessage)
@@ -586,8 +586,8 @@ class MavlinkMessage final
     ::google::protobuf::internal::ArenaStringPtr fields_json_;
     ::uint32_t system_id_;
     ::uint32_t component_id_;
-    ::uint32_t target_system_;
-    ::uint32_t target_component_;
+    ::uint32_t target_system_id_;
+    ::uint32_t target_component_id_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
@@ -2426,48 +2426,48 @@ inline void MavlinkMessage::_internal_set_component_id(::uint32_t value) {
   _impl_.component_id_ = value;
 }
 
-// uint32 target_system = 4;
-inline void MavlinkMessage::clear_target_system() {
+// uint32 target_system_id = 4;
+inline void MavlinkMessage::clear_target_system_id() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.target_system_ = 0u;
+  _impl_.target_system_id_ = 0u;
 }
-inline ::uint32_t MavlinkMessage::target_system() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.mavlink_direct.MavlinkMessage.target_system)
-  return _internal_target_system();
+inline ::uint32_t MavlinkMessage::target_system_id() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.mavlink_direct.MavlinkMessage.target_system_id)
+  return _internal_target_system_id();
 }
-inline void MavlinkMessage::set_target_system(::uint32_t value) {
-  _internal_set_target_system(value);
-  // @@protoc_insertion_point(field_set:mavsdk.rpc.mavlink_direct.MavlinkMessage.target_system)
+inline void MavlinkMessage::set_target_system_id(::uint32_t value) {
+  _internal_set_target_system_id(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.mavlink_direct.MavlinkMessage.target_system_id)
 }
-inline ::uint32_t MavlinkMessage::_internal_target_system() const {
+inline ::uint32_t MavlinkMessage::_internal_target_system_id() const {
   ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.target_system_;
+  return _impl_.target_system_id_;
 }
-inline void MavlinkMessage::_internal_set_target_system(::uint32_t value) {
+inline void MavlinkMessage::_internal_set_target_system_id(::uint32_t value) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.target_system_ = value;
+  _impl_.target_system_id_ = value;
 }
 
-// uint32 target_component = 5;
-inline void MavlinkMessage::clear_target_component() {
+// uint32 target_component_id = 5;
+inline void MavlinkMessage::clear_target_component_id() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.target_component_ = 0u;
+  _impl_.target_component_id_ = 0u;
 }
-inline ::uint32_t MavlinkMessage::target_component() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.mavlink_direct.MavlinkMessage.target_component)
-  return _internal_target_component();
+inline ::uint32_t MavlinkMessage::target_component_id() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.mavlink_direct.MavlinkMessage.target_component_id)
+  return _internal_target_component_id();
 }
-inline void MavlinkMessage::set_target_component(::uint32_t value) {
-  _internal_set_target_component(value);
-  // @@protoc_insertion_point(field_set:mavsdk.rpc.mavlink_direct.MavlinkMessage.target_component)
+inline void MavlinkMessage::set_target_component_id(::uint32_t value) {
+  _internal_set_target_component_id(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.mavlink_direct.MavlinkMessage.target_component_id)
 }
-inline ::uint32_t MavlinkMessage::_internal_target_component() const {
+inline ::uint32_t MavlinkMessage::_internal_target_component_id() const {
   ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.target_component_;
+  return _impl_.target_component_id_;
 }
-inline void MavlinkMessage::_internal_set_target_component(::uint32_t value) {
+inline void MavlinkMessage::_internal_set_target_component_id(::uint32_t value) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.target_component_ = value;
+  _impl_.target_component_id_ = value;
 }
 
 // string fields_json = 6;

--- a/src/mavsdk_server/src/plugins/mavlink_direct/mavlink_direct_service_impl.h
+++ b/src/mavsdk_server/src/plugins/mavlink_direct/mavlink_direct_service_impl.h
@@ -54,9 +54,9 @@ public:
 
         rpc_obj->set_component_id(mavlink_message.component_id);
 
-        rpc_obj->set_target_system(mavlink_message.target_system);
+        rpc_obj->set_target_system_id(mavlink_message.target_system_id);
 
-        rpc_obj->set_target_component(mavlink_message.target_component);
+        rpc_obj->set_target_component_id(mavlink_message.target_component_id);
 
         rpc_obj->set_fields_json(mavlink_message.fields_json);
 
@@ -74,9 +74,9 @@ public:
 
         obj.component_id = mavlink_message.component_id();
 
-        obj.target_system = mavlink_message.target_system();
+        obj.target_system_id = mavlink_message.target_system_id();
 
-        obj.target_component = mavlink_message.target_component();
+        obj.target_component_id = mavlink_message.target_component_id();
 
         obj.fields_json = mavlink_message.fields_json();
 

--- a/src/system_tests/CMakeLists.txt
+++ b/src/system_tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(system_tests_runner
     ftp_remove_dir.cpp
     ftp_compare_files.cpp
     ftp_list_dir.cpp
+    intercept.cpp
     mavlink_direct.cpp
     mavlink_direct_forwarding.cpp
     system_tests_runner.cpp

--- a/src/system_tests/intercept.cpp
+++ b/src/system_tests/intercept.cpp
@@ -321,7 +321,7 @@ TEST(SystemTest, InterceptJsonOutgoing)
     auto json_handle = mavsdk_autopilot.subscribe_outgoing_messages_json(
         [&json_prom, &intercept_called](Mavsdk::MavlinkMessage json_message) {
             LogInfo() << "Intercepted outgoing JSON message: " << json_message.message_name
-                      << " to system " << json_message.target_system
+                      << " to system " << json_message.target_system_id
                       << " with fields: " << json_message.fields_json;
 
             if (json_message.message_name == "GPS_RAW_INT") {
@@ -388,7 +388,7 @@ TEST(SystemTest, InterceptJsonOutgoing)
 
     LogInfo() << "Successfully tested outgoing JSON message interception";
     LogInfo() << "  - Message name: " << intercepted_message.message_name;
-    LogInfo() << "  - Target system: " << intercepted_message.target_system;
+    LogInfo() << "  - Target system: " << intercepted_message.target_system_id;
     LogInfo() << "  - Fields JSON length: " << intercepted_message.fields_json.length();
 
     // Cleanup

--- a/src/system_tests/intercept.cpp
+++ b/src/system_tests/intercept.cpp
@@ -1,0 +1,396 @@
+#include "log.h"
+#include "mavsdk.h"
+#include "plugins/telemetry/telemetry.h"
+#include "plugins/telemetry_server/telemetry_server.h"
+#include <chrono>
+#include <thread>
+#include <future>
+#include <gtest/gtest.h>
+#include <json/json.h>
+
+using namespace mavsdk;
+
+TEST(SystemTest, InterceptIncomingModifyLocal)
+{
+    // Create 3 MAVSDK instances: Sender -> Interceptor/Forwarder -> Receiver
+    Mavsdk mavsdk_sender{Mavsdk::Configuration{ComponentType::Autopilot}};
+    Mavsdk mavsdk_interceptor{Mavsdk::Configuration{ComponentType::GroundStation}};
+    Mavsdk mavsdk_receiver{Mavsdk::Configuration{ComponentType::GroundStation}};
+
+    // Set up connections with forwarding enabled on interceptor
+    ASSERT_EQ(
+        mavsdk_sender.add_any_connection("udpout://127.0.0.1:17000"), ConnectionResult::Success);
+    ASSERT_EQ(
+        mavsdk_interceptor.add_any_connection(
+            "udpin://0.0.0.0:17000", ForwardingOption::ForwardingOn),
+        ConnectionResult::Success);
+    ASSERT_EQ(
+        mavsdk_interceptor.add_any_connection(
+            "udpout://127.0.0.1:17001", ForwardingOption::ForwardingOn),
+        ConnectionResult::Success);
+    ASSERT_EQ(
+        mavsdk_receiver.add_any_connection("udpin://0.0.0.0:17001"), ConnectionResult::Success);
+
+    // Wait for connections to establish
+    LogInfo() << "Waiting for connections to establish...";
+
+    // Interceptor discovers sender
+    auto sender_system_opt = mavsdk_interceptor.first_autopilot(10.0);
+    ASSERT_TRUE(sender_system_opt);
+    auto sender_system = sender_system_opt.value();
+    ASSERT_TRUE(sender_system->has_autopilot());
+
+    // Receiver discovers sender (via forwarding)
+    auto sender_system_receiver_opt = mavsdk_receiver.first_autopilot(10.0);
+    ASSERT_TRUE(sender_system_receiver_opt);
+    auto sender_system_receiver = sender_system_receiver_opt.value();
+    ASSERT_TRUE(sender_system_receiver->has_autopilot());
+
+    // Wait for sender to discover interceptor connection
+    LogInfo() << "Waiting for sender to connect to interceptor...";
+    while (mavsdk_sender.systems().size() == 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    auto interceptor_system = mavsdk_sender.systems().at(0);
+
+    // Create telemetry instances
+    auto telemetry_interceptor = Telemetry{sender_system};
+    auto telemetry_receiver = Telemetry{sender_system_receiver};
+    auto telemetry_server = TelemetryServer{mavsdk_sender.server_component()};
+
+    // Original position values
+    const double original_lat = 47.3977421; // Zurich coordinates
+    const double original_lon = 8.5455938;
+    const float original_alt = 488.0f;
+
+    // Modified position values (what intercept will change to)
+    const double modified_lat = 37.7749295; // San Francisco coordinates
+    const double modified_lon = -122.4194155;
+
+    // Set up raw mavlink intercept callback on interceptor to modify incoming GLOBAL_POSITION_INT
+    std::atomic<bool> intercept_called{false};
+
+    mavsdk_interceptor.intercept_incoming_messages_async([&](mavlink_message_t& message) -> bool {
+        if (message.msgid == MAVLINK_MSG_ID_GLOBAL_POSITION_INT) {
+            LogInfo() << "Intercepting GLOBAL_POSITION_INT message from system "
+                      << (int)message.sysid;
+
+            // Decode the message
+            mavlink_global_position_int_t pos;
+            mavlink_msg_global_position_int_decode(&message, &pos);
+
+            LogInfo() << "Original coordinates: lat=" << (pos.lat / 1e7)
+                      << ", lon=" << (pos.lon / 1e7);
+
+            // Modify the coordinates to San Francisco
+            pos.lat = static_cast<int32_t>(modified_lat * 1e7);
+            pos.lon = static_cast<int32_t>(modified_lon * 1e7);
+
+            // Re-encode the modified message
+            mavlink_msg_global_position_int_encode(message.sysid, message.compid, &message, &pos);
+
+            LogInfo() << "Modified coordinates to San Francisco: lat=" << (pos.lat / 1e7)
+                      << ", lon=" << (pos.lon / 1e7);
+
+            intercept_called = true;
+        }
+        return true; // Keep the message
+    });
+
+    // Promise/future for interceptor telemetry
+    auto interceptor_prom = std::promise<Telemetry::Position>();
+    auto interceptor_fut = interceptor_prom.get_future();
+
+    // Promise/future for receiver telemetry
+    auto receiver_prom = std::promise<Telemetry::Position>();
+    auto receiver_fut = receiver_prom.get_future();
+
+    // Subscribe to position updates on interceptor
+    auto interceptor_handle =
+        telemetry_interceptor.subscribe_position([&interceptor_prom](Telemetry::Position position) {
+            LogInfo() << "Interceptor received position: lat=" << position.latitude_deg
+                      << ", lon=" << position.longitude_deg;
+            interceptor_prom.set_value(position);
+        });
+
+    // Subscribe to position updates on receiver
+    auto receiver_handle =
+        telemetry_receiver.subscribe_position([&receiver_prom](Telemetry::Position position) {
+            LogInfo() << "Receiver received position: lat=" << position.latitude_deg
+                      << ", lon=" << position.longitude_deg;
+            receiver_prom.set_value(position);
+        });
+
+    // Send position from sender
+    LogInfo() << "Publishing original position from sender...";
+    TelemetryServer::Position position{};
+    position.latitude_deg = original_lat;
+    position.longitude_deg = original_lon;
+    position.absolute_altitude_m = original_alt;
+    position.relative_altitude_m = original_alt;
+
+    // Empty velocity and heading for this test
+    TelemetryServer::VelocityNed velocity{};
+    TelemetryServer::Heading heading{};
+
+    ASSERT_EQ(
+        telemetry_server.publish_position(position, velocity, heading),
+        TelemetryServer::Result::Success);
+
+    // Wait for both telemetry callbacks
+    ASSERT_EQ(interceptor_fut.wait_for(std::chrono::seconds(10)), std::future_status::ready);
+    ASSERT_EQ(receiver_fut.wait_for(std::chrono::seconds(10)), std::future_status::ready);
+
+    // Give intercept callback time to complete
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    // Verify intercept was called
+    ASSERT_TRUE(intercept_called.load());
+
+    // Get the results
+    auto interceptor_position = interceptor_fut.get();
+    auto receiver_position = receiver_fut.get();
+
+    // Verify interceptor sees modified coordinates (San Francisco)
+    EXPECT_NEAR(interceptor_position.latitude_deg, modified_lat, 1e-6);
+    EXPECT_NEAR(interceptor_position.longitude_deg, modified_lon, 1e-6);
+    EXPECT_NEAR(interceptor_position.absolute_altitude_m, original_alt, 1.0f);
+
+    // FIXED BEHAVIOR: Receiver gets original coordinates (forwarded message not affected by
+    // intercept)
+    EXPECT_NEAR(
+        receiver_position.latitude_deg,
+        original_lat,
+        1e-6); // Should be original Zurich coordinates
+    EXPECT_NEAR(
+        receiver_position.longitude_deg,
+        original_lon,
+        1e-6); // Should be original Zurich coordinates
+    EXPECT_NEAR(receiver_position.absolute_altitude_m, original_alt, 1.0f);
+
+    LogInfo() << "Test completed successfully - intercept bug FIXED:";
+    LogInfo() << "  - Interceptor saw modified coordinates (San Francisco)";
+    LogInfo() << "  - Receiver saw original coordinates (Zurich)";
+    LogInfo() << "  - This proves intercept affects local processing but NOT forwarding";
+
+    // Cleanup
+    telemetry_interceptor.unsubscribe_position(interceptor_handle);
+    telemetry_receiver.unsubscribe_position(receiver_handle);
+    mavsdk_interceptor.intercept_incoming_messages_async(nullptr);
+}
+
+TEST(SystemTest, InterceptJsonIncoming)
+{
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{ComponentType::GroundStation}};
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{ComponentType::Autopilot}};
+
+    ASSERT_EQ(
+        mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
+        ConnectionResult::Success);
+    ASSERT_EQ(
+        mavsdk_autopilot.add_any_connection("udpout://127.0.0.1:17000"), ConnectionResult::Success);
+
+    // Ground station discovers the autopilot system
+    auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
+    ASSERT_TRUE(maybe_system);
+    auto system = maybe_system.value();
+    ASSERT_TRUE(system->has_autopilot());
+
+    // Wait for autopilot instance to discover the connection to the ground station
+    LogInfo() << "Waiting for autopilot system to connect...";
+    while (mavsdk_autopilot.systems().size() == 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    // Create telemetry instances
+    auto telemetry = Telemetry{system};
+    auto telemetry_server = TelemetryServer{mavsdk_autopilot.server_component()};
+
+    // Set up incoming JSON message interception on ground station
+    auto json_prom = std::promise<Mavsdk::MavlinkMessage>();
+    auto json_fut = json_prom.get_future();
+    std::atomic<bool> intercept_called{false};
+
+    auto json_handle = mavsdk_groundstation.subscribe_incoming_messages_json(
+        [&json_prom, &intercept_called](Mavsdk::MavlinkMessage json_message) {
+            LogInfo() << "Intercepted incoming JSON message: " << json_message.message_name
+                      << " from system " << json_message.system_id
+                      << " with fields: " << json_message.fields_json;
+
+            if (json_message.message_name == "GLOBAL_POSITION_INT") {
+                intercept_called = true;
+                json_prom.set_value(json_message);
+                return true; // Don't drop the message
+            }
+            return true; // Let other messages through
+        });
+
+    // Publish position from autopilot
+    LogInfo() << "Publishing position from autopilot...";
+    TelemetryServer::Position position{};
+    position.latitude_deg = 47.3977421; // Zurich coordinates
+    position.longitude_deg = 8.5455938;
+    position.absolute_altitude_m = 488.0f;
+    position.relative_altitude_m = 488.0f;
+
+    TelemetryServer::VelocityNed velocity{};
+    velocity.north_m_s = 1.5f;
+    velocity.east_m_s = 2.0f;
+    velocity.down_m_s = -0.5f;
+
+    TelemetryServer::Heading heading{};
+    heading.heading_deg = 180.0f;
+
+    ASSERT_EQ(
+        telemetry_server.publish_position(position, velocity, heading),
+        TelemetryServer::Result::Success);
+
+    // Wait for JSON interception to occur
+    ASSERT_EQ(json_fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    // Verify intercept was called
+    ASSERT_TRUE(intercept_called.load());
+
+    auto intercepted_message = json_fut.get();
+
+    // Verify the intercepted JSON message structure
+    EXPECT_EQ(intercepted_message.message_name, "GLOBAL_POSITION_INT");
+    EXPECT_EQ(intercepted_message.system_id, 1u); // Autopilot system ID
+    EXPECT_GT(intercepted_message.fields_json.length(), 0u);
+
+    // Parse JSON to verify field values
+    Json::Value json;
+    Json::Reader reader;
+    ASSERT_TRUE(reader.parse(intercepted_message.fields_json, json));
+
+    // Verify position fields from the intercepted message
+    EXPECT_NEAR(json["lat"].asInt() / 1e7, position.latitude_deg, 1e-6);
+    EXPECT_NEAR(json["lon"].asInt() / 1e7, position.longitude_deg, 1e-6);
+    EXPECT_NEAR(json["alt"].asInt() / 1e3, position.absolute_altitude_m, 1.0);
+    EXPECT_NEAR(json["relative_alt"].asInt() / 1e3, position.relative_altitude_m, 1.0);
+
+    // Verify velocity fields
+    EXPECT_NEAR(json["vx"].asInt() / 1e2, velocity.north_m_s, 0.1);
+    EXPECT_NEAR(json["vy"].asInt() / 1e2, velocity.east_m_s, 0.1);
+    EXPECT_NEAR(json["vz"].asInt() / 1e2, velocity.down_m_s, 0.1);
+
+    // Verify heading field
+    EXPECT_NEAR(json["hdg"].asInt() / 1e2, heading.heading_deg, 1.0);
+
+    LogInfo() << "Successfully tested incoming JSON message interception";
+    LogInfo() << "  - Message name: " << intercepted_message.message_name;
+    LogInfo() << "  - System ID: " << intercepted_message.system_id;
+    LogInfo() << "  - Fields JSON length: " << intercepted_message.fields_json.length();
+
+    // Cleanup
+    mavsdk_groundstation.unsubscribe_incoming_messages_json(json_handle);
+}
+
+TEST(SystemTest, InterceptJsonOutgoing)
+{
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{ComponentType::GroundStation}};
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{ComponentType::Autopilot}};
+
+    ASSERT_EQ(
+        mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
+        ConnectionResult::Success);
+    ASSERT_EQ(
+        mavsdk_autopilot.add_any_connection("udpout://127.0.0.1:17000"), ConnectionResult::Success);
+
+    // Ground station discovers the autopilot system
+    auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
+    ASSERT_TRUE(maybe_system);
+    auto system = maybe_system.value();
+    ASSERT_TRUE(system->has_autopilot());
+
+    // Wait for autopilot instance to discover the connection to the ground station
+    LogInfo() << "Waiting for autopilot system to connect...";
+    while (mavsdk_autopilot.systems().size() == 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    // Create telemetry instances
+    auto telemetry = Telemetry{system};
+    auto telemetry_server = TelemetryServer{mavsdk_autopilot.server_component()};
+
+    // Set up outgoing JSON message interception on autopilot
+    auto json_prom = std::promise<Mavsdk::MavlinkMessage>();
+    auto json_fut = json_prom.get_future();
+    std::atomic<bool> intercept_called{false};
+
+    auto json_handle = mavsdk_autopilot.subscribe_outgoing_messages_json(
+        [&json_prom, &intercept_called](Mavsdk::MavlinkMessage json_message) {
+            LogInfo() << "Intercepted outgoing JSON message: " << json_message.message_name
+                      << " to system " << json_message.target_system
+                      << " with fields: " << json_message.fields_json;
+
+            if (json_message.message_name == "GPS_RAW_INT") {
+                intercept_called = true;
+                json_prom.set_value(json_message);
+                return true; // Don't drop the message
+            }
+            return true; // Let other messages through
+        });
+
+    // Publish GPS data from autopilot
+    LogInfo() << "Publishing GPS data from autopilot...";
+    TelemetryServer::RawGps raw_gps{};
+    raw_gps.timestamp_us = 1234567890;
+    raw_gps.latitude_deg = 47.3977421; // Zurich coordinates
+    raw_gps.longitude_deg = 8.5455938;
+    raw_gps.absolute_altitude_m = 488.0f;
+    raw_gps.hdop = 1.0f;
+    raw_gps.vdop = 1.5f;
+    raw_gps.velocity_m_s = 15.0f;
+    raw_gps.cog_deg = 90.0f;
+    raw_gps.altitude_ellipsoid_m = 490.0f;
+    raw_gps.horizontal_uncertainty_m = 2.0f;
+    raw_gps.vertical_uncertainty_m = 3.0f;
+    raw_gps.velocity_uncertainty_m_s = 0.5f;
+    raw_gps.heading_uncertainty_deg = 5.0f;
+    raw_gps.yaw_deg = 90.0f;
+
+    TelemetryServer::GpsInfo gps_info{};
+    gps_info.num_satellites = 12;
+    gps_info.fix_type = TelemetryServer::FixType::Fix3D;
+
+    ASSERT_EQ(
+        telemetry_server.publish_raw_gps(raw_gps, gps_info), TelemetryServer::Result::Success);
+
+    // Wait for JSON interception to occur
+    ASSERT_EQ(json_fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    // Verify intercept was called
+    ASSERT_TRUE(intercept_called.load());
+
+    auto intercepted_message = json_fut.get();
+
+    // Verify the intercepted JSON message structure
+    EXPECT_EQ(intercepted_message.message_name, "GPS_RAW_INT");
+    EXPECT_GT(intercepted_message.fields_json.length(), 0u);
+
+    // Parse JSON to verify field values
+    Json::Value json;
+    Json::Reader reader;
+    ASSERT_TRUE(reader.parse(intercepted_message.fields_json, json));
+
+    // Verify GPS fields from the intercepted message
+    EXPECT_EQ(json["time_usec"].asUInt64(), raw_gps.timestamp_us);
+    EXPECT_EQ(json["fix_type"].asUInt(), static_cast<uint8_t>(gps_info.fix_type));
+    EXPECT_NEAR(json["lat"].asInt() / 1e7, raw_gps.latitude_deg, 1e-6);
+    EXPECT_NEAR(json["lon"].asInt() / 1e7, raw_gps.longitude_deg, 1e-6);
+    EXPECT_NEAR(json["alt"].asInt() / 1e3, raw_gps.absolute_altitude_m, 1.0);
+    EXPECT_NEAR(json["eph"].asInt() / 1e2, raw_gps.hdop, 0.1);
+    EXPECT_NEAR(json["epv"].asInt() / 1e2, raw_gps.vdop, 0.1);
+    EXPECT_NEAR(json["vel"].asInt() / 1e2, raw_gps.velocity_m_s, 0.1);
+    EXPECT_NEAR(json["cog"].asInt() / 1e2, raw_gps.cog_deg, 1.0);
+    EXPECT_EQ(json["satellites_visible"].asUInt(), gps_info.num_satellites);
+
+    LogInfo() << "Successfully tested outgoing JSON message interception";
+    LogInfo() << "  - Message name: " << intercepted_message.message_name;
+    LogInfo() << "  - Target system: " << intercepted_message.target_system;
+    LogInfo() << "  - Fields JSON length: " << intercepted_message.fields_json.length();
+
+    // Cleanup
+    mavsdk_autopilot.unsubscribe_outgoing_messages_json(json_handle);
+}

--- a/src/system_tests/mavlink_direct.cpp
+++ b/src/system_tests/mavlink_direct.cpp
@@ -60,8 +60,8 @@ TEST(SystemTest, MavlinkDirectRoundtrip)
     test_message.message_name = "GLOBAL_POSITION_INT";
     test_message.system_id = 1;
     test_message.component_id = 1;
-    test_message.target_system = 0;
-    test_message.target_component = 0;
+    test_message.target_system_id = 0;
+    test_message.target_component_id = 0;
     test_message.fields_json =
         R"({"time_boot_ms":12345,"lat":473977418,"lon":-1223974560,"alt":100500,"relative_alt":50250,"vx":100,"vy":-50,"vz":25,"hdg":18000})";
 
@@ -140,8 +140,8 @@ TEST(SystemTest, MavlinkDirectExtendedFields)
     compact_message.message_name = "SYS_STATUS";
     compact_message.system_id = 1;
     compact_message.component_id = 1;
-    compact_message.target_system = 0;
-    compact_message.target_component = 0;
+    compact_message.target_system_id = 0;
+    compact_message.target_component_id = 0;
     compact_message.fields_json =
         R"({"onboard_control_sensors_present":1,"onboard_control_sensors_enabled":1,"onboard_control_sensors_health":1,"load":500,"voltage_battery":12000,"current_battery":1000,"battery_remaining":75,"drop_rate_comm":0,"errors_comm":0,"errors_count1":0,"errors_count2":0,"errors_count3":0,"errors_count4":0})";
 
@@ -155,8 +155,8 @@ TEST(SystemTest, MavlinkDirectExtendedFields)
     full_message.message_name = "SYS_STATUS";
     full_message.system_id = 1;
     full_message.component_id = 1;
-    full_message.target_system = 0;
-    full_message.target_component = 0;
+    full_message.target_system_id = 0;
+    full_message.target_component_id = 0;
     full_message.fields_json =
         R"({"onboard_control_sensors_present":1,"onboard_control_sensors_enabled":1,"onboard_control_sensors_health":1,"load":500,"voltage_battery":12000,"current_battery":1000,"battery_remaining":75,"drop_rate_comm":0,"errors_comm":0,"errors_count1":0,"errors_count2":0,"errors_count3":0,"errors_count4":0,"onboard_control_sensors_present_extended":123,"onboard_control_sensors_enabled_extended":456,"onboard_control_sensors_health_extended":789})";
 
@@ -261,8 +261,8 @@ TEST(SystemTest, MavlinkDirectToTelemetry)
     test_message.message_name = "GLOBAL_POSITION_INT";
     test_message.system_id = 1;
     test_message.component_id = 1;
-    test_message.target_system = 0;
-    test_message.target_component = 0;
+    test_message.target_system_id = 0;
+    test_message.target_component_id = 0;
     test_message.fields_json =
         R"({"time_boot_ms":12345,"lat":473977418,"lon":-1223974560,"alt":100500,"relative_alt":50250,"vx":100,"vy":-50,"vz":25,"hdg":18000})";
 
@@ -412,8 +412,8 @@ TEST(SystemTest, MavlinkDirectArrayFields)
     partial_message.message_name = "GPS_STATUS";
     partial_message.system_id = 1;
     partial_message.component_id = 1;
-    partial_message.target_system = 0;
-    partial_message.target_component = 0;
+    partial_message.target_system_id = 0;
+    partial_message.target_component_id = 0;
     partial_message.fields_json =
         R"({"satellites_visible":3,"satellite_prn":[1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"satellite_used":[1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"satellite_elevation":[45,60,30,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"satellite_azimuth":[90,180,270,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"satellite_snr":[25,30,15,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]})";
 
@@ -427,8 +427,8 @@ TEST(SystemTest, MavlinkDirectArrayFields)
     full_message.message_name = "GPS_STATUS";
     full_message.system_id = 1;
     full_message.component_id = 1;
-    full_message.target_system = 0;
-    full_message.target_component = 0;
+    full_message.target_system_id = 0;
+    full_message.target_component_id = 0;
     full_message.fields_json =
         R"({"satellites_visible":20,"satellite_prn":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20],"satellite_used":[1,1,1,1,1,0,0,0,0,0,1,1,1,1,1,0,0,0,0,0],"satellite_elevation":[45,60,30,75,20,85,50,40,65,35,25,55,70,15,80,10,90,5,45,60],"satellite_azimuth":[0,36,72,108,144,180,216,252,28,64,100,136,172,208,244,20,56,92,128,164],"satellite_snr":[25,30,15,35,20,40,28,22,32,18,26,31,16,38,24,19,33,21,29,27]})";
 
@@ -583,8 +583,8 @@ TEST(SystemTest, MavlinkDirectLoadCustomXml)
     custom_message.message_name = "CUSTOM_TEST_MESSAGE";
     custom_message.system_id = 1;
     custom_message.component_id = 1;
-    custom_message.target_system = 0;
-    custom_message.target_component = 0;
+    custom_message.target_system_id = 0;
+    custom_message.target_component_id = 0;
     custom_message.fields_json = R"({"test_value":42,"counter":1337,"status":5})";
 
     auto send_result = sender_mavlink_direct.send_message(custom_message);

--- a/src/system_tests/mavlink_direct_forwarding.cpp
+++ b/src/system_tests/mavlink_direct_forwarding.cpp
@@ -39,7 +39,7 @@ TEST(SystemTest, MavlinkDirectForwardingKnownMessage)
         mavsdk_receiver.add_any_connection("udpin://0.0.0.0:17011"), ConnectionResult::Success);
 
     LogInfo() << "Waiting for connections to establish...";
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
     // Receiver discovers the sender system (autopilot) through the forwarder
     auto receiver_target_system = mavsdk_receiver.first_autopilot(10.0);
@@ -153,7 +153,7 @@ TEST(SystemTest, MavlinkDirectForwardingUnknownMessage)
 </mavlink>)";
 
     LogInfo() << "Waiting for connections to establish...";
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
     // Receiver discovers the sender system (autopilot) through the forwarder
     auto receiver_target_system = mavsdk_receiver.first_autopilot(10.0);

--- a/src/system_tests/mavlink_direct_forwarding.cpp
+++ b/src/system_tests/mavlink_direct_forwarding.cpp
@@ -75,8 +75,8 @@ TEST(SystemTest, MavlinkDirectForwardingKnownMessage)
     test_message.message_name = "GLOBAL_POSITION_INT";
     test_message.system_id = 1;
     test_message.component_id = 1;
-    test_message.target_system = 0;
-    test_message.target_component = 0;
+    test_message.target_system_id = 0;
+    test_message.target_component_id = 0;
     test_message.fields_json =
         R"({"time_boot_ms":12345,"lat":473977418,"lon":-1223974560,"alt":100500,"relative_alt":50250,"vx":100,"vy":-50,"vz":25,"hdg":18000})";
 
@@ -199,8 +199,8 @@ TEST(SystemTest, MavlinkDirectForwardingUnknownMessage)
     test_message.message_name = "CUSTOM_FORWARD_TEST";
     test_message.system_id = 1;
     test_message.component_id = 1;
-    test_message.target_system = 0;
-    test_message.target_component = 0;
+    test_message.target_system_id = 0;
+    test_message.target_component_id = 0;
     test_message.fields_json =
         R"({"test_id":12345,"sequence":1,"status":42,"message":"Hello through forwarder!"})";
 


### PR DESCRIPTION
This adds a new interception API based on the libmav JSON integration (see https://github.com/mavlink/MAVSDK/pull/2610), avoiding the MAVLink C header depend dependency. The JSON based API will replace the previous one by the next major release.


Currently on top of #2637.