### PR TITLE
core: fix UAF in unregister_all_blocking when registrations were deferred

### DIFF
--- a/cpp/src/mavsdk/core/mavlink_message_handler.cpp
+++ b/cpp/src/mavsdk/core/mavlink_message_handler.cpp
@@ -58,6 +58,22 @@ void MavlinkMessageHandler::unregister_all_blocking(const void* cookie)
 {
     // Blocking version for use in destructors - waits for any in-flight callbacks to complete.
     // WARNING: Do NOT call this from within a message handler callback - it will deadlock.
+
+    // Also purge any deferred registrations for this cookie from _register_later_table.
+    // If register_one() was called while process_message() held _mutex, the entries land in
+    // _register_later_table instead of _table.  Without this step, check_register_later()
+    // would later promote those stale entries into _table and fire callbacks on a
+    // destroyed object (heap-use-after-free).
+    {
+        std::lock_guard<std::mutex> register_later_lock(_register_later_mutex);
+        _register_later_table.erase(
+            std::remove_if(
+                _register_later_table.begin(),
+                _register_later_table.end(),
+                [&](const auto& entry) { return entry.cookie == cookie; }),
+            _register_later_table.end());
+    }
+
     std::lock_guard<std::mutex> lock(_mutex);
     _table.erase(
         std::remove_if(


### PR DESCRIPTION
## Root cause

`UploadWorkItem` (and the other `WorkItem` subclasses) register their
MAVLink message handlers in the **constructor**, which is called from the
main thread at any time — including while the I/O thread is inside
`process_message()` holding `MavlinkMessageHandler::_mutex`.

When that happens, `register_one_impl()` cannot acquire `_mutex` and
falls back to `_register_later_table`.

The destructor calls `unregister_all_blocking()` which only clears
`_table`. If the entries had landed in `_register_later_table`, they are
**not** removed. On the next `process_message()` call,
`check_register_later()` promotes those stale entries into `_table`,
where they are dispatched on an object that has already been destroyed.

ASAN reports this as:

```
WRITE of size 4 in UploadWorkItem::process_mission_request_int()
  (mavlink_mission_transfer_client.cpp:408)
freed by thread T0:
  weak_ptr<WorkItem>::operator=(weak_ptr&&)
  MissionRawImpl::upload_mission_items_async() (mission_raw_impl.cpp:168)
```

The reproducer is `Mission_RawUploadEmpty_Test`: the empty first upload
creates an `UploadWorkItem` that may fall into the deferred path; after
it is destroyed its stale handler is then fired for the
`MISSION_REQUEST_INT` that arrives for the second, real upload.

## Fix

Purge `_register_later_table` for the same cookie **before** acquiring
`_mutex` in `unregister_all_blocking()`.  This covers every case:

* entries already moved to `_table` → cleared by the existing `_table.erase()`
* entries still in `_register_later_table` → cleared by the new step
* entries being concurrently moved by `check_register_later()` → safe
  because both paths are guarded by their respective mutexes and the
  table is empty by the time `_table.erase()` runs

## Test

`system_tests/mission_raw_upload_empty` already exercises the exact
scenario (added as part of #1962). It should pass consistently with
ASAN/TSAN enabled after this fix.