### PR TITLE
Add missing python3 dependencies for Ubuntu

### DIFF
--- a/docs/en/cpp/guide/build_linux.md
+++ b/docs/en/cpp/guide/build_linux.md
@@ -4,12 +4,12 @@ This guide explains how to build MAVSDK from source on Linux systems.
 
 ## Requirements
 
-The build requirements are git, cmake, and a C++ compiler (GCC or Clang).
+The build requirements are git, cmake, and a C++ compiler (GCC or Clang), and python.
 
 ### Ubuntu
 ```bash
 sudo apt-get update
-sudo apt-get install build-essential cmake git
+sudo apt-get install build-essential cmake git python3 python3-pip
 ```
 
 ### Fedora


### PR DESCRIPTION
On a bare metal ubuntu container, dependencies were missing. After cloning the latest mavsdk:

```
$ docker run -v $(pwd):/ws -w /ws --net host -it ubuntu:22.04 bash
$ apt-get update
$ apt-get install apt-get install build-essential cmake git
$ cmake -DCMAKE_BUILD_TYPE=Debug -Bbuild -S.
```

Results in
```
Using cmake version: 3.22.1
-- Version: v3.10.2-56-g5b66d5fb
-- Version major: 3
-- Version minor: 10
-- Version patch: 2
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    DEPLOYMENT_TARGET
    ENABLE_STRICT_TRY_COMPILE
    PLATFORM


-- Build files have been written to: /ws/build/third_party/mavlink
[ 12%] Creating directories for 'mavlink'
[ 25%] Performing download step (git clone) for 'mavlink'
Cloning into 'mavlink'...
HEAD is now at 5e3a42b8 development: Remove parameter transaction proposal (#2169)
Submodule 'pymavlink' (https://github.com/ardupilot/pymavlink.git) registered for path 'pymavlink'
Cloning into '/ws/build/third_party/mavlink/mavlink/src/mavlink/pymavlink'...
Submodule path 'pymavlink': checked out '533161c47995ba47f5548636eed37a47e91072c0'
[ 37%] Performing update step for 'mavlink'
[ 50%] Performing patch step for 'mavlink'
Updated 0 paths from the index
[ 62%] Performing configure step for 'mavlink'
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find Python (missing: Python_EXECUTABLE Interpreter)
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.22/Modules/FindPython.cmake:561 (find_package_handle_standard_args)
  CMakeLists.txt:19 (find_package)


-- Configuring incomplete, errors occurred!
See also "/ws/build/third_party/mavlink/mavlink/src/mavlink-build/CMakeFiles/CMakeOutput.log".
gmake[2]: *** [CMakeFiles/mavlink.dir/build.make:92: mavlink/src/mavlink-stamp/mavlink-configure] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/mavlink.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2
CMake Error at third_party/cmake/build_target.cmake:51 (message):
  /ws/build/third_party/mavlink failed to build!
Call Stack (most recent call first):
  third_party/CMakeLists.txt:16 (build_target)


-- Configuring incomplete, errors occurred!
See also "/ws/build/CMakeFiles/CMakeOutput.log".
root@drone:/ws# python3 --version
bash: python3: command not found
```



And later, with pip:
```
[ 37%] Performing configure step for 'mavlink'
-- Found Python: /usr/bin/python3.10 (found version "3.10.12") found components: Interpreter 
/usr/bin/python3.10: No module named pip
CMake Error at CMakeLists.txt:29 (message):
  Python pip not found, pip is required


-- Configuring incomplete, errors occurred!
See also "/ws/build/third_party/mavlink/mavlink/src/mavlink-build/CMakeFiles/CMakeOutput.log".
gmake[2]: *** [CMakeFiles/mavlink.dir/build.make:92: mavlink/src/mavlink-stamp/mavlink-configure] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/mavlink.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2
CMake Error at third_party/cmake/build_target.cmake:51 (message):
  /ws/build/third_party/mavlink failed to build!
Call Stack (most recent call first):
  third_party/CMakeLists.txt:16 (build_target)
  
  ```