### PR TITLE
ci: cancel in-progress runs on new PR commits

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -15,6 +15,10 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -12,6 +12,10 @@ on:
     paths-ignore:
     - 'cpp/docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 defaults:
   run:
     working-directory: cpp

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,6 +16,10 @@ on:
     - '.github/workflows/docs_deploy.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 defaults:
   run:
     working-directory: cpp

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,6 +15,10 @@ on:
     - 'cpp/docs/**'
     - '.github/workflows/docs_deploy.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 defaults:
   run:
     working-directory: cpp

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,6 +15,10 @@ on:
     - 'cpp/docs/**'
     - '.github/workflows/docs_deploy.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 defaults:
   run:
     working-directory: cpp


### PR DESCRIPTION
Add a concurrency group to all build workflows (Linux, macOS, Windows, Fuzzing, Docs).  When a new commit is pushed to a PR, any in-progress run for the same workflow + ref is cancelled automatically, keeping the CI queue clean.

Pushes to main are excluded from cancellation
(cancel-in-progress: false when ref == refs/heads/main).