### PR TITLE
fix: tolerate transient EOF on serial async_read_some

### DIFF
--- a/cpp/src/mavsdk/core/serial_connection.cpp
+++ b/cpp/src/mavsdk/core/serial_connection.cpp
@@ -307,6 +307,16 @@ void SerialConnection::do_receive()
                 return;
             }
 
+            if (ec == asio::error::eof) {
+                // Asio maps a 0-byte read() to EOF. On serial ports with
+                // VMIN=0/VTIME=0 this can happen transiently (epoll signals
+                // readable but the driver has no bytes, BREAK, USB hiccup,
+                // etc.) — re-arm and keep going. A truly detached device will
+                // surface as a different error on the next read.
+                do_receive();
+                return;
+            }
+
             if (ec) {
                 LogErr("read failure: {}", ec.message());
                 // Do not re-arm on hard errors (port removed, etc.).


### PR DESCRIPTION
Asio maps a 0-byte read() to asio::error::eof, but on Linux serial ports configured with VMIN=0/VTIME=0 + O_NONBLOCK this can happen transiently (epoll wakeup with no bytes ready, BREAK, USB-serial hiccup). The old poll()/read() loop simply continued in that case; the asio handler was treating it as fatal and stopping the receive loop forever. Re-arm on EOF instead — a truly detached device will surface as a different error on the next read.