### PR TITLE
[v3] fix: bump libmavlike to add MAVLink v1 support in BufferParser

### DIFF
--- a/third_party/libmavlike/CMakeLists.txt
+++ b/third_party/libmavlike/CMakeLists.txt
@@ -29,7 +29,7 @@ endforeach()
 ExternalProject_add(
     libmavlike
     GIT_REPOSITORY https://github.com/julianoes/libmavlike
-    GIT_TAG 80dbd91a0c5d6f0a79f1e8597b820ba075d1cf15
+    GIT_TAG 90498b14262137ae10b633705810e81bdb85de9c
     PREFIX libmavlike
     CMAKE_ARGS ${CMAKE_ARGS}
     )


### PR DESCRIPTION
Backport of #2864 to the v3 branch.

Bumps libmavlike to [julianoes/libmavlike#2](https://github.com/julianoes/libmavlike/pull/2), which adds full MAVLink v1 support to `BufferParser`. Fixes `MavlinkDirect` subscribers over serial never receiving messages that ArduPilot sends as MAVLink v1 by default (HEARTBEAT, SYS_STATUS, GPS_RAW_INT, MISSION_CURRENT, etc.).

Only `third_party/libmavlike/CMakeLists.txt` changes — the GIT_TAG bump is identical to main.