### PR TITLE
Action: add set_home

### DIFF
--- a/c/src/cmavsdk/plugins/action/action.cpp
+++ b/c/src/cmavsdk/plugins/action/action.cpp
@@ -982,3 +982,20 @@ mavsdk_action_set_gps_global_origin(
 
     return translate_result(ret_value);
 }
+
+
+// SetHome sync
+mavsdk_action_result_t
+mavsdk_action_set_home(
+    mavsdk_action_t action,
+    bool use_current_location,
+    double latitude_deg,
+    double longitude_deg,
+    float absolute_altitude_m)
+{
+    auto wrapper = reinterpret_cast<mavsdk_action_wrapper*>(action);
+
+    auto ret_value = wrapper->cpp_plugin->set_home(        use_current_location,        latitude_deg,        longitude_deg,        absolute_altitude_m);
+
+    return translate_result(ret_value);
+}

--- a/c/src/cmavsdk/plugins/action/action.h
+++ b/c/src/cmavsdk/plugins/action/action.h
@@ -962,6 +962,24 @@ mavsdk_action_set_gps_global_origin(
     float absolute_altitude_m);
 
 
+/**
+ * @brief Get the current set home (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param set_home_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_action_result_t
+mavsdk_action_set_home(
+    mavsdk_action_t action,
+    bool use_current_location,
+    double latitude_deg,
+    double longitude_deg,
+    float absolute_altitude_m);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpp/docs/en/cpp/api_reference/classmavsdk_1_1_action.md
+++ b/cpp/docs/en/cpp/api_reference/classmavsdk_1_1_action.md
@@ -73,6 +73,7 @@ void | [set_return_to_launch_altitude_async](#classmavsdk_1_1_action_1acdc4360c2
 void | [set_current_speed_async](#classmavsdk_1_1_action_1afd210be0eba436c81da79107562a0b6c) (float speed_m_s, const [ResultCallback](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a70a7b6e742d0c86728dc2e1827dacccd) callback) | Set current speed.
 [Result](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1adc2e13257ef13de0e7610cf879a0ec51) | [set_current_speed](#classmavsdk_1_1_action_1af3b74cf3912411d9476b6eeac0984afb) (float speed_m_s)const | Set current speed.
 [Result](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1adc2e13257ef13de0e7610cf879a0ec51) | [set_gps_global_origin](#classmavsdk_1_1_action_1abf97620153fca87f2dd89a6eb96a8479) (double latitude_deg, double longitude_deg, float absolute_altitude_m)const | Set GPS Global Origin.
+[Result](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1adc2e13257ef13de0e7610cf879a0ec51) | [set_home](#classmavsdk_1_1_action_1a722270e068f74b0a57d2e3f771c3e455) (bool use_current_location, double latitude_deg, double longitude_deg, float absolute_altitude_m)const | Set home.
 const [Action](classmavsdk_1_1_action.md) & | [operator=](#classmavsdk_1_1_action_1a89482740f533e194fade200103b5adef) (const [Action](classmavsdk_1_1_action.md) &)=delete | Equality operator (object is not copyable).
 
 
@@ -1043,6 +1044,30 @@ This function is blocking.
 
 **Parameters**
 
+* double **latitude_deg** - 
+* double **longitude_deg** - 
+* float **absolute_altitude_m** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1adc2e13257ef13de0e7610cf879a0ec51) - Result of request.
+
+### set_home() {#classmavsdk_1_1_action_1a722270e068f74b0a57d2e3f771c3e455}
+```cpp
+Result mavsdk::Action::set_home(bool use_current_location, double latitude_deg, double longitude_deg, float absolute_altitude_m) const
+```
+
+
+Set home.
+
+Sets the home position.
+
+
+This function is blocking.
+
+**Parameters**
+
+* bool **use_current_location** - 
 * double **latitude_deg** - 
 * double **longitude_deg** - 
 * float **absolute_altitude_m** - 

--- a/cpp/src/mavsdk/plugins/action/action.cpp
+++ b/cpp/src/mavsdk/plugins/action/action.cpp
@@ -9,345 +9,277 @@
 
 namespace mavsdk {
 
-
-
-
-
 Action::Action(System& system) : PluginBase(), _impl{std::make_unique<ActionImpl>(system)} {}
 
-Action::Action(std::shared_ptr<System> system) : PluginBase(), _impl{std::make_unique<ActionImpl>(system)} {}
-
+Action::Action(std::shared_ptr<System> system) :
+    PluginBase(),
+    _impl{std::make_unique<ActionImpl>(system)}
+{}
 
 Action::~Action() {}
-
-
 
 void Action::arm_async(const ResultCallback callback)
 {
     _impl->arm_async(callback);
 }
 
-
-
 Action::Result Action::arm() const
 {
     return _impl->arm();
 }
-
-
 
 void Action::arm_force_async(const ResultCallback callback)
 {
     _impl->arm_force_async(callback);
 }
 
-
-
 Action::Result Action::arm_force() const
 {
     return _impl->arm_force();
 }
-
-
 
 void Action::disarm_async(const ResultCallback callback)
 {
     _impl->disarm_async(callback);
 }
 
-
-
 Action::Result Action::disarm() const
 {
     return _impl->disarm();
 }
-
-
 
 void Action::takeoff_async(const ResultCallback callback)
 {
     _impl->takeoff_async(callback);
 }
 
-
-
 Action::Result Action::takeoff() const
 {
     return _impl->takeoff();
 }
-
-
 
 void Action::land_async(const ResultCallback callback)
 {
     _impl->land_async(callback);
 }
 
-
-
 Action::Result Action::land() const
 {
     return _impl->land();
 }
-
-
 
 void Action::reboot_async(const ResultCallback callback)
 {
     _impl->reboot_async(callback);
 }
 
-
-
 Action::Result Action::reboot() const
 {
     return _impl->reboot();
 }
-
-
 
 void Action::shutdown_async(const ResultCallback callback)
 {
     _impl->shutdown_async(callback);
 }
 
-
-
 Action::Result Action::shutdown() const
 {
     return _impl->shutdown();
 }
-
-
 
 void Action::terminate_async(const ResultCallback callback)
 {
     _impl->terminate_async(callback);
 }
 
-
-
 Action::Result Action::terminate() const
 {
     return _impl->terminate();
 }
-
-
 
 void Action::kill_async(const ResultCallback callback)
 {
     _impl->kill_async(callback);
 }
 
-
-
 Action::Result Action::kill() const
 {
     return _impl->kill();
 }
-
-
 
 void Action::return_to_launch_async(const ResultCallback callback)
 {
     _impl->return_to_launch_async(callback);
 }
 
-
-
 Action::Result Action::return_to_launch() const
 {
     return _impl->return_to_launch();
 }
 
-
-
-void Action::goto_location_async(double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg, const ResultCallback callback)
+void Action::goto_location_async(
+    double latitude_deg,
+    double longitude_deg,
+    float absolute_altitude_m,
+    float yaw_deg,
+    const ResultCallback callback)
 {
     _impl->goto_location_async(latitude_deg, longitude_deg, absolute_altitude_m, yaw_deg, callback);
 }
 
-
-
-Action::Result Action::goto_location(double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg) const
+Action::Result Action::goto_location(
+    double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg) const
 {
     return _impl->goto_location(latitude_deg, longitude_deg, absolute_altitude_m, yaw_deg);
 }
 
-
-
-void Action::do_orbit_async(float radius_m, float velocity_ms, OrbitYawBehavior yaw_behavior, double latitude_deg, double longitude_deg, double absolute_altitude_m, const ResultCallback callback)
+void Action::do_orbit_async(
+    float radius_m,
+    float velocity_ms,
+    OrbitYawBehavior yaw_behavior,
+    double latitude_deg,
+    double longitude_deg,
+    double absolute_altitude_m,
+    const ResultCallback callback)
 {
-    _impl->do_orbit_async(radius_m, velocity_ms, yaw_behavior, latitude_deg, longitude_deg, absolute_altitude_m, callback);
+    _impl->do_orbit_async(
+        radius_m,
+        velocity_ms,
+        yaw_behavior,
+        latitude_deg,
+        longitude_deg,
+        absolute_altitude_m,
+        callback);
 }
 
-
-
-Action::Result Action::do_orbit(float radius_m, float velocity_ms, OrbitYawBehavior yaw_behavior, double latitude_deg, double longitude_deg, double absolute_altitude_m) const
+Action::Result Action::do_orbit(
+    float radius_m,
+    float velocity_ms,
+    OrbitYawBehavior yaw_behavior,
+    double latitude_deg,
+    double longitude_deg,
+    double absolute_altitude_m) const
 {
-    return _impl->do_orbit(radius_m, velocity_ms, yaw_behavior, latitude_deg, longitude_deg, absolute_altitude_m);
+    return _impl->do_orbit(
+        radius_m, velocity_ms, yaw_behavior, latitude_deg, longitude_deg, absolute_altitude_m);
 }
-
-
 
 void Action::hold_async(const ResultCallback callback)
 {
     _impl->hold_async(callback);
 }
 
-
-
 Action::Result Action::hold() const
 {
     return _impl->hold();
 }
-
-
 
 void Action::set_actuator_async(int32_t index, float value, const ResultCallback callback)
 {
     _impl->set_actuator_async(index, value, callback);
 }
 
-
-
 Action::Result Action::set_actuator(int32_t index, float value) const
 {
     return _impl->set_actuator(index, value);
 }
-
-
 
 void Action::set_relay_async(int32_t index, RelayCommand setting, const ResultCallback callback)
 {
     _impl->set_relay_async(index, setting, callback);
 }
 
-
-
 Action::Result Action::set_relay(int32_t index, RelayCommand setting) const
 {
     return _impl->set_relay(index, setting);
 }
-
-
 
 void Action::transition_to_fixedwing_async(const ResultCallback callback)
 {
     _impl->transition_to_fixedwing_async(callback);
 }
 
-
-
 Action::Result Action::transition_to_fixedwing() const
 {
     return _impl->transition_to_fixedwing();
 }
-
-
 
 void Action::transition_to_multicopter_async(const ResultCallback callback)
 {
     _impl->transition_to_multicopter_async(callback);
 }
 
-
-
 Action::Result Action::transition_to_multicopter() const
 {
     return _impl->transition_to_multicopter();
 }
-
-
 
 void Action::get_takeoff_altitude_async(const GetTakeoffAltitudeCallback callback)
 {
     _impl->get_takeoff_altitude_async(callback);
 }
 
-
-
 std::pair<Action::Result, float> Action::get_takeoff_altitude() const
 {
     return _impl->get_takeoff_altitude();
 }
-
-
 
 void Action::set_takeoff_altitude_async(float altitude, const ResultCallback callback)
 {
     _impl->set_takeoff_altitude_async(altitude, callback);
 }
 
-
-
 Action::Result Action::set_takeoff_altitude(float altitude) const
 {
     return _impl->set_takeoff_altitude(altitude);
 }
-
-
 
 void Action::get_return_to_launch_altitude_async(const GetReturnToLaunchAltitudeCallback callback)
 {
     _impl->get_return_to_launch_altitude_async(callback);
 }
 
-
-
 std::pair<Action::Result, float> Action::get_return_to_launch_altitude() const
 {
     return _impl->get_return_to_launch_altitude();
 }
 
-
-
-void Action::set_return_to_launch_altitude_async(float relative_altitude_m, const ResultCallback callback)
+void Action::set_return_to_launch_altitude_async(
+    float relative_altitude_m, const ResultCallback callback)
 {
     _impl->set_return_to_launch_altitude_async(relative_altitude_m, callback);
 }
-
-
 
 Action::Result Action::set_return_to_launch_altitude(float relative_altitude_m) const
 {
     return _impl->set_return_to_launch_altitude(relative_altitude_m);
 }
 
-
-
 void Action::set_current_speed_async(float speed_m_s, const ResultCallback callback)
 {
     _impl->set_current_speed_async(speed_m_s, callback);
 }
-
-
 
 Action::Result Action::set_current_speed(float speed_m_s) const
 {
     return _impl->set_current_speed(speed_m_s);
 }
 
-
-
-
-
-Action::Result Action::set_gps_global_origin(double latitude_deg, double longitude_deg, float absolute_altitude_m) const
+Action::Result Action::set_gps_global_origin(
+    double latitude_deg, double longitude_deg, float absolute_altitude_m) const
 {
     return _impl->set_gps_global_origin(latitude_deg, longitude_deg, absolute_altitude_m);
 }
 
-
-
-
-
-Action::Result Action::set_home(bool use_current_location, double latitude_deg, double longitude_deg, float absolute_altitude_m) const
+Action::Result Action::set_home(
+    bool use_current_location,
+    double latitude_deg,
+    double longitude_deg,
+    float absolute_altitude_m) const
 {
     return _impl->set_home(use_current_location, latitude_deg, longitude_deg, absolute_altitude_m);
 }
-
-
-
 
 MAVSDK_PUBLIC std::string_view to_string(Action::Result const& result)
 {
@@ -392,8 +324,6 @@ MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Action::Result const& 
     return str << to_string(result);
 }
 
-
-
 MAVSDK_PUBLIC std::string_view to_string(Action::OrbitYawBehavior const& orbit_yaw_behavior)
 {
     switch (orbit_yaw_behavior) {
@@ -412,7 +342,8 @@ MAVSDK_PUBLIC std::string_view to_string(Action::OrbitYawBehavior const& orbit_y
     }
 }
 
-MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Action::OrbitYawBehavior const& orbit_yaw_behavior)
+MAVSDK_PUBLIC std::ostream&
+operator<<(std::ostream& str, Action::OrbitYawBehavior const& orbit_yaw_behavior)
 {
     return str << to_string(orbit_yaw_behavior);
 }
@@ -433,6 +364,5 @@ MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Action::RelayCommand c
 {
     return str << to_string(relay_command);
 }
-
 
 } // namespace mavsdk

--- a/cpp/src/mavsdk/plugins/action/action.cpp
+++ b/cpp/src/mavsdk/plugins/action/action.cpp
@@ -9,268 +9,345 @@
 
 namespace mavsdk {
 
+
+
+
+
 Action::Action(System& system) : PluginBase(), _impl{std::make_unique<ActionImpl>(system)} {}
 
-Action::Action(std::shared_ptr<System> system) :
-    PluginBase(),
-    _impl{std::make_unique<ActionImpl>(system)}
-{}
+Action::Action(std::shared_ptr<System> system) : PluginBase(), _impl{std::make_unique<ActionImpl>(system)} {}
+
 
 Action::~Action() {}
+
+
 
 void Action::arm_async(const ResultCallback callback)
 {
     _impl->arm_async(callback);
 }
 
+
+
 Action::Result Action::arm() const
 {
     return _impl->arm();
 }
+
+
 
 void Action::arm_force_async(const ResultCallback callback)
 {
     _impl->arm_force_async(callback);
 }
 
+
+
 Action::Result Action::arm_force() const
 {
     return _impl->arm_force();
 }
+
+
 
 void Action::disarm_async(const ResultCallback callback)
 {
     _impl->disarm_async(callback);
 }
 
+
+
 Action::Result Action::disarm() const
 {
     return _impl->disarm();
 }
+
+
 
 void Action::takeoff_async(const ResultCallback callback)
 {
     _impl->takeoff_async(callback);
 }
 
+
+
 Action::Result Action::takeoff() const
 {
     return _impl->takeoff();
 }
+
+
 
 void Action::land_async(const ResultCallback callback)
 {
     _impl->land_async(callback);
 }
 
+
+
 Action::Result Action::land() const
 {
     return _impl->land();
 }
+
+
 
 void Action::reboot_async(const ResultCallback callback)
 {
     _impl->reboot_async(callback);
 }
 
+
+
 Action::Result Action::reboot() const
 {
     return _impl->reboot();
 }
+
+
 
 void Action::shutdown_async(const ResultCallback callback)
 {
     _impl->shutdown_async(callback);
 }
 
+
+
 Action::Result Action::shutdown() const
 {
     return _impl->shutdown();
 }
+
+
 
 void Action::terminate_async(const ResultCallback callback)
 {
     _impl->terminate_async(callback);
 }
 
+
+
 Action::Result Action::terminate() const
 {
     return _impl->terminate();
 }
+
+
 
 void Action::kill_async(const ResultCallback callback)
 {
     _impl->kill_async(callback);
 }
 
+
+
 Action::Result Action::kill() const
 {
     return _impl->kill();
 }
+
+
 
 void Action::return_to_launch_async(const ResultCallback callback)
 {
     _impl->return_to_launch_async(callback);
 }
 
+
+
 Action::Result Action::return_to_launch() const
 {
     return _impl->return_to_launch();
 }
 
-void Action::goto_location_async(
-    double latitude_deg,
-    double longitude_deg,
-    float absolute_altitude_m,
-    float yaw_deg,
-    const ResultCallback callback)
+
+
+void Action::goto_location_async(double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg, const ResultCallback callback)
 {
     _impl->goto_location_async(latitude_deg, longitude_deg, absolute_altitude_m, yaw_deg, callback);
 }
 
-Action::Result Action::goto_location(
-    double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg) const
+
+
+Action::Result Action::goto_location(double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg) const
 {
     return _impl->goto_location(latitude_deg, longitude_deg, absolute_altitude_m, yaw_deg);
 }
 
-void Action::do_orbit_async(
-    float radius_m,
-    float velocity_ms,
-    OrbitYawBehavior yaw_behavior,
-    double latitude_deg,
-    double longitude_deg,
-    double absolute_altitude_m,
-    const ResultCallback callback)
+
+
+void Action::do_orbit_async(float radius_m, float velocity_ms, OrbitYawBehavior yaw_behavior, double latitude_deg, double longitude_deg, double absolute_altitude_m, const ResultCallback callback)
 {
-    _impl->do_orbit_async(
-        radius_m,
-        velocity_ms,
-        yaw_behavior,
-        latitude_deg,
-        longitude_deg,
-        absolute_altitude_m,
-        callback);
+    _impl->do_orbit_async(radius_m, velocity_ms, yaw_behavior, latitude_deg, longitude_deg, absolute_altitude_m, callback);
 }
 
-Action::Result Action::do_orbit(
-    float radius_m,
-    float velocity_ms,
-    OrbitYawBehavior yaw_behavior,
-    double latitude_deg,
-    double longitude_deg,
-    double absolute_altitude_m) const
+
+
+Action::Result Action::do_orbit(float radius_m, float velocity_ms, OrbitYawBehavior yaw_behavior, double latitude_deg, double longitude_deg, double absolute_altitude_m) const
 {
-    return _impl->do_orbit(
-        radius_m, velocity_ms, yaw_behavior, latitude_deg, longitude_deg, absolute_altitude_m);
+    return _impl->do_orbit(radius_m, velocity_ms, yaw_behavior, latitude_deg, longitude_deg, absolute_altitude_m);
 }
+
+
 
 void Action::hold_async(const ResultCallback callback)
 {
     _impl->hold_async(callback);
 }
 
+
+
 Action::Result Action::hold() const
 {
     return _impl->hold();
 }
+
+
 
 void Action::set_actuator_async(int32_t index, float value, const ResultCallback callback)
 {
     _impl->set_actuator_async(index, value, callback);
 }
 
+
+
 Action::Result Action::set_actuator(int32_t index, float value) const
 {
     return _impl->set_actuator(index, value);
 }
+
+
 
 void Action::set_relay_async(int32_t index, RelayCommand setting, const ResultCallback callback)
 {
     _impl->set_relay_async(index, setting, callback);
 }
 
+
+
 Action::Result Action::set_relay(int32_t index, RelayCommand setting) const
 {
     return _impl->set_relay(index, setting);
 }
+
+
 
 void Action::transition_to_fixedwing_async(const ResultCallback callback)
 {
     _impl->transition_to_fixedwing_async(callback);
 }
 
+
+
 Action::Result Action::transition_to_fixedwing() const
 {
     return _impl->transition_to_fixedwing();
 }
+
+
 
 void Action::transition_to_multicopter_async(const ResultCallback callback)
 {
     _impl->transition_to_multicopter_async(callback);
 }
 
+
+
 Action::Result Action::transition_to_multicopter() const
 {
     return _impl->transition_to_multicopter();
 }
+
+
 
 void Action::get_takeoff_altitude_async(const GetTakeoffAltitudeCallback callback)
 {
     _impl->get_takeoff_altitude_async(callback);
 }
 
+
+
 std::pair<Action::Result, float> Action::get_takeoff_altitude() const
 {
     return _impl->get_takeoff_altitude();
 }
+
+
 
 void Action::set_takeoff_altitude_async(float altitude, const ResultCallback callback)
 {
     _impl->set_takeoff_altitude_async(altitude, callback);
 }
 
+
+
 Action::Result Action::set_takeoff_altitude(float altitude) const
 {
     return _impl->set_takeoff_altitude(altitude);
 }
+
+
 
 void Action::get_return_to_launch_altitude_async(const GetReturnToLaunchAltitudeCallback callback)
 {
     _impl->get_return_to_launch_altitude_async(callback);
 }
 
+
+
 std::pair<Action::Result, float> Action::get_return_to_launch_altitude() const
 {
     return _impl->get_return_to_launch_altitude();
 }
 
-void Action::set_return_to_launch_altitude_async(
-    float relative_altitude_m, const ResultCallback callback)
+
+
+void Action::set_return_to_launch_altitude_async(float relative_altitude_m, const ResultCallback callback)
 {
     _impl->set_return_to_launch_altitude_async(relative_altitude_m, callback);
 }
+
+
 
 Action::Result Action::set_return_to_launch_altitude(float relative_altitude_m) const
 {
     return _impl->set_return_to_launch_altitude(relative_altitude_m);
 }
 
+
+
 void Action::set_current_speed_async(float speed_m_s, const ResultCallback callback)
 {
     _impl->set_current_speed_async(speed_m_s, callback);
 }
+
+
 
 Action::Result Action::set_current_speed(float speed_m_s) const
 {
     return _impl->set_current_speed(speed_m_s);
 }
 
-Action::Result Action::set_gps_global_origin(
-    double latitude_deg, double longitude_deg, float absolute_altitude_m) const
+
+
+
+
+Action::Result Action::set_gps_global_origin(double latitude_deg, double longitude_deg, float absolute_altitude_m) const
 {
     return _impl->set_gps_global_origin(latitude_deg, longitude_deg, absolute_altitude_m);
 }
+
+
+
+
+
+Action::Result Action::set_home(bool use_current_location, double latitude_deg, double longitude_deg, float absolute_altitude_m) const
+{
+    return _impl->set_home(use_current_location, latitude_deg, longitude_deg, absolute_altitude_m);
+}
+
+
+
 
 MAVSDK_PUBLIC std::string_view to_string(Action::Result const& result)
 {
@@ -315,6 +392,8 @@ MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Action::Result const& 
     return str << to_string(result);
 }
 
+
+
 MAVSDK_PUBLIC std::string_view to_string(Action::OrbitYawBehavior const& orbit_yaw_behavior)
 {
     switch (orbit_yaw_behavior) {
@@ -333,8 +412,7 @@ MAVSDK_PUBLIC std::string_view to_string(Action::OrbitYawBehavior const& orbit_y
     }
 }
 
-MAVSDK_PUBLIC std::ostream&
-operator<<(std::ostream& str, Action::OrbitYawBehavior const& orbit_yaw_behavior)
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Action::OrbitYawBehavior const& orbit_yaw_behavior)
 {
     return str << to_string(orbit_yaw_behavior);
 }
@@ -355,5 +433,6 @@ MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& str, Action::RelayCommand c
 {
     return str << to_string(relay_command);
 }
+
 
 } // namespace mavsdk

--- a/cpp/src/mavsdk/plugins/action/action_impl.cpp
+++ b/cpp/src/mavsdk/plugins/action/action_impl.cpp
@@ -927,6 +927,32 @@ Action::Result ActionImpl::set_gps_global_origin(
     return fut.get();
 }
 
+Action::Result ActionImpl::set_home(
+    bool use_current_location,
+    double latitude_deg,
+    double longitude_deg,
+    float absolute_altitude_m) const
+{
+    auto prom = std::promise<Action::Result>{};
+    auto fut = prom.get_future();
+
+    MavlinkCommandSender::CommandInt command{};
+    command.command = MAV_CMD_DO_SET_HOME;
+    command.target_component_id = _system_impl->get_autopilot_id();
+    command.params.maybe_param1 = use_current_location ? 1.0f : 0.0f;
+    if (!use_current_location) {
+        command.params.x = int32_t(std::round(latitude_deg * 1e7));
+        command.params.y = int32_t(std::round(longitude_deg * 1e7));
+        command.params.maybe_z = absolute_altitude_m;
+    }
+
+    _system_impl->send_command_async(command, [&prom](MavlinkCommandSender::Result result, float) {
+        prom.set_value(action_result_from_command_result(result));
+    });
+
+    return fut.get();
+}
+
 Action::Result ActionImpl::action_result_from_command_result(MavlinkCommandSender::Result result)
 {
     switch (result) {

--- a/cpp/src/mavsdk/plugins/action/action_impl.hpp
+++ b/cpp/src/mavsdk/plugins/action/action_impl.hpp
@@ -100,6 +100,12 @@ public:
     Action::Result set_gps_global_origin(
         double latitude_deg, double longitude_deg, float absolute_altitude_m) const;
 
+    Action::Result set_home(
+        bool use_current_location,
+        double latitude_deg,
+        double longitude_deg,
+        float absolute_altitude_m) const;
+
     Action::Result set_return_to_launch_altitude(const float relative_altitude_m) const;
     std::pair<Action::Result, float> get_return_to_launch_altitude() const;
 

--- a/cpp/src/mavsdk/plugins/action/include/plugins/action/action.hpp
+++ b/cpp/src/mavsdk/plugins/action/include/plugins/action/action.hpp
@@ -813,6 +813,24 @@ public:
 
 
 
+
+
+    /**
+     * @brief Set home.
+     *
+     * Sets the home position.
+     *
+     * This function is blocking.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result set_home(bool use_current_location, double latitude_deg, double longitude_deg, float absolute_altitude_m) const;
+
+
+
+
     /**
      * @brief Copy constructor.
      */

