### PR TITLE
Fix unit test working directory for file-dependent tests

### DIFF
--- a/cpp/src/unit_tests/CMakeLists.txt
+++ b/cpp/src/unit_tests/CMakeLists.txt
@@ -28,4 +28,7 @@ target_include_directories(unit_tests_runner
 )
 
 
-add_test(unit_tests unit_tests_runner)
+add_test(NAME unit_tests
+    COMMAND unit_tests_runner
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)


### PR DESCRIPTION
## Summary
- Set `WORKING_DIRECTORY` on the unit test ctest registration so CameraDefinition and MissionRaw tests find their data files

## Motivation
30 unit tests (CameraDefinition and MissionRaw suites) fail when run via `ctest` because the test binary uses relative paths like `src/mavsdk/plugins/camera/e90_camera.xml` that only resolve correctly from the `cpp/` source root. Without an explicit `WORKING_DIRECTORY`, ctest runs the binary from the build directory where those paths don't exist.

## Changes
- **`cpp/src/unit_tests/CMakeLists.txt`**: Switch from `add_test(unit_tests unit_tests_runner)` to the `add_test(NAME ... COMMAND ... WORKING_DIRECTORY ...)` form, setting the working directory to `${CMAKE_SOURCE_DIR}`

## Test plan
- [x] All 30 previously-failing CameraDefinition and MissionRaw tests now pass
- [x] 287/290 unit tests pass (remaining 3 are FileCacheTest failures due to Docker user home directory permissions, unrelated)