### PR TITLE
refactor: use asio::post for internal-only deferred work instead of call_user_callback

### DIFF
--- a/cpp/src/mavsdk/core/mavlink_component_metadata.cpp
+++ b/cpp/src/mavsdk/core/mavlink_component_metadata.cpp
@@ -4,6 +4,7 @@
 #include "inflate_lzma.hpp"
 #include "unused.hpp"
 #include "system_impl.hpp"
+#include <asio/post.hpp>
 
 #include <utility>
 #include <filesystem>
@@ -200,49 +201,54 @@ void MavlinkComponentMetadata::retrieve_metadata(uint8_t compid, COMP_METADATA_T
                 const std::filesystem::path local_path =
                     tmp_download_path / std::filesystem::path(download_path).filename();
 
-                _system_impl.call_user_callback([this,
-                                                 download_path,
-                                                 tmp_download_path,
-                                                 &component,
-                                                 target_compid,
-                                                 local_path,
-                                                 compid,
-                                                 type,
-                                                 file_cache_tag]() {
-                    _system_impl.mavlink_ftp_client().download_async(
-                        download_path,
-                        tmp_download_path.string(),
-                        true,
-                        [this, &component, local_path, compid, type, file_cache_tag](
-                            MavlinkFtpClient::ClientResult download_result,
-                            MavlinkFtpClient::ProgressData progress_data) {
-                            if (download_result == MavlinkFtpClient::ClientResult::Next) {
-                                if (_verbose_debugging) {
-                                    LogDebug(
-                                        "File download progress: {}{}{}",
-                                        progress_data.bytes_transferred,
-                                        '/',
-                                        progress_data.total_bytes);
+                // Post to the io_context thread to avoid deadlocks. This is purely
+                // internal work (initiating an FTP download), not a user callback.
+                asio::post(
+                    _system_impl.io_context(),
+                    [this,
+                     download_path,
+                     tmp_download_path,
+                     &component,
+                     target_compid,
+                     local_path,
+                     compid,
+                     type,
+                     file_cache_tag]() {
+                        _system_impl.mavlink_ftp_client().download_async(
+                            download_path,
+                            tmp_download_path.string(),
+                            true,
+                            [this, &component, local_path, compid, type, file_cache_tag](
+                                MavlinkFtpClient::ClientResult download_result,
+                                MavlinkFtpClient::ProgressData progress_data) {
+                                if (download_result == MavlinkFtpClient::ClientResult::Next) {
+                                    if (_verbose_debugging) {
+                                        LogDebug(
+                                            "File download progress: {}{}{}",
+                                            progress_data.bytes_transferred,
+                                            '/',
+                                            progress_data.total_bytes);
+                                    }
+                                    // TODO: detect slow link (e.g. telemetry), and cancel download
+                                    // (fallback to http) e.g. by estimating the remaining download
+                                    // time, and cancel if >40s
+                                } else {
+                                    if (_verbose_debugging) {
+                                        LogDebug(
+                                            "File download ended with result {}",
+                                            static_cast<int>(download_result));
+                                    }
+                                    if (download_result ==
+                                        MavlinkFtpClient::ClientResult::Success) {
+                                        component.current_metadata_path() =
+                                            extract_and_cache_file(local_path, file_cache_tag);
+                                    }
+                                    // Move on to the next uri or type
+                                    retrieve_metadata(compid, type);
                                 }
-                                // TODO: detect slow link (e.g. telemetry), and cancel download
-                                // (fallback to http) e.g. by estimating the remaining download
-                                // time, and cancel if >40s
-                            } else {
-                                if (_verbose_debugging) {
-                                    LogDebug(
-                                        "File download ended with result {}",
-                                        static_cast<int>(download_result));
-                                }
-                                if (download_result == MavlinkFtpClient::ClientResult::Success) {
-                                    component.current_metadata_path() =
-                                        extract_and_cache_file(local_path, file_cache_tag);
-                                }
-                                // Move on to the next uri or type
-                                retrieve_metadata(compid, type);
-                            }
-                        },
-                        target_compid);
-                });
+                            },
+                            target_compid);
+                    });
 
             } else {
                 // http(s) download

--- a/cpp/src/mavsdk/core/system_impl.cpp
+++ b/cpp/src/mavsdk/core/system_impl.cpp
@@ -1,5 +1,6 @@
 #include "system.hpp"
 #include "mavsdk_impl.hpp"
+#include <asio/post.hpp>
 #include "mavlink_include.hpp"
 #include "system_impl.hpp"
 #include <mav/MessageSet.h>
@@ -632,9 +633,9 @@ void SystemImpl::set_connected()
 
             // Only send heartbeats if we're not shutting down
             if (!_should_exit) {
-                // We call this later to avoid deadlocks on creating the server components.
-                _mavsdk_impl.call_user_callback([this]() {
-                    // Send a heartbeat back immediately.
+                // Post to the io_context thread to avoid deadlocks when creating server
+                // components. This is purely internal work, not a user callback.
+                asio::post(_mavsdk_impl.io_context(), [this]() {
                     _mavsdk_impl.start_sending_heartbeats();
                 });
             }


### PR DESCRIPTION
## Summary

An audit of `call_user_callback` usages in `core/` found two call sites using it purely to escape a lock context, not to invoke any user-provided callback:

- **`system_impl.cpp`**: `start_sending_heartbeats()` on first system connection — comment already said "to avoid deadlocks on creating server components"
- **`mavlink_component_metadata.cpp`**: initiating an FTP metadata download — internal async work with no user code involved

Routing internal work through the user callback thread is misleading: it occupies the watchdog-guarded queue, burns the 1-second timeout budget on non-user work, and obscures intent. Both are replaced with `asio::post()` onto the io_context thread, which is the correct mechanism for deferring internal async work without holding locks.

All other `call_user_callback` usages in `core/` (16 call sites) dispatch genuine user-registered callbacks and are unchanged.

## Test plan

- [x] Build passes cleanly
- No behaviour change for user-visible callbacks