### PR TITLE
Update commit for libevents

### DIFF
--- a/cpp/third_party/libevents/CMakeLists.txt
+++ b/cpp/third_party/libevents/CMakeLists.txt
@@ -32,7 +32,7 @@ endforeach()
 ExternalProject_Add(
         libevents
         GIT_REPOSITORY https://github.com/mavlink/libevents.git
-        GIT_TAG 7c1720749dfe555ec2e71d5f9f753e6ac1244e1c
+        GIT_TAG 840a88ea226d4eb0fd4c391ce860317422756435
         SOURCE_SUBDIR libs/cpp
         CMAKE_ARGS "${CMAKE_ARGS}"
 )


### PR DESCRIPTION
Latest commit for libevents fixes issue with MAVSDK static build [here](https://github.com/mavlink/libevents/pull/14)