### PR TITLE
system_tests: Fix race in mission tests by registering server before connections

### DIFF
--- a/cpp/src/system_tests/mission_cancellation.cpp
+++ b/cpp/src/system_tests/mission_cancellation.cpp
@@ -35,13 +35,13 @@ TEST(SystemTest, MissionUploadCancellation)
     Mavsdk mavsdk_groundstation{Mavsdk::Configuration{ComponentType::GroundStation}};
     Mavsdk mavsdk_autopilot{Mavsdk::Configuration{ComponentType::Autopilot}};
 
+    auto mission_raw_server = MissionRawServer{mavsdk_autopilot.server_component()};
+
     ASSERT_EQ(
         mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
         ConnectionResult::Success);
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udpout://127.0.0.1:17000"), ConnectionResult::Success);
-
-    auto mission_raw_server = MissionRawServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);
@@ -87,13 +87,13 @@ TEST(SystemTest, MissionDownloadCancellation)
     Mavsdk mavsdk_groundstation{Mavsdk::Configuration{ComponentType::GroundStation}};
     Mavsdk mavsdk_autopilot{Mavsdk::Configuration{ComponentType::Autopilot}};
 
+    auto mission_raw_server = MissionRawServer{mavsdk_autopilot.server_component()};
+
     ASSERT_EQ(
         mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
         ConnectionResult::Success);
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udpout://127.0.0.1:17000"), ConnectionResult::Success);
-
-    auto mission_raw_server = MissionRawServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);

--- a/cpp/src/system_tests/mission_changed.cpp
+++ b/cpp/src/system_tests/mission_changed.cpp
@@ -24,14 +24,16 @@ TEST(SystemTest, MissionChanged)
     Mavsdk mavsdk_groundstation{Mavsdk::Configuration{ComponentType::GroundStation}};
     Mavsdk mavsdk_autopilot{Mavsdk::Configuration{ComponentType::Autopilot}};
 
+    // Set up the autopilot side with MissionRawServer before connections
+    // so capabilities (MISSION_INT) are available before the first
+    // AUTOPILOT_VERSION exchange.
+    auto mission_raw_server = MissionRawServer{mavsdk_autopilot.server_component()};
+
     ASSERT_EQ(
         mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
         ConnectionResult::Success);
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udpout://127.0.0.1:17000"), ConnectionResult::Success);
-
-    // Set up the autopilot side with MissionRawServer
-    auto mission_raw_server = MissionRawServer{mavsdk_autopilot.server_component()};
 
     // Wait for groundstation to discover autopilot
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);

--- a/cpp/src/system_tests/mission_raw_upload.cpp
+++ b/cpp/src/system_tests/mission_raw_upload.cpp
@@ -15,13 +15,15 @@ TEST(SystemTest, MissionRawUpload)
 
     Mavsdk mavsdk_autopilot{Mavsdk::Configuration{ComponentType::Autopilot}};
 
+    // Register server plugin before connections so capabilities (MISSION_INT)
+    // are available before the first AUTOPILOT_VERSION exchange.
+    auto mission_raw_server = MissionRawServer{mavsdk_autopilot.server_component()};
+
     ASSERT_EQ(
         mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
         ConnectionResult::Success);
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udpout://127.0.0.1:17000"), ConnectionResult::Success);
-
-    auto mission_raw_server = MissionRawServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);

--- a/cpp/src/system_tests/mission_raw_upload_empty.cpp
+++ b/cpp/src/system_tests/mission_raw_upload_empty.cpp
@@ -15,13 +15,13 @@ TEST(SystemTest, MissionRawUploadEmpty)
     Mavsdk mavsdk_groundstation{Mavsdk::Configuration{ComponentType::GroundStation}};
     Mavsdk mavsdk_autopilot{Mavsdk::Configuration{ComponentType::Autopilot}};
 
+    auto mission_raw_server = MissionRawServer{mavsdk_autopilot.server_component()};
+
     ASSERT_EQ(
         mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
         ConnectionResult::Success);
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udpout://127.0.0.1:17000"), ConnectionResult::Success);
-
-    auto mission_raw_server = MissionRawServer{mavsdk_autopilot.server_component()};
 
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);

--- a/cpp/src/system_tests/mission_transfer_lossy.cpp
+++ b/cpp/src/system_tests/mission_transfer_lossy.cpp
@@ -22,14 +22,15 @@ TEST(SystemTest, MissionTransferLossy)
     Mavsdk mavsdk_groundstation{Mavsdk::Configuration{ComponentType::GroundStation}};
     Mavsdk mavsdk_autopilot{Mavsdk::Configuration{ComponentType::Autopilot}};
 
+    // Set up the autopilot side with MissionRawServer before connections
+    // so capabilities (MISSION_INT) are available before AUTOPILOT_VERSION exchange.
+    auto mission_raw_server = MissionRawServer{mavsdk_autopilot.server_component()};
+
     ASSERT_EQ(
         mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
         ConnectionResult::Success);
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udpout://127.0.0.1:17000"), ConnectionResult::Success);
-
-    // Set up the autopilot side with MissionRawServer
-    auto mission_raw_server = MissionRawServer{mavsdk_autopilot.server_component()};
 
     // Wait for groundstation to discover autopilot
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);


### PR DESCRIPTION
MissionRawServer must be created before establishing connections so MAV_PROTOCOL_CAPABILITY_MISSION_INT is registered before the first AUTOPILOT_VERSION exchange. Otherwise the GCS may receive capabilities without MISSION_INT and reject uploads with "Int messages not supported".

Fixed in all 5 affected tests. Ran 5x with no flakiness.

Fixes #2702