### PR TITLE
fix: bridge MAVLink v1 messages to MavlinkDirect on serial connections

### DIFF
--- a/cpp/src/mavsdk/core/libmav_receiver.cpp
+++ b/cpp/src/mavsdk/core/libmav_receiver.cpp
@@ -237,6 +237,59 @@ std::optional<mav::Message> LibmavReceiver::create_message(const std::string& me
     return _mavsdk_impl.create_message_safe(message_name);
 }
 
+bool LibmavReceiver::bridge_from_mavlink_message(const mavlink_message_t& msg)
+{
+    // Re-encode the mavlink_message_t as a MAVLink v2 frame so that libmav's BufferParser
+    // (which only recognises the 0xFD magic byte) can parse it.  This is the fix for
+    // MAVLink v1 messages being silently skipped on serial connections.
+    mavlink_message_t v2_msg = msg;
+    v2_msg.magic = MAVLINK_STX; // force v2 encoding (0xFD)
+    v2_msg.incompat_flags = 0;
+    v2_msg.compat_flags = 0;
+
+    uint8_t v2_buffer[MAVLINK_MAX_PACKET_LEN];
+    uint16_t v2_len = mavlink_msg_to_send_buffer(v2_buffer, &v2_msg);
+    if (v2_len == 0) {
+        return false;
+    }
+
+    size_t bytes_consumed = 0;
+    auto message_opt = _mavsdk_impl.parse_message_safe(v2_buffer, v2_len, bytes_consumed);
+    if (!message_opt) {
+        return false;
+    }
+
+    auto message = message_opt.value();
+
+    if (_debugging) {
+        LogDebug("Bridged MAVLink v1 message: {} (ID: {})", message.name(), message.id());
+    }
+
+    auto header = message.header();
+    std::string json = libmav_message_to_json(message);
+
+    _last_libmav_message = message;
+    _last_message.message_name = message.name();
+    _last_message.system_id = header.systemId();
+    _last_message.component_id = header.componentId();
+
+    uint8_t target_system_id = 0;
+    uint8_t target_component_id = 0;
+    if (message.get("target_system", target_system_id) == mav::MessageResult::Success) {
+        _last_message.target_system_id = target_system_id;
+    } else {
+        _last_message.target_system_id = 0;
+    }
+    if (message.get("target_component", target_component_id) == mav::MessageResult::Success) {
+        _last_message.target_component_id = target_component_id;
+    } else {
+        _last_message.target_component_id = 0;
+    }
+
+    _last_message.fields_json = json;
+    return true;
+}
+
 bool LibmavReceiver::load_custom_xml(const std::string& xml_content)
 {
     // Note: This method should not be called directly on LibmavReceiver instances.

--- a/cpp/src/mavsdk/core/libmav_receiver.hpp
+++ b/cpp/src/mavsdk/core/libmav_receiver.hpp
@@ -53,6 +53,11 @@ public:
     // JSON conversion (made public for use in message interception)
     std::string libmav_message_to_json(const mav::Message& msg) const;
 
+    // Bridge a mavlink_message_t (which may be MAVLink v1) into the libmav receiver.
+    // Re-encodes the message as v2 so that libmav's v2-only parser can process it.
+    // Returns true and fills _last_message/_last_libmav_message if successful.
+    bool bridge_from_mavlink_message(const mavlink_message_t& msg);
+
 private:
     MavsdkImpl& _mavsdk_impl; // For thread-safe MessageSet access
     std::unique_ptr<mav::BufferParser> _buffer_parser;

--- a/cpp/src/mavsdk/core/serial_connection.cpp
+++ b/cpp/src/mavsdk/core/serial_connection.cpp
@@ -324,10 +324,25 @@ void SerialConnection::do_receive()
             auto parse_result = _mavlink_receiver->parse_message();
             while (parse_result != MavlinkReceiver::ParseResult::NoneAvailable) {
                 receive_message(parse_result, _mavlink_receiver->get_last_message(), this);
+
+                // MAVLink v1 messages (0xFE magic) are silently skipped by libmav's
+                // BufferParser, which only handles v2 (0xFD).  Bridge them explicitly so
+                // that MavlinkDirect subscribers receive all messages over serial.
+                if (_libmav_receiver &&
+                    parse_result == MavlinkReceiver::ParseResult::MessageParsed &&
+                    _mavlink_receiver->get_last_message().magic == MAVLINK_STX_MAVLINK1) {
+                    if (_libmav_receiver->bridge_from_mavlink_message(
+                            _mavlink_receiver->get_last_message())) {
+                        receive_libmav_message(_libmav_receiver->get_last_message(), this);
+                    }
+                }
+
                 parse_result = _mavlink_receiver->parse_message();
             }
 
             if (_libmav_receiver) {
+                // Handle v2 messages (and custom-XML messages the C library doesn't know)
+                // via the normal raw-stream parser.
                 _libmav_receiver->set_new_datagram(_recv_buffer.data(), static_cast<int>(recv_len));
                 while (_libmav_receiver->parse_message()) {
                     receive_libmav_message(_libmav_receiver->get_last_message(), this);


### PR DESCRIPTION
Fixes #2862.

## Root cause

`libmav`'s `BufferParser` only recognises the MAVLink v2 magic byte (`0xFD`). Any v1 frame (`0xFE`) arriving over a direct serial link was silently skipped, so `MavlinkDirect` subscribers never received HEARTBEAT, SYS_STATUS, GPS_RAW_INT and the other messages ArduPilot sends as v1 by default.

## Fix

When the standard C-library parser (`MavlinkReceiver`) successfully parses a v1 frame, re-encode it as v2 with `mavlink_msg_to_send_buffer` and feed it through `parse_message_safe` so libmav can deserialise the fields. A new `LibmavReceiver::bridge_from_mavlink_message()` method encapsulates the conversion.

The existing raw-stream libmav parser loop is unchanged — it continues to handle v2 messages and any custom-XML messages the C library does not know.

## Why UDP was unaffected

When connecting via a GCS relay (QGC / Mission Planner), the GCS has typically negotiated MAVLink v2 with the autopilot, so all forwarded UDP messages arrive as v2. Over a direct serial link ArduPilot boots into v1 and the bug manifests.