### PR TITLE
core: do not set disconnected state on heartbeat timeout

### DIFF
--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -262,7 +262,7 @@ void SystemImpl::process_autopilot_version(const mavlink_message_t& message)
 void SystemImpl::heartbeats_timed_out()
 {
     LogInfo() << "heartbeats timed out";
-    set_disconnected();
+    // set_disconnected();  due to the way we handle heartbeats, we don't want to set disconnected here
 }
 
 void SystemImpl::system_thread()


### PR DESCRIPTION
## Summary
- Prevent `set_disconnected()` from being called in `heartbeats_timed_out()`, which can incorrectly mark the system as disconnected during transient heartbeat gaps

## Motivation
When using UDP connections, heartbeat timeouts can occur transiently without the system actually being disconnected. Calling `set_disconnected()` on every heartbeat timeout causes unnecessary state transitions and triggers reconnection logic that disrupts ongoing operations.