### PR TITLE
mission_raw_server: Fix crash on empty mission upload

### DIFF
--- a/cpp/src/mavsdk/plugins/mission_raw_server/mission_raw_server_impl.cpp
+++ b/cpp/src/mavsdk/plugins/mission_raw_server/mission_raw_server_impl.cpp
@@ -203,7 +203,9 @@ void MissionRawServerImpl::process_mission_count(const mavlink_message_t& messag
             // Reset mission state after receiving because the previous mission is now inactive.
             if (type == MAV_MISSION_TYPE_MISSION) {
                 _mission_completed = false;
-                set_current_seq(0);
+                if (!items.empty()) {
+                    set_current_seq(0);
+                }
             }
         });
 }
@@ -410,15 +412,15 @@ void MissionRawServerImpl::set_current_item_complete()
 
 void MissionRawServerImpl::set_current_seq(std::size_t seq)
 {
-    if (_current_mission.size() < static_cast<size_t>(seq) || _current_mission.empty()) {
+    if (_current_mission.empty() || seq > _current_mission.size()) {
         return;
     }
 
     _current_seq = seq;
 
     // If mission is over, just set item to last one again
-    auto item = seq == _current_mission.size() ? _current_mission.back() :
-                                                 _current_mission.at(_current_seq);
+    auto index = (seq >= _current_mission.size()) ? _current_mission.size() - 1 : seq;
+    auto item = _current_mission.at(index);
     auto converted_item = convert_item(item);
     _current_item_changed_callbacks.queue(converted_item, [this](const auto& func) {
         _server_component_impl->call_user_callback(func);

--- a/cpp/src/system_tests/CMakeLists.txt
+++ b/cpp/src/system_tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(system_tests_runner
     param_custom_set_and_get.cpp
     param_get_all.cpp
     mission_raw_upload.cpp
+    mission_raw_upload_empty.cpp
     telemetry_subscription.cpp
     fs_helpers.cpp
     ftp_download_file.cpp

--- a/cpp/src/system_tests/mission_raw_upload_empty.cpp
+++ b/cpp/src/system_tests/mission_raw_upload_empty.cpp
@@ -1,0 +1,66 @@
+#include "log.h"
+#include "mavsdk.h"
+#include "plugins/mission_raw/mission_raw.h"
+#include "plugins/mission_raw_server/mission_raw_server.h"
+#include <future>
+#include <thread>
+#include <gtest/gtest.h>
+
+using namespace mavsdk;
+
+TEST(SystemTest, MissionRawUploadEmpty)
+{
+    // Regression test for #1962: uploading an empty mission must not crash.
+
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{ComponentType::GroundStation}};
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{ComponentType::Autopilot}};
+
+    ASSERT_EQ(
+        mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
+        ConnectionResult::Success);
+    ASSERT_EQ(
+        mavsdk_autopilot.add_any_connection("udpout://127.0.0.1:17000"), ConnectionResult::Success);
+
+    auto mission_raw_server = MissionRawServer{mavsdk_autopilot.server_component()};
+
+    auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
+    ASSERT_TRUE(maybe_system);
+    auto system = maybe_system.value();
+    ASSERT_TRUE(system->has_autopilot());
+
+    auto mission_raw = MissionRaw{system};
+
+    // Upload empty mission — this used to crash with a core dump.
+    std::vector<MissionRaw::MissionItem> empty_items;
+    auto result = mission_raw.upload_mission(empty_items);
+    LogInfo() << "Empty mission upload result: " << result;
+
+    // The result may vary depending on how the server handles empty missions,
+    // but the key assertion is that we don't crash (the original bug).
+    EXPECT_TRUE(
+        result == MissionRaw::Result::Success || result == MissionRaw::Result::InvalidArgument ||
+        result == MissionRaw::Result::NoMissionAvailable);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Now upload a normal mission to verify the server still works.
+    MissionRaw::MissionItem waypoint{};
+    waypoint.seq = 0;
+    waypoint.frame = 6;
+    waypoint.command = 16; // MAV_CMD_NAV_WAYPOINT
+    waypoint.current = 1;
+    waypoint.autocontinue = 1;
+    waypoint.param1 = 0;
+    waypoint.param2 = 0;
+    waypoint.param3 = 0;
+    waypoint.param4 = NAN;
+    waypoint.x = static_cast<int32_t>(47.398170 * 1e7);
+    waypoint.y = static_cast<int32_t>(8.545649 * 1e7);
+    waypoint.z = 10.0f;
+    waypoint.mission_type = 0;
+
+    std::vector<MissionRaw::MissionItem> items{waypoint};
+    EXPECT_EQ(mission_raw.upload_mission(items), MissionRaw::Result::Success);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+}


### PR DESCRIPTION
Uploading an empty mission (count=0) crashes mission_raw_server — set_current_seq() calls .back() on an empty vector.

Skip set_current_seq when uploaded items are empty, harden the bounds check, and add a regression test.

Fixes #1962