### PR TITLE
docs: update version references for v3 branch-off

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -144,8 +144,12 @@ export default defineConfig({
         text: "Version",
         items: [
           {
-            text: "main / v3",
+            text: "main / v4",
             link: "https://mavsdk.mavlink.io/main/en/cpp/api_changes.html",
+          },
+          {
+            text: "v3",
+            link: "https://mavsdk.mavlink.io/v3/en/cpp/api_changes.html",
           },
           {
             text: "v2",

--- a/docs/en/cpp/contributing/release.md
+++ b/docs/en/cpp/contributing/release.md
@@ -17,7 +17,7 @@ The idea is of course to automate this as much as possible.
    git tag vX.Y.Z
    git push origin vX.Y.Z
    ```
-1. - Update the version branch (e.g. `v3`) as well to track main.
+1. - Update the version branch (e.g. `v4`) as well to track main.
    - Create the release on GitHub for the pushed tag. Generate the changelog using the GitHub button.
 1. Check later if all artifacts have been uploaded correctly to the release.
 1. Update the Arch AUR repository. This depends on the AUR maintainer's credentials (currently julianoes).

--- a/docs/en/cpp/guide/general_usage.md
+++ b/docs/en/cpp/guide/general_usage.md
@@ -121,5 +121,5 @@ Not every mission command behaviour supported by the protocol and PX4 will be su
 
 In order to access the full mission API, the [MissionRaw](../api_reference/classmavsdk_1_1_mission_raw.html) plugin can be used instead.
 
-The MissionRaw also allows to [import QGC mission files](https://mavsdk.mavlink.io/main/en/cpp/api_reference/classmavsdk_1_1_mission_raw.html#classmavsdk_1_1_mission_raw_1a2a4ca261c37737e691c6954693d6d0a5).
+The MissionRaw also allows to [import QGC mission files](https://mavsdk.mavlink.io/v3/en/cpp/api_reference/classmavsdk_1_1_mission_raw.html#classmavsdk_1_1_mission_raw_1a2a4ca261c37737e691c6954693d6d0a5).
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,6 +1,6 @@
 <div style="float:right; padding:10px; margin-right:20px;"><img src="../assets/site/sdk_logo_full.png" title="MAVSDK Logo" width="400px"/></div>
 
-# MAVSDK (main / v3)
+# MAVSDK (v3)
 
 *MAVSDK* is a collection of libraries for various programming languages to interface with [MAVLink](https://mavlink.io/en/) systems such as drones, cameras or ground systems.
 
@@ -58,7 +58,7 @@ This project is maintained by volunteers:
 - [Julian Oes](https://github.com/julianoes) ([sponsoring](https://github.com/sponsors/julianoes), [consulting](https://julianoes.com)).
 - [Jonas Vautherin](https://github.com/JonasVautherin)
 
-Maintenance is not sponsored by any company, however, hosting of the [docs](https://mavsdk.mavlink.io/main/en/) and the [forum](https://discuss.px4.io/c/mavsdk/) is provided by the [Dronecode Foundation](https://dronecode.org).
+Maintenance is not sponsored by any company, however, hosting of the [docs](https://mavsdk.mavlink.io/v3/en/) and the [forum](https://discuss.px4.io/c/mavsdk/) is provided by the [Dronecode Foundation](https://dronecode.org).
 
 ## Support and issues
 


### PR DESCRIPTION
Now that v3 is branched off from main, update the version selector to show main/v4 and v3 separately, and point v3-branch docs links to the v3 deployment path.