### PR TITLE
Fix MAVSDK destructor

### DIFF
--- a/cpp/src/mavsdk/core/mavsdk_impl.cpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.cpp
@@ -101,6 +101,11 @@ MavsdkImpl::~MavsdkImpl()
 
     std::lock_guard lock(_mutex);
 
+    // Tell all systems to stop their threads BEFORE clearing
+    for (auto& pair : _systems) {
+        pair.second->_system_impl->signal_exit();
+    }
+
     _systems.clear();
     _connections.clear();
 }

--- a/cpp/src/mavsdk/core/system_impl.h
+++ b/cpp/src/mavsdk/core/system_impl.h
@@ -331,6 +331,8 @@ public:
 
     double timeout_s() const;
 
+    void signal_exit() { _should_exit = true; }
+
 private:
     static bool is_autopilot(uint8_t comp_id);
     static bool is_camera(uint8_t comp_id);


### PR DESCRIPTION
Without this, I see regular crashes (i.e. crashes almost every time) when stopping MAVSDK from language bindings. With it, I haven't seen a crash yet.