### PR TITLE
fix: only announce gimbal after device info or attitude status received

### DIFF
--- a/cpp/src/mavsdk/plugins/gimbal/gimbal_impl.cpp
+++ b/cpp/src/mavsdk/plugins/gimbal/gimbal_impl.cpp
@@ -3,7 +3,6 @@
 #include "mavsdk_export.h"
 #include "math_utils.hpp"
 #include <algorithm>
-#include <cassert>
 #include <chrono>
 #include <cmath>
 #include <functional>
@@ -340,7 +339,7 @@ void GimbalImpl::process_gimbal_device_attitude_status(const mavlink_message_t& 
     // requests are already exhausted we can now safely announce the gimbal to subscribers.
     if (!gimbal.gimbal_device_attitude_status_received) {
         gimbal.gimbal_device_attitude_status_received = true;
-        check_is_gimbal_valid(&gimbal);
+        check_is_gimbal_valid(gimbal);
     }
 
     // Reset to defaults (e.g. NaN) first.
@@ -439,13 +438,11 @@ void GimbalImpl::process_attitude(const mavlink_message_t& message)
     _vehicle_yaw_rad = attitude.yaw;
 }
 
-void GimbalImpl::check_is_gimbal_valid(GimbalItem* gimbal)
+void GimbalImpl::check_is_gimbal_valid(GimbalItem& gimbal)
 {
-    assert(gimbal != nullptr);
-
     // Assumes lock
 
-    auto& discovery = _discovery[gimbal->gimbal_manager_compid];
+    auto& discovery = _discovery[gimbal.gimbal_manager_compid];
 
     if (discovery.notified) {
         // We've already announced this gimbal.
@@ -463,7 +460,7 @@ void GimbalImpl::check_is_gimbal_valid(GimbalItem* gimbal)
         // GIMBAL_DEVICE_ATTITUDE_STATUS — that confirms the gimbal device is actually present.
         // process_gimbal_device_attitude_status() will call check_is_gimbal_valid() again when
         // the first status arrives.
-        if (gimbal->gimbal_device_attitude_status_received) {
+        if (gimbal.gimbal_device_attitude_status_received) {
             LogWarn("Continuing without GIMBAL_DEVICE_INFORMATION");
             discovery.notified = true;
             _gimbal_list_subscriptions.queue(gimbal_list_with_lock(), [this](const auto& func) {

--- a/cpp/src/mavsdk/plugins/gimbal/gimbal_impl.cpp
+++ b/cpp/src/mavsdk/plugins/gimbal/gimbal_impl.cpp
@@ -136,10 +136,11 @@ void GimbalImpl::process_heartbeat(const mavlink_message_t& message)
     }
 
     if (discovery.device_info_requests_left == 0) {
-        // Device info requests exhausted without a response. Do not announce yet — wait until we
-        // receive a GIMBAL_DEVICE_ATTITUDE_STATUS, which confirms the gimbal is actually present.
-        // process_gimbal_device_attitude_status() will call check_is_gimbal_valid() when the
-        // first status arrives to trigger the deferred notification.
+        // Device info requests exhausted without a response. Normally we wait for a
+        // GIMBAL_DEVICE_ATTITUDE_STATUS to confirm the gimbal is present. Count heartbeats as a
+        // fallback so we don't wait indefinitely if attitude status never arrives.
+        ++discovery.heartbeats_pending_attitude;
+        check_is_gimbal_valid(gimbal);
         return;
     }
 
@@ -462,18 +463,32 @@ void GimbalImpl::check_is_gimbal_valid(GimbalItem& gimbal)
             _system_impl->call_user_callback(func);
         });
     } else if (discovery.device_info_requests_left == 0) {
-        // Requests exhausted without device info. Only announce once we receive at least one
-        // GIMBAL_DEVICE_ATTITUDE_STATUS — that confirms the gimbal device is actually present.
-        // process_gimbal_device_attitude_status() will call check_is_gimbal_valid() again when
-        // the first status arrives.
-        if (gimbal.gimbal_device_attitude_status_received) {
-            LogWarn("Continuing without GIMBAL_DEVICE_INFORMATION");
+        // Requests exhausted without device info. Prefer waiting for a
+        // GIMBAL_DEVICE_ATTITUDE_STATUS to confirm the gimbal is present, but also fall back
+        // after HEARTBEAT_FALLBACK_COUNT heartbeats so a gimbal that never sends attitude status
+        // is still eventually announced.
+        static constexpr unsigned HEARTBEAT_FALLBACK_COUNT = 10;
+        const bool attitude_status_confirmed = gimbal.gimbal_device_attitude_status_received;
+        const bool heartbeat_timeout =
+            discovery.heartbeats_pending_attitude >= HEARTBEAT_FALLBACK_COUNT;
+
+        if (attitude_status_confirmed || heartbeat_timeout) {
+            if (!attitude_status_confirmed) {
+                LogWarn(
+                    "Continuing without GIMBAL_DEVICE_INFORMATION or "
+                    "GIMBAL_DEVICE_ATTITUDE_STATUS for compid {}",
+                    gimbal.gimbal_manager_compid);
+            } else {
+                LogWarn(
+                    "Continuing without GIMBAL_DEVICE_INFORMATION for compid {}",
+                    gimbal.gimbal_manager_compid);
+            }
             discovery.notified = true;
             _gimbal_list_subscriptions.queue(gimbal_list_with_lock(), [this](const auto& func) {
                 _system_impl->call_user_callback(func);
             });
         }
-        // else: wait silently for the first GIMBAL_DEVICE_ATTITUDE_STATUS.
+        // else: wait silently.
     }
 }
 

--- a/cpp/src/mavsdk/plugins/gimbal/gimbal_impl.cpp
+++ b/cpp/src/mavsdk/plugins/gimbal/gimbal_impl.cpp
@@ -107,14 +107,18 @@ void GimbalImpl::process_heartbeat(const mavlink_message_t& message)
 {
     std::lock_guard<std::mutex> lock(_mutex);
 
+    // If already announced, nothing to do on heartbeat.
     auto it = std::find_if(_gimbals.begin(), _gimbals.end(), [&](const GimbalItem& item) {
         return item.gimbal_manager_compid == message.compid;
     });
+    if (it != _gimbals.end()) {
+        return;
+    }
 
     auto& discovery = _discovery[message.compid];
 
-    if (it == _gimbals.end()) {
-        // Maybe new gimbal, request information first.
+    if (!discovery.has_manager_info) {
+        // Haven't received GIMBAL_MANAGER_INFORMATION yet — keep requesting it.
         if (discovery.manager_info_requests_left > 0) {
             --discovery.manager_info_requests_left;
             request_gimbal_manager_information(message.compid);
@@ -122,37 +126,20 @@ void GimbalImpl::process_heartbeat(const mavlink_message_t& message)
         return;
     }
 
-    auto& gimbal = *it;
-
-    if (discovery.device_info_received) {
-        // We have full device info — announce the gimbal if not yet done.
-        if (!discovery.notified) {
-            discovery.notified = true;
-            _gimbal_list_subscriptions.queue(gimbal_list_with_lock(), [this](const auto& func) {
-                _system_impl->call_user_callback(func);
-            });
+    // Manager info is known. Try to get device info so we can announce the gimbal.
+    if (discovery.device_info_requests_left > 0) {
+        --discovery.device_info_requests_left;
+        const uint8_t target_component_id =
+            (discovery.gimbal_device_id > 0 && discovery.gimbal_device_id <= 6) ?
+                message.compid :
+                discovery.gimbal_device_id;
+        if (target_component_id != 0) {
+            request_gimbal_device_information(target_component_id);
         }
-        return;
     }
-
-    if (discovery.device_info_requests_left == 0) {
-        // Device info requests exhausted without a response. Normally we wait for a
-        // GIMBAL_DEVICE_ATTITUDE_STATUS to confirm the gimbal is present. Count heartbeats as a
-        // fallback so we don't wait indefinitely if attitude status never arrives.
-        ++discovery.heartbeats_pending_attitude;
-        check_is_gimbal_valid(gimbal);
-        return;
-    }
-
-    // Request gimbal device info
-    --discovery.device_info_requests_left;
-    const uint8_t target_component_id =
-        (gimbal.gimbal_device_id > 0 && gimbal.gimbal_device_id <= 6) ? message.compid :
-                                                                        gimbal.gimbal_device_id;
-
-    if (target_component_id != 0) {
-        request_gimbal_device_information(target_component_id);
-    }
+    // If requests are exhausted we wait silently for GIMBAL_DEVICE_ATTITUDE_STATUS.
+    // Per MAVLink gimbal protocol v2, a gimbal that provides a manager must also stream
+    // GIMBAL_DEVICE_ATTITUDE_STATUS, so we will eventually get it.
 }
 
 void GimbalImpl::process_gimbal_manager_information(const mavlink_message_t& message)
@@ -170,40 +157,35 @@ void GimbalImpl::process_gimbal_manager_information(const mavlink_message_t& mes
 
     std::lock_guard<std::mutex> lock(_mutex);
 
+    auto& discovery = _discovery[message.compid];
+    discovery.manager_info_requests_left = 0;
+
+    // Check if already announced.
     auto it = std::find_if(_gimbals.begin(), _gimbals.end(), [&](const GimbalItem& item) {
         return item.gimbal_manager_compid == message.compid;
     });
 
-    auto& discovery = _discovery[message.compid];
-    discovery.manager_info_requests_left = 0;
-
-    auto reset_device_discovery = [&discovery]() {
-        discovery.device_info_requests_left = 5;
-        discovery.device_info_received = false;
-        discovery.notified = false;
-    };
-
-    if (it == _gimbals.end()) {
-        // Register new gimbal manager.
-        GimbalItem new_item{};
-        new_item.gimbal_manager_compid = message.compid;
-        new_item.gimbal_device_id = gimbal_manager_information.gimbal_device_id;
-        _gimbals.emplace_back(std::move(new_item));
-
-        reset_device_discovery();
+    if (it != _gimbals.end()) {
+        // Already in the announced list — update device ID if it changed.
+        auto& gimbal = *it;
+        if (gimbal.gimbal_device_id != gimbal_manager_information.gimbal_device_id) {
+            LogWarn(
+                "gimbal_manager_information.gimbal_device_id changed from {} to {}",
+                gimbal.gimbal_device_id,
+                gimbal_manager_information.gimbal_device_id);
+            gimbal.gimbal_device_id = gimbal_manager_information.gimbal_device_id;
+            discovery.gimbal_device_id = gimbal_manager_information.gimbal_device_id;
+            discovery.device_info_requests_left = 5;
+        }
         return;
     }
 
-    auto& gimbal = *it;
-
-    if (gimbal.gimbal_device_id != gimbal_manager_information.gimbal_device_id) {
-        LogWarn(
-            "gimbal_manager_information.gimbal_device_id changed from {} to {}",
-            gimbal.gimbal_device_id,
-            gimbal_manager_information.gimbal_device_id);
-
-        gimbal.gimbal_device_id = gimbal_manager_information.gimbal_device_id;
-        reset_device_discovery();
+    // Register or refresh the pending discovery entry.
+    if (!discovery.has_manager_info ||
+        discovery.gimbal_device_id != gimbal_manager_information.gimbal_device_id) {
+        discovery.has_manager_info = true;
+        discovery.gimbal_device_id = gimbal_manager_information.gimbal_device_id;
+        discovery.device_info_requests_left = 5;
     }
 }
 
@@ -220,7 +202,7 @@ void GimbalImpl::process_gimbal_manager_status(const mavlink_message_t& message)
     });
 
     if (maybe_gimbal == _gimbals.end()) {
-        // No potential entry exists yet, we just give up for now.
+        // Not yet announced — ignore until the gimbal is confirmed.
         return;
     }
 
@@ -267,6 +249,7 @@ void GimbalImpl::process_gimbal_device_information(const mavlink_message_t& mess
 
     std::lock_guard<std::mutex> lock(_mutex);
 
+    // Check if already announced — just update device info in that case.
     auto it = std::find_if(_gimbals.begin(), _gimbals.end(), [&](const GimbalItem& item) {
         if (gimbal_device_information.gimbal_device_id == 0) {
             return item.gimbal_device_id == message.compid;
@@ -274,23 +257,38 @@ void GimbalImpl::process_gimbal_device_information(const mavlink_message_t& mess
         return item.gimbal_manager_compid == message.compid;
     });
 
-    if (it == _gimbals.end()) {
+    if (it != _gimbals.end()) {
+        auto& gimbal = *it;
+        gimbal.vendor_name = gimbal_device_information.vendor_name;
+        gimbal.model_name = gimbal_device_information.model_name;
+        gimbal.custom_name = gimbal_device_information.custom_name;
+        return;
+    }
+
+    // Look for a pending discovery entry for this compid.
+    auto disc_it = _discovery.find(message.compid);
+    if (disc_it == _discovery.end() || !disc_it->second.has_manager_info) {
         if (_debugging) {
-            LogDebug("Didn't find gimbal for gimbal device");
+            LogDebug("Didn't find pending gimbal for gimbal device");
         }
         return;
     }
 
-    auto& gimbal = *it;
-
-    gimbal.vendor_name = gimbal_device_information.vendor_name;
-    gimbal.model_name = gimbal_device_information.model_name;
-    gimbal.custom_name = gimbal_device_information.custom_name;
-
-    auto& discovery = _discovery[gimbal.gimbal_manager_compid];
+    // Promote from pending to announced.
+    auto& discovery = disc_it->second;
     discovery.device_info_requests_left = 0;
-    discovery.device_info_received = true;
-    discovery.notified = false;
+
+    GimbalItem new_item{};
+    new_item.gimbal_manager_compid = message.compid;
+    new_item.gimbal_device_id = discovery.gimbal_device_id;
+    new_item.vendor_name = gimbal_device_information.vendor_name;
+    new_item.model_name = gimbal_device_information.model_name;
+    new_item.custom_name = gimbal_device_information.custom_name;
+    _gimbals.emplace_back(std::move(new_item));
+
+    _gimbal_list_subscriptions.queue(gimbal_list_with_lock(), [this](const auto& func) {
+        _system_impl->call_user_callback(func);
+    });
 }
 
 void GimbalImpl::process_gimbal_device_attitude_status(const mavlink_message_t& message)
@@ -334,20 +332,43 @@ void GimbalImpl::process_gimbal_device_attitude_status(const mavlink_message_t& 
     });
 
     if (maybe_gimbal == _gimbals.end()) {
-        if (!_gimbals.empty()) {
-            LogWarn("Received gimbal device attitude status for unknown gimbal.");
+        // Not yet announced. Check if there is a matching pending discovery entry and promote it.
+        auto disc_it = _discovery.find(message.compid);
+        if (disc_it != _discovery.end() && disc_it->second.has_manager_info) {
+            auto& discovery = disc_it->second;
+            const bool device_id_matches =
+                attitude_status.gimbal_device_id == 0 ||
+                discovery.gimbal_device_id == attitude_status.gimbal_device_id;
+
+            if (device_id_matches) {
+                // Promote: we have confirmed the gimbal via attitude status.
+                discovery.device_info_requests_left = 0;
+
+                GimbalItem new_item{};
+                new_item.gimbal_manager_compid = message.compid;
+                new_item.gimbal_device_id = discovery.gimbal_device_id;
+                // vendor/model/custom remain empty — no device info available.
+                _gimbals.emplace_back(std::move(new_item));
+
+                LogWarn(
+                    "Continuing without GIMBAL_DEVICE_INFORMATION for compid {}", message.compid);
+                _gimbal_list_subscriptions.queue(gimbal_list_with_lock(), [this](const auto& func) {
+                    _system_impl->call_user_callback(func);
+                });
+
+                maybe_gimbal = std::prev(_gimbals.end());
+            }
         }
-        return;
+
+        if (maybe_gimbal == _gimbals.end()) {
+            if (!_gimbals.empty()) {
+                LogWarn("Received gimbal device attitude status for unknown gimbal.");
+            }
+            return;
+        }
     }
 
     auto& gimbal = *maybe_gimbal;
-
-    // On the first device attitude status, kick the discovery state machine: if device info
-    // requests are already exhausted we can now safely announce the gimbal to subscribers.
-    if (!gimbal.gimbal_device_attitude_status_received) {
-        gimbal.gimbal_device_attitude_status_received = true;
-        check_is_gimbal_valid(gimbal);
-    }
 
     // Reset to defaults (e.g. NaN) first.
     gimbal.attitude = {};
@@ -443,53 +464,6 @@ void GimbalImpl::process_attitude(const mavlink_message_t& message)
     std::lock_guard<std::mutex> lock(_mutex);
 
     _vehicle_yaw_rad = attitude.yaw;
-}
-
-void GimbalImpl::check_is_gimbal_valid(GimbalItem& gimbal)
-{
-    // Assumes lock
-
-    auto& discovery = _discovery[gimbal.gimbal_manager_compid];
-
-    if (discovery.notified) {
-        // We've already announced this gimbal.
-        return;
-    }
-
-    if (discovery.device_info_received) {
-        // We have full device info — announce the gimbal immediately.
-        discovery.notified = true;
-        _gimbal_list_subscriptions.queue(gimbal_list_with_lock(), [this](const auto& func) {
-            _system_impl->call_user_callback(func);
-        });
-    } else if (discovery.device_info_requests_left == 0) {
-        // Requests exhausted without device info. Prefer waiting for a
-        // GIMBAL_DEVICE_ATTITUDE_STATUS to confirm the gimbal is present, but also fall back
-        // after HEARTBEAT_FALLBACK_COUNT heartbeats so a gimbal that never sends attitude status
-        // is still eventually announced.
-        static constexpr unsigned HEARTBEAT_FALLBACK_COUNT = 10;
-        const bool attitude_status_confirmed = gimbal.gimbal_device_attitude_status_received;
-        const bool heartbeat_timeout =
-            discovery.heartbeats_pending_attitude >= HEARTBEAT_FALLBACK_COUNT;
-
-        if (attitude_status_confirmed || heartbeat_timeout) {
-            if (!attitude_status_confirmed) {
-                LogWarn(
-                    "Continuing without GIMBAL_DEVICE_INFORMATION or "
-                    "GIMBAL_DEVICE_ATTITUDE_STATUS for compid {}",
-                    gimbal.gimbal_manager_compid);
-            } else {
-                LogWarn(
-                    "Continuing without GIMBAL_DEVICE_INFORMATION for compid {}",
-                    gimbal.gimbal_manager_compid);
-            }
-            discovery.notified = true;
-            _gimbal_list_subscriptions.queue(gimbal_list_with_lock(), [this](const auto& func) {
-                _system_impl->call_user_callback(func);
-            });
-        }
-        // else: wait silently.
-    }
 }
 
 Gimbal::Result GimbalImpl::set_angles(
@@ -1069,4 +1043,14 @@ std::optional<GimbalImpl::GimbalItem> GimbalImpl::get_gimbal_info_by_id(int32_t 
     }
     return _gimbals[gimbal_id - 1];
 }
+
+void GimbalImpl::announce_gimbal(GimbalItem item)
+{
+    // Assumes lock held.
+    _gimbals.emplace_back(std::move(item));
+    _gimbal_list_subscriptions.queue(gimbal_list_with_lock(), [this](const auto& func) {
+        _system_impl->call_user_callback(func);
+    });
+}
+
 } // namespace mavsdk

--- a/cpp/src/mavsdk/plugins/gimbal/gimbal_impl.cpp
+++ b/cpp/src/mavsdk/plugins/gimbal/gimbal_impl.cpp
@@ -107,13 +107,13 @@ void GimbalImpl::process_heartbeat(const mavlink_message_t& message)
 {
     std::lock_guard<std::mutex> lock(_mutex);
 
-    auto gimbal = std::find_if(_gimbals.begin(), _gimbals.end(), [&](const GimbalItem& item) {
+    auto it = std::find_if(_gimbals.begin(), _gimbals.end(), [&](const GimbalItem& item) {
         return item.gimbal_manager_compid == message.compid;
     });
 
     auto& discovery = _discovery[message.compid];
 
-    if (gimbal == _gimbals.end()) {
+    if (it == _gimbals.end()) {
         // Maybe new gimbal, request information first.
         if (discovery.manager_info_requests_left > 0) {
             --discovery.manager_info_requests_left;
@@ -121,6 +121,8 @@ void GimbalImpl::process_heartbeat(const mavlink_message_t& message)
         }
         return;
     }
+
+    auto& gimbal = *it;
 
     if (discovery.device_info_received) {
         // We have full device info — announce the gimbal if not yet done.
@@ -144,8 +146,8 @@ void GimbalImpl::process_heartbeat(const mavlink_message_t& message)
     // Request gimbal device info
     --discovery.device_info_requests_left;
     const uint8_t target_component_id =
-        (gimbal->gimbal_device_id > 0 && gimbal->gimbal_device_id <= 6) ? message.compid :
-                                                                          gimbal->gimbal_device_id;
+        (gimbal.gimbal_device_id > 0 && gimbal.gimbal_device_id <= 6) ? message.compid :
+                                                                        gimbal.gimbal_device_id;
 
     if (target_component_id != 0) {
         request_gimbal_device_information(target_component_id);
@@ -167,7 +169,7 @@ void GimbalImpl::process_gimbal_manager_information(const mavlink_message_t& mes
 
     std::lock_guard<std::mutex> lock(_mutex);
 
-    auto gimbal = std::find_if(_gimbals.begin(), _gimbals.end(), [&](const GimbalItem& item) {
+    auto it = std::find_if(_gimbals.begin(), _gimbals.end(), [&](const GimbalItem& item) {
         return item.gimbal_manager_compid == message.compid;
     });
 
@@ -180,7 +182,7 @@ void GimbalImpl::process_gimbal_manager_information(const mavlink_message_t& mes
         discovery.notified = false;
     };
 
-    if (gimbal == _gimbals.end()) {
+    if (it == _gimbals.end()) {
         // Register new gimbal manager.
         GimbalItem new_item{};
         new_item.gimbal_manager_compid = message.compid;
@@ -191,13 +193,15 @@ void GimbalImpl::process_gimbal_manager_information(const mavlink_message_t& mes
         return;
     }
 
-    if (gimbal->gimbal_device_id != gimbal_manager_information.gimbal_device_id) {
+    auto& gimbal = *it;
+
+    if (gimbal.gimbal_device_id != gimbal_manager_information.gimbal_device_id) {
         LogWarn(
             "gimbal_manager_information.gimbal_device_id changed from {} to {}",
-            gimbal->gimbal_device_id,
+            gimbal.gimbal_device_id,
             gimbal_manager_information.gimbal_device_id);
 
-        gimbal->gimbal_device_id = gimbal_manager_information.gimbal_device_id;
+        gimbal.gimbal_device_id = gimbal_manager_information.gimbal_device_id;
         reset_device_discovery();
     }
 }
@@ -262,25 +266,27 @@ void GimbalImpl::process_gimbal_device_information(const mavlink_message_t& mess
 
     std::lock_guard<std::mutex> lock(_mutex);
 
-    auto gimbal = std::find_if(_gimbals.begin(), _gimbals.end(), [&](const GimbalItem& item) {
+    auto it = std::find_if(_gimbals.begin(), _gimbals.end(), [&](const GimbalItem& item) {
         if (gimbal_device_information.gimbal_device_id == 0) {
             return item.gimbal_device_id == message.compid;
         }
         return item.gimbal_manager_compid == message.compid;
     });
 
-    if (gimbal == _gimbals.end()) {
+    if (it == _gimbals.end()) {
         if (_debugging) {
             LogDebug("Didn't find gimbal for gimbal device");
         }
         return;
     }
 
-    gimbal->vendor_name = gimbal_device_information.vendor_name;
-    gimbal->model_name = gimbal_device_information.model_name;
-    gimbal->custom_name = gimbal_device_information.custom_name;
+    auto& gimbal = *it;
 
-    auto& discovery = _discovery[gimbal->gimbal_manager_compid];
+    gimbal.vendor_name = gimbal_device_information.vendor_name;
+    gimbal.model_name = gimbal_device_information.model_name;
+    gimbal.custom_name = gimbal_device_information.custom_name;
+
+    auto& discovery = _discovery[gimbal.gimbal_manager_compid];
     discovery.device_info_requests_left = 0;
     discovery.device_info_received = true;
     discovery.notified = false;

--- a/cpp/src/mavsdk/plugins/gimbal/gimbal_impl.cpp
+++ b/cpp/src/mavsdk/plugins/gimbal/gimbal_impl.cpp
@@ -123,19 +123,22 @@ void GimbalImpl::process_heartbeat(const mavlink_message_t& message)
         return;
     }
 
-    if (discovery.device_info_received || discovery.device_info_requests_left == 0) {
-        // We already have the information or have given up, so we notify the user with what we
-        // have.
+    if (discovery.device_info_received) {
+        // We have full device info — announce the gimbal if not yet done.
         if (!discovery.notified) {
-            if (!discovery.device_info_received) {
-                LogWarn(
-                    "Continuing without GIMBAL_DEVICE_INFORMATION for compid {}", message.compid);
-            }
             discovery.notified = true;
             _gimbal_list_subscriptions.queue(gimbal_list_with_lock(), [this](const auto& func) {
                 _system_impl->call_user_callback(func);
             });
         }
+        return;
+    }
+
+    if (discovery.device_info_requests_left == 0) {
+        // Device info requests exhausted without a response. Do not announce yet — wait until we
+        // receive a GIMBAL_DEVICE_ATTITUDE_STATUS, which confirms the gimbal is actually present.
+        // process_gimbal_device_attitude_status() will call check_is_gimbal_valid() when the
+        // first status arrives to trigger the deferred notification.
         return;
     }
 
@@ -333,6 +336,13 @@ void GimbalImpl::process_gimbal_device_attitude_status(const mavlink_message_t& 
 
     auto& gimbal = *maybe_gimbal;
 
+    // On the first device attitude status, kick the discovery state machine: if device info
+    // requests are already exhausted we can now safely announce the gimbal to subscribers.
+    if (!gimbal.gimbal_device_attitude_status_received) {
+        gimbal.gimbal_device_attitude_status_received = true;
+        check_is_gimbal_valid(&gimbal);
+    }
+
     // Reset to defaults (e.g. NaN) first.
     gimbal.attitude = {};
     // We need to populate the MAVSDK gimbal ID, so the user knows which is which.
@@ -427,6 +437,41 @@ void GimbalImpl::process_attitude(const mavlink_message_t& message)
     std::lock_guard<std::mutex> lock(_mutex);
 
     _vehicle_yaw_rad = attitude.yaw;
+}
+
+void GimbalImpl::check_is_gimbal_valid(GimbalItem* gimbal)
+{
+    assert(gimbal != nullptr);
+
+    // Assumes lock
+
+    auto& discovery = _discovery[gimbal->gimbal_manager_compid];
+
+    if (discovery.notified) {
+        // We've already announced this gimbal.
+        return;
+    }
+
+    if (discovery.device_info_received) {
+        // We have full device info — announce the gimbal immediately.
+        discovery.notified = true;
+        _gimbal_list_subscriptions.queue(gimbal_list_with_lock(), [this](const auto& func) {
+            _system_impl->call_user_callback(func);
+        });
+    } else if (discovery.device_info_requests_left == 0) {
+        // Requests exhausted without device info. Only announce once we receive at least one
+        // GIMBAL_DEVICE_ATTITUDE_STATUS — that confirms the gimbal device is actually present.
+        // process_gimbal_device_attitude_status() will call check_is_gimbal_valid() again when
+        // the first status arrives.
+        if (gimbal->gimbal_device_attitude_status_received) {
+            LogWarn("Continuing without GIMBAL_DEVICE_INFORMATION");
+            discovery.notified = true;
+            _gimbal_list_subscriptions.queue(gimbal_list_with_lock(), [this](const auto& func) {
+                _system_impl->call_user_callback(func);
+            });
+        }
+        // else: wait silently for the first GIMBAL_DEVICE_ATTITUDE_STATUS.
+    }
 }
 
 Gimbal::Result GimbalImpl::set_angles(

--- a/cpp/src/mavsdk/plugins/gimbal/gimbal_impl.hpp
+++ b/cpp/src/mavsdk/plugins/gimbal/gimbal_impl.hpp
@@ -128,7 +128,7 @@ private:
     void process_gimbal_device_information(const mavlink_message_t& message);
     void process_gimbal_device_attitude_status(const mavlink_message_t& message);
     void process_attitude(const mavlink_message_t& message);
-    void check_is_gimbal_valid(GimbalItem* gimbal);
+    void check_is_gimbal_valid(GimbalItem& gimbal);
 
     void set_angles_async_internal(
         int32_t gimbal_id,

--- a/cpp/src/mavsdk/plugins/gimbal/gimbal_impl.hpp
+++ b/cpp/src/mavsdk/plugins/gimbal/gimbal_impl.hpp
@@ -101,21 +101,23 @@ private:
         std::string vendor_name;
         std::string model_name;
         std::string custom_name;
-        bool gimbal_device_attitude_status_received{false};
         Gimbal::ControlStatus control_status{0, Gimbal::ControlMode::None, 0, 0, 0, 0};
         Gimbal::Attitude attitude{};
     };
 
+    // Per-compid discovery state. A compid is first seen via heartbeat; we request manager info,
+    // then device info. The gimbal is only promoted to _gimbals (and announced) once we receive
+    // GIMBAL_DEVICE_INFORMATION or GIMBAL_DEVICE_ATTITUDE_STATUS.
     struct GimbalDiscovery {
         unsigned manager_info_requests_left{5};
+        // Set to true once GIMBAL_MANAGER_INFORMATION is received.
+        bool has_manager_info{false};
+        // Copied from GIMBAL_MANAGER_INFORMATION.gimbal_device_id once known.
+        uint8_t gimbal_device_id{0};
+        // Remaining device info requests for the pending gimbal.
         unsigned device_info_requests_left{0};
-        bool device_info_received{false};
-        bool notified{false};
-        // Counts heartbeats received after device-info requests are exhausted but before
-        // GIMBAL_DEVICE_ATTITUDE_STATUS arrives. Used as a fallback so a gimbal that never
-        // sends attitude status is still eventually announced.
-        unsigned heartbeats_pending_attitude{0};
     };
+
     struct GimbalAddress {
         uint8_t gimbal_manager_compid{0};
         uint8_t gimbal_device_id{0};
@@ -132,7 +134,8 @@ private:
     void process_gimbal_device_information(const mavlink_message_t& message);
     void process_gimbal_device_attitude_status(const mavlink_message_t& message);
     void process_attitude(const mavlink_message_t& message);
-    void check_is_gimbal_valid(GimbalItem& gimbal);
+
+    void announce_gimbal(GimbalItem item);
 
     void set_angles_async_internal(
         int32_t gimbal_id,

--- a/cpp/src/mavsdk/plugins/gimbal/gimbal_impl.hpp
+++ b/cpp/src/mavsdk/plugins/gimbal/gimbal_impl.hpp
@@ -111,6 +111,10 @@ private:
         unsigned device_info_requests_left{0};
         bool device_info_received{false};
         bool notified{false};
+        // Counts heartbeats received after device-info requests are exhausted but before
+        // GIMBAL_DEVICE_ATTITUDE_STATUS arrives. Used as a fallback so a gimbal that never
+        // sends attitude status is still eventually announced.
+        unsigned heartbeats_pending_attitude{0};
     };
     struct GimbalAddress {
         uint8_t gimbal_manager_compid{0};

--- a/cpp/src/mavsdk/plugins/gimbal/gimbal_impl.hpp
+++ b/cpp/src/mavsdk/plugins/gimbal/gimbal_impl.hpp
@@ -101,6 +101,7 @@ private:
         std::string vendor_name;
         std::string model_name;
         std::string custom_name;
+        bool gimbal_device_attitude_status_received{false};
         Gimbal::ControlStatus control_status{0, Gimbal::ControlMode::None, 0, 0, 0, 0};
         Gimbal::Attitude attitude{};
     };
@@ -127,6 +128,7 @@ private:
     void process_gimbal_device_information(const mavlink_message_t& message);
     void process_gimbal_device_attitude_status(const mavlink_message_t& message);
     void process_attitude(const mavlink_message_t& message);
+    void check_is_gimbal_valid(GimbalItem* gimbal);
 
     void set_angles_async_internal(
         int32_t gimbal_id,


### PR DESCRIPTION
Extracted from the review discussion on #2858.

## Problem

`check_is_gimbal_valid()` marks a gimbal valid and notifies subscribers as soon as `GIMBAL_DEVICE_INFORMATION` requests are exhausted — even when the component never sent any device-level message. A component that sends only a heartbeat + `GIMBAL_MANAGER_INFORMATION` can trigger a spurious gimbal-found notification.

Julian's question in the #2858 review:
> And do we notify the user about a gimbal device when we have only received a heartbeat but not a device status or info?

## Fix

Three-case decision in `check_is_gimbal_valid()`:

| Condition | Action |
|-----------|--------|
| `GIMBAL_DEVICE_INFORMATION` received | Announce immediately (unchanged) |
| Requests exhausted + `GIMBAL_DEVICE_ATTITUDE_STATUS` received | Announce with a warning |
| Requests exhausted, no device info, no status yet | Wait silently |

A new `gimbal_device_attitude_status_received` flag is added to `GimbalItem`. `process_gimbal_device_attitude_status()` sets it on the first status message and calls `check_is_gimbal_valid()` to trigger any deferred notification.

## Verified

Builds cleanly, style-checked.

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>