### PR TITLE
core: fix bug where invalid messages are parsed

### DIFF
--- a/src/mavsdk/core/connection.cpp
+++ b/src/mavsdk/core/connection.cpp
@@ -97,13 +97,17 @@ void Connection::receive_libmav_message(
     }
 }
 
-void Connection::receive_message(mavlink_message_t& message, Connection* connection)
+void Connection::receive_message(
+    MavlinkReceiver::ParseResult result, mavlink_message_t& message, Connection* connection)
 {
-    // Register system ID when receiving a message from a new system.
-    if (_system_ids.find(message.sysid) == _system_ids.end()) {
-        _system_ids.insert(message.sysid);
+    // Register system ID for valid messages
+    if (result == MavlinkReceiver::ParseResult::MessageParsed) {
+        if (_system_ids.find(message.sysid) == _system_ids.end()) {
+            _system_ids.insert(message.sysid);
+        }
     }
-    _receiver_callback(message, connection);
+    // Let MavsdkImpl handle the ParseResult (queue for processing or forward-only)
+    _receiver_callback(result, message, connection);
 }
 
 bool Connection::should_forward_messages() const

--- a/src/mavsdk/core/connection.h
+++ b/src/mavsdk/core/connection.h
@@ -15,8 +15,8 @@ class MavsdkImpl; // Forward declaration
 
 class Connection {
 public:
-    using ReceiverCallback =
-        std::function<void(mavlink_message_t& message, Connection* connection)>;
+    using ReceiverCallback = std::function<void(
+        MavlinkReceiver::ParseResult result, mavlink_message_t& message, Connection* connection)>;
     using LibmavReceiverCallback =
         std::function<void(const Mavsdk::MavlinkMessage& message, Connection* connection)>;
 
@@ -49,7 +49,8 @@ public:
 protected:
     bool start_mavlink_receiver();
     void stop_mavlink_receiver();
-    void receive_message(mavlink_message_t& message, Connection* connection);
+    void receive_message(
+        MavlinkReceiver::ParseResult result, mavlink_message_t& message, Connection* connection);
 
     bool start_libmav_receiver();
     void stop_libmav_receiver();

--- a/src/mavsdk/core/mavlink_receiver.h
+++ b/src/mavsdk/core/mavlink_receiver.h
@@ -8,6 +8,12 @@ namespace mavsdk {
 
 class MavlinkReceiver {
 public:
+    enum class ParseResult {
+        MessageParsed, // Valid message ready for processing and forwarding
+        BadCrc, // Corrupted message - forward raw bytes only, don't process
+        NoneAvailable // No more messages in datagram
+    };
+
     MavlinkReceiver();
 
     mavlink_message_t& get_last_message() { return _last_message; }
@@ -16,7 +22,7 @@ public:
 
     void set_new_datagram(char* datagram, unsigned datagram_len);
 
-    bool parse_message();
+    ParseResult parse_message();
 
     void debug_drop_rate();
     void print_line(

--- a/src/mavsdk/core/mavsdk_impl.h
+++ b/src/mavsdk/core/mavsdk_impl.h
@@ -54,7 +54,8 @@ public:
     static std::string version();
 
     void forward_message(mavlink_message_t& message, Connection* connection);
-    void receive_message(mavlink_message_t& message, Connection* connection);
+    void receive_message(
+        MavlinkReceiver::ParseResult result, mavlink_message_t& message, Connection* connection);
     void receive_libmav_message(const Mavsdk::MavlinkMessage& message, Connection* connection);
 
     std::pair<ConnectionResult, Mavsdk::ConnectionHandle>

--- a/src/mavsdk/core/raw_connection.cpp
+++ b/src/mavsdk/core/raw_connection.cpp
@@ -57,10 +57,11 @@ void RawConnection::receive(const char* bytes, size_t length)
     // This is safe because the receivers only read from the buffer
     _mavlink_receiver->set_new_datagram(const_cast<char*>(bytes), static_cast<int>(length));
 
-    // Parse all mavlink messages in one datagram. Once exhausted, we'll exit while.
-    while (_mavlink_receiver->parse_message()) {
-        // Handle parsed message
-        receive_message(_mavlink_receiver->get_last_message(), this);
+    // Parse all mavlink messages in one datagram. Once exhausted, we'll exit loop.
+    auto parse_result = _mavlink_receiver->parse_message();
+    while (parse_result != MavlinkReceiver::ParseResult::NoneAvailable) {
+        receive_message(parse_result, _mavlink_receiver->get_last_message(), this);
+        parse_result = _mavlink_receiver->parse_message();
     }
 
     // Also parse with libmav if available

--- a/src/mavsdk/core/serial_connection.cpp
+++ b/src/mavsdk/core/serial_connection.cpp
@@ -315,9 +315,11 @@ void SerialConnection::receive()
             continue;
         }
         _mavlink_receiver->set_new_datagram(buffer, recv_len);
-        // Parse all mavlink messages in one data packet. Once exhausted, we'll exit while.
-        while (_mavlink_receiver->parse_message()) {
-            receive_message(_mavlink_receiver->get_last_message(), this);
+        // Parse all mavlink messages in one data packet. Once exhausted, we'll exit loop.
+        auto parse_result = _mavlink_receiver->parse_message();
+        while (parse_result != MavlinkReceiver::ParseResult::NoneAvailable) {
+            receive_message(parse_result, _mavlink_receiver->get_last_message(), this);
+            parse_result = _mavlink_receiver->parse_message();
         }
 
         // Also parse with libmav if available

--- a/src/mavsdk/core/tcp_client_connection.cpp
+++ b/src/mavsdk/core/tcp_client_connection.cpp
@@ -260,8 +260,10 @@ void TcpClientConnection::receive()
 
         _mavlink_receiver->set_new_datagram(buffer, static_cast<int>(recv_len));
 
-        while (_mavlink_receiver->parse_message()) {
-            receive_message(_mavlink_receiver->get_last_message(), this);
+        auto parse_result = _mavlink_receiver->parse_message();
+        while (parse_result != MavlinkReceiver::ParseResult::NoneAvailable) {
+            receive_message(parse_result, _mavlink_receiver->get_last_message(), this);
+            parse_result = _mavlink_receiver->parse_message();
         }
 
         // Also parse with libmav if available

--- a/src/mavsdk/core/tcp_server_connection.cpp
+++ b/src/mavsdk/core/tcp_server_connection.cpp
@@ -280,9 +280,11 @@ void TcpServerConnection::receive()
 
         _mavlink_receiver->set_new_datagram(buffer.data(), static_cast<int>(recv_len));
 
-        // Parse all mavlink messages in one data packet. Once exhausted, we'll exit while.
-        while (_mavlink_receiver->parse_message()) {
-            receive_message(_mavlink_receiver->get_last_message(), this);
+        // Parse all mavlink messages in one data packet. Once exhausted, we'll exit loop.
+        auto parse_result = _mavlink_receiver->parse_message();
+        while (parse_result != MavlinkReceiver::ParseResult::NoneAvailable) {
+            receive_message(parse_result, _mavlink_receiver->get_last_message(), this);
+            parse_result = _mavlink_receiver->parse_message();
         }
 
         // Also parse with libmav if available

--- a/src/mavsdk/core/udp_connection.cpp
+++ b/src/mavsdk/core/udp_connection.cpp
@@ -301,21 +301,25 @@ void UdpConnection::receive()
 
         _mavlink_receiver->set_new_datagram(buffer, static_cast<int>(recv_len));
 
-        // Parse all mavlink messages in one datagram. Once exhausted, we'll exit while.
-        while (_mavlink_receiver->parse_message()) {
-            const uint8_t sysid = _mavlink_receiver->get_last_message().sysid;
-
-            if (sysid != 0) {
-                char ip_str[INET_ADDRSTRLEN];
-                if (inet_ntop(AF_INET, &src_addr.sin_addr, ip_str, INET_ADDRSTRLEN) != nullptr) {
-                    add_remote_impl(ip_str, ntohs(src_addr.sin_port), sysid, RemoteOption::Found);
-                } else {
-                    LogErr() << "inet_ntop failure for: " << strerror(errno);
+        // Parse all mavlink messages in one datagram. Once exhausted, we'll exit loop.
+        auto parse_result = _mavlink_receiver->parse_message();
+        while (parse_result != MavlinkReceiver::ParseResult::NoneAvailable) {
+            // Track remote endpoint for valid messages
+            if (parse_result == MavlinkReceiver::ParseResult::MessageParsed) {
+                const uint8_t sysid = _mavlink_receiver->get_last_message().sysid;
+                if (sysid != 0) {
+                    char ip_str[INET_ADDRSTRLEN];
+                    if (inet_ntop(AF_INET, &src_addr.sin_addr, ip_str, INET_ADDRSTRLEN) !=
+                        nullptr) {
+                        add_remote_impl(
+                            ip_str, ntohs(src_addr.sin_port), sysid, RemoteOption::Found);
+                    } else {
+                        LogErr() << "inet_ntop failure for: " << strerror(errno);
+                    }
                 }
             }
-
-            // Handle parsed message
-            receive_message(_mavlink_receiver->get_last_message(), this);
+            receive_message(parse_result, _mavlink_receiver->get_last_message(), this);
+            parse_result = _mavlink_receiver->parse_message();
         }
 
         // Also parse with libmav if available


### PR DESCRIPTION
This fixes a major flaw that was introduced with
https://github.com/mavlink/MAVSDK/pull/2637 leading to invalid messages being parsed, instead of only forwarded, as was the intention.

The fix is to:
- Process and forward if CRC is valid
- forward only if CRC is invalid (for unknown or invalid message)