### PR TITLE
Revert "telemetry: add energy_consumed_wh to Battery (#2882)"

### DIFF
--- a/c/src/cmavsdk/plugins/telemetry/telemetry.cpp
+++ b/c/src/cmavsdk/plugins/telemetry/telemetry.cpp
@@ -649,7 +649,6 @@ translate_battery_from_c(const mavsdk_telemetry_battery_t& c_struct) {
     cpp_struct.remaining_percent = c_struct.remaining_percent;
     cpp_struct.time_remaining_s = c_struct.time_remaining_s;
     cpp_struct.battery_function = translate_battery_function_from_c(c_struct.battery_function);
-    cpp_struct.energy_consumed_wh = c_struct.energy_consumed_wh;
     return cpp_struct;
 }
 
@@ -664,7 +663,6 @@ translate_battery_to_c(const mavsdk::Telemetry::Battery& cpp_struct) {
     c_struct.remaining_percent = cpp_struct.remaining_percent;
     c_struct.time_remaining_s = cpp_struct.time_remaining_s;
     c_struct.battery_function = translate_battery_function_to_c(cpp_struct.battery_function);
-    c_struct.energy_consumed_wh = cpp_struct.energy_consumed_wh;
     return c_struct;
 }
 

--- a/c/src/cmavsdk/plugins/telemetry/telemetry.h
+++ b/c/src/cmavsdk/plugins/telemetry/telemetry.h
@@ -602,8 +602,6 @@ typedef struct CMAVSDK_EXPORT {
     float time_remaining_s;
     /**  Function of the battery */
     mavsdk_telemetry_battery_function_t battery_function;
-    /**  Consumed energy in Watt-hours, NAN if autopilot does not provide energy consumption estimate */
-    float energy_consumed_wh;
 } mavsdk_telemetry_battery_t;
 
 /**

--- a/cpp/docs/en/cpp/api_reference/structmavsdk_1_1_telemetry_1_1_battery.md
+++ b/cpp/docs/en/cpp/api_reference/structmavsdk_1_1_telemetry_1_1_battery.md
@@ -26,8 +26,6 @@ float [time_remaining_s](#structmavsdk_1_1_telemetry_1_1_battery_1a9dd00470568d2
 
 [BatteryFunction](classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1adf751b819a1a38fc2b02442b5d5dae60) [battery_function](#structmavsdk_1_1_telemetry_1_1_battery_1a45654c797ef33bb134ac30313b73098c) {} - Function of the battery.
 
-float [energy_consumed_wh](#structmavsdk_1_1_telemetry_1_1_battery_1a38787c6e922563306484548630646f56) {float(NAN)} - Consumed energy in Watt-hours, NAN if autopilot does not provide energy consumption estimate.
-
 
 ## Field Documentation
 
@@ -110,14 +108,4 @@ BatteryFunction mavsdk::Telemetry::Battery::battery_function {}
 
 
 Function of the battery.
-
-
-### energy_consumed_wh {#structmavsdk_1_1_telemetry_1_1_battery_1a38787c6e922563306484548630646f56}
-
-```cpp
-float mavsdk::Telemetry::Battery::energy_consumed_wh {float(NAN)}
-```
-
-
-Consumed energy in Watt-hours, NAN if autopilot does not provide energy consumption estimate.
 

--- a/cpp/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.hpp
+++ b/cpp/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.hpp
@@ -504,7 +504,6 @@ public:
         float remaining_percent{float(NAN)}; /**< @brief Estimated battery remaining (range: 0 to 100) */
         float time_remaining_s{float(NAN)}; /**< @brief Estimated battery usage time remaining */
         BatteryFunction battery_function{}; /**< @brief Function of the battery */
