### PR TITLE
fix: hide third-party symbols from libmavsdk.so to prevent clashes

### DIFF
--- a/cpp/src/mavsdk/core/CMakeLists.txt
+++ b/cpp/src/mavsdk/core/CMakeLists.txt
@@ -186,6 +186,22 @@ set_target_properties(mavsdk
         VISIBILITY_INLINES_HIDDEN ON
     )
 
+# Use a linker symbol export list to hide symbols from statically-linked
+# third-party libraries (OpenSSL, tinyxml2, curl, etc.).
+# -fvisibility=hidden only affects code compiled with that flag;
+# pre-built static archives still export their symbols without this.
+if(BUILD_SHARED_LIBS)
+    if(APPLE)
+        target_link_options(mavsdk PRIVATE
+            "LINKER:-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libmavsdk.exported_symbols"
+        )
+    elseif(UNIX)
+        target_link_options(mavsdk PRIVATE
+            "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libmavsdk.version"
+        )
+    endif()
+endif()
+
 # Asio's io_context.hpp triggers a false-positive -Wnull-dereference with GCC
 # (executor comparison at io_context.hpp:967).  The warning comes from GCC's
 # data-flow analysis traversing inlined Asio internals; marking the Asio

--- a/cpp/src/mavsdk/core/libmavsdk.exported_symbols
+++ b/cpp/src/mavsdk/core/libmavsdk.exported_symbols
@@ -1,0 +1,22 @@
+# Exported symbols for macOS (ld64 -exported_symbols_list).
+# Only MAVSDK public API and test-support symbols are exported;
+# everything else (OpenSSL, tinyxml2, curl, etc.) is hidden.
+#
+# Patterns use ld64 glob syntax: * matches any sequence of characters.
+
+# mavsdk:: namespace (all mangled forms)
+__ZN6mavsdk*
+__ZNK6mavsdk*
+__ZTI*6mavsdk*
+__ZTS*6mavsdk*
+__ZTV*6mavsdk*
+__ZTT*6mavsdk*
+__ZThn*6mavsdk*
+__ZTv*6mavsdk*
+__ZGRN6mavsdk*
+
+# Asio throw_exception stubs (MAVSDK builds with -fno-exceptions)
+__ZN4asio6detail15throw_exception*
+
+# MAVLink channel status (used by tests that include mavlink headers)
+__Z26mavlink_get_channel_status*

--- a/cpp/src/mavsdk/core/libmavsdk.version
+++ b/cpp/src/mavsdk/core/libmavsdk.version
@@ -1,0 +1,22 @@
+{
+  global:
+    /* MAVSDK public + test API (mavsdk:: namespace) */
+    _ZN6mavsdk*;
+    _ZNK6mavsdk*;
+    _ZTI*6mavsdk*;
+    _ZTS*6mavsdk*;
+    _ZTV*6mavsdk*;
+    _ZTT*6mavsdk*;
+    _ZThn*6mavsdk*;
+    _ZTv*6mavsdk*;
+    _ZGRN6mavsdk*;
+
+    /* Asio throw_exception stubs (MAVSDK builds with -fno-exceptions) */
+    _ZN4asio6detail15throw_exception*;
+
+    /* MAVLink channel status (used by tests that include mavlink headers) */
+    _Z26mavlink_get_channel_status*;
+
+  local:
+    *;
+};


### PR DESCRIPTION
Related to #2852 but on main.

libmavsdk.so statically links OpenSSL, tinyxml2, and curl but their symbols remained globally visible. When loaded alongside libraries that use the same dependencies (e.g. ROS2 FastRTPS), the dynamic linker would resolve calls to MAVSDK's bundled copies, causing ABI mismatches and segfaults.

Add linker symbol export lists (GNU ld version script for Linux, ld64 exported_symbols_list for macOS) that restrict exports to the mavsdk:: namespace plus a few test-support symbols. This drops exported symbols from ~20,000 to ~2,900.