### PR TITLE
Update dockcross image, bringing support for Android 16KB alignment

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -697,7 +697,7 @@ jobs:
           submodules: recursive
           fetch-depth: 0
       - name: setup dockcross
-        run: docker run --rm dockcross/${{ matrix.arch_name }}:20250311-4bd0eec > ./dockcross-${{ matrix.arch_name }}; chmod +x ./dockcross-${{ matrix.arch_name }}
+        run: docker run --rm dockcross/${{ matrix.arch_name }}:20250818-0a27819 > ./dockcross-${{ matrix.arch_name }}; chmod +x ./dockcross-${{ matrix.arch_name }}
       - uses: actions/cache@v4
         id: cache
         with:
@@ -749,7 +749,7 @@ jobs:
           submodules: recursive
           fetch-depth: 0
       - name: setup dockcross
-        run: docker run --rm dockcross/${{ matrix.name }}:20250311-4bd0eec > ./dockcross-${{ matrix.name }}; chmod +x ./dockcross-${{ matrix.name }}
+        run: docker run --rm dockcross/${{ matrix.name }}:20250818-0a27819 > ./dockcross-${{ matrix.name }}; chmod +x ./dockcross-${{ matrix.name }}
       - uses: actions/cache@v4
         id: cache
         with:


### PR DESCRIPTION
The latest dockcross android images bring Android 16KB, which is now needed (see e.g. [here in MAVSDK-Java](https://github.com/mavlink/MAVSDK-Java/issues/214)).