### PR TITLE
mocap: Fix MavFrame enum sending wrong values on the wire

### DIFF
--- a/cpp/src/mavsdk/plugins/mocap/mocap_impl.cpp
+++ b/cpp/src/mavsdk/plugins/mocap/mocap_impl.cpp
@@ -290,7 +290,8 @@ Mocap::Result MocapImpl::send_odometry(const Mocap::Odometry& odometry)
             channel,
             &message,
             autopilot_time_usec,
-            static_cast<uint8_t>(odometry.frame_id),
+            odometry.frame_id == Mocap::Odometry::MavFrame::LocalFrd ? MAV_FRAME_LOCAL_FRD :
+                                                                       MAV_FRAME_RESERVED_14,
             static_cast<uint8_t>(MAV_FRAME_BODY_FRD),
             odometry.position_body.x_m,
             odometry.position_body.y_m,


### PR DESCRIPTION
The Odometry MavFrame proto enum uses values 0/1 but the actual MAVLink frame IDs are 14 (MAV_FRAME_MOCAP_NED) and 20 (MAV_FRAME_LOCAL_FRD). The static_cast sent proto values directly. Map to correct MAVLink constants instead.

Fixes #2001