-        float energy_consumed_wh{float(NAN)}; /**< @brief Consumed energy in Watt-hours, NAN if autopilot does not provide energy consumption estimate */
     };
 
     /**

--- a/cpp/src/mavsdk/plugins/telemetry/telemetry.cpp
+++ b/cpp/src/mavsdk/plugins/telemetry/telemetry.cpp
@@ -1054,9 +1054,7 @@ MAVSDK_PUBLIC bool operator==(const Telemetry::Battery& lhs, const Telemetry::Ba
             rhs.remaining_percent == lhs.remaining_percent) &&
            ((std::isnan(rhs.time_remaining_s) && std::isnan(lhs.time_remaining_s)) ||
             rhs.time_remaining_s == lhs.time_remaining_s) &&
-           (rhs.battery_function == lhs.battery_function) &&
-           ((std::isnan(rhs.energy_consumed_wh) && std::isnan(lhs.energy_consumed_wh)) ||
-            rhs.energy_consumed_wh == lhs.energy_consumed_wh);
+           (rhs.battery_function == lhs.battery_function);
 }
 
 MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::Battery const& battery)
@@ -1071,7 +1069,6 @@ MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Telemetry::Battery con
     str << "    remaining_percent: " << battery.remaining_percent << '\n';
     str << "    time_remaining_s: " << battery.time_remaining_s << '\n';
     str << "    battery_function: " << battery.battery_function << '\n';
-    str << "    energy_consumed_wh: " << battery.energy_consumed_wh << '\n';
     str << '}';
     return str;
 }

--- a/cpp/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/cpp/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -1264,10 +1264,6 @@ void TelemetryImpl::process_battery_status(const mavlink_message_t& message)
                                            bat_status.current_consumed * 1e-3f; // mAh to Ah
     new_battery.time_remaining_s =
         (bat_status.time_remaining == 0 ? static_cast<float>(NAN) : bat_status.time_remaining);
-    new_battery.energy_consumed_wh =
-        (bat_status.energy_consumed == -1) ?
-            static_cast<float>(NAN) :
-            static_cast<float>(bat_status.energy_consumed) / 36.0f; // hJ (100 J) to Wh (3600 J)
 
     Telemetry::BatteryFunction battery_function;
     switch (bat_status.battery_function) {

--- a/cpp/src/mavsdk_server/src/generated/telemetry/telemetry.pb.cc
+++ b/cpp/src/mavsdk_server/src/generated/telemetry/telemetry.pb.cc
@@ -2044,7 +2044,6 @@ inline constexpr Battery::Impl_::Impl_(
         remaining_percent_{0},
         time_remaining_s_{0},
         battery_function_{static_cast< ::mavsdk::rpc::telemetry::BatteryFunction >(0)},
-        energy_consumed_wh_{0},
         _cached_size_{0} {}
 
 template <typename>
@@ -4980,7 +4979,6 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::Battery, _impl_.remaining_percent_),
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::Battery, _impl_.time_remaining_s_),
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::Battery, _impl_.battery_function_),
-        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::Battery, _impl_.energy_consumed_wh_),
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::telemetry::Health, _internal_metadata_),
         ~0u,  // no _extensions_
@@ -5419,30 +5417,30 @@ static const ::_pbi::MigrationSchema
         {1190, -1, -1, sizeof(::mavsdk::rpc::telemetry::GpsInfo)},
         {1200, -1, -1, sizeof(::mavsdk::rpc::telemetry::RawGps)},
         {1222, -1, -1, sizeof(::mavsdk::rpc::telemetry::Battery)},
-        {1239, -1, -1, sizeof(::mavsdk::rpc::telemetry::Health)},
-        {1254, -1, -1, sizeof(::mavsdk::rpc::telemetry::RcStatus)},
-        {1265, -1, -1, sizeof(::mavsdk::rpc::telemetry::StatusText)},
-        {1275, -1, -1, sizeof(::mavsdk::rpc::telemetry::ActuatorControlTarget)},
-        {1285, -1, -1, sizeof(::mavsdk::rpc::telemetry::ActuatorOutputStatus)},
-        {1295, -1, -1, sizeof(::mavsdk::rpc::telemetry::Covariance)},
-        {1304, -1, -1, sizeof(::mavsdk::rpc::telemetry::VelocityBody)},
-        {1315, -1, -1, sizeof(::mavsdk::rpc::telemetry::PositionBody)},
-        {1326, 1343, -1, sizeof(::mavsdk::rpc::telemetry::Odometry)},
-        {1352, 1364, -1, sizeof(::mavsdk::rpc::telemetry::DistanceSensor)},
-        {1368, -1, -1, sizeof(::mavsdk::rpc::telemetry::ScaledPressure)},
-        {1381, -1, -1, sizeof(::mavsdk::rpc::telemetry::PositionNed)},
-        {1392, -1, -1, sizeof(::mavsdk::rpc::telemetry::VelocityNed)},
-        {1403, 1413, -1, sizeof(::mavsdk::rpc::telemetry::PositionVelocityNed)},
-        {1415, -1, -1, sizeof(::mavsdk::rpc::telemetry::GroundTruth)},
-        {1427, -1, -1, sizeof(::mavsdk::rpc::telemetry::FixedwingMetrics)},
-        {1441, -1, -1, sizeof(::mavsdk::rpc::telemetry::AccelerationFrd)},
-        {1452, -1, -1, sizeof(::mavsdk::rpc::telemetry::AngularVelocityFrd)},
-        {1463, -1, -1, sizeof(::mavsdk::rpc::telemetry::MagneticFieldFrd)},
-        {1474, 1487, -1, sizeof(::mavsdk::rpc::telemetry::Imu)},
-        {1492, -1, -1, sizeof(::mavsdk::rpc::telemetry::GpsGlobalOrigin)},
-        {1503, -1, -1, sizeof(::mavsdk::rpc::telemetry::Altitude)},
-        {1518, -1, -1, sizeof(::mavsdk::rpc::telemetry::Wind)},
-        {1534, -1, -1, sizeof(::mavsdk::rpc::telemetry::TelemetryResult)},
+        {1238, -1, -1, sizeof(::mavsdk::rpc::telemetry::Health)},
+        {1253, -1, -1, sizeof(::mavsdk::rpc::telemetry::RcStatus)},
+        {1264, -1, -1, sizeof(::mavsdk::rpc::telemetry::StatusText)},
+        {1274, -1, -1, sizeof(::mavsdk::rpc::telemetry::ActuatorControlTarget)},
+        {1284, -1, -1, sizeof(::mavsdk::rpc::telemetry::ActuatorOutputStatus)},
+        {1294, -1, -1, sizeof(::mavsdk::rpc::telemetry::Covariance)},
+        {1303, -1, -1, sizeof(::mavsdk::rpc::telemetry::VelocityBody)},
+        {1314, -1, -1, sizeof(::mavsdk::rpc::telemetry::PositionBody)},
+        {1325, 1342, -1, sizeof(::mavsdk::rpc::telemetry::Odometry)},
+        {1351, 1363, -1, sizeof(::mavsdk::rpc::telemetry::DistanceSensor)},
+        {1367, -1, -1, sizeof(::mavsdk::rpc::telemetry::ScaledPressure)},
+        {1380, -1, -1, sizeof(::mavsdk::rpc::telemetry::PositionNed)},
+        {1391, -1, -1, sizeof(::mavsdk::rpc::telemetry::VelocityNed)},
+        {1402, 1412, -1, sizeof(::mavsdk::rpc::telemetry::PositionVelocityNed)},
+        {1414, -1, -1, sizeof(::mavsdk::rpc::telemetry::GroundTruth)},
+        {1426, -1, -1, sizeof(::mavsdk::rpc::telemetry::FixedwingMetrics)},
+        {1440, -1, -1, sizeof(::mavsdk::rpc::telemetry::AccelerationFrd)},
+        {1451, -1, -1, sizeof(::mavsdk::rpc::telemetry::AngularVelocityFrd)},
+        {1462, -1, -1, sizeof(::mavsdk::rpc::telemetry::MagneticFieldFrd)},
+        {1473, 1486, -1, sizeof(::mavsdk::rpc::telemetry::Imu)},
+        {1491, -1, -1, sizeof(::mavsdk::rpc::telemetry::GpsGlobalOrigin)},
+        {1502, -1, -1, sizeof(::mavsdk::rpc::telemetry::Altitude)},
+        {1517, -1, -1, sizeof(::mavsdk::rpc::telemetry::Wind)},
+        {1533, -1, -1, sizeof(::mavsdk::rpc::telemetry::TelemetryResult)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::telemetry::_SubscribePositionRequest_default_instance_._instance,
@@ -5820,7 +5818,7 @@ const char descriptor_table_protodef_telemetry_2ftelemetry_2eproto[] ABSL_ATTRIB
     "ontal_uncertainty_m\030\n \001(\002\022\036\n\026vertical_un"
     "certainty_m\030\013 \001(\002\022 \n\030velocity_uncertaint"
     "y_m_s\030\014 \001(\002\022\037\n\027heading_uncertainty_deg\030\r"
-    " \001(\002\022\017\n\007yaw_deg\030\016 \001(\002\"\323\002\n\007Battery\022\021\n\002id\030"
+    " \001(\002\022\017\n\007yaw_deg\030\016 \001(\002\"\256\002\n\007Battery\022\021\n\002id\030"
     "\001 \001(\rB\005\202\265\030\0010\022!\n\020temperature_degc\030\002 \001(\002B\007"
     "\202\265\030\003NaN\022\032\n\tvoltage_v\030\003 \001(\002B\007\202\265\030\003NaN\022\"\n\021c"
     "urrent_battery_a\030\004 \001(\002B\007\202\265\030\003NaN\022%\n\024capac"
@@ -5828,322 +5826,321 @@ const char descriptor_table_protodef_telemetry_2ftelemetry_2eproto[] ABSL_ATTRIB
     "ing_percent\030\006 \001(\002B\007\202\265\030\003NaN\022!\n\020time_remai"
     "ning_s\030\007 \001(\002B\007\202\265\030\003NaN\022\?\n\020battery_functio"
     "n\030\010 \001(\0162%.mavsdk.rpc.telemetry.BatteryFu"
-    "nction\022#\n\022energy_consumed_wh\030\t \001(\002B\007\202\265\030\003"
-    "NaN\"\271\002\n\006Health\022.\n\033is_gyrometer_calibrati"
-    "on_ok\030\001 \001(\010B\t\202\265\030\005false\0222\n\037is_acceleromet"
-    "er_calibration_ok\030\002 \001(\010B\t\202\265\030\005false\0221\n\036is"
-    "_magnetometer_calibration_ok\030\003 \001(\010B\t\202\265\030\005"
-    "false\022\'\n\024is_local_position_ok\030\005 \001(\010B\t\202\265\030"
-    "\005false\022(\n\025is_global_position_ok\030\006 \001(\010B\t\202"
-    "\265\030\005false\022&\n\023is_home_position_ok\030\007 \001(\010B\t\202"
-    "\265\030\005false\022\035\n\nis_armable\030\010 \001(\010B\t\202\265\030\005false\""
-    "|\n\010RcStatus\022%\n\022was_available_once\030\001 \001(\010B"
-    "\t\202\265\030\005false\022\037\n\014is_available\030\002 \001(\010B\t\202\265\030\005fa"
-    "lse\022(\n\027signal_strength_percent\030\003 \001(\002B\007\202\265"
-    "\030\003NaN\"N\n\nStatusText\0222\n\004type\030\001 \001(\0162$.mavs"
-    "dk.rpc.telemetry.StatusTextType\022\014\n\004text\030"
-    "\002 \001(\t\"\?\n\025ActuatorControlTarget\022\024\n\005group\030"
-    "\001 \001(\005B\005\202\265\030\0010\022\020\n\010controls\030\002 \003(\002\"\?\n\024Actuat"
-    "orOutputStatus\022\025\n\006active\030\001 \001(\rB\005\202\265\030\0010\022\020\n"
-    "\010actuator\030\002 \003(\002\"\'\n\nCovariance\022\031\n\021covaria"
-    "nce_matrix\030\001 \003(\002\";\n\014VelocityBody\022\r\n\005x_m_"
-    "s\030\001 \001(\002\022\r\n\005y_m_s\030\002 \001(\002\022\r\n\005z_m_s\030\003 \001(\002\"5\n"
-    "\014PositionBody\022\013\n\003x_m\030\001 \001(\002\022\013\n\003y_m\030\002 \001(\002\022"
-    "\013\n\003z_m\030\003 \001(\002\"\354\004\n\010Odometry\022\021\n\ttime_usec\030\001"
-    " \001(\004\0229\n\010frame_id\030\002 \001(\0162\'.mavsdk.rpc.tele"
-    "metry.Odometry.MavFrame\022\?\n\016child_frame_i"
-    "d\030\003 \001(\0162\'.mavsdk.rpc.telemetry.Odometry."
-    "MavFrame\0229\n\rposition_body\030\004 \001(\0132\".mavsdk"
-    ".rpc.telemetry.PositionBody\022+\n\001q\030\005 \001(\0132 "
-    ".mavsdk.rpc.telemetry.Quaternion\0229\n\rvelo"
-    "city_body\030\006 \001(\0132\".mavsdk.rpc.telemetry.V"
-    "elocityBody\022H\n\025angular_velocity_body\030\007 \001"
-    "(\0132).mavsdk.rpc.telemetry.AngularVelocit"
-    "yBody\0229\n\017pose_covariance\030\010 \001(\0132 .mavsdk."
-    "rpc.telemetry.Covariance\022=\n\023velocity_cov"
-    "ariance\030\t \001(\0132 .mavsdk.rpc.telemetry.Cov"
-    "ariance\"j\n\010MavFrame\022\023\n\017MAV_FRAME_UNDEF\020\000"
-    "\022\026\n\022MAV_FRAME_BODY_NED\020\010\022\030\n\024MAV_FRAME_VI"
-    "SION_NED\020\020\022\027\n\023MAV_FRAME_ESTIM_NED\020\022\"\266\001\n\016"
-    "DistanceSensor\022#\n\022minimum_distance_m\030\001 \001"
-    "(\002B\007\202\265\030\003NaN\022#\n\022maximum_distance_m\030\002 \001(\002B"
-    "\007\202\265\030\003NaN\022#\n\022current_distance_m\030\003 \001(\002B\007\202\265"
-    "\030\003NaN\0225\n\013orientation\030\004 \001(\0132 .mavsdk.rpc."
-    "telemetry.EulerAngle\"\260\001\n\016ScaledPressure\022"
-    "\024\n\014timestamp_us\030\001 \001(\004\022\035\n\025absolute_pressu"
-    "re_hpa\030\002 \001(\002\022!\n\031differential_pressure_hp"
-    "a\030\003 \001(\002\022\027\n\017temperature_deg\030\004 \001(\002\022-\n%diff"
-    "erential_pressure_temperature_deg\030\005 \001(\002\""
-    "Y\n\013PositionNed\022\030\n\007north_m\030\001 \001(\002B\007\202\265\030\003NaN"
-    "\022\027\n\006east_m\030\002 \001(\002B\007\202\265\030\003NaN\022\027\n\006down_m\030\003 \001("
-    "\002B\007\202\265\030\003NaN\"D\n\013VelocityNed\022\021\n\tnorth_m_s\030\001"
-    " \001(\002\022\020\n\010east_m_s\030\002 \001(\002\022\020\n\010down_m_s\030\003 \001(\002"
-    "\"\177\n\023PositionVelocityNed\0223\n\010position\030\001 \001("
-    "\0132!.mavsdk.rpc.telemetry.PositionNed\0223\n\010"
-    "velocity\030\002 \001(\0132!.mavsdk.rpc.telemetry.Ve"
-    "locityNed\"\210\001\n\013GroundTruth\022\035\n\014latitude_de"
-    "g\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlongitude_deg\030\002 \001(\001B"
-    "\007\202\265\030\003NaN\022$\n\023absolute_altitude_m\030\003 \001(\002B\007\202"
-    "\265\030\003NaN\022\024\n\014timestamp_us\030\004 \001(\004\"\336\001\n\020Fixedwi"
-    "ngMetrics\022\035\n\014airspeed_m_s\030\001 \001(\002B\007\202\265\030\003NaN"
-    "\022$\n\023throttle_percentage\030\002 \001(\002B\007\202\265\030\003NaN\022\037"
-    "\n\016climb_rate_m_s\030\003 \001(\002B\007\202\265\030\003NaN\022 \n\017groun"
-    "dspeed_m_s\030\004 \001(\002B\007\202\265\030\003NaN\022\034\n\013heading_deg"
-    "\030\005 \001(\002B\007\202\265\030\003NaN\022$\n\023absolute_altitude_m\030\006"
-    " \001(\002B\007\202\265\030\003NaN\"i\n\017AccelerationFrd\022\035\n\014forw"
-    "ard_m_s2\030\001 \001(\002B\007\202\265\030\003NaN\022\033\n\nright_m_s2\030\002 "
-    "\001(\002B\007\202\265\030\003NaN\022\032\n\tdown_m_s2\030\003 \001(\002B\007\202\265\030\003NaN"
-    "\"o\n\022AngularVelocityFrd\022\036\n\rforward_rad_s\030"
-    "\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right_rad_s\030\002 \001(\002B\007\202\265\030"
-    "\003NaN\022\033\n\ndown_rad_s\030\003 \001(\002B\007\202\265\030\003NaN\"m\n\020Mag"
-    "neticFieldFrd\022\036\n\rforward_gauss\030\001 \001(\002B\007\202\265"
-    "\030\003NaN\022\034\n\013right_gauss\030\002 \001(\002B\007\202\265\030\003NaN\022\033\n\nd"
-    "own_gauss\030\003 \001(\002B\007\202\265\030\003NaN\"\213\002\n\003Imu\022\?\n\020acce"
-    "leration_frd\030\001 \001(\0132%.mavsdk.rpc.telemetr"
-    "y.AccelerationFrd\022F\n\024angular_velocity_fr"
-    "d\030\002 \001(\0132(.mavsdk.rpc.telemetry.AngularVe"
-    "locityFrd\022B\n\022magnetic_field_frd\030\003 \001(\0132&."
-    "mavsdk.rpc.telemetry.MagneticFieldFrd\022!\n"
-    "\020temperature_degc\030\004 \001(\002B\007\202\265\030\003NaN\022\024\n\014time"
-    "stamp_us\030\005 \001(\004\"m\n\017GpsGlobalOrigin\022\035\n\014lat"
-    "itude_deg\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlongitude_de"
-    "g\030\002 \001(\001B\007\202\265\030\003NaN\022\033\n\naltitude_m\030\003 \001(\002B\007\202\265"
-    "\030\003NaN\"\374\001\n\010Altitude\022%\n\024altitude_monotonic"
-    "_m\030\001 \001(\002B\007\202\265\030\003NaN\022 \n\017altitude_amsl_m\030\002 \001"
-    "(\002B\007\202\265\030\003NaN\022!\n\020altitude_local_m\030\003 \001(\002B\007\202"
-    "\265\030\003NaN\022$\n\023altitude_relative_m\030\004 \001(\002B\007\202\265\030"
-    "\003NaN\022#\n\022altitude_terrain_m\030\005 \001(\002B\007\202\265\030\003Na"
-    "N\022#\n\022bottom_clearance_m\030\006 \001(\002B\007\202\265\030\003NaN\022\024"
-    "\n\014timestamp_us\030\007 \001(\004\"\335\002\n\004Wind\022\037\n\016wind_x_"
-    "ned_m_s\030\001 \001(\002B\007\202\265\030\003NaN\022\037\n\016wind_y_ned_m_s"
-    "\030\002 \001(\002B\007\202\265\030\003NaN\022\037\n\016wind_z_ned_m_s\030\003 \001(\002B"
-    "\007\202\265\030\003NaN\0222\n!horizontal_variability_stdde"
-    "v_m_s\030\004 \001(\002B\007\202\265\030\003NaN\0220\n\037vertical_variabi"
-    "lity_stddev_m_s\030\005 \001(\002B\007\202\265\030\003NaN\022$\n\023wind_a"
-    "ltitude_msl_m\030\006 \001(\002B\007\202\265\030\003NaN\0223\n\"horizont"
-    "al_wind_speed_accuracy_m_s\030\007 \001(\002B\007\202\265\030\003Na"
-    "N\0221\n vertical_wind_speed_accuracy_m_s\030\010 "
-    "\001(\002B\007\202\265\030\003NaN\"\241\002\n\017TelemetryResult\022<\n\006resu"
-    "lt\030\001 \001(\0162,.mavsdk.rpc.telemetry.Telemetr"
-    "yResult.Result\022\022\n\nresult_str\030\002 \001(\t\"\273\001\n\006R"
-    "esult\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCC"
-    "ESS\020\001\022\024\n\020RESULT_NO_SYSTEM\020\002\022\033\n\027RESULT_CO"
-    "NNECTION_ERROR\020\003\022\017\n\013RESULT_BUSY\020\004\022\031\n\025RES"
-    "ULT_COMMAND_DENIED\020\005\022\022\n\016RESULT_TIMEOUT\020\006"
-    "\022\026\n\022RESULT_UNSUPPORTED\020\007*\244\001\n\007FixType\022\023\n\017"
-    "FIX_TYPE_NO_GPS\020\000\022\023\n\017FIX_TYPE_NO_FIX\020\001\022\023"
-    "\n\017FIX_TYPE_FIX_2D\020\002\022\023\n\017FIX_TYPE_FIX_3D\020\003"
-    "\022\025\n\021FIX_TYPE_FIX_DGPS\020\004\022\026\n\022FIX_TYPE_RTK_"
-    "FLOAT\020\005\022\026\n\022FIX_TYPE_RTK_FIXED\020\006*\247\001\n\017Batt"
-    "eryFunction\022\034\n\030BATTERY_FUNCTION_UNKNOWN\020"
-    "\000\022\030\n\024BATTERY_FUNCTION_ALL\020\001\022\037\n\033BATTERY_F"
-    "UNCTION_PROPULSION\020\002\022\035\n\031BATTERY_FUNCTION"
-    "_AVIONICS\020\003\022\034\n\030BATTERY_FUNCTION_PAYLOAD\020"
-    "\004*\206\003\n\nFlightMode\022\027\n\023FLIGHT_MODE_UNKNOWN\020"
-    "\000\022\025\n\021FLIGHT_MODE_READY\020\001\022\027\n\023FLIGHT_MODE_"
-    "TAKEOFF\020\002\022\024\n\020FLIGHT_MODE_HOLD\020\003\022\027\n\023FLIGH"
-    "T_MODE_MISSION\020\004\022 \n\034FLIGHT_MODE_RETURN_T"
-    "O_LAUNCH\020\005\022\024\n\020FLIGHT_MODE_LAND\020\006\022\030\n\024FLIG"
-    "HT_MODE_OFFBOARD\020\007\022\031\n\025FLIGHT_MODE_FOLLOW"
-    "_ME\020\010\022\026\n\022FLIGHT_MODE_MANUAL\020\t\022\026\n\022FLIGHT_"
-    "MODE_ALTCTL\020\n\022\026\n\022FLIGHT_MODE_POSCTL\020\013\022\024\n"
-    "\020FLIGHT_MODE_ACRO\020\014\022\032\n\026FLIGHT_MODE_STABI"
-    "LIZED\020\r\022\031\n\025FLIGHT_MODE_RATTITUDE\020\016*\371\001\n\016S"
-    "tatusTextType\022\032\n\026STATUS_TEXT_TYPE_DEBUG\020"
-    "\000\022\031\n\025STATUS_TEXT_TYPE_INFO\020\001\022\033\n\027STATUS_T"
-    "EXT_TYPE_NOTICE\020\002\022\034\n\030STATUS_TEXT_TYPE_WA"
-    "RNING\020\003\022\032\n\026STATUS_TEXT_TYPE_ERROR\020\004\022\035\n\031S"
-    "TATUS_TEXT_TYPE_CRITICAL\020\005\022\032\n\026STATUS_TEX"
-    "T_TYPE_ALERT\020\006\022\036\n\032STATUS_TEXT_TYPE_EMERG"
-    "ENCY\020\007*\223\001\n\013LandedState\022\030\n\024LANDED_STATE_U"
-    "NKNOWN\020\000\022\032\n\026LANDED_STATE_ON_GROUND\020\001\022\027\n\023"
-    "LANDED_STATE_IN_AIR\020\002\022\033\n\027LANDED_STATE_TA"
-    "KING_OFF\020\003\022\030\n\024LANDED_STATE_LANDING\020\004*\215\001\n"
-    "\tVtolState\022\030\n\024VTOL_STATE_UNDEFINED\020\000\022\037\n\033"
-    "VTOL_STATE_TRANSITION_TO_FW\020\001\022\037\n\033VTOL_ST"
-    "ATE_TRANSITION_TO_MC\020\002\022\021\n\rVTOL_STATE_MC\020"
-    "\003\022\021\n\rVTOL_STATE_FW\020\0042\2048\n\020TelemetryServic"
-    "e\022o\n\021SubscribePosition\022..mavsdk.rpc.tele"
-    "metry.SubscribePositionRequest\032&.mavsdk."
-    "rpc.telemetry.PositionResponse\"\0000\001\022c\n\rSu"
-    "bscribeHome\022*.mavsdk.rpc.telemetry.Subsc"
-    "ribeHomeRequest\032\".mavsdk.rpc.telemetry.H"
-    "omeResponse\"\0000\001\022f\n\016SubscribeInAir\022+.mavs"
-    "dk.rpc.telemetry.SubscribeInAirRequest\032#"
-    ".mavsdk.rpc.telemetry.InAirResponse\"\0000\001\022"
-    "x\n\024SubscribeLandedState\0221.mavsdk.rpc.tel"
-    "emetry.SubscribeLandedStateRequest\032).mav"
-    "sdk.rpc.telemetry.LandedStateResponse\"\0000"
-    "\001\022f\n\016SubscribeArmed\022+.mavsdk.rpc.telemet"
-    "ry.SubscribeArmedRequest\032#.mavsdk.rpc.te"
-    "lemetry.ArmedResponse\"\0000\001\022r\n\022SubscribeVt"
-    "olState\022/.mavsdk.rpc.telemetry.Subscribe"
-    "VtolStateRequest\032\'.mavsdk.rpc.telemetry."
-    "VtolStateResponse\"\0000\001\022\215\001\n\033SubscribeAttit"
-    "udeQuaternion\0228.mavsdk.rpc.telemetry.Sub"
-    "scribeAttitudeQuaternionRequest\0320.mavsdk"
-    ".rpc.telemetry.AttitudeQuaternionRespons"
-    "e\"\0000\001\022~\n\026SubscribeAttitudeEuler\0223.mavsdk"
-    ".rpc.telemetry.SubscribeAttitudeEulerReq"
-    "uest\032+.mavsdk.rpc.telemetry.AttitudeEule"
-    "rResponse\"\0000\001\022\250\001\n$SubscribeAttitudeAngul"
-    "arVelocityBody\022A.mavsdk.rpc.telemetry.Su"
-    "bscribeAttitudeAngularVelocityBodyReques"
-    "t\0329.mavsdk.rpc.telemetry.AttitudeAngular"
-    "VelocityBodyResponse\"\0000\001\022x\n\024SubscribeVel"
-    "ocityNed\0221.mavsdk.rpc.telemetry.Subscrib"
-    "eVelocityNedRequest\032).mavsdk.rpc.telemet"
-    "ry.VelocityNedResponse\"\0000\001\022l\n\020SubscribeG"
-    "psInfo\022-.mavsdk.rpc.telemetry.SubscribeG"
-    "psInfoRequest\032%.mavsdk.rpc.telemetry.Gps"
-    "InfoResponse\"\0000\001\022i\n\017SubscribeRawGps\022,.ma"
-    "vsdk.rpc.telemetry.SubscribeRawGpsReques"
-    "t\032$.mavsdk.rpc.telemetry.RawGpsResponse\""
-    "\0000\001\022l\n\020SubscribeBattery\022-.mavsdk.rpc.tel"
-    "emetry.SubscribeBatteryRequest\032%.mavsdk."
-    "rpc.telemetry.BatteryResponse\"\0000\001\022u\n\023Sub"
-    "scribeFlightMode\0220.mavsdk.rpc.telemetry."
-    "SubscribeFlightModeRequest\032(.mavsdk.rpc."
-    "telemetry.FlightModeResponse\"\0000\001\022i\n\017Subs"
-    "cribeHealth\022,.mavsdk.rpc.telemetry.Subsc"
-    "ribeHealthRequest\032$.mavsdk.rpc.telemetry"
-    ".HealthResponse\"\0000\001\022o\n\021SubscribeRcStatus"
-    "\022..mavsdk.rpc.telemetry.SubscribeRcStatu"
-    "sRequest\032&.mavsdk.rpc.telemetry.RcStatus"
-    "Response\"\0000\001\022u\n\023SubscribeStatusText\0220.ma"
-    "vsdk.rpc.telemetry.SubscribeStatusTextRe"
-    "quest\032(.mavsdk.rpc.telemetry.StatusTextR"
-    "esponse\"\0000\001\022\226\001\n\036SubscribeActuatorControl"
-    "Target\022;.mavsdk.rpc.telemetry.SubscribeA"
-    "ctuatorControlTargetRequest\0323.mavsdk.rpc"
-    ".telemetry.ActuatorControlTargetResponse"
-    "\"\0000\001\022\223\001\n\035SubscribeActuatorOutputStatus\022:"
-    ".mavsdk.rpc.telemetry.SubscribeActuatorO"
-    "utputStatusRequest\0322.mavsdk.rpc.telemetr"
-    "y.ActuatorOutputStatusResponse\"\0000\001\022o\n\021Su"
-    "bscribeOdometry\022..mavsdk.rpc.telemetry.S"
-    "ubscribeOdometryRequest\032&.mavsdk.rpc.tel"
-    "emetry.OdometryResponse\"\0000\001\022\220\001\n\034Subscrib"
-    "ePositionVelocityNed\0229.mavsdk.rpc.teleme"
-    "try.SubscribePositionVelocityNedRequest\032"
-    "1.mavsdk.rpc.telemetry.PositionVelocityN"
-    "edResponse\"\0000\001\022x\n\024SubscribeGroundTruth\0221"
-    ".mavsdk.rpc.telemetry.SubscribeGroundTru"
-    "thRequest\032).mavsdk.rpc.telemetry.GroundT"
-    "ruthResponse\"\0000\001\022\207\001\n\031SubscribeFixedwingM"
-    "etrics\0226.mavsdk.rpc.telemetry.SubscribeF"
-    "ixedwingMetricsRequest\032..mavsdk.rpc.tele"
-    "metry.FixedwingMetricsResponse\"\0000\001\022`\n\014Su"
-    "bscribeImu\022).mavsdk.rpc.telemetry.Subscr"
-    "ibeImuRequest\032!.mavsdk.rpc.telemetry.Imu"
-    "Response\"\0000\001\022r\n\022SubscribeScaledImu\022/.mav"
-    "sdk.rpc.telemetry.SubscribeScaledImuRequ"
-    "est\032\'.mavsdk.rpc.telemetry.ScaledImuResp"
-    "onse\"\0000\001\022i\n\017SubscribeRawImu\022,.mavsdk.rpc"
-    ".telemetry.SubscribeRawImuRequest\032$.mavs"
-    "dk.rpc.telemetry.RawImuResponse\"\0000\001\022x\n\024S"
-    "ubscribeHealthAllOk\0221.mavsdk.rpc.telemet"
-    "ry.SubscribeHealthAllOkRequest\032).mavsdk."
-    "rpc.telemetry.HealthAllOkResponse\"\0000\001\022~\n"
-    "\026SubscribeUnixEpochTime\0223.mavsdk.rpc.tel"
-    "emetry.SubscribeUnixEpochTimeRequest\032+.m"
-    "avsdk.rpc.telemetry.UnixEpochTimeRespons"
-    "e\"\0000\001\022\201\001\n\027SubscribeDistanceSensor\0224.mavs"
-    "dk.rpc.telemetry.SubscribeDistanceSensor"
-    "Request\032,.mavsdk.rpc.telemetry.DistanceS"
-    "ensorResponse\"\0000\001\022\201\001\n\027SubscribeScaledPre"
-    "ssure\0224.mavsdk.rpc.telemetry.SubscribeSc"
-    "aledPressureRequest\032,.mavsdk.rpc.telemet"
-    "ry.ScaledPressureResponse\"\0000\001\022l\n\020Subscri"
-    "beHeading\022-.mavsdk.rpc.telemetry.Subscri"
-    "beHeadingRequest\032%.mavsdk.rpc.telemetry."
-    "HeadingResponse\"\0000\001\022o\n\021SubscribeAltitude"
-    "\022..mavsdk.rpc.telemetry.SubscribeAltitud"
-    "eRequest\032&.mavsdk.rpc.telemetry.Altitude"
-    "Response\"\0000\001\022c\n\rSubscribeWind\022*.mavsdk.r"
-    "pc.telemetry.SubscribeWindRequest\032\".mavs"
-    "dk.rpc.telemetry.WindResponse\"\0000\001\022p\n\017Set"
-    "RatePosition\022,.mavsdk.rpc.telemetry.SetR"
-    "atePositionRequest\032-.mavsdk.rpc.telemetr"
-    "y.SetRatePositionResponse\"\000\022d\n\013SetRateHo"
-    "me\022(.mavsdk.rpc.telemetry.SetRateHomeReq"
-    "uest\032).mavsdk.rpc.telemetry.SetRateHomeR"
-    "esponse\"\000\022g\n\014SetRateInAir\022).mavsdk.rpc.t"
-    "elemetry.SetRateInAirRequest\032*.mavsdk.rp"
-    "c.telemetry.SetRateInAirResponse\"\000\022y\n\022Se"
-    "tRateLandedState\022/.mavsdk.rpc.telemetry."
-    "SetRateLandedStateRequest\0320.mavsdk.rpc.t"
-    "elemetry.SetRateLandedStateResponse\"\000\022s\n"
-    "\020SetRateVtolState\022-.mavsdk.rpc.telemetry"
-    ".SetRateVtolStateRequest\032..mavsdk.rpc.te"
-    "lemetry.SetRateVtolStateResponse\"\000\022\216\001\n\031S"
-    "etRateAttitudeQuaternion\0226.mavsdk.rpc.te"
-    "lemetry.SetRateAttitudeQuaternionRequest"
-    "\0327.mavsdk.rpc.telemetry.SetRateAttitudeQ"
-    "uaternionResponse\"\000\022\177\n\024SetRateAttitudeEu"
-    "ler\0221.mavsdk.rpc.telemetry.SetRateAttitu"
-    "deEulerRequest\0322.mavsdk.rpc.telemetry.Se"
-    "tRateAttitudeEulerResponse\"\000\022y\n\022SetRateV"
-    "elocityNed\022/.mavsdk.rpc.telemetry.SetRat"
-    "eVelocityNedRequest\0320.mavsdk.rpc.telemet"
-    "ry.SetRateVelocityNedResponse\"\000\022m\n\016SetRa"
-    "teGpsInfo\022+.mavsdk.rpc.telemetry.SetRate"
-    "GpsInfoRequest\032,.mavsdk.rpc.telemetry.Se"
-    "tRateGpsInfoResponse\"\000\022j\n\rSetRateRawGps\022"
-    "*.mavsdk.rpc.telemetry.SetRateRawGpsRequ"
-    "est\032+.mavsdk.rpc.telemetry.SetRateRawGps"
-    "Response\"\000\022m\n\016SetRateBattery\022+.mavsdk.rp"
-    "c.telemetry.SetRateBatteryRequest\032,.mavs"
-    "dk.rpc.telemetry.SetRateBatteryResponse\""
-    "\000\022p\n\017SetRateRcStatus\022,.mavsdk.rpc.teleme"
-    "try.SetRateRcStatusRequest\032-.mavsdk.rpc."
-    "telemetry.SetRateRcStatusResponse\"\000\022\227\001\n\034"
-    "SetRateActuatorControlTarget\0229.mavsdk.rp"
-    "c.telemetry.SetRateActuatorControlTarget"
-    "Request\032:.mavsdk.rpc.telemetry.SetRateAc"
-    "tuatorControlTargetResponse\"\000\022\224\001\n\033SetRat"
-    "eActuatorOutputStatus\0228.mavsdk.rpc.telem"
-    "etry.SetRateActuatorOutputStatusRequest\032"
-    "9.mavsdk.rpc.telemetry.SetRateActuatorOu"
-    "tputStatusResponse\"\000\022p\n\017SetRateOdometry\022"
-    ",.mavsdk.rpc.telemetry.SetRateOdometryRe"
-    "quest\032-.mavsdk.rpc.telemetry.SetRateOdom"
-    "etryResponse\"\000\022\221\001\n\032SetRatePositionVeloci"
-    "tyNed\0227.mavsdk.rpc.telemetry.SetRatePosi"
-    "tionVelocityNedRequest\0328.mavsdk.rpc.tele"
-    "metry.SetRatePositionVelocityNedResponse"
-    "\"\000\022y\n\022SetRateGroundTruth\022/.mavsdk.rpc.te"
-    "lemetry.SetRateGroundTruthRequest\0320.mavs"
-    "dk.rpc.telemetry.SetRateGroundTruthRespo"
-    "nse\"\000\022\210\001\n\027SetRateFixedwingMetrics\0224.mavs"
-    "dk.rpc.telemetry.SetRateFixedwingMetrics"
-    "Request\0325.mavsdk.rpc.telemetry.SetRateFi"
-    "xedwingMetricsResponse\"\000\022a\n\nSetRateImu\022\'"
-    ".mavsdk.rpc.telemetry.SetRateImuRequest\032"
-    "(.mavsdk.rpc.telemetry.SetRateImuRespons"
-    "e\"\000\022s\n\020SetRateScaledImu\022-.mavsdk.rpc.tel"
-    "emetry.SetRateScaledImuRequest\032..mavsdk."
-    "rpc.telemetry.SetRateScaledImuResponse\"\000"
-    "\022j\n\rSetRateRawImu\022*.mavsdk.rpc.telemetry"
-    ".SetRateRawImuRequest\032+.mavsdk.rpc.telem"
-    "etry.SetRateRawImuResponse\"\000\022\177\n\024SetRateU"
-    "nixEpochTime\0221.mavsdk.rpc.telemetry.SetR"
-    "ateUnixEpochTimeRequest\0322.mavsdk.rpc.tel"
-    "emetry.SetRateUnixEpochTimeResponse\"\000\022\202\001"
-    "\n\025SetRateDistanceSensor\0222.mavsdk.rpc.tel"
-    "emetry.SetRateDistanceSensorRequest\0323.ma"
-    "vsdk.rpc.telemetry.SetRateDistanceSensor"
-    "Response\"\000\022p\n\017SetRateAltitude\022,.mavsdk.r"
-    "pc.telemetry.SetRateAltitudeRequest\032-.ma"
-    "vsdk.rpc.telemetry.SetRateAltitudeRespon"
-    "se\"\000\022j\n\rSetRateHealth\022*.mavsdk.rpc.telem"
-    "etry.SetRateHealthRequest\032+.mavsdk.rpc.t"
-    "elemetry.SetRateHealthResponse\"\000\022y\n\022GetG"
-    "psGlobalOrigin\022/.mavsdk.rpc.telemetry.Ge"
-    "tGpsGlobalOriginRequest\0320.mavsdk.rpc.tel"
-    "emetry.GetGpsGlobalOriginResponse\"\000B%\n\023i"
-    "o.mavsdk.telemetryB\016TelemetryProtob\006prot"
-    "o3"
+    "nction\"\271\002\n\006Health\022.\n\033is_gyrometer_calibr"
+    "ation_ok\030\001 \001(\010B\t\202\265\030\005false\0222\n\037is_accelero"
+    "meter_calibration_ok\030\002 \001(\010B\t\202\265\030\005false\0221\n"
+    "\036is_magnetometer_calibration_ok\030\003 \001(\010B\t\202"
+    "\265\030\005false\022\'\n\024is_local_position_ok\030\005 \001(\010B\t"
+    "\202\265\030\005false\022(\n\025is_global_position_ok\030\006 \001(\010"
+    "B\t\202\265\030\005false\022&\n\023is_home_position_ok\030\007 \001(\010"
+    "B\t\202\265\030\005false\022\035\n\nis_armable\030\010 \001(\010B\t\202\265\030\005fal"
+    "se\"|\n\010RcStatus\022%\n\022was_available_once\030\001 \001"
+    "(\010B\t\202\265\030\005false\022\037\n\014is_available\030\002 \001(\010B\t\202\265\030"
+    "\005false\022(\n\027signal_strength_percent\030\003 \001(\002B"
+    "\007\202\265\030\003NaN\"N\n\nStatusText\0222\n\004type\030\001 \001(\0162$.m"
+    "avsdk.rpc.telemetry.StatusTextType\022\014\n\004te"
+    "xt\030\002 \001(\t\"\?\n\025ActuatorControlTarget\022\024\n\005gro"
+    "up\030\001 \001(\005B\005\202\265\030\0010\022\020\n\010controls\030\002 \003(\002\"\?\n\024Act"
+    "uatorOutputStatus\022\025\n\006active\030\001 \001(\rB\005\202\265\030\0010"
+    "\022\020\n\010actuator\030\002 \003(\002\"\'\n\nCovariance\022\031\n\021cova"
+    "riance_matrix\030\001 \003(\002\";\n\014VelocityBody\022\r\n\005x"
+    "_m_s\030\001 \001(\002\022\r\n\005y_m_s\030\002 \001(\002\022\r\n\005z_m_s\030\003 \001(\002"
+    "\"5\n\014PositionBody\022\013\n\003x_m\030\001 \001(\002\022\013\n\003y_m\030\002 \001"
+    "(\002\022\013\n\003z_m\030\003 \001(\002\"\354\004\n\010Odometry\022\021\n\ttime_use"
+    "c\030\001 \001(\004\0229\n\010frame_id\030\002 \001(\0162\'.mavsdk.rpc.t"
+    "elemetry.Odometry.MavFrame\022\?\n\016child_fram"
+    "e_id\030\003 \001(\0162\'.mavsdk.rpc.telemetry.Odomet"
+    "ry.MavFrame\0229\n\rposition_body\030\004 \001(\0132\".mav"
+    "sdk.rpc.telemetry.PositionBody\022+\n\001q\030\005 \001("
+    "\0132 .mavsdk.rpc.telemetry.Quaternion\0229\n\rv"
+    "elocity_body\030\006 \001(\0132\".mavsdk.rpc.telemetr"
+    "y.VelocityBody\022H\n\025angular_velocity_body\030"
+    "\007 \001(\0132).mavsdk.rpc.telemetry.AngularVelo"
+    "cityBody\0229\n\017pose_covariance\030\010 \001(\0132 .mavs"
+    "dk.rpc.telemetry.Covariance\022=\n\023velocity_"
+    "covariance\030\t \001(\0132 .mavsdk.rpc.telemetry."
+    "Covariance\"j\n\010MavFrame\022\023\n\017MAV_FRAME_UNDE"
+    "F\020\000\022\026\n\022MAV_FRAME_BODY_NED\020\010\022\030\n\024MAV_FRAME"
+    "_VISION_NED\020\020\022\027\n\023MAV_FRAME_ESTIM_NED\020\022\"\266"
+    "\001\n\016DistanceSensor\022#\n\022minimum_distance_m\030"
+    "\001 \001(\002B\007\202\265\030\003NaN\022#\n\022maximum_distance_m\030\002 \001"
+    "(\002B\007\202\265\030\003NaN\022#\n\022current_distance_m\030\003 \001(\002B"
+    "\007\202\265\030\003NaN\0225\n\013orientation\030\004 \001(\0132 .mavsdk.r"
+    "pc.telemetry.EulerAngle\"\260\001\n\016ScaledPressu"
+    "re\022\024\n\014timestamp_us\030\001 \001(\004\022\035\n\025absolute_pre"
+    "ssure_hpa\030\002 \001(\002\022!\n\031differential_pressure"
+    "_hpa\030\003 \001(\002\022\027\n\017temperature_deg\030\004 \001(\002\022-\n%d"
+    "ifferential_pressure_temperature_deg\030\005 \001"
+    "(\002\"Y\n\013PositionNed\022\030\n\007north_m\030\001 \001(\002B\007\202\265\030\003"
+    "NaN\022\027\n\006east_m\030\002 \001(\002B\007\202\265\030\003NaN\022\027\n\006down_m\030\003"
+    " \001(\002B\007\202\265\030\003NaN\"D\n\013VelocityNed\022\021\n\tnorth_m_"
+    "s\030\001 \001(\002\022\020\n\010east_m_s\030\002 \001(\002\022\020\n\010down_m_s\030\003 "
+    "\001(\002\"\177\n\023PositionVelocityNed\0223\n\010position\030\001"
+    " \001(\0132!.mavsdk.rpc.telemetry.PositionNed\022"
+    "3\n\010velocity\030\002 \001(\0132!.mavsdk.rpc.telemetry"
+    ".VelocityNed\"\210\001\n\013GroundTruth\022\035\n\014latitude"
+    "_deg\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlongitude_deg\030\002 \001"
+    "(\001B\007\202\265\030\003NaN\022$\n\023absolute_altitude_m\030\003 \001(\002"
+    "B\007\202\265\030\003NaN\022\024\n\014timestamp_us\030\004 \001(\004\"\336\001\n\020Fixe"
+    "dwingMetrics\022\035\n\014airspeed_m_s\030\001 \001(\002B\007\202\265\030\003"
+    "NaN\022$\n\023throttle_percentage\030\002 \001(\002B\007\202\265\030\003Na"
+    "N\022\037\n\016climb_rate_m_s\030\003 \001(\002B\007\202\265\030\003NaN\022 \n\017gr"
+    "oundspeed_m_s\030\004 \001(\002B\007\202\265\030\003NaN\022\034\n\013heading_"
+    "deg\030\005 \001(\002B\007\202\265\030\003NaN\022$\n\023absolute_altitude_"
+    "m\030\006 \001(\002B\007\202\265\030\003NaN\"i\n\017AccelerationFrd\022\035\n\014f"
+    "orward_m_s2\030\001 \001(\002B\007\202\265\030\003NaN\022\033\n\nright_m_s2"
+    "\030\002 \001(\002B\007\202\265\030\003NaN\022\032\n\tdown_m_s2\030\003 \001(\002B\007\202\265\030\003"
+    "NaN\"o\n\022AngularVelocityFrd\022\036\n\rforward_rad"
+    "_s\030\001 \001(\002B\007\202\265\030\003NaN\022\034\n\013right_rad_s\030\002 \001(\002B\007"
+    "\202\265\030\003NaN\022\033\n\ndown_rad_s\030\003 \001(\002B\007\202\265\030\003NaN\"m\n\020"
+    "MagneticFieldFrd\022\036\n\rforward_gauss\030\001 \001(\002B"
+    "\007\202\265\030\003NaN\022\034\n\013right_gauss\030\002 \001(\002B\007\202\265\030\003NaN\022\033"
+    "\n\ndown_gauss\030\003 \001(\002B\007\202\265\030\003NaN\"\213\002\n\003Imu\022\?\n\020a"
+    "cceleration_frd\030\001 \001(\0132%.mavsdk.rpc.telem"
+    "etry.AccelerationFrd\022F\n\024angular_velocity"
+    "_frd\030\002 \001(\0132(.mavsdk.rpc.telemetry.Angula"
+    "rVelocityFrd\022B\n\022magnetic_field_frd\030\003 \001(\013"
+    "2&.mavsdk.rpc.telemetry.MagneticFieldFrd"
+    "\022!\n\020temperature_degc\030\004 \001(\002B\007\202\265\030\003NaN\022\024\n\014t"
+    "imestamp_us\030\005 \001(\004\"m\n\017GpsGlobalOrigin\022\035\n\014"
+    "latitude_deg\030\001 \001(\001B\007\202\265\030\003NaN\022\036\n\rlongitude"
+    "_deg\030\002 \001(\001B\007\202\265\030\003NaN\022\033\n\naltitude_m\030\003 \001(\002B"
+    "\007\202\265\030\003NaN\"\374\001\n\010Altitude\022%\n\024altitude_monoto"
+    "nic_m\030\001 \001(\002B\007\202\265\030\003NaN\022 \n\017altitude_amsl_m\030"
+    "\002 \001(\002B\007\202\265\030\003NaN\022!\n\020altitude_local_m\030\003 \001(\002"
+    "B\007\202\265\030\003NaN\022$\n\023altitude_relative_m\030\004 \001(\002B\007"
+    "\202\265\030\003NaN\022#\n\022altitude_terrain_m\030\005 \001(\002B\007\202\265\030"
+    "\003NaN\022#\n\022bottom_clearance_m\030\006 \001(\002B\007\202\265\030\003Na"
+    "N\022\024\n\014timestamp_us\030\007 \001(\004\"\335\002\n\004Wind\022\037\n\016wind"
+    "_x_ned_m_s\030\001 \001(\002B\007\202\265\030\003NaN\022\037\n\016wind_y_ned_"
+    "m_s\030\002 \001(\002B\007\202\265\030\003NaN\022\037\n\016wind_z_ned_m_s\030\003 \001"
+    "(\002B\007\202\265\030\003NaN\0222\n!horizontal_variability_st"
+    "ddev_m_s\030\004 \001(\002B\007\202\265\030\003NaN\0220\n\037vertical_vari"
+    "ability_stddev_m_s\030\005 \001(\002B\007\202\265\030\003NaN\022$\n\023win"
+    "d_altitude_msl_m\030\006 \001(\002B\007\202\265\030\003NaN\0223\n\"horiz"
+    "ontal_wind_speed_accuracy_m_s\030\007 \001(\002B\007\202\265\030"
+    "\003NaN\0221\n vertical_wind_speed_accuracy_m_s"
+    "\030\010 \001(\002B\007\202\265\030\003NaN\"\241\002\n\017TelemetryResult\022<\n\006r"
+    "esult\030\001 \001(\0162,.mavsdk.rpc.telemetry.Telem"
+    "etryResult.Result\022\022\n\nresult_str\030\002 \001(\t\"\273\001"
+    "\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESULT_S"
+    "UCCESS\020\001\022\024\n\020RESULT_NO_SYSTEM\020\002\022\033\n\027RESULT"
+    "_CONNECTION_ERROR\020\003\022\017\n\013RESULT_BUSY\020\004\022\031\n\025"
+    "RESULT_COMMAND_DENIED\020\005\022\022\n\016RESULT_TIMEOU"
+    "T\020\006\022\026\n\022RESULT_UNSUPPORTED\020\007*\244\001\n\007FixType\022"
+    "\023\n\017FIX_TYPE_NO_GPS\020\000\022\023\n\017FIX_TYPE_NO_FIX\020"
+    "\001\022\023\n\017FIX_TYPE_FIX_2D\020\002\022\023\n\017FIX_TYPE_FIX_3"
+    "D\020\003\022\025\n\021FIX_TYPE_FIX_DGPS\020\004\022\026\n\022FIX_TYPE_R"
+    "TK_FLOAT\020\005\022\026\n\022FIX_TYPE_RTK_FIXED\020\006*\247\001\n\017B"
+    "atteryFunction\022\034\n\030BATTERY_FUNCTION_UNKNO"
+    "WN\020\000\022\030\n\024BATTERY_FUNCTION_ALL\020\001\022\037\n\033BATTER"
+    "Y_FUNCTION_PROPULSION\020\002\022\035\n\031BATTERY_FUNCT"
+    "ION_AVIONICS\020\003\022\034\n\030BATTERY_FUNCTION_PAYLO"
+    "AD\020\004*\206\003\n\nFlightMode\022\027\n\023FLIGHT_MODE_UNKNO"
+    "WN\020\000\022\025\n\021FLIGHT_MODE_READY\020\001\022\027\n\023FLIGHT_MO"
+    "DE_TAKEOFF\020\002\022\024\n\020FLIGHT_MODE_HOLD\020\003\022\027\n\023FL"
+    "IGHT_MODE_MISSION\020\004\022 \n\034FLIGHT_MODE_RETUR"
+    "N_TO_LAUNCH\020\005\022\024\n\020FLIGHT_MODE_LAND\020\006\022\030\n\024F"
+    "LIGHT_MODE_OFFBOARD\020\007\022\031\n\025FLIGHT_MODE_FOL"
+    "LOW_ME\020\010\022\026\n\022FLIGHT_MODE_MANUAL\020\t\022\026\n\022FLIG"
+    "HT_MODE_ALTCTL\020\n\022\026\n\022FLIGHT_MODE_POSCTL\020\013"
+    "\022\024\n\020FLIGHT_MODE_ACRO\020\014\022\032\n\026FLIGHT_MODE_ST"
+    "ABILIZED\020\r\022\031\n\025FLIGHT_MODE_RATTITUDE\020\016*\371\001"
+    "\n\016StatusTextType\022\032\n\026STATUS_TEXT_TYPE_DEB"
+    "UG\020\000\022\031\n\025STATUS_TEXT_TYPE_INFO\020\001\022\033\n\027STATU"
+    "S_TEXT_TYPE_NOTICE\020\002\022\034\n\030STATUS_TEXT_TYPE"
+    "_WARNING\020\003\022\032\n\026STATUS_TEXT_TYPE_ERROR\020\004\022\035"
+    "\n\031STATUS_TEXT_TYPE_CRITICAL\020\005\022\032\n\026STATUS_"
+    "TEXT_TYPE_ALERT\020\006\022\036\n\032STATUS_TEXT_TYPE_EM"
+    "ERGENCY\020\007*\223\001\n\013LandedState\022\030\n\024LANDED_STAT"
+    "E_UNKNOWN\020\000\022\032\n\026LANDED_STATE_ON_GROUND\020\001\022"
+    "\027\n\023LANDED_STATE_IN_AIR\020\002\022\033\n\027LANDED_STATE"
+    "_TAKING_OFF\020\003\022\030\n\024LANDED_STATE_LANDING\020\004*"
+    "\215\001\n\tVtolState\022\030\n\024VTOL_STATE_UNDEFINED\020\000\022"
+    "\037\n\033VTOL_STATE_TRANSITION_TO_FW\020\001\022\037\n\033VTOL"
+    "_STATE_TRANSITION_TO_MC\020\002\022\021\n\rVTOL_STATE_"
+    "MC\020\003\022\021\n\rVTOL_STATE_FW\020\0042\2048\n\020TelemetrySer"
+    "vice\022o\n\021SubscribePosition\022..mavsdk.rpc.t"
+    "elemetry.SubscribePositionRequest\032&.mavs"
+    "dk.rpc.telemetry.PositionResponse\"\0000\001\022c\n"
+    "\rSubscribeHome\022*.mavsdk.rpc.telemetry.Su"
+    "bscribeHomeRequest\032\".mavsdk.rpc.telemetr"
+    "y.HomeResponse\"\0000\001\022f\n\016SubscribeInAir\022+.m"
+    "avsdk.rpc.telemetry.SubscribeInAirReques"
+    "t\032#.mavsdk.rpc.telemetry.InAirResponse\"\000"
+    "0\001\022x\n\024SubscribeLandedState\0221.mavsdk.rpc."
+    "telemetry.SubscribeLandedStateRequest\032)."
+    "mavsdk.rpc.telemetry.LandedStateResponse"
+    "\"\0000\001\022f\n\016SubscribeArmed\022+.mavsdk.rpc.tele"
+    "metry.SubscribeArmedRequest\032#.mavsdk.rpc"
+    ".telemetry.ArmedResponse\"\0000\001\022r\n\022Subscrib"
+    "eVtolState\022/.mavsdk.rpc.telemetry.Subscr"
+    "ibeVtolStateRequest\032\'.mavsdk.rpc.telemet"
+    "ry.VtolStateResponse\"\0000\001\022\215\001\n\033SubscribeAt"
+    "titudeQuaternion\0228.mavsdk.rpc.telemetry."
+    "SubscribeAttitudeQuaternionRequest\0320.mav"
+    "sdk.rpc.telemetry.AttitudeQuaternionResp"
+    "onse\"\0000\001\022~\n\026SubscribeAttitudeEuler\0223.mav"
+    "sdk.rpc.telemetry.SubscribeAttitudeEuler"
+    "Request\032+.mavsdk.rpc.telemetry.AttitudeE"
+    "ulerResponse\"\0000\001\022\250\001\n$SubscribeAttitudeAn"
+    "gularVelocityBody\022A.mavsdk.rpc.telemetry"
+    ".SubscribeAttitudeAngularVelocityBodyReq"
+    "uest\0329.mavsdk.rpc.telemetry.AttitudeAngu"
+    "larVelocityBodyResponse\"\0000\001\022x\n\024Subscribe"
+    "VelocityNed\0221.mavsdk.rpc.telemetry.Subsc"
+    "ribeVelocityNedRequest\032).mavsdk.rpc.tele"
+    "metry.VelocityNedResponse\"\0000\001\022l\n\020Subscri"
+    "beGpsInfo\022-.mavsdk.rpc.telemetry.Subscri"
+    "beGpsInfoRequest\032%.mavsdk.rpc.telemetry."
+    "GpsInfoResponse\"\0000\001\022i\n\017SubscribeRawGps\022,"
+    ".mavsdk.rpc.telemetry.SubscribeRawGpsReq"
+    "uest\032$.mavsdk.rpc.telemetry.RawGpsRespon"
+    "se\"\0000\001\022l\n\020SubscribeBattery\022-.mavsdk.rpc."
+    "telemetry.SubscribeBatteryRequest\032%.mavs"
+    "dk.rpc.telemetry.BatteryResponse\"\0000\001\022u\n\023"
+    "SubscribeFlightMode\0220.mavsdk.rpc.telemet"
+    "ry.SubscribeFlightModeRequest\032(.mavsdk.r"
+    "pc.telemetry.FlightModeResponse\"\0000\001\022i\n\017S"
+    "ubscribeHealth\022,.mavsdk.rpc.telemetry.Su"
+    "bscribeHealthRequest\032$.mavsdk.rpc.teleme"
+    "try.HealthResponse\"\0000\001\022o\n\021SubscribeRcSta"
+    "tus\022..mavsdk.rpc.telemetry.SubscribeRcSt"
+    "atusRequest\032&.mavsdk.rpc.telemetry.RcSta"
+    "tusResponse\"\0000\001\022u\n\023SubscribeStatusText\0220"
+    ".mavsdk.rpc.telemetry.SubscribeStatusTex"
+    "tRequest\032(.mavsdk.rpc.telemetry.StatusTe"
+    "xtResponse\"\0000\001\022\226\001\n\036SubscribeActuatorCont"
+    "rolTarget\022;.mavsdk.rpc.telemetry.Subscri"
+    "beActuatorControlTargetRequest\0323.mavsdk."
+    "rpc.telemetry.ActuatorControlTargetRespo"
+    "nse\"\0000\001\022\223\001\n\035SubscribeActuatorOutputStatu"
+    "s\022:.mavsdk.rpc.telemetry.SubscribeActuat"
+    "orOutputStatusRequest\0322.mavsdk.rpc.telem"
+    "etry.ActuatorOutputStatusResponse\"\0000\001\022o\n"
+    "\021SubscribeOdometry\022..mavsdk.rpc.telemetr"
+    "y.SubscribeOdometryRequest\032&.mavsdk.rpc."
+    "telemetry.OdometryResponse\"\0000\001\022\220\001\n\034Subsc"
+    "ribePositionVelocityNed\0229.mavsdk.rpc.tel"
+    "emetry.SubscribePositionVelocityNedReque"
+    "st\0321.mavsdk.rpc.telemetry.PositionVeloci"
+    "tyNedResponse\"\0000\001\022x\n\024SubscribeGroundTrut"
+    "h\0221.mavsdk.rpc.telemetry.SubscribeGround"
+    "TruthRequest\032).mavsdk.rpc.telemetry.Grou"
+    "ndTruthResponse\"\0000\001\022\207\001\n\031SubscribeFixedwi"
+    "ngMetrics\0226.mavsdk.rpc.telemetry.Subscri"
+    "beFixedwingMetricsRequest\032..mavsdk.rpc.t"
+    "elemetry.FixedwingMetricsResponse\"\0000\001\022`\n"
+    "\014SubscribeImu\022).mavsdk.rpc.telemetry.Sub"
+    "scribeImuRequest\032!.mavsdk.rpc.telemetry."
+    "ImuResponse\"\0000\001\022r\n\022SubscribeScaledImu\022/."
+    "mavsdk.rpc.telemetry.SubscribeScaledImuR"
+    "equest\032\'.mavsdk.rpc.telemetry.ScaledImuR"
+    "esponse\"\0000\001\022i\n\017SubscribeRawImu\022,.mavsdk."
+    "rpc.telemetry.SubscribeRawImuRequest\032$.m"
+    "avsdk.rpc.telemetry.RawImuResponse\"\0000\001\022x"
+    "\n\024SubscribeHealthAllOk\0221.mavsdk.rpc.tele"
+    "metry.SubscribeHealthAllOkRequest\032).mavs"
+    "dk.rpc.telemetry.HealthAllOkResponse\"\0000\001"
+    "\022~\n\026SubscribeUnixEpochTime\0223.mavsdk.rpc."
+    "telemetry.SubscribeUnixEpochTimeRequest\032"
+    "+.mavsdk.rpc.telemetry.UnixEpochTimeResp"
+    "onse\"\0000\001\022\201\001\n\027SubscribeDistanceSensor\0224.m"
+    "avsdk.rpc.telemetry.SubscribeDistanceSen"
+    "sorRequest\032,.mavsdk.rpc.telemetry.Distan"
+    "ceSensorResponse\"\0000\001\022\201\001\n\027SubscribeScaled"
+    "Pressure\0224.mavsdk.rpc.telemetry.Subscrib"
+    "eScaledPressureRequest\032,.mavsdk.rpc.tele"
+    "metry.ScaledPressureResponse\"\0000\001\022l\n\020Subs"
+    "cribeHeading\022-.mavsdk.rpc.telemetry.Subs"
+    "cribeHeadingRequest\032%.mavsdk.rpc.telemet"
+    "ry.HeadingResponse\"\0000\001\022o\n\021SubscribeAltit"
+    "ude\022..mavsdk.rpc.telemetry.SubscribeAlti"
+    "tudeRequest\032&.mavsdk.rpc.telemetry.Altit"
+    "udeResponse\"\0000\001\022c\n\rSubscribeWind\022*.mavsd"
+    "k.rpc.telemetry.SubscribeWindRequest\032\".m"
+    "avsdk.rpc.telemetry.WindResponse\"\0000\001\022p\n\017"
+    "SetRatePosition\022,.mavsdk.rpc.telemetry.S"
+    "etRatePositionRequest\032-.mavsdk.rpc.telem"
+    "etry.SetRatePositionResponse\"\000\022d\n\013SetRat"
+    "eHome\022(.mavsdk.rpc.telemetry.SetRateHome"
+    "Request\032).mavsdk.rpc.telemetry.SetRateHo"
+    "meResponse\"\000\022g\n\014SetRateInAir\022).mavsdk.rp"
+    "c.telemetry.SetRateInAirRequest\032*.mavsdk"
+    ".rpc.telemetry.SetRateInAirResponse\"\000\022y\n"
+    "\022SetRateLandedState\022/.mavsdk.rpc.telemet"
+    "ry.SetRateLandedStateRequest\0320.mavsdk.rp"
+    "c.telemetry.SetRateLandedStateResponse\"\000"
+    "\022s\n\020SetRateVtolState\022-.mavsdk.rpc.teleme"
+    "try.SetRateVtolStateRequest\032..mavsdk.rpc"
+    ".telemetry.SetRateVtolStateResponse\"\000\022\216\001"
+    "\n\031SetRateAttitudeQuaternion\0226.mavsdk.rpc"
+    ".telemetry.SetRateAttitudeQuaternionRequ"
+    "est\0327.mavsdk.rpc.telemetry.SetRateAttitu"
+    "deQuaternionResponse\"\000\022\177\n\024SetRateAttitud"
+    "eEuler\0221.mavsdk.rpc.telemetry.SetRateAtt"
+    "itudeEulerRequest\0322.mavsdk.rpc.telemetry"
+    ".SetRateAttitudeEulerResponse\"\000\022y\n\022SetRa"
+    "teVelocityNed\022/.mavsdk.rpc.telemetry.Set"
+    "RateVelocityNedRequest\0320.mavsdk.rpc.tele"
+    "metry.SetRateVelocityNedResponse\"\000\022m\n\016Se"
+    "tRateGpsInfo\022+.mavsdk.rpc.telemetry.SetR"
+    "ateGpsInfoRequest\032,.mavsdk.rpc.telemetry"
+    ".SetRateGpsInfoResponse\"\000\022j\n\rSetRateRawG"
+    "ps\022*.mavsdk.rpc.telemetry.SetRateRawGpsR"
+    "equest\032+.mavsdk.rpc.telemetry.SetRateRaw"
+    "GpsResponse\"\000\022m\n\016SetRateBattery\022+.mavsdk"
+    ".rpc.telemetry.SetRateBatteryRequest\032,.m"
+    "avsdk.rpc.telemetry.SetRateBatteryRespon"
+    "se\"\000\022p\n\017SetRateRcStatus\022,.mavsdk.rpc.tel"
+    "emetry.SetRateRcStatusRequest\032-.mavsdk.r"
+    "pc.telemetry.SetRateRcStatusResponse\"\000\022\227"
+    "\001\n\034SetRateActuatorControlTarget\0229.mavsdk"
+    ".rpc.telemetry.SetRateActuatorControlTar"
+    "getRequest\032:.mavsdk.rpc.telemetry.SetRat"
+    "eActuatorControlTargetResponse\"\000\022\224\001\n\033Set"
+    "RateActuatorOutputStatus\0228.mavsdk.rpc.te"
+    "lemetry.SetRateActuatorOutputStatusReque"
+    "st\0329.mavsdk.rpc.telemetry.SetRateActuato"
+    "rOutputStatusResponse\"\000\022p\n\017SetRateOdomet"
+    "ry\022,.mavsdk.rpc.telemetry.SetRateOdometr"
+    "yRequest\032-.mavsdk.rpc.telemetry.SetRateO"
+    "dometryResponse\"\000\022\221\001\n\032SetRatePositionVel"
+    "ocityNed\0227.mavsdk.rpc.telemetry.SetRateP"
+    "ositionVelocityNedRequest\0328.mavsdk.rpc.t"
+    "elemetry.SetRatePositionVelocityNedRespo"
+    "nse\"\000\022y\n\022SetRateGroundTruth\022/.mavsdk.rpc"
+    ".telemetry.SetRateGroundTruthRequest\0320.m"
+    "avsdk.rpc.telemetry.SetRateGroundTruthRe"
+    "sponse\"\000\022\210\001\n\027SetRateFixedwingMetrics\0224.m"
+    "avsdk.rpc.telemetry.SetRateFixedwingMetr"
+    "icsRequest\0325.mavsdk.rpc.telemetry.SetRat"
+    "eFixedwingMetricsResponse\"\000\022a\n\nSetRateIm"
+    "u\022\'.mavsdk.rpc.telemetry.SetRateImuReque"
+    "st\032(.mavsdk.rpc.telemetry.SetRateImuResp"
+    "onse\"\000\022s\n\020SetRateScaledImu\022-.mavsdk.rpc."
+    "telemetry.SetRateScaledImuRequest\032..mavs"
+    "dk.rpc.telemetry.SetRateScaledImuRespons"
+    "e\"\000\022j\n\rSetRateRawImu\022*.mavsdk.rpc.teleme"
+    "try.SetRateRawImuRequest\032+.mavsdk.rpc.te"
+    "lemetry.SetRateRawImuResponse\"\000\022\177\n\024SetRa"
+    "teUnixEpochTime\0221.mavsdk.rpc.telemetry.S"
+    "etRateUnixEpochTimeRequest\0322.mavsdk.rpc."
+    "telemetry.SetRateUnixEpochTimeResponse\"\000"
+    "\022\202\001\n\025SetRateDistanceSensor\0222.mavsdk.rpc."
+    "telemetry.SetRateDistanceSensorRequest\0323"
+    ".mavsdk.rpc.telemetry.SetRateDistanceSen"
+    "sorResponse\"\000\022p\n\017SetRateAltitude\022,.mavsd"
+    "k.rpc.telemetry.SetRateAltitudeRequest\032-"
+    ".mavsdk.rpc.telemetry.SetRateAltitudeRes"
+    "ponse\"\000\022j\n\rSetRateHealth\022*.mavsdk.rpc.te"
+    "lemetry.SetRateHealthRequest\032+.mavsdk.rp"
+    "c.telemetry.SetRateHealthResponse\"\000\022y\n\022G"
+    "etGpsGlobalOrigin\022/.mavsdk.rpc.telemetry"
+    ".GetGpsGlobalOriginRequest\0320.mavsdk.rpc."
+    "telemetry.GetGpsGlobalOriginResponse\"\000B%"
+    "\n\023io.mavsdk.telemetryB\016TelemetryProtob\006p"
+    "roto3"
 };
 static const ::_pbi::DescriptorTable* const descriptor_table_telemetry_2ftelemetry_2eproto_deps[1] =
     {
@@ -6153,7 +6150,7 @@ static ::absl::once_flag descriptor_table_telemetry_2ftelemetry_2eproto_once;
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_telemetry_2ftelemetry_2eproto = {
     false,
     false,
-    21682,
+    21645,
     descriptor_table_protodef_telemetry_2ftelemetry_2eproto,
     "telemetry/telemetry.proto",
     &descriptor_table_telemetry_2ftelemetry_2eproto_once,
@@ -32455,9 +32452,9 @@ inline void Battery::SharedCtor(::_pb::Arena* arena) {
   ::memset(reinterpret_cast<char *>(&_impl_) +
                offsetof(Impl_, id_),
            0,
-           offsetof(Impl_, energy_consumed_wh_) -
+           offsetof(Impl_, battery_function_) -
                offsetof(Impl_, id_) +
-               sizeof(Impl_::energy_consumed_wh_));
+               sizeof(Impl_::battery_function_));
 }
 Battery::~Battery() {
   // @@protoc_insertion_point(destructor:mavsdk.rpc.telemetry.Battery)
@@ -32506,15 +32503,15 @@ const ::google::protobuf::internal::ClassData* Battery::GetClassData() const {
   return _class_data_.base();
 }
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<4, 9, 0, 0, 2> Battery::_table_ = {
+const ::_pbi::TcParseTable<3, 8, 0, 0, 2> Battery::_table_ = {
   {
     0,  // no _has_bits_
     0, // no _extensions_
-    9, 120,  // max_field_number, fast_idx_mask
+    8, 56,  // max_field_number, fast_idx_mask
     offsetof(decltype(_table_), field_lookup_table),
-    4294966784,  // skipmap
+    4294967040,  // skipmap
     offsetof(decltype(_table_), field_entries),
-    9,  // num_field_entries
+    8,  // num_field_entries
     0,  // num_aux_entries
     offsetof(decltype(_table_), field_names),  // no aux_entries
     _class_data_.base(),
@@ -32524,7 +32521,9 @@ const ::_pbi::TcParseTable<4, 9, 0, 0, 2> Battery::_table_ = {
     ::_pbi::TcParser::GetTable<::mavsdk::rpc::telemetry::Battery>(),  // to_prefetch
     #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
   }, {{
-    {::_pbi::TcParser::MiniParse, {}},
+    // .mavsdk.rpc.telemetry.BatteryFunction battery_function = 8;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(Battery, _impl_.battery_function_), 63>(),
+     {64, 63, 0, PROTOBUF_FIELD_OFFSET(Battery, _impl_.battery_function_)}},
     // uint32 id = 1 [(.mavsdk.options.default_value) = "0"];
     {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(Battery, _impl_.id_), 63>(),
      {8, 63, 0, PROTOBUF_FIELD_OFFSET(Battery, _impl_.id_)}},
@@ -32546,18 +32545,6 @@ const ::_pbi::TcParseTable<4, 9, 0, 0, 2> Battery::_table_ = {
     // float time_remaining_s = 7 [(.mavsdk.options.default_value) = "NaN"];
     {::_pbi::TcParser::FastF32S1,
      {61, 63, 0, PROTOBUF_FIELD_OFFSET(Battery, _impl_.time_remaining_s_)}},
-    // .mavsdk.rpc.telemetry.BatteryFunction battery_function = 8;
-    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(Battery, _impl_.battery_function_), 63>(),
-     {64, 63, 0, PROTOBUF_FIELD_OFFSET(Battery, _impl_.battery_function_)}},
-    // float energy_consumed_wh = 9 [(.mavsdk.options.default_value) = "NaN"];
-    {::_pbi::TcParser::FastF32S1,
-     {77, 63, 0, PROTOBUF_FIELD_OFFSET(Battery, _impl_.energy_consumed_wh_)}},
-    {::_pbi::TcParser::MiniParse, {}},
-    {::_pbi::TcParser::MiniParse, {}},
-    {::_pbi::TcParser::MiniParse, {}},
-    {::_pbi::TcParser::MiniParse, {}},
-    {::_pbi::TcParser::MiniParse, {}},
-    {::_pbi::TcParser::MiniParse, {}},
   }}, {{
     65535, 65535
   }}, {{
@@ -32585,9 +32572,6 @@ const ::_pbi::TcParseTable<4, 9, 0, 0, 2> Battery::_table_ = {
     // .mavsdk.rpc.telemetry.BatteryFunction battery_function = 8;
     {PROTOBUF_FIELD_OFFSET(Battery, _impl_.battery_function_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kOpenEnum)},
-    // float energy_consumed_wh = 9 [(.mavsdk.options.default_value) = "NaN"];
-    {PROTOBUF_FIELD_OFFSET(Battery, _impl_.energy_consumed_wh_), 0, 0,
-    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
   }},
   // no aux_entries
   {{
@@ -32602,8 +32586,8 @@ PROTOBUF_NOINLINE void Battery::Clear() {
   (void) cached_has_bits;
 
   ::memset(&_impl_.id_, 0, static_cast<::size_t>(
-      reinterpret_cast<char*>(&_impl_.energy_consumed_wh_) -
-      reinterpret_cast<char*>(&_impl_.id_)) + sizeof(_impl_.energy_consumed_wh_));
+      reinterpret_cast<char*>(&_impl_.battery_function_) -
+      reinterpret_cast<char*>(&_impl_.id_)) + sizeof(_impl_.battery_function_));
   _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
 }
 
@@ -32678,13 +32662,6 @@ PROTOBUF_NOINLINE void Battery::Clear() {
                 8, this_._internal_battery_function(), target);
           }
 
-          // float energy_consumed_wh = 9 [(.mavsdk.options.default_value) = "NaN"];
-          if (::absl::bit_cast<::uint32_t>(this_._internal_energy_consumed_wh()) != 0) {
-            target = stream->EnsureSpace(target);
-            target = ::_pbi::WireFormatLite::WriteFloatToArray(
-                9, this_._internal_energy_consumed_wh(), target);
-          }
-
           if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
             target =
                 ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
@@ -32744,10 +32721,6 @@ PROTOBUF_NOINLINE void Battery::Clear() {
               total_size += 1 +
                             ::_pbi::WireFormatLite::EnumSize(this_._internal_battery_function());
             }
-            // float energy_consumed_wh = 9 [(.mavsdk.options.default_value) = "NaN"];
-            if (::absl::bit_cast<::uint32_t>(this_._internal_energy_consumed_wh()) != 0) {
-              total_size += 5;
-            }
           }
           return this_.MaybeComputeUnknownFieldsSize(total_size,
                                                      &this_._impl_._cached_size_);
@@ -32785,9 +32758,6 @@ void Battery::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google:
   if (from._internal_battery_function() != 0) {
     _this->_impl_.battery_function_ = from._impl_.battery_function_;
   }
-  if (::absl::bit_cast<::uint32_t>(from._internal_energy_consumed_wh()) != 0) {
-    _this->_impl_.energy_consumed_wh_ = from._impl_.energy_consumed_wh_;
-  }
   _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
 }
 
@@ -32803,8 +32773,8 @@ void Battery::InternalSwap(Battery* PROTOBUF_RESTRICT other) {
   using std::swap;
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
   ::google::protobuf::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(Battery, _impl_.energy_consumed_wh_)
-      + sizeof(Battery::_impl_.energy_consumed_wh_)
+      PROTOBUF_FIELD_OFFSET(Battery, _impl_.battery_function_)
+      + sizeof(Battery::_impl_.battery_function_)
       - PROTOBUF_FIELD_OFFSET(Battery, _impl_.id_)>(
           reinterpret_cast<char*>(&_impl_.id_),
           reinterpret_cast<char*>(&other->_impl_.id_));

--- a/cpp/src/mavsdk_server/src/generated/telemetry/telemetry.pb.h
+++ b/cpp/src/mavsdk_server/src/generated/telemetry/telemetry.pb.h
@@ -16899,7 +16899,6 @@ class Battery final
     kRemainingPercentFieldNumber = 6,
     kTimeRemainingSFieldNumber = 7,
     kBatteryFunctionFieldNumber = 8,
-    kEnergyConsumedWhFieldNumber = 9,
   };
   // uint32 id = 1 [(.mavsdk.options.default_value) = "0"];
   void clear_id() ;
@@ -16981,22 +16980,12 @@ class Battery final
   void _internal_set_battery_function(::mavsdk::rpc::telemetry::BatteryFunction value);
 
   public:
-  // float energy_consumed_wh = 9 [(.mavsdk.options.default_value) = "NaN"];
-  void clear_energy_consumed_wh() ;
-  float energy_consumed_wh() const;
-  void set_energy_consumed_wh(float value);
-
-  private:
-  float _internal_energy_consumed_wh() const;
-  void _internal_set_energy_consumed_wh(float value);
-
-  public:
   // @@protoc_insertion_point(class_scope:mavsdk.rpc.telemetry.Battery)
  private:
   class _Internal;
   friend class ::google::protobuf::internal::TcParser;
   static const ::google::protobuf::internal::TcParseTable<
-      4, 9, 0,
+      3, 8, 0,
       0, 2>
       _table_;
 
@@ -17022,7 +17011,6 @@ class Battery final
     float remaining_percent_;
     float time_remaining_s_;
     int battery_function_;
-    float energy_consumed_wh_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
@@ -38055,28 +38043,6 @@ inline ::mavsdk::rpc::telemetry::BatteryFunction Battery::_internal_battery_func
 inline void Battery::_internal_set_battery_function(::mavsdk::rpc::telemetry::BatteryFunction value) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.battery_function_ = value;
-}
-
-// float energy_consumed_wh = 9 [(.mavsdk.options.default_value) = "NaN"];
-inline void Battery::clear_energy_consumed_wh() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.energy_consumed_wh_ = 0;
-}
-inline float Battery::energy_consumed_wh() const {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.telemetry.Battery.energy_consumed_wh)
-  return _internal_energy_consumed_wh();
-}
-inline void Battery::set_energy_consumed_wh(float value) {
-  _internal_set_energy_consumed_wh(value);
-  // @@protoc_insertion_point(field_set:mavsdk.rpc.telemetry.Battery.energy_consumed_wh)
-}
-inline float Battery::_internal_energy_consumed_wh() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.energy_consumed_wh_;
-}
-inline void Battery::_internal_set_energy_consumed_wh(float value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.energy_consumed_wh_ = value;
 }
 
 // -------------------------------------------------------------------

--- a/cpp/src/mavsdk_server/src/plugins/telemetry/telemetry_service_impl.hpp
+++ b/cpp/src/mavsdk_server/src/plugins/telemetry/telemetry_service_impl.hpp
@@ -908,10 +908,6 @@ public:
                 
             
         
-            
-        rpc_obj->set_energy_consumed_wh(battery.energy_consumed_wh);
-            
-        
 
         return rpc_obj;
     }
@@ -951,10 +947,6 @@ public:
         
             
         obj.battery_function = translateFromRpcBatteryFunction(battery.battery_function());
-            
-        
-            
-        obj.energy_consumed_wh = battery.energy_consumed_wh();
             
         
         return obj;

--- a/py/mavsdk/mavsdk/plugins/telemetry/telemetry.py
+++ b/py/mavsdk/mavsdk/plugins/telemetry/telemetry.py
@@ -253,7 +253,6 @@ class BatteryCStruct(ctypes.Structure):
         ("remaining_percent", ctypes.c_float),
         ("time_remaining_s", ctypes.c_float),
         ("battery_function", ctypes.c_int),
-        ("energy_consumed_wh", ctypes.c_float),
     ]
 
 
@@ -1015,7 +1014,6 @@ class Battery:
         remaining_percent=None,
         time_remaining_s=None,
         battery_function=None,
-        energy_consumed_wh=None,
     ):
         self.id = id
         self.temperature_degc = temperature_degc
@@ -1025,7 +1023,6 @@ class Battery:
         self.remaining_percent = remaining_percent
         self.time_remaining_s = time_remaining_s
         self.battery_function = battery_function
-        self.energy_consumed_wh = energy_consumed_wh
 
     @classmethod
     def from_c_struct(cls, c_struct):
@@ -1039,7 +1036,6 @@ class Battery:
         instance.remaining_percent = c_struct.remaining_percent
         instance.time_remaining_s = c_struct.time_remaining_s
         instance.battery_function = BatteryFunction(c_struct.battery_function)
-        instance.energy_consumed_wh = c_struct.energy_consumed_wh
         return instance
 
     def to_c_struct(self):
@@ -1053,7 +1049,6 @@ class Battery:
         c_struct.remaining_percent = self.remaining_percent
         c_struct.time_remaining_s = self.time_remaining_s
         c_struct.battery_function = int(self.battery_function)
-        c_struct.energy_consumed_wh = self.energy_consumed_wh
         return c_struct
 
     def __str__(self):
@@ -1066,7 +1061,6 @@ class Battery:
         fields.append(f"remaining_percent={self.remaining_percent}")
         fields.append(f"time_remaining_s={self.time_remaining_s}")
         fields.append(f"battery_function={self.battery_function}")
-        fields.append(f"energy_consumed_wh={self.energy_consumed_wh}")
         return f"Battery({', '.join(fields)})"
 
 


### PR DESCRIPTION
Reverts #2882.

The `energy_consumed_wh` field does not address the original issue (#1748), which asked for current readings (`current_battery_a` — already present in the API). Reverting to avoid confusion.