### PR TITLE
Added support ardupilot mission and land start command for ardupilot

### DIFF
--- a/src/mavsdk/plugins/mission/include/plugins/mission/mission.h
+++ b/src/mavsdk/plugins/mission/include/plugins/mission/mission.h
@@ -95,6 +95,7 @@ public:
         enum class VehicleAction {
             None, /**< @brief No action. */
             Takeoff, /**< @brief Vehicle will takeoff and go to defined waypoint. */
+            LandStart, /**< @brief Upon reaching the checkpoint, the vehicle begins to land.. */
             Land, /**< @brief When a waypoint is reached vehicle will land at current position. */
             TransitionToFw, /**< @brief When a waypoint is reached vehicle will transition to
                                fixed-wing mode. */


### PR DESCRIPTION
Missions in ArduPilot aren't being read because some commands aren't being processed. Missions differ between ArduPilot and PX4.
<img width="1564" height="971" alt="image" src="https://github.com/user-attachments/assets/87820d36-7ccd-42bc-9b53-d4d42c8da562" />

<img width="1556" height="941" alt="image" src="https://github.com/user-attachments/assets/08894c10-a6b7-4c25-b196-218dcb0c6467" />