--- a/cpp/src/mavsdk/plugins/action/mocks/action_mock.hpp
+++ b/cpp/src/mavsdk/plugins/action/mocks/action_mock.hpp
@@ -35,6 +35,7 @@ public:
     MOCK_CONST_METHOD1(set_return_to_launch_altitude, Action::Result(float)) {};
     MOCK_CONST_METHOD1(set_current_speed, Action::Result(float)) {};
     MOCK_CONST_METHOD3(set_gps_global_origin, Action::Result(double, double, float)) {};
+    MOCK_CONST_METHOD4(set_home, Action::Result(bool, double, double, float)) {};
 };
 
 } // namespace testing

--- a/cpp/src/mavsdk_server/src/generated/action/action.grpc.pb.cc
+++ b/cpp/src/mavsdk_server/src/generated/action/action.grpc.pb.cc
@@ -47,6 +47,7 @@ static const char* ActionService_method_names[] = {
   "/mavsdk.rpc.action.ActionService/SetReturnToLaunchAltitude",
   "/mavsdk.rpc.action.ActionService/SetCurrentSpeed",
   "/mavsdk.rpc.action.ActionService/SetGpsGlobalOrigin",
+  "/mavsdk.rpc.action.ActionService/SetHome",
 };
 
 std::unique_ptr< ActionService::Stub> ActionService::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
