### PR TITLE
ftp: use global sequence counter to prevent stale response loops

### DIFF
--- a/src/mavsdk/core/mavlink_ftp_client.h
+++ b/src/mavsdk/core/mavlink_ftp_client.h
@@ -230,7 +230,6 @@ private:
         bool started{false};
         Opcode last_opcode{};
         uint16_t last_received_seq_number{0};
-        uint16_t last_sent_seq_number{0};
         uint8_t target_compid{};
         Work(Item new_item, uint8_t target_compid_) :
             item(std::move(new_item)),
@@ -328,6 +327,8 @@ private:
     TimeoutHandler::Cookie _timeout_cookie{};
 
     LockedQueue<Work> _work_queue{};
+
+    uint16_t _last_sent_seq_number{0};
 
     bool _debugging{false};
 };


### PR DESCRIPTION
PX4's FTP server caches its last reply and uses seq+1 matching to detect retransmissions. When the client's seq counter reset to 0 for each new work item, PX4 would match against its cached reply and resend the old response instead of processing the new request. This caused sequential operations to time out.

Move last_sent_seq_number from per-work-item to class-level so seq numbers increase monotonically. Also increment seq on retries so the client can escape stale cached replies from previous sessions.