### PR TITLE
core: hide symbols by default, export only public API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,16 +44,6 @@ set(MAVLINK_XML_PATH "" CACHE PATH "Where the mavlink xml files are located.")
 
 project(mavsdk_superbuild)
 
-# FIXME: in the future we need to mark library methods that need to be visible manually
-#        and remove CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.
-#        At the moment, we are running into the 65535 object limit on Windows likely because of this.
-if (BUILD_SHARED_LIBS AND MSVC AND BUILD_MAVSDK_SERVER)
-    message(FATAL_ERROR
-        "To build mavsdk_server on Windows, you need to use BUILD_SHARED_LIBS=OFF.\n"
-        "This avoids the Windows 65535 object limit when statically linking all dependencies.\n"
-        "Use: cmake -DBUILD_SHARED_LIBS=OFF ..."
-    )
-endif()
 
 if (BUILD_BACKEND)
     message(FATAL_ERROR "The argument BUILD_BACKEND has been replaced by BUILD_MAVSDK_SERVER. To build mavsdk_server, use -DBUILD_MAVSDK_SERVER=ON.")

--- a/cmake/compiler_flags.cmake
+++ b/cmake/compiler_flags.cmake
@@ -4,7 +4,7 @@ endif()
 
 if(MSVC)
     add_definitions(-DWINDOWS -D_USE_MATH_DEFINES -DNOMINMAX -DWIN32_LEAN_AND_MEAN)
-    set(warnings "-W2")
+    set(warnings "-W2 -wd4251")
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
     # Needed by gRPC headers
@@ -12,10 +12,6 @@ if(MSVC)
 
     # Needed by big auto-generated grpc/protobuf header files
     add_definitions(-bigobj)
-
-    # We need this so Windows links to e.g. mavsdk_telemetry.dll.
-    # Without this option it will look for mavsdk_telemetry.lib and fail.
-    option(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS "Export all symbols on Windows" ON)
 
     if(NOT BUILD_SHARED_LIBS)
         add_definitions(-DCURL_STATICLIB)
@@ -28,6 +24,7 @@ else()
         add_definitions(-fno-exceptions)
         set(warnings "-Wall -Wextra -Wshadow -Wno-strict-aliasing -Wold-style-cast -Wdouble-promotion -Wformat=2 -Wno-address-of-packed-member")
     endif()
