### PR TITLE
fix: bump mission cancellation test to 10000 items

### DIFF
--- a/cpp/src/system_tests/mission_cancellation.cpp
+++ b/cpp/src/system_tests/mission_cancellation.cpp
@@ -22,8 +22,9 @@ static Mission::MissionItem add_waypoint(
 static Mission::MissionPlan create_mission_plan()
 {
     Mission::MissionPlan mission_plan{};
-    // 1000 items so the transfer takes long enough that a mid-flight cancel is reliable.
-    for (unsigned i = 0; i < 1000; ++i) {
+    // 10000 items so the transfer takes long enough that a mid-flight cancel is reliable
+    // even on a fast loopback link where the user callback queue lags behind.
+    for (unsigned i = 0; i < 10000; ++i) {
         mission_plan.mission_items.push_back(
             add_waypoint(47.3981703270545, 8.54564902186397, 20.0, 3.0, true, -90.0, 0.0, false));
     }


### PR DESCRIPTION
## Summary

- Bump the mission cancellation system test from 1,000 to 10,000 items so the transfer cannot complete on loopback before the user callback queue delivers the progress notification that triggers the cancel.
- With 1,000 items the transfer could finish before `cancel_mission_upload()` was called, resulting in `Success` instead of `TransferCancelled`.

## Test plan

- [x] `SystemTest.MissionUploadCancellation` passes consistently (verified locally)
- [x] `SystemTest.MissionDownloadCancellation` passes consistently (verified locally)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)