### PR TITLE
telemetry: Use REQUEST_DATA_STREAM for ArduPilot set_rate

### DIFF
--- a/cpp/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/cpp/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -237,6 +237,11 @@ Telemetry::Result TelemetryImpl::set_rate_position(double rate_hz)
     _position_rate_hz = rate_hz;
     double max_rate_hz = std::max(_position_rate_hz, _velocity_ned_rate_hz);
 
+    if (_system_impl->effective_autopilot() == Autopilot::ArduPilot) {
+        send_request_data_stream(MAV_DATA_STREAM_POSITION, max_rate_hz);
+        return Telemetry::Result::Success;
+    }
+
     return telemetry_result_from_command_result(
         _system_impl->set_msg_rate(MAVLINK_MSG_ID_GLOBAL_POSITION_INT, max_rate_hz));
 }
@@ -271,6 +276,11 @@ Telemetry::Result TelemetryImpl::set_rate_attitude_quaternion(double rate_hz)
 
 Telemetry::Result TelemetryImpl::set_rate_attitude_euler(double rate_hz)
 {
+    if (_system_impl->effective_autopilot() == Autopilot::ArduPilot) {
+        send_request_data_stream(MAV_DATA_STREAM_EXTRA1, rate_hz);
+        return Telemetry::Result::Success;
+    }
+
     return telemetry_result_from_command_result(
         _system_impl->set_msg_rate(MAVLINK_MSG_ID_ATTITUDE, rate_hz));
 }
@@ -279,6 +289,11 @@ Telemetry::Result TelemetryImpl::set_rate_velocity_ned(double rate_hz)
 {
     _velocity_ned_rate_hz = rate_hz;
     double max_rate_hz = std::max(_position_rate_hz, _velocity_ned_rate_hz);
+
+    if (_system_impl->effective_autopilot() == Autopilot::ArduPilot) {
+        send_request_data_stream(MAV_DATA_STREAM_POSITION, max_rate_hz);
+        return Telemetry::Result::Success;
+    }
 
     return telemetry_result_from_command_result(
         _system_impl->set_msg_rate(MAVLINK_MSG_ID_GLOBAL_POSITION_INT, max_rate_hz));
@@ -397,6 +412,15 @@ void TelemetryImpl::set_rate_position_async(double rate_hz, Telemetry::ResultCal
     _position_rate_hz = rate_hz;
     double max_rate_hz = std::max(_position_rate_hz, _velocity_ned_rate_hz);
 
+    if (_system_impl->effective_autopilot() == Autopilot::ArduPilot) {
+        send_request_data_stream(MAV_DATA_STREAM_POSITION, max_rate_hz);
+        if (callback) {
+            _system_impl->call_user_callback(
+                [callback]() { callback(Telemetry::Result::Success); });
+        }
+        return;
+    }
+
     _system_impl->set_msg_rate_async(
         MAVLINK_MSG_ID_GLOBAL_POSITION_INT,
         max_rate_hz,
@@ -469,6 +493,15 @@ void TelemetryImpl::set_rate_attitude_quaternion_async(
 void TelemetryImpl::set_rate_attitude_euler_async(
     double rate_hz, Telemetry::ResultCallback callback)
 {
+    if (_system_impl->effective_autopilot() == Autopilot::ArduPilot) {
+        send_request_data_stream(MAV_DATA_STREAM_EXTRA1, rate_hz);
+        if (callback) {
+            _system_impl->call_user_callback(
+                [callback]() { callback(Telemetry::Result::Success); });
+        }
+        return;
+    }
+
     _system_impl->set_msg_rate_async(
         MAVLINK_MSG_ID_ATTITUDE,
         rate_hz,
@@ -481,6 +514,15 @@ void TelemetryImpl::set_rate_velocity_ned_async(double rate_hz, Telemetry::Resul
 {
     _velocity_ned_rate_hz = rate_hz;
     double max_rate_hz = std::max(_position_rate_hz, _velocity_ned_rate_hz);
+
+    if (_system_impl->effective_autopilot() == Autopilot::ArduPilot) {
+        send_request_data_stream(MAV_DATA_STREAM_POSITION, max_rate_hz);
+        if (callback) {
+            _system_impl->call_user_callback(
+                [callback]() { callback(Telemetry::Result::Success); });
+        }
+        return;
+    }
 
     _system_impl->set_msg_rate_async(
         MAVLINK_MSG_ID_GLOBAL_POSITION_INT,
@@ -2618,6 +2660,30 @@ std::pair<Telemetry::Result, Telemetry::GpsGlobalOrigin> TelemetryImpl::get_gps_
             prom.set_value(std::make_pair(result, gps_global_origin));
         });
     return fut.get();
+}
+
+void TelemetryImpl::send_request_data_stream(uint8_t stream_id, double rate_hz)
+{
+    auto target_sysid = _system_impl->get_system_id();
+    auto target_compid = _system_impl->get_autopilot_id();
+    uint16_t msg_rate = static_cast<uint16_t>(rate_hz);
+    uint8_t start_stop = (rate_hz > 0) ? 1 : 0;
+
+    _system_impl->queue_message([target_sysid, target_compid, stream_id, msg_rate, start_stop](
+                                    MavlinkAddress mavlink_address, uint8_t channel) {
+        mavlink_message_t message;
+        mavlink_msg_request_data_stream_pack_chan(
+            mavlink_address.system_id,
+            mavlink_address.component_id,
+            channel,
+            &message,
+            target_sysid,
+            target_compid,
+            stream_id,
+            msg_rate,
+            start_stop);
+        return message;
+    });
 }
 
 } // namespace mavsdk

--- a/cpp/src/mavsdk/plugins/telemetry/telemetry_impl.h
+++ b/cpp/src/mavsdk/plugins/telemetry/telemetry_impl.h
@@ -269,6 +269,7 @@ private:
     void receive_statustext(const MavlinkStatustextHandler::Statustext&);
 
     void request_home_position_again();
+    void send_request_data_stream(uint8_t stream_id, double rate_hz);
 
     static bool sys_status_present_enabled_health(
         const mavlink_sys_status_t& sys_status, MAV_SYS_STATUS_SENSOR flag);


### PR DESCRIPTION
ArduPilot doesn't reliably ACK MAV_CMD_SET_MESSAGE_INTERVAL on serial links, so set_rate_position and set_rate_attitude_euler fail.

For ArduPilot, use the legacy REQUEST_DATA_STREAM message (fire-and-forget) instead. Maps position to MAV_DATA_STREAM_POSITION and attitude to MAV_DATA_STREAM_EXTRA1. Also fixes set_rate_velocity_ned which shares the same GLOBAL_POSITION_INT message.

Fixes #2742