### PR TITLE
docs: update version references for v4/main after v3 branch-off

### DIFF
--- a/cpp/docs/.vitepress/config.mjs
+++ b/cpp/docs/.vitepress/config.mjs
@@ -137,8 +137,12 @@ export default defineConfig({
         text: "Version",
         items: [
           {
-            text: "main / v3",
+            text: "main / v4",
             link: "https://mavsdk.mavlink.io/main/en/cpp/api_changes.html",
+          },
+          {
+            text: "v3",
+            link: "https://mavsdk.mavlink.io/v3/en/cpp/api_changes.html",
           },
           {
             text: "v2",

--- a/cpp/docs/en/cpp/contributing/release.md
+++ b/cpp/docs/en/cpp/contributing/release.md
@@ -17,7 +17,7 @@ The idea is of course to automate this as much as possible.
    git tag vX.Y.Z
    git push origin vX.Y.Z
    ```
-1. - Update the version branch (e.g. `v3`) as well to track main.
+1. - Update the version branch (e.g. `v4`) as well to track main.
    - Create the release on GitHub for the pushed tag. Generate the changelog using the GitHub button.
 1. Check later if all artifacts have been uploaded correctly to the release.
 1. Update the Arch AUR repository. This depends on the AUR maintainer's credentials (currently julianoes).

--- a/cpp/docs/en/index.md
+++ b/cpp/docs/en/index.md
@@ -1,6 +1,6 @@
 <div style="float:right; padding:10px; margin-right:20px;"><img src="../assets/site/sdk_logo_full.png" title="MAVSDK Logo" width="400px"/></div>
 
-# MAVSDK (main / v3)
+# MAVSDK (main / v4)
 
 *MAVSDK* is a collection of libraries for various programming languages to interface with [MAVLink](https://mavlink.io/en/) systems such as drones, cameras or ground systems.
 


### PR DESCRIPTION
Version selector now shows main/v4 and adds v3 as a separate entry. Title updated to reflect main tracks v4.