### PR TITLE
Fix: Only set the current item if index is validated

### DIFF
--- a/src/mavsdk/plugins/mission_raw/mission_raw_impl.cpp
+++ b/src/mavsdk/plugins/mission_raw/mission_raw_impl.cpp
@@ -558,9 +558,9 @@ void MissionRawImpl::set_current_mission_item_async(
         _system_impl->call_user_callback([callback]() {
             if (callback) {
                 callback(MissionRaw::Result::InvalidArgument);
-                return;
             }
         });
+        return;
     }
 
     _system_impl->mission_transfer_client().set_current_item_async(


### PR DESCRIPTION
Fix for #2663.

Makes sure `set_current_mission_item_async` returns early to avoid calling callback a second time.
