### PR TITLE
ci: remove manylinux2014-aarch64 workaround after fix upstream

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -728,7 +728,7 @@ jobs:
         run: ./dockcross-${{ matrix.arch_name }} cmake --build build/manylinux/cpp -j$(nproc) --target install
       - name: configure c
         working-directory: .
-        run: ./dockcross-${{ matrix.arch_name }} cmake -DCMAKE_INSTALL_PREFIX=build/manylinux/c/install -DCMAKE_PREFIX_PATH="/work/build/manylinux/cpp/install;/work/build/manylinux/cpp/third_party/install" -DBUILD_SHARED_LIBS=ON -DBUILD_EXAMPLES=OFF -Bbuild/manylinux/c -Sc
+        run: ./dockcross-${{ matrix.arch_name }} cmake -DCMAKE_INSTALL_PREFIX=build/manylinux/c/install -DCMAKE_PREFIX_PATH="/work/build/manylinux/cpp/install;/work/build/manylinux/cpp/third_party/install" -DBUILD_SHARED_LIBS=ON -DBUILD_EXAMPLES=OFF -DBUNDLE_STATIC_RUNTIME=ON -Bbuild/manylinux/c -Sc
       - name: build c
         working-directory: .
         run: ./dockcross-${{ matrix.arch_name }} cmake --build build/manylinux/c -j$(nproc) --target install


### PR DESCRIPTION
I fixed manylinux2014-aarch64 upstream so we should be able to remove the workaround in CI.