### PR TITLE
Fix dropped messages by libmav_receiver.cpp

### DIFF
--- a/src/mavsdk/core/libmav_receiver.cpp
+++ b/src/mavsdk/core/libmav_receiver.cpp
@@ -86,9 +86,14 @@ bool LibmavReceiver::parse_libmav_message_from_buffer(const uint8_t* buffer, siz
 
     _last_message.fields_json = json;
 
-    // Clear the original datagram since we processed it
-    _datagram = nullptr;
-    _datagram_len = 0;
+    // Advance the datagram pointer by the bytes we actually consumed,
+    // in case there are more messages in the same datagram.
+    _datagram += bytes_consumed;
+    _datagram_len -= bytes_consumed;
+
+    if (_datagram_len == 0) {
+        _datagram = nullptr;
+    }
 
     return true;
 }


### PR DESCRIPTION
PR to receive all MAVLink messages when using `libmav_receiver.cpp`

Background: we noticed significant amount of messages being dropped by MAVSDK server. This was verified by comparing received message count between `pymavlink` and `mavsdk_server`, while using discretely sent msg type (`CAMERA_IMAGE_CAPTURED`) for easier counting. On pymavlink, all messages came through. MAVSDK dropped roughly a third of messages. Missing messages was double checked with other streams.

In `mavlink_receiver.cpp`, there is a comment:
`// Note that one datagram can contain multiple mavlink messages.`

But `libmav_receiver.cpp` always set `datagram` to `nullptr` after parsing one message - essentially discarding any remaining messages in the `datagram`.

Changes tested with PX4-based flightcontroller connected over serial to aarch64/Ubuntu 22.04-based machine running mavsdk_server binary. No message drops observed with patched code.