### PR TITLE
c: improve cmake install

### DIFF
--- a/c/src/CMakeLists.txt
+++ b/c/src/CMakeLists.txt
@@ -83,8 +83,20 @@ install(
     FILES_MATCHING PATTERN "*.h"
 )
 
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmavsdkConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/cmavsdkConfig.cmake
+    INSTALL_DESTINATION lib/cmake/cmavsdk
+)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmavsdkConfig.cmake
+    DESTINATION lib/cmake/cmavsdk
+)
+
 install(EXPORT cmavsdkTargets
-    FILE cmavsdkConfig.cmake
+    FILE cmavsdkTargets.cmake
     NAMESPACE CMAVSDK::
     DESTINATION lib/cmake/cmavsdk
 )

--- a/c/src/cmavsdkConfig.cmake.in
+++ b/c/src/cmavsdkConfig.cmake.in
@@ -1,0 +1,5 @@
+include(CMakeFindDependencyMacro)
+
+find_dependency(MAVSDK REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/cmavsdkTargets.cmake")


### PR DESCRIPTION
So that we can `find_package(CMAVSDK REQUIRED)` like we do with `MAVSDK`.