### PR TITLE
CMake custom command fails in certain build configurations

### DIFF
--- a/src/mavsdk/core/CMakeLists.txt
+++ b/src/mavsdk/core/CMakeLists.txt
@@ -32,7 +32,7 @@ add_custom_command(
         -DCOMMON_XML_PATH=${MAVLINK_COMMON_XML}
         -DARDUPILOTMEGA_XML_PATH=${MAVLINK_ARDUPILOTMEGA_XML}
         -DOUTPUT_HEADER=${EMBEDDED_XML_HEADER}
-        -P ${CMAKE_SOURCE_DIR}/cmake/generate_embedded_xml.cmake
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/generate_embedded_xml.cmake
     DEPENDS ${MAVLINK_MINIMAL_XML} ${MAVLINK_STANDARD_XML} ${MAVLINK_COMMON_XML} ${MAVLINK_ARDUPILOTMEGA_XML}
     COMMENT "Generating embedded MAVLink XML header for core"
     VERBATIM


### PR DESCRIPTION
Hello,

When adding the project via FetchContent, or when including it as a subdirectory, an error occurs when building. Specifically, when building the `generate_core_mavlink_xml_header` target, an error occurs as CMake can't find `cmake/generate_embedded_xml.cmake`. 

This can be reproduced by the following CMake file:

```
cmake_minimum_required(VERSION 4.2)

project(test)

add_subdirectory(MAVSDK)
```

In this case, we are adding a sub-directory that contains the MAVSDK source, but this could be done via FetchContent as well. Configuring will go ok, but if CMake is asked to build all targets then the error occurs.

This is because there is a custom [CMake command](https://github.com/mavlink/MAVSDK/blob/0267319f4ae3408127e6857c3c6ada26e29e712c/src/mavsdk/core/CMakeLists.txt#L27) that uses the `CMAKE_SOURCE_DIR` variable to locate the root of the project. The problem is, when including MAVSDK using the methods defined above, this variable instead points to the root of the project including MAVSDK. Because the parent project does not have this file, a build error occurs. We fix this by instead navigating to the root manually from the problematic CMake file.

Please let me know if there are any changes required, this is a small patch. Also, if it is not intended to include MAVSDK in this way, then this change might not be useful.

Thanks!