### PR TITLE
Telemetry: use ESTIMATOR_STATUS for is_global_position_ok

### DIFF
--- a/cpp/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/cpp/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -106,6 +106,11 @@ void TelemetryImpl::init()
         this);
 
     _system_impl->register_mavlink_message_handler(
+        MAVLINK_MSG_ID_ESTIMATOR_STATUS,
+        [this](const mavlink_message_t& message) { process_estimator_status(message); },
+        this);
+
+    _system_impl->register_mavlink_message_handler(
         MAVLINK_MSG_ID_HEARTBEAT,
         [this](const mavlink_message_t& message) { process_heartbeat(message); },
         this);
@@ -1188,19 +1193,21 @@ void TelemetryImpl::process_sys_status(const mavlink_message_t& message)
             sys_status.onboard_control_sensors_health & MAV_SYS_STATUS_SENSOR_3D_MAG);
     }
 
-    const bool global_position_ok =
+    const bool gps_health_ok =
         sys_status_present_enabled_health(sys_status, MAV_SYS_STATUS_SENSOR_GPS);
 
     // FIXME: There is nothing really set in PX4 for local position from what I can tell,
     //        so the best we can do for now is to set it based on GPS as a fallback.
 
     const bool local_position_ok =
-        global_position_ok ||
+        gps_health_ok ||
         sys_status_present_enabled_health(sys_status, MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW) ||
         sys_status_present_enabled_health(sys_status, MAV_SYS_STATUS_SENSOR_VISION_POSITION);
 
     set_health_local_position(local_position_ok);
-    set_health_global_position(global_position_ok);
+    if (!_has_estimator_status) {
+        set_health_global_position(gps_health_ok);
+    }
 
     set_rc_status({rc_ok}, std::nullopt);
 
@@ -1221,6 +1228,21 @@ bool TelemetryImpl::sys_status_present_enabled_health(
     return (sys_status.onboard_control_sensors_present & flag) != 0 &&
            // (sys_status.onboard_control_sensors_enabled & flag) != 0 &&
            (sys_status.onboard_control_sensors_health & flag) != 0;
+}
+
+void TelemetryImpl::process_estimator_status(const mavlink_message_t& message)
+{
+    mavlink_estimator_status_t estimator_status;
+    mavlink_msg_estimator_status_decode(&message, &estimator_status);
+
+    _has_estimator_status = true;
+
+    const bool global_position_ok = (estimator_status.flags & ESTIMATOR_PRED_POS_HORIZ_ABS) != 0;
+    set_health_global_position(global_position_ok);
+
+    std::lock_guard<std::mutex> lock(_subscription_mutex);
+    _health_all_ok_subscriptions.queue(
+        health_all_ok(), [this](const auto& func) { _system_impl->call_user_callback(func); });
 }
 
 void TelemetryImpl::process_battery_status(const mavlink_message_t& message)

--- a/cpp/src/mavsdk/plugins/telemetry/telemetry_impl.hpp
+++ b/cpp/src/mavsdk/plugins/telemetry/telemetry_impl.hpp
@@ -256,6 +256,7 @@ private:
     void process_extended_sys_state(const mavlink_message_t& message);
     void process_fixedwing_metrics(const mavlink_message_t& message);
     void process_sys_status(const mavlink_message_t& message);
+    void process_estimator_status(const mavlink_message_t& message);
     void process_battery_status(const mavlink_message_t& message);
     void process_heartbeat(const mavlink_message_t& message);
     void process_rc_channels(const mavlink_message_t& message);
@@ -431,6 +432,10 @@ private:
     // Battery info can be extracted from SYS_STATUS or from BATTERY_STATUS.
     // If no BATTERY_STATUS messages are received, use info from SYS_STATUS.
     bool _has_bat_status{false};
+
+    // Global position validity from ESTIMATOR_STATUS takes precedence over GPS sensor health.
+    // If no ESTIMATOR_STATUS messages are received, fall back to GPS sensor health from SYS_STATUS.
+    bool _has_estimator_status{false};
 
     CallEveryHandler::Cookie _homepos_cookie{};
 


### PR DESCRIPTION
Fixes #1852.

## Problem

`is_global_position_ok` was derived from GPS sensor health in `SYS_STATUS`, which doesn't reflect EKF fusion state. A drone can have GPS signal but the EKF may not yet have a valid global position estimate (e.g. during initialization or after a GPS glitch).

## Fix

Register a handler for `MAVLINK_MSG_ID_ESTIMATOR_STATUS`. When received, use the `ESTIMATOR_PRED_POS_HORIZ_ABS` flag (EKF predicts absolute horizontal position) to set global position health.

Falls back to GPS sensor health from `SYS_STATUS` if no `ESTIMATOR_STATUS` messages are received (older firmware / non-EKF setups).

## Files changed

- `telemetry_impl.hpp`: added `process_estimator_status()` declaration, `_has_estimator_status` flag
- `telemetry_impl.cpp`: register ESTIMATOR_STATUS handler in `init()`, modify `process_sys_status()` to skip global position update when estimator status is available, add `process_estimator_status()` implementation

Closes #1852