### PR TITLE
core: make timeout configurable

### DIFF
--- a/docs/en/cpp/api_reference/classmavsdk_1_1_mavsdk.md
+++ b/docs/en/cpp/api_reference/classmavsdk_1_1_mavsdk.md
@@ -55,6 +55,8 @@ std::vector< std::shared_ptr< [System](classmavsdk_1_1_system.md) > > | [systems
 std::optional< std::shared_ptr< [System](classmavsdk_1_1_system.md) > > | [first_autopilot](#classmavsdk_1_1_mavsdk_1aa1bcb865693dbd140478e75ce58699b7) (double timeout_s)const | Get the first autopilot that has been discovered.
 void | [set_configuration](#classmavsdk_1_1_mavsdk_1acaeea86253493dc15b6540d2100a1b86) ([Configuration](classmavsdk_1_1_mavsdk_1_1_configuration.md) configuration) | Set [Configuration](classmavsdk_1_1_mavsdk_1_1_configuration.md) of SDK.
 void | [set_timeout_s](#classmavsdk_1_1_mavsdk_1a765f37b61462addcfd961e720585d2c6) (double timeout_s) | Set timeout of MAVLink transfers.
+void | [set_heartbeat_timeout_s](#classmavsdk_1_1_mavsdk_1afbab63cf2a795e4ca7262836d5fe4b46) (double timeout_s) | Set heartbeat timeout.
+double | [get_heartbeat_timeout_s](#classmavsdk_1_1_mavsdk_1a6179b858f74415251ef43da11bc6edbc) () const | Get heartbeat timeout.
 [NewSystemHandle](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1ae0727f2bed9cbf276d161ada0a432b8c) | [subscribe_on_new_system](#classmavsdk_1_1_mavsdk_1a5b7c958ad2e4529dc7b950ab26618575) (const [NewSystemCallback](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a7a283c6a75e852a56be4c5862f8a3fab) & callback) | Get notification about a change in systems.
 void | [unsubscribe_on_new_system](#classmavsdk_1_1_mavsdk_1ad7f77f1295a700ee73cccc345019c1ff) ([NewSystemHandle](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1ae0727f2bed9cbf276d161ada0a432b8c) handle) | unsubscribe from subscribe_on_new_system.
 std::shared_ptr< [ServerComponent](classmavsdk_1_1_server_component.md) > | [server_component](#classmavsdk_1_1_mavsdk_1a693a2f665c35d6b01d6144819d353280) (unsigned instance=0) | Get server component with default type of [Mavsdk](classmavsdk_1_1_mavsdk.md) instance.
@@ -422,6 +424,33 @@ The default timeout used is generally DEFAULT_SERIAL_BAUDRATE (0.5 seconds) seco
 **Parameters**
 
 * double **timeout_s** - 
+
+### set_heartbeat_timeout_s() {#classmavsdk_1_1_mavsdk_1afbab63cf2a795e4ca7262836d5fe4b46}
+```cpp
+void mavsdk::Mavsdk::set_heartbeat_timeout_s(double timeout_s)
+```
+
+
+Set heartbeat timeout.
+
+The default heartbeat timeout is 3 seconds. If no heartbeat is received within this time, the system is considered disconnected.
+
+**Parameters**
+
+* double **timeout_s** - Timeout in seconds.
+
+### get_heartbeat_timeout_s() {#classmavsdk_1_1_mavsdk_1a6179b858f74415251ef43da11bc6edbc}
+```cpp
+double mavsdk::Mavsdk::get_heartbeat_timeout_s() const
+```
+
+
+Get heartbeat timeout.
+
+
+**Returns**
+
+&emsp;double - Timeout in seconds.
 
 ### subscribe_on_new_system() {#classmavsdk_1_1_mavsdk_1a5b7c958ad2e4529dc7b950ab26618575}
 ```cpp

--- a/src/mavsdk/core/include/mavsdk/mavsdk.h
+++ b/src/mavsdk/core/include/mavsdk/mavsdk.h
@@ -318,6 +318,23 @@ public:
     void set_timeout_s(double timeout_s);
 
     /**
+     * @brief Set heartbeat timeout.
+     *
+     * The default heartbeat timeout is 3 seconds. If no heartbeat is received
+     * within this time, the system is considered disconnected.
+     *
+     * @param timeout_s Timeout in seconds.
+     */
+    void set_heartbeat_timeout_s(double timeout_s);
+
+    /**
+     * @brief Get heartbeat timeout.
+     *
+     * @return Timeout in seconds.
+     */
+    double get_heartbeat_timeout_s() const;
+
+    /**
      * @brief Callback type discover and timeout notifications.
      */
     using NewSystemCallback = std::function<void()>;

--- a/src/mavsdk/core/mavsdk.cpp
+++ b/src/mavsdk/core/mavsdk.cpp
@@ -53,6 +53,16 @@ void Mavsdk::set_timeout_s(double timeout_s)
     _impl->set_timeout_s(timeout_s);
 }
 
+void Mavsdk::set_heartbeat_timeout_s(double timeout_s)
+{
+    _impl->set_heartbeat_timeout_s(timeout_s);
+}
+
+double Mavsdk::get_heartbeat_timeout_s() const
+{
+    return _impl->heartbeat_timeout_s();
+}
+
 Mavsdk::NewSystemHandle Mavsdk::subscribe_on_new_system(const NewSystemCallback& callback)
 {
     return _impl->subscribe_on_new_system(callback);

--- a/src/mavsdk/core/mavsdk_impl.h
+++ b/src/mavsdk/core/mavsdk_impl.h
@@ -122,8 +122,10 @@ public:
         const std::string& filename, int linenumber, const std::function<void()>& func);
 
     void set_timeout_s(double timeout_s) { _timeout_s = timeout_s; }
+    double timeout_s() const { return _timeout_s; }
 
-    double timeout_s() const { return _timeout_s; };
+    void set_heartbeat_timeout_s(double timeout_s) { _heartbeat_timeout_s = timeout_s; }
+    double heartbeat_timeout_s() const { return _heartbeat_timeout_s; }
 
     MavlinkMessageHandler mavlink_message_handler{};
 
@@ -149,6 +151,7 @@ public:
 
 private:
     static constexpr float DEFAULT_TIMEOUT_S = 0.5f;
+    static constexpr double DEFAULT_HEARTBEAT_TIMEOUT_S = 3.0;
 
     std::pair<ConnectionResult, Mavsdk::ConnectionHandle>
     add_udp_connection(const CliArg::Udp& udp, ForwardingOption forwarding_option);
@@ -263,6 +266,7 @@ private:
     CallbackList<const char*, size_t> _raw_bytes_subscriptions{};
 
     std::atomic<double> _timeout_s{DEFAULT_TIMEOUT_S};
+    std::atomic<double> _heartbeat_timeout_s{DEFAULT_HEARTBEAT_TIMEOUT_S};
 
     struct ReceivedMessage {
         mavlink_message_t message;

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -625,8 +625,8 @@ void SystemImpl::set_connected()
                 });
             }
 
-            _heartbeat_timeout_cookie =
-                register_timeout_handler([this] { heartbeats_timed_out(); }, HEARTBEAT_TIMEOUT_S);
+            _heartbeat_timeout_cookie = register_timeout_handler(
+                [this] { heartbeats_timed_out(); }, _mavsdk_impl.heartbeat_timeout_s());
 
             enable_needed = true;
 

--- a/src/mavsdk/core/system_impl.h
+++ b/src/mavsdk/core/system_impl.h
@@ -402,8 +402,6 @@ private:
     std::thread* _system_thread{nullptr};
     std::atomic<bool> _should_exit{false};
 
-    static constexpr double HEARTBEAT_TIMEOUT_S = 3.0;
-
     std::atomic<bool> _connected{false};
     CallbackList<bool> _is_connected_callbacks{};
     TimeoutHandler::Cookie _heartbeat_timeout_cookie{};


### PR DESCRIPTION
This adds a getter and setter to change the heartbeat timeout if a different timeout from 3 seconds is required.

Needs #2730 merged first.

Closes #2727.