### PR TITLE
mission: fix data race on last_upload / last_download weak_ptrs

### DIFF
--- a/cpp/src/mavsdk/plugins/mission/mission_impl.cpp
+++ b/cpp/src/mavsdk/plugins/mission/mission_impl.cpp
@@ -96,20 +96,23 @@ Mission::Result MissionImpl::upload_mission(const Mission::MissionPlan& mission_
 void MissionImpl::upload_mission_async(
     const Mission::MissionPlan& mission_plan, const Mission::ResultCallback& callback)
 {
-    if (_mission_data.last_upload.lock()) {
-        _system_impl->call_user_callback([callback]() {
-            if (callback) {
-                callback(Mission::Result::Busy);
-            }
-        });
-        return;
+    {
+        std::lock_guard<std::mutex> lock(_mission_data.transfer_mutex);
+        if (_mission_data.last_upload.lock()) {
+            _system_impl->call_user_callback([callback]() {
+                if (callback) {
+                    callback(Mission::Result::Busy);
+                }
+            });
+            return;
+        }
     }
 
     reset_mission_progress();
 
     const auto int_items = convert_to_int_items(mission_plan.mission_items);
 
-    _mission_data.last_upload = _system_impl->mission_transfer_client().upload_items_async(
+    auto upload = _system_impl->mission_transfer_client().upload_items_async(
         MAV_MISSION_TYPE_MISSION,
         _system_impl->get_system_id(),
         int_items,
@@ -121,26 +124,32 @@ void MissionImpl::upload_mission_async(
                 }
             });
         });
+
+    std::lock_guard<std::mutex> lock(_mission_data.transfer_mutex);
+    _mission_data.last_upload = std::move(upload);
 }
 
 void MissionImpl::upload_mission_with_progress_async(
     const Mission::MissionPlan& mission_plan,
     const Mission::UploadMissionWithProgressCallback callback)
 {
-    if (_mission_data.last_upload.lock()) {
-        _system_impl->call_user_callback([callback]() {
-            if (callback) {
-                callback(Mission::Result::Busy, Mission::ProgressData{});
-            }
-        });
-        return;
+    {
+        std::lock_guard<std::mutex> lock(_mission_data.transfer_mutex);
+        if (_mission_data.last_upload.lock()) {
+            _system_impl->call_user_callback([callback]() {
+                if (callback) {
+                    callback(Mission::Result::Busy, Mission::ProgressData{});
+                }
+            });
+            return;
+        }
     }
 
     reset_mission_progress();
 
     const auto int_items = convert_to_int_items(mission_plan.mission_items);
 
-    _mission_data.last_upload = _system_impl->mission_transfer_client().upload_items_async(
+    auto upload = _system_impl->mission_transfer_client().upload_items_async(
         MAV_MISSION_TYPE_MISSION,
         _system_impl->get_system_id(),
         int_items,
@@ -159,11 +168,19 @@ void MissionImpl::upload_mission_with_progress_async(
                 }
             });
         });
