### PR TITLE
fix(mavlink_passthrough): export operator<< for Result with MAVSDK_PUBLIC

### DIFF
--- a/cpp/src/mavsdk/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.hpp
+++ b/cpp/src/mavsdk/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.hpp
@@ -91,7 +91,7 @@ public:
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, MavlinkPassthrough::Result const& result);
+    friend MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, MavlinkPassthrough::Result const& result);
 
     /**
      * @brief Send message (deprecated).


### PR DESCRIPTION
The `friend std::ostream& operator<<` for `MavlinkPassthrough::Result` in `mavlink_passthrough.hpp` is missing the `MAVSDK_PUBLIC` visibility specifier, so the symbol is hidden in `libmavsdk.so` and consumers hit a linker error when they try to stream a `Result` (e.g. `std::cout << result;`).

The equivalent `operator<<` for `MavlinkDirect::Result` in `mavlink_direct.hpp` already uses `MAVSDK_PUBLIC` — this PR just mirrors that pattern for consistency.

Fixes #2880.