### PR TITLE
mavlink_direct: handle (u)int > 2^32

### DIFF
--- a/src/mavsdk/plugins/mavlink_direct/mavlink_direct_impl.cpp
+++ b/src/mavsdk/plugins/mavlink_direct/mavlink_direct_impl.cpp
@@ -233,69 +233,20 @@ bool MavlinkDirectImpl::json_to_libmav_message(
         const Json::Value& field_value = json[field_name];
 
         // Convert JSON values to appropriate types and set in message
-        if (field_value.isInt()) {
-            auto result = msg.set(field_name, static_cast<int32_t>(field_value.asInt()));
+        // libmav handles type casting based on field definition, so we just need to pass
+        // int64/uint64
+        if (field_value.isInt() || field_value.isInt64()) {
+            int64_t value = field_value.asInt64();
+            auto result = msg.set(field_name, value);
             if (result != ::mav::MessageResult::Success) {
-                // Try as other integer types
-                if (msg.set(field_name, static_cast<uint32_t>(field_value.asUInt())) !=
-                        ::mav::MessageResult::Success &&
-                    msg.set(field_name, static_cast<int16_t>(field_value.asInt())) !=
-                        ::mav::MessageResult::Success &&
-                    msg.set(field_name, static_cast<uint16_t>(field_value.asUInt())) !=
-                        ::mav::MessageResult::Success &&
-                    msg.set(field_name, static_cast<int8_t>(field_value.asInt())) !=
-                        ::mav::MessageResult::Success &&
-                    msg.set(field_name, static_cast<uint8_t>(field_value.asUInt())) !=
-                        ::mav::MessageResult::Success) {
-                    LogWarn() << "Failed to set integer field " << field_name << " = "
-                              << field_value.asInt();
-                }
+                LogWarn() << "Failed to set integer field " << field_name << " = " << value;
             }
-        } else if (field_value.isInt64()) {
-            auto result = msg.set(field_name, static_cast<int64_t>(field_value.asInt64()));
+        } else if (field_value.isUInt() || field_value.isUInt64()) {
+            uint64_t value = field_value.asUInt64();
+            auto result = msg.set(field_name, value);
             if (result != ::mav::MessageResult::Success) {
-                // Try as other integer types
-                if (msg.set(field_name, static_cast<uint32_t>(field_value.asUInt())) !=
-                        ::mav::MessageResult::Success &&
-                    msg.set(field_name, static_cast<int16_t>(field_value.asInt())) !=
-                        ::mav::MessageResult::Success &&
-                    msg.set(field_name, static_cast<uint16_t>(field_value.asUInt())) !=
-                        ::mav::MessageResult::Success &&
-                    msg.set(field_name, static_cast<int8_t>(field_value.asInt())) !=
-                        ::mav::MessageResult::Success &&
-                    msg.set(field_name, static_cast<uint8_t>(field_value.asUInt())) !=
-                        ::mav::MessageResult::Success) {
-                    LogWarn() << "Failed to set integer64 field " << field_name << " = "
-                              << field_value.asInt64();
-                }
-            }
-        } else if (field_value.isUInt()) {
-            auto result = msg.set(field_name, static_cast<uint32_t>(field_value.asUInt()));
-            if (result != ::mav::MessageResult::Success) {
-                // Try as other unsigned integer types
-                if (msg.set(field_name, static_cast<uint64_t>(field_value.asUInt64())) !=
-                        ::mav::MessageResult::Success &&
-                    msg.set(field_name, static_cast<uint16_t>(field_value.asUInt())) !=
-                        ::mav::MessageResult::Success &&
-                    msg.set(field_name, static_cast<uint8_t>(field_value.asUInt())) !=
-                        ::mav::MessageResult::Success) {
-                    LogWarn() << "Failed to set unsigned integer field " << field_name << " = "
-                              << field_value.asUInt();
-                }
-            }
-        } else if (field_value.isUInt64()) {
-            auto result = msg.set(field_name, static_cast<uint32_t>(field_value.asUInt64()));
-            if (result != ::mav::MessageResult::Success) {
-                // Try as other unsigned integer types
-                if (msg.set(field_name, static_cast<uint64_t>(field_value.asUInt64())) !=
-                        ::mav::MessageResult::Success &&
-                    msg.set(field_name, static_cast<uint16_t>(field_value.asUInt())) !=
-                        ::mav::MessageResult::Success &&
-                    msg.set(field_name, static_cast<uint8_t>(field_value.asUInt())) !=
-                        ::mav::MessageResult::Success) {
-                    LogWarn() << "Failed to set unsigned integer64 field " << field_name << " = "
-                              << field_value.asUInt64();
-                }
+                LogWarn() << "Failed to set unsigned integer field " << field_name << " = "
+                          << value;
             }
         } else if (field_value.isNull() || field_value.isDouble()) {
             // Handle float/double values (including null -> NaN)

--- a/src/mavsdk/plugins/mavlink_direct/mavlink_direct_impl.cpp
+++ b/src/mavsdk/plugins/mavlink_direct/mavlink_direct_impl.cpp
@@ -251,6 +251,24 @@ bool MavlinkDirectImpl::json_to_libmav_message(
                               << field_value.asInt();
                 }
             }
+        } else if (field_value.isInt64()) {
+            auto result = msg.set(field_name, static_cast<int64_t>(field_value.asInt64()));
+            if (result != ::mav::MessageResult::Success) {
+                // Try as other integer types
+                if (msg.set(field_name, static_cast<uint32_t>(field_value.asUInt())) !=
+                        ::mav::MessageResult::Success &&
+                    msg.set(field_name, static_cast<int16_t>(field_value.asInt())) !=
+                        ::mav::MessageResult::Success &&
+                    msg.set(field_name, static_cast<uint16_t>(field_value.asUInt())) !=
+                        ::mav::MessageResult::Success &&
+                    msg.set(field_name, static_cast<int8_t>(field_value.asInt())) !=
+                        ::mav::MessageResult::Success &&
+                    msg.set(field_name, static_cast<uint8_t>(field_value.asUInt())) !=
+                        ::mav::MessageResult::Success) {
+                    LogWarn() << "Failed to set integer64 field " << field_name << " = "
+                              << field_value.asInt64();
+                }
+            }
         } else if (field_value.isUInt()) {
             auto result = msg.set(field_name, static_cast<uint32_t>(field_value.asUInt()));
             if (result != ::mav::MessageResult::Success) {
@@ -263,6 +281,20 @@ bool MavlinkDirectImpl::json_to_libmav_message(
                         ::mav::MessageResult::Success) {
                     LogWarn() << "Failed to set unsigned integer field " << field_name << " = "
                               << field_value.asUInt();
+                }
+            }
+        } else if (field_value.isUInt64()) {
+            auto result = msg.set(field_name, static_cast<uint32_t>(field_value.asUInt64()));
+            if (result != ::mav::MessageResult::Success) {
+                // Try as other unsigned integer types
+                if (msg.set(field_name, static_cast<uint64_t>(field_value.asUInt64())) !=
+                        ::mav::MessageResult::Success &&
+                    msg.set(field_name, static_cast<uint16_t>(field_value.asUInt())) !=
+                        ::mav::MessageResult::Success &&
+                    msg.set(field_name, static_cast<uint8_t>(field_value.asUInt())) !=
+                        ::mav::MessageResult::Success) {
+                    LogWarn() << "Failed to set unsigned integer64 field " << field_name << " = "
+                              << field_value.asUInt64();
                 }
             }
         } else if (field_value.isNull() || field_value.isDouble()) {

--- a/src/system_tests/intercept.cpp
+++ b/src/system_tests/intercept.cpp
@@ -335,7 +335,7 @@ TEST(SystemTest, InterceptJsonOutgoing)
     // Publish GPS data from autopilot
     LogInfo() << "Publishing GPS data from autopilot...";
     TelemetryServer::RawGps raw_gps{};
-    raw_gps.timestamp_us = 1234567890;
+    raw_gps.timestamp_us = 1234567890123456789;
     raw_gps.latitude_deg = 47.3977421; // Zurich coordinates
     raw_gps.longitude_deg = 8.5455938;
     raw_gps.absolute_altitude_m = 488.0f;


### PR DESCRIPTION
It turns out jsoncpp uses isUInt for numbers below 2^32 and isUInt64 for numbers above 2^32.

Fixes #2679.