+
 
 
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/docs/en/cpp/api_reference/namespacemavsdk.md
+++ b/docs/en/cpp/api_reference/namespacemavsdk.md
@@ -69,11 +69,11 @@ enum [Vehicle](#namespacemavsdk_1a9e3a3a502dc8313cb931a8a44cc6f95b) | Vehicle ty
 
 Type | Name | Description
 --- | --- | ---
-std::ostream & | [operator<<](#namespacemavsdk_1ad782054ca8c33116d0210acca8c55ce6) (std::ostream & os, const [Autopilot](namespacemavsdk.md#namespacemavsdk_1aba05635d1785223a4d7b457ae0407297) & autopilot) | Stream operator to print information about an `Autopilot`.
-std::string | [base64_encode](#namespacemavsdk_1a57a9962be22a61e5c36a66bc17e6a2a7) (std::vector< uint8_t > & raw) | Encode raw bytes to a base64 string.
-std::vector< uint8_t > | [base64_decode](#namespacemavsdk_1a34e7609c9e2ddcc72a74bbc79daf9c19) (const std::string & str) | Decode a base64 string into raw bytes.
-std::ostream & | [operator<<](#namespacemavsdk_1aab2fde9b1e274959eb378afef9e0747f) (std::ostream & os, const [CompatibilityMode](namespacemavsdk.md#namespacemavsdk_1af0f9146b2086797ae56671d20bd29d00) & mode) | Stream operator to print information about a `CompatibilityMode`.
-std::ostream & | [operator<<](#namespacemavsdk_1a2aa91d8b846b07fe7f305b399375ce5f) (std::ostream & str, const [ConnectionResult](namespacemavsdk.md#namespacemavsdk_1a0bad93f6d037051ac3906a0bcc09f992) & result) | Stream operator to print information about a `ConnectionResult`.
+MAVSDK_PUBLIC std::ostream & | [operator<<](#namespacemavsdk_1afe9c20bc5ec76ce959d7d6361e7287e9) (std::ostream & os, const [Autopilot](namespacemavsdk.md#namespacemavsdk_1aba05635d1785223a4d7b457ae0407297) & autopilot) | Stream operator to print information about an `Autopilot`.
+MAVSDK_PUBLIC std::string | [base64_encode](#namespacemavsdk_1a941ae59331101898e2cbe2720d4d16b3) (std::vector< uint8_t > & raw) | Encode raw bytes to a base64 string.
+MAVSDK_PUBLIC std::vector< uint8_t > | [base64_decode](#namespacemavsdk_1a7f2b751289c1257fccf1d23aa087656a) (const std::string & str) | Decode a base64 string into raw bytes.
+MAVSDK_TEST_EXPORT std::ostream & | [operator<<](#namespacemavsdk_1a4582b6eac9ac0bd0cdda49aecaf4395b) (std::ostream & os, const [CompatibilityMode](namespacemavsdk.md#namespacemavsdk_1af0f9146b2086797ae56671d20bd29d00) & mode) | Stream operator to print information about a `CompatibilityMode`.
+MAVSDK_PUBLIC std::ostream & | [operator<<](#namespacemavsdk_1ad44fcd033d04558206f7b68517308071) (std::ostream & str, const [ConnectionResult](namespacemavsdk.md#namespacemavsdk_1a0bad93f6d037051ac3906a0bcc09f992) & result) | Stream operator to print information about a `ConnectionResult`.
 &nbsp; | [overloaded](#namespacemavsdk_1a724e321aaff91eb2ba28279e0292e552) (Ts...)-> overloaded< Ts... > | Template deduction helper for `overloaded`
 std::ostream & | [operator<<](#namespacemavsdk_1a3e7a55e89629afd2a079d79c047e8dbd) (std::ostream & os, const [Vehicle](namespacemavsdk.md#namespacemavsdk_1a9e3a3a502dc8313cb931a8a44cc6f95b) & vehicle) | Stream operator to print information about a `Vehicle`.
 [Vehicle](namespacemavsdk.md#namespacemavsdk_1a9e3a3a502dc8313cb931a8a44cc6f95b) | [to_vehicle_from_mav_type](#namespacemavsdk_1a4dede924df915e32b4807aa87a98b5bb) (MAV_TYPE type) | Convert a 'MAV_TYPE' to a `Vehicle`.
@@ -225,13 +225,13 @@ Value | Description
 ## Function Documentation
 
 
-### operator<<() {#namespacemavsdk_1ad782054ca8c33116d0210acca8c55ce6}
+### operator<<() {#namespacemavsdk_1afe9c20bc5ec76ce959d7d6361e7287e9}
 
 ```
 #include: autopilot.h
 ```
 ```cpp
-std::ostream & mavsdk::operator<<(std::ostream &os, const Autopilot &autopilot)
+MAVSDK_PUBLIC std::ostream & mavsdk::operator<<(std::ostream &os, const Autopilot &autopilot)
 ```
 
 
@@ -245,15 +245,15 @@ Stream operator to print information about an `Autopilot`.
 
 **Returns**
 
-&emsp;std::ostream & - A reference to the stream.
+&emsp;MAVSDK_PUBLIC std::ostream & - A reference to the stream.
 
-### base64_encode() {#namespacemavsdk_1a57a9962be22a61e5c36a66bc17e6a2a7}
+### base64_encode() {#namespacemavsdk_1a941ae59331101898e2cbe2720d4d16b3}
 
 ```
 #include: base64.h
 ```
 ```cpp
-std::string mavsdk::base64_encode(std::vector< uint8_t > &raw)
+MAVSDK_PUBLIC std::string mavsdk::base64_encode(std::vector< uint8_t > &raw)
 ```
 
 
@@ -266,15 +266,15 @@ Encode raw bytes to a base64 string.
 
 **Returns**
 
-&emsp;std::string - Base64 string
+&emsp;MAVSDK_PUBLIC std::string - Base64 string
 
-### base64_decode() {#namespacemavsdk_1a34e7609c9e2ddcc72a74bbc79daf9c19}
+### base64_decode() {#namespacemavsdk_1a7f2b751289c1257fccf1d23aa087656a}
 
 ```
 #include: base64.h
 ```
 ```cpp
-std::vector< uint8_t > mavsdk::base64_decode(const std::string &str)
+MAVSDK_PUBLIC std::vector< uint8_t > mavsdk::base64_decode(const std::string &str)
 ```
 
 
@@ -287,15 +287,15 @@ Decode a base64 string into raw bytes.
 
 **Returns**
 
-&emsp;std::vector< uint8_t > - Raw bytes
+&emsp;MAVSDK_PUBLIC std::vector< uint8_t > - Raw bytes
 
-### operator<<() {#namespacemavsdk_1aab2fde9b1e274959eb378afef9e0747f}
+### operator<<() {#namespacemavsdk_1a4582b6eac9ac0bd0cdda49aecaf4395b}
 
 ```
 #include: compatibility_mode.h
 ```
 ```cpp
-std::ostream & mavsdk::operator<<(std::ostream &os, const CompatibilityMode &mode)
+MAVSDK_TEST_EXPORT std::ostream & mavsdk::operator<<(std::ostream &os, const CompatibilityMode &mode)
 ```
 
 
@@ -309,15 +309,15 @@ Stream operator to print information about a `CompatibilityMode`.
 
 **Returns**
 
-&emsp;std::ostream & - A reference to the stream.
+&emsp;MAVSDK_TEST_EXPORT std::ostream & - A reference to the stream.
 
-### operator<<() {#namespacemavsdk_1a2aa91d8b846b07fe7f305b399375ce5f}
+### operator<<() {#namespacemavsdk_1ad44fcd033d04558206f7b68517308071}
 
 ```
 #include: connection_result.h
 ```
 ```cpp
-std::ostream & mavsdk::operator<<(std::ostream &str, const ConnectionResult &result)
+MAVSDK_PUBLIC std::ostream & mavsdk::operator<<(std::ostream &str, const ConnectionResult &result)
 ```
 
 
@@ -331,7 +331,7 @@ Stream operator to print information about a `ConnectionResult`.
 
 **Returns**
 
-&emsp;std::ostream & - A reference to the stream.
+&emsp;MAVSDK_PUBLIC std::ostream & - A reference to the stream.
 
 ### overloaded() {#namespacemavsdk_1a724e321aaff91eb2ba28279e0292e552}
 

--- a/src/mavsdk/core/CMakeLists.txt
+++ b/src/mavsdk/core/CMakeLists.txt
@@ -135,6 +135,12 @@ else()
     )
 endif()
 
+target_compile_definitions(mavsdk PRIVATE MAVSDK_BUILD)
+
+if (BUILD_SHARED_LIBS)
+    target_compile_definitions(mavsdk PUBLIC MAVSDK_SHARED)
+endif()
+
 set_target_properties(mavsdk PROPERTIES
     VERSION ${MAVSDK_VERSION_STRING}
     SOVERSION ${MAVSDK_SOVERSION_STRING}
@@ -174,7 +180,10 @@ if((BUILD_STATIC_MAVSDK_SERVER AND ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")) OR
 endif()
 
 set_target_properties(mavsdk
-    PROPERTIES COMPILE_FLAGS ${warnings}
+    PROPERTIES
+        COMPILE_FLAGS ${warnings}
+        CXX_VISIBILITY_PRESET hidden
+        VISIBILITY_INLINES_HIDDEN ON
     )
 
 target_include_directories(mavsdk
@@ -211,6 +220,7 @@ install(FILES
     include/mavsdk/handle.h
     include/mavsdk/system.h
     include/mavsdk/mavsdk.h
+    include/mavsdk/mavsdk_export.h
     include/mavsdk/log_callback.h
     include/mavsdk/plugin_base.h
     include/mavsdk/server_plugin_base.h

--- a/src/mavsdk/core/call_every_handler.h
+++ b/src/mavsdk/core/call_every_handler.h
@@ -6,10 +6,11 @@
 #include <functional>
 #include <list>
 #include "mavsdk_time.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
-class CallEveryHandler {
+class MAVSDK_TEST_EXPORT CallEveryHandler {
 public:
     explicit CallEveryHandler(Time& time);
     ~CallEveryHandler() = default;

--- a/src/mavsdk/core/callback_list.h
+++ b/src/mavsdk/core/callback_list.h
@@ -7,12 +7,13 @@
 #include <utility>
 #include <vector>
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
 template<typename... Args> class CallbackListImpl;
 
-template<typename... Args> class CallbackList {
+template<typename... Args> class MAVSDK_PUBLIC CallbackList {
 public:
     CallbackList();
     ~CallbackList();

--- a/src/mavsdk/core/callback_list_test.cpp
+++ b/src/mavsdk/core/callback_list_test.cpp
@@ -1,3 +1,10 @@
+// This test provides its own explicit template instantiations of CallbackList
+// and includes the .tpp implementation file, so on MSVC we need MAVSDK_BUILD
+// to get dllexport (not dllimport) on the class template.
+#ifndef MAVSDK_BUILD
+#define MAVSDK_BUILD
+#endif
+
 #include <atomic>
 #include <mutex>
 #include <thread>

--- a/src/mavsdk/core/cli_arg.h
+++ b/src/mavsdk/core/cli_arg.h
@@ -4,10 +4,11 @@
 #include <string>
 #include <string_view>
 #include <variant>
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
-class CliArg {
+class MAVSDK_TEST_EXPORT CliArg {
 public:
     struct Udp {
         enum class Mode {

--- a/src/mavsdk/core/connection_result.cpp
+++ b/src/mavsdk/core/connection_result.cpp
@@ -2,7 +2,7 @@
 
 namespace mavsdk {
 
-std::ostream& operator<<(std::ostream& str, const ConnectionResult& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, const ConnectionResult& result)
 {
     switch (result) {
         case ConnectionResult::Success:

--- a/src/mavsdk/core/curl_wrapper.h
+++ b/src/mavsdk/core/curl_wrapper.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include "curl_include.h"
 #include "curl_wrapper_types.h"
+#include "mavsdk_export.h"
 
 #ifdef TESTING
 #include <gmock/gmock.h>
@@ -12,7 +13,7 @@ using namespace testing;
 
 namespace mavsdk {
 
-class ICurlWrapper {
+class MAVSDK_TEST_EXPORT ICurlWrapper {
 public:
     ICurlWrapper() = default;
     virtual ~ICurlWrapper() = default;
@@ -23,7 +24,7 @@ public:
         const ProgressCallback& progress_callback) = 0;
 };
 
-class CurlWrapper : public ICurlWrapper {
+class MAVSDK_TEST_EXPORT CurlWrapper : public ICurlWrapper {
 public:
     // ICurlWrapper
     CurlWrapper() = default;

--- a/src/mavsdk/core/file_cache.h
+++ b/src/mavsdk/core/file_cache.h
@@ -9,6 +9,7 @@
 #include <optional>
 #include <string>
 #include <map>
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -21,7 +22,7 @@ namespace mavsdk {
  *   (however there is no lock held when returning a file from a cache, so the assumption is that
  *   the cache is large enough so no other process evicts the file until it is used).
  */
-class FileCache {
+class MAVSDK_TEST_EXPORT FileCache {
 public:
     FileCache(std::filesystem::path path, int max_num_files, bool verbose_debugging = false);
 

--- a/src/mavsdk/core/fs_utils.h
+++ b/src/mavsdk/core/fs_utils.h
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <filesystem>
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -9,13 +10,14 @@ namespace mavsdk {
  * Get the path to the system's cache directory with a MAVSDK-specific subdirectory.
  * The path does not necessarily exist yet.
  */
-std::optional<std::filesystem::path> get_cache_directory();
+MAVSDK_TEST_EXPORT std::optional<std::filesystem::path> get_cache_directory();
 
 /**
  * Create a random subdirectory in the system's tmp directory
  * @param prefix directory prefix
  */
-std::optional<std::filesystem::path> create_tmp_directory(const std::string& prefix);
+MAVSDK_TEST_EXPORT std::optional<std::filesystem::path>
+create_tmp_directory(const std::string& prefix);
 
 std::string replace_non_ascii_and_whitespace(const std::string& input);
 

--- a/src/mavsdk/core/hostname_to_ip.h
+++ b/src/mavsdk/core/hostname_to_ip.h
@@ -2,9 +2,10 @@
 
 #include <string>
 #include <optional>
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
-std::optional<std::string> resolve_hostname_to_ip(const std::string& hostname);
+MAVSDK_TEST_EXPORT std::optional<std::string> resolve_hostname_to_ip(const std::string& hostname);
 
 } // namespace mavsdk

--- a/src/mavsdk/core/http_loader.cpp
+++ b/src/mavsdk/core/http_loader.cpp
@@ -4,6 +4,12 @@
 
 namespace mavsdk {
 
+HttpLoader::HttpLoader(std::unique_ptr<ICurlWrapper> curl_wrapper) :
+    _curl_wrapper(std::move(curl_wrapper))
+{
+    start();
+}
+
 HttpLoader::HttpLoader() : _curl_wrapper(std::make_unique<CurlWrapper>(CurlWrapper()))
 {
     start();

--- a/src/mavsdk/core/http_loader.h
+++ b/src/mavsdk/core/http_loader.h
@@ -9,6 +9,7 @@
 #include <functional>
 #include "locked_queue.h"
 #include "curl_wrapper.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -16,15 +17,9 @@ class ICurlWrapper;
 
 using TextDownloadCallback = std::function<void(bool success, const std::string& content)>;
 
-class HttpLoader {
+class MAVSDK_TEST_EXPORT HttpLoader {
 public:
-#ifdef TESTING
-    HttpLoader(std::unique_ptr<ICurlWrapper> curl_wrapper) : _curl_wrapper(std::move(curl_wrapper))
-    {
-        start();
-    }
-#endif
-
+    HttpLoader(std::unique_ptr<ICurlWrapper> curl_wrapper);
     HttpLoader();
     ~HttpLoader();
 

--- a/src/mavsdk/core/include/mavsdk/autopilot.h
+++ b/src/mavsdk/core/include/mavsdk/autopilot.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <sstream>
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -18,6 +19,6 @@ enum class Autopilot {
  *
  * @return A reference to the stream.
  */
-std::ostream& operator<<(std::ostream& os, const Autopilot& autopilot);
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& os, const Autopilot& autopilot);
 
 } // namespace mavsdk

--- a/src/mavsdk/core/include/mavsdk/base64.h
+++ b/src/mavsdk/core/include/mavsdk/base64.h
@@ -2,6 +2,8 @@
 #include <vector>
 #include <string>
 
+#include "mavsdk_export.h"
+
 // Taken from https://stackoverflow.com/a/13935718/8548472
 
 namespace mavsdk {
@@ -13,7 +15,7 @@ namespace mavsdk {
  *
  * @return Base64 string
  */
-std::string base64_encode(std::vector<uint8_t>& raw);
+MAVSDK_PUBLIC std::string base64_encode(std::vector<uint8_t>& raw);
 
 /**
  * @brief Decode a base64 string into raw bytes
@@ -22,6 +24,6 @@ std::string base64_encode(std::vector<uint8_t>& raw);
  *
  * @return Raw bytes
  */
-std::vector<uint8_t> base64_decode(const std::string& str);
+MAVSDK_PUBLIC std::vector<uint8_t> base64_decode(const std::string& str);
 
 } // namespace mavsdk

--- a/src/mavsdk/core/include/mavsdk/compatibility_mode.h
+++ b/src/mavsdk/core/include/mavsdk/compatibility_mode.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <sstream>
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -22,6 +23,6 @@ enum class CompatibilityMode {
  *
  * @return A reference to the stream.
  */
-std::ostream& operator<<(std::ostream& os, const CompatibilityMode& mode);
+MAVSDK_TEST_EXPORT std::ostream& operator<<(std::ostream& os, const CompatibilityMode& mode);
 
 } // namespace mavsdk

--- a/src/mavsdk/core/include/mavsdk/connection_result.h
+++ b/src/mavsdk/core/include/mavsdk/connection_result.h
@@ -2,6 +2,8 @@
 
 #include <sstream>
 
+#include "mavsdk_export.h"
+
 /**
  * @brief Namespace for all mavsdk types.
  */
@@ -35,6 +37,6 @@ enum class ConnectionResult {
  *
  * @return A reference to the stream.
  */
-std::ostream& operator<<(std::ostream& str, const ConnectionResult& result);
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, const ConnectionResult& result);
 
 } // namespace mavsdk

--- a/src/mavsdk/core/include/mavsdk/geometry.h
+++ b/src/mavsdk/core/include/mavsdk/geometry.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "mavsdk_export.h"
+
 namespace mavsdk::geometry {
 
 /**
@@ -11,7 +13,7 @@ namespace mavsdk::geometry {
  * and inspired by the implementations in:
  * https://github.com/PX4/ecl/blob/master/geo/geo.cpp
  */
-class CoordinateTransformation {
+class MAVSDK_PUBLIC CoordinateTransformation {
 public:
     /**
      * @brief Type for global coordinate in latitude/longitude in degrees.

--- a/src/mavsdk/core/include/mavsdk/log_callback.h
+++ b/src/mavsdk/core/include/mavsdk/log_callback.h
@@ -3,6 +3,8 @@
 #include <string>
 #include <functional>
 
+#include "mavsdk_export.h"
+
 namespace mavsdk::log {
 
 // defined numeric values can be useful for filtering message by severity
@@ -14,7 +16,7 @@ enum class Level : int { Debug = 0, Info = 1, Warn = 2, Err = 3 };
 using Callback =
     std::function<bool(Level level, const std::string& message, const std::string& file, int line)>;
 
-extern Callback& get_callback();
-extern void subscribe(const Callback& callback);
+MAVSDK_PUBLIC Callback& get_callback();
+MAVSDK_PUBLIC void subscribe(const Callback& callback);
 
 } // namespace mavsdk::log

--- a/src/mavsdk/core/include/mavsdk/mavlink_include.h.in
+++ b/src/mavsdk/core/include/mavsdk/mavlink_include.h.in
@@ -2,7 +2,16 @@
 
 #include "mavlink/mavlink_types.h"
 
+// We provide our own mavlink_get_channel_status with controlled storage,
+// and export it so that tests can link against it.
 #define MAVLINK_GET_CHANNEL_STATUS
+#if defined(_WIN32) && defined(MAVSDK_SHARED) && defined(MAVSDK_BUILD)
+__declspec(dllexport)
+#elif defined(_WIN32) && defined(MAVSDK_SHARED)
+__declspec(dllimport)
+#elif !defined(_WIN32)
+__attribute__((visibility("default")))
+#endif
 mavlink_status_t* mavlink_get_channel_status(uint8_t chan);
 
 #include "mavlink/@MAVLINK_DIALECT@/mavlink.h"

--- a/src/mavsdk/core/include/mavsdk/mavsdk.h
+++ b/src/mavsdk/core/include/mavsdk/mavsdk.h
@@ -15,6 +15,7 @@
 #include "server_component.h"
 #include "connection_result.h"
 #include "mavlink_include.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -38,7 +39,7 @@ class MavsdkImpl;
  * An instance of this class must be created and kept alive in order to use the library.
  * The instance can be destroyed after use in order to break connections and release all resources.
  */
-class Mavsdk {
+class MAVSDK_PUBLIC Mavsdk {
 public:
     /**
      * @brief Returns the version of MAVSDK.
@@ -189,7 +190,7 @@ public:
     /**
      * @brief Possible configurations.
      */
-    class Configuration {
+    class MAVSDK_PUBLIC Configuration {
     public:
         /**
          * @brief Create new Configuration via manually configured

--- a/src/mavsdk/core/include/mavsdk/mavsdk_export.h
+++ b/src/mavsdk/core/include/mavsdk/mavsdk_export.h
@@ -1,0 +1,52 @@
+#pragma once
+
+/**
+ * @brief Marks a class or function as part of the public MAVSDK C++ API.
+ *
+ * On Unix the library is built with -fvisibility=hidden, so only explicitly
+ * annotated symbols are exported from the shared library.
+ *
+ * On Windows, dllexport/dllimport are only used when building/consuming
+ * a shared library (MAVSDK_SHARED is defined). For static builds these
+ * macros are no-ops.
+ */
+
+#if defined(_WIN32) && defined(MAVSDK_SHARED)
+#ifdef MAVSDK_BUILD
+#define MAVSDK_PUBLIC __declspec(dllexport)
+#else
+#define MAVSDK_PUBLIC __declspec(dllimport)
+#endif
+#elif !defined(_WIN32)
+#define MAVSDK_PUBLIC __attribute__((visibility("default")))
+#else
+#define MAVSDK_PUBLIC
+#endif
+
+/**
+ * @brief Marks an internal class or function that unit tests need to access.
+ */
+#if defined(_WIN32) && defined(MAVSDK_SHARED)
+#ifdef MAVSDK_BUILD
+#define MAVSDK_TEST_EXPORT __declspec(dllexport)
+#else
+#define MAVSDK_TEST_EXPORT __declspec(dllimport)
+#endif
+#elif !defined(_WIN32)
+#define MAVSDK_TEST_EXPORT __attribute__((visibility("default")))
+#else
+#define MAVSDK_TEST_EXPORT
+#endif
+
+/**
+ * @brief Export attribute for explicit template instantiations.
+ *
+ * On Unix, MAVSDK_PUBLIC on the class template already sets visibility,
+ * so explicit instantiations don't need it (and GCC warns if you add it).
+ * On Windows shared builds, dllexport on the explicit instantiation is required.
+ */
+#if defined(_WIN32) && defined(MAVSDK_SHARED)
+#define MAVSDK_TEMPL_INST MAVSDK_PUBLIC
+#else
+#define MAVSDK_TEMPL_INST
+#endif

--- a/src/mavsdk/core/include/mavsdk/plugin_base.h
+++ b/src/mavsdk/core/include/mavsdk/plugin_base.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#include "mavsdk_export.h"
+
 namespace mavsdk {
 
 /**
  * @brief Base class for every plugin.
  */
-class PluginBase {
+class MAVSDK_PUBLIC PluginBase {
 public:
     /**
      * @brief Default Constructor.

--- a/src/mavsdk/core/include/mavsdk/server_component.h
+++ b/src/mavsdk/core/include/mavsdk/server_component.h
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <memory>
 
+#include "mavsdk_export.h"
+
 namespace mavsdk {
 
 class MavsdkImpl;
@@ -12,7 +14,7 @@ class ServerPluginImplBase;
 /**
  * @brief This class represents a component, used to initialize a server plugin.
  */
-class ServerComponent {
+class MAVSDK_PUBLIC ServerComponent {
 public:
     /**
      * @private Constructor, used internally

--- a/src/mavsdk/core/include/mavsdk/server_plugin_base.h
+++ b/src/mavsdk/core/include/mavsdk/server_plugin_base.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#include "mavsdk_export.h"
+
 namespace mavsdk {
 
 /**
  * @brief Base class for every server plugin.
  */
-class ServerPluginBase {
+class MAVSDK_PUBLIC ServerPluginBase {
 public:
     /**
      * @brief Default Constructor.

--- a/src/mavsdk/core/include/mavsdk/system.h
+++ b/src/mavsdk/core/include/mavsdk/system.h
@@ -10,6 +10,7 @@
 #include "deprecated.h"
 #include "handle.h"
 #include "vehicle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -25,7 +26,7 @@ class PluginImplBase;
  * cameras. They are not created directly by application code, but are returned by the Mavsdk
  * class.
  */
-class System {
+class MAVSDK_PUBLIC System {
 public:
     /** @private Constructor, used internally
      *

--- a/src/mavsdk/core/log.cpp
+++ b/src/mavsdk/core/log.cpp
@@ -28,7 +28,7 @@ static log::Callback callback_{nullptr};
 // Dedicated mutex for logging operations - moved from header to avoid inlining issues
 static std::mutex log_mutex_{};
 
-std::mutex& get_log_mutex()
+MAVSDK_TEST_EXPORT std::mutex& get_log_mutex()
 {
     return log_mutex_;
 }
@@ -38,7 +38,7 @@ std::ostream& operator<<(std::ostream& os, std::byte b)
     return os << std::bitset<8>(std::to_integer<int>(b));
 }
 
-log::Callback& log::get_callback()
+MAVSDK_PUBLIC log::Callback& log::get_callback()
 {
     std::lock_guard<std::mutex> lock(callback_mutex_);
     return callback_;
@@ -50,7 +50,7 @@ void log::subscribe(const log::Callback& callback)
     callback_ = callback;
 }
 
-void set_color(Color color)
+MAVSDK_TEST_EXPORT void set_color(Color color)
 {
 #if defined(WINDOWS)
     HANDLE handle = GetStdHandle(STD_OUTPUT_HANDLE);

--- a/src/mavsdk/core/log.h
+++ b/src/mavsdk/core/log.h
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <sstream>
 #include "log_callback.h"
+#include "mavsdk_export.h"
 
 #if defined(ANDROID)
 #include <android/log.h>
@@ -31,13 +32,13 @@
 namespace mavsdk {
 
 // Mutex moved to log.cpp to avoid inlining issues
-std::mutex& get_log_mutex();
+MAVSDK_TEST_EXPORT std::mutex& get_log_mutex();
 
 std::ostream& operator<<(std::ostream& os, std::byte b);
 
 enum class Color { Red, Green, Yellow, Blue, Gray, Reset };
 
-void set_color(Color color);
+MAVSDK_TEST_EXPORT void set_color(Color color);
 
 class LogDetailed {
 public:

--- a/src/mavsdk/core/math_utils.h
+++ b/src/mavsdk/core/math_utils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "mavsdk_export.h"
+
 namespace mavsdk {
 
 struct Quaternion {
@@ -15,13 +17,13 @@ struct EulerAngle {
     float yaw_deg;
 };
 
-bool operator==(const Quaternion& lhs, const Quaternion& rhs);
+MAVSDK_TEST_EXPORT bool operator==(const Quaternion& lhs, const Quaternion& rhs);
 bool operator==(const EulerAngle& lhs, const EulerAngle& rhs);
 
-EulerAngle to_euler_angle_from_quaternion(Quaternion quaternion);
-Quaternion to_quaternion_from_euler_angle(EulerAngle euler_angle);
+MAVSDK_TEST_EXPORT EulerAngle to_euler_angle_from_quaternion(Quaternion quaternion);
+MAVSDK_TEST_EXPORT Quaternion to_quaternion_from_euler_angle(EulerAngle euler_angle);
 
-Quaternion operator*(const Quaternion& lhs, const Quaternion& rhs);
+MAVSDK_TEST_EXPORT Quaternion operator*(const Quaternion& lhs, const Quaternion& rhs);
 
 // Instead of using the constant from math.h or cmath we define it ourselves. This way
 // we don't import all the other C math functions and make sure to use the C++ functions

--- a/src/mavsdk/core/mavlink_channel_status.cpp
+++ b/src/mavsdk/core/mavlink_channel_status.cpp
@@ -1,5 +1,6 @@
 #include "mavlink_include.h"
 
+// Exported via the declaration in mavlink_include.h.in.
 mavlink_status_t* mavlink_get_channel_status(uint8_t chan)
 {
     static mavlink_status_t m_mavlink_status[MAVLINK_COMM_NUM_BUFFERS];

--- a/src/mavsdk/core/mavlink_channels.h
+++ b/src/mavsdk/core/mavlink_channels.h
@@ -2,10 +2,11 @@
 
 #include <cstdint>
 #include <mutex>
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
-class MavlinkChannels {
+class MAVSDK_TEST_EXPORT MavlinkChannels {
 public:
     static MavlinkChannels& Instance()
     {

--- a/src/mavsdk/core/mavlink_component_metadata.h
+++ b/src/mavsdk/core/mavlink_component_metadata.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "callback_list.h"
+#include "mavsdk_export.h"
 #include "file_cache.h"
 #include "mavlink_command_sender.h"
 #include <json/json.h>
@@ -87,7 +88,7 @@ private:
     std::optional<std::string> _json_translation; ///< the final json translation summary
 };
 
-class MavlinkComponentMetadata {
+class MAVSDK_TEST_EXPORT MavlinkComponentMetadata {
 public:
     explicit MavlinkComponentMetadata(SystemImpl& system_impl);
     ~MavlinkComponentMetadata();

--- a/src/mavsdk/core/mavlink_message_handler.h
+++ b/src/mavsdk/core/mavlink_message_handler.h
@@ -6,10 +6,11 @@
 #include <vector>
 #include <optional>
 #include "mavlink_include.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
-class MavlinkMessageHandler {
+class MAVSDK_TEST_EXPORT MavlinkMessageHandler {
 public:
     MavlinkMessageHandler();
 

--- a/src/mavsdk/core/mavlink_mission_transfer_client.h
+++ b/src/mavsdk/core/mavlink_mission_transfer_client.h
@@ -7,6 +7,9 @@
 #include <memory>
 #include <mutex>
 #include <vector>
+#include <asio/io_context.hpp>
+#include <asio/post.hpp>
+#include <deque>
 #include "autopilot.h"
 #include "autopilot_callback.h"
 #include "mavlink_address.h"
@@ -16,10 +19,11 @@
 #include "timeout_s_callback.h"
 #include "locked_queue.h"
 #include "sender.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
-class MavlinkMissionTransferClient {
+class MAVSDK_TEST_EXPORT MavlinkMissionTransferClient {
 public:
     enum class Result {
         Success,

--- a/src/mavsdk/core/mavlink_mission_transfer_client.h
+++ b/src/mavsdk/core/mavlink_mission_transfer_client.h
@@ -7,9 +7,6 @@
 #include <memory>
 #include <mutex>
 #include <vector>
-#include <asio/io_context.hpp>
-#include <asio/post.hpp>
-#include <deque>
 #include "autopilot.h"
 #include "autopilot_callback.h"
 #include "mavlink_address.h"

--- a/src/mavsdk/core/mavlink_mission_transfer_server.h
+++ b/src/mavsdk/core/mavlink_mission_transfer_server.h
@@ -13,10 +13,11 @@
 #include "timeout_s_callback.h"
 #include "locked_queue.h"
 #include "sender.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
-class MavlinkMissionTransferServer {
+class MAVSDK_TEST_EXPORT MavlinkMissionTransferServer {
 public:
     enum class Result {
         Success,

--- a/src/mavsdk/core/mavlink_parameter_cache.h
+++ b/src/mavsdk/core/mavlink_parameter_cache.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "param_value.h"
+#include "mavsdk_export.h"
 
 #include <cstdint>
 #include <limits>
@@ -11,7 +12,7 @@
 
 namespace mavsdk {
 
-class MavlinkParameterCache {
+class MAVSDK_TEST_EXPORT MavlinkParameterCache {
 public:
     struct Param {
         std::string id;

--- a/src/mavsdk/core/mavlink_statustext_handler.h
+++ b/src/mavsdk/core/mavlink_statustext_handler.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include "mavlink_include.h"
+#include "mavsdk_export.h"
 #include <string>
 #include <optional>
 
 namespace mavsdk {
 
-class MavlinkStatustextHandler {
+class MAVSDK_TEST_EXPORT MavlinkStatustextHandler {
 public:
     MavlinkStatustextHandler() = default;
     ~MavlinkStatustextHandler() = default;

--- a/src/mavsdk/core/mavsdk_impl.cpp
+++ b/src/mavsdk/core/mavsdk_impl.cpp
@@ -22,9 +22,11 @@
 #include "embedded_mavlink_xml.h"
 #include <mav/MessageSet.h>
 
+#include "mavsdk_export.h"
+
 namespace mavsdk {
 
-template class CallbackList<>;
+template class MAVSDK_TEMPL_INST CallbackList<>;
 
 MavsdkImpl::MavsdkImpl(const Mavsdk::Configuration& configuration) :
     timeout_handler(time),

--- a/src/mavsdk/core/mavsdk_time.h
+++ b/src/mavsdk/core/mavsdk_time.h
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <mutex>
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -9,7 +10,7 @@ using SteadyTimePoint = std::chrono::time_point<std::chrono::steady_clock>;
 using SystemTimePoint = std::chrono::time_point<std::chrono::system_clock>;
 using AutopilotTimePoint = std::chrono::time_point<std::chrono::system_clock>;
 
-class Time {
+class MAVSDK_TEST_EXPORT Time {
 public:
     Time() = default;
     virtual ~Time() = default;
@@ -31,7 +32,7 @@ public:
     virtual void sleep_for(std::chrono::nanoseconds ns);
 };
 
-class FakeTime : public Time {
+class MAVSDK_TEST_EXPORT FakeTime : public Time {
 public:
     FakeTime();
     ~FakeTime() override = default;

--- a/src/mavsdk/core/param_value.h
+++ b/src/mavsdk/core/param_value.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "mavlink_include.h"
+#include "mavsdk_export.h"
 #include "log.h"
 #include <array>
 #include <cstdint>
@@ -15,7 +16,7 @@ namespace mavsdk {
 /**
  * This is a c++ helper for a mavlink extended or non-extended param value.
  */
-class ParamValue {
+class MAVSDK_TEST_EXPORT ParamValue {
 public:
     bool set_from_mavlink_param_value_bytewise(const mavlink_param_value_t& mavlink_value);
     bool set_from_mavlink_param_value_cast(const mavlink_param_value_t& mavlink_value);
@@ -129,6 +130,6 @@ private:
         _value{};
 };
 
-std::ostream& operator<<(std::ostream& str, const ParamValue& obj);
+MAVSDK_TEST_EXPORT std::ostream& operator<<(std::ostream& str, const ParamValue& obj);
 
 } // namespace mavsdk

--- a/src/mavsdk/core/string_utils.h
+++ b/src/mavsdk/core/string_utils.h
@@ -1,11 +1,12 @@
 #pragma once
 
 #include <string>
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
-bool starts_with(const std::string& str, const std::string& prefix);
+MAVSDK_TEST_EXPORT bool starts_with(const std::string& str, const std::string& prefix);
 
-std::string strip_prefix(const std::string& str, const std::string& prefix);
+MAVSDK_TEST_EXPORT std::string strip_prefix(const std::string& str, const std::string& prefix);
 
 } // namespace mavsdk

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -9,6 +9,7 @@
 #include "ardupilot_custom_mode.h"
 #include "callback_list.tpp"
 #include "unused.h"
+#include "mavsdk_export.h"
 #include <cassert>
 #include <cstdlib>
 #include <functional>
@@ -17,9 +18,9 @@
 
 namespace mavsdk {
 
-template class CallbackList<bool>;
-template class CallbackList<ComponentType>;
-template class CallbackList<ComponentType, uint8_t>;
+template class MAVSDK_TEMPL_INST CallbackList<bool>;
+template class MAVSDK_TEMPL_INST CallbackList<ComponentType>;
+template class MAVSDK_TEMPL_INST CallbackList<ComponentType, uint8_t>;
 
 SystemImpl::SystemImpl(MavsdkImpl& mavsdk_impl) :
     _mavsdk_impl(mavsdk_impl),

--- a/src/mavsdk/core/timeout_handler.h
+++ b/src/mavsdk/core/timeout_handler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "mavsdk_time.h"
+#include "mavsdk_export.h"
 
 #include <cstdint>
 #include <mutex>
@@ -10,7 +11,7 @@
 
 namespace mavsdk {
 
-class TimeoutHandler {
+class MAVSDK_TEST_EXPORT TimeoutHandler {
 public:
     explicit TimeoutHandler(Time& time);
     ~TimeoutHandler() = default;

--- a/src/mavsdk/plugins/action/action.cpp
+++ b/src/mavsdk/plugins/action/action.cpp
@@ -272,7 +272,7 @@ Action::Result Action::set_gps_global_origin(
     return _impl->set_gps_global_origin(latitude_deg, longitude_deg, absolute_altitude_m);
 }
 
-std::ostream& operator<<(std::ostream& str, Action::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Action::Result const& result)
 {
     switch (result) {
         case Action::Result::Unknown:
@@ -310,7 +310,8 @@ std::ostream& operator<<(std::ostream& str, Action::Result const& result)
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Action::OrbitYawBehavior const& orbit_yaw_behavior)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Action::OrbitYawBehavior const& orbit_yaw_behavior)
 {
     switch (orbit_yaw_behavior) {
         case Action::OrbitYawBehavior::HoldFrontToCircleCenter:
@@ -328,7 +329,7 @@ std::ostream& operator<<(std::ostream& str, Action::OrbitYawBehavior const& orbi
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Action::RelayCommand const& relay_command)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Action::RelayCommand const& relay_command)
 {
     switch (relay_command) {
         case Action::RelayCommand::On:

--- a/src/mavsdk/plugins/action/include/plugins/action/action.h
+++ b/src/mavsdk/plugins/action/include/plugins/action/action.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -25,7 +26,7 @@ class ActionImpl;
 /**
  * @brief Enable simple actions such as arming, taking off, and landing.
  */
-class Action : public PluginBase {
+class MAVSDK_PUBLIC Action : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -75,7 +76,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Action::OrbitYawBehavior const& orbit_yaw_behavior);
 
     /**
@@ -91,7 +92,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Action::RelayCommand const& relay_command);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Action::RelayCommand const& relay_command);
 
     /**
      * @brief Possible results returned for action requests.
@@ -120,7 +122,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Action::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Action::Result const& result);
 
     /**
      * @brief Callback type for asynchronous Action calls.

--- a/src/mavsdk/plugins/action_server/action_server.cpp
+++ b/src/mavsdk/plugins/action_server/action_server.cpp
@@ -132,7 +132,7 @@ ActionServer::Result ActionServer::set_flight_mode_internal(FlightMode flight_mo
     return _impl->set_flight_mode_internal(flight_mode);
 }
 
-bool operator==(
+MAVSDK_PUBLIC bool operator==(
     const ActionServer::AllowableFlightModes& lhs, const ActionServer::AllowableFlightModes& rhs)
 {
     return (rhs.can_auto_mode == lhs.can_auto_mode) &&
@@ -144,7 +144,7 @@ bool operator==(
            (rhs.can_auto_loiter_mode == lhs.can_auto_loiter_mode);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, ActionServer::AllowableFlightModes const& allowable_flight_modes)
 {
     str << std::setprecision(15);
@@ -160,12 +160,13 @@ operator<<(std::ostream& str, ActionServer::AllowableFlightModes const& allowabl
     return str;
 }
 
-bool operator==(const ActionServer::ArmDisarm& lhs, const ActionServer::ArmDisarm& rhs)
+MAVSDK_PUBLIC bool
+operator==(const ActionServer::ArmDisarm& lhs, const ActionServer::ArmDisarm& rhs)
 {
     return (rhs.arm == lhs.arm) && (rhs.force == lhs.force);
 }
 
-std::ostream& operator<<(std::ostream& str, ActionServer::ArmDisarm const& arm_disarm)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, ActionServer::ArmDisarm const& arm_disarm)
 {
     str << std::setprecision(15);
     str << "arm_disarm:" << '\n' << "{\n";
@@ -175,7 +176,7 @@ std::ostream& operator<<(std::ostream& str, ActionServer::ArmDisarm const& arm_d
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, ActionServer::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, ActionServer::Result const& result)
 {
     switch (result) {
         case ActionServer::Result::Unknown:
@@ -209,7 +210,8 @@ std::ostream& operator<<(std::ostream& str, ActionServer::Result const& result)
     }
 }
 
-std::ostream& operator<<(std::ostream& str, ActionServer::FlightMode const& flight_mode)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, ActionServer::FlightMode const& flight_mode)
 {
     switch (flight_mode) {
         case ActionServer::FlightMode::Unknown:

--- a/src/mavsdk/plugins/action_server/action_server_impl.cpp
+++ b/src/mavsdk/plugins/action_server/action_server_impl.cpp
@@ -3,12 +3,13 @@
 #include "flight_mode.h"
 #include "callback_list.tpp"
 #include "px4_custom_mode.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
-template class CallbackList<ActionServer::Result, ActionServer::ArmDisarm>;
-template class CallbackList<ActionServer::Result, ActionServer::FlightMode>;
-template class CallbackList<ActionServer::Result, bool>;
+template class MAVSDK_TEMPL_INST CallbackList<ActionServer::Result, ActionServer::ArmDisarm>;
+template class MAVSDK_TEMPL_INST CallbackList<ActionServer::Result, ActionServer::FlightMode>;
+template class MAVSDK_TEMPL_INST CallbackList<ActionServer::Result, bool>;
 
 ActionServer::FlightMode
 ActionServerImpl::telemetry_flight_mode_from_flight_mode(FlightMode flight_mode)

--- a/src/mavsdk/plugins/action_server/include/plugins/action_server/action_server.h
+++ b/src/mavsdk/plugins/action_server/include/plugins/action_server/action_server.h
@@ -16,6 +16,7 @@
 #include "server_plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -25,7 +26,7 @@ class ActionServerImpl;
 /**
  * @brief Provide vehicle actions (as a server) such as arming, taking off, and landing.
  */
-class ActionServer : public ServerPluginBase {
+class MAVSDK_PUBLIC ActionServer : public ServerPluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a ServerComponent instance.
@@ -73,7 +74,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, ActionServer::FlightMode const& flight_mode);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, ActionServer::FlightMode const& flight_mode);
 
     /**
      * @brief State to check if the vehicle can transition to
@@ -94,7 +96,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const ActionServer::AllowableFlightModes& lhs,
         const ActionServer::AllowableFlightModes& rhs);
 
@@ -103,7 +105,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, ActionServer::AllowableFlightModes const& allowable_flight_modes);
 
     /**
@@ -119,14 +121,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const ActionServer::ArmDisarm& lhs, const ActionServer::ArmDisarm& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const ActionServer::ArmDisarm& lhs, const ActionServer::ArmDisarm& rhs);
 
     /**
      * @brief Stream operator to print information about a `ActionServer::ArmDisarm`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, ActionServer::ArmDisarm const& arm_disarm);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, ActionServer::ArmDisarm const& arm_disarm);
 
     /**
      * @brief Possible results returned for action requests.
@@ -154,7 +158,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, ActionServer::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, ActionServer::Result const& result);
 
     /**
      * @brief Callback type for asynchronous ActionServer calls.

--- a/src/mavsdk/plugins/arm_authorizer_server/arm_authorizer_server.cpp
+++ b/src/mavsdk/plugins/arm_authorizer_server/arm_authorizer_server.cpp
@@ -40,7 +40,7 @@ ArmAuthorizerServer::Result ArmAuthorizerServer::reject_arm_authorization(
     return _impl->reject_arm_authorization(temporarily, reason, extra_info);
 }
 
-std::ostream& operator<<(std::ostream& str, ArmAuthorizerServer::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, ArmAuthorizerServer::Result const& result)
 {
     switch (result) {
         case ArmAuthorizerServer::Result::Unknown:
@@ -54,7 +54,7 @@ std::ostream& operator<<(std::ostream& str, ArmAuthorizerServer::Result const& r
     }
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, ArmAuthorizerServer::RejectionReason const& rejection_reason)
 {
     switch (rejection_reason) {

--- a/src/mavsdk/plugins/arm_authorizer_server/include/plugins/arm_authorizer_server/arm_authorizer_server.h
+++ b/src/mavsdk/plugins/arm_authorizer_server/include/plugins/arm_authorizer_server/arm_authorizer_server.h
@@ -17,6 +17,7 @@
 #include "server_plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -26,7 +27,7 @@ class ArmAuthorizerServerImpl;
 /**
  * @brief Use arm authorization.
  */
-class ArmAuthorizerServer : public ServerPluginBase {
+class MAVSDK_PUBLIC ArmAuthorizerServer : public ServerPluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a ServerComponent instance.
@@ -64,7 +65,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, ArmAuthorizerServer::RejectionReason const& rejection_reason);
 
     /**
@@ -81,7 +82,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, ArmAuthorizerServer::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, ArmAuthorizerServer::Result const& result);
 
     /**
      * @brief Callback type for asynchronous ArmAuthorizerServer calls.

--- a/src/mavsdk/plugins/calibration/calibration.cpp
+++ b/src/mavsdk/plugins/calibration/calibration.cpp
@@ -54,7 +54,7 @@ Calibration::Result Calibration::cancel() const
     return _impl->cancel();
 }
 
-std::ostream& operator<<(std::ostream& str, Calibration::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Calibration::Result const& result)
 {
     switch (result) {
         case Calibration::Result::Unknown:
@@ -86,7 +86,8 @@ std::ostream& operator<<(std::ostream& str, Calibration::Result const& result)
     }
 }
 
-bool operator==(const Calibration::ProgressData& lhs, const Calibration::ProgressData& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Calibration::ProgressData& lhs, const Calibration::ProgressData& rhs)
 {
     return (rhs.has_progress == lhs.has_progress) &&
            ((std::isnan(rhs.progress) && std::isnan(lhs.progress)) ||
@@ -94,7 +95,8 @@ bool operator==(const Calibration::ProgressData& lhs, const Calibration::Progres
            (rhs.has_status_text == lhs.has_status_text) && (rhs.status_text == lhs.status_text);
 }
 
-std::ostream& operator<<(std::ostream& str, Calibration::ProgressData const& progress_data)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Calibration::ProgressData const& progress_data)
 {
     str << std::setprecision(15);
     str << "progress_data:" << '\n' << "{\n";

--- a/src/mavsdk/plugins/calibration/calibration_statustext_parser.h
+++ b/src/mavsdk/plugins/calibration/calibration_statustext_parser.h
@@ -2,10 +2,11 @@
 
 #include <string>
 #include <cmath>
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
-class CalibrationStatustextParser {
+class MAVSDK_TEST_EXPORT CalibrationStatustextParser {
 public:
     CalibrationStatustextParser();
     ~CalibrationStatustextParser();

--- a/src/mavsdk/plugins/calibration/include/plugins/calibration/calibration.h
+++ b/src/mavsdk/plugins/calibration/include/plugins/calibration/calibration.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -25,7 +26,7 @@ class CalibrationImpl;
 /**
  * @brief Enable to calibrate sensors of a drone such as gyro, accelerometer, and magnetometer.
  */
-class Calibration : public PluginBase {
+class MAVSDK_PUBLIC Calibration : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -82,7 +83,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Calibration::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Calibration::Result const& result);
 
     /**
      * @brief Progress data coming from calibration.
@@ -103,7 +105,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Calibration::ProgressData& lhs, const Calibration::ProgressData& rhs);
 
     /**
@@ -111,7 +113,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Calibration::ProgressData const& progress_data);
 
     /**

--- a/src/mavsdk/plugins/camera/camera.cpp
+++ b/src/mavsdk/plugins/camera/camera.cpp
@@ -394,12 +394,12 @@ Camera::Result Camera::focus_range(int32_t component_id, float range) const
     return _impl->focus_range(component_id, range);
 }
 
-bool operator==(const Camera::Option& lhs, const Camera::Option& rhs)
+MAVSDK_PUBLIC bool operator==(const Camera::Option& lhs, const Camera::Option& rhs)
 {
     return (rhs.option_id == lhs.option_id) && (rhs.option_description == lhs.option_description);
 }
 
-std::ostream& operator<<(std::ostream& str, Camera::Option const& option)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Camera::Option const& option)
 {
     str << std::setprecision(15);
     str << "option:" << '\n' << "{\n";
@@ -409,14 +409,14 @@ std::ostream& operator<<(std::ostream& str, Camera::Option const& option)
     return str;
 }
 
-bool operator==(const Camera::Setting& lhs, const Camera::Setting& rhs)
+MAVSDK_PUBLIC bool operator==(const Camera::Setting& lhs, const Camera::Setting& rhs)
 {
     return (rhs.setting_id == lhs.setting_id) &&
            (rhs.setting_description == lhs.setting_description) && (rhs.option == lhs.option) &&
            (rhs.is_range == lhs.is_range);
 }
 
-std::ostream& operator<<(std::ostream& str, Camera::Setting const& setting)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Camera::Setting const& setting)
 {
     str << std::setprecision(15);
     str << "setting:" << '\n' << "{\n";
@@ -428,14 +428,15 @@ std::ostream& operator<<(std::ostream& str, Camera::Setting const& setting)
     return str;
 }
 
-bool operator==(const Camera::SettingOptions& lhs, const Camera::SettingOptions& rhs)
+MAVSDK_PUBLIC bool operator==(const Camera::SettingOptions& lhs, const Camera::SettingOptions& rhs)
 {
     return (rhs.component_id == lhs.component_id) && (rhs.setting_id == lhs.setting_id) &&
            (rhs.setting_description == lhs.setting_description) && (rhs.options == lhs.options) &&
            (rhs.is_range == lhs.is_range);
 }
 
-std::ostream& operator<<(std::ostream& str, Camera::SettingOptions const& setting_options)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Camera::SettingOptions const& setting_options)
 {
     str << std::setprecision(15);
     str << "setting_options:" << '\n' << "{\n";
@@ -452,7 +453,8 @@ std::ostream& operator<<(std::ostream& str, Camera::SettingOptions const& settin
     return str;
 }
 
-bool operator==(const Camera::VideoStreamSettings& lhs, const Camera::VideoStreamSettings& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Camera::VideoStreamSettings& lhs, const Camera::VideoStreamSettings& rhs)
 {
     return ((std::isnan(rhs.frame_rate_hz) && std::isnan(lhs.frame_rate_hz)) ||
             rhs.frame_rate_hz == lhs.frame_rate_hz) &&
@@ -464,7 +466,7 @@ bool operator==(const Camera::VideoStreamSettings& lhs, const Camera::VideoStrea
             rhs.horizontal_fov_deg == lhs.horizontal_fov_deg);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, Camera::VideoStreamSettings const& video_stream_settings)
 {
     str << std::setprecision(15);
@@ -481,7 +483,7 @@ operator<<(std::ostream& str, Camera::VideoStreamSettings const& video_stream_se
     return str;
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, Camera::VideoStreamInfo::VideoStreamStatus const& video_stream_status)
 {
     switch (video_stream_status) {
@@ -494,7 +496,7 @@ operator<<(std::ostream& str, Camera::VideoStreamInfo::VideoStreamStatus const& 
     }
 }
 
-std::ostream& operator<<(
+MAVSDK_PUBLIC std::ostream& operator<<(
     std::ostream& str, Camera::VideoStreamInfo::VideoStreamSpectrum const& video_stream_spectrum)
 {
     switch (video_stream_spectrum) {
@@ -508,13 +510,15 @@ std::ostream& operator<<(
             return str << "Unknown";
     }
 }
-bool operator==(const Camera::VideoStreamInfo& lhs, const Camera::VideoStreamInfo& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Camera::VideoStreamInfo& lhs, const Camera::VideoStreamInfo& rhs)
 {
     return (rhs.stream_id == lhs.stream_id) && (rhs.settings == lhs.settings) &&
            (rhs.status == lhs.status) && (rhs.spectrum == lhs.spectrum);
 }
 
-std::ostream& operator<<(std::ostream& str, Camera::VideoStreamInfo const& video_stream_info)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Camera::VideoStreamInfo const& video_stream_info)
 {
     str << std::setprecision(15);
     str << "video_stream_info:" << '\n' << "{\n";
@@ -526,12 +530,12 @@ std::ostream& operator<<(std::ostream& str, Camera::VideoStreamInfo const& video
     return str;
 }
 
-bool operator==(const Camera::ModeUpdate& lhs, const Camera::ModeUpdate& rhs)
+MAVSDK_PUBLIC bool operator==(const Camera::ModeUpdate& lhs, const Camera::ModeUpdate& rhs)
 {
     return (rhs.component_id == lhs.component_id) && (rhs.mode == lhs.mode);
 }
 
-std::ostream& operator<<(std::ostream& str, Camera::ModeUpdate const& mode_update)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Camera::ModeUpdate const& mode_update)
 {
     str << std::setprecision(15);
     str << "mode_update:" << '\n' << "{\n";
@@ -541,13 +545,15 @@ std::ostream& operator<<(std::ostream& str, Camera::ModeUpdate const& mode_updat
     return str;
 }
 
-bool operator==(const Camera::VideoStreamUpdate& lhs, const Camera::VideoStreamUpdate& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Camera::VideoStreamUpdate& lhs, const Camera::VideoStreamUpdate& rhs)
 {
     return (rhs.component_id == lhs.component_id) &&
            (rhs.video_stream_info == lhs.video_stream_info);
 }
 
-std::ostream& operator<<(std::ostream& str, Camera::VideoStreamUpdate const& video_stream_update)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Camera::VideoStreamUpdate const& video_stream_update)
 {
     str << std::setprecision(15);
     str << "video_stream_update:" << '\n' << "{\n";
@@ -557,7 +563,8 @@ std::ostream& operator<<(std::ostream& str, Camera::VideoStreamUpdate const& vid
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, Camera::Storage::StorageStatus const& storage_status)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Camera::Storage::StorageStatus const& storage_status)
 {
     switch (storage_status) {
         case Camera::Storage::StorageStatus::NotAvailable:
@@ -573,7 +580,8 @@ std::ostream& operator<<(std::ostream& str, Camera::Storage::StorageStatus const
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Camera::Storage::StorageType const& storage_type)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Camera::Storage::StorageType const& storage_type)
 {
     switch (storage_type) {
         case Camera::Storage::StorageType::Unknown:
@@ -592,7 +600,7 @@ std::ostream& operator<<(std::ostream& str, Camera::Storage::StorageType const& 
             return str << "Unknown";
     }
 }
-bool operator==(const Camera::Storage& lhs, const Camera::Storage& rhs)
+MAVSDK_PUBLIC bool operator==(const Camera::Storage& lhs, const Camera::Storage& rhs)
 {
     return (rhs.component_id == lhs.component_id) && (rhs.video_on == lhs.video_on) &&
            (rhs.photo_interval_on == lhs.photo_interval_on) &&
@@ -609,7 +617,7 @@ bool operator==(const Camera::Storage& lhs, const Camera::Storage& rhs)
            (rhs.storage_type == lhs.storage_type);
 }
 
-std::ostream& operator<<(std::ostream& str, Camera::Storage const& storage)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Camera::Storage const& storage)
 {
     str << std::setprecision(15);
     str << "storage:" << '\n' << "{\n";
@@ -628,12 +636,13 @@ std::ostream& operator<<(std::ostream& str, Camera::Storage const& storage)
     return str;
 }
 
-bool operator==(const Camera::StorageUpdate& lhs, const Camera::StorageUpdate& rhs)
+MAVSDK_PUBLIC bool operator==(const Camera::StorageUpdate& lhs, const Camera::StorageUpdate& rhs)
 {
     return (rhs.component_id == lhs.component_id) && (rhs.storage == lhs.storage);
 }
 
-std::ostream& operator<<(std::ostream& str, Camera::StorageUpdate const& storage_update)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Camera::StorageUpdate const& storage_update)
 {
     str << std::setprecision(15);
     str << "storage_update:" << '\n' << "{\n";
@@ -643,12 +652,13 @@ std::ostream& operator<<(std::ostream& str, Camera::StorageUpdate const& storage
     return str;
 }
 
-bool operator==(const Camera::CurrentSettingsUpdate& lhs, const Camera::CurrentSettingsUpdate& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Camera::CurrentSettingsUpdate& lhs, const Camera::CurrentSettingsUpdate& rhs)
 {
     return (rhs.component_id == lhs.component_id) && (rhs.current_settings == lhs.current_settings);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, Camera::CurrentSettingsUpdate const& current_settings_update)
 {
     str << std::setprecision(15);
@@ -665,14 +675,14 @@ operator<<(std::ostream& str, Camera::CurrentSettingsUpdate const& current_setti
     return str;
 }
 
-bool operator==(
+MAVSDK_PUBLIC bool operator==(
     const Camera::PossibleSettingOptionsUpdate& lhs,
     const Camera::PossibleSettingOptionsUpdate& rhs)
 {
     return (rhs.component_id == lhs.component_id) && (rhs.setting_options == lhs.setting_options);
 }
 
-std::ostream& operator<<(
+MAVSDK_PUBLIC std::ostream& operator<<(
     std::ostream& str, Camera::PossibleSettingOptionsUpdate const& possible_setting_options_update)
 {
     str << std::setprecision(15);
@@ -689,7 +699,7 @@ std::ostream& operator<<(
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, Camera::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Camera::Result const& result)
 {
     switch (result) {
         case Camera::Result::Unknown:
@@ -723,7 +733,7 @@ std::ostream& operator<<(std::ostream& str, Camera::Result const& result)
     }
 }
 
-bool operator==(const Camera::Position& lhs, const Camera::Position& rhs)
+MAVSDK_PUBLIC bool operator==(const Camera::Position& lhs, const Camera::Position& rhs)
 {
     return ((std::isnan(rhs.latitude_deg) && std::isnan(lhs.latitude_deg)) ||
             rhs.latitude_deg == lhs.latitude_deg) &&
@@ -735,7 +745,7 @@ bool operator==(const Camera::Position& lhs, const Camera::Position& rhs)
             rhs.relative_altitude_m == lhs.relative_altitude_m);
 }
 
-std::ostream& operator<<(std::ostream& str, Camera::Position const& position)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Camera::Position const& position)
 {
     str << std::setprecision(15);
     str << "position:" << '\n' << "{\n";
@@ -747,7 +757,7 @@ std::ostream& operator<<(std::ostream& str, Camera::Position const& position)
     return str;
 }
 
-bool operator==(const Camera::Quaternion& lhs, const Camera::Quaternion& rhs)
+MAVSDK_PUBLIC bool operator==(const Camera::Quaternion& lhs, const Camera::Quaternion& rhs)
 {
     return ((std::isnan(rhs.w) && std::isnan(lhs.w)) || rhs.w == lhs.w) &&
            ((std::isnan(rhs.x) && std::isnan(lhs.x)) || rhs.x == lhs.x) &&
@@ -755,7 +765,7 @@ bool operator==(const Camera::Quaternion& lhs, const Camera::Quaternion& rhs)
            ((std::isnan(rhs.z) && std::isnan(lhs.z)) || rhs.z == lhs.z);
 }
 
-std::ostream& operator<<(std::ostream& str, Camera::Quaternion const& quaternion)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Camera::Quaternion const& quaternion)
 {
     str << std::setprecision(15);
     str << "quaternion:" << '\n' << "{\n";
@@ -767,7 +777,7 @@ std::ostream& operator<<(std::ostream& str, Camera::Quaternion const& quaternion
     return str;
 }
 
-bool operator==(const Camera::EulerAngle& lhs, const Camera::EulerAngle& rhs)
+MAVSDK_PUBLIC bool operator==(const Camera::EulerAngle& lhs, const Camera::EulerAngle& rhs)
 {
     return ((std::isnan(rhs.roll_deg) && std::isnan(lhs.roll_deg)) ||
             rhs.roll_deg == lhs.roll_deg) &&
@@ -776,7 +786,7 @@ bool operator==(const Camera::EulerAngle& lhs, const Camera::EulerAngle& rhs)
            ((std::isnan(rhs.yaw_deg) && std::isnan(lhs.yaw_deg)) || rhs.yaw_deg == lhs.yaw_deg);
 }
 
-std::ostream& operator<<(std::ostream& str, Camera::EulerAngle const& euler_angle)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Camera::EulerAngle const& euler_angle)
 {
     str << std::setprecision(15);
     str << "euler_angle:" << '\n' << "{\n";
@@ -787,7 +797,7 @@ std::ostream& operator<<(std::ostream& str, Camera::EulerAngle const& euler_angl
     return str;
 }
 
-bool operator==(const Camera::CaptureInfo& lhs, const Camera::CaptureInfo& rhs)
+MAVSDK_PUBLIC bool operator==(const Camera::CaptureInfo& lhs, const Camera::CaptureInfo& rhs)
 {
     return (rhs.component_id == lhs.component_id) && (rhs.position == lhs.position) &&
            (rhs.attitude_quaternion == lhs.attitude_quaternion) &&
@@ -796,7 +806,7 @@ bool operator==(const Camera::CaptureInfo& lhs, const Camera::CaptureInfo& rhs)
            (rhs.index == lhs.index) && (rhs.file_url == lhs.file_url);
 }
 
-std::ostream& operator<<(std::ostream& str, Camera::CaptureInfo const& capture_info)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Camera::CaptureInfo const& capture_info)
 {
     str << std::setprecision(15);
     str << "capture_info:" << '\n' << "{\n";
@@ -812,7 +822,7 @@ std::ostream& operator<<(std::ostream& str, Camera::CaptureInfo const& capture_i
     return str;
 }
 
-bool operator==(const Camera::Information& lhs, const Camera::Information& rhs)
+MAVSDK_PUBLIC bool operator==(const Camera::Information& lhs, const Camera::Information& rhs)
 {
     return (rhs.component_id == lhs.component_id) && (rhs.vendor_name == lhs.vendor_name) &&
            (rhs.model_name == lhs.model_name) &&
@@ -827,7 +837,7 @@ bool operator==(const Camera::Information& lhs, const Camera::Information& rhs)
            (rhs.vertical_resolution_px == lhs.vertical_resolution_px);
 }
 
-std::ostream& operator<<(std::ostream& str, Camera::Information const& information)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Camera::Information const& information)
 {
     str << std::setprecision(15);
     str << "information:" << '\n' << "{\n";
@@ -843,12 +853,12 @@ std::ostream& operator<<(std::ostream& str, Camera::Information const& informati
     return str;
 }
 
-bool operator==(const Camera::CameraList& lhs, const Camera::CameraList& rhs)
+MAVSDK_PUBLIC bool operator==(const Camera::CameraList& lhs, const Camera::CameraList& rhs)
 {
     return (rhs.cameras == lhs.cameras);
 }
 
-std::ostream& operator<<(std::ostream& str, Camera::CameraList const& camera_list)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Camera::CameraList const& camera_list)
 {
     str << std::setprecision(15);
     str << "camera_list:" << '\n' << "{\n";
@@ -861,7 +871,7 @@ std::ostream& operator<<(std::ostream& str, Camera::CameraList const& camera_lis
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, Camera::Mode const& mode)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Camera::Mode const& mode)
 {
     switch (mode) {
         case Camera::Mode::Unknown:
@@ -875,7 +885,7 @@ std::ostream& operator<<(std::ostream& str, Camera::Mode const& mode)
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Camera::PhotosRange const& photos_range)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Camera::PhotosRange const& photos_range)
 {
     switch (photos_range) {
         case Camera::PhotosRange::All:

--- a/src/mavsdk/plugins/camera/camera_definition.h
+++ b/src/mavsdk/plugins/camera/camera_definition.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "mavlink_parameter_client.h"
+#include "mavsdk_export.h"
 #include <tinyxml2.h>
 #include <vector>
 #include <memory>
@@ -10,7 +11,7 @@
 #include <utility>
 namespace mavsdk {
 
-class CameraDefinition {
+class MAVSDK_TEST_EXPORT CameraDefinition {
 public:
     CameraDefinition() = default;
     ~CameraDefinition() = default;

--- a/src/mavsdk/plugins/camera/camera_impl.cpp
+++ b/src/mavsdk/plugins/camera/camera_impl.cpp
@@ -22,14 +22,16 @@
 #include <string>
 #include <thread>
 
+#include "mavsdk_export.h"
+
 namespace mavsdk {
 
-template class CallbackList<Camera::Mode>;
-template class CallbackList<std::vector<Camera::Setting>>;
-template class CallbackList<std::vector<Camera::SettingOptions>>;
-template class CallbackList<Camera::CaptureInfo>;
-template class CallbackList<Camera::VideoStreamInfo>;
-template class CallbackList<Camera::Storage>;
+template class MAVSDK_TEMPL_INST CallbackList<Camera::Mode>;
+template class MAVSDK_TEMPL_INST CallbackList<std::vector<Camera::Setting>>;
+template class MAVSDK_TEMPL_INST CallbackList<std::vector<Camera::SettingOptions>>;
+template class MAVSDK_TEMPL_INST CallbackList<Camera::CaptureInfo>;
+template class MAVSDK_TEMPL_INST CallbackList<Camera::VideoStreamInfo>;
+template class MAVSDK_TEMPL_INST CallbackList<Camera::Storage>;
 
 CameraImpl::CameraImpl(System& system) : PluginImplBase(system)
 {

--- a/src/mavsdk/plugins/camera/include/plugins/camera/camera.h
+++ b/src/mavsdk/plugins/camera/include/plugins/camera/camera.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -31,7 +32,7 @@ class CameraImpl;
  * instantiated separately for every camera and the camera selected using
  * `select_camera`.
  */
-class Camera : public PluginBase {
+class MAVSDK_PUBLIC Camera : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -78,7 +79,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Camera::Mode const& mode);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Camera::Mode const& mode);
 
     /**
      * @brief Photos range type.
@@ -93,7 +94,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Camera::PhotosRange const& photos_range);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Camera::PhotosRange const& photos_range);
 
     /**
      * @brief Type to represent a setting option.
@@ -108,14 +110,14 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Camera::Option& lhs, const Camera::Option& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Camera::Option& lhs, const Camera::Option& rhs);
 
     /**
      * @brief Stream operator to print information about a `Camera::Option`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Camera::Option const& option);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Camera::Option const& option);
 
     /**
      * @brief Type to represent a setting with a selected option.
@@ -135,14 +137,15 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Camera::Setting& lhs, const Camera::Setting& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Camera::Setting& lhs, const Camera::Setting& rhs);
 
     /**
      * @brief Stream operator to print information about a `Camera::Setting`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Camera::Setting const& setting);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Camera::Setting const& setting);
 
     /**
      * @brief Type to represent a setting with a list of options to choose from.
@@ -162,14 +165,15 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Camera::SettingOptions& lhs, const Camera::SettingOptions& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Camera::SettingOptions& lhs, const Camera::SettingOptions& rhs);
 
     /**
      * @brief Stream operator to print information about a `Camera::SettingOptions`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Camera::SettingOptions const& setting_options);
 
     /**
@@ -190,7 +194,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Camera::VideoStreamSettings& lhs, const Camera::VideoStreamSettings& rhs);
 
     /**
@@ -198,7 +202,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Camera::VideoStreamSettings const& video_stream_settings);
 
     /**
@@ -218,7 +222,7 @@ public:
          *
          * @return A reference to the stream.
          */
-        friend std::ostream& operator<<(
+        friend MAVSDK_PUBLIC std::ostream& operator<<(
             std::ostream& str,
             Camera::VideoStreamInfo::VideoStreamStatus const& video_stream_status);
 
@@ -236,7 +240,7 @@ public:
          *
          * @return A reference to the stream.
          */
-        friend std::ostream& operator<<(
+        friend MAVSDK_PUBLIC std::ostream& operator<<(
             std::ostream& str,
             Camera::VideoStreamInfo::VideoStreamSpectrum const& video_stream_spectrum);
 
@@ -251,14 +255,15 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Camera::VideoStreamInfo& lhs, const Camera::VideoStreamInfo& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Camera::VideoStreamInfo& lhs, const Camera::VideoStreamInfo& rhs);
 
     /**
      * @brief Stream operator to print information about a `Camera::VideoStreamInfo`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Camera::VideoStreamInfo const& video_stream_info);
 
     /**
@@ -274,14 +279,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Camera::ModeUpdate& lhs, const Camera::ModeUpdate& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Camera::ModeUpdate& lhs, const Camera::ModeUpdate& rhs);
 
     /**
      * @brief Stream operator to print information about a `Camera::ModeUpdate`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Camera::ModeUpdate const& mode_update);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Camera::ModeUpdate const& mode_update);
 
     /**
      * @brief An update about a video stream
@@ -296,7 +303,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Camera::VideoStreamUpdate& lhs, const Camera::VideoStreamUpdate& rhs);
 
     /**
@@ -304,7 +311,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Camera::VideoStreamUpdate const& video_stream_update);
 
     /**
@@ -327,7 +334,7 @@ public:
          *
          * @return A reference to the stream.
          */
-        friend std::ostream&
+        friend MAVSDK_PUBLIC std::ostream&
         operator<<(std::ostream& str, Camera::Storage::StorageStatus const& storage_status);
 
         /**
@@ -347,7 +354,7 @@ public:
          *
          * @return A reference to the stream.
          */
-        friend std::ostream&
+        friend MAVSDK_PUBLIC std::ostream&
         operator<<(std::ostream& str, Camera::Storage::StorageType const& storage_type);
 
         int32_t component_id{}; /**< @brief Component ID */
@@ -369,14 +376,15 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Camera::Storage& lhs, const Camera::Storage& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Camera::Storage& lhs, const Camera::Storage& rhs);
 
     /**
      * @brief Stream operator to print information about a `Camera::Storage`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Camera::Storage const& storage);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Camera::Storage const& storage);
 
     /**
      * @brief An update about storage
@@ -391,14 +399,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Camera::StorageUpdate& lhs, const Camera::StorageUpdate& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Camera::StorageUpdate& lhs, const Camera::StorageUpdate& rhs);
 
     /**
      * @brief Stream operator to print information about a `Camera::StorageUpdate`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Camera::StorageUpdate const& storage_update);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Camera::StorageUpdate const& storage_update);
 
     /**
      * @brief An update about a current setting
@@ -413,7 +423,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Camera::CurrentSettingsUpdate& lhs, const Camera::CurrentSettingsUpdate& rhs);
 
     /**
@@ -421,7 +431,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Camera::CurrentSettingsUpdate const& current_settings_update);
 
     /**
@@ -438,7 +448,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const Camera::PossibleSettingOptionsUpdate& lhs,
         const Camera::PossibleSettingOptionsUpdate& rhs);
 
@@ -447,7 +457,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(
+    friend MAVSDK_PUBLIC std::ostream& operator<<(
         std::ostream& str,
         Camera::PossibleSettingOptionsUpdate const& possible_setting_options_update);
 
@@ -475,7 +485,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Camera::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Camera::Result const& result);
 
     /**
      * @brief Position type in global coordinates.
@@ -492,14 +502,15 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Camera::Position& lhs, const Camera::Position& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Camera::Position& lhs, const Camera::Position& rhs);
 
     /**
      * @brief Stream operator to print information about a `Camera::Position`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Camera::Position const& position);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Camera::Position const& position);
 
     /**
      * @brief Quaternion type.
@@ -523,14 +534,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Camera::Quaternion& lhs, const Camera::Quaternion& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Camera::Quaternion& lhs, const Camera::Quaternion& rhs);
 
     /**
      * @brief Stream operator to print information about a `Camera::Quaternion`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Camera::Quaternion const& quaternion);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Camera::Quaternion const& quaternion);
 
     /**
      * @brief Euler angle type.
@@ -551,14 +564,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Camera::EulerAngle& lhs, const Camera::EulerAngle& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Camera::EulerAngle& lhs, const Camera::EulerAngle& rhs);
 
     /**
      * @brief Stream operator to print information about a `Camera::EulerAngle`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Camera::EulerAngle const& euler_angle);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Camera::EulerAngle const& euler_angle);
 
     /**
      * @brief Information about a picture just captured.
@@ -581,14 +596,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Camera::CaptureInfo& lhs, const Camera::CaptureInfo& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Camera::CaptureInfo& lhs, const Camera::CaptureInfo& rhs);
 
     /**
      * @brief Stream operator to print information about a `Camera::CaptureInfo`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Camera::CaptureInfo const& capture_info);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Camera::CaptureInfo const& capture_info);
 
     /**
      * @brief Type to represent a camera information.
@@ -609,14 +626,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Camera::Information& lhs, const Camera::Information& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Camera::Information& lhs, const Camera::Information& rhs);
 
     /**
      * @brief Stream operator to print information about a `Camera::Information`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Camera::Information const& information);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Camera::Information const& information);
 
     /**
      * @brief Camera list
@@ -630,14 +649,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Camera::CameraList& lhs, const Camera::CameraList& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Camera::CameraList& lhs, const Camera::CameraList& rhs);
 
     /**
      * @brief Stream operator to print information about a `Camera::CameraList`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Camera::CameraList const& camera_list);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Camera::CameraList const& camera_list);
 
     /**
      * @brief Callback type for asynchronous Camera calls.

--- a/src/mavsdk/plugins/camera_server/camera_server.cpp
+++ b/src/mavsdk/plugins/camera_server/camera_server.cpp
@@ -332,7 +332,8 @@ CameraServer::respond_tracking_off_command(CameraFeedback stop_video_feedback) c
     return _impl->respond_tracking_off_command(stop_video_feedback);
 }
 
-bool operator==(const CameraServer::Information& lhs, const CameraServer::Information& rhs)
+MAVSDK_PUBLIC bool
+operator==(const CameraServer::Information& lhs, const CameraServer::Information& rhs)
 {
     return (rhs.vendor_name == lhs.vendor_name) && (rhs.model_name == lhs.model_name) &&
            (rhs.firmware_version == lhs.firmware_version) &&
@@ -352,7 +353,8 @@ bool operator==(const CameraServer::Information& lhs, const CameraServer::Inform
            (rhs.video_in_image_mode_supported == lhs.video_in_image_mode_supported);
 }
 
-std::ostream& operator<<(std::ostream& str, CameraServer::Information const& information)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, CameraServer::Information const& information)
 {
     str << std::setprecision(15);
     str << "information:" << '\n' << "{\n";
@@ -375,12 +377,14 @@ std::ostream& operator<<(std::ostream& str, CameraServer::Information const& inf
     return str;
 }
 
-bool operator==(const CameraServer::VideoStreaming& lhs, const CameraServer::VideoStreaming& rhs)
+MAVSDK_PUBLIC bool
+operator==(const CameraServer::VideoStreaming& lhs, const CameraServer::VideoStreaming& rhs)
 {
     return (rhs.has_rtsp_server == lhs.has_rtsp_server) && (rhs.rtsp_uri == lhs.rtsp_uri);
 }
 
-std::ostream& operator<<(std::ostream& str, CameraServer::VideoStreaming const& video_streaming)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, CameraServer::VideoStreaming const& video_streaming)
 {
     str << std::setprecision(15);
     str << "video_streaming:" << '\n' << "{\n";
@@ -390,7 +394,7 @@ std::ostream& operator<<(std::ostream& str, CameraServer::VideoStreaming const& 
     return str;
 }
 
-bool operator==(const CameraServer::Position& lhs, const CameraServer::Position& rhs)
+MAVSDK_PUBLIC bool operator==(const CameraServer::Position& lhs, const CameraServer::Position& rhs)
 {
     return ((std::isnan(rhs.latitude_deg) && std::isnan(lhs.latitude_deg)) ||
             rhs.latitude_deg == lhs.latitude_deg) &&
@@ -402,7 +406,7 @@ bool operator==(const CameraServer::Position& lhs, const CameraServer::Position&
             rhs.relative_altitude_m == lhs.relative_altitude_m);
 }
 
-std::ostream& operator<<(std::ostream& str, CameraServer::Position const& position)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, CameraServer::Position const& position)
 {
     str << std::setprecision(15);
     str << "position:" << '\n' << "{\n";
@@ -414,7 +418,8 @@ std::ostream& operator<<(std::ostream& str, CameraServer::Position const& positi
     return str;
 }
 
-bool operator==(const CameraServer::Quaternion& lhs, const CameraServer::Quaternion& rhs)
+MAVSDK_PUBLIC bool
+operator==(const CameraServer::Quaternion& lhs, const CameraServer::Quaternion& rhs)
 {
     return ((std::isnan(rhs.w) && std::isnan(lhs.w)) || rhs.w == lhs.w) &&
            ((std::isnan(rhs.x) && std::isnan(lhs.x)) || rhs.x == lhs.x) &&
@@ -422,7 +427,8 @@ bool operator==(const CameraServer::Quaternion& lhs, const CameraServer::Quatern
            ((std::isnan(rhs.z) && std::isnan(lhs.z)) || rhs.z == lhs.z);
 }
 
-std::ostream& operator<<(std::ostream& str, CameraServer::Quaternion const& quaternion)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, CameraServer::Quaternion const& quaternion)
 {
     str << std::setprecision(15);
     str << "quaternion:" << '\n' << "{\n";
@@ -434,14 +440,16 @@ std::ostream& operator<<(std::ostream& str, CameraServer::Quaternion const& quat
     return str;
 }
 
-bool operator==(const CameraServer::CaptureInfo& lhs, const CameraServer::CaptureInfo& rhs)
+MAVSDK_PUBLIC bool
+operator==(const CameraServer::CaptureInfo& lhs, const CameraServer::CaptureInfo& rhs)
 {
     return (rhs.position == lhs.position) && (rhs.attitude_quaternion == lhs.attitude_quaternion) &&
            (rhs.time_utc_us == lhs.time_utc_us) && (rhs.is_success == lhs.is_success) &&
            (rhs.index == lhs.index) && (rhs.file_url == lhs.file_url);
 }
 
-std::ostream& operator<<(std::ostream& str, CameraServer::CaptureInfo const& capture_info)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, CameraServer::CaptureInfo const& capture_info)
 {
     str << std::setprecision(15);
     str << "capture_info:" << '\n' << "{\n";
@@ -455,7 +463,7 @@ std::ostream& operator<<(std::ostream& str, CameraServer::CaptureInfo const& cap
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, CameraServer::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, CameraServer::Result const& result)
 {
     switch (result) {
         case CameraServer::Result::Unknown:
@@ -481,7 +489,7 @@ std::ostream& operator<<(std::ostream& str, CameraServer::Result const& result)
     }
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, CameraServer::StorageInformation::StorageStatus const& storage_status)
 {
     switch (storage_status) {
@@ -498,7 +506,7 @@ operator<<(std::ostream& str, CameraServer::StorageInformation::StorageStatus co
     }
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, CameraServer::StorageInformation::StorageType const& storage_type)
 {
     switch (storage_type) {
@@ -518,8 +526,8 @@ operator<<(std::ostream& str, CameraServer::StorageInformation::StorageType cons
             return str << "Unknown";
     }
 }
-bool operator==(
-    const CameraServer::StorageInformation& lhs, const CameraServer::StorageInformation& rhs)
+MAVSDK_PUBLIC bool
+operator==(const CameraServer::StorageInformation& lhs, const CameraServer::StorageInformation& rhs)
 {
     return ((std::isnan(rhs.used_storage_mib) && std::isnan(lhs.used_storage_mib)) ||
             rhs.used_storage_mib == lhs.used_storage_mib) &&
@@ -535,7 +543,7 @@ bool operator==(
             rhs.write_speed_mib_s == lhs.write_speed_mib_s);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, CameraServer::StorageInformation const& storage_information)
 {
     str << std::setprecision(15);
@@ -552,7 +560,7 @@ operator<<(std::ostream& str, CameraServer::StorageInformation const& storage_in
     return str;
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, CameraServer::CaptureStatus::ImageStatus const& image_status)
 {
     switch (image_status) {
@@ -569,7 +577,7 @@ operator<<(std::ostream& str, CameraServer::CaptureStatus::ImageStatus const& im
     }
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, CameraServer::CaptureStatus::VideoStatus const& video_status)
 {
     switch (video_status) {
@@ -581,7 +589,8 @@ operator<<(std::ostream& str, CameraServer::CaptureStatus::VideoStatus const& vi
             return str << "Unknown";
     }
 }
-bool operator==(const CameraServer::CaptureStatus& lhs, const CameraServer::CaptureStatus& rhs)
+MAVSDK_PUBLIC bool
+operator==(const CameraServer::CaptureStatus& lhs, const CameraServer::CaptureStatus& rhs)
 {
     return ((std::isnan(rhs.image_interval_s) && std::isnan(lhs.image_interval_s)) ||
             rhs.image_interval_s == lhs.image_interval_s) &&
@@ -593,7 +602,8 @@ bool operator==(const CameraServer::CaptureStatus& lhs, const CameraServer::Capt
            (rhs.image_count == lhs.image_count);
 }
 
-std::ostream& operator<<(std::ostream& str, CameraServer::CaptureStatus const& capture_status)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, CameraServer::CaptureStatus const& capture_status)
 {
     str << std::setprecision(15);
     str << "capture_status:" << '\n' << "{\n";
@@ -607,14 +617,16 @@ std::ostream& operator<<(std::ostream& str, CameraServer::CaptureStatus const& c
     return str;
 }
 
-bool operator==(const CameraServer::TrackPoint& lhs, const CameraServer::TrackPoint& rhs)
+MAVSDK_PUBLIC bool
+operator==(const CameraServer::TrackPoint& lhs, const CameraServer::TrackPoint& rhs)
 {
     return ((std::isnan(rhs.point_x) && std::isnan(lhs.point_x)) || rhs.point_x == lhs.point_x) &&
            ((std::isnan(rhs.point_y) && std::isnan(lhs.point_y)) || rhs.point_y == lhs.point_y) &&
            ((std::isnan(rhs.radius) && std::isnan(lhs.radius)) || rhs.radius == lhs.radius);
 }
 
-std::ostream& operator<<(std::ostream& str, CameraServer::TrackPoint const& track_point)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, CameraServer::TrackPoint const& track_point)
 {
     str << std::setprecision(15);
     str << "track_point:" << '\n' << "{\n";
@@ -625,7 +637,8 @@ std::ostream& operator<<(std::ostream& str, CameraServer::TrackPoint const& trac
     return str;
 }
 
-bool operator==(const CameraServer::TrackRectangle& lhs, const CameraServer::TrackRectangle& rhs)
+MAVSDK_PUBLIC bool
+operator==(const CameraServer::TrackRectangle& lhs, const CameraServer::TrackRectangle& rhs)
 {
     return ((std::isnan(rhs.top_left_corner_x) && std::isnan(lhs.top_left_corner_x)) ||
             rhs.top_left_corner_x == lhs.top_left_corner_x) &&
@@ -637,7 +650,8 @@ bool operator==(const CameraServer::TrackRectangle& lhs, const CameraServer::Tra
             rhs.bottom_right_corner_y == lhs.bottom_right_corner_y);
 }
 
-std::ostream& operator<<(std::ostream& str, CameraServer::TrackRectangle const& track_rectangle)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, CameraServer::TrackRectangle const& track_rectangle)
 {
     str << std::setprecision(15);
     str << "track_rectangle:" << '\n' << "{\n";
@@ -649,7 +663,8 @@ std::ostream& operator<<(std::ostream& str, CameraServer::TrackRectangle const& 
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, CameraServer::CameraFeedback const& camera_feedback)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, CameraServer::CameraFeedback const& camera_feedback)
 {
     switch (camera_feedback) {
         case CameraServer::CameraFeedback::Unknown:
@@ -665,7 +680,7 @@ std::ostream& operator<<(std::ostream& str, CameraServer::CameraFeedback const& 
     }
 }
 
-std::ostream& operator<<(std::ostream& str, CameraServer::Mode const& mode)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, CameraServer::Mode const& mode)
 {
     switch (mode) {
         case CameraServer::Mode::Unknown:

--- a/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
+++ b/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
@@ -1,11 +1,12 @@
 #include "camera_server_impl.h"
 #include "callback_list.tpp"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
-template class CallbackList<int32_t>;
-template class CallbackList<CameraServer::TrackPoint>;
-template class CallbackList<CameraServer::TrackRectangle>;
+template class MAVSDK_TEMPL_INST CallbackList<int32_t>;
+template class MAVSDK_TEMPL_INST CallbackList<CameraServer::TrackPoint>;
+template class MAVSDK_TEMPL_INST CallbackList<CameraServer::TrackRectangle>;
 
 CameraServerImpl::CameraServerImpl(std::shared_ptr<ServerComponent> server_component) :
     ServerPluginImplBase(server_component)

--- a/src/mavsdk/plugins/camera_server/include/plugins/camera_server/camera_server.h
+++ b/src/mavsdk/plugins/camera_server/include/plugins/camera_server/camera_server.h
@@ -16,6 +16,7 @@
 #include "server_plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -25,7 +26,7 @@ class CameraServerImpl;
 /**
  * @brief Provides handling of camera interface
  */
-class CameraServer : public ServerPluginBase {
+class MAVSDK_PUBLIC CameraServer : public ServerPluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a ServerComponent instance.
@@ -60,7 +61,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, CameraServer::CameraFeedback const& camera_feedback);
 
     /**
@@ -77,7 +78,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, CameraServer::Mode const& mode);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, CameraServer::Mode const& mode);
 
     /**
      * @brief Type to represent a camera information.
@@ -108,7 +110,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const CameraServer::Information& lhs, const CameraServer::Information& rhs);
 
     /**
@@ -116,7 +118,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, CameraServer::Information const& information);
 
     /**
@@ -132,7 +134,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const CameraServer::VideoStreaming& lhs, const CameraServer::VideoStreaming& rhs);
 
     /**
@@ -140,7 +142,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, CameraServer::VideoStreaming const& video_streaming);
 
     /**
@@ -158,14 +160,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const CameraServer::Position& lhs, const CameraServer::Position& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const CameraServer::Position& lhs, const CameraServer::Position& rhs);
 
     /**
      * @brief Stream operator to print information about a `CameraServer::Position`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, CameraServer::Position const& position);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, CameraServer::Position const& position);
 
     /**
      * @brief Quaternion type.
@@ -189,7 +193,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const CameraServer::Quaternion& lhs, const CameraServer::Quaternion& rhs);
 
     /**
@@ -197,7 +201,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, CameraServer::Quaternion const& quaternion);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, CameraServer::Quaternion const& quaternion);
 
     /**
      * @brief Information about a picture just captured.
@@ -217,7 +222,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const CameraServer::CaptureInfo& lhs, const CameraServer::CaptureInfo& rhs);
 
     /**
@@ -225,7 +230,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, CameraServer::CaptureInfo const& capture_info);
 
     /**
@@ -248,7 +253,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, CameraServer::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, CameraServer::Result const& result);
 
     /**
      * @brief Information about the camera storage.
@@ -270,7 +276,7 @@ public:
          *
          * @return A reference to the stream.
          */
-        friend std::ostream& operator<<(
+        friend MAVSDK_PUBLIC std::ostream& operator<<(
             std::ostream& str,
             CameraServer::StorageInformation::StorageStatus const& storage_status);
 
@@ -291,7 +297,7 @@ public:
          *
          * @return A reference to the stream.
          */
-        friend std::ostream& operator<<(
+        friend MAVSDK_PUBLIC std::ostream& operator<<(
             std::ostream& str, CameraServer::StorageInformation::StorageType const& storage_type);
 
         float used_storage_mib{}; /**< @brief Used storage (in MiB) */
@@ -309,7 +315,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const CameraServer::StorageInformation& lhs, const CameraServer::StorageInformation& rhs);
 
     /**
@@ -317,7 +323,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, CameraServer::StorageInformation const& storage_information);
 
     /**
@@ -339,7 +345,7 @@ public:
          *
          * @return A reference to the stream.
          */
-        friend std::ostream&
+        friend MAVSDK_PUBLIC std::ostream&
         operator<<(std::ostream& str, CameraServer::CaptureStatus::ImageStatus const& image_status);
 
         /**
@@ -355,7 +361,7 @@ public:
          *
          * @return A reference to the stream.
          */
-        friend std::ostream&
+        friend MAVSDK_PUBLIC std::ostream&
         operator<<(std::ostream& str, CameraServer::CaptureStatus::VideoStatus const& video_status);
 
         float image_interval_s{}; /**< @brief Image capture interval (in s) */
@@ -372,7 +378,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const CameraServer::CaptureStatus& lhs, const CameraServer::CaptureStatus& rhs);
 
     /**
@@ -380,7 +386,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, CameraServer::CaptureStatus const& capture_status);
 
     /**
@@ -400,7 +406,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const CameraServer::TrackPoint& lhs, const CameraServer::TrackPoint& rhs);
 
     /**
@@ -408,7 +414,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, CameraServer::TrackPoint const& track_point);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, CameraServer::TrackPoint const& track_point);
 
     /**
      * @brief Rectangle description type
@@ -429,7 +436,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const CameraServer::TrackRectangle& lhs, const CameraServer::TrackRectangle& rhs);
 
     /**
@@ -437,7 +444,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, CameraServer::TrackRectangle const& track_rectangle);
 
     /**

--- a/src/mavsdk/plugins/component_metadata/component_metadata.cpp
+++ b/src/mavsdk/plugins/component_metadata/component_metadata.cpp
@@ -53,13 +53,14 @@ ComponentMetadata::get_metadata(uint32_t compid, MetadataType metadata_type) con
     return _impl->get_metadata(compid, metadata_type);
 }
 
-bool operator==(
-    const ComponentMetadata::MetadataData& lhs, const ComponentMetadata::MetadataData& rhs)
+MAVSDK_PUBLIC bool
+operator==(const ComponentMetadata::MetadataData& lhs, const ComponentMetadata::MetadataData& rhs)
 {
     return (rhs.json_metadata == lhs.json_metadata);
 }
 
-std::ostream& operator<<(std::ostream& str, ComponentMetadata::MetadataData const& metadata_data)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, ComponentMetadata::MetadataData const& metadata_data)
 {
     str << std::setprecision(15);
     str << "metadata_data:" << '\n' << "{\n";
@@ -68,7 +69,7 @@ std::ostream& operator<<(std::ostream& str, ComponentMetadata::MetadataData cons
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, ComponentMetadata::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, ComponentMetadata::Result const& result)
 {
     switch (result) {
         case ComponentMetadata::Result::Success:
@@ -94,14 +95,14 @@ std::ostream& operator<<(std::ostream& str, ComponentMetadata::Result const& res
     }
 }
 
-bool operator==(
+MAVSDK_PUBLIC bool operator==(
     const ComponentMetadata::MetadataUpdate& lhs, const ComponentMetadata::MetadataUpdate& rhs)
 {
     return (rhs.compid == lhs.compid) && (rhs.type == lhs.type) &&
            (rhs.json_metadata == lhs.json_metadata);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, ComponentMetadata::MetadataUpdate const& metadata_update)
 {
     str << std::setprecision(15);
@@ -113,7 +114,8 @@ operator<<(std::ostream& str, ComponentMetadata::MetadataUpdate const& metadata_
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, ComponentMetadata::MetadataType const& metadata_type)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, ComponentMetadata::MetadataType const& metadata_type)
 {
     switch (metadata_type) {
         case ComponentMetadata::MetadataType::AllCompleted:

--- a/src/mavsdk/plugins/component_metadata/include/plugins/component_metadata/component_metadata.h
+++ b/src/mavsdk/plugins/component_metadata/include/plugins/component_metadata/component_metadata.h
@@ -17,6 +17,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -26,7 +27,7 @@ class ComponentMetadataImpl;
 /**
  * @brief Access component metadata json definitions, such as parameters.
  */
-class ComponentMetadata : public PluginBase {
+class MAVSDK_PUBLIC ComponentMetadata : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -75,7 +76,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, ComponentMetadata::MetadataType const& metadata_type);
 
     /**
@@ -90,7 +91,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const ComponentMetadata::MetadataData& lhs, const ComponentMetadata::MetadataData& rhs);
 
     /**
@@ -98,7 +99,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, ComponentMetadata::MetadataData const& metadata_data);
 
     /**
@@ -121,7 +122,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, ComponentMetadata::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, ComponentMetadata::Result const& result);
 
     /**
      * @brief Metadata for a given component and type
@@ -137,7 +139,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const ComponentMetadata::MetadataUpdate& lhs, const ComponentMetadata::MetadataUpdate& rhs);
 
     /**
@@ -145,7 +147,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, ComponentMetadata::MetadataUpdate const& metadata_update);
 
     /**

--- a/src/mavsdk/plugins/component_metadata_server/component_metadata_server.cpp
+++ b/src/mavsdk/plugins/component_metadata_server/component_metadata_server.cpp
@@ -25,13 +25,14 @@ void ComponentMetadataServer::set_metadata(std::vector<Metadata> metadata) const
     _impl->set_metadata(metadata);
 }
 
-bool operator==(
+MAVSDK_PUBLIC bool operator==(
     const ComponentMetadataServer::Metadata& lhs, const ComponentMetadataServer::Metadata& rhs)
 {
     return (rhs.type == lhs.type) && (rhs.json_metadata == lhs.json_metadata);
 }
 
-std::ostream& operator<<(std::ostream& str, ComponentMetadataServer::Metadata const& metadata)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, ComponentMetadataServer::Metadata const& metadata)
 {
     str << std::setprecision(15);
     str << "metadata:" << '\n' << "{\n";
@@ -41,7 +42,7 @@ std::ostream& operator<<(std::ostream& str, ComponentMetadataServer::Metadata co
     return str;
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, ComponentMetadataServer::MetadataType const& metadata_type)
 {
     switch (metadata_type) {

--- a/src/mavsdk/plugins/component_metadata_server/include/plugins/component_metadata_server/component_metadata_server.h
+++ b/src/mavsdk/plugins/component_metadata_server/include/plugins/component_metadata_server/component_metadata_server.h
@@ -17,6 +17,7 @@
 #include "server_plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -26,7 +27,7 @@ class ComponentMetadataServerImpl;
 /**
  * @brief Provide component metadata json definitions, such as parameters.
  */
-class ComponentMetadataServer : public ServerPluginBase {
+class MAVSDK_PUBLIC ComponentMetadataServer : public ServerPluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a ServerComponent instance.
@@ -60,7 +61,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, ComponentMetadataServer::MetadataType const& metadata_type);
 
     /**
@@ -76,7 +77,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const ComponentMetadataServer::Metadata& lhs, const ComponentMetadataServer::Metadata& rhs);
 
     /**
@@ -84,7 +85,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, ComponentMetadataServer::Metadata const& metadata);
 
     /**

--- a/src/mavsdk/plugins/events/events.cpp
+++ b/src/mavsdk/plugins/events/events.cpp
@@ -51,14 +51,14 @@ Events::get_health_and_arming_checks_report() const
     return _impl->get_health_and_arming_checks_report();
 }
 
-bool operator==(const Events::Event& lhs, const Events::Event& rhs)
+MAVSDK_PUBLIC bool operator==(const Events::Event& lhs, const Events::Event& rhs)
 {
     return (rhs.compid == lhs.compid) && (rhs.message == lhs.message) &&
            (rhs.description == lhs.description) && (rhs.log_level == lhs.log_level) &&
            (rhs.event_namespace == lhs.event_namespace) && (rhs.event_name == lhs.event_name);
 }
 
-std::ostream& operator<<(std::ostream& str, Events::Event const& event)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Events::Event const& event)
 {
     str << std::setprecision(15);
     str << "event:" << '\n' << "{\n";
@@ -72,14 +72,14 @@ std::ostream& operator<<(std::ostream& str, Events::Event const& event)
     return str;
 }
 
-bool operator==(
+MAVSDK_PUBLIC bool operator==(
     const Events::HealthAndArmingCheckProblem& lhs, const Events::HealthAndArmingCheckProblem& rhs)
 {
     return (rhs.message == lhs.message) && (rhs.description == lhs.description) &&
            (rhs.log_level == lhs.log_level) && (rhs.health_component == lhs.health_component);
 }
 
-std::ostream& operator<<(
+MAVSDK_PUBLIC std::ostream& operator<<(
     std::ostream& str, Events::HealthAndArmingCheckProblem const& health_and_arming_check_problem)
 {
     str << std::setprecision(15);
@@ -92,14 +92,14 @@ std::ostream& operator<<(
     return str;
 }
 
-bool operator==(
-    const Events::HealthAndArmingCheckMode& lhs, const Events::HealthAndArmingCheckMode& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Events::HealthAndArmingCheckMode& lhs, const Events::HealthAndArmingCheckMode& rhs)
 {
     return (rhs.mode_name == lhs.mode_name) && (rhs.can_arm_or_run == lhs.can_arm_or_run) &&
            (rhs.problems == lhs.problems);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, Events::HealthAndArmingCheckMode const& health_and_arming_check_mode)
 {
     str << std::setprecision(15);
@@ -117,14 +117,15 @@ operator<<(std::ostream& str, Events::HealthAndArmingCheckMode const& health_and
     return str;
 }
 
-bool operator==(const Events::HealthComponentReport& lhs, const Events::HealthComponentReport& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Events::HealthComponentReport& lhs, const Events::HealthComponentReport& rhs)
 {
     return (rhs.name == lhs.name) && (rhs.label == lhs.label) &&
            (rhs.is_present == lhs.is_present) && (rhs.has_error == lhs.has_error) &&
            (rhs.has_warning == lhs.has_warning);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, Events::HealthComponentReport const& health_component_report)
 {
     str << std::setprecision(15);
@@ -138,7 +139,7 @@ operator<<(std::ostream& str, Events::HealthComponentReport const& health_compon
     return str;
 }
 
-bool operator==(
+MAVSDK_PUBLIC bool operator==(
     const Events::HealthAndArmingCheckReport& lhs, const Events::HealthAndArmingCheckReport& rhs)
 {
     return (rhs.current_mode_intention == lhs.current_mode_intention) &&
@@ -146,7 +147,7 @@ bool operator==(
            (rhs.all_problems == lhs.all_problems);
 }
 
-std::ostream& operator<<(
+MAVSDK_PUBLIC std::ostream& operator<<(
     std::ostream& str, Events::HealthAndArmingCheckReport const& health_and_arming_check_report)
 {
     str << std::setprecision(15);
@@ -171,7 +172,7 @@ std::ostream& operator<<(
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, Events::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Events::Result const& result)
 {
     switch (result) {
         case Events::Result::Success:
@@ -197,7 +198,7 @@ std::ostream& operator<<(std::ostream& str, Events::Result const& result)
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Events::LogLevel const& log_level)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Events::LogLevel const& log_level)
 {
     switch (log_level) {
         case Events::LogLevel::Emergency:

--- a/src/mavsdk/plugins/events/include/plugins/events/events.h
+++ b/src/mavsdk/plugins/events/include/plugins/events/events.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -25,7 +26,7 @@ class EventsImpl;
 /**
  * @brief Get event notifications, such as takeoff, or arming checks
  */
-class Events : public PluginBase {
+class MAVSDK_PUBLIC Events : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -77,7 +78,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Events::LogLevel const& log_level);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Events::LogLevel const& log_level);
 
     /**
      * @brief Event type
@@ -97,14 +99,14 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Events::Event& lhs, const Events::Event& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Events::Event& lhs, const Events::Event& rhs);
 
     /**
      * @brief Stream operator to print information about a `Events::Event`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Events::Event const& event);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Events::Event const& event);
 
     /**
      * @brief Health and arming check problem type
@@ -122,7 +124,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const Events::HealthAndArmingCheckProblem& lhs,
         const Events::HealthAndArmingCheckProblem& rhs);
 
@@ -131,7 +133,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(
+    friend MAVSDK_PUBLIC std::ostream& operator<<(
         std::ostream& str,
         Events::HealthAndArmingCheckProblem const& health_and_arming_check_problem);
 
@@ -151,7 +153,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const Events::HealthAndArmingCheckMode& lhs, const Events::HealthAndArmingCheckMode& rhs);
 
     /**
@@ -159,7 +161,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(
+    friend MAVSDK_PUBLIC std::ostream& operator<<(
         std::ostream& str, Events::HealthAndArmingCheckMode const& health_and_arming_check_mode);
 
     /**
@@ -179,7 +181,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Events::HealthComponentReport& lhs, const Events::HealthComponentReport& rhs);
 
     /**
@@ -187,7 +189,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Events::HealthComponentReport const& health_component_report);
 
     /**
@@ -207,7 +209,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const Events::HealthAndArmingCheckReport& lhs,
         const Events::HealthAndArmingCheckReport& rhs);
 
@@ -216,7 +218,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(
+    friend MAVSDK_PUBLIC std::ostream& operator<<(
         std::ostream& str,
         Events::HealthAndArmingCheckReport const& health_and_arming_check_report);
 
@@ -240,7 +242,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Events::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Events::Result const& result);
 
     /**
      * @brief Callback type for asynchronous Events calls.

--- a/src/mavsdk/plugins/failure/failure.cpp
+++ b/src/mavsdk/plugins/failure/failure.cpp
@@ -24,7 +24,7 @@ Failure::inject(FailureUnit failure_unit, FailureType failure_type, int32_t inst
     return _impl->inject(failure_unit, failure_type, instance);
 }
 
-std::ostream& operator<<(std::ostream& str, Failure::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Failure::Result const& result)
 {
     switch (result) {
         case Failure::Result::Unknown:
@@ -48,7 +48,7 @@ std::ostream& operator<<(std::ostream& str, Failure::Result const& result)
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Failure::FailureUnit const& failure_unit)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Failure::FailureUnit const& failure_unit)
 {
     switch (failure_unit) {
         case Failure::FailureUnit::SensorGyro:
@@ -86,7 +86,7 @@ std::ostream& operator<<(std::ostream& str, Failure::FailureUnit const& failure_
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Failure::FailureType const& failure_type)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Failure::FailureType const& failure_type)
 {
     switch (failure_type) {
         case Failure::FailureType::Ok:

--- a/src/mavsdk/plugins/failure/include/plugins/failure/failure.h
+++ b/src/mavsdk/plugins/failure/include/plugins/failure/failure.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -25,7 +26,7 @@ class FailureImpl;
 /**
  * @brief Inject failures into system to test failsafes.
  */
-class Failure : public PluginBase {
+class MAVSDK_PUBLIC Failure : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -84,7 +85,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Failure::FailureUnit const& failure_unit);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Failure::FailureUnit const& failure_unit);
 
     /**
      * @brief A failure type
@@ -105,7 +107,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Failure::FailureType const& failure_type);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Failure::FailureType const& failure_type);
 
     /**
      * @brief Possible results returned for failure requests.
@@ -126,7 +129,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Failure::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Failure::Result const& result);
 
     /**
      * @brief Callback type for asynchronous Failure calls.

--- a/src/mavsdk/plugins/follow_me/follow_me.cpp
+++ b/src/mavsdk/plugins/follow_me/follow_me.cpp
@@ -56,7 +56,7 @@ FollowMe::Result FollowMe::stop() const
     return _impl->stop();
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, FollowMe::Config::FollowAltitudeMode const& follow_altitude_mode)
 {
     switch (follow_altitude_mode) {
@@ -70,7 +70,7 @@ operator<<(std::ostream& str, FollowMe::Config::FollowAltitudeMode const& follow
             return str << "Unknown";
     }
 }
-bool operator==(const FollowMe::Config& lhs, const FollowMe::Config& rhs)
+MAVSDK_PUBLIC bool operator==(const FollowMe::Config& lhs, const FollowMe::Config& rhs)
 {
     return ((std::isnan(rhs.follow_height_m) && std::isnan(lhs.follow_height_m)) ||
             rhs.follow_height_m == lhs.follow_height_m) &&
@@ -85,7 +85,7 @@ bool operator==(const FollowMe::Config& lhs, const FollowMe::Config& rhs)
             rhs.follow_angle_deg == lhs.follow_angle_deg);
 }
 
-std::ostream& operator<<(std::ostream& str, FollowMe::Config const& config)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, FollowMe::Config const& config)
 {
     str << std::setprecision(15);
     str << "config:" << '\n' << "{\n";
@@ -99,7 +99,8 @@ std::ostream& operator<<(std::ostream& str, FollowMe::Config const& config)
     return str;
 }
 
-bool operator==(const FollowMe::TargetLocation& lhs, const FollowMe::TargetLocation& rhs)
+MAVSDK_PUBLIC bool
+operator==(const FollowMe::TargetLocation& lhs, const FollowMe::TargetLocation& rhs)
 {
     return ((std::isnan(rhs.latitude_deg) && std::isnan(lhs.latitude_deg)) ||
             rhs.latitude_deg == lhs.latitude_deg) &&
@@ -115,7 +116,8 @@ bool operator==(const FollowMe::TargetLocation& lhs, const FollowMe::TargetLocat
             rhs.velocity_z_m_s == lhs.velocity_z_m_s);
 }
 
-std::ostream& operator<<(std::ostream& str, FollowMe::TargetLocation const& target_location)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, FollowMe::TargetLocation const& target_location)
 {
     str << std::setprecision(15);
     str << "target_location:" << '\n' << "{\n";
@@ -129,7 +131,7 @@ std::ostream& operator<<(std::ostream& str, FollowMe::TargetLocation const& targ
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, FollowMe::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, FollowMe::Result const& result)
 {
     switch (result) {
         case FollowMe::Result::Unknown:

--- a/src/mavsdk/plugins/follow_me/include/plugins/follow_me/follow_me.h
+++ b/src/mavsdk/plugins/follow_me/include/plugins/follow_me/follow_me.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -26,7 +27,7 @@ class FollowMeImpl;
  * @brief Allow users to command the vehicle to follow a specific target.
  * The target is provided as a GPS coordinate and altitude.
  */
-class FollowMe : public PluginBase {
+class MAVSDK_PUBLIC FollowMe : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -80,7 +81,7 @@ public:
          *
          * @return A reference to the stream.
          */
-        friend std::ostream& operator<<(
+        friend MAVSDK_PUBLIC std::ostream& operator<<(
             std::ostream& str, FollowMe::Config::FollowAltitudeMode const& follow_altitude_mode);
 
         float follow_height_m{
@@ -105,14 +106,15 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const FollowMe::Config& lhs, const FollowMe::Config& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const FollowMe::Config& lhs, const FollowMe::Config& rhs);
 
     /**
      * @brief Stream operator to print information about a `FollowMe::Config`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, FollowMe::Config const& config);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, FollowMe::Config const& config);
 
     /**
      * @brief Target location for the vehicle to follow
@@ -134,7 +136,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const FollowMe::TargetLocation& lhs, const FollowMe::TargetLocation& rhs);
 
     /**
@@ -142,7 +144,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, FollowMe::TargetLocation const& target_location);
 
     /**
@@ -165,7 +167,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, FollowMe::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, FollowMe::Result const& result);
 
     /**
      * @brief Callback type for asynchronous FollowMe calls.

--- a/src/mavsdk/plugins/ftp/ftp.cpp
+++ b/src/mavsdk/plugins/ftp/ftp.cpp
@@ -103,12 +103,13 @@ Ftp::Result Ftp::set_target_compid(uint32_t compid) const
     return _impl->set_target_compid(compid);
 }
 
-bool operator==(const Ftp::ListDirectoryData& lhs, const Ftp::ListDirectoryData& rhs)
+MAVSDK_PUBLIC bool operator==(const Ftp::ListDirectoryData& lhs, const Ftp::ListDirectoryData& rhs)
 {
     return (rhs.dirs == lhs.dirs) && (rhs.files == lhs.files);
 }
 
-std::ostream& operator<<(std::ostream& str, Ftp::ListDirectoryData const& list_directory_data)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Ftp::ListDirectoryData const& list_directory_data)
 {
     str << std::setprecision(15);
     str << "list_directory_data:" << '\n' << "{\n";
@@ -126,12 +127,12 @@ std::ostream& operator<<(std::ostream& str, Ftp::ListDirectoryData const& list_d
     return str;
 }
 
-bool operator==(const Ftp::ProgressData& lhs, const Ftp::ProgressData& rhs)
+MAVSDK_PUBLIC bool operator==(const Ftp::ProgressData& lhs, const Ftp::ProgressData& rhs)
 {
     return (rhs.bytes_transferred == lhs.bytes_transferred) && (rhs.total_bytes == lhs.total_bytes);
 }
 
-std::ostream& operator<<(std::ostream& str, Ftp::ProgressData const& progress_data)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Ftp::ProgressData const& progress_data)
 {
     str << std::setprecision(15);
     str << "progress_data:" << '\n' << "{\n";
@@ -141,7 +142,7 @@ std::ostream& operator<<(std::ostream& str, Ftp::ProgressData const& progress_da
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, Ftp::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Ftp::Result const& result)
 {
     switch (result) {
         case Ftp::Result::Unknown:

--- a/src/mavsdk/plugins/ftp/include/plugins/ftp/ftp.h
+++ b/src/mavsdk/plugins/ftp/include/plugins/ftp/ftp.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -25,7 +26,7 @@ class FtpImpl;
 /**
  * @brief Implements file transfer functionality using MAVLink FTP.
  */
-class Ftp : public PluginBase {
+class MAVSDK_PUBLIC Ftp : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -71,14 +72,15 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Ftp::ListDirectoryData& lhs, const Ftp::ListDirectoryData& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Ftp::ListDirectoryData& lhs, const Ftp::ListDirectoryData& rhs);
 
     /**
      * @brief Stream operator to print information about a `Ftp::ListDirectoryData`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Ftp::ListDirectoryData const& list_directory_data);
 
     /**
@@ -94,14 +96,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Ftp::ProgressData& lhs, const Ftp::ProgressData& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Ftp::ProgressData& lhs, const Ftp::ProgressData& rhs);
 
     /**
      * @brief Stream operator to print information about a `Ftp::ProgressData`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Ftp::ProgressData const& progress_data);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Ftp::ProgressData const& progress_data);
 
     /**
      * @brief Possible results returned for FTP commands
@@ -127,7 +131,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Ftp::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Ftp::Result const& result);
 
     /**
      * @brief Callback type for asynchronous Ftp calls.

--- a/src/mavsdk/plugins/ftp_server/ftp_server.cpp
+++ b/src/mavsdk/plugins/ftp_server/ftp_server.cpp
@@ -21,7 +21,7 @@ FtpServer::Result FtpServer::set_root_dir(std::string path) const
     return _impl->set_root_dir(path);
 }
 
-std::ostream& operator<<(std::ostream& str, FtpServer::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, FtpServer::Result const& result)
 {
     switch (result) {
         case FtpServer::Result::Unknown:

--- a/src/mavsdk/plugins/ftp_server/include/plugins/ftp_server/ftp_server.h
+++ b/src/mavsdk/plugins/ftp_server/include/plugins/ftp_server/ftp_server.h
@@ -16,6 +16,7 @@
 #include "server_plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -25,7 +26,7 @@ class FtpServerImpl;
 /**
  * @brief Provide files or directories to transfer.
  */
-class FtpServer : public ServerPluginBase {
+class MAVSDK_PUBLIC FtpServer : public ServerPluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a ServerComponent instance.
@@ -60,7 +61,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, FtpServer::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, FtpServer::Result const& result);
 
     /**
      * @brief Callback type for asynchronous FtpServer calls.

--- a/src/mavsdk/plugins/geofence/geofence.cpp
+++ b/src/mavsdk/plugins/geofence/geofence.cpp
@@ -53,7 +53,7 @@ Geofence::Result Geofence::clear_geofence() const
     return _impl->clear_geofence();
 }
 
-bool operator==(const Geofence::Point& lhs, const Geofence::Point& rhs)
+MAVSDK_PUBLIC bool operator==(const Geofence::Point& lhs, const Geofence::Point& rhs)
 {
     return ((std::isnan(rhs.latitude_deg) && std::isnan(lhs.latitude_deg)) ||
             rhs.latitude_deg == lhs.latitude_deg) &&
@@ -61,7 +61,7 @@ bool operator==(const Geofence::Point& lhs, const Geofence::Point& rhs)
             rhs.longitude_deg == lhs.longitude_deg);
 }
 
-std::ostream& operator<<(std::ostream& str, Geofence::Point const& point)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Geofence::Point const& point)
 {
     str << std::setprecision(15);
     str << "point:" << '\n' << "{\n";
@@ -71,12 +71,12 @@ std::ostream& operator<<(std::ostream& str, Geofence::Point const& point)
     return str;
 }
 
-bool operator==(const Geofence::Polygon& lhs, const Geofence::Polygon& rhs)
+MAVSDK_PUBLIC bool operator==(const Geofence::Polygon& lhs, const Geofence::Polygon& rhs)
 {
     return (rhs.points == lhs.points) && (rhs.fence_type == lhs.fence_type);
 }
 
-std::ostream& operator<<(std::ostream& str, Geofence::Polygon const& polygon)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Geofence::Polygon const& polygon)
 {
     str << std::setprecision(15);
     str << "polygon:" << '\n' << "{\n";
@@ -90,14 +90,14 @@ std::ostream& operator<<(std::ostream& str, Geofence::Polygon const& polygon)
     return str;
 }
 
-bool operator==(const Geofence::Circle& lhs, const Geofence::Circle& rhs)
+MAVSDK_PUBLIC bool operator==(const Geofence::Circle& lhs, const Geofence::Circle& rhs)
 {
     return (rhs.point == lhs.point) &&
            ((std::isnan(rhs.radius) && std::isnan(lhs.radius)) || rhs.radius == lhs.radius) &&
            (rhs.fence_type == lhs.fence_type);
 }
 
-std::ostream& operator<<(std::ostream& str, Geofence::Circle const& circle)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Geofence::Circle const& circle)
 {
     str << std::setprecision(15);
     str << "circle:" << '\n' << "{\n";
@@ -108,12 +108,13 @@ std::ostream& operator<<(std::ostream& str, Geofence::Circle const& circle)
     return str;
 }
 
-bool operator==(const Geofence::GeofenceData& lhs, const Geofence::GeofenceData& rhs)
+MAVSDK_PUBLIC bool operator==(const Geofence::GeofenceData& lhs, const Geofence::GeofenceData& rhs)
 {
     return (rhs.polygons == lhs.polygons) && (rhs.circles == lhs.circles);
 }
 
-std::ostream& operator<<(std::ostream& str, Geofence::GeofenceData const& geofence_data)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Geofence::GeofenceData const& geofence_data)
 {
     str << std::setprecision(15);
     str << "geofence_data:" << '\n' << "{\n";
@@ -131,7 +132,7 @@ std::ostream& operator<<(std::ostream& str, Geofence::GeofenceData const& geofen
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, Geofence::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Geofence::Result const& result)
 {
     switch (result) {
         case Geofence::Result::Unknown:
@@ -155,7 +156,7 @@ std::ostream& operator<<(std::ostream& str, Geofence::Result const& result)
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Geofence::FenceType const& fence_type)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Geofence::FenceType const& fence_type)
 {
     switch (fence_type) {
         case Geofence::FenceType::Inclusion:

--- a/src/mavsdk/plugins/geofence/include/plugins/geofence/geofence.h
+++ b/src/mavsdk/plugins/geofence/include/plugins/geofence/geofence.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -25,7 +26,7 @@ class GeofenceImpl;
 /**
  * @brief Enable setting a geofence.
  */
-class Geofence : public PluginBase {
+class MAVSDK_PUBLIC Geofence : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -71,7 +72,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Geofence::FenceType const& fence_type);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Geofence::FenceType const& fence_type);
 
     /**
      * @brief Point type.
@@ -86,14 +88,14 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Geofence::Point& lhs, const Geofence::Point& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Geofence::Point& lhs, const Geofence::Point& rhs);
 
     /**
      * @brief Stream operator to print information about a `Geofence::Point`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Geofence::Point const& point);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Geofence::Point const& point);
 
     /**
      * @brief Polygon type.
@@ -108,14 +110,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Geofence::Polygon& lhs, const Geofence::Polygon& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Geofence::Polygon& lhs, const Geofence::Polygon& rhs);
 
     /**
      * @brief Stream operator to print information about a `Geofence::Polygon`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Geofence::Polygon const& polygon);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Geofence::Polygon const& polygon);
 
     /**
      * @brief Circular type.
@@ -131,14 +135,15 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Geofence::Circle& lhs, const Geofence::Circle& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Geofence::Circle& lhs, const Geofence::Circle& rhs);
 
     /**
      * @brief Stream operator to print information about a `Geofence::Circle`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Geofence::Circle const& circle);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Geofence::Circle const& circle);
 
     /**
      * @brief Geofence data type.
@@ -153,14 +158,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Geofence::GeofenceData& lhs, const Geofence::GeofenceData& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Geofence::GeofenceData& lhs, const Geofence::GeofenceData& rhs);
 
     /**
      * @brief Stream operator to print information about a `Geofence::GeofenceData`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Geofence::GeofenceData const& geofence_data);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Geofence::GeofenceData const& geofence_data);
 
     /**
      * @brief Possible results returned for geofence requests.
@@ -181,7 +188,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Geofence::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Geofence::Result const& result);
 
     /**
      * @brief Callback type for asynchronous Geofence calls.

--- a/src/mavsdk/plugins/gimbal/gimbal.cpp
+++ b/src/mavsdk/plugins/gimbal/gimbal.cpp
@@ -163,7 +163,7 @@ std::pair<Gimbal::Result, Gimbal::Attitude> Gimbal::get_attitude(int32_t gimbal_
     return _impl->get_attitude(gimbal_id);
 }
 
-bool operator==(const Gimbal::Quaternion& lhs, const Gimbal::Quaternion& rhs)
+MAVSDK_PUBLIC bool operator==(const Gimbal::Quaternion& lhs, const Gimbal::Quaternion& rhs)
 {
     return ((std::isnan(rhs.w) && std::isnan(lhs.w)) || rhs.w == lhs.w) &&
            ((std::isnan(rhs.x) && std::isnan(lhs.x)) || rhs.x == lhs.x) &&
@@ -171,7 +171,7 @@ bool operator==(const Gimbal::Quaternion& lhs, const Gimbal::Quaternion& rhs)
            ((std::isnan(rhs.z) && std::isnan(lhs.z)) || rhs.z == lhs.z);
 }
 
-std::ostream& operator<<(std::ostream& str, Gimbal::Quaternion const& quaternion)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Gimbal::Quaternion const& quaternion)
 {
     str << std::setprecision(15);
     str << "quaternion:" << '\n' << "{\n";
@@ -183,7 +183,7 @@ std::ostream& operator<<(std::ostream& str, Gimbal::Quaternion const& quaternion
     return str;
 }
 
-bool operator==(const Gimbal::EulerAngle& lhs, const Gimbal::EulerAngle& rhs)
+MAVSDK_PUBLIC bool operator==(const Gimbal::EulerAngle& lhs, const Gimbal::EulerAngle& rhs)
 {
     return ((std::isnan(rhs.roll_deg) && std::isnan(lhs.roll_deg)) ||
             rhs.roll_deg == lhs.roll_deg) &&
@@ -192,7 +192,7 @@ bool operator==(const Gimbal::EulerAngle& lhs, const Gimbal::EulerAngle& rhs)
            ((std::isnan(rhs.yaw_deg) && std::isnan(lhs.yaw_deg)) || rhs.yaw_deg == lhs.yaw_deg);
 }
 
-std::ostream& operator<<(std::ostream& str, Gimbal::EulerAngle const& euler_angle)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Gimbal::EulerAngle const& euler_angle)
 {
     str << std::setprecision(15);
     str << "euler_angle:" << '\n' << "{\n";
@@ -203,7 +203,8 @@ std::ostream& operator<<(std::ostream& str, Gimbal::EulerAngle const& euler_angl
     return str;
 }
 
-bool operator==(const Gimbal::AngularVelocityBody& lhs, const Gimbal::AngularVelocityBody& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Gimbal::AngularVelocityBody& lhs, const Gimbal::AngularVelocityBody& rhs)
 {
     return ((std::isnan(rhs.roll_rad_s) && std::isnan(lhs.roll_rad_s)) ||
             rhs.roll_rad_s == lhs.roll_rad_s) &&
@@ -213,7 +214,7 @@ bool operator==(const Gimbal::AngularVelocityBody& lhs, const Gimbal::AngularVel
             rhs.yaw_rad_s == lhs.yaw_rad_s);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, Gimbal::AngularVelocityBody const& angular_velocity_body)
 {
     str << std::setprecision(15);
@@ -225,7 +226,7 @@ operator<<(std::ostream& str, Gimbal::AngularVelocityBody const& angular_velocit
     return str;
 }
 
-bool operator==(const Gimbal::Attitude& lhs, const Gimbal::Attitude& rhs)
+MAVSDK_PUBLIC bool operator==(const Gimbal::Attitude& lhs, const Gimbal::Attitude& rhs)
 {
     return (rhs.gimbal_id == lhs.gimbal_id) &&
            (rhs.euler_angle_forward == lhs.euler_angle_forward) &&
@@ -235,7 +236,7 @@ bool operator==(const Gimbal::Attitude& lhs, const Gimbal::Attitude& rhs)
            (rhs.angular_velocity == lhs.angular_velocity) && (rhs.timestamp_us == lhs.timestamp_us);
 }
 
-std::ostream& operator<<(std::ostream& str, Gimbal::Attitude const& attitude)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Gimbal::Attitude const& attitude)
 {
     str << std::setprecision(15);
     str << "attitude:" << '\n' << "{\n";
@@ -250,7 +251,7 @@ std::ostream& operator<<(std::ostream& str, Gimbal::Attitude const& attitude)
     return str;
 }
 
-bool operator==(const Gimbal::GimbalItem& lhs, const Gimbal::GimbalItem& rhs)
+MAVSDK_PUBLIC bool operator==(const Gimbal::GimbalItem& lhs, const Gimbal::GimbalItem& rhs)
 {
     return (rhs.gimbal_id == lhs.gimbal_id) && (rhs.vendor_name == lhs.vendor_name) &&
            (rhs.model_name == lhs.model_name) && (rhs.custom_name == lhs.custom_name) &&
@@ -258,7 +259,7 @@ bool operator==(const Gimbal::GimbalItem& lhs, const Gimbal::GimbalItem& rhs)
            (rhs.gimbal_device_id == lhs.gimbal_device_id);
 }
 
-std::ostream& operator<<(std::ostream& str, Gimbal::GimbalItem const& gimbal_item)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Gimbal::GimbalItem const& gimbal_item)
 {
     str << std::setprecision(15);
     str << "gimbal_item:" << '\n' << "{\n";
@@ -272,12 +273,12 @@ std::ostream& operator<<(std::ostream& str, Gimbal::GimbalItem const& gimbal_ite
     return str;
 }
 
-bool operator==(const Gimbal::GimbalList& lhs, const Gimbal::GimbalList& rhs)
+MAVSDK_PUBLIC bool operator==(const Gimbal::GimbalList& lhs, const Gimbal::GimbalList& rhs)
 {
     return (rhs.gimbals == lhs.gimbals);
 }
 
-std::ostream& operator<<(std::ostream& str, Gimbal::GimbalList const& gimbal_list)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Gimbal::GimbalList const& gimbal_list)
 {
     str << std::setprecision(15);
     str << "gimbal_list:" << '\n' << "{\n";
@@ -290,7 +291,7 @@ std::ostream& operator<<(std::ostream& str, Gimbal::GimbalList const& gimbal_lis
     return str;
 }
 
-bool operator==(const Gimbal::ControlStatus& lhs, const Gimbal::ControlStatus& rhs)
+MAVSDK_PUBLIC bool operator==(const Gimbal::ControlStatus& lhs, const Gimbal::ControlStatus& rhs)
 {
     return (rhs.gimbal_id == lhs.gimbal_id) && (rhs.control_mode == lhs.control_mode) &&
            (rhs.sysid_primary_control == lhs.sysid_primary_control) &&
@@ -299,7 +300,8 @@ bool operator==(const Gimbal::ControlStatus& lhs, const Gimbal::ControlStatus& r
            (rhs.compid_secondary_control == lhs.compid_secondary_control);
 }
 
-std::ostream& operator<<(std::ostream& str, Gimbal::ControlStatus const& control_status)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Gimbal::ControlStatus const& control_status)
 {
     str << std::setprecision(15);
     str << "control_status:" << '\n' << "{\n";
@@ -313,7 +315,7 @@ std::ostream& operator<<(std::ostream& str, Gimbal::ControlStatus const& control
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, Gimbal::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Gimbal::Result const& result)
 {
     switch (result) {
         case Gimbal::Result::Unknown:
@@ -335,7 +337,7 @@ std::ostream& operator<<(std::ostream& str, Gimbal::Result const& result)
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Gimbal::GimbalMode const& gimbal_mode)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Gimbal::GimbalMode const& gimbal_mode)
 {
     switch (gimbal_mode) {
         case Gimbal::GimbalMode::YawFollow:
@@ -347,7 +349,7 @@ std::ostream& operator<<(std::ostream& str, Gimbal::GimbalMode const& gimbal_mod
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Gimbal::ControlMode const& control_mode)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Gimbal::ControlMode const& control_mode)
 {
     switch (control_mode) {
         case Gimbal::ControlMode::None:
@@ -361,7 +363,7 @@ std::ostream& operator<<(std::ostream& str, Gimbal::ControlMode const& control_m
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Gimbal::SendMode const& send_mode)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Gimbal::SendMode const& send_mode)
 {
     switch (send_mode) {
         case Gimbal::SendMode::Once:

--- a/src/mavsdk/plugins/gimbal/gimbal_impl.cpp
+++ b/src/mavsdk/plugins/gimbal/gimbal_impl.cpp
@@ -1,5 +1,6 @@
 #include "gimbal_impl.h"
 #include "callback_list.tpp"
+#include "mavsdk_export.h"
 #include "math_utils.h"
 #include <algorithm>
 #include <cassert>
@@ -9,7 +10,7 @@
 
 namespace mavsdk {
 
-template class CallbackList<Gimbal::ControlStatus>;
+template class MAVSDK_TEMPL_INST CallbackList<Gimbal::ControlStatus>;
 
 GimbalImpl::GimbalImpl(System& system) : PluginImplBase(system)
 {

--- a/src/mavsdk/plugins/gimbal/include/plugins/gimbal/gimbal.h
+++ b/src/mavsdk/plugins/gimbal/include/plugins/gimbal/gimbal.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -26,7 +27,7 @@ class GimbalImpl;
  * @brief Provide control over a gimbal within the MAVLink
  * Gimbal Protocol: https://mavlink.io/en/services/gimbal_v2.html
  */
-class Gimbal : public PluginBase {
+class MAVSDK_PUBLIC Gimbal : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -72,7 +73,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Gimbal::GimbalMode const& gimbal_mode);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Gimbal::GimbalMode const& gimbal_mode);
 
     /**
      * @brief Control mode
@@ -88,7 +90,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Gimbal::ControlMode const& control_mode);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Gimbal::ControlMode const& control_mode);
 
     /**
      * @brief The send mode type
@@ -105,7 +108,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Gimbal::SendMode const& send_mode);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Gimbal::SendMode const& send_mode);
 
     /**
      * @brief Quaternion type.
@@ -129,14 +133,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Gimbal::Quaternion& lhs, const Gimbal::Quaternion& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Gimbal::Quaternion& lhs, const Gimbal::Quaternion& rhs);
 
     /**
      * @brief Stream operator to print information about a `Gimbal::Quaternion`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Gimbal::Quaternion const& quaternion);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Gimbal::Quaternion const& quaternion);
 
     /**
      * @brief Euler angle type.
@@ -161,14 +167,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Gimbal::EulerAngle& lhs, const Gimbal::EulerAngle& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Gimbal::EulerAngle& lhs, const Gimbal::EulerAngle& rhs);
 
     /**
      * @brief Stream operator to print information about a `Gimbal::EulerAngle`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Gimbal::EulerAngle const& euler_angle);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Gimbal::EulerAngle const& euler_angle);
 
     /**
      * @brief Gimbal angular rate type
@@ -184,7 +192,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Gimbal::AngularVelocityBody& lhs, const Gimbal::AngularVelocityBody& rhs);
 
     /**
@@ -192,7 +200,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Gimbal::AngularVelocityBody const& angular_velocity_body);
 
     /**
@@ -213,14 +221,15 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Gimbal::Attitude& lhs, const Gimbal::Attitude& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Gimbal::Attitude& lhs, const Gimbal::Attitude& rhs);
 
     /**
      * @brief Stream operator to print information about a `Gimbal::Attitude`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Gimbal::Attitude const& attitude);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Gimbal::Attitude const& attitude);
 
     /**
      * @brief Gimbal list item
@@ -240,14 +249,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Gimbal::GimbalItem& lhs, const Gimbal::GimbalItem& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Gimbal::GimbalItem& lhs, const Gimbal::GimbalItem& rhs);
 
     /**
      * @brief Stream operator to print information about a `Gimbal::GimbalItem`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Gimbal::GimbalItem const& gimbal_item);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Gimbal::GimbalItem const& gimbal_item);
 
     /**
      * @brief Gimbal list
@@ -261,14 +272,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Gimbal::GimbalList& lhs, const Gimbal::GimbalList& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Gimbal::GimbalList& lhs, const Gimbal::GimbalList& rhs);
 
     /**
      * @brief Stream operator to print information about a `Gimbal::GimbalList`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Gimbal::GimbalList const& gimbal_list);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Gimbal::GimbalList const& gimbal_list);
 
     /**
      * @brief Control status
@@ -292,14 +305,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Gimbal::ControlStatus& lhs, const Gimbal::ControlStatus& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Gimbal::ControlStatus& lhs, const Gimbal::ControlStatus& rhs);
 
     /**
      * @brief Stream operator to print information about a `Gimbal::ControlStatus`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Gimbal::ControlStatus const& control_status);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Gimbal::ControlStatus const& control_status);
 
     /**
      * @brief Possible results returned for gimbal commands.
@@ -319,7 +334,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Gimbal::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Gimbal::Result const& result);
 
     /**
      * @brief Callback type for asynchronous Gimbal calls.

--- a/src/mavsdk/plugins/gripper/gripper.cpp
+++ b/src/mavsdk/plugins/gripper/gripper.cpp
@@ -38,7 +38,7 @@ Gripper::Result Gripper::release(uint32_t instance) const
     return _impl->release(instance);
 }
 
-std::ostream& operator<<(std::ostream& str, Gripper::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Gripper::Result const& result)
 {
     switch (result) {
         case Gripper::Result::Unknown:
@@ -60,7 +60,8 @@ std::ostream& operator<<(std::ostream& str, Gripper::Result const& result)
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Gripper::GripperAction const& gripper_action)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Gripper::GripperAction const& gripper_action)
 {
     switch (gripper_action) {
         case Gripper::GripperAction::Release:

--- a/src/mavsdk/plugins/gripper/include/plugins/gripper/gripper.h
+++ b/src/mavsdk/plugins/gripper/include/plugins/gripper/gripper.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -25,7 +26,7 @@ class GripperImpl;
 /**
  * @brief Allows users to send gripper actions.
  */
-class Gripper : public PluginBase {
+class MAVSDK_PUBLIC Gripper : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -74,7 +75,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Gripper::GripperAction const& gripper_action);
 
     /**
@@ -95,7 +96,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Gripper::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Gripper::Result const& result);
 
     /**
      * @brief Callback type for asynchronous Gripper calls.

--- a/src/mavsdk/plugins/info/include/plugins/info/info.h
+++ b/src/mavsdk/plugins/info/include/plugins/info/info.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -25,7 +26,7 @@ class InfoImpl;
 /**
  * @brief Provide information about the hardware and/or software of a system.
  */
-class Info : public PluginBase {
+class MAVSDK_PUBLIC Info : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -74,14 +75,15 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Info::FlightInfo& lhs, const Info::FlightInfo& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Info::FlightInfo& lhs, const Info::FlightInfo& rhs);
 
     /**
      * @brief Stream operator to print information about a `Info::FlightInfo`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Info::FlightInfo const& flight_info);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Info::FlightInfo const& flight_info);
 
     /**
      * @brief System identification.
@@ -99,14 +101,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Info::Identification& lhs, const Info::Identification& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Info::Identification& lhs, const Info::Identification& rhs);
 
     /**
      * @brief Stream operator to print information about a `Info::Identification`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Info::Identification const& identification);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Info::Identification const& identification);
 
     /**
      * @brief System product information.
@@ -123,14 +127,14 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Info::Product& lhs, const Info::Product& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Info::Product& lhs, const Info::Product& rhs);
 
     /**
      * @brief Stream operator to print information about a `Info::Product`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Info::Product const& product);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Info::Product const& product);
 
     /**
      * @brief System version information.
@@ -153,7 +157,7 @@ public:
          *
          * @return A reference to the stream.
          */
-        friend std::ostream& operator<<(
+        friend MAVSDK_PUBLIC std::ostream& operator<<(
             std::ostream& str,
             Info::Version::FlightSoftwareVersionType const& flight_software_version_type);
 
@@ -177,14 +181,14 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Info::Version& lhs, const Info::Version& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Info::Version& lhs, const Info::Version& rhs);
 
     /**
      * @brief Stream operator to print information about a `Info::Version`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Info::Version const& version);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Info::Version const& version);
 
     /**
      * @brief Possible results returned for info requests.
@@ -201,7 +205,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Info::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Info::Result const& result);
 
     /**
      * @brief Callback type for asynchronous Info calls.

--- a/src/mavsdk/plugins/info/info.cpp
+++ b/src/mavsdk/plugins/info/info.cpp
@@ -57,14 +57,14 @@ void Info::unsubscribe_flight_information(FlightInformationHandle handle)
     _impl->unsubscribe_flight_information(handle);
 }
 
-bool operator==(const Info::FlightInfo& lhs, const Info::FlightInfo& rhs)
+MAVSDK_PUBLIC bool operator==(const Info::FlightInfo& lhs, const Info::FlightInfo& rhs)
 {
     return (rhs.time_boot_ms == lhs.time_boot_ms) && (rhs.flight_uid == lhs.flight_uid) &&
            (rhs.duration_since_arming_ms == lhs.duration_since_arming_ms) &&
            (rhs.duration_since_takeoff_ms == lhs.duration_since_takeoff_ms);
 }
 
-std::ostream& operator<<(std::ostream& str, Info::FlightInfo const& flight_info)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Info::FlightInfo const& flight_info)
 {
     str << std::setprecision(15);
     str << "flight_info:" << '\n' << "{\n";
@@ -76,12 +76,13 @@ std::ostream& operator<<(std::ostream& str, Info::FlightInfo const& flight_info)
     return str;
 }
 
-bool operator==(const Info::Identification& lhs, const Info::Identification& rhs)
+MAVSDK_PUBLIC bool operator==(const Info::Identification& lhs, const Info::Identification& rhs)
 {
     return (rhs.hardware_uid == lhs.hardware_uid) && (rhs.legacy_uid == lhs.legacy_uid);
 }
 
-std::ostream& operator<<(std::ostream& str, Info::Identification const& identification)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Info::Identification const& identification)
 {
     str << std::setprecision(15);
     str << "identification:" << '\n' << "{\n";
@@ -91,13 +92,13 @@ std::ostream& operator<<(std::ostream& str, Info::Identification const& identifi
     return str;
 }
 
-bool operator==(const Info::Product& lhs, const Info::Product& rhs)
+MAVSDK_PUBLIC bool operator==(const Info::Product& lhs, const Info::Product& rhs)
 {
     return (rhs.vendor_id == lhs.vendor_id) && (rhs.vendor_name == lhs.vendor_name) &&
            (rhs.product_id == lhs.product_id) && (rhs.product_name == lhs.product_name);
 }
 
-std::ostream& operator<<(std::ostream& str, Info::Product const& product)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Info::Product const& product)
 {
     str << std::setprecision(15);
     str << "product:" << '\n' << "{\n";
@@ -109,7 +110,7 @@ std::ostream& operator<<(std::ostream& str, Info::Product const& product)
     return str;
 }
 
-std::ostream& operator<<(
+MAVSDK_PUBLIC std::ostream& operator<<(
     std::ostream& str, Info::Version::FlightSoftwareVersionType const& flight_software_version_type)
 {
     switch (flight_software_version_type) {
@@ -129,7 +130,7 @@ std::ostream& operator<<(
             return str << "Unknown";
     }
 }
-bool operator==(const Info::Version& lhs, const Info::Version& rhs)
+MAVSDK_PUBLIC bool operator==(const Info::Version& lhs, const Info::Version& rhs)
 {
     return (rhs.flight_sw_major == lhs.flight_sw_major) &&
            (rhs.flight_sw_minor == lhs.flight_sw_minor) &&
@@ -144,7 +145,7 @@ bool operator==(const Info::Version& lhs, const Info::Version& rhs)
            (rhs.flight_sw_version_type == lhs.flight_sw_version_type);
 }
 
-std::ostream& operator<<(std::ostream& str, Info::Version const& version)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Info::Version const& version)
 {
     str << std::setprecision(15);
     str << "version:" << '\n' << "{\n";
@@ -164,7 +165,7 @@ std::ostream& operator<<(std::ostream& str, Info::Version const& version)
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, Info::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Info::Result const& result)
 {
     switch (result) {
         case Info::Result::Unknown:

--- a/src/mavsdk/plugins/info/info_impl.cpp
+++ b/src/mavsdk/plugins/info/info_impl.cpp
@@ -5,10 +5,11 @@
 #include "info_impl.h"
 #include "system.h"
 #include "callback_list.tpp"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
-template class CallbackList<Info::FlightInfo>;
+template class MAVSDK_TEMPL_INST CallbackList<Info::FlightInfo>;
 
 InfoImpl::InfoImpl(System& system) : PluginImplBase(system)
 {

--- a/src/mavsdk/plugins/log_files/include/plugins/log_files/log_files.h
+++ b/src/mavsdk/plugins/log_files/include/plugins/log_files/log_files.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -26,7 +27,7 @@ class LogFilesImpl;
  * @brief Allow to download log files from the vehicle after a flight is complete.
  * For log streaming during flight check the logging plugin.
  */
-class LogFiles : public PluginBase {
+class MAVSDK_PUBLIC LogFiles : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -71,14 +72,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const LogFiles::ProgressData& lhs, const LogFiles::ProgressData& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const LogFiles::ProgressData& lhs, const LogFiles::ProgressData& rhs);
 
     /**
      * @brief Stream operator to print information about a `LogFiles::ProgressData`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, LogFiles::ProgressData const& progress_data);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, LogFiles::ProgressData const& progress_data);
 
     /**
      * @brief Log file entry type.
@@ -95,14 +98,14 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const LogFiles::Entry& lhs, const LogFiles::Entry& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const LogFiles::Entry& lhs, const LogFiles::Entry& rhs);
 
     /**
      * @brief Stream operator to print information about a `LogFiles::Entry`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, LogFiles::Entry const& entry);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, LogFiles::Entry const& entry);
 
     /**
      * @brief Possible results returned for calibration commands
@@ -123,7 +126,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, LogFiles::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, LogFiles::Result const& result);
 
     /**
      * @brief Callback type for asynchronous LogFiles calls.

--- a/src/mavsdk/plugins/log_files/log_files.cpp
+++ b/src/mavsdk/plugins/log_files/log_files.cpp
@@ -42,12 +42,13 @@ LogFiles::Result LogFiles::erase_all_log_files() const
     return _impl->erase_all_log_files();
 }
 
-bool operator==(const LogFiles::ProgressData& lhs, const LogFiles::ProgressData& rhs)
+MAVSDK_PUBLIC bool operator==(const LogFiles::ProgressData& lhs, const LogFiles::ProgressData& rhs)
 {
     return ((std::isnan(rhs.progress) && std::isnan(lhs.progress)) || rhs.progress == lhs.progress);
 }
 
-std::ostream& operator<<(std::ostream& str, LogFiles::ProgressData const& progress_data)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, LogFiles::ProgressData const& progress_data)
 {
     str << std::setprecision(15);
     str << "progress_data:" << '\n' << "{\n";
@@ -56,12 +57,12 @@ std::ostream& operator<<(std::ostream& str, LogFiles::ProgressData const& progre
     return str;
 }
 
-bool operator==(const LogFiles::Entry& lhs, const LogFiles::Entry& rhs)
+MAVSDK_PUBLIC bool operator==(const LogFiles::Entry& lhs, const LogFiles::Entry& rhs)
 {
     return (rhs.id == lhs.id) && (rhs.date == lhs.date) && (rhs.size_bytes == lhs.size_bytes);
 }
 
-std::ostream& operator<<(std::ostream& str, LogFiles::Entry const& entry)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, LogFiles::Entry const& entry)
 {
     str << std::setprecision(15);
     str << "entry:" << '\n' << "{\n";
@@ -72,7 +73,7 @@ std::ostream& operator<<(std::ostream& str, LogFiles::Entry const& entry)
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, LogFiles::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, LogFiles::Result const& result)
 {
     switch (result) {
         case LogFiles::Result::Unknown:

--- a/src/mavsdk/plugins/log_streaming/include/plugins/log_streaming/log_streaming.h
+++ b/src/mavsdk/plugins/log_streaming/include/plugins/log_streaming/log_streaming.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -25,7 +26,7 @@ class LogStreamingImpl;
 /**
  * @brief Provide log streaming data.
  */
-class LogStreaming : public PluginBase {
+class MAVSDK_PUBLIC LogStreaming : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -70,7 +71,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const LogStreaming::LogStreamingRaw& lhs, const LogStreaming::LogStreamingRaw& rhs);
 
     /**
@@ -78,7 +79,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, LogStreaming::LogStreamingRaw const& log_streaming_raw);
 
     /**
@@ -100,7 +101,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, LogStreaming::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, LogStreaming::Result const& result);
 
     /**
      * @brief Callback type for asynchronous LogStreaming calls.

--- a/src/mavsdk/plugins/log_streaming/log_streaming.cpp
+++ b/src/mavsdk/plugins/log_streaming/log_streaming.cpp
@@ -55,12 +55,14 @@ void LogStreaming::unsubscribe_log_streaming_raw(LogStreamingRawHandle handle)
     _impl->unsubscribe_log_streaming_raw(handle);
 }
 
-bool operator==(const LogStreaming::LogStreamingRaw& lhs, const LogStreaming::LogStreamingRaw& rhs)
+MAVSDK_PUBLIC bool
+operator==(const LogStreaming::LogStreamingRaw& lhs, const LogStreaming::LogStreamingRaw& rhs)
 {
     return (rhs.data_base64 == lhs.data_base64);
 }
 
-std::ostream& operator<<(std::ostream& str, LogStreaming::LogStreamingRaw const& log_streaming_raw)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, LogStreaming::LogStreamingRaw const& log_streaming_raw)
 {
     str << std::setprecision(15);
     str << "log_streaming_raw:" << '\n' << "{\n";
@@ -69,7 +71,7 @@ std::ostream& operator<<(std::ostream& str, LogStreaming::LogStreamingRaw const&
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, LogStreaming::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, LogStreaming::Result const& result)
 {
     switch (result) {
         case LogStreaming::Result::Success:

--- a/src/mavsdk/plugins/log_streaming/log_streaming_impl.cpp
+++ b/src/mavsdk/plugins/log_streaming/log_streaming_impl.cpp
@@ -5,11 +5,12 @@
 #include "log_streaming_backend_ardupilot.h"
 #include "plugins/log_streaming/log_streaming.h"
 #include "callback_list.tpp"
+#include "mavsdk_export.h"
 #include "base64.h"
 
 namespace mavsdk {
 
-template class CallbackList<LogStreaming::LogStreamingRaw>;
+template class MAVSDK_TEMPL_INST CallbackList<LogStreaming::LogStreamingRaw>;
 
 LogStreamingImpl::LogStreamingImpl(System& system) : PluginImplBase(system)
 {

--- a/src/mavsdk/plugins/manual_control/include/plugins/manual_control/manual_control.h
+++ b/src/mavsdk/plugins/manual_control/include/plugins/manual_control/manual_control.h
@@ -17,6 +17,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -26,7 +27,7 @@ class ManualControlImpl;
 /**
  * @brief Enable manual control using e.g. a joystick or gamepad.
  */
-class ManualControl : public PluginBase {
+class MAVSDK_PUBLIC ManualControl : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -79,7 +80,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, ManualControl::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, ManualControl::Result const& result);
 
     /**
      * @brief Callback type for asynchronous ManualControl calls.

--- a/src/mavsdk/plugins/manual_control/manual_control.cpp
+++ b/src/mavsdk/plugins/manual_control/manual_control.cpp
@@ -48,7 +48,7 @@ ManualControl::set_manual_control_input(float x, float y, float z, float r) cons
     return _impl->set_manual_control_input(x, y, z, r);
 }
 
-std::ostream& operator<<(std::ostream& str, ManualControl::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, ManualControl::Result const& result)
 {
     switch (result) {
         case ManualControl::Result::Unknown:

--- a/src/mavsdk/plugins/mavlink_direct/include/plugins/mavlink_direct/mavlink_direct.h
+++ b/src/mavsdk/plugins/mavlink_direct/include/plugins/mavlink_direct/mavlink_direct.h
@@ -17,6 +17,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -26,7 +27,7 @@ class MavlinkDirectImpl;
 /**
  * @brief Enable direct MAVLink communication using libmav.
  */
-class MavlinkDirect : public PluginBase {
+class MAVSDK_PUBLIC MavlinkDirect : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -78,7 +79,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const MavlinkDirect::MavlinkMessage& lhs, const MavlinkDirect::MavlinkMessage& rhs);
 
     /**
@@ -86,7 +87,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, MavlinkDirect::MavlinkMessage const& mavlink_message);
 
     /**
@@ -108,7 +109,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, MavlinkDirect::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, MavlinkDirect::Result const& result);
 
     /**
      * @brief Callback type for asynchronous MavlinkDirect calls.

--- a/src/mavsdk/plugins/mavlink_direct/mavlink_direct.cpp
+++ b/src/mavsdk/plugins/mavlink_direct/mavlink_direct.cpp
@@ -45,7 +45,8 @@ MavlinkDirect::Result MavlinkDirect::load_custom_xml(std::string xml_content) co
     return _impl->load_custom_xml(xml_content);
 }
 
-bool operator==(const MavlinkDirect::MavlinkMessage& lhs, const MavlinkDirect::MavlinkMessage& rhs)
+MAVSDK_PUBLIC bool
+operator==(const MavlinkDirect::MavlinkMessage& lhs, const MavlinkDirect::MavlinkMessage& rhs)
 {
     return (rhs.message_name == lhs.message_name) && (rhs.system_id == lhs.system_id) &&
            (rhs.component_id == lhs.component_id) &&
@@ -54,7 +55,8 @@ bool operator==(const MavlinkDirect::MavlinkMessage& lhs, const MavlinkDirect::M
            (rhs.fields_json == lhs.fields_json);
 }
 
-std::ostream& operator<<(std::ostream& str, MavlinkDirect::MavlinkMessage const& mavlink_message)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, MavlinkDirect::MavlinkMessage const& mavlink_message)
 {
     str << std::setprecision(15);
     str << "mavlink_message:" << '\n' << "{\n";
@@ -68,7 +70,7 @@ std::ostream& operator<<(std::ostream& str, MavlinkDirect::MavlinkMessage const&
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, MavlinkDirect::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, MavlinkDirect::Result const& result)
 {
     switch (result) {
         case MavlinkDirect::Result::Unknown:

--- a/src/mavsdk/plugins/mavlink_direct/mavlink_direct_impl.cpp
+++ b/src/mavsdk/plugins/mavlink_direct/mavlink_direct_impl.cpp
@@ -8,10 +8,11 @@
 #include "log.h"
 #include "connection.h"
 #include "callback_list.tpp"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
-template class CallbackList<MavlinkDirect::MavlinkMessage>;
+template class MAVSDK_TEMPL_INST CallbackList<MavlinkDirect::MavlinkMessage>;
 
 MavlinkDirectImpl::MavlinkDirectImpl(System& system) : PluginImplBase(system)
 {

--- a/src/mavsdk/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.h
+++ b/src/mavsdk/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.h
@@ -32,7 +32,7 @@ class MavlinkPassthroughImpl;
  *          - Custom message support via XML loading
  *          - Better language wrapper integration
  */
-class MavlinkPassthrough : public PluginBase {
+class MAVSDK_PUBLIC MavlinkPassthrough : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.

--- a/src/mavsdk/plugins/mavlink_passthrough/mavlink_passthrough_impl.cpp
+++ b/src/mavsdk/plugins/mavlink_passthrough/mavlink_passthrough_impl.cpp
@@ -3,10 +3,11 @@
 #include "plugins/mavlink_passthrough/mavlink_passthrough.h"
 #include "system.h"
 #include "callback_list.tpp"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
-template class CallbackList<const mavlink_message_t&>;
+template class MAVSDK_TEMPL_INST CallbackList<const mavlink_message_t&>;
 
 MavlinkPassthroughImpl::MavlinkPassthroughImpl(System& system) : PluginImplBase(system)
 {

--- a/src/mavsdk/plugins/mission/include/plugins/mission/mission.h
+++ b/src/mavsdk/plugins/mission/include/plugins/mission/mission.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -25,7 +26,7 @@ class MissionImpl;
 /**
  * @brief Enable waypoint missions.
  */
-class Mission : public PluginBase {
+class MAVSDK_PUBLIC Mission : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -86,7 +87,7 @@ public:
          *
          * @return A reference to the stream.
          */
-        friend std::ostream&
+        friend MAVSDK_PUBLIC std::ostream&
         operator<<(std::ostream& str, Mission::MissionItem::CameraAction const& camera_action);
 
         /**
@@ -107,7 +108,7 @@ public:
          *
          * @return A reference to the stream.
          */
-        friend std::ostream&
+        friend MAVSDK_PUBLIC std::ostream&
         operator<<(std::ostream& str, Mission::MissionItem::VehicleAction const& vehicle_action);
 
         double latitude_deg{double(NAN)}; /**< @brief Latitude in degrees (range: -90 to +90) */
@@ -139,14 +140,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Mission::MissionItem& lhs, const Mission::MissionItem& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Mission::MissionItem& lhs, const Mission::MissionItem& rhs);
 
     /**
      * @brief Stream operator to print information about a `Mission::MissionItem`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Mission::MissionItem const& mission_item);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Mission::MissionItem const& mission_item);
 
     /**
      * @brief Mission plan type
@@ -160,14 +163,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Mission::MissionPlan& lhs, const Mission::MissionPlan& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Mission::MissionPlan& lhs, const Mission::MissionPlan& rhs);
 
     /**
      * @brief Stream operator to print information about a `Mission::MissionPlan`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Mission::MissionPlan const& mission_plan);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Mission::MissionPlan const& mission_plan);
 
     /**
      * @brief Mission progress type.
@@ -183,7 +188,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Mission::MissionProgress& lhs, const Mission::MissionProgress& rhs);
 
     /**
@@ -191,7 +196,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Mission::MissionProgress const& mission_progress);
 
     /**
@@ -222,7 +227,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Mission::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Mission::Result const& result);
 
     /**
      * @brief Progress data coming from mission upload.
@@ -236,14 +241,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Mission::ProgressData& lhs, const Mission::ProgressData& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Mission::ProgressData& lhs, const Mission::ProgressData& rhs);
 
     /**
      * @brief Stream operator to print information about a `Mission::ProgressData`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Mission::ProgressData const& progress_data);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Mission::ProgressData const& progress_data);
 
     /**
      * @brief Progress data coming from mission download, or the mission itself (if the transfer
@@ -263,7 +270,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const Mission::ProgressDataOrMission& lhs, const Mission::ProgressDataOrMission& rhs);
 
     /**
@@ -271,7 +278,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Mission::ProgressDataOrMission const& progress_data_or_mission);
 
     /**

--- a/src/mavsdk/plugins/mission/mission.cpp
+++ b/src/mavsdk/plugins/mission/mission.cpp
@@ -138,7 +138,8 @@ Mission::Result Mission::set_return_to_launch_after_mission(bool enable) const
     return _impl->set_return_to_launch_after_mission(enable);
 }
 
-std::ostream& operator<<(std::ostream& str, Mission::MissionItem::CameraAction const& camera_action)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Mission::MissionItem::CameraAction const& camera_action)
 {
     switch (camera_action) {
         case Mission::MissionItem::CameraAction::None:
@@ -162,7 +163,7 @@ std::ostream& operator<<(std::ostream& str, Mission::MissionItem::CameraAction c
     }
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, Mission::MissionItem::VehicleAction const& vehicle_action)
 {
     switch (vehicle_action) {
@@ -180,7 +181,7 @@ operator<<(std::ostream& str, Mission::MissionItem::VehicleAction const& vehicle
             return str << "Unknown";
     }
 }
-bool operator==(const Mission::MissionItem& lhs, const Mission::MissionItem& rhs)
+MAVSDK_PUBLIC bool operator==(const Mission::MissionItem& lhs, const Mission::MissionItem& rhs)
 {
     return ((std::isnan(rhs.latitude_deg) && std::isnan(lhs.latitude_deg)) ||
             (std::fabs(rhs.latitude_deg - lhs.latitude_deg) < 1e-07)) &&
@@ -208,7 +209,7 @@ bool operator==(const Mission::MissionItem& lhs, const Mission::MissionItem& rhs
            (rhs.vehicle_action == lhs.vehicle_action);
 }
 
-std::ostream& operator<<(std::ostream& str, Mission::MissionItem const& mission_item)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Mission::MissionItem const& mission_item)
 {
     str << std::setprecision(15);
     str << "mission_item:" << '\n' << "{\n";
@@ -230,12 +231,12 @@ std::ostream& operator<<(std::ostream& str, Mission::MissionItem const& mission_
     return str;
 }
 
-bool operator==(const Mission::MissionPlan& lhs, const Mission::MissionPlan& rhs)
+MAVSDK_PUBLIC bool operator==(const Mission::MissionPlan& lhs, const Mission::MissionPlan& rhs)
 {
     return (rhs.mission_items == lhs.mission_items);
 }
 
-std::ostream& operator<<(std::ostream& str, Mission::MissionPlan const& mission_plan)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Mission::MissionPlan const& mission_plan)
 {
     str << std::setprecision(15);
     str << "mission_plan:" << '\n' << "{\n";
@@ -249,12 +250,14 @@ std::ostream& operator<<(std::ostream& str, Mission::MissionPlan const& mission_
     return str;
 }
 
-bool operator==(const Mission::MissionProgress& lhs, const Mission::MissionProgress& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Mission::MissionProgress& lhs, const Mission::MissionProgress& rhs)
 {
     return (rhs.current == lhs.current) && (rhs.total == lhs.total);
 }
 
-std::ostream& operator<<(std::ostream& str, Mission::MissionProgress const& mission_progress)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Mission::MissionProgress const& mission_progress)
 {
     str << std::setprecision(15);
     str << "mission_progress:" << '\n' << "{\n";
@@ -264,7 +267,7 @@ std::ostream& operator<<(std::ostream& str, Mission::MissionProgress const& miss
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, Mission::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Mission::Result const& result)
 {
     switch (result) {
         case Mission::Result::Unknown:
@@ -304,12 +307,13 @@ std::ostream& operator<<(std::ostream& str, Mission::Result const& result)
     }
 }
 
-bool operator==(const Mission::ProgressData& lhs, const Mission::ProgressData& rhs)
+MAVSDK_PUBLIC bool operator==(const Mission::ProgressData& lhs, const Mission::ProgressData& rhs)
 {
     return ((std::isnan(rhs.progress) && std::isnan(lhs.progress)) || rhs.progress == lhs.progress);
 }
 
-std::ostream& operator<<(std::ostream& str, Mission::ProgressData const& progress_data)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Mission::ProgressData const& progress_data)
 {
     str << std::setprecision(15);
     str << "progress_data:" << '\n' << "{\n";
@@ -318,8 +322,8 @@ std::ostream& operator<<(std::ostream& str, Mission::ProgressData const& progres
     return str;
 }
 
-bool operator==(
-    const Mission::ProgressDataOrMission& lhs, const Mission::ProgressDataOrMission& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Mission::ProgressDataOrMission& lhs, const Mission::ProgressDataOrMission& rhs)
 {
     return (rhs.has_progress == lhs.has_progress) &&
            ((std::isnan(rhs.progress) && std::isnan(lhs.progress)) ||
@@ -327,7 +331,7 @@ bool operator==(
            (rhs.has_mission == lhs.has_mission) && (rhs.mission_plan == lhs.mission_plan);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, Mission::ProgressDataOrMission const& progress_data_or_mission)
 {
     str << std::setprecision(15);

--- a/src/mavsdk/plugins/mission/mission_impl.cpp
+++ b/src/mavsdk/plugins/mission/mission_impl.cpp
@@ -2,12 +2,13 @@
 #include "system.h"
 #include "unused.h"
 #include "callback_list.tpp"
+#include "mavsdk_export.h"
 #include <algorithm>
 #include <cmath>
 
 namespace mavsdk {
 
-template class CallbackList<Mission::MissionProgress>;
+template class MAVSDK_TEMPL_INST CallbackList<Mission::MissionProgress>;
 
 using MissionItem = Mission::MissionItem;
 using CameraAction = Mission::MissionItem::CameraAction;

--- a/src/mavsdk/plugins/mission_raw/include/plugins/mission_raw/mission_raw.h
+++ b/src/mavsdk/plugins/mission_raw/include/plugins/mission_raw/mission_raw.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -25,7 +26,7 @@ class MissionRawImpl;
 /**
  * @brief Enable raw missions as exposed by MAVLink.
  */
-class MissionRaw : public PluginBase {
+class MAVSDK_PUBLIC MissionRaw : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -72,7 +73,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const MissionRaw::MissionProgress& lhs, const MissionRaw::MissionProgress& rhs);
 
     /**
@@ -80,7 +81,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, MissionRaw::MissionProgress const& mission_progress);
 
     /**
@@ -110,14 +111,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const MissionRaw::MissionItem& lhs, const MissionRaw::MissionItem& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const MissionRaw::MissionItem& lhs, const MissionRaw::MissionItem& rhs);
 
     /**
      * @brief Stream operator to print information about a `MissionRaw::MissionItem`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, MissionRaw::MissionItem const& mission_item);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, MissionRaw::MissionItem const& mission_item);
 
     /**
      * @brief Mission import data
@@ -133,7 +136,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const MissionRaw::MissionImportData& lhs, const MissionRaw::MissionImportData& rhs);
 
     /**
@@ -141,7 +144,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, MissionRaw::MissionImportData const& mission_import_data);
 
     /**
@@ -177,7 +180,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, MissionRaw::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, MissionRaw::Result const& result);
 
     /**
      * @brief Callback type for asynchronous MissionRaw calls.

--- a/src/mavsdk/plugins/mission_raw/mission_import.h
+++ b/src/mavsdk/plugins/mission_raw/mission_import.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "plugins/mission_raw/mission_raw.h"
+#include "mavsdk_export.h"
 #include "sender.h"
 #include "autopilot.h"
 #include <optional>
@@ -10,7 +11,7 @@
 
 namespace mavsdk {
 
-class MissionImport {
+class MAVSDK_TEST_EXPORT MissionImport {
 public:
     static std::pair<MissionRaw::Result, MissionRaw::MissionImportData>
     parse_json(const std::string& raw_json, Autopilot autopilot);

--- a/src/mavsdk/plugins/mission_raw/mission_raw.cpp
+++ b/src/mavsdk/plugins/mission_raw/mission_raw.cpp
@@ -197,12 +197,14 @@ std::pair<MissionRaw::Result, bool> MissionRaw::is_mission_finished() const
     return _impl->is_mission_finished();
 }
 
-bool operator==(const MissionRaw::MissionProgress& lhs, const MissionRaw::MissionProgress& rhs)
+MAVSDK_PUBLIC bool
+operator==(const MissionRaw::MissionProgress& lhs, const MissionRaw::MissionProgress& rhs)
 {
     return (rhs.current == lhs.current) && (rhs.total == lhs.total);
 }
 
-std::ostream& operator<<(std::ostream& str, MissionRaw::MissionProgress const& mission_progress)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, MissionRaw::MissionProgress const& mission_progress)
 {
     str << std::setprecision(15);
     str << "mission_progress:" << '\n' << "{\n";
@@ -212,7 +214,8 @@ std::ostream& operator<<(std::ostream& str, MissionRaw::MissionProgress const& m
     return str;
 }
 
-bool operator==(const MissionRaw::MissionItem& lhs, const MissionRaw::MissionItem& rhs)
+MAVSDK_PUBLIC bool
+operator==(const MissionRaw::MissionItem& lhs, const MissionRaw::MissionItem& rhs)
 {
     return (rhs.seq == lhs.seq) && (rhs.frame == lhs.frame) && (rhs.command == lhs.command) &&
            (rhs.current == lhs.current) && (rhs.autocontinue == lhs.autocontinue) &&
@@ -225,7 +228,8 @@ bool operator==(const MissionRaw::MissionItem& lhs, const MissionRaw::MissionIte
            (rhs.mission_type == lhs.mission_type);
 }
 
-std::ostream& operator<<(std::ostream& str, MissionRaw::MissionItem const& mission_item)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, MissionRaw::MissionItem const& mission_item)
 {
     str << std::setprecision(15);
     str << "mission_item:" << '\n' << "{\n";
@@ -246,13 +250,14 @@ std::ostream& operator<<(std::ostream& str, MissionRaw::MissionItem const& missi
     return str;
 }
 
-bool operator==(const MissionRaw::MissionImportData& lhs, const MissionRaw::MissionImportData& rhs)
+MAVSDK_PUBLIC bool
+operator==(const MissionRaw::MissionImportData& lhs, const MissionRaw::MissionImportData& rhs)
 {
     return (rhs.mission_items == lhs.mission_items) && (rhs.geofence_items == lhs.geofence_items) &&
            (rhs.rally_items == lhs.rally_items);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, MissionRaw::MissionImportData const& mission_import_data)
 {
     str << std::setprecision(15);
@@ -282,7 +287,7 @@ operator<<(std::ostream& str, MissionRaw::MissionImportData const& mission_impor
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, MissionRaw::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, MissionRaw::Result const& result)
 {
     switch (result) {
         case MissionRaw::Result::Unknown:

--- a/src/mavsdk/plugins/mission_raw/mission_raw_impl.cpp
+++ b/src/mavsdk/plugins/mission_raw/mission_raw_impl.cpp
@@ -6,10 +6,12 @@
 #include <fstream> // for `std::ifstream`
 #include <sstream> // for `std::stringstream`
 
+#include "mavsdk_export.h"
+
 namespace mavsdk {
 
-template class CallbackList<MissionRaw::MissionProgress>;
-template class CallbackList<bool>;
+template class MAVSDK_TEMPL_INST CallbackList<MissionRaw::MissionProgress>;
+template class MAVSDK_TEMPL_INST CallbackList<bool>;
 
 // This is an empty item that can be sent to ArduPilot to mimic clearing of mission.
 constexpr MissionRaw::MissionItem empty_item{0, 3, 16, 1};

--- a/src/mavsdk/plugins/mission_raw_server/include/plugins/mission_raw_server/mission_raw_server.h
+++ b/src/mavsdk/plugins/mission_raw_server/include/plugins/mission_raw_server/mission_raw_server.h
@@ -17,6 +17,7 @@
 #include "server_plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -27,7 +28,7 @@ class MissionRawServerImpl;
  * @brief Acts as a vehicle and receives incoming missions from GCS (in raw MAVLINK format).
  * Provides current mission item state, so the server can progress through missions.
  */
-class MissionRawServer : public ServerPluginBase {
+class MAVSDK_PUBLIC MissionRawServer : public ServerPluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a ServerComponent instance.
@@ -74,7 +75,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const MissionRawServer::MissionItem& lhs, const MissionRawServer::MissionItem& rhs);
 
     /**
@@ -82,7 +83,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, MissionRawServer::MissionItem const& mission_item);
 
     /**
@@ -97,7 +98,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const MissionRawServer::MissionPlan& lhs, const MissionRawServer::MissionPlan& rhs);
 
     /**
@@ -105,7 +106,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, MissionRawServer::MissionPlan const& mission_plan);
 
     /**
@@ -122,7 +123,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const MissionRawServer::MissionProgress& lhs, const MissionRawServer::MissionProgress& rhs);
 
     /**
@@ -130,7 +131,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, MissionRawServer::MissionProgress const& mission_progress);
 
     /**
@@ -158,7 +159,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, MissionRawServer::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, MissionRawServer::Result const& result);
 
     /**
      * @brief Callback type for asynchronous MissionRawServer calls.

--- a/src/mavsdk/plugins/mission_raw_server/mission_raw_server.cpp
+++ b/src/mavsdk/plugins/mission_raw_server/mission_raw_server.cpp
@@ -59,7 +59,8 @@ void MissionRawServer::unsubscribe_clear_all(ClearAllHandle handle)
     _impl->unsubscribe_clear_all(handle);
 }
 
-bool operator==(const MissionRawServer::MissionItem& lhs, const MissionRawServer::MissionItem& rhs)
+MAVSDK_PUBLIC bool
+operator==(const MissionRawServer::MissionItem& lhs, const MissionRawServer::MissionItem& rhs)
 {
     return (rhs.seq == lhs.seq) && (rhs.frame == lhs.frame) && (rhs.command == lhs.command) &&
            (rhs.current == lhs.current) && (rhs.autocontinue == lhs.autocontinue) &&
@@ -72,7 +73,8 @@ bool operator==(const MissionRawServer::MissionItem& lhs, const MissionRawServer
            (rhs.mission_type == lhs.mission_type);
 }
 
-std::ostream& operator<<(std::ostream& str, MissionRawServer::MissionItem const& mission_item)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, MissionRawServer::MissionItem const& mission_item)
 {
     str << std::setprecision(15);
     str << "mission_item:" << '\n' << "{\n";
@@ -93,12 +95,14 @@ std::ostream& operator<<(std::ostream& str, MissionRawServer::MissionItem const&
     return str;
 }
 
-bool operator==(const MissionRawServer::MissionPlan& lhs, const MissionRawServer::MissionPlan& rhs)
+MAVSDK_PUBLIC bool
+operator==(const MissionRawServer::MissionPlan& lhs, const MissionRawServer::MissionPlan& rhs)
 {
     return (rhs.mission_items == lhs.mission_items);
 }
 
-std::ostream& operator<<(std::ostream& str, MissionRawServer::MissionPlan const& mission_plan)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, MissionRawServer::MissionPlan const& mission_plan)
 {
     str << std::setprecision(15);
     str << "mission_plan:" << '\n' << "{\n";
@@ -112,13 +116,13 @@ std::ostream& operator<<(std::ostream& str, MissionRawServer::MissionPlan const&
     return str;
 }
 
-bool operator==(
+MAVSDK_PUBLIC bool operator==(
     const MissionRawServer::MissionProgress& lhs, const MissionRawServer::MissionProgress& rhs)
 {
     return (rhs.current == lhs.current) && (rhs.total == lhs.total);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, MissionRawServer::MissionProgress const& mission_progress)
 {
     str << std::setprecision(15);
@@ -129,7 +133,7 @@ operator<<(std::ostream& str, MissionRawServer::MissionProgress const& mission_p
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, MissionRawServer::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, MissionRawServer::Result const& result)
 {
     switch (result) {
         case MissionRawServer::Result::Unknown:

--- a/src/mavsdk/plugins/mission_raw_server/mission_raw_server_impl.cpp
+++ b/src/mavsdk/plugins/mission_raw_server/mission_raw_server_impl.cpp
@@ -1,12 +1,14 @@
 #include "mission_raw_server_impl.h"
 #include "callback_list.tpp"
+#include "mavsdk_export.h"
 #include "mavlink_address.h"
 
 namespace mavsdk {
 
-template class CallbackList<MissionRawServer::Result, MissionRawServer::MissionPlan>;
-template class CallbackList<MissionRawServer::MissionItem>;
-template class CallbackList<uint32_t>;
+template class MAVSDK_TEMPL_INST
+    CallbackList<MissionRawServer::Result, MissionRawServer::MissionPlan>;
+template class MAVSDK_TEMPL_INST CallbackList<MissionRawServer::MissionItem>;
+template class MAVSDK_TEMPL_INST CallbackList<uint32_t>;
 
 MissionRawServerImpl::MissionRawServerImpl(std::shared_ptr<ServerComponent> server_component) :
     ServerPluginImplBase(server_component)

--- a/src/mavsdk/plugins/mocap/include/plugins/mocap/mocap.h
+++ b/src/mavsdk/plugins/mocap/include/plugins/mocap/mocap.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -27,7 +28,7 @@ class MocapImpl;
  * order to allow navigation without global positioning sources available
  * (e.g. indoors, or when flying under a bridge. etc.).
  */
-class Mocap : public PluginBase {
+class MAVSDK_PUBLIC Mocap : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -74,14 +75,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Mocap::PositionBody& lhs, const Mocap::PositionBody& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Mocap::PositionBody& lhs, const Mocap::PositionBody& rhs);
 
     /**
      * @brief Stream operator to print information about a `Mocap::PositionBody`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Mocap::PositionBody const& position_body);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Mocap::PositionBody const& position_body);
 
     /**
      * @brief Body angle type
@@ -97,14 +100,15 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Mocap::AngleBody& lhs, const Mocap::AngleBody& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Mocap::AngleBody& lhs, const Mocap::AngleBody& rhs);
 
     /**
      * @brief Stream operator to print information about a `Mocap::AngleBody`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Mocap::AngleBody const& angle_body);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Mocap::AngleBody const& angle_body);
 
     /**
      * @brief Speed type, represented in the Body (X Y Z) frame and in metres/second.
@@ -120,14 +124,15 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Mocap::SpeedBody& lhs, const Mocap::SpeedBody& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Mocap::SpeedBody& lhs, const Mocap::SpeedBody& rhs);
 
     /**
      * @brief Stream operator to print information about a `Mocap::SpeedBody`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Mocap::SpeedBody const& speed_body);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Mocap::SpeedBody const& speed_body);
 
     /**
      * @brief Speed type, represented in NED (North East Down) coordinates.
@@ -143,14 +148,15 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Mocap::SpeedNed& lhs, const Mocap::SpeedNed& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Mocap::SpeedNed& lhs, const Mocap::SpeedNed& rhs);
 
     /**
      * @brief Stream operator to print information about a `Mocap::SpeedNed`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Mocap::SpeedNed const& speed_ned);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Mocap::SpeedNed const& speed_ned);
 
     /**
      * @brief Angular velocity type
@@ -166,7 +172,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Mocap::AngularVelocityBody& lhs, const Mocap::AngularVelocityBody& rhs);
 
     /**
@@ -174,7 +180,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Mocap::AngularVelocityBody const& angular_velocity_body);
 
     /**
@@ -192,14 +198,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Mocap::Covariance& lhs, const Mocap::Covariance& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Mocap::Covariance& lhs, const Mocap::Covariance& rhs);
 
     /**
      * @brief Stream operator to print information about a `Mocap::Covariance`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Mocap::Covariance const& covariance);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Mocap::Covariance const& covariance);
 
     /**
      * @brief Quaternion type.
@@ -223,14 +231,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Mocap::Quaternion& lhs, const Mocap::Quaternion& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Mocap::Quaternion& lhs, const Mocap::Quaternion& rhs);
 
     /**
      * @brief Stream operator to print information about a `Mocap::Quaternion`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Mocap::Quaternion const& quaternion);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Mocap::Quaternion const& quaternion);
 
     /**
      * @brief Global position/attitude estimate from a vision source.
@@ -250,7 +260,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Mocap::VisionPositionEstimate& lhs, const Mocap::VisionPositionEstimate& rhs);
 
     /**
@@ -258,7 +268,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Mocap::VisionPositionEstimate const& vision_position_estimate);
 
     /**
@@ -277,7 +287,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Mocap::VisionSpeedEstimate& lhs, const Mocap::VisionSpeedEstimate& rhs);
 
     /**
@@ -285,7 +295,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Mocap::VisionSpeedEstimate const& vision_speed_estimate);
 
     /**
@@ -305,7 +315,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Mocap::AttitudePositionMocap& lhs, const Mocap::AttitudePositionMocap& rhs);
 
     /**
@@ -313,7 +323,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Mocap::AttitudePositionMocap const& attitude_position_mocap);
 
     /**
@@ -334,7 +344,7 @@ public:
          *
          * @return A reference to the stream.
          */
-        friend std::ostream&
+        friend MAVSDK_PUBLIC std::ostream&
         operator<<(std::ostream& str, Mocap::Odometry::MavFrame const& mav_frame);
 
         /**
@@ -357,7 +367,7 @@ public:
          *
          * @return A reference to the stream.
          */
-        friend std::ostream&
+        friend MAVSDK_PUBLIC std::ostream&
         operator<<(std::ostream& str, Mocap::Odometry::MavEstimatorType const& mav_estimator_type);
 
         uint64_t time_usec{}; /**< @brief Timestamp (0 to use Backend timestamp). */
@@ -382,14 +392,15 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Mocap::Odometry& lhs, const Mocap::Odometry& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Mocap::Odometry& lhs, const Mocap::Odometry& rhs);
 
     /**
      * @brief Stream operator to print information about a `Mocap::Odometry`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Mocap::Odometry const& odometry);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Mocap::Odometry const& odometry);
 
     /**
      * @brief Possible results returned for mocap requests
@@ -408,7 +419,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Mocap::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Mocap::Result const& result);
 
     /**
      * @brief Callback type for asynchronous Mocap calls.

--- a/src/mavsdk/plugins/mocap/mocap.cpp
+++ b/src/mavsdk/plugins/mocap/mocap.cpp
@@ -52,14 +52,14 @@ Mocap::Result Mocap::set_odometry(Odometry odometry) const
     return _impl->set_odometry(odometry);
 }
 
-bool operator==(const Mocap::PositionBody& lhs, const Mocap::PositionBody& rhs)
+MAVSDK_PUBLIC bool operator==(const Mocap::PositionBody& lhs, const Mocap::PositionBody& rhs)
 {
     return ((std::isnan(rhs.x_m) && std::isnan(lhs.x_m)) || rhs.x_m == lhs.x_m) &&
            ((std::isnan(rhs.y_m) && std::isnan(lhs.y_m)) || rhs.y_m == lhs.y_m) &&
            ((std::isnan(rhs.z_m) && std::isnan(lhs.z_m)) || rhs.z_m == lhs.z_m);
 }
 
-std::ostream& operator<<(std::ostream& str, Mocap::PositionBody const& position_body)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Mocap::PositionBody const& position_body)
 {
     str << std::setprecision(15);
     str << "position_body:" << '\n' << "{\n";
@@ -70,7 +70,7 @@ std::ostream& operator<<(std::ostream& str, Mocap::PositionBody const& position_
     return str;
 }
 
-bool operator==(const Mocap::AngleBody& lhs, const Mocap::AngleBody& rhs)
+MAVSDK_PUBLIC bool operator==(const Mocap::AngleBody& lhs, const Mocap::AngleBody& rhs)
 {
     return ((std::isnan(rhs.roll_rad) && std::isnan(lhs.roll_rad)) ||
             rhs.roll_rad == lhs.roll_rad) &&
@@ -79,7 +79,7 @@ bool operator==(const Mocap::AngleBody& lhs, const Mocap::AngleBody& rhs)
            ((std::isnan(rhs.yaw_rad) && std::isnan(lhs.yaw_rad)) || rhs.yaw_rad == lhs.yaw_rad);
 }
 
-std::ostream& operator<<(std::ostream& str, Mocap::AngleBody const& angle_body)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Mocap::AngleBody const& angle_body)
 {
     str << std::setprecision(15);
     str << "angle_body:" << '\n' << "{\n";
@@ -90,14 +90,14 @@ std::ostream& operator<<(std::ostream& str, Mocap::AngleBody const& angle_body)
     return str;
 }
 
-bool operator==(const Mocap::SpeedBody& lhs, const Mocap::SpeedBody& rhs)
+MAVSDK_PUBLIC bool operator==(const Mocap::SpeedBody& lhs, const Mocap::SpeedBody& rhs)
 {
     return ((std::isnan(rhs.x_m_s) && std::isnan(lhs.x_m_s)) || rhs.x_m_s == lhs.x_m_s) &&
            ((std::isnan(rhs.y_m_s) && std::isnan(lhs.y_m_s)) || rhs.y_m_s == lhs.y_m_s) &&
            ((std::isnan(rhs.z_m_s) && std::isnan(lhs.z_m_s)) || rhs.z_m_s == lhs.z_m_s);
 }
 
-std::ostream& operator<<(std::ostream& str, Mocap::SpeedBody const& speed_body)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Mocap::SpeedBody const& speed_body)
 {
     str << std::setprecision(15);
     str << "speed_body:" << '\n' << "{\n";
@@ -108,7 +108,7 @@ std::ostream& operator<<(std::ostream& str, Mocap::SpeedBody const& speed_body)
     return str;
 }
 
-bool operator==(const Mocap::SpeedNed& lhs, const Mocap::SpeedNed& rhs)
+MAVSDK_PUBLIC bool operator==(const Mocap::SpeedNed& lhs, const Mocap::SpeedNed& rhs)
 {
     return ((std::isnan(rhs.north_m_s) && std::isnan(lhs.north_m_s)) ||
             rhs.north_m_s == lhs.north_m_s) &&
@@ -117,7 +117,7 @@ bool operator==(const Mocap::SpeedNed& lhs, const Mocap::SpeedNed& rhs)
            ((std::isnan(rhs.down_m_s) && std::isnan(lhs.down_m_s)) || rhs.down_m_s == lhs.down_m_s);
 }
 
-std::ostream& operator<<(std::ostream& str, Mocap::SpeedNed const& speed_ned)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Mocap::SpeedNed const& speed_ned)
 {
     str << std::setprecision(15);
     str << "speed_ned:" << '\n' << "{\n";
@@ -128,7 +128,8 @@ std::ostream& operator<<(std::ostream& str, Mocap::SpeedNed const& speed_ned)
     return str;
 }
 
-bool operator==(const Mocap::AngularVelocityBody& lhs, const Mocap::AngularVelocityBody& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Mocap::AngularVelocityBody& lhs, const Mocap::AngularVelocityBody& rhs)
 {
     return ((std::isnan(rhs.roll_rad_s) && std::isnan(lhs.roll_rad_s)) ||
             rhs.roll_rad_s == lhs.roll_rad_s) &&
@@ -138,7 +139,8 @@ bool operator==(const Mocap::AngularVelocityBody& lhs, const Mocap::AngularVeloc
             rhs.yaw_rad_s == lhs.yaw_rad_s);
 }
 
-std::ostream& operator<<(std::ostream& str, Mocap::AngularVelocityBody const& angular_velocity_body)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Mocap::AngularVelocityBody const& angular_velocity_body)
 {
     str << std::setprecision(15);
     str << "angular_velocity_body:" << '\n' << "{\n";
@@ -149,12 +151,12 @@ std::ostream& operator<<(std::ostream& str, Mocap::AngularVelocityBody const& an
     return str;
 }
 
-bool operator==(const Mocap::Covariance& lhs, const Mocap::Covariance& rhs)
+MAVSDK_PUBLIC bool operator==(const Mocap::Covariance& lhs, const Mocap::Covariance& rhs)
 {
     return (rhs.covariance_matrix == lhs.covariance_matrix);
 }
 
-std::ostream& operator<<(std::ostream& str, Mocap::Covariance const& covariance)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Mocap::Covariance const& covariance)
 {
     str << std::setprecision(15);
     str << "covariance:" << '\n' << "{\n";
@@ -168,7 +170,7 @@ std::ostream& operator<<(std::ostream& str, Mocap::Covariance const& covariance)
     return str;
 }
 
-bool operator==(const Mocap::Quaternion& lhs, const Mocap::Quaternion& rhs)
+MAVSDK_PUBLIC bool operator==(const Mocap::Quaternion& lhs, const Mocap::Quaternion& rhs)
 {
     return ((std::isnan(rhs.w) && std::isnan(lhs.w)) || rhs.w == lhs.w) &&
            ((std::isnan(rhs.x) && std::isnan(lhs.x)) || rhs.x == lhs.x) &&
@@ -176,7 +178,7 @@ bool operator==(const Mocap::Quaternion& lhs, const Mocap::Quaternion& rhs)
            ((std::isnan(rhs.z) && std::isnan(lhs.z)) || rhs.z == lhs.z);
 }
 
-std::ostream& operator<<(std::ostream& str, Mocap::Quaternion const& quaternion)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Mocap::Quaternion const& quaternion)
 {
     str << std::setprecision(15);
     str << "quaternion:" << '\n' << "{\n";
@@ -188,14 +190,15 @@ std::ostream& operator<<(std::ostream& str, Mocap::Quaternion const& quaternion)
     return str;
 }
 
-bool operator==(const Mocap::VisionPositionEstimate& lhs, const Mocap::VisionPositionEstimate& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Mocap::VisionPositionEstimate& lhs, const Mocap::VisionPositionEstimate& rhs)
 {
     return (rhs.time_usec == lhs.time_usec) && (rhs.position_body == lhs.position_body) &&
            (rhs.angle_body == lhs.angle_body) && (rhs.pose_covariance == lhs.pose_covariance) &&
            (rhs.reset_counter == lhs.reset_counter);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, Mocap::VisionPositionEstimate const& vision_position_estimate)
 {
     str << std::setprecision(15);
@@ -209,14 +212,16 @@ operator<<(std::ostream& str, Mocap::VisionPositionEstimate const& vision_positi
     return str;
 }
 
-bool operator==(const Mocap::VisionSpeedEstimate& lhs, const Mocap::VisionSpeedEstimate& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Mocap::VisionSpeedEstimate& lhs, const Mocap::VisionSpeedEstimate& rhs)
 {
     return (rhs.time_usec == lhs.time_usec) && (rhs.speed_ned == lhs.speed_ned) &&
            (rhs.speed_covariance == lhs.speed_covariance) &&
            (rhs.reset_counter == lhs.reset_counter);
 }
 
-std::ostream& operator<<(std::ostream& str, Mocap::VisionSpeedEstimate const& vision_speed_estimate)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Mocap::VisionSpeedEstimate const& vision_speed_estimate)
 {
     str << std::setprecision(15);
     str << "vision_speed_estimate:" << '\n' << "{\n";
@@ -228,13 +233,14 @@ std::ostream& operator<<(std::ostream& str, Mocap::VisionSpeedEstimate const& vi
     return str;
 }
 
-bool operator==(const Mocap::AttitudePositionMocap& lhs, const Mocap::AttitudePositionMocap& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Mocap::AttitudePositionMocap& lhs, const Mocap::AttitudePositionMocap& rhs)
 {
     return (rhs.time_usec == lhs.time_usec) && (rhs.q == lhs.q) &&
            (rhs.position_body == lhs.position_body) && (rhs.pose_covariance == lhs.pose_covariance);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, Mocap::AttitudePositionMocap const& attitude_position_mocap)
 {
     str << std::setprecision(15);
@@ -247,7 +253,8 @@ operator<<(std::ostream& str, Mocap::AttitudePositionMocap const& attitude_posit
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, Mocap::Odometry::MavFrame const& mav_frame)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Mocap::Odometry::MavFrame const& mav_frame)
 {
     switch (mav_frame) {
         case Mocap::Odometry::MavFrame::MocapNed:
@@ -259,7 +266,7 @@ std::ostream& operator<<(std::ostream& str, Mocap::Odometry::MavFrame const& mav
     }
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, Mocap::Odometry::MavEstimatorType const& mav_estimator_type)
 {
     switch (mav_estimator_type) {
@@ -285,7 +292,7 @@ operator<<(std::ostream& str, Mocap::Odometry::MavEstimatorType const& mav_estim
             return str << "Unknown";
     }
 }
-bool operator==(const Mocap::Odometry& lhs, const Mocap::Odometry& rhs)
+MAVSDK_PUBLIC bool operator==(const Mocap::Odometry& lhs, const Mocap::Odometry& rhs)
 {
     return (rhs.time_usec == lhs.time_usec) && (rhs.frame_id == lhs.frame_id) &&
            (rhs.position_body == lhs.position_body) && (rhs.q == lhs.q) &&
@@ -297,7 +304,7 @@ bool operator==(const Mocap::Odometry& lhs, const Mocap::Odometry& rhs)
            (rhs.quality_percent == lhs.quality_percent);
 }
 
-std::ostream& operator<<(std::ostream& str, Mocap::Odometry const& odometry)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Mocap::Odometry const& odometry)
 {
     str << std::setprecision(15);
     str << "odometry:" << '\n' << "{\n";
@@ -316,7 +323,7 @@ std::ostream& operator<<(std::ostream& str, Mocap::Odometry const& odometry)
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, Mocap::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Mocap::Result const& result)
 {
     switch (result) {
         case Mocap::Result::Unknown:

--- a/src/mavsdk/plugins/offboard/include/plugins/offboard/offboard.h
+++ b/src/mavsdk/plugins/offboard/include/plugins/offboard/offboard.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -32,7 +33,7 @@ class OffboardImpl;
  * Mavsdk automatically sends setpoints at 20Hz (PX4 Offboard mode requires that setpoints
  * are minimally sent at 2Hz).
  */
-class Offboard : public PluginBase {
+class MAVSDK_PUBLIC Offboard : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -80,14 +81,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Offboard::Attitude& lhs, const Offboard::Attitude& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Offboard::Attitude& lhs, const Offboard::Attitude& rhs);
 
     /**
      * @brief Stream operator to print information about a `Offboard::Attitude`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Offboard::Attitude const& attitude);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Offboard::Attitude const& attitude);
 
     /**
      * @brief Eight controls that will be given to the group. Each control is a normalized
@@ -102,7 +105,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const Offboard::ActuatorControlGroup& lhs, const Offboard::ActuatorControlGroup& rhs);
 
     /**
@@ -110,7 +113,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Offboard::ActuatorControlGroup const& actuator_control_group);
 
     /**
@@ -139,7 +142,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Offboard::ActuatorControl& lhs, const Offboard::ActuatorControl& rhs);
 
     /**
@@ -147,7 +150,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Offboard::ActuatorControl const& actuator_control);
 
     /**
@@ -169,14 +172,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Offboard::AttitudeRate& lhs, const Offboard::AttitudeRate& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Offboard::AttitudeRate& lhs, const Offboard::AttitudeRate& rhs);
 
     /**
      * @brief Stream operator to print information about a `Offboard::AttitudeRate`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Offboard::AttitudeRate const& attitude_rate);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Offboard::AttitudeRate const& attitude_rate);
 
     /**
      * @brief Type for position commands in NED (North East Down) coordinates and yaw.
@@ -194,7 +199,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Offboard::PositionNedYaw& lhs, const Offboard::PositionNedYaw& rhs);
 
     /**
@@ -202,7 +207,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Offboard::PositionNedYaw const& position_ned_yaw);
 
     /**
@@ -224,7 +229,7 @@ public:
          *
          * @return A reference to the stream.
          */
-        friend std::ostream& operator<<(
+        friend MAVSDK_PUBLIC std::ostream& operator<<(
             std::ostream& str, Offboard::PositionGlobalYaw::AltitudeType const& altitude_type);
 
         double lat_deg{}; /**< @brief Latitude (in degrees) */
@@ -240,7 +245,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Offboard::PositionGlobalYaw& lhs, const Offboard::PositionGlobalYaw& rhs);
 
     /**
@@ -248,7 +253,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Offboard::PositionGlobalYaw const& position_global_yaw);
 
     /**
@@ -267,7 +272,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const Offboard::VelocityBodyYawspeed& lhs, const Offboard::VelocityBodyYawspeed& rhs);
 
     /**
@@ -275,7 +280,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Offboard::VelocityBodyYawspeed const& velocity_body_yawspeed);
 
     /**
@@ -294,7 +299,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Offboard::VelocityNedYaw& lhs, const Offboard::VelocityNedYaw& rhs);
 
     /**
@@ -302,7 +307,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Offboard::VelocityNedYaw const& velocity_ned_yaw);
 
     /**
@@ -319,7 +324,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Offboard::AccelerationNed& lhs, const Offboard::AccelerationNed& rhs);
 
     /**
@@ -327,7 +332,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Offboard::AccelerationNed const& acceleration_ned);
 
     /**
@@ -350,7 +355,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Offboard::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Offboard::Result const& result);
 
     /**
      * @brief Callback type for asynchronous Offboard calls.

--- a/src/mavsdk/plugins/offboard/offboard.cpp
+++ b/src/mavsdk/plugins/offboard/offboard.cpp
@@ -108,7 +108,7 @@ Offboard::Result Offboard::set_acceleration_ned(AccelerationNed acceleration_ned
     return _impl->set_acceleration_ned(acceleration_ned);
 }
 
-bool operator==(const Offboard::Attitude& lhs, const Offboard::Attitude& rhs)
+MAVSDK_PUBLIC bool operator==(const Offboard::Attitude& lhs, const Offboard::Attitude& rhs)
 {
     return ((std::isnan(rhs.roll_deg) && std::isnan(lhs.roll_deg)) ||
             rhs.roll_deg == lhs.roll_deg) &&
@@ -119,7 +119,7 @@ bool operator==(const Offboard::Attitude& lhs, const Offboard::Attitude& rhs)
             rhs.thrust_value == lhs.thrust_value);
 }
 
-std::ostream& operator<<(std::ostream& str, Offboard::Attitude const& attitude)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Offboard::Attitude const& attitude)
 {
     str << std::setprecision(15);
     str << "attitude:" << '\n' << "{\n";
@@ -131,13 +131,13 @@ std::ostream& operator<<(std::ostream& str, Offboard::Attitude const& attitude)
     return str;
 }
 
-bool operator==(
-    const Offboard::ActuatorControlGroup& lhs, const Offboard::ActuatorControlGroup& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Offboard::ActuatorControlGroup& lhs, const Offboard::ActuatorControlGroup& rhs)
 {
     return (rhs.controls == lhs.controls);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, Offboard::ActuatorControlGroup const& actuator_control_group)
 {
     str << std::setprecision(15);
@@ -153,12 +153,14 @@ operator<<(std::ostream& str, Offboard::ActuatorControlGroup const& actuator_con
     return str;
 }
 
-bool operator==(const Offboard::ActuatorControl& lhs, const Offboard::ActuatorControl& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Offboard::ActuatorControl& lhs, const Offboard::ActuatorControl& rhs)
 {
     return (rhs.groups == lhs.groups);
 }
 
-std::ostream& operator<<(std::ostream& str, Offboard::ActuatorControl const& actuator_control)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Offboard::ActuatorControl const& actuator_control)
 {
     str << std::setprecision(15);
     str << "actuator_control:" << '\n' << "{\n";
@@ -171,7 +173,7 @@ std::ostream& operator<<(std::ostream& str, Offboard::ActuatorControl const& act
     return str;
 }
 
-bool operator==(const Offboard::AttitudeRate& lhs, const Offboard::AttitudeRate& rhs)
+MAVSDK_PUBLIC bool operator==(const Offboard::AttitudeRate& lhs, const Offboard::AttitudeRate& rhs)
 {
     return ((std::isnan(rhs.roll_deg_s) && std::isnan(lhs.roll_deg_s)) ||
             rhs.roll_deg_s == lhs.roll_deg_s) &&
@@ -183,7 +185,8 @@ bool operator==(const Offboard::AttitudeRate& lhs, const Offboard::AttitudeRate&
             rhs.thrust_value == lhs.thrust_value);
 }
 
-std::ostream& operator<<(std::ostream& str, Offboard::AttitudeRate const& attitude_rate)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Offboard::AttitudeRate const& attitude_rate)
 {
     str << std::setprecision(15);
     str << "attitude_rate:" << '\n' << "{\n";
@@ -195,7 +198,8 @@ std::ostream& operator<<(std::ostream& str, Offboard::AttitudeRate const& attitu
     return str;
 }
 
-bool operator==(const Offboard::PositionNedYaw& lhs, const Offboard::PositionNedYaw& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Offboard::PositionNedYaw& lhs, const Offboard::PositionNedYaw& rhs)
 {
     return ((std::isnan(rhs.north_m) && std::isnan(lhs.north_m)) || rhs.north_m == lhs.north_m) &&
            ((std::isnan(rhs.east_m) && std::isnan(lhs.east_m)) || rhs.east_m == lhs.east_m) &&
@@ -203,7 +207,8 @@ bool operator==(const Offboard::PositionNedYaw& lhs, const Offboard::PositionNed
            ((std::isnan(rhs.yaw_deg) && std::isnan(lhs.yaw_deg)) || rhs.yaw_deg == lhs.yaw_deg);
 }
 
-std::ostream& operator<<(std::ostream& str, Offboard::PositionNedYaw const& position_ned_yaw)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Offboard::PositionNedYaw const& position_ned_yaw)
 {
     str << std::setprecision(15);
     str << "position_ned_yaw:" << '\n' << "{\n";
@@ -215,7 +220,7 @@ std::ostream& operator<<(std::ostream& str, Offboard::PositionNedYaw const& posi
     return str;
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, Offboard::PositionGlobalYaw::AltitudeType const& altitude_type)
 {
     switch (altitude_type) {
@@ -229,7 +234,8 @@ operator<<(std::ostream& str, Offboard::PositionGlobalYaw::AltitudeType const& a
             return str << "Unknown";
     }
 }
-bool operator==(const Offboard::PositionGlobalYaw& lhs, const Offboard::PositionGlobalYaw& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Offboard::PositionGlobalYaw& lhs, const Offboard::PositionGlobalYaw& rhs)
 {
     return ((std::isnan(rhs.lat_deg) && std::isnan(lhs.lat_deg)) || rhs.lat_deg == lhs.lat_deg) &&
            ((std::isnan(rhs.lon_deg) && std::isnan(lhs.lon_deg)) || rhs.lon_deg == lhs.lon_deg) &&
@@ -238,7 +244,8 @@ bool operator==(const Offboard::PositionGlobalYaw& lhs, const Offboard::Position
            (rhs.altitude_type == lhs.altitude_type);
 }
 
-std::ostream& operator<<(std::ostream& str, Offboard::PositionGlobalYaw const& position_global_yaw)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Offboard::PositionGlobalYaw const& position_global_yaw)
 {
     str << std::setprecision(15);
     str << "position_global_yaw:" << '\n' << "{\n";
@@ -251,8 +258,8 @@ std::ostream& operator<<(std::ostream& str, Offboard::PositionGlobalYaw const& p
     return str;
 }
 
-bool operator==(
-    const Offboard::VelocityBodyYawspeed& lhs, const Offboard::VelocityBodyYawspeed& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Offboard::VelocityBodyYawspeed& lhs, const Offboard::VelocityBodyYawspeed& rhs)
 {
     return ((std::isnan(rhs.forward_m_s) && std::isnan(lhs.forward_m_s)) ||
             rhs.forward_m_s == lhs.forward_m_s) &&
@@ -264,7 +271,7 @@ bool operator==(
             rhs.yawspeed_deg_s == lhs.yawspeed_deg_s);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, Offboard::VelocityBodyYawspeed const& velocity_body_yawspeed)
 {
     str << std::setprecision(15);
@@ -277,7 +284,8 @@ operator<<(std::ostream& str, Offboard::VelocityBodyYawspeed const& velocity_bod
     return str;
 }
 
-bool operator==(const Offboard::VelocityNedYaw& lhs, const Offboard::VelocityNedYaw& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Offboard::VelocityNedYaw& lhs, const Offboard::VelocityNedYaw& rhs)
 {
     return ((std::isnan(rhs.north_m_s) && std::isnan(lhs.north_m_s)) ||
             rhs.north_m_s == lhs.north_m_s) &&
@@ -288,7 +296,8 @@ bool operator==(const Offboard::VelocityNedYaw& lhs, const Offboard::VelocityNed
            ((std::isnan(rhs.yaw_deg) && std::isnan(lhs.yaw_deg)) || rhs.yaw_deg == lhs.yaw_deg);
 }
 
-std::ostream& operator<<(std::ostream& str, Offboard::VelocityNedYaw const& velocity_ned_yaw)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Offboard::VelocityNedYaw const& velocity_ned_yaw)
 {
     str << std::setprecision(15);
     str << "velocity_ned_yaw:" << '\n' << "{\n";
@@ -300,7 +309,8 @@ std::ostream& operator<<(std::ostream& str, Offboard::VelocityNedYaw const& velo
     return str;
 }
 
-bool operator==(const Offboard::AccelerationNed& lhs, const Offboard::AccelerationNed& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Offboard::AccelerationNed& lhs, const Offboard::AccelerationNed& rhs)
 {
     return ((std::isnan(rhs.north_m_s2) && std::isnan(lhs.north_m_s2)) ||
             rhs.north_m_s2 == lhs.north_m_s2) &&
@@ -310,7 +320,8 @@ bool operator==(const Offboard::AccelerationNed& lhs, const Offboard::Accelerati
             rhs.down_m_s2 == lhs.down_m_s2);
 }
 
-std::ostream& operator<<(std::ostream& str, Offboard::AccelerationNed const& acceleration_ned)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Offboard::AccelerationNed const& acceleration_ned)
 {
     str << std::setprecision(15);
     str << "acceleration_ned:" << '\n' << "{\n";
@@ -321,7 +332,7 @@ std::ostream& operator<<(std::ostream& str, Offboard::AccelerationNed const& acc
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, Offboard::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Offboard::Result const& result)
 {
     switch (result) {
         case Offboard::Result::Unknown:

--- a/src/mavsdk/plugins/param/include/plugins/param/param.h
+++ b/src/mavsdk/plugins/param/include/plugins/param/param.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -25,7 +26,7 @@ class ParamImpl;
 /**
  * @brief Provide raw access to get and set parameters.
  */
-class Param : public PluginBase {
+class MAVSDK_PUBLIC Param : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -71,7 +72,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Param::ProtocolVersion const& protocol_version);
 
     /**
@@ -87,14 +88,15 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Param::IntParam& lhs, const Param::IntParam& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Param::IntParam& lhs, const Param::IntParam& rhs);
 
     /**
      * @brief Stream operator to print information about a `Param::IntParam`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Param::IntParam const& int_param);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Param::IntParam const& int_param);
 
     /**
      * @brief Type for float parameters.
@@ -109,14 +111,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Param::FloatParam& lhs, const Param::FloatParam& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Param::FloatParam& lhs, const Param::FloatParam& rhs);
 
     /**
      * @brief Stream operator to print information about a `Param::FloatParam`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Param::FloatParam const& float_param);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Param::FloatParam const& float_param);
 
     /**
      * @brief Type for custom parameters
@@ -131,14 +135,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Param::CustomParam& lhs, const Param::CustomParam& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Param::CustomParam& lhs, const Param::CustomParam& rhs);
 
     /**
      * @brief Stream operator to print information about a `Param::CustomParam`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Param::CustomParam const& custom_param);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Param::CustomParam const& custom_param);
 
     /**
      * @brief Type collecting all integer, float, and custom parameters.
@@ -157,14 +163,15 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Param::AllParams& lhs, const Param::AllParams& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Param::AllParams& lhs, const Param::AllParams& rhs);
 
     /**
      * @brief Stream operator to print information about a `Param::AllParams`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Param::AllParams const& all_params);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Param::AllParams const& all_params);
 
     /**
      * @brief Possible results returned for param requests.
@@ -194,7 +201,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Param::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Param::Result const& result);
 
     /**
      * @brief Callback type for asynchronous Param calls.

--- a/src/mavsdk/plugins/param/param.cpp
+++ b/src/mavsdk/plugins/param/param.cpp
@@ -63,12 +63,12 @@ Param::Result Param::select_component(int32_t component_id, ProtocolVersion prot
     return _impl->select_component(component_id, protocol_version);
 }
 
-bool operator==(const Param::IntParam& lhs, const Param::IntParam& rhs)
+MAVSDK_PUBLIC bool operator==(const Param::IntParam& lhs, const Param::IntParam& rhs)
 {
     return (rhs.name == lhs.name) && (rhs.value == lhs.value);
 }
 
-std::ostream& operator<<(std::ostream& str, Param::IntParam const& int_param)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Param::IntParam const& int_param)
 {
     str << std::setprecision(15);
     str << "int_param:" << '\n' << "{\n";
@@ -78,13 +78,13 @@ std::ostream& operator<<(std::ostream& str, Param::IntParam const& int_param)
     return str;
 }
 
-bool operator==(const Param::FloatParam& lhs, const Param::FloatParam& rhs)
+MAVSDK_PUBLIC bool operator==(const Param::FloatParam& lhs, const Param::FloatParam& rhs)
 {
     return (rhs.name == lhs.name) &&
            ((std::isnan(rhs.value) && std::isnan(lhs.value)) || rhs.value == lhs.value);
 }
 
-std::ostream& operator<<(std::ostream& str, Param::FloatParam const& float_param)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Param::FloatParam const& float_param)
 {
     str << std::setprecision(15);
     str << "float_param:" << '\n' << "{\n";
@@ -94,12 +94,12 @@ std::ostream& operator<<(std::ostream& str, Param::FloatParam const& float_param
     return str;
 }
 
-bool operator==(const Param::CustomParam& lhs, const Param::CustomParam& rhs)
+MAVSDK_PUBLIC bool operator==(const Param::CustomParam& lhs, const Param::CustomParam& rhs)
 {
     return (rhs.name == lhs.name) && (rhs.value == lhs.value);
 }
 
-std::ostream& operator<<(std::ostream& str, Param::CustomParam const& custom_param)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Param::CustomParam const& custom_param)
 {
     str << std::setprecision(15);
     str << "custom_param:" << '\n' << "{\n";
@@ -109,13 +109,13 @@ std::ostream& operator<<(std::ostream& str, Param::CustomParam const& custom_par
     return str;
 }
 
-bool operator==(const Param::AllParams& lhs, const Param::AllParams& rhs)
+MAVSDK_PUBLIC bool operator==(const Param::AllParams& lhs, const Param::AllParams& rhs)
 {
     return (rhs.int_params == lhs.int_params) && (rhs.float_params == lhs.float_params) &&
            (rhs.custom_params == lhs.custom_params);
 }
 
-std::ostream& operator<<(std::ostream& str, Param::AllParams const& all_params)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Param::AllParams const& all_params)
 {
     str << std::setprecision(15);
     str << "all_params:" << '\n' << "{\n";
@@ -138,7 +138,7 @@ std::ostream& operator<<(std::ostream& str, Param::AllParams const& all_params)
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, Param::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Param::Result const& result)
 {
     switch (result) {
         case Param::Result::Unknown:
@@ -180,7 +180,8 @@ std::ostream& operator<<(std::ostream& str, Param::Result const& result)
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Param::ProtocolVersion const& protocol_version)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Param::ProtocolVersion const& protocol_version)
 {
     switch (protocol_version) {
         case Param::ProtocolVersion::V1:

--- a/src/mavsdk/plugins/param_server/include/plugins/param_server/param_server.h
+++ b/src/mavsdk/plugins/param_server/include/plugins/param_server/param_server.h
@@ -16,6 +16,7 @@
 #include "server_plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -25,7 +26,7 @@ class ParamServerImpl;
 /**
  * @brief Provide raw access to retrieve and provide server parameters.
  */
-class ParamServer : public ServerPluginBase {
+class MAVSDK_PUBLIC ParamServer : public ServerPluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a ServerComponent instance.
@@ -58,14 +59,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const ParamServer::IntParam& lhs, const ParamServer::IntParam& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const ParamServer::IntParam& lhs, const ParamServer::IntParam& rhs);
 
     /**
      * @brief Stream operator to print information about a `ParamServer::IntParam`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, ParamServer::IntParam const& int_param);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, ParamServer::IntParam const& int_param);
 
     /**
      * @brief Type for float parameters.
@@ -80,14 +83,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const ParamServer::FloatParam& lhs, const ParamServer::FloatParam& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const ParamServer::FloatParam& lhs, const ParamServer::FloatParam& rhs);
 
     /**
      * @brief Stream operator to print information about a `ParamServer::FloatParam`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, ParamServer::FloatParam const& float_param);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, ParamServer::FloatParam const& float_param);
 
     /**
      * @brief Type for float parameters.
@@ -102,7 +107,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const ParamServer::CustomParam& lhs, const ParamServer::CustomParam& rhs);
 
     /**
@@ -110,7 +115,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, ParamServer::CustomParam const& custom_param);
 
     /**
@@ -130,14 +135,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const ParamServer::AllParams& lhs, const ParamServer::AllParams& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const ParamServer::AllParams& lhs, const ParamServer::AllParams& rhs);
 
     /**
      * @brief Stream operator to print information about a `ParamServer::AllParams`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, ParamServer::AllParams const& all_params);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, ParamServer::AllParams const& all_params);
 
     /**
      * @brief Possible results returned for param requests.
@@ -158,7 +165,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, ParamServer::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, ParamServer::Result const& result);
 
     /**
      * @brief Callback type for asynchronous ParamServer calls.

--- a/src/mavsdk/plugins/param_server/param_server.cpp
+++ b/src/mavsdk/plugins/param_server/param_server.cpp
@@ -95,12 +95,12 @@ void ParamServer::unsubscribe_changed_param_custom(ChangedParamCustomHandle hand
     _impl->unsubscribe_changed_param_custom(handle);
 }
 
-bool operator==(const ParamServer::IntParam& lhs, const ParamServer::IntParam& rhs)
+MAVSDK_PUBLIC bool operator==(const ParamServer::IntParam& lhs, const ParamServer::IntParam& rhs)
 {
     return (rhs.name == lhs.name) && (rhs.value == lhs.value);
 }
 
-std::ostream& operator<<(std::ostream& str, ParamServer::IntParam const& int_param)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, ParamServer::IntParam const& int_param)
 {
     str << std::setprecision(15);
     str << "int_param:" << '\n' << "{\n";
@@ -110,13 +110,15 @@ std::ostream& operator<<(std::ostream& str, ParamServer::IntParam const& int_par
     return str;
 }
 
-bool operator==(const ParamServer::FloatParam& lhs, const ParamServer::FloatParam& rhs)
+MAVSDK_PUBLIC bool
+operator==(const ParamServer::FloatParam& lhs, const ParamServer::FloatParam& rhs)
 {
     return (rhs.name == lhs.name) &&
            ((std::isnan(rhs.value) && std::isnan(lhs.value)) || rhs.value == lhs.value);
 }
 
-std::ostream& operator<<(std::ostream& str, ParamServer::FloatParam const& float_param)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, ParamServer::FloatParam const& float_param)
 {
     str << std::setprecision(15);
     str << "float_param:" << '\n' << "{\n";
@@ -126,12 +128,14 @@ std::ostream& operator<<(std::ostream& str, ParamServer::FloatParam const& float
     return str;
 }
 
-bool operator==(const ParamServer::CustomParam& lhs, const ParamServer::CustomParam& rhs)
+MAVSDK_PUBLIC bool
+operator==(const ParamServer::CustomParam& lhs, const ParamServer::CustomParam& rhs)
 {
     return (rhs.name == lhs.name) && (rhs.value == lhs.value);
 }
 
-std::ostream& operator<<(std::ostream& str, ParamServer::CustomParam const& custom_param)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, ParamServer::CustomParam const& custom_param)
 {
     str << std::setprecision(15);
     str << "custom_param:" << '\n' << "{\n";
@@ -141,13 +145,13 @@ std::ostream& operator<<(std::ostream& str, ParamServer::CustomParam const& cust
     return str;
 }
 
-bool operator==(const ParamServer::AllParams& lhs, const ParamServer::AllParams& rhs)
+MAVSDK_PUBLIC bool operator==(const ParamServer::AllParams& lhs, const ParamServer::AllParams& rhs)
 {
     return (rhs.int_params == lhs.int_params) && (rhs.float_params == lhs.float_params) &&
            (rhs.custom_params == lhs.custom_params);
 }
 
-std::ostream& operator<<(std::ostream& str, ParamServer::AllParams const& all_params)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, ParamServer::AllParams const& all_params)
 {
     str << std::setprecision(15);
     str << "all_params:" << '\n' << "{\n";
@@ -170,7 +174,7 @@ std::ostream& operator<<(std::ostream& str, ParamServer::AllParams const& all_pa
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, ParamServer::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, ParamServer::Result const& result)
 {
     switch (result) {
         case ParamServer::Result::Unknown:

--- a/src/mavsdk/plugins/param_server/param_server_impl.cpp
+++ b/src/mavsdk/plugins/param_server/param_server_impl.cpp
@@ -1,13 +1,14 @@
 #include "param_server_impl.h"
 #include "callback_list.tpp"
+#include "mavsdk_export.h"
 #include <thread>
 #include <chrono>
 
 namespace mavsdk {
 
-template class CallbackList<ParamServer::IntParam>;
-template class CallbackList<ParamServer::FloatParam>;
-template class CallbackList<ParamServer::CustomParam>;
+template class MAVSDK_TEMPL_INST CallbackList<ParamServer::IntParam>;
+template class MAVSDK_TEMPL_INST CallbackList<ParamServer::FloatParam>;
+template class MAVSDK_TEMPL_INST CallbackList<ParamServer::CustomParam>;
 
 ParamServerImpl::ParamServerImpl(std::shared_ptr<ServerComponent> server_component) :
     ServerPluginImplBase(server_component)

--- a/src/mavsdk/plugins/rtk/include/plugins/rtk/rtk.h
+++ b/src/mavsdk/plugins/rtk/include/plugins/rtk/rtk.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -25,7 +26,7 @@ class RtkImpl;
 /**
  * @brief Service to send RTK corrections to the vehicle.
  */
-class Rtk : public PluginBase {
+class MAVSDK_PUBLIC Rtk : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -70,14 +71,15 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Rtk::RtcmData& lhs, const Rtk::RtcmData& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Rtk::RtcmData& lhs, const Rtk::RtcmData& rhs);
 
     /**
      * @brief Stream operator to print information about a `Rtk::RtcmData`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Rtk::RtcmData const& rtcm_data);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Rtk::RtcmData const& rtcm_data);
 
     /**
      * @brief Possible results returned for rtk requests.
@@ -95,7 +97,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Rtk::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Rtk::Result const& result);
 
     /**
      * @brief Callback type for asynchronous Rtk calls.

--- a/src/mavsdk/plugins/rtk/rtk.cpp
+++ b/src/mavsdk/plugins/rtk/rtk.cpp
@@ -22,12 +22,12 @@ Rtk::Result Rtk::send_rtcm_data(RtcmData rtcm_data) const
     return _impl->send_rtcm_data(rtcm_data);
 }
 
-bool operator==(const Rtk::RtcmData& lhs, const Rtk::RtcmData& rhs)
+MAVSDK_PUBLIC bool operator==(const Rtk::RtcmData& lhs, const Rtk::RtcmData& rhs)
 {
     return (rhs.data_base64 == lhs.data_base64);
 }
 
-std::ostream& operator<<(std::ostream& str, Rtk::RtcmData const& rtcm_data)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Rtk::RtcmData const& rtcm_data)
 {
     str << std::setprecision(15);
     str << "rtcm_data:" << '\n' << "{\n";
@@ -36,7 +36,7 @@ std::ostream& operator<<(std::ostream& str, Rtk::RtcmData const& rtcm_data)
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, Rtk::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Rtk::Result const& result)
 {
     switch (result) {
         case Rtk::Result::Unknown:

--- a/src/mavsdk/plugins/server_utility/include/plugins/server_utility/server_utility.h
+++ b/src/mavsdk/plugins/server_utility/include/plugins/server_utility/server_utility.h
@@ -17,6 +17,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -26,7 +27,7 @@ class ServerUtilityImpl;
 /**
  * @brief Utility for onboard MAVSDK instances for common "server" tasks.
  */
-class ServerUtility : public PluginBase {
+class MAVSDK_PUBLIC ServerUtility : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -78,7 +79,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, ServerUtility::StatusTextType const& status_text_type);
 
     /**
@@ -97,7 +98,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, ServerUtility::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, ServerUtility::Result const& result);
 
     /**
      * @brief Callback type for asynchronous ServerUtility calls.

--- a/src/mavsdk/plugins/server_utility/server_utility.cpp
+++ b/src/mavsdk/plugins/server_utility/server_utility.cpp
@@ -27,7 +27,7 @@ ServerUtility::Result ServerUtility::send_status_text(StatusTextType type, std::
     return _impl->send_status_text(type, text);
 }
 
-std::ostream& operator<<(std::ostream& str, ServerUtility::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, ServerUtility::Result const& result)
 {
     switch (result) {
         case ServerUtility::Result::Unknown:
@@ -45,7 +45,8 @@ std::ostream& operator<<(std::ostream& str, ServerUtility::Result const& result)
     }
 }
 
-std::ostream& operator<<(std::ostream& str, ServerUtility::StatusTextType const& status_text_type)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, ServerUtility::StatusTextType const& status_text_type)
 {
     switch (status_text_type) {
         case ServerUtility::StatusTextType::Debug:

--- a/src/mavsdk/plugins/shell/include/plugins/shell/shell.h
+++ b/src/mavsdk/plugins/shell/include/plugins/shell/shell.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -25,7 +26,7 @@ class ShellImpl;
 /**
  * @brief Allow to communicate with the vehicle's system shell.
  */
-class Shell : public PluginBase {
+class MAVSDK_PUBLIC Shell : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -75,7 +76,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Shell::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Shell::Result const& result);
 
     /**
      * @brief Callback type for asynchronous Shell calls.

--- a/src/mavsdk/plugins/shell/shell.cpp
+++ b/src/mavsdk/plugins/shell/shell.cpp
@@ -33,7 +33,7 @@ void Shell::unsubscribe_receive(ReceiveHandle handle)
     _impl->unsubscribe_receive(handle);
 }
 
-std::ostream& operator<<(std::ostream& str, Shell::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Shell::Result const& result)
 {
     switch (result) {
         case Shell::Result::Unknown:

--- a/src/mavsdk/plugins/shell/shell_impl.cpp
+++ b/src/mavsdk/plugins/shell/shell_impl.cpp
@@ -2,10 +2,11 @@
 #include "mavlink_address.h"
 #include "system.h"
 #include "callback_list.tpp"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
-template class CallbackList<std::string>;
+template class MAVSDK_TEMPL_INST CallbackList<std::string>;
 
 void ShellImpl::init()
 {

--- a/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -28,7 +29,7 @@ class TelemetryImpl;
  * Certain Telemetry Topics such as, Position or Velocity_Ned require GPS Fix before data gets
  * published.
  */
-class Telemetry : public PluginBase {
+class MAVSDK_PUBLIC Telemetry : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -79,7 +80,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::FixType const& fix_type);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::FixType const& fix_type);
 
     /**
      * @brief Battery function type.
@@ -97,7 +99,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Telemetry::BatteryFunction const& battery_function);
 
     /**
@@ -129,7 +131,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::FlightMode const& flight_mode);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::FlightMode const& flight_mode);
 
     /**
      * @brief Status types.
@@ -150,7 +153,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Telemetry::StatusTextType const& status_text_type);
 
     /**
@@ -169,7 +172,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::LandedState const& landed_state);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::LandedState const& landed_state);
 
     /**
      * @brief VTOL State enumeration
@@ -187,7 +191,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::VtolState const& vtol_state);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::VtolState const& vtol_state);
 
     /**
      * @brief Position type in global coordinates.
@@ -206,14 +211,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::Position& lhs, const Telemetry::Position& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Telemetry::Position& lhs, const Telemetry::Position& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::Position`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::Position const& position);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::Position const& position);
 
     /**
      * @brief Heading type used for global position
@@ -227,14 +234,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::Heading& lhs, const Telemetry::Heading& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Telemetry::Heading& lhs, const Telemetry::Heading& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::Heading`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::Heading const& heading);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::Heading const& heading);
 
     /**
      * @brief Quaternion type.
@@ -259,14 +268,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::Quaternion& lhs, const Telemetry::Quaternion& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Telemetry::Quaternion& lhs, const Telemetry::Quaternion& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::Quaternion`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::Quaternion const& quaternion);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::Quaternion const& quaternion);
 
     /**
      * @brief Euler angle type.
@@ -291,14 +302,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::EulerAngle& lhs, const Telemetry::EulerAngle& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Telemetry::EulerAngle& lhs, const Telemetry::EulerAngle& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::EulerAngle`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::EulerAngle const& euler_angle);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::EulerAngle const& euler_angle);
 
     /**
      * @brief Angular velocity type.
@@ -314,7 +327,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const Telemetry::AngularVelocityBody& lhs, const Telemetry::AngularVelocityBody& rhs);
 
     /**
@@ -322,7 +335,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Telemetry::AngularVelocityBody const& angular_velocity_body);
 
     /**
@@ -338,14 +351,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::GpsInfo& lhs, const Telemetry::GpsInfo& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Telemetry::GpsInfo& lhs, const Telemetry::GpsInfo& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::GpsInfo`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::GpsInfo const& gps_info);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::GpsInfo const& gps_info);
 
     /**
      * @brief Raw GPS information type.
@@ -380,14 +395,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::RawGps& lhs, const Telemetry::RawGps& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Telemetry::RawGps& lhs, const Telemetry::RawGps& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::RawGps`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::RawGps const& raw_gps);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::RawGps const& raw_gps);
 
     /**
      * @brief Battery type.
@@ -413,14 +430,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::Battery& lhs, const Telemetry::Battery& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Telemetry::Battery& lhs, const Telemetry::Battery& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::Battery`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::Battery const& battery);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::Battery const& battery);
 
     /**
      * @brief Health type.
@@ -445,14 +464,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::Health& lhs, const Telemetry::Health& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Telemetry::Health& lhs, const Telemetry::Health& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::Health`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::Health const& health);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::Health const& health);
 
     /**
      * @brief Remote control status type.
@@ -469,14 +490,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::RcStatus& lhs, const Telemetry::RcStatus& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Telemetry::RcStatus& lhs, const Telemetry::RcStatus& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::RcStatus`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::RcStatus const& rc_status);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::RcStatus const& rc_status);
 
     /**
      * @brief StatusText information type.
@@ -491,14 +514,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::StatusText& lhs, const Telemetry::StatusText& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Telemetry::StatusText& lhs, const Telemetry::StatusText& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::StatusText`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::StatusText const& status_text);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::StatusText const& status_text);
 
     /**
      * @brief Actuator control target type.
@@ -515,7 +540,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const Telemetry::ActuatorControlTarget& lhs, const Telemetry::ActuatorControlTarget& rhs);
 
     /**
@@ -523,7 +548,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Telemetry::ActuatorControlTarget const& actuator_control_target);
 
     /**
@@ -539,7 +564,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const Telemetry::ActuatorOutputStatus& lhs, const Telemetry::ActuatorOutputStatus& rhs);
 
     /**
@@ -547,7 +572,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Telemetry::ActuatorOutputStatus const& actuator_output_status);
 
     /**
@@ -567,14 +592,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::Covariance& lhs, const Telemetry::Covariance& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Telemetry::Covariance& lhs, const Telemetry::Covariance& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::Covariance`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::Covariance const& covariance);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::Covariance const& covariance);
 
     /**
      * @brief Velocity type, represented in the Body (X Y Z) frame and in metres/second.
@@ -590,14 +617,15 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::VelocityBody& lhs, const Telemetry::VelocityBody& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Telemetry::VelocityBody& lhs, const Telemetry::VelocityBody& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::VelocityBody`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Telemetry::VelocityBody const& velocity_body);
 
     /**
@@ -614,14 +642,15 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::PositionBody& lhs, const Telemetry::PositionBody& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Telemetry::PositionBody& lhs, const Telemetry::PositionBody& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::PositionBody`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Telemetry::PositionBody const& position_body);
 
     /**
@@ -647,7 +676,7 @@ public:
          *
          * @return A reference to the stream.
          */
-        friend std::ostream&
+        friend MAVSDK_PUBLIC std::ostream&
         operator<<(std::ostream& str, Telemetry::Odometry::MavFrame const& mav_frame);
 
         uint64_t time_usec{}; /**< @brief Timestamp (0 to use Backend timestamp). */
@@ -668,14 +697,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::Odometry& lhs, const Telemetry::Odometry& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Telemetry::Odometry& lhs, const Telemetry::Odometry& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::Odometry`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::Odometry const& odometry);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::Odometry const& odometry);
 
     /**
      * @brief DistanceSensor message type.
@@ -695,7 +726,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Telemetry::DistanceSensor& lhs, const Telemetry::DistanceSensor& rhs);
 
     /**
@@ -703,7 +734,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Telemetry::DistanceSensor const& distance_sensor);
 
     /**
@@ -723,7 +754,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Telemetry::ScaledPressure& lhs, const Telemetry::ScaledPressure& rhs);
 
     /**
@@ -731,7 +762,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Telemetry::ScaledPressure const& scaled_pressure);
 
     /**
@@ -748,14 +779,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::PositionNed& lhs, const Telemetry::PositionNed& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Telemetry::PositionNed& lhs, const Telemetry::PositionNed& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::PositionNed`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::PositionNed const& position_ned);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::PositionNed const& position_ned);
 
     /**
      * @brief VelocityNed message type.
@@ -771,14 +804,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::VelocityNed& lhs, const Telemetry::VelocityNed& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Telemetry::VelocityNed& lhs, const Telemetry::VelocityNed& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::VelocityNed`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::VelocityNed const& velocity_ned);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::VelocityNed const& velocity_ned);
 
     /**
      * @brief PositionVelocityNed message type.
@@ -793,7 +828,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const Telemetry::PositionVelocityNed& lhs, const Telemetry::PositionVelocityNed& rhs);
 
     /**
@@ -801,7 +836,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Telemetry::PositionVelocityNed const& position_velocity_ned);
 
     /**
@@ -820,14 +855,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::GroundTruth& lhs, const Telemetry::GroundTruth& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Telemetry::GroundTruth& lhs, const Telemetry::GroundTruth& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::GroundTruth`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::GroundTruth const& ground_truth);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::GroundTruth const& ground_truth);
 
     /**
      * @brief FixedwingMetrics message type.
@@ -848,7 +885,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Telemetry::FixedwingMetrics& lhs, const Telemetry::FixedwingMetrics& rhs);
 
     /**
@@ -856,7 +893,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Telemetry::FixedwingMetrics const& fixedwing_metrics);
 
     /**
@@ -876,7 +913,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Telemetry::AccelerationFrd& lhs, const Telemetry::AccelerationFrd& rhs);
 
     /**
@@ -884,7 +921,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Telemetry::AccelerationFrd const& acceleration_frd);
 
     /**
@@ -904,7 +941,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Telemetry::AngularVelocityFrd& lhs, const Telemetry::AngularVelocityFrd& rhs);
 
     /**
@@ -912,7 +949,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Telemetry::AngularVelocityFrd const& angular_velocity_frd);
 
     /**
@@ -932,7 +969,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Telemetry::MagneticFieldFrd& lhs, const Telemetry::MagneticFieldFrd& rhs);
 
     /**
@@ -940,7 +977,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Telemetry::MagneticFieldFrd const& magnetic_field_frd);
 
     /**
@@ -959,14 +996,14 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::Imu& lhs, const Telemetry::Imu& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Telemetry::Imu& lhs, const Telemetry::Imu& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::Imu`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::Imu const& imu);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::Imu const& imu);
 
     /**
      * @brief Gps global origin type.
@@ -982,7 +1019,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Telemetry::GpsGlobalOrigin& lhs, const Telemetry::GpsGlobalOrigin& rhs);
 
     /**
@@ -990,7 +1027,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Telemetry::GpsGlobalOrigin const& gps_global_origin);
 
     /**
@@ -1015,14 +1052,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::Altitude& lhs, const Telemetry::Altitude& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Telemetry::Altitude& lhs, const Telemetry::Altitude& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::Altitude`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::Altitude const& altitude);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::Altitude const& altitude);
 
     /**
      * @brief Wind message type
@@ -1050,14 +1089,14 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::Wind& lhs, const Telemetry::Wind& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Telemetry::Wind& lhs, const Telemetry::Wind& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::Wind`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::Wind const& wind);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::Wind const& wind);
 
     /**
      * @brief Possible results returned for telemetry requests.
@@ -1078,7 +1117,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Telemetry::Result const& result);
 
     /**
      * @brief Callback type for asynchronous Telemetry calls.

--- a/src/mavsdk/plugins/telemetry/telemetry.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry.cpp
@@ -817,7 +817,7 @@ std::pair<Telemetry::Result, Telemetry::GpsGlobalOrigin> Telemetry::get_gps_glob
     return _impl->get_gps_global_origin();
 }
 
-bool operator==(const Telemetry::Position& lhs, const Telemetry::Position& rhs)
+MAVSDK_PUBLIC bool operator==(const Telemetry::Position& lhs, const Telemetry::Position& rhs)
 {
     return ((std::isnan(rhs.latitude_deg) && std::isnan(lhs.latitude_deg)) ||
             rhs.latitude_deg == lhs.latitude_deg) &&
@@ -829,7 +829,7 @@ bool operator==(const Telemetry::Position& lhs, const Telemetry::Position& rhs)
             rhs.relative_altitude_m == lhs.relative_altitude_m);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::Position const& position)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::Position const& position)
 {
     str << std::setprecision(15);
     str << "position:" << '\n' << "{\n";
@@ -841,14 +841,14 @@ std::ostream& operator<<(std::ostream& str, Telemetry::Position const& position)
     return str;
 }
 
-bool operator==(const Telemetry::Heading& lhs, const Telemetry::Heading& rhs)
+MAVSDK_PUBLIC bool operator==(const Telemetry::Heading& lhs, const Telemetry::Heading& rhs)
 {
     return (
         (std::isnan(rhs.heading_deg) && std::isnan(lhs.heading_deg)) ||
         rhs.heading_deg == lhs.heading_deg);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::Heading const& heading)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::Heading const& heading)
 {
     str << std::setprecision(15);
     str << "heading:" << '\n' << "{\n";
@@ -857,7 +857,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::Heading const& heading)
     return str;
 }
 
-bool operator==(const Telemetry::Quaternion& lhs, const Telemetry::Quaternion& rhs)
+MAVSDK_PUBLIC bool operator==(const Telemetry::Quaternion& lhs, const Telemetry::Quaternion& rhs)
 {
     return ((std::isnan(rhs.w) && std::isnan(lhs.w)) || rhs.w == lhs.w) &&
            ((std::isnan(rhs.x) && std::isnan(lhs.x)) || rhs.x == lhs.x) &&
@@ -866,7 +866,7 @@ bool operator==(const Telemetry::Quaternion& lhs, const Telemetry::Quaternion& r
            (rhs.timestamp_us == lhs.timestamp_us);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::Quaternion const& quaternion)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::Quaternion const& quaternion)
 {
     str << std::setprecision(15);
     str << "quaternion:" << '\n' << "{\n";
@@ -879,7 +879,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::Quaternion const& quatern
     return str;
 }
 
-bool operator==(const Telemetry::EulerAngle& lhs, const Telemetry::EulerAngle& rhs)
+MAVSDK_PUBLIC bool operator==(const Telemetry::EulerAngle& lhs, const Telemetry::EulerAngle& rhs)
 {
     return ((std::isnan(rhs.roll_deg) && std::isnan(lhs.roll_deg)) ||
             rhs.roll_deg == lhs.roll_deg) &&
@@ -889,7 +889,7 @@ bool operator==(const Telemetry::EulerAngle& lhs, const Telemetry::EulerAngle& r
            (rhs.timestamp_us == lhs.timestamp_us);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::EulerAngle const& euler_angle)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::EulerAngle const& euler_angle)
 {
     str << std::setprecision(15);
     str << "euler_angle:" << '\n' << "{\n";
@@ -901,8 +901,8 @@ std::ostream& operator<<(std::ostream& str, Telemetry::EulerAngle const& euler_a
     return str;
 }
 
-bool operator==(
-    const Telemetry::AngularVelocityBody& lhs, const Telemetry::AngularVelocityBody& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Telemetry::AngularVelocityBody& lhs, const Telemetry::AngularVelocityBody& rhs)
 {
     return ((std::isnan(rhs.roll_rad_s) && std::isnan(lhs.roll_rad_s)) ||
             rhs.roll_rad_s == lhs.roll_rad_s) &&
@@ -912,7 +912,7 @@ bool operator==(
             rhs.yaw_rad_s == lhs.yaw_rad_s);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, Telemetry::AngularVelocityBody const& angular_velocity_body)
 {
     str << std::setprecision(15);
@@ -924,12 +924,12 @@ operator<<(std::ostream& str, Telemetry::AngularVelocityBody const& angular_velo
     return str;
 }
 
-bool operator==(const Telemetry::GpsInfo& lhs, const Telemetry::GpsInfo& rhs)
+MAVSDK_PUBLIC bool operator==(const Telemetry::GpsInfo& lhs, const Telemetry::GpsInfo& rhs)
 {
     return (rhs.num_satellites == lhs.num_satellites) && (rhs.fix_type == lhs.fix_type);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::GpsInfo const& gps_info)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::GpsInfo const& gps_info)
 {
     str << std::setprecision(15);
     str << "gps_info:" << '\n' << "{\n";
@@ -939,7 +939,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::GpsInfo const& gps_info)
     return str;
 }
 
-bool operator==(const Telemetry::RawGps& lhs, const Telemetry::RawGps& rhs)
+MAVSDK_PUBLIC bool operator==(const Telemetry::RawGps& lhs, const Telemetry::RawGps& rhs)
 {
     return (rhs.timestamp_us == lhs.timestamp_us) &&
            ((std::isnan(rhs.latitude_deg) && std::isnan(lhs.latitude_deg)) ||
@@ -968,7 +968,7 @@ bool operator==(const Telemetry::RawGps& lhs, const Telemetry::RawGps& rhs)
            ((std::isnan(rhs.yaw_deg) && std::isnan(lhs.yaw_deg)) || rhs.yaw_deg == lhs.yaw_deg);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::RawGps const& raw_gps)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::RawGps const& raw_gps)
 {
     str << std::setprecision(15);
     str << "raw_gps:" << '\n' << "{\n";
@@ -990,7 +990,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::RawGps const& raw_gps)
     return str;
 }
 
-bool operator==(const Telemetry::Battery& lhs, const Telemetry::Battery& rhs)
+MAVSDK_PUBLIC bool operator==(const Telemetry::Battery& lhs, const Telemetry::Battery& rhs)
 {
     return (rhs.id == lhs.id) &&
            ((std::isnan(rhs.temperature_degc) && std::isnan(lhs.temperature_degc)) ||
@@ -1008,7 +1008,7 @@ bool operator==(const Telemetry::Battery& lhs, const Telemetry::Battery& rhs)
            (rhs.battery_function == lhs.battery_function);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::Battery const& battery)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::Battery const& battery)
 {
     str << std::setprecision(15);
     str << "battery:" << '\n' << "{\n";
@@ -1024,7 +1024,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::Battery const& battery)
     return str;
 }
 
-bool operator==(const Telemetry::Health& lhs, const Telemetry::Health& rhs)
+MAVSDK_PUBLIC bool operator==(const Telemetry::Health& lhs, const Telemetry::Health& rhs)
 {
     return (rhs.is_gyrometer_calibration_ok == lhs.is_gyrometer_calibration_ok) &&
            (rhs.is_accelerometer_calibration_ok == lhs.is_accelerometer_calibration_ok) &&
@@ -1035,7 +1035,7 @@ bool operator==(const Telemetry::Health& lhs, const Telemetry::Health& rhs)
            (rhs.is_armable == lhs.is_armable);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::Health const& health)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::Health const& health)
 {
     str << std::setprecision(15);
     str << "health:" << '\n' << "{\n";
@@ -1051,7 +1051,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::Health const& health)
     return str;
 }
 
-bool operator==(const Telemetry::RcStatus& lhs, const Telemetry::RcStatus& rhs)
+MAVSDK_PUBLIC bool operator==(const Telemetry::RcStatus& lhs, const Telemetry::RcStatus& rhs)
 {
     return (rhs.was_available_once == lhs.was_available_once) &&
            (rhs.is_available == lhs.is_available) &&
@@ -1059,7 +1059,7 @@ bool operator==(const Telemetry::RcStatus& lhs, const Telemetry::RcStatus& rhs)
             rhs.signal_strength_percent == lhs.signal_strength_percent);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::RcStatus const& rc_status)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::RcStatus const& rc_status)
 {
     str << std::setprecision(15);
     str << "rc_status:" << '\n' << "{\n";
@@ -1070,12 +1070,12 @@ std::ostream& operator<<(std::ostream& str, Telemetry::RcStatus const& rc_status
     return str;
 }
 
-bool operator==(const Telemetry::StatusText& lhs, const Telemetry::StatusText& rhs)
+MAVSDK_PUBLIC bool operator==(const Telemetry::StatusText& lhs, const Telemetry::StatusText& rhs)
 {
     return (rhs.type == lhs.type) && (rhs.text == lhs.text);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::StatusText const& status_text)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::StatusText const& status_text)
 {
     str << std::setprecision(15);
     str << "status_text:" << '\n' << "{\n";
@@ -1085,13 +1085,13 @@ std::ostream& operator<<(std::ostream& str, Telemetry::StatusText const& status_
     return str;
 }
 
-bool operator==(
-    const Telemetry::ActuatorControlTarget& lhs, const Telemetry::ActuatorControlTarget& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Telemetry::ActuatorControlTarget& lhs, const Telemetry::ActuatorControlTarget& rhs)
 {
     return (rhs.group == lhs.group) && (rhs.controls == lhs.controls);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, Telemetry::ActuatorControlTarget const& actuator_control_target)
 {
     str << std::setprecision(15);
@@ -1108,13 +1108,13 @@ operator<<(std::ostream& str, Telemetry::ActuatorControlTarget const& actuator_c
     return str;
 }
 
-bool operator==(
-    const Telemetry::ActuatorOutputStatus& lhs, const Telemetry::ActuatorOutputStatus& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Telemetry::ActuatorOutputStatus& lhs, const Telemetry::ActuatorOutputStatus& rhs)
 {
     return (rhs.active == lhs.active) && (rhs.actuator == lhs.actuator);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, Telemetry::ActuatorOutputStatus const& actuator_output_status)
 {
     str << std::setprecision(15);
@@ -1131,12 +1131,12 @@ operator<<(std::ostream& str, Telemetry::ActuatorOutputStatus const& actuator_ou
     return str;
 }
 
-bool operator==(const Telemetry::Covariance& lhs, const Telemetry::Covariance& rhs)
+MAVSDK_PUBLIC bool operator==(const Telemetry::Covariance& lhs, const Telemetry::Covariance& rhs)
 {
     return (rhs.covariance_matrix == lhs.covariance_matrix);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::Covariance const& covariance)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::Covariance const& covariance)
 {
     str << std::setprecision(15);
     str << "covariance:" << '\n' << "{\n";
@@ -1150,14 +1150,16 @@ std::ostream& operator<<(std::ostream& str, Telemetry::Covariance const& covaria
     return str;
 }
 
-bool operator==(const Telemetry::VelocityBody& lhs, const Telemetry::VelocityBody& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Telemetry::VelocityBody& lhs, const Telemetry::VelocityBody& rhs)
 {
     return ((std::isnan(rhs.x_m_s) && std::isnan(lhs.x_m_s)) || rhs.x_m_s == lhs.x_m_s) &&
            ((std::isnan(rhs.y_m_s) && std::isnan(lhs.y_m_s)) || rhs.y_m_s == lhs.y_m_s) &&
            ((std::isnan(rhs.z_m_s) && std::isnan(lhs.z_m_s)) || rhs.z_m_s == lhs.z_m_s);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::VelocityBody const& velocity_body)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Telemetry::VelocityBody const& velocity_body)
 {
     str << std::setprecision(15);
     str << "velocity_body:" << '\n' << "{\n";
@@ -1168,14 +1170,16 @@ std::ostream& operator<<(std::ostream& str, Telemetry::VelocityBody const& veloc
     return str;
 }
 
-bool operator==(const Telemetry::PositionBody& lhs, const Telemetry::PositionBody& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Telemetry::PositionBody& lhs, const Telemetry::PositionBody& rhs)
 {
     return ((std::isnan(rhs.x_m) && std::isnan(lhs.x_m)) || rhs.x_m == lhs.x_m) &&
            ((std::isnan(rhs.y_m) && std::isnan(lhs.y_m)) || rhs.y_m == lhs.y_m) &&
            ((std::isnan(rhs.z_m) && std::isnan(lhs.z_m)) || rhs.z_m == lhs.z_m);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::PositionBody const& position_body)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Telemetry::PositionBody const& position_body)
 {
     str << std::setprecision(15);
     str << "position_body:" << '\n' << "{\n";
@@ -1186,7 +1190,8 @@ std::ostream& operator<<(std::ostream& str, Telemetry::PositionBody const& posit
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::Odometry::MavFrame const& mav_frame)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Telemetry::Odometry::MavFrame const& mav_frame)
 {
     switch (mav_frame) {
         case Telemetry::Odometry::MavFrame::Undef:
@@ -1201,7 +1206,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::Odometry::MavFrame const&
             return str << "Unknown";
     }
 }
-bool operator==(const Telemetry::Odometry& lhs, const Telemetry::Odometry& rhs)
+MAVSDK_PUBLIC bool operator==(const Telemetry::Odometry& lhs, const Telemetry::Odometry& rhs)
 {
     return (rhs.time_usec == lhs.time_usec) && (rhs.frame_id == lhs.frame_id) &&
            (rhs.child_frame_id == lhs.child_frame_id) && (rhs.position_body == lhs.position_body) &&
@@ -1211,7 +1216,7 @@ bool operator==(const Telemetry::Odometry& lhs, const Telemetry::Odometry& rhs)
            (rhs.velocity_covariance == lhs.velocity_covariance);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::Odometry const& odometry)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::Odometry const& odometry)
 {
     str << std::setprecision(15);
     str << "odometry:" << '\n' << "{\n";
@@ -1228,7 +1233,8 @@ std::ostream& operator<<(std::ostream& str, Telemetry::Odometry const& odometry)
     return str;
 }
 
-bool operator==(const Telemetry::DistanceSensor& lhs, const Telemetry::DistanceSensor& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Telemetry::DistanceSensor& lhs, const Telemetry::DistanceSensor& rhs)
 {
     return ((std::isnan(rhs.minimum_distance_m) && std::isnan(lhs.minimum_distance_m)) ||
             rhs.minimum_distance_m == lhs.minimum_distance_m) &&
@@ -1239,7 +1245,8 @@ bool operator==(const Telemetry::DistanceSensor& lhs, const Telemetry::DistanceS
            (rhs.orientation == lhs.orientation);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::DistanceSensor const& distance_sensor)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Telemetry::DistanceSensor const& distance_sensor)
 {
     str << std::setprecision(15);
     str << "distance_sensor:" << '\n' << "{\n";
@@ -1251,7 +1258,8 @@ std::ostream& operator<<(std::ostream& str, Telemetry::DistanceSensor const& dis
     return str;
 }
 
-bool operator==(const Telemetry::ScaledPressure& lhs, const Telemetry::ScaledPressure& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Telemetry::ScaledPressure& lhs, const Telemetry::ScaledPressure& rhs)
 {
     return (rhs.timestamp_us == lhs.timestamp_us) &&
            ((std::isnan(rhs.absolute_pressure_hpa) && std::isnan(lhs.absolute_pressure_hpa)) ||
@@ -1266,7 +1274,8 @@ bool operator==(const Telemetry::ScaledPressure& lhs, const Telemetry::ScaledPre
             rhs.differential_pressure_temperature_deg == lhs.differential_pressure_temperature_deg);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::ScaledPressure const& scaled_pressure)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Telemetry::ScaledPressure const& scaled_pressure)
 {
     str << std::setprecision(15);
     str << "scaled_pressure:" << '\n' << "{\n";
@@ -1280,14 +1289,15 @@ std::ostream& operator<<(std::ostream& str, Telemetry::ScaledPressure const& sca
     return str;
 }
 
-bool operator==(const Telemetry::PositionNed& lhs, const Telemetry::PositionNed& rhs)
+MAVSDK_PUBLIC bool operator==(const Telemetry::PositionNed& lhs, const Telemetry::PositionNed& rhs)
 {
     return ((std::isnan(rhs.north_m) && std::isnan(lhs.north_m)) || rhs.north_m == lhs.north_m) &&
            ((std::isnan(rhs.east_m) && std::isnan(lhs.east_m)) || rhs.east_m == lhs.east_m) &&
            ((std::isnan(rhs.down_m) && std::isnan(lhs.down_m)) || rhs.down_m == lhs.down_m);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::PositionNed const& position_ned)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Telemetry::PositionNed const& position_ned)
 {
     str << std::setprecision(15);
     str << "position_ned:" << '\n' << "{\n";
@@ -1298,7 +1308,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::PositionNed const& positi
     return str;
 }
 
-bool operator==(const Telemetry::VelocityNed& lhs, const Telemetry::VelocityNed& rhs)
+MAVSDK_PUBLIC bool operator==(const Telemetry::VelocityNed& lhs, const Telemetry::VelocityNed& rhs)
 {
     return ((std::isnan(rhs.north_m_s) && std::isnan(lhs.north_m_s)) ||
             rhs.north_m_s == lhs.north_m_s) &&
@@ -1307,7 +1317,8 @@ bool operator==(const Telemetry::VelocityNed& lhs, const Telemetry::VelocityNed&
            ((std::isnan(rhs.down_m_s) && std::isnan(lhs.down_m_s)) || rhs.down_m_s == lhs.down_m_s);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::VelocityNed const& velocity_ned)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Telemetry::VelocityNed const& velocity_ned)
 {
     str << std::setprecision(15);
     str << "velocity_ned:" << '\n' << "{\n";
@@ -1318,13 +1329,13 @@ std::ostream& operator<<(std::ostream& str, Telemetry::VelocityNed const& veloci
     return str;
 }
 
-bool operator==(
-    const Telemetry::PositionVelocityNed& lhs, const Telemetry::PositionVelocityNed& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Telemetry::PositionVelocityNed& lhs, const Telemetry::PositionVelocityNed& rhs)
 {
     return (rhs.position == lhs.position) && (rhs.velocity == lhs.velocity);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, Telemetry::PositionVelocityNed const& position_velocity_ned)
 {
     str << std::setprecision(15);
@@ -1335,7 +1346,7 @@ operator<<(std::ostream& str, Telemetry::PositionVelocityNed const& position_vel
     return str;
 }
 
-bool operator==(const Telemetry::GroundTruth& lhs, const Telemetry::GroundTruth& rhs)
+MAVSDK_PUBLIC bool operator==(const Telemetry::GroundTruth& lhs, const Telemetry::GroundTruth& rhs)
 {
     return ((std::isnan(rhs.latitude_deg) && std::isnan(lhs.latitude_deg)) ||
             rhs.latitude_deg == lhs.latitude_deg) &&
@@ -1346,7 +1357,8 @@ bool operator==(const Telemetry::GroundTruth& lhs, const Telemetry::GroundTruth&
            (rhs.timestamp_us == lhs.timestamp_us);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::GroundTruth const& ground_truth)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Telemetry::GroundTruth const& ground_truth)
 {
     str << std::setprecision(15);
     str << "ground_truth:" << '\n' << "{\n";
@@ -1358,7 +1370,8 @@ std::ostream& operator<<(std::ostream& str, Telemetry::GroundTruth const& ground
     return str;
 }
 
-bool operator==(const Telemetry::FixedwingMetrics& lhs, const Telemetry::FixedwingMetrics& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Telemetry::FixedwingMetrics& lhs, const Telemetry::FixedwingMetrics& rhs)
 {
     return ((std::isnan(rhs.airspeed_m_s) && std::isnan(lhs.airspeed_m_s)) ||
             rhs.airspeed_m_s == lhs.airspeed_m_s) &&
@@ -1374,7 +1387,8 @@ bool operator==(const Telemetry::FixedwingMetrics& lhs, const Telemetry::Fixedwi
             rhs.absolute_altitude_m == lhs.absolute_altitude_m);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::FixedwingMetrics const& fixedwing_metrics)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Telemetry::FixedwingMetrics const& fixedwing_metrics)
 {
     str << std::setprecision(15);
     str << "fixedwing_metrics:" << '\n' << "{\n";
@@ -1388,7 +1402,8 @@ std::ostream& operator<<(std::ostream& str, Telemetry::FixedwingMetrics const& f
     return str;
 }
 
-bool operator==(const Telemetry::AccelerationFrd& lhs, const Telemetry::AccelerationFrd& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Telemetry::AccelerationFrd& lhs, const Telemetry::AccelerationFrd& rhs)
 {
     return ((std::isnan(rhs.forward_m_s2) && std::isnan(lhs.forward_m_s2)) ||
             rhs.forward_m_s2 == lhs.forward_m_s2) &&
@@ -1398,7 +1413,8 @@ bool operator==(const Telemetry::AccelerationFrd& lhs, const Telemetry::Accelera
             rhs.down_m_s2 == lhs.down_m_s2);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::AccelerationFrd const& acceleration_frd)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Telemetry::AccelerationFrd const& acceleration_frd)
 {
     str << std::setprecision(15);
     str << "acceleration_frd:" << '\n' << "{\n";
@@ -1409,7 +1425,8 @@ std::ostream& operator<<(std::ostream& str, Telemetry::AccelerationFrd const& ac
     return str;
 }
 
-bool operator==(const Telemetry::AngularVelocityFrd& lhs, const Telemetry::AngularVelocityFrd& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Telemetry::AngularVelocityFrd& lhs, const Telemetry::AngularVelocityFrd& rhs)
 {
     return ((std::isnan(rhs.forward_rad_s) && std::isnan(lhs.forward_rad_s)) ||
             rhs.forward_rad_s == lhs.forward_rad_s) &&
@@ -1419,7 +1436,7 @@ bool operator==(const Telemetry::AngularVelocityFrd& lhs, const Telemetry::Angul
             rhs.down_rad_s == lhs.down_rad_s);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, Telemetry::AngularVelocityFrd const& angular_velocity_frd)
 {
     str << std::setprecision(15);
@@ -1431,7 +1448,8 @@ operator<<(std::ostream& str, Telemetry::AngularVelocityFrd const& angular_veloc
     return str;
 }
 
-bool operator==(const Telemetry::MagneticFieldFrd& lhs, const Telemetry::MagneticFieldFrd& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Telemetry::MagneticFieldFrd& lhs, const Telemetry::MagneticFieldFrd& rhs)
 {
     return ((std::isnan(rhs.forward_gauss) && std::isnan(lhs.forward_gauss)) ||
             rhs.forward_gauss == lhs.forward_gauss) &&
@@ -1441,7 +1459,8 @@ bool operator==(const Telemetry::MagneticFieldFrd& lhs, const Telemetry::Magneti
             rhs.down_gauss == lhs.down_gauss);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::MagneticFieldFrd const& magnetic_field_frd)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Telemetry::MagneticFieldFrd const& magnetic_field_frd)
 {
     str << std::setprecision(15);
     str << "magnetic_field_frd:" << '\n' << "{\n";
@@ -1452,7 +1471,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::MagneticFieldFrd const& m
     return str;
 }
 
-bool operator==(const Telemetry::Imu& lhs, const Telemetry::Imu& rhs)
+MAVSDK_PUBLIC bool operator==(const Telemetry::Imu& lhs, const Telemetry::Imu& rhs)
 {
     return (rhs.acceleration_frd == lhs.acceleration_frd) &&
            (rhs.angular_velocity_frd == lhs.angular_velocity_frd) &&
@@ -1462,7 +1481,7 @@ bool operator==(const Telemetry::Imu& lhs, const Telemetry::Imu& rhs)
            (rhs.timestamp_us == lhs.timestamp_us);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::Imu const& imu)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::Imu const& imu)
 {
     str << std::setprecision(15);
     str << "imu:" << '\n' << "{\n";
@@ -1475,7 +1494,8 @@ std::ostream& operator<<(std::ostream& str, Telemetry::Imu const& imu)
     return str;
 }
 
-bool operator==(const Telemetry::GpsGlobalOrigin& lhs, const Telemetry::GpsGlobalOrigin& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Telemetry::GpsGlobalOrigin& lhs, const Telemetry::GpsGlobalOrigin& rhs)
 {
     return ((std::isnan(rhs.latitude_deg) && std::isnan(lhs.latitude_deg)) ||
             rhs.latitude_deg == lhs.latitude_deg) &&
@@ -1485,7 +1505,8 @@ bool operator==(const Telemetry::GpsGlobalOrigin& lhs, const Telemetry::GpsGloba
             rhs.altitude_m == lhs.altitude_m);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::GpsGlobalOrigin const& gps_global_origin)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Telemetry::GpsGlobalOrigin const& gps_global_origin)
 {
     str << std::setprecision(15);
     str << "gps_global_origin:" << '\n' << "{\n";
@@ -1496,7 +1517,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::GpsGlobalOrigin const& gp
     return str;
 }
 
-bool operator==(const Telemetry::Altitude& lhs, const Telemetry::Altitude& rhs)
+MAVSDK_PUBLIC bool operator==(const Telemetry::Altitude& lhs, const Telemetry::Altitude& rhs)
 {
     return ((std::isnan(rhs.altitude_monotonic_m) && std::isnan(lhs.altitude_monotonic_m)) ||
             rhs.altitude_monotonic_m == lhs.altitude_monotonic_m) &&
@@ -1513,7 +1534,7 @@ bool operator==(const Telemetry::Altitude& lhs, const Telemetry::Altitude& rhs)
            (rhs.timestamp_us == lhs.timestamp_us);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::Altitude const& altitude)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::Altitude const& altitude)
 {
     str << std::setprecision(15);
     str << "altitude:" << '\n' << "{\n";
@@ -1528,7 +1549,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::Altitude const& altitude)
     return str;
 }
 
-bool operator==(const Telemetry::Wind& lhs, const Telemetry::Wind& rhs)
+MAVSDK_PUBLIC bool operator==(const Telemetry::Wind& lhs, const Telemetry::Wind& rhs)
 {
     return ((std::isnan(rhs.wind_x_ned_m_s) && std::isnan(lhs.wind_x_ned_m_s)) ||
             rhs.wind_x_ned_m_s == lhs.wind_x_ned_m_s) &&
@@ -1552,7 +1573,7 @@ bool operator==(const Telemetry::Wind& lhs, const Telemetry::Wind& rhs)
             rhs.vertical_wind_speed_accuracy_m_s == lhs.vertical_wind_speed_accuracy_m_s);
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::Wind const& wind)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::Wind const& wind)
 {
     str << std::setprecision(15);
     str << "wind:" << '\n' << "{\n";
@@ -1571,7 +1592,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::Wind const& wind)
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::Result const& result)
 {
     switch (result) {
         case Telemetry::Result::Unknown:
@@ -1595,7 +1616,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::Result const& result)
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::FixType const& fix_type)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::FixType const& fix_type)
 {
     switch (fix_type) {
         case Telemetry::FixType::NoGps:
@@ -1617,7 +1638,8 @@ std::ostream& operator<<(std::ostream& str, Telemetry::FixType const& fix_type)
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::BatteryFunction const& battery_function)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Telemetry::BatteryFunction const& battery_function)
 {
     switch (battery_function) {
         case Telemetry::BatteryFunction::Unknown:
@@ -1635,7 +1657,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::BatteryFunction const& ba
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::FlightMode const& flight_mode)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::FlightMode const& flight_mode)
 {
     switch (flight_mode) {
         case Telemetry::FlightMode::Unknown:
@@ -1673,7 +1695,8 @@ std::ostream& operator<<(std::ostream& str, Telemetry::FlightMode const& flight_
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::StatusTextType const& status_text_type)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Telemetry::StatusTextType const& status_text_type)
 {
     switch (status_text_type) {
         case Telemetry::StatusTextType::Debug:
@@ -1697,7 +1720,8 @@ std::ostream& operator<<(std::ostream& str, Telemetry::StatusTextType const& sta
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::LandedState const& landed_state)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Telemetry::LandedState const& landed_state)
 {
     switch (landed_state) {
         case Telemetry::LandedState::Unknown:
@@ -1715,7 +1739,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::LandedState const& landed
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Telemetry::VtolState const& vtol_state)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::VtolState const& vtol_state)
 {
     switch (vtol_state) {
         case Telemetry::VtolState::Undefined:

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -2,6 +2,7 @@
 #include "system.h"
 #include "math_utils.h"
 #include "callback_list.tpp"
+#include "mavsdk_export.h"
 
 #include <cmath>
 #include <functional>
@@ -12,34 +13,34 @@
 
 namespace mavsdk {
 
-template class CallbackList<Telemetry::PositionVelocityNed>;
-template class CallbackList<Telemetry::Position>;
-template class CallbackList<bool>;
-template class CallbackList<Telemetry::StatusText>;
-template class CallbackList<Telemetry::Quaternion>;
-template class CallbackList<Telemetry::AngularVelocityBody>;
-template class CallbackList<Telemetry::GroundTruth>;
-template class CallbackList<Telemetry::FixedwingMetrics>;
-template class CallbackList<Telemetry::EulerAngle>;
-template class CallbackList<Telemetry::VelocityNed>;
-template class CallbackList<Telemetry::Imu>;
-template class CallbackList<Telemetry::GpsInfo>;
-template class CallbackList<Telemetry::RawGps>;
-template class CallbackList<Telemetry::Battery>;
-template class CallbackList<Telemetry::FlightMode>;
-template class CallbackList<Telemetry::Health>;
-template class CallbackList<Telemetry::VtolState>;
-template class CallbackList<Telemetry::LandedState>;
-template class CallbackList<Telemetry::RcStatus>;
-template class CallbackList<uint64_t>;
-template class CallbackList<Telemetry::ActuatorControlTarget>;
-template class CallbackList<Telemetry::ActuatorOutputStatus>;
-template class CallbackList<Telemetry::Odometry>;
-template class CallbackList<Telemetry::DistanceSensor>;
-template class CallbackList<Telemetry::ScaledPressure>;
-template class CallbackList<Telemetry::Heading>;
-template class CallbackList<Telemetry::Altitude>;
-template class CallbackList<Telemetry::Wind>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::PositionVelocityNed>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::Position>;
+template class MAVSDK_TEMPL_INST CallbackList<bool>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::StatusText>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::Quaternion>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::AngularVelocityBody>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::GroundTruth>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::FixedwingMetrics>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::EulerAngle>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::VelocityNed>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::Imu>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::GpsInfo>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::RawGps>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::Battery>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::FlightMode>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::Health>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::VtolState>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::LandedState>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::RcStatus>;
+template class MAVSDK_TEMPL_INST CallbackList<uint64_t>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::ActuatorControlTarget>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::ActuatorOutputStatus>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::Odometry>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::DistanceSensor>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::ScaledPressure>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::Heading>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::Altitude>;
+template class MAVSDK_TEMPL_INST CallbackList<Telemetry::Wind>;
 
 TelemetryImpl::TelemetryImpl(System& system) : PluginImplBase(system)
 {

--- a/src/mavsdk/plugins/telemetry_server/include/plugins/telemetry_server/telemetry_server.h
+++ b/src/mavsdk/plugins/telemetry_server/include/plugins/telemetry_server/telemetry_server.h
@@ -17,6 +17,7 @@
 #include "server_plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -27,7 +28,7 @@ class TelemetryServerImpl;
  * @brief Allow users to provide vehicle telemetry and state information
  * (e.g. battery, GPS, RC connection, flight mode etc.) and set telemetry update rates.
  */
-class TelemetryServer : public ServerPluginBase {
+class MAVSDK_PUBLIC TelemetryServer : public ServerPluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a ServerComponent instance.
@@ -65,7 +66,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, TelemetryServer::FixType const& fix_type);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, TelemetryServer::FixType const& fix_type);
 
     /**
      * @brief Maps to MAV_VTOL_STATE
@@ -83,7 +85,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, TelemetryServer::VtolState const& vtol_state);
 
     /**
@@ -105,7 +107,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, TelemetryServer::StatusTextType const& status_text_type);
 
     /**
@@ -124,7 +126,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, TelemetryServer::LandedState const& landed_state);
 
     /**
@@ -144,7 +146,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const TelemetryServer::Position& lhs, const TelemetryServer::Position& rhs);
 
     /**
@@ -152,7 +154,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, TelemetryServer::Position const& position);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, TelemetryServer::Position const& position);
 
     /**
      * @brief Heading type used for global position
@@ -166,7 +169,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const TelemetryServer::Heading& lhs, const TelemetryServer::Heading& rhs);
 
     /**
@@ -174,7 +177,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, TelemetryServer::Heading const& heading);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, TelemetryServer::Heading const& heading);
 
     /**
      * @brief Quaternion type.
@@ -199,7 +203,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const TelemetryServer::Quaternion& lhs, const TelemetryServer::Quaternion& rhs);
 
     /**
@@ -207,7 +211,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, TelemetryServer::Quaternion const& quaternion);
 
     /**
@@ -233,7 +237,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const TelemetryServer::EulerAngle& lhs, const TelemetryServer::EulerAngle& rhs);
 
     /**
@@ -241,7 +245,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, TelemetryServer::EulerAngle const& euler_angle);
 
     /**
@@ -258,7 +262,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const TelemetryServer::AngularVelocityBody& lhs,
         const TelemetryServer::AngularVelocityBody& rhs);
 
@@ -267,7 +271,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(
+    friend MAVSDK_PUBLIC std::ostream& operator<<(
         std::ostream& str, TelemetryServer::AngularVelocityBody const& angular_velocity_body);
 
     /**
@@ -283,7 +287,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const TelemetryServer::GpsInfo& lhs, const TelemetryServer::GpsInfo& rhs);
 
     /**
@@ -291,7 +295,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, TelemetryServer::GpsInfo const& gps_info);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, TelemetryServer::GpsInfo const& gps_info);
 
     /**
      * @brief Raw GPS information type.
@@ -326,14 +331,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const TelemetryServer::RawGps& lhs, const TelemetryServer::RawGps& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const TelemetryServer::RawGps& lhs, const TelemetryServer::RawGps& rhs);
 
     /**
      * @brief Stream operator to print information about a `TelemetryServer::RawGps`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, TelemetryServer::RawGps const& raw_gps);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, TelemetryServer::RawGps const& raw_gps);
 
     /**
      * @brief Battery type.
@@ -349,7 +356,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const TelemetryServer::Battery& lhs, const TelemetryServer::Battery& rhs);
 
     /**
@@ -357,7 +364,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, TelemetryServer::Battery const& battery);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, TelemetryServer::Battery const& battery);
 
     /**
      * @brief Remote control status type.
@@ -374,7 +382,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const TelemetryServer::RcStatus& lhs, const TelemetryServer::RcStatus& rhs);
 
     /**
@@ -382,7 +390,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, TelemetryServer::RcStatus const& rc_status);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, TelemetryServer::RcStatus const& rc_status);
 
     /**
      * @brief StatusText information type.
@@ -397,7 +406,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const TelemetryServer::StatusText& lhs, const TelemetryServer::StatusText& rhs);
 
     /**
@@ -405,7 +414,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, TelemetryServer::StatusText const& status_text);
 
     /**
@@ -423,7 +432,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const TelemetryServer::ActuatorControlTarget& lhs,
         const TelemetryServer::ActuatorControlTarget& rhs);
 
@@ -432,7 +441,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(
+    friend MAVSDK_PUBLIC std::ostream& operator<<(
         std::ostream& str, TelemetryServer::ActuatorControlTarget const& actuator_control_target);
 
     /**
@@ -448,7 +457,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const TelemetryServer::ActuatorOutputStatus& lhs,
         const TelemetryServer::ActuatorOutputStatus& rhs);
 
@@ -457,7 +466,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(
+    friend MAVSDK_PUBLIC std::ostream& operator<<(
         std::ostream& str, TelemetryServer::ActuatorOutputStatus const& actuator_output_status);
 
     /**
@@ -477,7 +486,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const TelemetryServer::Covariance& lhs, const TelemetryServer::Covariance& rhs);
 
     /**
@@ -485,7 +494,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, TelemetryServer::Covariance const& covariance);
 
     /**
@@ -502,7 +511,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const TelemetryServer::VelocityBody& lhs, const TelemetryServer::VelocityBody& rhs);
 
     /**
@@ -510,7 +519,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, TelemetryServer::VelocityBody const& velocity_body);
 
     /**
@@ -527,7 +536,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const TelemetryServer::PositionBody& lhs, const TelemetryServer::PositionBody& rhs);
 
     /**
@@ -535,7 +544,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, TelemetryServer::PositionBody const& position_body);
 
     /**
@@ -561,7 +570,7 @@ public:
          *
          * @return A reference to the stream.
          */
-        friend std::ostream&
+        friend MAVSDK_PUBLIC std::ostream&
         operator<<(std::ostream& str, TelemetryServer::Odometry::MavFrame const& mav_frame);
 
         uint64_t time_usec{}; /**< @brief Timestamp (0 to use Backend timestamp). */
@@ -582,7 +591,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const TelemetryServer::Odometry& lhs, const TelemetryServer::Odometry& rhs);
 
     /**
@@ -590,7 +599,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, TelemetryServer::Odometry const& odometry);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, TelemetryServer::Odometry const& odometry);
 
     /**
      * @brief DistanceSensor message type.
@@ -609,7 +619,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const TelemetryServer::DistanceSensor& lhs, const TelemetryServer::DistanceSensor& rhs);
 
     /**
@@ -617,7 +627,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, TelemetryServer::DistanceSensor const& distance_sensor);
 
     /**
@@ -637,7 +647,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const TelemetryServer::ScaledPressure& lhs, const TelemetryServer::ScaledPressure& rhs);
 
     /**
@@ -645,7 +655,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, TelemetryServer::ScaledPressure const& scaled_pressure);
 
     /**
@@ -662,7 +672,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const TelemetryServer::PositionNed& lhs, const TelemetryServer::PositionNed& rhs);
 
     /**
@@ -670,7 +680,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, TelemetryServer::PositionNed const& position_ned);
 
     /**
@@ -687,7 +697,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const TelemetryServer::VelocityNed& lhs, const TelemetryServer::VelocityNed& rhs);
 
     /**
@@ -695,7 +705,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, TelemetryServer::VelocityNed const& velocity_ned);
 
     /**
@@ -711,7 +721,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const TelemetryServer::PositionVelocityNed& lhs,
         const TelemetryServer::PositionVelocityNed& rhs);
 
@@ -720,7 +730,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(
+    friend MAVSDK_PUBLIC std::ostream& operator<<(
         std::ostream& str, TelemetryServer::PositionVelocityNed const& position_velocity_ned);
 
     /**
@@ -739,7 +749,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const TelemetryServer::GroundTruth& lhs, const TelemetryServer::GroundTruth& rhs);
 
     /**
@@ -747,7 +757,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, TelemetryServer::GroundTruth const& ground_truth);
 
     /**
@@ -769,7 +779,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const TelemetryServer::FixedwingMetrics& lhs, const TelemetryServer::FixedwingMetrics& rhs);
 
     /**
@@ -777,7 +787,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, TelemetryServer::FixedwingMetrics const& fixedwing_metrics);
 
     /**
@@ -797,7 +807,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const TelemetryServer::AccelerationFrd& lhs, const TelemetryServer::AccelerationFrd& rhs);
 
     /**
@@ -805,7 +815,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, TelemetryServer::AccelerationFrd const& acceleration_frd);
 
     /**
@@ -825,7 +835,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const TelemetryServer::AngularVelocityFrd& lhs,
         const TelemetryServer::AngularVelocityFrd& rhs);
 
@@ -834,7 +844,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, TelemetryServer::AngularVelocityFrd const& angular_velocity_frd);
 
     /**
@@ -854,7 +864,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
+    friend MAVSDK_PUBLIC bool operator==(
         const TelemetryServer::MagneticFieldFrd& lhs, const TelemetryServer::MagneticFieldFrd& rhs);
 
     /**
@@ -862,7 +872,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, TelemetryServer::MagneticFieldFrd const& magnetic_field_frd);
 
     /**
@@ -881,14 +891,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const TelemetryServer::Imu& lhs, const TelemetryServer::Imu& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const TelemetryServer::Imu& lhs, const TelemetryServer::Imu& rhs);
 
     /**
      * @brief Stream operator to print information about a `TelemetryServer::Imu`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, TelemetryServer::Imu const& imu);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, TelemetryServer::Imu const& imu);
 
     /**
      * @brief Possible results returned for telemetry requests.
@@ -909,7 +921,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, TelemetryServer::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, TelemetryServer::Result const& result);
 
     /**
      * @brief Callback type for asynchronous TelemetryServer calls.

--- a/src/mavsdk/plugins/telemetry_server/telemetry_server.cpp
+++ b/src/mavsdk/plugins/telemetry_server/telemetry_server.cpp
@@ -143,7 +143,8 @@ TelemetryServer::publish_visual_flight_rules_hud(FixedwingMetrics fixed_wing_met
     return _impl->publish_visual_flight_rules_hud(fixed_wing_metrics);
 }
 
-bool operator==(const TelemetryServer::Position& lhs, const TelemetryServer::Position& rhs)
+MAVSDK_PUBLIC bool
+operator==(const TelemetryServer::Position& lhs, const TelemetryServer::Position& rhs)
 {
     return ((std::isnan(rhs.latitude_deg) && std::isnan(lhs.latitude_deg)) ||
             rhs.latitude_deg == lhs.latitude_deg) &&
@@ -155,7 +156,7 @@ bool operator==(const TelemetryServer::Position& lhs, const TelemetryServer::Pos
             rhs.relative_altitude_m == lhs.relative_altitude_m);
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::Position const& position)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, TelemetryServer::Position const& position)
 {
     str << std::setprecision(15);
     str << "position:" << '\n' << "{\n";
@@ -167,14 +168,15 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::Position const& pos
     return str;
 }
 
-bool operator==(const TelemetryServer::Heading& lhs, const TelemetryServer::Heading& rhs)
+MAVSDK_PUBLIC bool
+operator==(const TelemetryServer::Heading& lhs, const TelemetryServer::Heading& rhs)
 {
     return (
         (std::isnan(rhs.heading_deg) && std::isnan(lhs.heading_deg)) ||
         rhs.heading_deg == lhs.heading_deg);
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::Heading const& heading)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, TelemetryServer::Heading const& heading)
 {
     str << std::setprecision(15);
     str << "heading:" << '\n' << "{\n";
@@ -183,7 +185,8 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::Heading const& head
     return str;
 }
 
-bool operator==(const TelemetryServer::Quaternion& lhs, const TelemetryServer::Quaternion& rhs)
+MAVSDK_PUBLIC bool
+operator==(const TelemetryServer::Quaternion& lhs, const TelemetryServer::Quaternion& rhs)
 {
     return ((std::isnan(rhs.w) && std::isnan(lhs.w)) || rhs.w == lhs.w) &&
            ((std::isnan(rhs.x) && std::isnan(lhs.x)) || rhs.x == lhs.x) &&
@@ -192,7 +195,8 @@ bool operator==(const TelemetryServer::Quaternion& lhs, const TelemetryServer::Q
            (rhs.timestamp_us == lhs.timestamp_us);
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::Quaternion const& quaternion)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, TelemetryServer::Quaternion const& quaternion)
 {
     str << std::setprecision(15);
     str << "quaternion:" << '\n' << "{\n";
@@ -205,7 +209,8 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::Quaternion const& q
     return str;
 }
 
-bool operator==(const TelemetryServer::EulerAngle& lhs, const TelemetryServer::EulerAngle& rhs)
+MAVSDK_PUBLIC bool
+operator==(const TelemetryServer::EulerAngle& lhs, const TelemetryServer::EulerAngle& rhs)
 {
     return ((std::isnan(rhs.roll_deg) && std::isnan(lhs.roll_deg)) ||
             rhs.roll_deg == lhs.roll_deg) &&
@@ -215,7 +220,8 @@ bool operator==(const TelemetryServer::EulerAngle& lhs, const TelemetryServer::E
            (rhs.timestamp_us == lhs.timestamp_us);
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::EulerAngle const& euler_angle)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, TelemetryServer::EulerAngle const& euler_angle)
 {
     str << std::setprecision(15);
     str << "euler_angle:" << '\n' << "{\n";
@@ -227,7 +233,7 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::EulerAngle const& e
     return str;
 }
 
-bool operator==(
+MAVSDK_PUBLIC bool operator==(
     const TelemetryServer::AngularVelocityBody& lhs,
     const TelemetryServer::AngularVelocityBody& rhs)
 {
@@ -239,7 +245,7 @@ bool operator==(
             rhs.yaw_rad_s == lhs.yaw_rad_s);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, TelemetryServer::AngularVelocityBody const& angular_velocity_body)
 {
     str << std::setprecision(15);
@@ -251,12 +257,13 @@ operator<<(std::ostream& str, TelemetryServer::AngularVelocityBody const& angula
     return str;
 }
 
-bool operator==(const TelemetryServer::GpsInfo& lhs, const TelemetryServer::GpsInfo& rhs)
+MAVSDK_PUBLIC bool
+operator==(const TelemetryServer::GpsInfo& lhs, const TelemetryServer::GpsInfo& rhs)
 {
     return (rhs.num_satellites == lhs.num_satellites) && (rhs.fix_type == lhs.fix_type);
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::GpsInfo const& gps_info)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, TelemetryServer::GpsInfo const& gps_info)
 {
     str << std::setprecision(15);
     str << "gps_info:" << '\n' << "{\n";
@@ -266,7 +273,8 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::GpsInfo const& gps_
     return str;
 }
 
-bool operator==(const TelemetryServer::RawGps& lhs, const TelemetryServer::RawGps& rhs)
+MAVSDK_PUBLIC bool
+operator==(const TelemetryServer::RawGps& lhs, const TelemetryServer::RawGps& rhs)
 {
     return (rhs.timestamp_us == lhs.timestamp_us) &&
            ((std::isnan(rhs.latitude_deg) && std::isnan(lhs.latitude_deg)) ||
@@ -295,7 +303,7 @@ bool operator==(const TelemetryServer::RawGps& lhs, const TelemetryServer::RawGp
            ((std::isnan(rhs.yaw_deg) && std::isnan(lhs.yaw_deg)) || rhs.yaw_deg == lhs.yaw_deg);
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::RawGps const& raw_gps)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, TelemetryServer::RawGps const& raw_gps)
 {
     str << std::setprecision(15);
     str << "raw_gps:" << '\n' << "{\n";
@@ -317,7 +325,8 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::RawGps const& raw_g
     return str;
 }
 
-bool operator==(const TelemetryServer::Battery& lhs, const TelemetryServer::Battery& rhs)
+MAVSDK_PUBLIC bool
+operator==(const TelemetryServer::Battery& lhs, const TelemetryServer::Battery& rhs)
 {
     return ((std::isnan(rhs.voltage_v) && std::isnan(lhs.voltage_v)) ||
             rhs.voltage_v == lhs.voltage_v) &&
@@ -325,7 +334,7 @@ bool operator==(const TelemetryServer::Battery& lhs, const TelemetryServer::Batt
             rhs.remaining_percent == lhs.remaining_percent);
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::Battery const& battery)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, TelemetryServer::Battery const& battery)
 {
     str << std::setprecision(15);
     str << "battery:" << '\n' << "{\n";
@@ -335,7 +344,8 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::Battery const& batt
     return str;
 }
 
-bool operator==(const TelemetryServer::RcStatus& lhs, const TelemetryServer::RcStatus& rhs)
+MAVSDK_PUBLIC bool
+operator==(const TelemetryServer::RcStatus& lhs, const TelemetryServer::RcStatus& rhs)
 {
     return (rhs.was_available_once == lhs.was_available_once) &&
            (rhs.is_available == lhs.is_available) &&
@@ -343,7 +353,8 @@ bool operator==(const TelemetryServer::RcStatus& lhs, const TelemetryServer::RcS
             rhs.signal_strength_percent == lhs.signal_strength_percent);
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::RcStatus const& rc_status)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, TelemetryServer::RcStatus const& rc_status)
 {
     str << std::setprecision(15);
     str << "rc_status:" << '\n' << "{\n";
@@ -354,12 +365,14 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::RcStatus const& rc_
     return str;
 }
 
-bool operator==(const TelemetryServer::StatusText& lhs, const TelemetryServer::StatusText& rhs)
+MAVSDK_PUBLIC bool
+operator==(const TelemetryServer::StatusText& lhs, const TelemetryServer::StatusText& rhs)
 {
     return (rhs.type == lhs.type) && (rhs.text == lhs.text);
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::StatusText const& status_text)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, TelemetryServer::StatusText const& status_text)
 {
     str << std::setprecision(15);
     str << "status_text:" << '\n' << "{\n";
@@ -369,14 +382,14 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::StatusText const& s
     return str;
 }
 
-bool operator==(
+MAVSDK_PUBLIC bool operator==(
     const TelemetryServer::ActuatorControlTarget& lhs,
     const TelemetryServer::ActuatorControlTarget& rhs)
 {
     return (rhs.group == lhs.group) && (rhs.controls == lhs.controls);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, TelemetryServer::ActuatorControlTarget const& actuator_control_target)
 {
     str << std::setprecision(15);
@@ -393,14 +406,14 @@ operator<<(std::ostream& str, TelemetryServer::ActuatorControlTarget const& actu
     return str;
 }
 
-bool operator==(
+MAVSDK_PUBLIC bool operator==(
     const TelemetryServer::ActuatorOutputStatus& lhs,
     const TelemetryServer::ActuatorOutputStatus& rhs)
 {
     return (rhs.active == lhs.active) && (rhs.actuator == lhs.actuator);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, TelemetryServer::ActuatorOutputStatus const& actuator_output_status)
 {
     str << std::setprecision(15);
@@ -417,12 +430,14 @@ operator<<(std::ostream& str, TelemetryServer::ActuatorOutputStatus const& actua
     return str;
 }
 
-bool operator==(const TelemetryServer::Covariance& lhs, const TelemetryServer::Covariance& rhs)
+MAVSDK_PUBLIC bool
+operator==(const TelemetryServer::Covariance& lhs, const TelemetryServer::Covariance& rhs)
 {
     return (rhs.covariance_matrix == lhs.covariance_matrix);
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::Covariance const& covariance)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, TelemetryServer::Covariance const& covariance)
 {
     str << std::setprecision(15);
     str << "covariance:" << '\n' << "{\n";
@@ -436,14 +451,16 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::Covariance const& c
     return str;
 }
 
-bool operator==(const TelemetryServer::VelocityBody& lhs, const TelemetryServer::VelocityBody& rhs)
+MAVSDK_PUBLIC bool
+operator==(const TelemetryServer::VelocityBody& lhs, const TelemetryServer::VelocityBody& rhs)
 {
     return ((std::isnan(rhs.x_m_s) && std::isnan(lhs.x_m_s)) || rhs.x_m_s == lhs.x_m_s) &&
            ((std::isnan(rhs.y_m_s) && std::isnan(lhs.y_m_s)) || rhs.y_m_s == lhs.y_m_s) &&
            ((std::isnan(rhs.z_m_s) && std::isnan(lhs.z_m_s)) || rhs.z_m_s == lhs.z_m_s);
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::VelocityBody const& velocity_body)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, TelemetryServer::VelocityBody const& velocity_body)
 {
     str << std::setprecision(15);
     str << "velocity_body:" << '\n' << "{\n";
@@ -454,14 +471,16 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::VelocityBody const&
     return str;
 }
 
-bool operator==(const TelemetryServer::PositionBody& lhs, const TelemetryServer::PositionBody& rhs)
+MAVSDK_PUBLIC bool
+operator==(const TelemetryServer::PositionBody& lhs, const TelemetryServer::PositionBody& rhs)
 {
     return ((std::isnan(rhs.x_m) && std::isnan(lhs.x_m)) || rhs.x_m == lhs.x_m) &&
            ((std::isnan(rhs.y_m) && std::isnan(lhs.y_m)) || rhs.y_m == lhs.y_m) &&
            ((std::isnan(rhs.z_m) && std::isnan(lhs.z_m)) || rhs.z_m == lhs.z_m);
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::PositionBody const& position_body)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, TelemetryServer::PositionBody const& position_body)
 {
     str << std::setprecision(15);
     str << "position_body:" << '\n' << "{\n";
@@ -472,7 +491,8 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::PositionBody const&
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::Odometry::MavFrame const& mav_frame)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, TelemetryServer::Odometry::MavFrame const& mav_frame)
 {
     switch (mav_frame) {
         case TelemetryServer::Odometry::MavFrame::Undef:
@@ -487,7 +507,8 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::Odometry::MavFrame 
             return str << "Unknown";
     }
 }
-bool operator==(const TelemetryServer::Odometry& lhs, const TelemetryServer::Odometry& rhs)
+MAVSDK_PUBLIC bool
+operator==(const TelemetryServer::Odometry& lhs, const TelemetryServer::Odometry& rhs)
 {
     return (rhs.time_usec == lhs.time_usec) && (rhs.frame_id == lhs.frame_id) &&
            (rhs.child_frame_id == lhs.child_frame_id) && (rhs.position_body == lhs.position_body) &&
@@ -497,7 +518,7 @@ bool operator==(const TelemetryServer::Odometry& lhs, const TelemetryServer::Odo
            (rhs.velocity_covariance == lhs.velocity_covariance);
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::Odometry const& odometry)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, TelemetryServer::Odometry const& odometry)
 {
     str << std::setprecision(15);
     str << "odometry:" << '\n' << "{\n";
@@ -514,8 +535,8 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::Odometry const& odo
     return str;
 }
 
-bool operator==(
-    const TelemetryServer::DistanceSensor& lhs, const TelemetryServer::DistanceSensor& rhs)
+MAVSDK_PUBLIC bool
+operator==(const TelemetryServer::DistanceSensor& lhs, const TelemetryServer::DistanceSensor& rhs)
 {
     return ((std::isnan(rhs.minimum_distance_m) && std::isnan(lhs.minimum_distance_m)) ||
             rhs.minimum_distance_m == lhs.minimum_distance_m) &&
@@ -525,7 +546,8 @@ bool operator==(
             rhs.current_distance_m == lhs.current_distance_m);
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::DistanceSensor const& distance_sensor)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, TelemetryServer::DistanceSensor const& distance_sensor)
 {
     str << std::setprecision(15);
     str << "distance_sensor:" << '\n' << "{\n";
@@ -536,8 +558,8 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::DistanceSensor cons
     return str;
 }
 
-bool operator==(
-    const TelemetryServer::ScaledPressure& lhs, const TelemetryServer::ScaledPressure& rhs)
+MAVSDK_PUBLIC bool
+operator==(const TelemetryServer::ScaledPressure& lhs, const TelemetryServer::ScaledPressure& rhs)
 {
     return (rhs.timestamp_us == lhs.timestamp_us) &&
            ((std::isnan(rhs.absolute_pressure_hpa) && std::isnan(lhs.absolute_pressure_hpa)) ||
@@ -552,7 +574,8 @@ bool operator==(
             rhs.differential_pressure_temperature_deg == lhs.differential_pressure_temperature_deg);
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::ScaledPressure const& scaled_pressure)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, TelemetryServer::ScaledPressure const& scaled_pressure)
 {
     str << std::setprecision(15);
     str << "scaled_pressure:" << '\n' << "{\n";
@@ -566,14 +589,16 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::ScaledPressure cons
     return str;
 }
 
-bool operator==(const TelemetryServer::PositionNed& lhs, const TelemetryServer::PositionNed& rhs)
+MAVSDK_PUBLIC bool
+operator==(const TelemetryServer::PositionNed& lhs, const TelemetryServer::PositionNed& rhs)
 {
     return ((std::isnan(rhs.north_m) && std::isnan(lhs.north_m)) || rhs.north_m == lhs.north_m) &&
            ((std::isnan(rhs.east_m) && std::isnan(lhs.east_m)) || rhs.east_m == lhs.east_m) &&
            ((std::isnan(rhs.down_m) && std::isnan(lhs.down_m)) || rhs.down_m == lhs.down_m);
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::PositionNed const& position_ned)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, TelemetryServer::PositionNed const& position_ned)
 {
     str << std::setprecision(15);
     str << "position_ned:" << '\n' << "{\n";
@@ -584,7 +609,8 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::PositionNed const& 
     return str;
 }
 
-bool operator==(const TelemetryServer::VelocityNed& lhs, const TelemetryServer::VelocityNed& rhs)
+MAVSDK_PUBLIC bool
+operator==(const TelemetryServer::VelocityNed& lhs, const TelemetryServer::VelocityNed& rhs)
 {
     return ((std::isnan(rhs.north_m_s) && std::isnan(lhs.north_m_s)) ||
             rhs.north_m_s == lhs.north_m_s) &&
@@ -593,7 +619,8 @@ bool operator==(const TelemetryServer::VelocityNed& lhs, const TelemetryServer::
            ((std::isnan(rhs.down_m_s) && std::isnan(lhs.down_m_s)) || rhs.down_m_s == lhs.down_m_s);
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::VelocityNed const& velocity_ned)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, TelemetryServer::VelocityNed const& velocity_ned)
 {
     str << std::setprecision(15);
     str << "velocity_ned:" << '\n' << "{\n";
@@ -604,14 +631,14 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::VelocityNed const& 
     return str;
 }
 
-bool operator==(
+MAVSDK_PUBLIC bool operator==(
     const TelemetryServer::PositionVelocityNed& lhs,
     const TelemetryServer::PositionVelocityNed& rhs)
 {
     return (rhs.position == lhs.position) && (rhs.velocity == lhs.velocity);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, TelemetryServer::PositionVelocityNed const& position_velocity_ned)
 {
     str << std::setprecision(15);
@@ -622,7 +649,8 @@ operator<<(std::ostream& str, TelemetryServer::PositionVelocityNed const& positi
     return str;
 }
 
-bool operator==(const TelemetryServer::GroundTruth& lhs, const TelemetryServer::GroundTruth& rhs)
+MAVSDK_PUBLIC bool
+operator==(const TelemetryServer::GroundTruth& lhs, const TelemetryServer::GroundTruth& rhs)
 {
     return ((std::isnan(rhs.latitude_deg) && std::isnan(lhs.latitude_deg)) ||
             rhs.latitude_deg == lhs.latitude_deg) &&
@@ -633,7 +661,8 @@ bool operator==(const TelemetryServer::GroundTruth& lhs, const TelemetryServer::
            (rhs.timestamp_us == lhs.timestamp_us);
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::GroundTruth const& ground_truth)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, TelemetryServer::GroundTruth const& ground_truth)
 {
     str << std::setprecision(15);
     str << "ground_truth:" << '\n' << "{\n";
@@ -645,7 +674,7 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::GroundTruth const& 
     return str;
 }
 
-bool operator==(
+MAVSDK_PUBLIC bool operator==(
     const TelemetryServer::FixedwingMetrics& lhs, const TelemetryServer::FixedwingMetrics& rhs)
 {
     return ((std::isnan(rhs.airspeed_m_s) && std::isnan(lhs.airspeed_m_s)) ||
@@ -662,7 +691,7 @@ bool operator==(
             rhs.absolute_altitude_m == lhs.absolute_altitude_m);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, TelemetryServer::FixedwingMetrics const& fixedwing_metrics)
 {
     str << std::setprecision(15);
@@ -677,8 +706,8 @@ operator<<(std::ostream& str, TelemetryServer::FixedwingMetrics const& fixedwing
     return str;
 }
 
-bool operator==(
-    const TelemetryServer::AccelerationFrd& lhs, const TelemetryServer::AccelerationFrd& rhs)
+MAVSDK_PUBLIC bool
+operator==(const TelemetryServer::AccelerationFrd& lhs, const TelemetryServer::AccelerationFrd& rhs)
 {
     return ((std::isnan(rhs.forward_m_s2) && std::isnan(lhs.forward_m_s2)) ||
             rhs.forward_m_s2 == lhs.forward_m_s2) &&
@@ -688,7 +717,7 @@ bool operator==(
             rhs.down_m_s2 == lhs.down_m_s2);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, TelemetryServer::AccelerationFrd const& acceleration_frd)
 {
     str << std::setprecision(15);
@@ -700,7 +729,7 @@ operator<<(std::ostream& str, TelemetryServer::AccelerationFrd const& accelerati
     return str;
 }
 
-bool operator==(
+MAVSDK_PUBLIC bool operator==(
     const TelemetryServer::AngularVelocityFrd& lhs, const TelemetryServer::AngularVelocityFrd& rhs)
 {
     return ((std::isnan(rhs.forward_rad_s) && std::isnan(lhs.forward_rad_s)) ||
@@ -711,7 +740,7 @@ bool operator==(
             rhs.down_rad_s == lhs.down_rad_s);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, TelemetryServer::AngularVelocityFrd const& angular_velocity_frd)
 {
     str << std::setprecision(15);
@@ -723,7 +752,7 @@ operator<<(std::ostream& str, TelemetryServer::AngularVelocityFrd const& angular
     return str;
 }
 
-bool operator==(
+MAVSDK_PUBLIC bool operator==(
     const TelemetryServer::MagneticFieldFrd& lhs, const TelemetryServer::MagneticFieldFrd& rhs)
 {
     return ((std::isnan(rhs.forward_gauss) && std::isnan(lhs.forward_gauss)) ||
@@ -734,7 +763,7 @@ bool operator==(
             rhs.down_gauss == lhs.down_gauss);
 }
 
-std::ostream&
+MAVSDK_PUBLIC std::ostream&
 operator<<(std::ostream& str, TelemetryServer::MagneticFieldFrd const& magnetic_field_frd)
 {
     str << std::setprecision(15);
@@ -746,7 +775,7 @@ operator<<(std::ostream& str, TelemetryServer::MagneticFieldFrd const& magnetic_
     return str;
 }
 
-bool operator==(const TelemetryServer::Imu& lhs, const TelemetryServer::Imu& rhs)
+MAVSDK_PUBLIC bool operator==(const TelemetryServer::Imu& lhs, const TelemetryServer::Imu& rhs)
 {
     return (rhs.acceleration_frd == lhs.acceleration_frd) &&
            (rhs.angular_velocity_frd == lhs.angular_velocity_frd) &&
@@ -756,7 +785,7 @@ bool operator==(const TelemetryServer::Imu& lhs, const TelemetryServer::Imu& rhs
            (rhs.timestamp_us == lhs.timestamp_us);
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::Imu const& imu)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, TelemetryServer::Imu const& imu)
 {
     str << std::setprecision(15);
     str << "imu:" << '\n' << "{\n";
@@ -769,7 +798,7 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::Imu const& imu)
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, TelemetryServer::Result const& result)
 {
     switch (result) {
         case TelemetryServer::Result::Unknown:
@@ -793,7 +822,7 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::Result const& resul
     }
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::FixType const& fix_type)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, TelemetryServer::FixType const& fix_type)
 {
     switch (fix_type) {
         case TelemetryServer::FixType::NoGps:
@@ -815,7 +844,8 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::FixType const& fix_
     }
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::VtolState const& vtol_state)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, TelemetryServer::VtolState const& vtol_state)
 {
     switch (vtol_state) {
         case TelemetryServer::VtolState::Undefined:
@@ -833,7 +863,8 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::VtolState const& vt
     }
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::StatusTextType const& status_text_type)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, TelemetryServer::StatusTextType const& status_text_type)
 {
     switch (status_text_type) {
         case TelemetryServer::StatusTextType::Debug:
@@ -857,7 +888,8 @@ std::ostream& operator<<(std::ostream& str, TelemetryServer::StatusTextType cons
     }
 }
 
-std::ostream& operator<<(std::ostream& str, TelemetryServer::LandedState const& landed_state)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, TelemetryServer::LandedState const& landed_state)
 {
     switch (landed_state) {
         case TelemetryServer::LandedState::Unknown:

--- a/src/mavsdk/plugins/transponder/include/plugins/transponder/transponder.h
+++ b/src/mavsdk/plugins/transponder/include/plugins/transponder/transponder.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -26,7 +27,7 @@ class TransponderImpl;
  * @brief Allow users to get ADS-B information
  * and set ADS-B update rates.
  */
-class Transponder : public PluginBase {
+class MAVSDK_PUBLIC Transponder : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -90,7 +91,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Transponder::AdsbEmitterType const& adsb_emitter_type);
 
     /**
@@ -106,7 +107,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Transponder::AdsbAltitudeType const& adsb_altitude_type);
 
     /**
@@ -134,7 +135,7 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
+    friend MAVSDK_PUBLIC bool
     operator==(const Transponder::AdsbVehicle& lhs, const Transponder::AdsbVehicle& rhs);
 
     /**
@@ -142,7 +143,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Transponder::AdsbVehicle const& adsb_vehicle);
 
     /**
@@ -163,7 +164,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Transponder::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Transponder::Result const& result);
 
     /**
      * @brief Callback type for asynchronous Transponder calls.

--- a/src/mavsdk/plugins/transponder/transponder.cpp
+++ b/src/mavsdk/plugins/transponder/transponder.cpp
@@ -49,7 +49,8 @@ Transponder::Result Transponder::set_rate_transponder(double rate_hz) const
     return _impl->set_rate_transponder(rate_hz);
 }
 
-bool operator==(const Transponder::AdsbVehicle& lhs, const Transponder::AdsbVehicle& rhs)
+MAVSDK_PUBLIC bool
+operator==(const Transponder::AdsbVehicle& lhs, const Transponder::AdsbVehicle& rhs)
 {
     return (rhs.icao_address == lhs.icao_address) &&
            ((std::isnan(rhs.latitude_deg) && std::isnan(lhs.latitude_deg)) ||
@@ -69,7 +70,8 @@ bool operator==(const Transponder::AdsbVehicle& lhs, const Transponder::AdsbVehi
            (rhs.squawk == lhs.squawk) && (rhs.tslc_s == lhs.tslc_s);
 }
 
-std::ostream& operator<<(std::ostream& str, Transponder::AdsbVehicle const& adsb_vehicle)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Transponder::AdsbVehicle const& adsb_vehicle)
 {
     str << std::setprecision(15);
     str << "adsb_vehicle:" << '\n' << "{\n";
@@ -89,7 +91,7 @@ std::ostream& operator<<(std::ostream& str, Transponder::AdsbVehicle const& adsb
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, Transponder::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Transponder::Result const& result)
 {
     switch (result) {
         case Transponder::Result::Unknown:
@@ -111,7 +113,8 @@ std::ostream& operator<<(std::ostream& str, Transponder::Result const& result)
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Transponder::AdsbEmitterType const& adsb_emitter_type)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Transponder::AdsbEmitterType const& adsb_emitter_type)
 {
     switch (adsb_emitter_type) {
         case Transponder::AdsbEmitterType::NoInfo:
@@ -159,7 +162,8 @@ std::ostream& operator<<(std::ostream& str, Transponder::AdsbEmitterType const& 
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Transponder::AdsbAltitudeType const& adsb_altitude_type)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Transponder::AdsbAltitudeType const& adsb_altitude_type)
 {
     switch (adsb_altitude_type) {
         case Transponder::AdsbAltitudeType::PressureQnh:

--- a/src/mavsdk/plugins/transponder/transponder_impl.cpp
+++ b/src/mavsdk/plugins/transponder/transponder_impl.cpp
@@ -1,9 +1,10 @@
 #include "transponder_impl.h"
 #include "callback_list.tpp"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
-template class CallbackList<Transponder::AdsbVehicle>;
+template class MAVSDK_TEMPL_INST CallbackList<Transponder::AdsbVehicle>;
 
 TransponderImpl::TransponderImpl(System& system) : PluginImplBase(system)
 {

--- a/src/mavsdk/plugins/tune/include/plugins/tune/tune.h
+++ b/src/mavsdk/plugins/tune/include/plugins/tune/tune.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -25,7 +26,7 @@ class TuneImpl;
 /**
  * @brief Enable creating and sending a tune to be played on the system.
  */
-class Tune : public PluginBase {
+class MAVSDK_PUBLIC Tune : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -90,7 +91,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Tune::SongElement const& song_element);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Tune::SongElement const& song_element);
 
     /**
      * @brief Tune description, containing song elements and tempo.
@@ -106,14 +108,15 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Tune::TuneDescription& lhs, const Tune::TuneDescription& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Tune::TuneDescription& lhs, const Tune::TuneDescription& rhs);
 
     /**
      * @brief Stream operator to print information about a `Tune::TuneDescription`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream&
+    friend MAVSDK_PUBLIC std::ostream&
     operator<<(std::ostream& str, Tune::TuneDescription const& tune_description);
 
     /**
@@ -133,7 +136,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Tune::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Tune::Result const& result);
 
     /**
      * @brief Callback type for asynchronous Tune calls.

--- a/src/mavsdk/plugins/tune/tune.cpp
+++ b/src/mavsdk/plugins/tune/tune.cpp
@@ -28,12 +28,13 @@ Tune::Result Tune::play_tune(TuneDescription tune_description) const
     return _impl->play_tune(tune_description);
 }
 
-bool operator==(const Tune::TuneDescription& lhs, const Tune::TuneDescription& rhs)
+MAVSDK_PUBLIC bool operator==(const Tune::TuneDescription& lhs, const Tune::TuneDescription& rhs)
 {
     return (rhs.song_elements == lhs.song_elements) && (rhs.tempo == lhs.tempo);
 }
 
-std::ostream& operator<<(std::ostream& str, Tune::TuneDescription const& tune_description)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Tune::TuneDescription const& tune_description)
 {
     str << std::setprecision(15);
     str << "tune_description:" << '\n' << "{\n";
@@ -49,7 +50,7 @@ std::ostream& operator<<(std::ostream& str, Tune::TuneDescription const& tune_de
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, Tune::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Tune::Result const& result)
 {
     switch (result) {
         case Tune::Result::Unknown:
@@ -69,7 +70,7 @@ std::ostream& operator<<(std::ostream& str, Tune::Result const& result)
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Tune::SongElement const& song_element)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Tune::SongElement const& song_element)
 {
     switch (song_element) {
         case Tune::SongElement::StyleLegato:

--- a/src/mavsdk/plugins/winch/include/plugins/winch/winch.h
+++ b/src/mavsdk/plugins/winch/include/plugins/winch/winch.h
@@ -16,6 +16,7 @@
 #include "plugin_base.h"
 
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -26,7 +27,7 @@ class WinchImpl;
  * @brief Allows users to send winch actions, as well as receive status information from winch
  * systems.
  */
-class Winch : public PluginBase {
+class MAVSDK_PUBLIC Winch : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -84,7 +85,8 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Winch::WinchAction const& winch_action);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Winch::WinchAction const& winch_action);
 
     /**
      * @brief Winch Status Flags.
@@ -120,14 +122,16 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Winch::StatusFlags& lhs, const Winch::StatusFlags& rhs);
+    friend MAVSDK_PUBLIC bool
+    operator==(const Winch::StatusFlags& lhs, const Winch::StatusFlags& rhs);
 
     /**
      * @brief Stream operator to print information about a `Winch::StatusFlags`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Winch::StatusFlags const& status_flags);
+    friend MAVSDK_PUBLIC std::ostream&
+    operator<<(std::ostream& str, Winch::StatusFlags const& status_flags);
 
     /**
      * @brief Status type.
@@ -148,14 +152,14 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Winch::Status& lhs, const Winch::Status& rhs);
+    friend MAVSDK_PUBLIC bool operator==(const Winch::Status& lhs, const Winch::Status& rhs);
 
     /**
      * @brief Stream operator to print information about a `Winch::Status`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Winch::Status const& status);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Winch::Status const& status);
 
     /**
      * @brief Possible results returned for winch action requests.
@@ -175,7 +179,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Winch::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Winch::Result const& result);
 
     /**
      * @brief Callback type for asynchronous Winch calls.

--- a/src/mavsdk/plugins/winch/winch.cpp
+++ b/src/mavsdk/plugins/winch/winch.cpp
@@ -138,7 +138,7 @@ Winch::Result Winch::load_payload(uint32_t instance) const
     return _impl->load_payload(instance);
 }
 
-bool operator==(const Winch::StatusFlags& lhs, const Winch::StatusFlags& rhs)
+MAVSDK_PUBLIC bool operator==(const Winch::StatusFlags& lhs, const Winch::StatusFlags& rhs)
 {
     return (rhs.healthy == lhs.healthy) && (rhs.fully_retracted == lhs.fully_retracted) &&
            (rhs.moving == lhs.moving) && (rhs.clutch_engaged == lhs.clutch_engaged) &&
@@ -149,7 +149,7 @@ bool operator==(const Winch::StatusFlags& lhs, const Winch::StatusFlags& rhs)
            (rhs.load_line == lhs.load_line) && (rhs.load_payload == lhs.load_payload);
 }
 
-std::ostream& operator<<(std::ostream& str, Winch::StatusFlags const& status_flags)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Winch::StatusFlags const& status_flags)
 {
     str << std::setprecision(15);
     str << "status_flags:" << '\n' << "{\n";
@@ -171,7 +171,7 @@ std::ostream& operator<<(std::ostream& str, Winch::StatusFlags const& status_fla
     return str;
 }
 
-bool operator==(const Winch::Status& lhs, const Winch::Status& rhs)
+MAVSDK_PUBLIC bool operator==(const Winch::Status& lhs, const Winch::Status& rhs)
 {
     return (rhs.time_usec == lhs.time_usec) &&
            ((std::isnan(rhs.line_length_m) && std::isnan(lhs.line_length_m)) ||
@@ -187,7 +187,7 @@ bool operator==(const Winch::Status& lhs, const Winch::Status& rhs)
            (rhs.temperature_c == lhs.temperature_c) && (rhs.status_flags == lhs.status_flags);
 }
 
-std::ostream& operator<<(std::ostream& str, Winch::Status const& status)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Winch::Status const& status)
 {
     str << std::setprecision(15);
     str << "status:" << '\n' << "{\n";
@@ -203,7 +203,7 @@ std::ostream& operator<<(std::ostream& str, Winch::Status const& status)
     return str;
 }
 
-std::ostream& operator<<(std::ostream& str, Winch::Result const& result)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Winch::Result const& result)
 {
     switch (result) {
         case Winch::Result::Unknown:
@@ -225,7 +225,7 @@ std::ostream& operator<<(std::ostream& str, Winch::Result const& result)
     }
 }
 
-std::ostream& operator<<(std::ostream& str, Winch::WinchAction const& winch_action)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Winch::WinchAction const& winch_action)
 {
     switch (winch_action) {
         case Winch::WinchAction::Relaxed:

--- a/src/mavsdk/plugins/winch/winch_impl.cpp
+++ b/src/mavsdk/plugins/winch/winch_impl.cpp
@@ -1,10 +1,11 @@
 #include "winch_impl.h"
 #include "system.h"
 #include "callback_list.tpp"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
-template class CallbackList<Winch::Status>;
+template class MAVSDK_TEMPL_INST CallbackList<Winch::Status>;
 
 WinchImpl::WinchImpl(System& system) : PluginImplBase(system)
 {

--- a/src/mavsdk_server/src/CMakeLists.txt
+++ b/src/mavsdk_server/src/CMakeLists.txt
@@ -39,6 +39,11 @@ target_link_libraries(mavsdk_server
     gRPC::grpc++
 )
 
+target_compile_definitions(mavsdk_server PRIVATE MAVSDK_BUILD)
+if(BUILD_SHARED_LIBS)
+    target_compile_definitions(mavsdk_server PUBLIC MAVSDK_SHARED)
+endif()
+
 if(BUILD_WITH_PROTO_REFLECTION)
     add_definitions(-DENABLE_PROTO_REFLECTION)
     target_link_libraries(mavsdk_server PRIVATE gRPC::grpc++_reflection)

--- a/src/mavsdk_server/src/mavsdk_server_api.h
+++ b/src/mavsdk_server/src/mavsdk_server_api.h
@@ -10,11 +10,7 @@ extern "C" {
 #include <stdint.h>
 #endif
 
-#ifdef WINDOWS
-#define DLLExport __declspec(dllexport)
-#else
-#define DLLExport __attribute__((visibility("default")))
-#endif
+#include "mavsdk_export.h"
 
 struct MavsdkServer;
 
@@ -23,7 +19,7 @@ struct MavsdkServer;
  *
  * @param mavsdk_server Pointer to pointer to MavsdkServer.
  */
-DLLExport void mavsdk_server_init(struct MavsdkServer** mavsdk_server);
+MAVSDK_PUBLIC void mavsdk_server_init(struct MavsdkServer** mavsdk_server);
 
 /*
  * Run MavsdkServer.
@@ -33,7 +29,7 @@ DLLExport void mavsdk_server_init(struct MavsdkServer** mavsdk_server);
  * @param mavsdk_server_port gRPC server port
  * @return 0 if successful
  */
-DLLExport int mavsdk_server_run(
+MAVSDK_PUBLIC int mavsdk_server_run(
     struct MavsdkServer* mavsdk_server, const char* system_address, const int mavsdk_server_port);
 
 /*
@@ -49,7 +45,7 @@ DLLExport int mavsdk_server_run(
  * @param component_id MAVLink component ID for MAVSDK
  * @return 0 if successful
  */
-DLLExport int mavsdk_server_run_with_mavlink_ids(
+MAVSDK_PUBLIC int mavsdk_server_run_with_mavlink_ids(
     struct MavsdkServer* mavsdk_server,
     const char* system_address,
     const int mavsdk_server_port,
@@ -62,28 +58,28 @@ DLLExport int mavsdk_server_run_with_mavlink_ids(
  * @param mavsdk_server Pointer to initialized MavsdkServer
  * @return gRPC port used
  */
-DLLExport int mavsdk_server_get_port(struct MavsdkServer* mavsdk_server);
+MAVSDK_PUBLIC int mavsdk_server_get_port(struct MavsdkServer* mavsdk_server);
 
 /*
  * Attach to MavsdkServer. This only returns once the server is stopped.
  *
  * @param mavsdk_server Pointer to initialized MavsdkServer
  */
-DLLExport void mavsdk_server_attach(struct MavsdkServer* mavsdk_server);
+MAVSDK_PUBLIC void mavsdk_server_attach(struct MavsdkServer* mavsdk_server);
 
 /*
  * Stop MavsdkServer.
  *
  * @param mavsdk_server Pointer to initialized MavsdkServer
  */
-DLLExport void mavsdk_server_stop(struct MavsdkServer* mavsdk_server);
+MAVSDK_PUBLIC void mavsdk_server_stop(struct MavsdkServer* mavsdk_server);
 
 /*
  * Clean up MavsdkServer object. Counter part to mavsdk_server_init.
  *
  * @param mavsdk_server Pointer to initialized MavsdkServer
  */
-DLLExport void mavsdk_server_destroy(struct MavsdkServer* mavsdk_server);
+MAVSDK_PUBLIC void mavsdk_server_destroy(struct MavsdkServer* mavsdk_server);
 
 #ifdef __cplusplus
 }

--- a/templates/plugin_cpp/enum.j2
+++ b/templates/plugin_cpp/enum.j2
@@ -1,4 +1,4 @@
-std::ostream& operator<<(std::ostream& str, {{ plugin_name.upper_camel_case }}::{% if parent_struct and not name.upper_camel_case.endswith("Result") %}{{ parent_struct.upper_camel_case }}::{% endif %}{{ name.upper_camel_case }} const& {{ name.lower_snake_case }})
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, {{ plugin_name.upper_camel_case }}::{% if parent_struct and not name.upper_camel_case.endswith("Result") %}{{ parent_struct.upper_camel_case }}::{% endif %}{{ name.upper_camel_case }} const& {{ name.lower_snake_case }})
 {
     switch ({{ name.lower_snake_case }}) {
         {%- for value in values %}

--- a/templates/plugin_cpp/struct.j2
+++ b/templates/plugin_cpp/struct.j2
@@ -3,7 +3,7 @@
 {% endfor -%}
 
 {% if not name.upper_camel_case.endswith('Result') -%}
-bool operator==(const {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}& lhs, const {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}& rhs)
+MAVSDK_PUBLIC bool operator==(const {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}& lhs, const {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}& rhs)
 {
     return
     {%- for field in fields %}
@@ -22,7 +22,7 @@ bool operator==(const {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_ca
     {%- endfor %}
 }
 
-std::ostream& operator<<(std::ostream& str, {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }} const& {{ name.lower_snake_case }})
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }} const& {{ name.lower_snake_case }})
 {
     str << std::setprecision(15);
     str << "{{ name.lower_snake_case }}:" << '\n'

--- a/templates/plugin_h/enum.j2
+++ b/templates/plugin_h/enum.j2
@@ -12,4 +12,4 @@ enum class {{ name.upper_camel_case }} {
  *
  * @return A reference to the stream.
  */
-friend std::ostream& operator<<(std::ostream& str, {{ plugin_name.upper_camel_case }}::{% if parent_struct and not name.upper_camel_case.endswith("Result") %}{{ parent_struct.upper_camel_case }}::{% endif %}{{ name.upper_camel_case }} const& {{ name.lower_snake_case }});
+friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, {{ plugin_name.upper_camel_case }}::{% if parent_struct and not name.upper_camel_case.endswith("Result") %}{{ parent_struct.upper_camel_case }}::{% endif %}{{ name.upper_camel_case }} const& {{ name.lower_snake_case }});

--- a/templates/plugin_h/file.j2
+++ b/templates/plugin_h/file.j2
@@ -19,6 +19,7 @@
 #include "plugin_base.h"
 {% endif %}
 #include "handle.h"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -32,7 +33,7 @@ class {{ plugin_name.upper_camel_case }}Impl;
 /**
  * @brief {{ class_description | replace('\n', '\n *')}}
  */
-class {{ plugin_name.upper_camel_case }} : public {% if is_server %}ServerPluginBase{% else %}PluginBase{% endif %} {
+class MAVSDK_PUBLIC {{ plugin_name.upper_camel_case }} : public {% if is_server %}ServerPluginBase{% else %}PluginBase{% endif %} {
 public:
 {% if is_server %}
     /**

--- a/templates/plugin_h/struct.j2
+++ b/templates/plugin_h/struct.j2
@@ -31,12 +31,12 @@ struct {{ name.upper_camel_case }} {
  *
  * @return `true` if items are equal.
  */
-friend bool operator==(const {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}& lhs, const {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}& rhs);
+friend MAVSDK_PUBLIC bool operator==(const {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}& lhs, const {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}& rhs);
 
 /**
  * @brief Stream operator to print information about a `{{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}`.
  *
  * @return A reference to the stream.
  */
-friend std::ostream& operator<<(std::ostream& str, {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }} const& {{ name.lower_snake_case }});
+friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }} const& {{ name.lower_snake_case }});
 {% endif -%}

--- a/templates/plugin_impl_cpp/struct.j2
+++ b/templates/plugin_impl_cpp/struct.j2
@@ -3,7 +3,7 @@
 {% endfor -%}
 
 {% if not name.upper_camel_case.endswith('Result') -%}
-bool operator==(const {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}& lhs, const {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}& rhs)
+MAVSDK_PUBLIC bool operator==(const {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}& lhs, const {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }}& rhs)
 {
     return
     {%- for field in fields %}
@@ -22,7 +22,7 @@ bool operator==(const {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_ca
     {%- endfor %}
 }
 
-std::ostream& operator<<(std::ostream& str, {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }} const& {{ name.lower_snake_case }})
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, {{ plugin_name.upper_camel_case }}::{{ name.upper_camel_case }} const& {{ name.lower_snake_case }})
 {
     str << std::setprecision(15);
     str << "{{ name.lower_snake_case }}:" << '\n'


### PR DESCRIPTION
Backport of #2824 to v3. Fixes segfault when MAVSDK is used alongside ROS2 (or any library sharing bundled dependencies like OpenSSL/tinyxml2) due to symbol conflicts from leaked third-party symbols.

- Add mavsdk_export.h with MAVSDK_PUBLIC, MAVSDK_TEST_EXPORT, and MAVSDK_TEMPL_INST macros
- Set CXX_VISIBILITY_PRESET=hidden and VISIBILITY_INLINES_HIDDEN=ON
- MAVSDK_SHARED compile definition gates dllexport/dllimport so that static builds on Windows are unaffected
- Annotate all public classes, free functions, operator overloads, and explicit template instantiations
- Update jinja2 templates to emit MAVSDK_PUBLIC on generated operator== and operator<< definitions
- Disable MSVC C4251 warning for DLL interface on STL members

Fixes #2852