@@ -79,6 +80,7 @@ ActionService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& chan
   , rpcmethod_SetReturnToLaunchAltitude_(ActionService_method_names[20], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_SetCurrentSpeed_(ActionService_method_names[21], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_SetGpsGlobalOrigin_(ActionService_method_names[22], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetHome_(ActionService_method_names[23], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status ActionService::Stub::Arm(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ArmRequest& request, ::mavsdk::rpc::action::ArmResponse* response) {
@@ -610,6 +612,29 @@ void ActionService::Stub::async::SetGpsGlobalOrigin(::grpc::ClientContext* conte
   return result;
 }
 
+::grpc::Status ActionService::Stub::SetHome(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetHomeRequest& request, ::mavsdk::rpc::action::SetHomeResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::action::SetHomeRequest, ::mavsdk::rpc::action::SetHomeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_SetHome_, context, request, response);
+}
+
+void ActionService::Stub::async::SetHome(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetHomeRequest* request, ::mavsdk::rpc::action::SetHomeResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::action::SetHomeRequest, ::mavsdk::rpc::action::SetHomeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetHome_, context, request, response, std::move(f));
+}
+
+void ActionService::Stub::async::SetHome(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetHomeRequest* request, ::mavsdk::rpc::action::SetHomeResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetHome_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::SetHomeResponse>* ActionService::Stub::PrepareAsyncSetHomeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetHomeRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::action::SetHomeResponse, ::mavsdk::rpc::action::SetHomeRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_SetHome_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::SetHomeResponse>* ActionService::Stub::AsyncSetHomeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetHomeRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncSetHomeRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
 ActionService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       ActionService_method_names[0],
@@ -841,6 +866,16 @@ ActionService::Service::Service() {
              ::mavsdk::rpc::action::SetGpsGlobalOriginResponse* resp) {
                return service->SetGpsGlobalOrigin(ctx, req, resp);
              }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      ActionService_method_names[23],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::SetHomeRequest, ::mavsdk::rpc::action::SetHomeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](ActionService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::action::SetHomeRequest* req,
+             ::mavsdk::rpc::action::SetHomeResponse* resp) {
+               return service->SetHome(ctx, req, resp);
+             }, this)));
 }
 
 ActionService::Service::~Service() {
@@ -1001,6 +1036,13 @@ ActionService::Service::~Service() {
 }
 
 ::grpc::Status ActionService::Service::SetGpsGlobalOrigin(::grpc::ServerContext* context, const ::mavsdk::rpc::action::SetGpsGlobalOriginRequest* request, ::mavsdk::rpc::action::SetGpsGlobalOriginResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status ActionService::Service::SetHome(::grpc::ServerContext* context, const ::mavsdk::rpc::action::SetHomeRequest* request, ::mavsdk::rpc::action::SetHomeResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/cpp/src/mavsdk_server/src/generated/action/action.grpc.pb.h
+++ b/cpp/src/mavsdk_server/src/generated/action/action.grpc.pb.h
@@ -309,6 +309,17 @@ class ActionService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::SetGpsGlobalOriginResponse>> PrepareAsyncSetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetGpsGlobalOriginRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::SetGpsGlobalOriginResponse>>(PrepareAsyncSetGpsGlobalOriginRaw(context, request, cq));
     }
+    //
+    // Set home.
+    //
+    // Sets the home position.
+    virtual ::grpc::Status SetHome(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetHomeRequest& request, ::mavsdk::rpc::action::SetHomeResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::SetHomeResponse>> AsyncSetHome(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetHomeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::SetHomeResponse>>(AsyncSetHomeRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::SetHomeResponse>> PrepareAsyncSetHome(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetHomeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::SetHomeResponse>>(PrepareAsyncSetHomeRaw(context, request, cq));
+    }
     class async_interface {
      public:
       virtual ~async_interface() {}
@@ -468,6 +479,12 @@ class ActionService final {
       // Sets the GPS coordinates of the vehicle local origin (0,0,0) position.
       virtual void SetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetGpsGlobalOriginRequest* request, ::mavsdk::rpc::action::SetGpsGlobalOriginResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void SetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetGpsGlobalOriginRequest* request, ::mavsdk::rpc::action::SetGpsGlobalOriginResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      //
+      // Set home.
+      //
+      // Sets the home position.
+      virtual void SetHome(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetHomeRequest* request, ::mavsdk::rpc::action::SetHomeResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void SetHome(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetHomeRequest* request, ::mavsdk::rpc::action::SetHomeResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
     };
     typedef class async_interface experimental_async_interface;
     virtual class async_interface* async() { return nullptr; }
@@ -519,6 +536,8 @@ class ActionService final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::SetCurrentSpeedResponse>* PrepareAsyncSetCurrentSpeedRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetCurrentSpeedRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::SetGpsGlobalOriginResponse>* AsyncSetGpsGlobalOriginRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetGpsGlobalOriginRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::SetGpsGlobalOriginResponse>* PrepareAsyncSetGpsGlobalOriginRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetGpsGlobalOriginRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::SetHomeResponse>* AsyncSetHomeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetHomeRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::SetHomeResponse>* PrepareAsyncSetHomeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetHomeRequest& request, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
@@ -684,6 +703,13 @@ class ActionService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::SetGpsGlobalOriginResponse>> PrepareAsyncSetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetGpsGlobalOriginRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::SetGpsGlobalOriginResponse>>(PrepareAsyncSetGpsGlobalOriginRaw(context, request, cq));
     }
+    ::grpc::Status SetHome(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetHomeRequest& request, ::mavsdk::rpc::action::SetHomeResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::SetHomeResponse>> AsyncSetHome(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetHomeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::SetHomeResponse>>(AsyncSetHomeRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::SetHomeResponse>> PrepareAsyncSetHome(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetHomeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::SetHomeResponse>>(PrepareAsyncSetHomeRaw(context, request, cq));
+    }
     class async final :
       public StubInterface::async_interface {
      public:
@@ -733,6 +759,8 @@ class ActionService final {
       void SetCurrentSpeed(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetCurrentSpeedRequest* request, ::mavsdk::rpc::action::SetCurrentSpeedResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void SetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetGpsGlobalOriginRequest* request, ::mavsdk::rpc::action::SetGpsGlobalOriginResponse* response, std::function<void(::grpc::Status)>) override;
       void SetGpsGlobalOrigin(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetGpsGlobalOriginRequest* request, ::mavsdk::rpc::action::SetGpsGlobalOriginResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SetHome(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetHomeRequest* request, ::mavsdk::rpc::action::SetHomeResponse* response, std::function<void(::grpc::Status)>) override;
+      void SetHome(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetHomeRequest* request, ::mavsdk::rpc::action::SetHomeResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
      private:
       friend class Stub;
       explicit async(Stub* stub): stub_(stub) { }
@@ -790,6 +818,8 @@ class ActionService final {
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::SetCurrentSpeedResponse>* PrepareAsyncSetCurrentSpeedRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetCurrentSpeedRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::SetGpsGlobalOriginResponse>* AsyncSetGpsGlobalOriginRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetGpsGlobalOriginRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::SetGpsGlobalOriginResponse>* PrepareAsyncSetGpsGlobalOriginRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetGpsGlobalOriginRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::SetHomeResponse>* AsyncSetHomeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetHomeRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::SetHomeResponse>* PrepareAsyncSetHomeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::SetHomeRequest& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_Arm_;
     const ::grpc::internal::RpcMethod rpcmethod_ArmForce_;
     const ::grpc::internal::RpcMethod rpcmethod_Disarm_;
@@ -813,6 +843,7 @@ class ActionService final {
     const ::grpc::internal::RpcMethod rpcmethod_SetReturnToLaunchAltitude_;
     const ::grpc::internal::RpcMethod rpcmethod_SetCurrentSpeed_;
     const ::grpc::internal::RpcMethod rpcmethod_SetGpsGlobalOrigin_;
+    const ::grpc::internal::RpcMethod rpcmethod_SetHome_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
 
@@ -953,6 +984,11 @@ class ActionService final {
     //
     // Sets the GPS coordinates of the vehicle local origin (0,0,0) position.
     virtual ::grpc::Status SetGpsGlobalOrigin(::grpc::ServerContext* context, const ::mavsdk::rpc::action::SetGpsGlobalOriginRequest* request, ::mavsdk::rpc::action::SetGpsGlobalOriginResponse* response);
+    //
+    // Set home.
+    //
+    // Sets the home position.
+    virtual ::grpc::Status SetHome(::grpc::ServerContext* context, const ::mavsdk::rpc::action::SetHomeRequest* request, ::mavsdk::rpc::action::SetHomeResponse* response);
   };
   template <class BaseClass>
   class WithAsyncMethod_Arm : public BaseClass {
@@ -1414,7 +1450,27 @@ class ActionService final {
       ::grpc::Service::RequestAsyncUnary(22, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_Arm<WithAsyncMethod_ArmForce<WithAsyncMethod_Disarm<WithAsyncMethod_Takeoff<WithAsyncMethod_Land<WithAsyncMethod_Reboot<WithAsyncMethod_Shutdown<WithAsyncMethod_Terminate<WithAsyncMethod_Kill<WithAsyncMethod_ReturnToLaunch<WithAsyncMethod_GotoLocation<WithAsyncMethod_DoOrbit<WithAsyncMethod_Hold<WithAsyncMethod_SetActuator<WithAsyncMethod_SetRelay<WithAsyncMethod_TransitionToFixedwing<WithAsyncMethod_TransitionToMulticopter<WithAsyncMethod_GetTakeoffAltitude<WithAsyncMethod_SetTakeoffAltitude<WithAsyncMethod_GetReturnToLaunchAltitude<WithAsyncMethod_SetReturnToLaunchAltitude<WithAsyncMethod_SetCurrentSpeed<WithAsyncMethod_SetGpsGlobalOrigin<Service > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
+  template <class BaseClass>
+  class WithAsyncMethod_SetHome : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SetHome() {
+      ::grpc::Service::MarkMethodAsync(23);
+    }
+    ~WithAsyncMethod_SetHome() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetHome(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::SetHomeRequest* /*request*/, ::mavsdk::rpc::action::SetHomeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetHome(::grpc::ServerContext* context, ::mavsdk::rpc::action::SetHomeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::SetHomeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(23, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  typedef WithAsyncMethod_Arm<WithAsyncMethod_ArmForce<WithAsyncMethod_Disarm<WithAsyncMethod_Takeoff<WithAsyncMethod_Land<WithAsyncMethod_Reboot<WithAsyncMethod_Shutdown<WithAsyncMethod_Terminate<WithAsyncMethod_Kill<WithAsyncMethod_ReturnToLaunch<WithAsyncMethod_GotoLocation<WithAsyncMethod_DoOrbit<WithAsyncMethod_Hold<WithAsyncMethod_SetActuator<WithAsyncMethod_SetRelay<WithAsyncMethod_TransitionToFixedwing<WithAsyncMethod_TransitionToMulticopter<WithAsyncMethod_GetTakeoffAltitude<WithAsyncMethod_SetTakeoffAltitude<WithAsyncMethod_GetReturnToLaunchAltitude<WithAsyncMethod_SetReturnToLaunchAltitude<WithAsyncMethod_SetCurrentSpeed<WithAsyncMethod_SetGpsGlobalOrigin<WithAsyncMethod_SetHome<Service > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_Arm : public BaseClass {
    private:
@@ -2036,7 +2092,34 @@ class ActionService final {
     virtual ::grpc::ServerUnaryReactor* SetGpsGlobalOrigin(
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::action::SetGpsGlobalOriginRequest* /*request*/, ::mavsdk::rpc::action::SetGpsGlobalOriginResponse* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_Arm<WithCallbackMethod_ArmForce<WithCallbackMethod_Disarm<WithCallbackMethod_Takeoff<WithCallbackMethod_Land<WithCallbackMethod_Reboot<WithCallbackMethod_Shutdown<WithCallbackMethod_Terminate<WithCallbackMethod_Kill<WithCallbackMethod_ReturnToLaunch<WithCallbackMethod_GotoLocation<WithCallbackMethod_DoOrbit<WithCallbackMethod_Hold<WithCallbackMethod_SetActuator<WithCallbackMethod_SetRelay<WithCallbackMethod_TransitionToFixedwing<WithCallbackMethod_TransitionToMulticopter<WithCallbackMethod_GetTakeoffAltitude<WithCallbackMethod_SetTakeoffAltitude<WithCallbackMethod_GetReturnToLaunchAltitude<WithCallbackMethod_SetReturnToLaunchAltitude<WithCallbackMethod_SetCurrentSpeed<WithCallbackMethod_SetGpsGlobalOrigin<Service > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
+  template <class BaseClass>
+  class WithCallbackMethod_SetHome : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SetHome() {
+      ::grpc::Service::MarkMethodCallback(23,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetHomeRequest, ::mavsdk::rpc::action::SetHomeResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action::SetHomeRequest* request, ::mavsdk::rpc::action::SetHomeResponse* response) { return this->SetHome(context, request, response); }));}
+    void SetMessageAllocatorFor_SetHome(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::action::SetHomeRequest, ::mavsdk::rpc::action::SetHomeResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(23);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetHomeRequest, ::mavsdk::rpc::action::SetHomeResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_SetHome() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetHome(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::SetHomeRequest* /*request*/, ::mavsdk::rpc::action::SetHomeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* SetHome(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::action::SetHomeRequest* /*request*/, ::mavsdk::rpc::action::SetHomeResponse* /*response*/)  { return nullptr; }
+  };
+  typedef WithCallbackMethod_Arm<WithCallbackMethod_ArmForce<WithCallbackMethod_Disarm<WithCallbackMethod_Takeoff<WithCallbackMethod_Land<WithCallbackMethod_Reboot<WithCallbackMethod_Shutdown<WithCallbackMethod_Terminate<WithCallbackMethod_Kill<WithCallbackMethod_ReturnToLaunch<WithCallbackMethod_GotoLocation<WithCallbackMethod_DoOrbit<WithCallbackMethod_Hold<WithCallbackMethod_SetActuator<WithCallbackMethod_SetRelay<WithCallbackMethod_TransitionToFixedwing<WithCallbackMethod_TransitionToMulticopter<WithCallbackMethod_GetTakeoffAltitude<WithCallbackMethod_SetTakeoffAltitude<WithCallbackMethod_GetReturnToLaunchAltitude<WithCallbackMethod_SetReturnToLaunchAltitude<WithCallbackMethod_SetCurrentSpeed<WithCallbackMethod_SetGpsGlobalOrigin<WithCallbackMethod_SetHome<Service > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_Arm : public BaseClass {
@@ -2425,6 +2508,23 @@ class ActionService final {
     }
     // disable synchronous version of this method
     ::grpc::Status SetGpsGlobalOrigin(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::SetGpsGlobalOriginRequest* /*request*/, ::mavsdk::rpc::action::SetGpsGlobalOriginResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_SetHome : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SetHome() {
+      ::grpc::Service::MarkMethodGeneric(23);
+    }
+    ~WithGenericMethod_SetHome() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetHome(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::SetHomeRequest* /*request*/, ::mavsdk::rpc::action::SetHomeResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -2887,6 +2987,26 @@ class ActionService final {
     }
     void RequestSetGpsGlobalOrigin(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(22, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_SetHome : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SetHome() {
+      ::grpc::Service::MarkMethodRaw(23);
+    }
+    ~WithRawMethod_SetHome() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetHome(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::SetHomeRequest* /*request*/, ::mavsdk::rpc::action::SetHomeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetHome(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(23, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -3393,6 +3513,28 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     virtual ::grpc::ServerUnaryReactor* SetGpsGlobalOrigin(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_SetHome : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SetHome() {
+      ::grpc::Service::MarkMethodRawCallback(23,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetHome(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_SetHome() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetHome(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::SetHomeRequest* /*request*/, ::mavsdk::rpc::action::SetHomeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* SetHome(
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
@@ -4016,9 +4158,36 @@ class ActionService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedSetGpsGlobalOrigin(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::action::SetGpsGlobalOriginRequest,::mavsdk::rpc::action::SetGpsGlobalOriginResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_Arm<WithStreamedUnaryMethod_ArmForce<WithStreamedUnaryMethod_Disarm<WithStreamedUnaryMethod_Takeoff<WithStreamedUnaryMethod_Land<WithStreamedUnaryMethod_Reboot<WithStreamedUnaryMethod_Shutdown<WithStreamedUnaryMethod_Terminate<WithStreamedUnaryMethod_Kill<WithStreamedUnaryMethod_ReturnToLaunch<WithStreamedUnaryMethod_GotoLocation<WithStreamedUnaryMethod_DoOrbit<WithStreamedUnaryMethod_Hold<WithStreamedUnaryMethod_SetActuator<WithStreamedUnaryMethod_SetRelay<WithStreamedUnaryMethod_TransitionToFixedwing<WithStreamedUnaryMethod_TransitionToMulticopter<WithStreamedUnaryMethod_GetTakeoffAltitude<WithStreamedUnaryMethod_SetTakeoffAltitude<WithStreamedUnaryMethod_GetReturnToLaunchAltitude<WithStreamedUnaryMethod_SetReturnToLaunchAltitude<WithStreamedUnaryMethod_SetCurrentSpeed<WithStreamedUnaryMethod_SetGpsGlobalOrigin<Service > > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_SetHome : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_SetHome() {
+      ::grpc::Service::MarkMethodStreamed(23,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::action::SetHomeRequest, ::mavsdk::rpc::action::SetHomeResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::action::SetHomeRequest, ::mavsdk::rpc::action::SetHomeResponse>* streamer) {
+                       return this->StreamedSetHome(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_SetHome() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SetHome(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::SetHomeRequest* /*request*/, ::mavsdk::rpc::action::SetHomeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedSetHome(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::action::SetHomeRequest,::mavsdk::rpc::action::SetHomeResponse>* server_unary_streamer) = 0;
+  };
+  typedef WithStreamedUnaryMethod_Arm<WithStreamedUnaryMethod_ArmForce<WithStreamedUnaryMethod_Disarm<WithStreamedUnaryMethod_Takeoff<WithStreamedUnaryMethod_Land<WithStreamedUnaryMethod_Reboot<WithStreamedUnaryMethod_Shutdown<WithStreamedUnaryMethod_Terminate<WithStreamedUnaryMethod_Kill<WithStreamedUnaryMethod_ReturnToLaunch<WithStreamedUnaryMethod_GotoLocation<WithStreamedUnaryMethod_DoOrbit<WithStreamedUnaryMethod_Hold<WithStreamedUnaryMethod_SetActuator<WithStreamedUnaryMethod_SetRelay<WithStreamedUnaryMethod_TransitionToFixedwing<WithStreamedUnaryMethod_TransitionToMulticopter<WithStreamedUnaryMethod_GetTakeoffAltitude<WithStreamedUnaryMethod_SetTakeoffAltitude<WithStreamedUnaryMethod_GetReturnToLaunchAltitude<WithStreamedUnaryMethod_SetReturnToLaunchAltitude<WithStreamedUnaryMethod_SetCurrentSpeed<WithStreamedUnaryMethod_SetGpsGlobalOrigin<WithStreamedUnaryMethod_SetHome<Service > > > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
   typedef Service SplitStreamedService;
-  typedef WithStreamedUnaryMethod_Arm<WithStreamedUnaryMethod_ArmForce<WithStreamedUnaryMethod_Disarm<WithStreamedUnaryMethod_Takeoff<WithStreamedUnaryMethod_Land<WithStreamedUnaryMethod_Reboot<WithStreamedUnaryMethod_Shutdown<WithStreamedUnaryMethod_Terminate<WithStreamedUnaryMethod_Kill<WithStreamedUnaryMethod_ReturnToLaunch<WithStreamedUnaryMethod_GotoLocation<WithStreamedUnaryMethod_DoOrbit<WithStreamedUnaryMethod_Hold<WithStreamedUnaryMethod_SetActuator<WithStreamedUnaryMethod_SetRelay<WithStreamedUnaryMethod_TransitionToFixedwing<WithStreamedUnaryMethod_TransitionToMulticopter<WithStreamedUnaryMethod_GetTakeoffAltitude<WithStreamedUnaryMethod_SetTakeoffAltitude<WithStreamedUnaryMethod_GetReturnToLaunchAltitude<WithStreamedUnaryMethod_SetReturnToLaunchAltitude<WithStreamedUnaryMethod_SetCurrentSpeed<WithStreamedUnaryMethod_SetGpsGlobalOrigin<Service > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_Arm<WithStreamedUnaryMethod_ArmForce<WithStreamedUnaryMethod_Disarm<WithStreamedUnaryMethod_Takeoff<WithStreamedUnaryMethod_Land<WithStreamedUnaryMethod_Reboot<WithStreamedUnaryMethod_Shutdown<WithStreamedUnaryMethod_Terminate<WithStreamedUnaryMethod_Kill<WithStreamedUnaryMethod_ReturnToLaunch<WithStreamedUnaryMethod_GotoLocation<WithStreamedUnaryMethod_DoOrbit<WithStreamedUnaryMethod_Hold<WithStreamedUnaryMethod_SetActuator<WithStreamedUnaryMethod_SetRelay<WithStreamedUnaryMethod_TransitionToFixedwing<WithStreamedUnaryMethod_TransitionToMulticopter<WithStreamedUnaryMethod_GetTakeoffAltitude<WithStreamedUnaryMethod_SetTakeoffAltitude<WithStreamedUnaryMethod_GetReturnToLaunchAltitude<WithStreamedUnaryMethod_SetReturnToLaunchAltitude<WithStreamedUnaryMethod_SetCurrentSpeed<WithStreamedUnaryMethod_SetGpsGlobalOrigin<WithStreamedUnaryMethod_SetHome<Service > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace action

--- a/cpp/src/mavsdk_server/src/generated/action/action.pb.cc
+++ b/cpp/src/mavsdk_server/src/generated/action/action.pb.cc
@@ -194,6 +194,34 @@ struct SetRelayRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetRelayRequestDefaultTypeInternal _SetRelayRequest_default_instance_;
 
+inline constexpr SetHomeRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : latitude_deg_{0},
+        use_current_location_{false},
+        absolute_altitude_m_{0},
+        longitude_deg_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR SetHomeRequest::SetHomeRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct SetHomeRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SetHomeRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SetHomeRequestDefaultTypeInternal() {}
+  union {
+    SetHomeRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetHomeRequestDefaultTypeInternal _SetHomeRequest_default_instance_;
+
 inline constexpr SetGpsGlobalOriginRequest::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : latitude_deg_{0},
@@ -737,6 +765,31 @@ struct SetRelayResponseDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetRelayResponseDefaultTypeInternal _SetRelayResponse_default_instance_;
+
+inline constexpr SetHomeResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        action_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR SetHomeResponse::SetHomeResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct SetHomeResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SetHomeResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SetHomeResponseDefaultTypeInternal() {}
+  union {
+    SetHomeResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetHomeResponseDefaultTypeInternal _SetHomeResponse_default_instance_;
 
 inline constexpr SetGpsGlobalOriginResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -1562,6 +1615,28 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::SetGpsGlobalOriginResponse, _impl_.action_result_),
         0,
         ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::SetHomeRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::SetHomeRequest, _impl_.use_current_location_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::SetHomeRequest, _impl_.latitude_deg_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::SetHomeRequest, _impl_.longitude_deg_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::SetHomeRequest, _impl_.absolute_altitude_m_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::SetHomeResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::SetHomeResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::SetHomeResponse, _impl_.action_result_),
+        0,
+        ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::ActionResult, _internal_metadata_),
         ~0u,  // no _extensions_
         ~0u,  // no _oneof_case_
@@ -1621,7 +1696,9 @@ static const ::_pbi::MigrationSchema
         {407, 416, -1, sizeof(::mavsdk::rpc::action::SetCurrentSpeedResponse)},
         {417, -1, -1, sizeof(::mavsdk::rpc::action::SetGpsGlobalOriginRequest)},
         {428, 437, -1, sizeof(::mavsdk::rpc::action::SetGpsGlobalOriginResponse)},
-        {438, -1, -1, sizeof(::mavsdk::rpc::action::ActionResult)},
+        {438, -1, -1, sizeof(::mavsdk::rpc::action::SetHomeRequest)},
+        {450, 459, -1, sizeof(::mavsdk::rpc::action::SetHomeResponse)},
+        {460, -1, -1, sizeof(::mavsdk::rpc::action::ActionResult)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::action::_ArmRequest_default_instance_._instance,
@@ -1670,6 +1747,8 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::action::_SetCurrentSpeedResponse_default_instance_._instance,
     &::mavsdk::rpc::action::_SetGpsGlobalOriginRequest_default_instance_._instance,
     &::mavsdk::rpc::action::_SetGpsGlobalOriginResponse_default_instance_._instance,
+    &::mavsdk::rpc::action::_SetHomeRequest_default_instance_._instance,
+    &::mavsdk::rpc::action::_SetHomeResponse_default_instance_._instance,
     &::mavsdk::rpc::action::_ActionResult_default_instance_._instance,
 };
 const char descriptor_table_protodef_action_2faction_2eproto[] ABSL_ATTRIBUTE_SECTION_VARIABLE(
@@ -1749,86 +1828,93 @@ const char descriptor_table_protodef_action_2faction_2eproto[] ABSL_ATTRIBUTE_SE
     "\002 \001(\001\022\033\n\023absolute_altitude_m\030\003 \001(\002\"T\n\032Se"
     "tGpsGlobalOriginResponse\0226\n\raction_resul"
     "t\030\001 \001(\0132\037.mavsdk.rpc.action.ActionResult"
-    "\"\215\004\n\014ActionResult\0226\n\006result\030\001 \001(\0162&.mavs"
-    "dk.rpc.action.ActionResult.Result\022\022\n\nres"
-    "ult_str\030\002 \001(\t\"\260\003\n\006Result\022\022\n\016RESULT_UNKNO"
-    "WN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\024\n\020RESULT_NO_SY"
-    "STEM\020\002\022\033\n\027RESULT_CONNECTION_ERROR\020\003\022\017\n\013R"
-    "ESULT_BUSY\020\004\022\031\n\025RESULT_COMMAND_DENIED\020\005\022"
-    ".\n*RESULT_COMMAND_DENIED_LANDED_STATE_UN"
-    "KNOWN\020\006\022$\n RESULT_COMMAND_DENIED_NOT_LAN"
-    "DED\020\007\022\022\n\016RESULT_TIMEOUT\020\010\022*\n&RESULT_VTOL"
-    "_TRANSITION_SUPPORT_UNKNOWN\020\t\022%\n!RESULT_"
-    "NO_VTOL_TRANSITION_SUPPORT\020\n\022\032\n\026RESULT_P"
-    "ARAMETER_ERROR\020\013\022\026\n\022RESULT_UNSUPPORTED\020\014"
-    "\022\021\n\rRESULT_FAILED\020\r\022\033\n\027RESULT_INVALID_AR"
-    "GUMENT\020\016*\363\001\n\020OrbitYawBehavior\0222\n.ORBIT_Y"
-    "AW_BEHAVIOR_HOLD_FRONT_TO_CIRCLE_CENTER\020"
-    "\000\022+\n\'ORBIT_YAW_BEHAVIOR_HOLD_INITIAL_HEA"
-    "DING\020\001\022#\n\037ORBIT_YAW_BEHAVIOR_UNCONTROLLE"
-    "D\020\002\0223\n/ORBIT_YAW_BEHAVIOR_HOLD_FRONT_TAN"
-    "GENT_TO_CIRCLE\020\003\022$\n ORBIT_YAW_BEHAVIOR_R"
-    "C_CONTROLLED\020\004*;\n\014RelayCommand\022\024\n\020RELAY_"
-    "COMMAND_ON\020\000\022\025\n\021RELAY_COMMAND_OFF\020\0012\365\021\n\r"
-    "ActionService\022F\n\003Arm\022\035.mavsdk.rpc.action"
-    ".ArmRequest\032\036.mavsdk.rpc.action.ArmRespo"
-    "nse\"\000\022U\n\010ArmForce\022\".mavsdk.rpc.action.Ar"
-    "mForceRequest\032#.mavsdk.rpc.action.ArmFor"
-    "ceResponse\"\000\022O\n\006Disarm\022 .mavsdk.rpc.acti"
-    "on.DisarmRequest\032!.mavsdk.rpc.action.Dis"
-    "armResponse\"\000\022R\n\007Takeoff\022!.mavsdk.rpc.ac"
-    "tion.TakeoffRequest\032\".mavsdk.rpc.action."
-    "TakeoffResponse\"\000\022I\n\004Land\022\036.mavsdk.rpc.a"
-    "ction.LandRequest\032\037.mavsdk.rpc.action.La"
-    "ndResponse\"\000\022O\n\006Reboot\022 .mavsdk.rpc.acti"
-    "on.RebootRequest\032!.mavsdk.rpc.action.Reb"
-    "ootResponse\"\000\022U\n\010Shutdown\022\".mavsdk.rpc.a"
-    "ction.ShutdownRequest\032#.mavsdk.rpc.actio"
-    "n.ShutdownResponse\"\000\022X\n\tTerminate\022#.mavs"
-    "dk.rpc.action.TerminateRequest\032$.mavsdk."
-    "rpc.action.TerminateResponse\"\000\022I\n\004Kill\022\036"
-    ".mavsdk.rpc.action.KillRequest\032\037.mavsdk."
-    "rpc.action.KillResponse\"\000\022g\n\016ReturnToLau"
-    "nch\022(.mavsdk.rpc.action.ReturnToLaunchRe"
-    "quest\032).mavsdk.rpc.action.ReturnToLaunch"
-    "Response\"\000\022a\n\014GotoLocation\022&.mavsdk.rpc."
-    "action.GotoLocationRequest\032\'.mavsdk.rpc."
-    "action.GotoLocationResponse\"\000\022R\n\007DoOrbit"
-    "\022!.mavsdk.rpc.action.DoOrbitRequest\032\".ma"
-    "vsdk.rpc.action.DoOrbitResponse\"\000\022I\n\004Hol"
-    "d\022\036.mavsdk.rpc.action.HoldRequest\032\037.mavs"
-    "dk.rpc.action.HoldResponse\"\000\022^\n\013SetActua"
-    "tor\022%.mavsdk.rpc.action.SetActuatorReque"
-    "st\032&.mavsdk.rpc.action.SetActuatorRespon"
-    "se\"\000\022U\n\010SetRelay\022\".mavsdk.rpc.action.Set"
-    "RelayRequest\032#.mavsdk.rpc.action.SetRela"
-    "yResponse\"\000\022|\n\025TransitionToFixedwing\022/.m"
-    "avsdk.rpc.action.TransitionToFixedwingRe"
-    "quest\0320.mavsdk.rpc.action.TransitionToFi"
-    "xedwingResponse\"\000\022\202\001\n\027TransitionToMultic"
-    "opter\0221.mavsdk.rpc.action.TransitionToMu"
-    "lticopterRequest\0322.mavsdk.rpc.action.Tra"
-    "nsitionToMulticopterResponse\"\000\022s\n\022GetTak"
-    "eoffAltitude\022,.mavsdk.rpc.action.GetTake"
-    "offAltitudeRequest\032-.mavsdk.rpc.action.G"
-    "etTakeoffAltitudeResponse\"\000\022s\n\022SetTakeof"
-    "fAltitude\022,.mavsdk.rpc.action.SetTakeoff"
-    "AltitudeRequest\032-.mavsdk.rpc.action.SetT"
-    "akeoffAltitudeResponse\"\000\022\210\001\n\031GetReturnTo"
-    "LaunchAltitude\0223.mavsdk.rpc.action.GetRe"
-    "turnToLaunchAltitudeRequest\0324.mavsdk.rpc"
-    ".action.GetReturnToLaunchAltitudeRespons"
-    "e\"\000\022\210\001\n\031SetReturnToLaunchAltitude\0223.mavs"
-    "dk.rpc.action.SetReturnToLaunchAltitudeR"
-    "equest\0324.mavsdk.rpc.action.SetReturnToLa"
-    "unchAltitudeResponse\"\000\022j\n\017SetCurrentSpee"
-    "d\022).mavsdk.rpc.action.SetCurrentSpeedReq"
-    "uest\032*.mavsdk.rpc.action.SetCurrentSpeed"
-    "Response\"\000\022w\n\022SetGpsGlobalOrigin\022,.mavsd"
-    "k.rpc.action.SetGpsGlobalOriginRequest\032-"
-    ".mavsdk.rpc.action.SetGpsGlobalOriginRes"
-    "ponse\"\004\200\265\030\001B\037\n\020io.mavsdk.actionB\013ActionP"
-    "rotob\006proto3"
+    "\"x\n\016SetHomeRequest\022\034\n\024use_current_locati"
+    "on\030\001 \001(\010\022\024\n\014latitude_deg\030\002 \001(\001\022\025\n\rlongit"
+    "ude_deg\030\003 \001(\001\022\033\n\023absolute_altitude_m\030\004 \001"
+    "(\002\"I\n\017SetHomeResponse\0226\n\raction_result\030\001"
+    " \001(\0132\037.mavsdk.rpc.action.ActionResult\"\215\004"
+    "\n\014ActionResult\0226\n\006result\030\001 \001(\0162&.mavsdk."
+    "rpc.action.ActionResult.Result\022\022\n\nresult"
+    "_str\030\002 \001(\t\"\260\003\n\006Result\022\022\n\016RESULT_UNKNOWN\020"
+    "\000\022\022\n\016RESULT_SUCCESS\020\001\022\024\n\020RESULT_NO_SYSTE"
+    "M\020\002\022\033\n\027RESULT_CONNECTION_ERROR\020\003\022\017\n\013RESU"
+    "LT_BUSY\020\004\022\031\n\025RESULT_COMMAND_DENIED\020\005\022.\n*"
+    "RESULT_COMMAND_DENIED_LANDED_STATE_UNKNO"
+    "WN\020\006\022$\n RESULT_COMMAND_DENIED_NOT_LANDED"
+    "\020\007\022\022\n\016RESULT_TIMEOUT\020\010\022*\n&RESULT_VTOL_TR"
+    "ANSITION_SUPPORT_UNKNOWN\020\t\022%\n!RESULT_NO_"
+    "VTOL_TRANSITION_SUPPORT\020\n\022\032\n\026RESULT_PARA"
+    "METER_ERROR\020\013\022\026\n\022RESULT_UNSUPPORTED\020\014\022\021\n"
+    "\rRESULT_FAILED\020\r\022\033\n\027RESULT_INVALID_ARGUM"
+    "ENT\020\016*\363\001\n\020OrbitYawBehavior\0222\n.ORBIT_YAW_"
+    "BEHAVIOR_HOLD_FRONT_TO_CIRCLE_CENTER\020\000\022+"
+    "\n\'ORBIT_YAW_BEHAVIOR_HOLD_INITIAL_HEADIN"
+    "G\020\001\022#\n\037ORBIT_YAW_BEHAVIOR_UNCONTROLLED\020\002"
+    "\0223\n/ORBIT_YAW_BEHAVIOR_HOLD_FRONT_TANGEN"
+    "T_TO_CIRCLE\020\003\022$\n ORBIT_YAW_BEHAVIOR_RC_C"
+    "ONTROLLED\020\004*;\n\014RelayCommand\022\024\n\020RELAY_COM"
+    "MAND_ON\020\000\022\025\n\021RELAY_COMMAND_OFF\020\0012\315\022\n\rAct"
+    "ionService\022F\n\003Arm\022\035.mavsdk.rpc.action.Ar"
+    "mRequest\032\036.mavsdk.rpc.action.ArmResponse"
+    "\"\000\022U\n\010ArmForce\022\".mavsdk.rpc.action.ArmFo"
+    "rceRequest\032#.mavsdk.rpc.action.ArmForceR"
+    "esponse\"\000\022O\n\006Disarm\022 .mavsdk.rpc.action."
+    "DisarmRequest\032!.mavsdk.rpc.action.Disarm"
+    "Response\"\000\022R\n\007Takeoff\022!.mavsdk.rpc.actio"
+    "n.TakeoffRequest\032\".mavsdk.rpc.action.Tak"
+    "eoffResponse\"\000\022I\n\004Land\022\036.mavsdk.rpc.acti"
+    "on.LandRequest\032\037.mavsdk.rpc.action.LandR"
+    "esponse\"\000\022O\n\006Reboot\022 .mavsdk.rpc.action."
+    "RebootRequest\032!.mavsdk.rpc.action.Reboot"
+    "Response\"\000\022U\n\010Shutdown\022\".mavsdk.rpc.acti"
+    "on.ShutdownRequest\032#.mavsdk.rpc.action.S"
+    "hutdownResponse\"\000\022X\n\tTerminate\022#.mavsdk."
+    "rpc.action.TerminateRequest\032$.mavsdk.rpc"
+    ".action.TerminateResponse\"\000\022I\n\004Kill\022\036.ma"
+    "vsdk.rpc.action.KillRequest\032\037.mavsdk.rpc"
+    ".action.KillResponse\"\000\022g\n\016ReturnToLaunch"
+    "\022(.mavsdk.rpc.action.ReturnToLaunchReque"
+    "st\032).mavsdk.rpc.action.ReturnToLaunchRes"
+    "ponse\"\000\022a\n\014GotoLocation\022&.mavsdk.rpc.act"
+    "ion.GotoLocationRequest\032\'.mavsdk.rpc.act"
+    "ion.GotoLocationResponse\"\000\022R\n\007DoOrbit\022!."
+    "mavsdk.rpc.action.DoOrbitRequest\032\".mavsd"
+    "k.rpc.action.DoOrbitResponse\"\000\022I\n\004Hold\022\036"
+    ".mavsdk.rpc.action.HoldRequest\032\037.mavsdk."
+    "rpc.action.HoldResponse\"\000\022^\n\013SetActuator"
+    "\022%.mavsdk.rpc.action.SetActuatorRequest\032"
+    "&.mavsdk.rpc.action.SetActuatorResponse\""
+    "\000\022U\n\010SetRelay\022\".mavsdk.rpc.action.SetRel"
+    "ayRequest\032#.mavsdk.rpc.action.SetRelayRe"
+    "sponse\"\000\022|\n\025TransitionToFixedwing\022/.mavs"
+    "dk.rpc.action.TransitionToFixedwingReque"
+    "st\0320.mavsdk.rpc.action.TransitionToFixed"
+    "wingResponse\"\000\022\202\001\n\027TransitionToMulticopt"
+    "er\0221.mavsdk.rpc.action.TransitionToMulti"
+    "copterRequest\0322.mavsdk.rpc.action.Transi"
+    "tionToMulticopterResponse\"\000\022s\n\022GetTakeof"
+    "fAltitude\022,.mavsdk.rpc.action.GetTakeoff"
+    "AltitudeRequest\032-.mavsdk.rpc.action.GetT"
+    "akeoffAltitudeResponse\"\000\022s\n\022SetTakeoffAl"
+    "titude\022,.mavsdk.rpc.action.SetTakeoffAlt"
+    "itudeRequest\032-.mavsdk.rpc.action.SetTake"
+    "offAltitudeResponse\"\000\022\210\001\n\031GetReturnToLau"
+    "nchAltitude\0223.mavsdk.rpc.action.GetRetur"
+    "nToLaunchAltitudeRequest\0324.mavsdk.rpc.ac"
+    "tion.GetReturnToLaunchAltitudeResponse\"\000"
+    "\022\210\001\n\031SetReturnToLaunchAltitude\0223.mavsdk."
+    "rpc.action.SetReturnToLaunchAltitudeRequ"
+    "est\0324.mavsdk.rpc.action.SetReturnToLaunc"
+    "hAltitudeResponse\"\000\022j\n\017SetCurrentSpeed\022)"
+    ".mavsdk.rpc.action.SetCurrentSpeedReques"
+    "t\032*.mavsdk.rpc.action.SetCurrentSpeedRes"
+    "ponse\"\000\022w\n\022SetGpsGlobalOrigin\022,.mavsdk.r"
+    "pc.action.SetGpsGlobalOriginRequest\032-.ma"
+    "vsdk.rpc.action.SetGpsGlobalOriginRespon"
+    "se\"\004\200\265\030\001\022V\n\007SetHome\022!.mavsdk.rpc.action."
+    "SetHomeRequest\032\".mavsdk.rpc.action.SetHo"
+    "meResponse\"\004\200\265\030\001B\037\n\020io.mavsdk.actionB\013Ac"
+    "tionProtob\006proto3"
 };
 static const ::_pbi::DescriptorTable* const descriptor_table_action_2faction_2eproto_deps[1] =
     {
@@ -1838,13 +1924,13 @@ static ::absl::once_flag descriptor_table_action_2faction_2eproto_once;
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_action_2faction_2eproto = {
     false,
     false,
-    6172,
+    6457,
     descriptor_table_protodef_action_2faction_2eproto,
     "action/action.proto",
     &descriptor_table_action_2faction_2eproto_once,
     descriptor_table_action_2faction_2eproto_deps,
     1,
-    47,
+    49,
     schemas,
     file_default_instances,
     TableStruct_action_2faction_2eproto::offsets,
@@ -11228,6 +11314,535 @@ void SetGpsGlobalOriginResponse::InternalSwap(SetGpsGlobalOriginResponse* PROTOB
 }
 
 ::google::protobuf::Metadata SetGpsGlobalOriginResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SetHomeRequest::_Internal {
+ public:
+};
+
+SetHomeRequest::SetHomeRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.action.SetHomeRequest)
+}
+SetHomeRequest::SetHomeRequest(
+    ::google::protobuf::Arena* arena, const SetHomeRequest& from)
+    : SetHomeRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE SetHomeRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void SetHomeRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  ::memset(reinterpret_cast<char *>(&_impl_) +
+               offsetof(Impl_, latitude_deg_),
+           0,
+           offsetof(Impl_, longitude_deg_) -
+               offsetof(Impl_, latitude_deg_) +
+               sizeof(Impl_::longitude_deg_));
+}
+SetHomeRequest::~SetHomeRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.action.SetHomeRequest)
+  SharedDtor(*this);
+}
+inline void SetHomeRequest::SharedDtor(MessageLite& self) {
+  SetHomeRequest& this_ = static_cast<SetHomeRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* SetHomeRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SetHomeRequest(arena);
+}
+constexpr auto SetHomeRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SetHomeRequest),
+                                            alignof(SetHomeRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SetHomeRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SetHomeRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SetHomeRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<SetHomeRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SetHomeRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<SetHomeRequest>(), &SetHomeRequest::ByteSizeLong,
+            &SetHomeRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SetHomeRequest, _impl_._cached_size_),
+        false,
+    },
+    &SetHomeRequest::kDescriptorMethods,
+    &descriptor_table_action_2faction_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SetHomeRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<2, 4, 0, 0, 2> SetHomeRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    4, 24,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967280,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    4,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::action::SetHomeRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // float absolute_altitude_m = 4;
+    {::_pbi::TcParser::FastF32S1,
+     {37, 63, 0, PROTOBUF_FIELD_OFFSET(SetHomeRequest, _impl_.absolute_altitude_m_)}},
+    // bool use_current_location = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(SetHomeRequest, _impl_.use_current_location_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(SetHomeRequest, _impl_.use_current_location_)}},
+    // double latitude_deg = 2;
+    {::_pbi::TcParser::FastF64S1,
+     {17, 63, 0, PROTOBUF_FIELD_OFFSET(SetHomeRequest, _impl_.latitude_deg_)}},
+    // double longitude_deg = 3;
+    {::_pbi::TcParser::FastF64S1,
+     {25, 63, 0, PROTOBUF_FIELD_OFFSET(SetHomeRequest, _impl_.longitude_deg_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // bool use_current_location = 1;
+    {PROTOBUF_FIELD_OFFSET(SetHomeRequest, _impl_.use_current_location_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kBool)},
+    // double latitude_deg = 2;
+    {PROTOBUF_FIELD_OFFSET(SetHomeRequest, _impl_.latitude_deg_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kDouble)},
+    // double longitude_deg = 3;
+    {PROTOBUF_FIELD_OFFSET(SetHomeRequest, _impl_.longitude_deg_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kDouble)},
+    // float absolute_altitude_m = 4;
+    {PROTOBUF_FIELD_OFFSET(SetHomeRequest, _impl_.absolute_altitude_m_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void SetHomeRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action.SetHomeRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  ::memset(&_impl_.latitude_deg_, 0, static_cast<::size_t>(
+      reinterpret_cast<char*>(&_impl_.longitude_deg_) -
+      reinterpret_cast<char*>(&_impl_.latitude_deg_)) + sizeof(_impl_.longitude_deg_));
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* SetHomeRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const SetHomeRequest& this_ = static_cast<const SetHomeRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* SetHomeRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const SetHomeRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action.SetHomeRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // bool use_current_location = 1;
+          if (this_._internal_use_current_location() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteBoolToArray(
+                1, this_._internal_use_current_location(), target);
+          }
+
+          // double latitude_deg = 2;
+          if (::absl::bit_cast<::uint64_t>(this_._internal_latitude_deg()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteDoubleToArray(
+                2, this_._internal_latitude_deg(), target);
+          }
+
+          // double longitude_deg = 3;
+          if (::absl::bit_cast<::uint64_t>(this_._internal_longitude_deg()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteDoubleToArray(
+                3, this_._internal_longitude_deg(), target);
+          }
+
+          // float absolute_altitude_m = 4;
+          if (::absl::bit_cast<::uint32_t>(this_._internal_absolute_altitude_m()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                4, this_._internal_absolute_altitude_m(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action.SetHomeRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t SetHomeRequest::ByteSizeLong(const MessageLite& base) {
+          const SetHomeRequest& this_ = static_cast<const SetHomeRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t SetHomeRequest::ByteSizeLong() const {
+          const SetHomeRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action.SetHomeRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+          ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+           {
+            // double latitude_deg = 2;
+            if (::absl::bit_cast<::uint64_t>(this_._internal_latitude_deg()) != 0) {
+              total_size += 9;
+            }
+            // bool use_current_location = 1;
+            if (this_._internal_use_current_location() != 0) {
+              total_size += 2;
+            }
+            // float absolute_altitude_m = 4;
+            if (::absl::bit_cast<::uint32_t>(this_._internal_absolute_altitude_m()) != 0) {
+              total_size += 5;
+            }
+            // double longitude_deg = 3;
+            if (::absl::bit_cast<::uint64_t>(this_._internal_longitude_deg()) != 0) {
+              total_size += 9;
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void SetHomeRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<SetHomeRequest*>(&to_msg);
+  auto& from = static_cast<const SetHomeRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action.SetHomeRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (::absl::bit_cast<::uint64_t>(from._internal_latitude_deg()) != 0) {
+    _this->_impl_.latitude_deg_ = from._impl_.latitude_deg_;
+  }
+  if (from._internal_use_current_location() != 0) {
+    _this->_impl_.use_current_location_ = from._impl_.use_current_location_;
+  }
+  if (::absl::bit_cast<::uint32_t>(from._internal_absolute_altitude_m()) != 0) {
+    _this->_impl_.absolute_altitude_m_ = from._impl_.absolute_altitude_m_;
+  }
+  if (::absl::bit_cast<::uint64_t>(from._internal_longitude_deg()) != 0) {
+    _this->_impl_.longitude_deg_ = from._impl_.longitude_deg_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SetHomeRequest::CopyFrom(const SetHomeRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action.SetHomeRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void SetHomeRequest::InternalSwap(SetHomeRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::google::protobuf::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(SetHomeRequest, _impl_.longitude_deg_)
+      + sizeof(SetHomeRequest::_impl_.longitude_deg_)
+      - PROTOBUF_FIELD_OFFSET(SetHomeRequest, _impl_.latitude_deg_)>(
+          reinterpret_cast<char*>(&_impl_.latitude_deg_),
+          reinterpret_cast<char*>(&other->_impl_.latitude_deg_));
+}
+
+::google::protobuf::Metadata SetHomeRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SetHomeResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<SetHomeResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(SetHomeResponse, _impl_._has_bits_);
+};
+
+SetHomeResponse::SetHomeResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.action.SetHomeResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE SetHomeResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::action::SetHomeResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+SetHomeResponse::SetHomeResponse(
+    ::google::protobuf::Arena* arena,
+    const SetHomeResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SetHomeResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.action_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::action::ActionResult>(
+                              arena, *from._impl_.action_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.action.SetHomeResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE SetHomeResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void SetHomeResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.action_result_ = {};
+}
+SetHomeResponse::~SetHomeResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.action.SetHomeResponse)
+  SharedDtor(*this);
+}
+inline void SetHomeResponse::SharedDtor(MessageLite& self) {
+  SetHomeResponse& this_ = static_cast<SetHomeResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.action_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* SetHomeResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SetHomeResponse(arena);
+}
+constexpr auto SetHomeResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SetHomeResponse),
+                                            alignof(SetHomeResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SetHomeResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SetHomeResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SetHomeResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<SetHomeResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SetHomeResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<SetHomeResponse>(), &SetHomeResponse::ByteSizeLong,
+            &SetHomeResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SetHomeResponse, _impl_._cached_size_),
+        false,
+    },
+    &SetHomeResponse::kDescriptorMethods,
+    &descriptor_table_action_2faction_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SetHomeResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> SetHomeResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(SetHomeResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::action::SetHomeResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.action.ActionResult action_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(SetHomeResponse, _impl_.action_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.action.ActionResult action_result = 1;
+    {PROTOBUF_FIELD_OFFSET(SetHomeResponse, _impl_.action_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::action::ActionResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void SetHomeResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action.SetHomeResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.action_result_ != nullptr);
+    _impl_.action_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* SetHomeResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const SetHomeResponse& this_ = static_cast<const SetHomeResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* SetHomeResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const SetHomeResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action.SetHomeResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.action.ActionResult action_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.action_result_, this_._impl_.action_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action.SetHomeResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t SetHomeResponse::ByteSizeLong(const MessageLite& base) {
+          const SetHomeResponse& this_ = static_cast<const SetHomeResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t SetHomeResponse::ByteSizeLong() const {
+          const SetHomeResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action.SetHomeResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.action.ActionResult action_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.action_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void SetHomeResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<SetHomeResponse*>(&to_msg);
+  auto& from = static_cast<const SetHomeResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action.SetHomeResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.action_result_ != nullptr);
+    if (_this->_impl_.action_result_ == nullptr) {
+      _this->_impl_.action_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::action::ActionResult>(arena, *from._impl_.action_result_);
+    } else {
+      _this->_impl_.action_result_->MergeFrom(*from._impl_.action_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SetHomeResponse::CopyFrom(const SetHomeResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action.SetHomeResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void SetHomeResponse::InternalSwap(SetHomeResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.action_result_, other->_impl_.action_result_);
+}
+
+::google::protobuf::Metadata SetHomeResponse::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================

--- a/cpp/src/mavsdk_server/src/generated/action/action.pb.h
+++ b/cpp/src/mavsdk_server/src/generated/action/action.pb.h
@@ -150,6 +150,12 @@ extern SetGpsGlobalOriginRequestDefaultTypeInternal _SetGpsGlobalOriginRequest_d
 class SetGpsGlobalOriginResponse;
 struct SetGpsGlobalOriginResponseDefaultTypeInternal;
 extern SetGpsGlobalOriginResponseDefaultTypeInternal _SetGpsGlobalOriginResponse_default_instance_;
+class SetHomeRequest;
+struct SetHomeRequestDefaultTypeInternal;
+extern SetHomeRequestDefaultTypeInternal _SetHomeRequest_default_instance_;
+class SetHomeResponse;
+struct SetHomeResponseDefaultTypeInternal;
+extern SetHomeResponseDefaultTypeInternal _SetHomeResponse_default_instance_;
 class SetRelayRequest;
 struct SetRelayRequestDefaultTypeInternal;
 extern SetRelayRequestDefaultTypeInternal _SetRelayRequest_default_instance_;
@@ -1637,6 +1643,233 @@ class SetRelayRequest final
                           const SetRelayRequest& from_msg);
     ::int32_t index_;
     int setting_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_action_2faction_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SetHomeRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.action.SetHomeRequest) */ {
+ public:
+  inline SetHomeRequest() : SetHomeRequest(nullptr) {}
+  ~SetHomeRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SetHomeRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SetHomeRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SetHomeRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SetHomeRequest(const SetHomeRequest& from) : SetHomeRequest(nullptr, from) {}
+  inline SetHomeRequest(SetHomeRequest&& from) noexcept
+      : SetHomeRequest(nullptr, std::move(from)) {}
+  inline SetHomeRequest& operator=(const SetHomeRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetHomeRequest& operator=(SetHomeRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SetHomeRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SetHomeRequest* internal_default_instance() {
+    return reinterpret_cast<const SetHomeRequest*>(
+        &_SetHomeRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 46;
+  friend void swap(SetHomeRequest& a, SetHomeRequest& b) { a.Swap(&b); }
+  inline void Swap(SetHomeRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetHomeRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SetHomeRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<SetHomeRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const SetHomeRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const SetHomeRequest& from) { SetHomeRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(SetHomeRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.action.SetHomeRequest"; }
+
+ protected:
+  explicit SetHomeRequest(::google::protobuf::Arena* arena);
+  SetHomeRequest(::google::protobuf::Arena* arena, const SetHomeRequest& from);
+  SetHomeRequest(::google::protobuf::Arena* arena, SetHomeRequest&& from) noexcept
+      : SetHomeRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kLatitudeDegFieldNumber = 2,
+    kUseCurrentLocationFieldNumber = 1,
+    kAbsoluteAltitudeMFieldNumber = 4,
+    kLongitudeDegFieldNumber = 3,
+  };
+  // double latitude_deg = 2;
+  void clear_latitude_deg() ;
+  double latitude_deg() const;
+  void set_latitude_deg(double value);
+
+  private:
+  double _internal_latitude_deg() const;
+  void _internal_set_latitude_deg(double value);
+
+  public:
+  // bool use_current_location = 1;
+  void clear_use_current_location() ;
+  bool use_current_location() const;
+  void set_use_current_location(bool value);
+
+  private:
+  bool _internal_use_current_location() const;
+  void _internal_set_use_current_location(bool value);
+
+  public:
+  // float absolute_altitude_m = 4;
+  void clear_absolute_altitude_m() ;
+  float absolute_altitude_m() const;
+  void set_absolute_altitude_m(float value);
+
+  private:
+  float _internal_absolute_altitude_m() const;
+  void _internal_set_absolute_altitude_m(float value);
+
+  public:
+  // double longitude_deg = 3;
+  void clear_longitude_deg() ;
+  double longitude_deg() const;
+  void set_longitude_deg(double value);
+
+  private:
+  double _internal_longitude_deg() const;
+  void _internal_set_longitude_deg(double value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action.SetHomeRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      2, 4, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SetHomeRequest& from_msg);
+    double latitude_deg_;
+    bool use_current_location_;
+    float absolute_altitude_m_;
+    double longitude_deg_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
@@ -4252,7 +4485,7 @@ class ActionResult final
     return reinterpret_cast<const ActionResult*>(
         &_ActionResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 46;
+  static constexpr int kIndexInFileMessages = 48;
   friend void swap(ActionResult& a, ActionResult& b) { a.Swap(&b); }
   inline void Swap(ActionResult* other) {
     if (other == this) return;
@@ -5999,6 +6232,203 @@ class SetRelayResponse final
     inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
                           ::google::protobuf::Arena* arena, const Impl_& from,
                           const SetRelayResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::action::ActionResult* action_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_action_2faction_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SetHomeResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.action.SetHomeResponse) */ {
+ public:
+  inline SetHomeResponse() : SetHomeResponse(nullptr) {}
+  ~SetHomeResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SetHomeResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SetHomeResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SetHomeResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SetHomeResponse(const SetHomeResponse& from) : SetHomeResponse(nullptr, from) {}
+  inline SetHomeResponse(SetHomeResponse&& from) noexcept
+      : SetHomeResponse(nullptr, std::move(from)) {}
+  inline SetHomeResponse& operator=(const SetHomeResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetHomeResponse& operator=(SetHomeResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SetHomeResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SetHomeResponse* internal_default_instance() {
+    return reinterpret_cast<const SetHomeResponse*>(
+        &_SetHomeResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 47;
+  friend void swap(SetHomeResponse& a, SetHomeResponse& b) { a.Swap(&b); }
+  inline void Swap(SetHomeResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetHomeResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SetHomeResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<SetHomeResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const SetHomeResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const SetHomeResponse& from) { SetHomeResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(SetHomeResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.action.SetHomeResponse"; }
+
+ protected:
+  explicit SetHomeResponse(::google::protobuf::Arena* arena);
+  SetHomeResponse(::google::protobuf::Arena* arena, const SetHomeResponse& from);
+  SetHomeResponse(::google::protobuf::Arena* arena, SetHomeResponse&& from) noexcept
+      : SetHomeResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kActionResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.action.ActionResult action_result = 1;
+  bool has_action_result() const;
+  void clear_action_result() ;
+  const ::mavsdk::rpc::action::ActionResult& action_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::action::ActionResult* release_action_result();
+  ::mavsdk::rpc::action::ActionResult* mutable_action_result();
+  void set_allocated_action_result(::mavsdk::rpc::action::ActionResult* value);
+  void unsafe_arena_set_allocated_action_result(::mavsdk::rpc::action::ActionResult* value);
+  ::mavsdk::rpc::action::ActionResult* unsafe_arena_release_action_result();
+
+  private:
+  const ::mavsdk::rpc::action::ActionResult& _internal_action_result() const;
+  ::mavsdk::rpc::action::ActionResult* _internal_mutable_action_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action.SetHomeResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SetHomeResponse& from_msg);
     ::google::protobuf::internal::HasBits<1> _has_bits_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     ::mavsdk::rpc::action::ActionResult* action_result_;
@@ -11873,6 +12303,198 @@ inline void SetGpsGlobalOriginResponse::set_allocated_action_result(::mavsdk::rp
 
   _impl_.action_result_ = reinterpret_cast<::mavsdk::rpc::action::ActionResult*>(value);
   // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.action.SetGpsGlobalOriginResponse.action_result)
+}
+
+// -------------------------------------------------------------------
+
+// SetHomeRequest
+
+// bool use_current_location = 1;
+inline void SetHomeRequest::clear_use_current_location() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.use_current_location_ = false;
+}
+inline bool SetHomeRequest::use_current_location() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action.SetHomeRequest.use_current_location)
+  return _internal_use_current_location();
+}
+inline void SetHomeRequest::set_use_current_location(bool value) {
+  _internal_set_use_current_location(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.action.SetHomeRequest.use_current_location)
+}
+inline bool SetHomeRequest::_internal_use_current_location() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.use_current_location_;
+}
+inline void SetHomeRequest::_internal_set_use_current_location(bool value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.use_current_location_ = value;
+}
+
+// double latitude_deg = 2;
+inline void SetHomeRequest::clear_latitude_deg() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.latitude_deg_ = 0;
+}
+inline double SetHomeRequest::latitude_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action.SetHomeRequest.latitude_deg)
+  return _internal_latitude_deg();
+}
+inline void SetHomeRequest::set_latitude_deg(double value) {
+  _internal_set_latitude_deg(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.action.SetHomeRequest.latitude_deg)
+}
+inline double SetHomeRequest::_internal_latitude_deg() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.latitude_deg_;
+}
+inline void SetHomeRequest::_internal_set_latitude_deg(double value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.latitude_deg_ = value;
+}
+
+// double longitude_deg = 3;
+inline void SetHomeRequest::clear_longitude_deg() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.longitude_deg_ = 0;
+}
+inline double SetHomeRequest::longitude_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action.SetHomeRequest.longitude_deg)
+  return _internal_longitude_deg();
+}
+inline void SetHomeRequest::set_longitude_deg(double value) {
+  _internal_set_longitude_deg(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.action.SetHomeRequest.longitude_deg)
+}
+inline double SetHomeRequest::_internal_longitude_deg() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.longitude_deg_;
+}
+inline void SetHomeRequest::_internal_set_longitude_deg(double value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.longitude_deg_ = value;
+}
+
+// float absolute_altitude_m = 4;
+inline void SetHomeRequest::clear_absolute_altitude_m() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.absolute_altitude_m_ = 0;
+}
+inline float SetHomeRequest::absolute_altitude_m() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action.SetHomeRequest.absolute_altitude_m)
+  return _internal_absolute_altitude_m();
+}
+inline void SetHomeRequest::set_absolute_altitude_m(float value) {
+  _internal_set_absolute_altitude_m(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.action.SetHomeRequest.absolute_altitude_m)
+}
+inline float SetHomeRequest::_internal_absolute_altitude_m() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.absolute_altitude_m_;
+}
+inline void SetHomeRequest::_internal_set_absolute_altitude_m(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.absolute_altitude_m_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// SetHomeResponse
+
+// .mavsdk.rpc.action.ActionResult action_result = 1;
+inline bool SetHomeResponse::has_action_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.action_result_ != nullptr);
+  return value;
+}
+inline void SetHomeResponse::clear_action_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.action_result_ != nullptr) _impl_.action_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::action::ActionResult& SetHomeResponse::_internal_action_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::action::ActionResult* p = _impl_.action_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::action::ActionResult&>(::mavsdk::rpc::action::_ActionResult_default_instance_);
+}
+inline const ::mavsdk::rpc::action::ActionResult& SetHomeResponse::action_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action.SetHomeResponse.action_result)
+  return _internal_action_result();
+}
+inline void SetHomeResponse::unsafe_arena_set_allocated_action_result(::mavsdk::rpc::action::ActionResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.action_result_);
+  }
+  _impl_.action_result_ = reinterpret_cast<::mavsdk::rpc::action::ActionResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.action.SetHomeResponse.action_result)
+}
+inline ::mavsdk::rpc::action::ActionResult* SetHomeResponse::release_action_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::action::ActionResult* released = _impl_.action_result_;
+  _impl_.action_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::action::ActionResult* SetHomeResponse::unsafe_arena_release_action_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.action.SetHomeResponse.action_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::action::ActionResult* temp = _impl_.action_result_;
+  _impl_.action_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::action::ActionResult* SetHomeResponse::_internal_mutable_action_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.action_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::action::ActionResult>(GetArena());
+    _impl_.action_result_ = reinterpret_cast<::mavsdk::rpc::action::ActionResult*>(p);
+  }
+  return _impl_.action_result_;
+}
+inline ::mavsdk::rpc::action::ActionResult* SetHomeResponse::mutable_action_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::action::ActionResult* _msg = _internal_mutable_action_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.action.SetHomeResponse.action_result)
+  return _msg;
+}
+inline void SetHomeResponse::set_allocated_action_result(::mavsdk::rpc::action::ActionResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.action_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.action_result_ = reinterpret_cast<::mavsdk::rpc::action::ActionResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.action.SetHomeResponse.action_result)
 }
 
 // -------------------------------------------------------------------

--- a/cpp/src/mavsdk_server/src/grpc_server.cpp
+++ b/cpp/src/mavsdk_server/src/grpc_server.cpp
@@ -22,6 +22,7 @@ int GrpcServer::run()
 
     builder.RegisterService(&_core);
 
+
 #ifdef ACTION_ENABLED
     builder.RegisterService(&_action_service);
 #endif
@@ -166,6 +167,7 @@ int GrpcServer::run()
     builder.RegisterService(&_winch_service);
 #endif
 
+
 #ifdef ENABLE_PROTO_REFLECTION
     grpc::reflection::InitProtoReflectionServerBuilderPlugin();
 #endif
@@ -196,6 +198,7 @@ void GrpcServer::stop()
 {
     if (_server != nullptr) {
         _core.stop();
+
 
 #ifdef ACTION_ENABLED
         _action_service.stop();

--- a/cpp/src/mavsdk_server/src/grpc_server.cpp
+++ b/cpp/src/mavsdk_server/src/grpc_server.cpp
@@ -22,7 +22,6 @@ int GrpcServer::run()
 
     builder.RegisterService(&_core);
 
-
 #ifdef ACTION_ENABLED
     builder.RegisterService(&_action_service);
 #endif
@@ -167,7 +166,6 @@ int GrpcServer::run()
     builder.RegisterService(&_winch_service);
 #endif
 
-
 #ifdef ENABLE_PROTO_REFLECTION
     grpc::reflection::InitProtoReflectionServerBuilderPlugin();
 #endif
@@ -198,7 +196,6 @@ void GrpcServer::stop()
 {
     if (_server != nullptr) {
         _core.stop();
-
 
 #ifdef ACTION_ENABLED
         _action_service.stop();

--- a/cpp/src/mavsdk_server/src/plugins/action/action_service_impl.hpp
+++ b/cpp/src/mavsdk_server/src/plugins/action/action_service_impl.hpp
@@ -903,6 +903,45 @@ public:
         return grpc::Status::OK;
     }
 
+    grpc::Status SetHome(
+        grpc::ServerContext* /* context */,
+        const rpc::action::SetHomeRequest* request,
+        rpc::action::SetHomeResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                auto result = mavsdk::Action::Result::NoSystem;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("SetHome sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+            
+        
+            
+        
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->set_home(request->use_current_location(), request->latitude_deg(), request->longitude_deg(), request->absolute_altitude_m());
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
 
     void stop() {
         _stopped.store(true);

--- a/py/aiomavsdk/aiomavsdk/plugins/action/action.py
+++ b/py/aiomavsdk/aiomavsdk/plugins/action/action.py
@@ -473,6 +473,33 @@ class ActionAsync:
             ),
         )
 
+    async def set_home(
+        self, use_current_location, latitude_deg, longitude_deg, absolute_altitude_m
+    ):
+        """
+               Set home.
+
+        Sets the home position.
+
+               Parameters
+               ----------
+               use_current_location : bool
+               latitude_deg : float
+               longitude_deg : float
+               absolute_altitude_m : float
+               Raises
+               ------
+               ActionError
+                   If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None,
+            lambda: self._plugin.set_home(
+                use_current_location, latitude_deg, longitude_deg, absolute_altitude_m
+            ),
+        )
+
     def destroy(self):
         self._subscription_handles.clear()
         self._plugin.destroy()

--- a/py/mavsdk/mavsdk/plugins/action/action.py
+++ b/py/mavsdk/mavsdk/plugins/action/action.py
@@ -893,6 +893,24 @@ class Action:
 
         return result
 
+    def set_home(
+        self, use_current_location, latitude_deg, longitude_deg, absolute_altitude_m
+    ):
+        """Get set_home (blocking)"""
+
+        result_code = self._lib.mavsdk_action_set_home(
+            self._handle,
+            use_current_location,
+            latitude_deg,
+            longitude_deg,
+            absolute_altitude_m,
+        )
+        result = ActionResult(result_code)
+        if result != ActionResult.SUCCESS:
+            raise Exception(f"set_home failed: {result}")
+
+        return result
+
     def destroy(self):
         """Destroy the plugin instance"""
         if self._handle:
@@ -1272,3 +1290,13 @@ _cmavsdk_lib.mavsdk_action_set_gps_global_origin.argtypes = [
 ]
 
 _cmavsdk_lib.mavsdk_action_set_gps_global_origin.restype = ctypes.c_int
+
+_cmavsdk_lib.mavsdk_action_set_home.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_bool,
+    ctypes.c_double,
+    ctypes.c_double,
+    ctypes.c_float,
+]
+
+_cmavsdk_lib.mavsdk_action_set_home.restype = ctypes.c_int


### PR DESCRIPTION
Adds `set_home()` action to MAVSDK, allowing to set the home position using `MAV_CMD_DO_SET_HOME`.

The function accepts either the current location (with `use_current_location=true`) or explicit latitude/longitude/altitude coordinates.

Also updates generated files for all languages (C++, C, Python) to match current MAVSDK-Proto, including:
- Based on https://github.com/mavlink/MAVSDK-Proto/pull/397.
- Updated geofence, mission_raw, mocap, telemetry, telemetry_server bindings to match current proto

Closes #2799