### PR TITLE
Fix: empty mission now return empty

### DIFF
--- a/cpp/src/mavsdk/plugins/mission/mission_impl.cpp
+++ b/cpp/src/mavsdk/plugins/mission/mission_impl.cpp
@@ -644,7 +644,10 @@ std::pair<Mission::Result, Mission::MissionPlan> MissionImpl::convert_to_result_
 
     _mission_data.mavlink_mission_item_to_mission_item_indices.clear();
 
-    Mission::DownloadMissionCallback callback;
+    if (int_items.empty()) {
+        return result_pair;
+    }
+
     {
         _enable_return_to_launch_after_mission = false;
 


### PR DESCRIPTION
When downloading empty mission the mavsdk returns array with 1 empty item, now it returns 0 items.