### PR TITLE
fix: bump libmavlike to add MAVLink v1 support in BufferParser

### DIFF
--- a/cpp/third_party/libmavlike/CMakeLists.txt
+++ b/cpp/third_party/libmavlike/CMakeLists.txt
@@ -29,7 +29,7 @@ endforeach()
 ExternalProject_add(
     libmavlike
     GIT_REPOSITORY https://github.com/julianoes/libmavlike
-    GIT_TAG 80dbd91a0c5d6f0a79f1e8597b820ba075d1cf15
+    GIT_TAG 90498b14262137ae10b633705810e81bdb85de9c
     PREFIX libmavlike
     CMAKE_ARGS ${CMAKE_ARGS}
     )


### PR DESCRIPTION
## Problem

Closes #2862.

`MavlinkDirect` subscribers connected over serial never received messages that ArduPilot sends as MAVLink v1 by default (HEARTBEAT, SYS_STATUS, GPS_RAW_INT, MISSION_CURRENT, etc.). The same messages were received fine over UDP (where a GCS relay re-sends them as v2) and via MavlinkPassthrough (which uses the standard C library parser that handles both v1 and v2).

Root cause: `LibmavReceiver` uses libmavlike's `BufferParser`, which previously only scanned for the MAVLink v2 magic byte (`0xFD`). MAVLink v1 packets (`0xFE`) were silently skipped.

## Fix

Bump libmavlike to [julianoes/libmavlike#2](https://github.com/julianoes/libmavlike/pull/2), which adds full MAVLink v1 support to `BufferParser`:

- `parseMessage()` now detects both magic bytes
- `parseV1Message()` validates the v1 CRC and promotes the packet into the v2 backing-memory layout so `Message::_instantiateFromMemory` can be reused — callers receive a uniform `Message` regardless of wire version
- New tests cover: valid v1 parse, bad CRC, unknown ID, partial header/payload, garbage prefix, and mixed v1+v2 buffers in both orders