### PR TITLE
c: add an option to bundle static runtime (for manylinux builds)

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -15,6 +15,7 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
 
+option(BUNDLE_STATIC_RUNTIME "Statically link libgcc, libstdc++, and libatomic into the shared library" OFF)
 option(BUILD_EXAMPLES "Build examples" ON)
 
 add_subdirectory(src)

--- a/c/src/CMakeLists.txt
+++ b/c/src/CMakeLists.txt
@@ -52,6 +52,18 @@ target_compile_options(cmavsdk
         -fvisibility=hidden
 )
 
+if(BUNDLE_STATIC_RUNTIME)
+    if(NOT (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang" AND UNIX AND NOT APPLE))
+        message(WARNING "BUNDLE_STATIC_RUNTIME is only supported on Linux with GCC/Clang")
+    endif()
+
+    target_link_options(cmavsdk PRIVATE
+        -static-libgcc
+        -static-libstdc++
+    )
+    target_link_libraries(cmavsdk PRIVATE atomic.a)
+endif()
+
 set_target_properties(cmavsdk PROPERTIES
     VERSION ${PROJECT_VERSION}
     SOVERSION 3


### PR DESCRIPTION
This is needed for manylinux builds of cmavsdk