### PR TITLE
cmake: only link stdc++fs for GCC < 9

### DIFF
--- a/src/mavsdk/CMakeLists.txt
+++ b/src/mavsdk/CMakeLists.txt
@@ -23,7 +23,8 @@ target_link_libraries(mavsdk
     mav::mav
 )
 
-if (NOT APPLE AND NOT ANDROID AND NOT MSVC)
+if (NOT APPLE AND NOT ANDROID AND NOT MSVC
+    AND NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 9))
     target_link_libraries(mavsdk
         PRIVATE
         stdc++fs


### PR DESCRIPTION
Newer GCC versions (>= 9) include the C++17 filesystem library in libstdc++ by default, so linking stdc++fs explicitly is unnecessary and may cause build errors.

Update the CMake condition to link stdc++fs only when using GCC < 9, while keeping the existing exclusions for Apple, Android, and MSVC.