### PR TITLE
Fix: setting current mission item

### DIFF
--- a/cpp/src/mavsdk/plugins/mission/mission_impl.cpp
+++ b/cpp/src/mavsdk/plugins/mission/mission_impl.cpp
@@ -890,11 +890,11 @@ void MissionImpl::clear_mission_async(const Mission::ResultCallback& callback)
 
 Mission::Result MissionImpl::set_current_mission_item(int current)
 {
-    auto prom = std::make_shared<std::promise<Mission::Result>>();
-    auto fut = prom->get_future();
+    auto prom = std::promise<Mission::Result>();
+    auto fut = prom.get_future();
 
     set_current_mission_item_async(
-        current, [prom](Mission::Result result) { prom->set_value(result); });
+        current, [&prom](Mission::Result result) { prom.set_value(result); });
     return fut.get();
 }
 


### PR DESCRIPTION
Setting current mission item when the argument outside mission items range or there is no mission downloaded, would result in a crash. This is faced when using mavsdk server: it exists with error code.