### PR TITLE
[v3] fix: add linker version script to hide third-party symbols (#2852)

### DIFF
--- a/src/mavsdk/core/CMakeLists.txt
+++ b/src/mavsdk/core/CMakeLists.txt
@@ -186,6 +186,22 @@ set_target_properties(mavsdk
         VISIBILITY_INLINES_HIDDEN ON
     )
 
+# Use a linker symbol export list to hide symbols from statically-linked
+# third-party libraries (OpenSSL, tinyxml2, curl, etc.).
+# -fvisibility=hidden only affects code compiled with that flag;
+# pre-built static archives still export their symbols without this.
+if(BUILD_SHARED_LIBS)
+    if(APPLE)
+        target_link_options(mavsdk PRIVATE
+            "LINKER:-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libmavsdk.exported_symbols"
+        )
+    elseif(UNIX)
+        target_link_options(mavsdk PRIVATE
+            "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libmavsdk.version"
+        )
+    endif()
+endif()
+
 target_include_directories(mavsdk
     PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/mavsdk>

--- a/src/mavsdk/core/libmavsdk.exported_symbols
+++ b/src/mavsdk/core/libmavsdk.exported_symbols
@@ -1,0 +1,19 @@
+# Exported symbols for macOS (ld64 -exported_symbols_list).
+# Only MAVSDK public API and test-support symbols are exported;
+# everything else (OpenSSL, tinyxml2, curl, etc.) is hidden.
+#
+# Patterns use ld64 glob syntax: * matches any sequence of characters.
+
+# mavsdk:: namespace (all mangled forms)
+__ZN6mavsdk*
+__ZNK6mavsdk*
+__ZTI*6mavsdk*
+__ZTS*6mavsdk*
+__ZTV*6mavsdk*
+__ZTT*6mavsdk*
+__ZThn*6mavsdk*
+__ZTv*6mavsdk*
+__ZGRN6mavsdk*
+
+# MAVLink channel status (used by tests that include mavlink headers)
+__Z26mavlink_get_channel_status*

--- a/src/mavsdk/core/libmavsdk.version
+++ b/src/mavsdk/core/libmavsdk.version
@@ -1,0 +1,19 @@
+{
+  global:
+    /* MAVSDK public + test API (mavsdk:: namespace) */
+    _ZN6mavsdk*;
+    _ZNK6mavsdk*;
+    _ZTI*6mavsdk*;
+    _ZTS*6mavsdk*;
+    _ZTV*6mavsdk*;
+    _ZTT*6mavsdk*;
+    _ZThn*6mavsdk*;
+    _ZTv*6mavsdk*;
+    _ZGRN6mavsdk*;
+
+    /* MAVLink channel status (used by tests that include mavlink headers) */
+    _Z26mavlink_get_channel_status*;
+
+  local:
+    *;
+};

--- a/src/system_tests/CMakeLists.txt
+++ b/src/system_tests/CMakeLists.txt
@@ -64,6 +64,10 @@ set_target_properties(system_tests_runner
     PROPERTIES COMPILE_FLAGS ${warnings}
 )
 
+if(NOT APPLE AND NOT ANDROID AND NOT MSVC)
+    target_link_libraries(system_tests_runner PRIVATE stdc++fs)
+endif()
+
 if(ENABLE_CPPTRACE)
     find_package(cpptrace REQUIRED)
     target_link_libraries(system_tests_runner

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -28,4 +28,8 @@ target_include_directories(unit_tests_runner
 )
 
 
+if(NOT APPLE AND NOT ANDROID AND NOT MSVC)
+    target_link_libraries(unit_tests_runner stdc++fs)
+endif()
+
 add_test(unit_tests unit_tests_runner)


### PR DESCRIPTION
Closes #2852

The visibility annotations from #2855 only affect code compiled with -fvisibility=hidden. Statically-linked third-party libraries (OpenSSL, tinyxml2, curl) were built without it, so their symbols still leak from libmavsdk.so and clash with other libraries (e.g. ROS2 FastRTPS).

Add linker symbol export lists (GNU ld version script for Linux, ld64 exported_symbols_list for macOS) that restrict exports to the mavsdk:: namespace plus mavlink_get_channel_status (needed by tests).