### PR TITLE
mavlink_direct: fix message filtering

### DIFF
--- a/src/mavsdk/core/system_impl.h
+++ b/src/mavsdk/core/system_impl.h
@@ -77,16 +77,12 @@ public:
 
     void process_libmav_message(const Mavsdk::MavlinkMessage& message);
 
-    void register_libmav_message_handler(
-        const std::string& message_name, const LibmavMessageCallback& callback, const void* cookie);
-    void register_libmav_message_handler_with_compid(
-        const std::string& message_name,
-        uint8_t cmp_id,
-        const LibmavMessageCallback& callback,
-        const void* cookie);
+    Handle<Mavsdk::MavlinkMessage> register_libmav_message_handler(
+        const std::string& message_name, const LibmavMessageCallback& callback);
+    Handle<Mavsdk::MavlinkMessage> register_libmav_message_handler_with_compid(
+        const std::string& message_name, uint8_t cmp_id, const LibmavMessageCallback& callback);
 
-    void unregister_libmav_message_handler(const std::string& message_name, const void* cookie);
-    void unregister_all_libmav_message_handlers(const void* cookie);
+    void unregister_libmav_message_handler(Handle<Mavsdk::MavlinkMessage> handle);
 
     // Get connections for sending messages
     std::vector<Connection*> get_connections() const;
@@ -382,15 +378,8 @@ private:
 
     MavlinkMessageHandler _mavlink_message_handler{};
 
-    // Libmav message handling
-    struct LibmavMessageHandler {
-        std::string message_name;
-        LibmavMessageCallback callback;
-        const void* cookie;
-        std::optional<uint8_t> component_id; // If specified, only messages from this component
-    };
-    std::mutex _libmav_message_handlers_mutex{};
-    std::vector<LibmavMessageHandler> _libmav_message_handlers{};
+    // Libmav message handling using CallbackList for thread safety
+    CallbackList<Mavsdk::MavlinkMessage> _libmav_message_callbacks{};
 
     bool _message_debugging = false;
 

--- a/src/mavsdk/plugins/mavlink_direct/mavlink_direct_impl.h
+++ b/src/mavsdk/plugins/mavlink_direct/mavlink_direct_impl.h
@@ -10,7 +10,6 @@
 #include <optional>
 #include <map>
 #include <mutex>
-#include "handle_factory.h"
 
 namespace mavsdk {
 
@@ -37,11 +36,9 @@ public:
     MavlinkDirect::Result load_custom_xml(const std::string& xml_content);
 
 private:
-    // Thread-safe callback management using CallbackList pattern (like other plugins)
-    CallbackList<MavlinkDirect::MavlinkMessage> _message_subscriptions{};
-
-    // Map to track message names for each subscription handle (protected by CallbackList's mutex)
-    std::map<MavlinkDirect::MessageHandle, std::string> _handle_to_message_name{};
+    // Internal callback management
+    CallbackList<MavlinkDirect::MavlinkMessage> _callbacks{};
+    Handle<Mavsdk::MavlinkMessage> _system_subscription{};
 
     bool _debugging = false;
 


### PR DESCRIPTION
The message filtering was not correct with 2 or more subscriptions as they would conflict with each other. This should now be fixed with each subscription keeping track of what to filter out.

While doing so we switched to the new and nicer Handle/Subscription API in SystemImpl rather than the ugly void* cookie thing.

Fixes #2648.