### PR TITLE
Fix protoc-gen-mavsdk to v1.*

### DIFF
--- a/tools/generate_from_protos.sh
+++ b/tools/generate_from_protos.sh
@@ -91,7 +91,7 @@ command -v ${protoc_binary} > /dev/null && command -v ${protoc_grpc_binary} > /d
 }
 
 echo "Installing protoc-gen-mavsdk locally into build folder"
-python3 -m pip install --upgrade --target=${build_dir}/pb_plugins ${script_dir}/../proto/pb_plugins
+python3 -m pip install --upgrade --target=${build_dir}/pb_plugins "protoc-gen-mavsdk~=1.2"
 
 protoc_gen_mavsdk="${build_dir}/pb_plugins/bin/protoc-gen-mavsdk"
 export PYTHONPATH="${build_dir}/pb_plugins:${PYTHONPATH}"


### PR DESCRIPTION
Instead of installing protoc-gen-mavsdk from sources, this pulls it from pypi. Moreover, it fixes it to major version v1, because a major update to protoc-gen-mavsdk would require changes in the templates.

@julianoes: any chance you could try to run this and see if it works for you?