### PR TITLE
docs: fix dependabot vulnerabilities 

### DIFF
--- a/cpp/docs/.vitepress/config.mjs
+++ b/cpp/docs/.vitepress/config.mjs
@@ -1,9 +1,6 @@
 import { defineConfig } from "vitepress";
 const getSidebar = require("./get_sidebar.js");
 
-// Tabs: https://github.com/Red-Asuka/vitepress-plugin-tabs
-import tabsPlugin from "@red-asuka/vitepress-plugin-tabs";
-
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title: "MAVSDK Guide",
@@ -23,10 +20,6 @@ export default defineConfig({
   ignoreDeadLinks: true,
   markdown: {
     math: true,
-    config: (md) => {
-      // use more markdown-it plugins!
-      tabsPlugin(md); //https://github.com/Red-Asuka/vitepress-plugin-tabs
-    },
   },
   locales: {
     en: {

--- a/cpp/docs/.vitepress/theme/index.js
+++ b/cpp/docs/.vitepress/theme/index.js
@@ -20,10 +20,6 @@ if (inBrowser) {
 // Support redirect plugin
 import Redirect from "./components/Redirect.vue";
 
-// Tabs: https://github.com/Red-Asuka/vitepress-plugin-tabs
-import { Tab, Tabs } from "vue3-tabs-component";
-import "@red-asuka/vitepress-plugin-tabs/dist/style.css";
-
 /** @type {import('vitepress').Theme} */
 export default {
   extends: DefaultTheme,
@@ -34,9 +30,6 @@ export default {
   },
   enhanceApp({ app, router, siteData }) {
     app.component("Redirect", Redirect); //Redirect plugin
-    //Tabs: https://github.com/Red-Asuka/vitepress-plugin-tabs
-    app.component("Tab", Tab);
-    app.component("Tabs", Tabs);
   },
 
   // to support medium zoom: https://github.com/vuejs/vitepress/issues/854

--- a/cpp/docs/package.json
+++ b/cpp/docs/package.json
@@ -14,11 +14,15 @@
   },
   "dependencies": {
     "vitepress": "^1.5.0",
-    "@red-asuka/vitepress-plugin-tabs": "^0.0.3",
     "lite-youtube-embed": "^0.3.2",
     "markdown-it-mathjax3": "^4.3.2",
     "medium-zoom": "^1.1.0",
-    "open-editor": "^5.0.0",
-    "vue3-tabs-component": "^1.3.7"
+    "open-editor": "^5.0.0"
+  },
+  "resolutions": {
+    "esbuild": "^0.25.0"
+  },
+  "overrides": {
+    "esbuild": "^0.25.0"
   }
 }


### PR DESCRIPTION
by removing unused tabs plugin and overriding esbuild

Remove @red-asuka/vitepress-plugin-tabs and vue3-tabs-component which pulled in vulnerable markdown-it@^13 but were never used in any docs page. Add resolutions/overrides to force esbuild@^0.25.0 to fix GHSA-67mh-4wv8-2f99.