+
+    std::lock_guard<std::mutex> lock(_mission_data.transfer_mutex);
+    _mission_data.last_upload = std::move(upload);
 }
 
 Mission::Result MissionImpl::cancel_mission_upload() const
 {
-    auto ptr = _mission_data.last_upload.lock();
+    std::shared_ptr<MavlinkMissionTransferClient::WorkItem> ptr;
+    {
+        std::lock_guard<std::mutex> lock(_mission_data.transfer_mutex);
+        ptr = _mission_data.last_upload.lock();
+    }
+
     if (ptr) {
         ptr->cancel();
     } else {
@@ -187,17 +204,20 @@ std::pair<Mission::Result, Mission::MissionPlan> MissionImpl::download_mission()
 
 void MissionImpl::download_mission_async(const Mission::DownloadMissionCallback& callback)
 {
-    if (_mission_data.last_download.lock()) {
-        _system_impl->call_user_callback([callback]() {
-            if (callback) {
-                Mission::MissionPlan mission_plan{};
-                callback(Mission::Result::Busy, mission_plan);
-            }
-        });
-        return;
+    {
+        std::lock_guard<std::mutex> lock(_mission_data.transfer_mutex);
+        if (_mission_data.last_download.lock()) {
+            _system_impl->call_user_callback([callback]() {
+                if (callback) {
+                    Mission::MissionPlan mission_plan{};
+                    callback(Mission::Result::Busy, mission_plan);
+                }
+            });
+            return;
+        }
     }
 
-    _mission_data.last_download = _system_impl->mission_transfer_client().download_items_async(
+    auto download = _system_impl->mission_transfer_client().download_items_async(
         MAV_MISSION_TYPE_MISSION,
         _system_impl->get_system_id(),
         [this, callback](
@@ -208,24 +228,30 @@ void MissionImpl::download_mission_async(const Mission::DownloadMissionCallback&
                 callback(result_and_items.first, result_and_items.second);
             });
         });
+
+    std::lock_guard<std::mutex> lock(_mission_data.transfer_mutex);
+    _mission_data.last_download = std::move(download);
 }
 
 void MissionImpl::download_mission_with_progress_async(
     const Mission::DownloadMissionWithProgressCallback callback)
 {
-    if (_mission_data.last_download.lock()) {
-        _system_impl->call_user_callback([callback]() {
-            if (callback) {
-                Mission::ProgressDataOrMission progress_data_or_mission{};
-                progress_data_or_mission.has_mission = false;
-                progress_data_or_mission.has_progress = false;
-                callback(Mission::Result::Busy, progress_data_or_mission);
-            }
-        });
-        return;
+    {
+        std::lock_guard<std::mutex> lock(_mission_data.transfer_mutex);
+        if (_mission_data.last_download.lock()) {
+            _system_impl->call_user_callback([callback]() {
+                if (callback) {
+                    Mission::ProgressDataOrMission progress_data_or_mission{};
+                    progress_data_or_mission.has_mission = false;
+                    progress_data_or_mission.has_progress = false;
+                    callback(Mission::Result::Busy, progress_data_or_mission);
+                }
+            });
+            return;
+        }
     }
 
-    _mission_data.last_download = _system_impl->mission_transfer_client().download_items_async(
+    auto download = _system_impl->mission_transfer_client().download_items_async(
         MAV_MISSION_TYPE_MISSION,
         _system_impl->get_system_id(),
         [this, callback](
@@ -251,11 +277,19 @@ void MissionImpl::download_mission_with_progress_async(
                 callback(Mission::Result::Next, progress_data_or_mission);
             });
         });
+
+    std::lock_guard<std::mutex> lock(_mission_data.transfer_mutex);
+    _mission_data.last_download = std::move(download);
 }
 
 Mission::Result MissionImpl::cancel_mission_download() const
 {
-    auto ptr = _mission_data.last_download.lock();
+    std::shared_ptr<MavlinkMissionTransferClient::WorkItem> ptr;
+    {
+        std::lock_guard<std::mutex> lock(_mission_data.transfer_mutex);
+        ptr = _mission_data.last_download.lock();
+    }
+
     if (ptr) {
         ptr->cancel();
     } else {

--- a/cpp/src/mavsdk/plugins/mission/mission_impl.h
+++ b/cpp/src/mavsdk/plugins/mission/mission_impl.h
@@ -124,6 +124,11 @@ private:
         CallbackList<Mission::MissionProgress> mission_progress_callbacks{};
         int last_current_reported_mission_item{-1};
         int last_total_reported_mission_item{-1};
+        // Separate mutex for last_upload / last_download so their read/write
+        // accesses can be synchronised without conflicting with the progress
+        // fields guarded by `mutex` above (reset_mission_progress() holds that
+        // one while we need to assign last_upload in the same call stack).
+        mutable std::mutex transfer_mutex{};
         std::weak_ptr<MavlinkMissionTransferClient::WorkItem> last_upload{};
         std::weak_ptr<MavlinkMissionTransferClient::WorkItem> last_download{};
         bool gimbal_v2_in_control{false};


### PR DESCRIPTION
## Problem

ThreadSanitizer reported a data race in `MissionImpl`:

```
SUMMARY: ThreadSanitizer: data race mission_impl.cpp:166
  in mavsdk::MissionImpl::cancel_mission_upload() const

Write at mission_impl.cpp:143 by thread T1:
  #4 mavsdk::MissionImpl::upload_mission_with_progress_async(...)

Read at mission_impl.cpp:166 by thread T2:
  #4 mavsdk::MissionImpl::cancel_mission_upload() const
```

`upload_mission_with_progress_async()` assigns `_mission_data.last_upload` on the caller's thread at the same time as `cancel_mission_upload()` reads it via `lock()` on the user-callback thread. The same race exists for `last_download` / `cancel_mission_download()`.

The existing `_mission_data.mutex` cannot be used to guard these accesses because `reset_mission_progress()` also holds that mutex and is called in the same function, which would cause a recursive-lock deadlock.

## Fix

Add a second mutex `transfer_mutex` to `MissionData`, dedicated solely to `last_upload` and `last_download`. All six functions that access those fields now hold `transfer_mutex`:

- `upload_mission_async` / `upload_mission_with_progress_async`: for the busy check at the top, and for the final assignment after `upload_items_async()` returns
- `cancel_mission_upload`: for the `lock()` call; mutex released before `ptr->cancel()` to avoid holding two locks at once
- Same pattern for the three download equivalents

Related to PR #2806 (system test for mission cancellation).