### PR TITLE
examples: fix gimbal device tester

### DIFF
--- a/examples/gimbal_device_tester/gimbal_device_tester.cpp
+++ b/examples/gimbal_device_tester/gimbal_device_tester.cpp
@@ -751,7 +751,18 @@ void subscribe_to_heartbeat(MavlinkPassthrough& mavlink_passthrough)
 
             {
                 std::lock_guard<std::mutex> lock(receiver_data.mutex);
-                receiver_data.mav_type = heartbeat.type;
+                switch (message.compid) {
+                    case MAV_COMP_ID_GIMBAL:
+                    case MAV_COMP_ID_GIMBAL2:
+                    case MAV_COMP_ID_GIMBAL3:
+                    case MAV_COMP_ID_GIMBAL4:
+                    case MAV_COMP_ID_GIMBAL5:
+                    case MAV_COMP_ID_GIMBAL6:
+                        receiver_data.mav_type = heartbeat.type;
+                        break;
+                    default:
+                        break;
+                }
             }
         });
 }


### PR DESCRIPTION
In case if system under test consists of several components i.e. send several Heartbeats (gimbal + camera, for ex.) sysid_compid_correct test may fail if the latest read Heartbeat was not from the gimbal device

close #2686