### PR TITLE
On Linux, force local install of openssl in lib instead of e.g. lib64

### DIFF
--- a/third_party/openssl/CMakeLists.txt
+++ b/third_party/openssl/CMakeLists.txt
@@ -141,7 +141,7 @@ else()
         openssl
         URL https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
         PREFIX openssl
-        CONFIGURE_COMMAND <SOURCE_DIR>/config ${OPENSSL_BUILD_TYPE} --prefix=${CMAKE_INSTALL_PREFIX} no-shared
+        CONFIGURE_COMMAND <SOURCE_DIR>/config ${OPENSSL_BUILD_TYPE} --prefix=${CMAKE_INSTALL_PREFIX} --libdir=lib no-shared
         BUILD_COMMAND make -j${BUILD_PARALLEL_JOBS} build_libs
         INSTALL_COMMAND make install_dev
         )


### PR DESCRIPTION
I have found that on some platforms (in my case Ubuntu 22.04), OpenSSL gets installed in `lib64/`, and then pkgconfig does not find it. Whereas installing it in `lib/` works.

I figure it may help in some cases if it doesn't break the CI.