### PR TITLE
test: skip Curl.DownloadText_HTTP_Success — S3 bucket gone

### DIFF
--- a/cpp/src/mavsdk/core/curl_test.cpp
+++ b/cpp/src/mavsdk/core/curl_test.cpp
@@ -36,6 +36,7 @@ protected:
 
 TEST_F(Curl, DownloadText_HTTP_Success)
 {
+    GTEST_SKIP() << "S3 bucket no longer exists, skipping flaky external test";
     std::string content;
 
     CurlWrapper curl_wrapper;


### PR DESCRIPTION
## Problem

The S3 bucket referenced in `Curl.DownloadText_HTTP_Success` no longer exists — it returns `NoSuchBucket`. This causes the test to fail and blocks CI on unrelated PRs.

## Fix

Skip `DownloadText_HTTP_Success` with `GTEST_SKIP()` while the bucket issue is unresolved. All other curl tests (file-not-found, download-file, progress feedback) continue to run.

Note: Julian noted in #2870 that a different/valid bucket should be used — that can be a follow-up once a replacement URL is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)