### PR TITLE
info: update to remove GetFlightInformation, keep SubscribeFlightInformation

### DIFF
--- a/c/src/cmavsdk/plugins/info/info.cpp
+++ b/c/src/cmavsdk/plugins/info/info.cpp
@@ -368,25 +368,6 @@ void mavsdk_info_destroy(mavsdk_info_t info) {
 // ===== Method Implementations =====
 
 
-// GetFlightInformation sync
-mavsdk_info_result_t
-mavsdk_info_get_flight_information(
-    mavsdk_info_t info,
-    mavsdk_info_flight_info_t* flight_info_out)
-{
-    auto wrapper = reinterpret_cast<mavsdk_info_wrapper*>(info);
-
-    auto result_pair = wrapper->cpp_plugin->get_flight_information(
-);
-
-    if (flight_info_out != nullptr) {
-        *flight_info_out = translate_flight_info_to_c(result_pair.second);
-    }
-
-    return translate_result(result_pair.first);
-}
-
-
 // GetIdentification sync
 mavsdk_info_result_t
 mavsdk_info_get_identification(

--- a/c/src/cmavsdk/plugins/info/info.h
+++ b/c/src/cmavsdk/plugins/info/info.h
@@ -332,21 +332,6 @@ CMAVSDK_EXPORT void mavsdk_info_destroy(mavsdk_info_t info);
 // ===== Methods =====
 
 /**
- * @brief Get the current get flight information (blocking).
- *
- * This function blocks until a value is available.
- *
- * @param telemetry The telemetry instance.
- * @param get_flight_information_out Pointer to store the result.
- */
-CMAVSDK_EXPORT
-mavsdk_info_result_t
-mavsdk_info_get_flight_information(
-    mavsdk_info_t info,
-    mavsdk_info_flight_info_t* flight_info_out);
-
-
-/**
  * @brief Get the current get identification (blocking).
  *
  * This function blocks until a value is available.

--- a/cpp/docs/en/cpp/api_reference/classmavsdk_1_1_info.md
+++ b/cpp/docs/en/cpp/api_reference/classmavsdk_1_1_info.md
@@ -37,7 +37,6 @@ Type | Name | Description
 &nbsp; | [Info](#classmavsdk_1_1_info_1ae67e006f16f1e1aa12efe94120ef83ec) (std::shared_ptr< [System](classmavsdk_1_1_system.md) > system) | Constructor. Creates the plugin for a specific [System](classmavsdk_1_1_system.md).
 &nbsp; | [~Info](#classmavsdk_1_1_info_1abbf48bc4b9aa5b9fdbdb54ec3e398f65) () override | Destructor (internal use only).
 &nbsp; | [Info](#classmavsdk_1_1_info_1a0f6e0851757046c540fe7ce920eb3fa2) (const [Info](classmavsdk_1_1_info.md) & other) | Copy constructor.
-std::pair< [Result](classmavsdk_1_1_info.md#classmavsdk_1_1_info_1ab1798ed39271915800b25aaa05d1d45a), [Info::FlightInfo](structmavsdk_1_1_info_1_1_flight_info.md) > | [get_flight_information](#classmavsdk_1_1_info_1a5ae8681909c3298b2df5c0722a30aa3c) () const | Get flight information of the system.
 std::pair< [Result](classmavsdk_1_1_info.md#classmavsdk_1_1_info_1ab1798ed39271915800b25aaa05d1d45a), [Info::Identification](structmavsdk_1_1_info_1_1_identification.md) > | [get_identification](#classmavsdk_1_1_info_1a76739913366e334a4638aa187d7c40d4) () const | Get the identification of the system.
 std::pair< [Result](classmavsdk_1_1_info.md#classmavsdk_1_1_info_1ab1798ed39271915800b25aaa05d1d45a), [Info::Product](structmavsdk_1_1_info_1_1_product.md) > | [get_product](#classmavsdk_1_1_info_1a508cf835acaed0fad69badda62206fed) () const | Get product information of the system.
 std::pair< [Result](classmavsdk_1_1_info.md#classmavsdk_1_1_info_1ab1798ed39271915800b25aaa05d1d45a), [Info::Version](structmavsdk_1_1_info_1_1_version.md) > | [get_version](#classmavsdk_1_1_info_1a2ad33d89a7dd64192641bba03816a9f9) () const | Get the version information of the system.
@@ -159,20 +158,6 @@ Value | Description
 
 ## Member Function Documentation
 
-
-### get_flight_information() {#classmavsdk_1_1_info_1a5ae8681909c3298b2df5c0722a30aa3c}
-```cpp
-std::pair< Result, Info::FlightInfo > mavsdk::Info::get_flight_information() const
-```
-
-
-Get flight information of the system.
-
-This function is blocking.
-
-**Returns**
-
-&emsp;std::pair< [Result](classmavsdk_1_1_info.md#classmavsdk_1_1_info_1ab1798ed39271915800b25aaa05d1d45a), [Info::FlightInfo](structmavsdk_1_1_info_1_1_flight_info.md) > - Result of request.
 
 ### get_identification() {#classmavsdk_1_1_info_1a76739913366e334a4638aa187d7c40d4}
 ```cpp

--- a/cpp/src/mavsdk/plugins/info/include/plugins/info/info.hpp
+++ b/cpp/src/mavsdk/plugins/info/include/plugins/info/info.hpp
@@ -249,20 +249,6 @@ public:
 
 
     /**
-     * @brief Get flight information of the system.
-     *
-     * This function is blocking.
-     *
-     * @return Result of request.
-     */
-    std::pair<Result, Info::FlightInfo> get_flight_information() const;
-
-
-
-
-
-
-    /**
      * @brief Get the identification of the system.
      *
      * This function is blocking.

--- a/cpp/src/mavsdk/plugins/info/info.cpp
+++ b/cpp/src/mavsdk/plugins/info/info.cpp
@@ -21,11 +21,6 @@ Info::Info(std::shared_ptr<System> system) : PluginBase(), _impl{std::make_uniqu
 
 Info::~Info() {}
 
-std::pair<Info::Result, Info::FlightInfo> Info::get_flight_information() const
-{
-    return _impl->get_flight_information();
-}
-
 std::pair<Info::Result, Info::Identification> Info::get_identification() const
 {
     return _impl->get_identification();

--- a/cpp/src/mavsdk_server/src/generated/info/info.grpc.pb.cc
+++ b/cpp/src/mavsdk_server/src/generated/info/info.grpc.pb.cc
@@ -24,7 +24,6 @@ namespace rpc {
 namespace info {
 
 static const char* InfoService_method_names[] = {
-  "/mavsdk.rpc.info.InfoService/GetFlightInformation",
   "/mavsdk.rpc.info.InfoService/GetIdentification",
   "/mavsdk.rpc.info.InfoService/GetProduct",
   "/mavsdk.rpc.info.InfoService/GetVersion",
@@ -39,36 +38,12 @@ std::unique_ptr< InfoService::Stub> InfoService::NewStub(const std::shared_ptr< 
 }
 
 InfoService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options)
-  : channel_(channel), rpcmethod_GetFlightInformation_(InfoService_method_names[0], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_GetIdentification_(InfoService_method_names[1], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_GetProduct_(InfoService_method_names[2], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_GetVersion_(InfoService_method_names[3], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_GetSpeedFactor_(InfoService_method_names[4], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SubscribeFlightInformation_(InfoService_method_names[5], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  : channel_(channel), rpcmethod_GetIdentification_(InfoService_method_names[0], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetProduct_(InfoService_method_names[1], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetVersion_(InfoService_method_names[2], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetSpeedFactor_(InfoService_method_names[3], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubscribeFlightInformation_(InfoService_method_names[4], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
   {}
-
-::grpc::Status InfoService::Stub::GetFlightInformation(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest& request, ::mavsdk::rpc::info::GetFlightInformationResponse* response) {
-  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::info::GetFlightInformationRequest, ::mavsdk::rpc::info::GetFlightInformationResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_GetFlightInformation_, context, request, response);
-}
-
-void InfoService::Stub::async::GetFlightInformation(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest* request, ::mavsdk::rpc::info::GetFlightInformationResponse* response, std::function<void(::grpc::Status)> f) {
-  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::info::GetFlightInformationRequest, ::mavsdk::rpc::info::GetFlightInformationResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_GetFlightInformation_, context, request, response, std::move(f));
-}
-
-void InfoService::Stub::async::GetFlightInformation(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest* request, ::mavsdk::rpc::info::GetFlightInformationResponse* response, ::grpc::ClientUnaryReactor* reactor) {
-  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_GetFlightInformation_, context, request, response, reactor);
-}
-
-::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::info::GetFlightInformationResponse>* InfoService::Stub::PrepareAsyncGetFlightInformationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::info::GetFlightInformationResponse, ::mavsdk::rpc::info::GetFlightInformationRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_GetFlightInformation_, context, request);
-}
-
-::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::info::GetFlightInformationResponse>* InfoService::Stub::AsyncGetFlightInformationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest& request, ::grpc::CompletionQueue* cq) {
-  auto* result =
-    this->PrepareAsyncGetFlightInformationRaw(context, request, cq);
-  result->StartCall();
-  return result;
-}
 
 ::grpc::Status InfoService::Stub::GetIdentification(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetIdentificationRequest& request, ::mavsdk::rpc::info::GetIdentificationResponse* response) {
   return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::info::GetIdentificationRequest, ::mavsdk::rpc::info::GetIdentificationResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_GetIdentification_, context, request, response);
@@ -182,16 +157,6 @@ InfoService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       InfoService_method_names[0],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler< InfoService::Service, ::mavsdk::rpc::info::GetFlightInformationRequest, ::mavsdk::rpc::info::GetFlightInformationResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
-          [](InfoService::Service* service,
-             ::grpc::ServerContext* ctx,
-             const ::mavsdk::rpc::info::GetFlightInformationRequest* req,
-             ::mavsdk::rpc::info::GetFlightInformationResponse* resp) {
-               return service->GetFlightInformation(ctx, req, resp);
-             }, this)));
-  AddMethod(new ::grpc::internal::RpcServiceMethod(
-      InfoService_method_names[1],
-      ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< InfoService::Service, ::mavsdk::rpc::info::GetIdentificationRequest, ::mavsdk::rpc::info::GetIdentificationResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](InfoService::Service* service,
              ::grpc::ServerContext* ctx,
@@ -200,7 +165,7 @@ InfoService::Service::Service() {
                return service->GetIdentification(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      InfoService_method_names[2],
+      InfoService_method_names[1],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< InfoService::Service, ::mavsdk::rpc::info::GetProductRequest, ::mavsdk::rpc::info::GetProductResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](InfoService::Service* service,
@@ -210,7 +175,7 @@ InfoService::Service::Service() {
                return service->GetProduct(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      InfoService_method_names[3],
+      InfoService_method_names[2],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< InfoService::Service, ::mavsdk::rpc::info::GetVersionRequest, ::mavsdk::rpc::info::GetVersionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](InfoService::Service* service,
@@ -220,7 +185,7 @@ InfoService::Service::Service() {
                return service->GetVersion(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      InfoService_method_names[4],
+      InfoService_method_names[3],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< InfoService::Service, ::mavsdk::rpc::info::GetSpeedFactorRequest, ::mavsdk::rpc::info::GetSpeedFactorResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](InfoService::Service* service,
@@ -230,7 +195,7 @@ InfoService::Service::Service() {
                return service->GetSpeedFactor(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      InfoService_method_names[5],
+      InfoService_method_names[4],
       ::grpc::internal::RpcMethod::SERVER_STREAMING,
       new ::grpc::internal::ServerStreamingHandler< InfoService::Service, ::mavsdk::rpc::info::SubscribeFlightInformationRequest, ::mavsdk::rpc::info::FlightInformationResponse>(
           [](InfoService::Service* service,
@@ -242,13 +207,6 @@ InfoService::Service::Service() {
 }
 
 InfoService::Service::~Service() {
-}
-
-::grpc::Status InfoService::Service::GetFlightInformation(::grpc::ServerContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest* request, ::mavsdk::rpc::info::GetFlightInformationResponse* response) {
-  (void) context;
-  (void) request;
-  (void) response;
-  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
 ::grpc::Status InfoService::Service::GetIdentification(::grpc::ServerContext* context, const ::mavsdk::rpc::info::GetIdentificationRequest* request, ::mavsdk::rpc::info::GetIdentificationResponse* response) {

--- a/cpp/src/mavsdk_server/src/generated/info/info.grpc.pb.h
+++ b/cpp/src/mavsdk_server/src/generated/info/info.grpc.pb.h
@@ -38,14 +38,6 @@ class InfoService final {
   class StubInterface {
    public:
     virtual ~StubInterface() {}
-    // Get flight information of the system.
-    virtual ::grpc::Status GetFlightInformation(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest& request, ::mavsdk::rpc::info::GetFlightInformationResponse* response) = 0;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::info::GetFlightInformationResponse>> AsyncGetFlightInformation(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::info::GetFlightInformationResponse>>(AsyncGetFlightInformationRaw(context, request, cq));
-    }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::info::GetFlightInformationResponse>> PrepareAsyncGetFlightInformation(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::info::GetFlightInformationResponse>>(PrepareAsyncGetFlightInformationRaw(context, request, cq));
-    }
     // Get the identification of the system.
     virtual ::grpc::Status GetIdentification(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetIdentificationRequest& request, ::mavsdk::rpc::info::GetIdentificationResponse* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::info::GetIdentificationResponse>> AsyncGetIdentification(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetIdentificationRequest& request, ::grpc::CompletionQueue* cq) {
@@ -91,9 +83,6 @@ class InfoService final {
     class async_interface {
      public:
       virtual ~async_interface() {}
-      // Get flight information of the system.
-      virtual void GetFlightInformation(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest* request, ::mavsdk::rpc::info::GetFlightInformationResponse* response, std::function<void(::grpc::Status)>) = 0;
-      virtual void GetFlightInformation(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest* request, ::mavsdk::rpc::info::GetFlightInformationResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       // Get the identification of the system.
       virtual void GetIdentification(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetIdentificationRequest* request, ::mavsdk::rpc::info::GetIdentificationResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void GetIdentification(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetIdentificationRequest* request, ::mavsdk::rpc::info::GetIdentificationResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
@@ -113,8 +102,6 @@ class InfoService final {
     virtual class async_interface* async() { return nullptr; }
     class async_interface* experimental_async() { return async(); }
    private:
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::info::GetFlightInformationResponse>* AsyncGetFlightInformationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::info::GetFlightInformationResponse>* PrepareAsyncGetFlightInformationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::info::GetIdentificationResponse>* AsyncGetIdentificationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetIdentificationRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::info::GetIdentificationResponse>* PrepareAsyncGetIdentificationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetIdentificationRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::info::GetProductResponse>* AsyncGetProductRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetProductRequest& request, ::grpc::CompletionQueue* cq) = 0;
@@ -130,13 +117,6 @@ class InfoService final {
   class Stub final : public StubInterface {
    public:
     Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
-    ::grpc::Status GetFlightInformation(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest& request, ::mavsdk::rpc::info::GetFlightInformationResponse* response) override;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::info::GetFlightInformationResponse>> AsyncGetFlightInformation(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::info::GetFlightInformationResponse>>(AsyncGetFlightInformationRaw(context, request, cq));
-    }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::info::GetFlightInformationResponse>> PrepareAsyncGetFlightInformation(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::info::GetFlightInformationResponse>>(PrepareAsyncGetFlightInformationRaw(context, request, cq));
-    }
     ::grpc::Status GetIdentification(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetIdentificationRequest& request, ::mavsdk::rpc::info::GetIdentificationResponse* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::info::GetIdentificationResponse>> AsyncGetIdentification(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetIdentificationRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::info::GetIdentificationResponse>>(AsyncGetIdentificationRaw(context, request, cq));
@@ -177,8 +157,6 @@ class InfoService final {
     class async final :
       public StubInterface::async_interface {
      public:
-      void GetFlightInformation(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest* request, ::mavsdk::rpc::info::GetFlightInformationResponse* response, std::function<void(::grpc::Status)>) override;
-      void GetFlightInformation(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest* request, ::mavsdk::rpc::info::GetFlightInformationResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void GetIdentification(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetIdentificationRequest* request, ::mavsdk::rpc::info::GetIdentificationResponse* response, std::function<void(::grpc::Status)>) override;
       void GetIdentification(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetIdentificationRequest* request, ::mavsdk::rpc::info::GetIdentificationResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void GetProduct(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetProductRequest* request, ::mavsdk::rpc::info::GetProductResponse* response, std::function<void(::grpc::Status)>) override;
@@ -199,8 +177,6 @@ class InfoService final {
    private:
     std::shared_ptr< ::grpc::ChannelInterface> channel_;
     class async async_stub_{this};
-    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::info::GetFlightInformationResponse>* AsyncGetFlightInformationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::info::GetFlightInformationResponse>* PrepareAsyncGetFlightInformationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::info::GetIdentificationResponse>* AsyncGetIdentificationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetIdentificationRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::info::GetIdentificationResponse>* PrepareAsyncGetIdentificationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetIdentificationRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::info::GetProductResponse>* AsyncGetProductRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::info::GetProductRequest& request, ::grpc::CompletionQueue* cq) override;
@@ -212,7 +188,6 @@ class InfoService final {
     ::grpc::ClientReader< ::mavsdk::rpc::info::FlightInformationResponse>* SubscribeFlightInformationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::info::SubscribeFlightInformationRequest& request) override;
     ::grpc::ClientAsyncReader< ::mavsdk::rpc::info::FlightInformationResponse>* AsyncSubscribeFlightInformationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::info::SubscribeFlightInformationRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
     ::grpc::ClientAsyncReader< ::mavsdk::rpc::info::FlightInformationResponse>* PrepareAsyncSubscribeFlightInformationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::info::SubscribeFlightInformationRequest& request, ::grpc::CompletionQueue* cq) override;
-    const ::grpc::internal::RpcMethod rpcmethod_GetFlightInformation_;
     const ::grpc::internal::RpcMethod rpcmethod_GetIdentification_;
     const ::grpc::internal::RpcMethod rpcmethod_GetProduct_;
     const ::grpc::internal::RpcMethod rpcmethod_GetVersion_;
@@ -225,8 +200,6 @@ class InfoService final {
    public:
     Service();
     virtual ~Service();
-    // Get flight information of the system.
-    virtual ::grpc::Status GetFlightInformation(::grpc::ServerContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest* request, ::mavsdk::rpc::info::GetFlightInformationResponse* response);
     // Get the identification of the system.
     virtual ::grpc::Status GetIdentification(::grpc::ServerContext* context, const ::mavsdk::rpc::info::GetIdentificationRequest* request, ::mavsdk::rpc::info::GetIdentificationResponse* response);
     // Get product information of the system.
@@ -239,32 +212,12 @@ class InfoService final {
     virtual ::grpc::Status SubscribeFlightInformation(::grpc::ServerContext* context, const ::mavsdk::rpc::info::SubscribeFlightInformationRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::info::FlightInformationResponse>* writer);
   };
   template <class BaseClass>
-  class WithAsyncMethod_GetFlightInformation : public BaseClass {
-   private:
-    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
-   public:
-    WithAsyncMethod_GetFlightInformation() {
-      ::grpc::Service::MarkMethodAsync(0);
-    }
-    ~WithAsyncMethod_GetFlightInformation() override {
-      BaseClassMustBeDerivedFromService(this);
-    }
-    // disable synchronous version of this method
-    ::grpc::Status GetFlightInformation(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::info::GetFlightInformationRequest* /*request*/, ::mavsdk::rpc::info::GetFlightInformationResponse* /*response*/) override {
-      abort();
-      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-    }
-    void RequestGetFlightInformation(::grpc::ServerContext* context, ::mavsdk::rpc::info::GetFlightInformationRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::info::GetFlightInformationResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(0, context, request, response, new_call_cq, notification_cq, tag);
-    }
-  };
-  template <class BaseClass>
   class WithAsyncMethod_GetIdentification : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_GetIdentification() {
-      ::grpc::Service::MarkMethodAsync(1);
+      ::grpc::Service::MarkMethodAsync(0);
     }
     ~WithAsyncMethod_GetIdentification() override {
       BaseClassMustBeDerivedFromService(this);
@@ -275,7 +228,7 @@ class InfoService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetIdentification(::grpc::ServerContext* context, ::mavsdk::rpc::info::GetIdentificationRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::info::GetIdentificationResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(0, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -284,7 +237,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_GetProduct() {
-      ::grpc::Service::MarkMethodAsync(2);
+      ::grpc::Service::MarkMethodAsync(1);
     }
     ~WithAsyncMethod_GetProduct() override {
       BaseClassMustBeDerivedFromService(this);
@@ -295,7 +248,7 @@ class InfoService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetProduct(::grpc::ServerContext* context, ::mavsdk::rpc::info::GetProductRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::info::GetProductResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -304,7 +257,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_GetVersion() {
-      ::grpc::Service::MarkMethodAsync(3);
+      ::grpc::Service::MarkMethodAsync(2);
     }
     ~WithAsyncMethod_GetVersion() override {
       BaseClassMustBeDerivedFromService(this);
@@ -315,7 +268,7 @@ class InfoService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetVersion(::grpc::ServerContext* context, ::mavsdk::rpc::info::GetVersionRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::info::GetVersionResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -324,7 +277,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_GetSpeedFactor() {
-      ::grpc::Service::MarkMethodAsync(4);
+      ::grpc::Service::MarkMethodAsync(3);
     }
     ~WithAsyncMethod_GetSpeedFactor() override {
       BaseClassMustBeDerivedFromService(this);
@@ -335,7 +288,7 @@ class InfoService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetSpeedFactor(::grpc::ServerContext* context, ::mavsdk::rpc::info::GetSpeedFactorRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::info::GetSpeedFactorResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -344,7 +297,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SubscribeFlightInformation() {
-      ::grpc::Service::MarkMethodAsync(5);
+      ::grpc::Service::MarkMethodAsync(4);
     }
     ~WithAsyncMethod_SubscribeFlightInformation() override {
       BaseClassMustBeDerivedFromService(this);
@@ -355,50 +308,23 @@ class InfoService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeFlightInformation(::grpc::ServerContext* context, ::mavsdk::rpc::info::SubscribeFlightInformationRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::info::FlightInformationResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(5, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(4, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_GetFlightInformation<WithAsyncMethod_GetIdentification<WithAsyncMethod_GetProduct<WithAsyncMethod_GetVersion<WithAsyncMethod_GetSpeedFactor<WithAsyncMethod_SubscribeFlightInformation<Service > > > > > > AsyncService;
-  template <class BaseClass>
-  class WithCallbackMethod_GetFlightInformation : public BaseClass {
-   private:
-    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
-   public:
-    WithCallbackMethod_GetFlightInformation() {
-      ::grpc::Service::MarkMethodCallback(0,
-          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::info::GetFlightInformationRequest, ::mavsdk::rpc::info::GetFlightInformationResponse>(
-            [this](
-                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::info::GetFlightInformationRequest* request, ::mavsdk::rpc::info::GetFlightInformationResponse* response) { return this->GetFlightInformation(context, request, response); }));}
-    void SetMessageAllocatorFor_GetFlightInformation(
-        ::grpc::MessageAllocator< ::mavsdk::rpc::info::GetFlightInformationRequest, ::mavsdk::rpc::info::GetFlightInformationResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(0);
-      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::info::GetFlightInformationRequest, ::mavsdk::rpc::info::GetFlightInformationResponse>*>(handler)
-              ->SetMessageAllocator(allocator);
-    }
-    ~WithCallbackMethod_GetFlightInformation() override {
-      BaseClassMustBeDerivedFromService(this);
-    }
-    // disable synchronous version of this method
-    ::grpc::Status GetFlightInformation(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::info::GetFlightInformationRequest* /*request*/, ::mavsdk::rpc::info::GetFlightInformationResponse* /*response*/) override {
-      abort();
-      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-    }
-    virtual ::grpc::ServerUnaryReactor* GetFlightInformation(
-      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::info::GetFlightInformationRequest* /*request*/, ::mavsdk::rpc::info::GetFlightInformationResponse* /*response*/)  { return nullptr; }
-  };
+  typedef WithAsyncMethod_GetIdentification<WithAsyncMethod_GetProduct<WithAsyncMethod_GetVersion<WithAsyncMethod_GetSpeedFactor<WithAsyncMethod_SubscribeFlightInformation<Service > > > > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_GetIdentification : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_GetIdentification() {
-      ::grpc::Service::MarkMethodCallback(1,
+      ::grpc::Service::MarkMethodCallback(0,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::info::GetIdentificationRequest, ::mavsdk::rpc::info::GetIdentificationResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::info::GetIdentificationRequest* request, ::mavsdk::rpc::info::GetIdentificationResponse* response) { return this->GetIdentification(context, request, response); }));}
     void SetMessageAllocatorFor_GetIdentification(
         ::grpc::MessageAllocator< ::mavsdk::rpc::info::GetIdentificationRequest, ::mavsdk::rpc::info::GetIdentificationResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(1);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(0);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::info::GetIdentificationRequest, ::mavsdk::rpc::info::GetIdentificationResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -419,13 +345,13 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_GetProduct() {
-      ::grpc::Service::MarkMethodCallback(2,
+      ::grpc::Service::MarkMethodCallback(1,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::info::GetProductRequest, ::mavsdk::rpc::info::GetProductResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::info::GetProductRequest* request, ::mavsdk::rpc::info::GetProductResponse* response) { return this->GetProduct(context, request, response); }));}
     void SetMessageAllocatorFor_GetProduct(
         ::grpc::MessageAllocator< ::mavsdk::rpc::info::GetProductRequest, ::mavsdk::rpc::info::GetProductResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(2);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(1);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::info::GetProductRequest, ::mavsdk::rpc::info::GetProductResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -446,13 +372,13 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_GetVersion() {
-      ::grpc::Service::MarkMethodCallback(3,
+      ::grpc::Service::MarkMethodCallback(2,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::info::GetVersionRequest, ::mavsdk::rpc::info::GetVersionResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::info::GetVersionRequest* request, ::mavsdk::rpc::info::GetVersionResponse* response) { return this->GetVersion(context, request, response); }));}
     void SetMessageAllocatorFor_GetVersion(
         ::grpc::MessageAllocator< ::mavsdk::rpc::info::GetVersionRequest, ::mavsdk::rpc::info::GetVersionResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(3);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(2);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::info::GetVersionRequest, ::mavsdk::rpc::info::GetVersionResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -473,13 +399,13 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_GetSpeedFactor() {
-      ::grpc::Service::MarkMethodCallback(4,
+      ::grpc::Service::MarkMethodCallback(3,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::info::GetSpeedFactorRequest, ::mavsdk::rpc::info::GetSpeedFactorResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::info::GetSpeedFactorRequest* request, ::mavsdk::rpc::info::GetSpeedFactorResponse* response) { return this->GetSpeedFactor(context, request, response); }));}
     void SetMessageAllocatorFor_GetSpeedFactor(
         ::grpc::MessageAllocator< ::mavsdk::rpc::info::GetSpeedFactorRequest, ::mavsdk::rpc::info::GetSpeedFactorResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(4);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(3);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::info::GetSpeedFactorRequest, ::mavsdk::rpc::info::GetSpeedFactorResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -500,7 +426,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SubscribeFlightInformation() {
-      ::grpc::Service::MarkMethodCallback(5,
+      ::grpc::Service::MarkMethodCallback(4,
           new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::info::SubscribeFlightInformationRequest, ::mavsdk::rpc::info::FlightInformationResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::info::SubscribeFlightInformationRequest* request) { return this->SubscribeFlightInformation(context, request); }));
@@ -516,32 +442,15 @@ class InfoService final {
     virtual ::grpc::ServerWriteReactor< ::mavsdk::rpc::info::FlightInformationResponse>* SubscribeFlightInformation(
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::info::SubscribeFlightInformationRequest* /*request*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_GetFlightInformation<WithCallbackMethod_GetIdentification<WithCallbackMethod_GetProduct<WithCallbackMethod_GetVersion<WithCallbackMethod_GetSpeedFactor<WithCallbackMethod_SubscribeFlightInformation<Service > > > > > > CallbackService;
+  typedef WithCallbackMethod_GetIdentification<WithCallbackMethod_GetProduct<WithCallbackMethod_GetVersion<WithCallbackMethod_GetSpeedFactor<WithCallbackMethod_SubscribeFlightInformation<Service > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
-  template <class BaseClass>
-  class WithGenericMethod_GetFlightInformation : public BaseClass {
-   private:
-    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
-   public:
-    WithGenericMethod_GetFlightInformation() {
-      ::grpc::Service::MarkMethodGeneric(0);
-    }
-    ~WithGenericMethod_GetFlightInformation() override {
-      BaseClassMustBeDerivedFromService(this);
-    }
-    // disable synchronous version of this method
-    ::grpc::Status GetFlightInformation(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::info::GetFlightInformationRequest* /*request*/, ::mavsdk::rpc::info::GetFlightInformationResponse* /*response*/) override {
-      abort();
-      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-    }
-  };
   template <class BaseClass>
   class WithGenericMethod_GetIdentification : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_GetIdentification() {
-      ::grpc::Service::MarkMethodGeneric(1);
+      ::grpc::Service::MarkMethodGeneric(0);
     }
     ~WithGenericMethod_GetIdentification() override {
       BaseClassMustBeDerivedFromService(this);
@@ -558,7 +467,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_GetProduct() {
-      ::grpc::Service::MarkMethodGeneric(2);
+      ::grpc::Service::MarkMethodGeneric(1);
     }
     ~WithGenericMethod_GetProduct() override {
       BaseClassMustBeDerivedFromService(this);
@@ -575,7 +484,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_GetVersion() {
-      ::grpc::Service::MarkMethodGeneric(3);
+      ::grpc::Service::MarkMethodGeneric(2);
     }
     ~WithGenericMethod_GetVersion() override {
       BaseClassMustBeDerivedFromService(this);
@@ -592,7 +501,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_GetSpeedFactor() {
-      ::grpc::Service::MarkMethodGeneric(4);
+      ::grpc::Service::MarkMethodGeneric(3);
     }
     ~WithGenericMethod_GetSpeedFactor() override {
       BaseClassMustBeDerivedFromService(this);
@@ -609,7 +518,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SubscribeFlightInformation() {
-      ::grpc::Service::MarkMethodGeneric(5);
+      ::grpc::Service::MarkMethodGeneric(4);
     }
     ~WithGenericMethod_SubscribeFlightInformation() override {
       BaseClassMustBeDerivedFromService(this);
@@ -621,32 +530,12 @@ class InfoService final {
     }
   };
   template <class BaseClass>
-  class WithRawMethod_GetFlightInformation : public BaseClass {
-   private:
-    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
-   public:
-    WithRawMethod_GetFlightInformation() {
-      ::grpc::Service::MarkMethodRaw(0);
-    }
-    ~WithRawMethod_GetFlightInformation() override {
-      BaseClassMustBeDerivedFromService(this);
-    }
-    // disable synchronous version of this method
-    ::grpc::Status GetFlightInformation(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::info::GetFlightInformationRequest* /*request*/, ::mavsdk::rpc::info::GetFlightInformationResponse* /*response*/) override {
-      abort();
-      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-    }
-    void RequestGetFlightInformation(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(0, context, request, response, new_call_cq, notification_cq, tag);
-    }
-  };
-  template <class BaseClass>
   class WithRawMethod_GetIdentification : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_GetIdentification() {
-      ::grpc::Service::MarkMethodRaw(1);
+      ::grpc::Service::MarkMethodRaw(0);
     }
     ~WithRawMethod_GetIdentification() override {
       BaseClassMustBeDerivedFromService(this);
@@ -657,7 +546,7 @@ class InfoService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetIdentification(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(0, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -666,7 +555,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_GetProduct() {
-      ::grpc::Service::MarkMethodRaw(2);
+      ::grpc::Service::MarkMethodRaw(1);
     }
     ~WithRawMethod_GetProduct() override {
       BaseClassMustBeDerivedFromService(this);
@@ -677,7 +566,7 @@ class InfoService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetProduct(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -686,7 +575,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_GetVersion() {
-      ::grpc::Service::MarkMethodRaw(3);
+      ::grpc::Service::MarkMethodRaw(2);
     }
     ~WithRawMethod_GetVersion() override {
       BaseClassMustBeDerivedFromService(this);
@@ -697,7 +586,7 @@ class InfoService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetVersion(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -706,7 +595,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_GetSpeedFactor() {
-      ::grpc::Service::MarkMethodRaw(4);
+      ::grpc::Service::MarkMethodRaw(3);
     }
     ~WithRawMethod_GetSpeedFactor() override {
       BaseClassMustBeDerivedFromService(this);
@@ -717,7 +606,7 @@ class InfoService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetSpeedFactor(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -726,7 +615,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SubscribeFlightInformation() {
-      ::grpc::Service::MarkMethodRaw(5);
+      ::grpc::Service::MarkMethodRaw(4);
     }
     ~WithRawMethod_SubscribeFlightInformation() override {
       BaseClassMustBeDerivedFromService(this);
@@ -737,30 +626,8 @@ class InfoService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeFlightInformation(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(5, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(4, context, request, writer, new_call_cq, notification_cq, tag);
     }
-  };
-  template <class BaseClass>
-  class WithRawCallbackMethod_GetFlightInformation : public BaseClass {
-   private:
-    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
-   public:
-    WithRawCallbackMethod_GetFlightInformation() {
-      ::grpc::Service::MarkMethodRawCallback(0,
-          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
-            [this](
-                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->GetFlightInformation(context, request, response); }));
-    }
-    ~WithRawCallbackMethod_GetFlightInformation() override {
-      BaseClassMustBeDerivedFromService(this);
-    }
-    // disable synchronous version of this method
-    ::grpc::Status GetFlightInformation(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::info::GetFlightInformationRequest* /*request*/, ::mavsdk::rpc::info::GetFlightInformationResponse* /*response*/) override {
-      abort();
-      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-    }
-    virtual ::grpc::ServerUnaryReactor* GetFlightInformation(
-      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
   class WithRawCallbackMethod_GetIdentification : public BaseClass {
@@ -768,7 +635,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_GetIdentification() {
-      ::grpc::Service::MarkMethodRawCallback(1,
+      ::grpc::Service::MarkMethodRawCallback(0,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->GetIdentification(context, request, response); }));
@@ -790,7 +657,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_GetProduct() {
-      ::grpc::Service::MarkMethodRawCallback(2,
+      ::grpc::Service::MarkMethodRawCallback(1,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->GetProduct(context, request, response); }));
@@ -812,7 +679,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_GetVersion() {
-      ::grpc::Service::MarkMethodRawCallback(3,
+      ::grpc::Service::MarkMethodRawCallback(2,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->GetVersion(context, request, response); }));
@@ -834,7 +701,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_GetSpeedFactor() {
-      ::grpc::Service::MarkMethodRawCallback(4,
+      ::grpc::Service::MarkMethodRawCallback(3,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->GetSpeedFactor(context, request, response); }));
@@ -856,7 +723,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SubscribeFlightInformation() {
-      ::grpc::Service::MarkMethodRawCallback(5,
+      ::grpc::Service::MarkMethodRawCallback(4,
           new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeFlightInformation(context, request); }));
@@ -873,39 +740,12 @@ class InfoService final {
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)  { return nullptr; }
   };
   template <class BaseClass>
-  class WithStreamedUnaryMethod_GetFlightInformation : public BaseClass {
-   private:
-    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
-   public:
-    WithStreamedUnaryMethod_GetFlightInformation() {
-      ::grpc::Service::MarkMethodStreamed(0,
-        new ::grpc::internal::StreamedUnaryHandler<
-          ::mavsdk::rpc::info::GetFlightInformationRequest, ::mavsdk::rpc::info::GetFlightInformationResponse>(
-            [this](::grpc::ServerContext* context,
-                   ::grpc::ServerUnaryStreamer<
-                     ::mavsdk::rpc::info::GetFlightInformationRequest, ::mavsdk::rpc::info::GetFlightInformationResponse>* streamer) {
-                       return this->StreamedGetFlightInformation(context,
-                         streamer);
-                  }));
-    }
-    ~WithStreamedUnaryMethod_GetFlightInformation() override {
-      BaseClassMustBeDerivedFromService(this);
-    }
-    // disable regular version of this method
-    ::grpc::Status GetFlightInformation(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::info::GetFlightInformationRequest* /*request*/, ::mavsdk::rpc::info::GetFlightInformationResponse* /*response*/) override {
-      abort();
-      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-    }
-    // replace default version of method with streamed unary
-    virtual ::grpc::Status StreamedGetFlightInformation(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::info::GetFlightInformationRequest,::mavsdk::rpc::info::GetFlightInformationResponse>* server_unary_streamer) = 0;
-  };
-  template <class BaseClass>
   class WithStreamedUnaryMethod_GetIdentification : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_GetIdentification() {
-      ::grpc::Service::MarkMethodStreamed(1,
+      ::grpc::Service::MarkMethodStreamed(0,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::info::GetIdentificationRequest, ::mavsdk::rpc::info::GetIdentificationResponse>(
             [this](::grpc::ServerContext* context,
@@ -932,7 +772,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_GetProduct() {
-      ::grpc::Service::MarkMethodStreamed(2,
+      ::grpc::Service::MarkMethodStreamed(1,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::info::GetProductRequest, ::mavsdk::rpc::info::GetProductResponse>(
             [this](::grpc::ServerContext* context,
@@ -959,7 +799,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_GetVersion() {
-      ::grpc::Service::MarkMethodStreamed(3,
+      ::grpc::Service::MarkMethodStreamed(2,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::info::GetVersionRequest, ::mavsdk::rpc::info::GetVersionResponse>(
             [this](::grpc::ServerContext* context,
@@ -986,7 +826,7 @@ class InfoService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_GetSpeedFactor() {
-      ::grpc::Service::MarkMethodStreamed(4,
+      ::grpc::Service::MarkMethodStreamed(3,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::info::GetSpeedFactorRequest, ::mavsdk::rpc::info::GetSpeedFactorResponse>(
             [this](::grpc::ServerContext* context,
@@ -1007,14 +847,14 @@ class InfoService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedGetSpeedFactor(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::info::GetSpeedFactorRequest,::mavsdk::rpc::info::GetSpeedFactorResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_GetFlightInformation<WithStreamedUnaryMethod_GetIdentification<WithStreamedUnaryMethod_GetProduct<WithStreamedUnaryMethod_GetVersion<WithStreamedUnaryMethod_GetSpeedFactor<Service > > > > > StreamedUnaryService;
+  typedef WithStreamedUnaryMethod_GetIdentification<WithStreamedUnaryMethod_GetProduct<WithStreamedUnaryMethod_GetVersion<WithStreamedUnaryMethod_GetSpeedFactor<Service > > > > StreamedUnaryService;
   template <class BaseClass>
   class WithSplitStreamingMethod_SubscribeFlightInformation : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithSplitStreamingMethod_SubscribeFlightInformation() {
-      ::grpc::Service::MarkMethodStreamed(5,
+      ::grpc::Service::MarkMethodStreamed(4,
         new ::grpc::internal::SplitServerStreamingHandler<
           ::mavsdk::rpc::info::SubscribeFlightInformationRequest, ::mavsdk::rpc::info::FlightInformationResponse>(
             [this](::grpc::ServerContext* context,
@@ -1036,7 +876,7 @@ class InfoService final {
     virtual ::grpc::Status StreamedSubscribeFlightInformation(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::info::SubscribeFlightInformationRequest,::mavsdk::rpc::info::FlightInformationResponse>* server_split_streamer) = 0;
   };
   typedef WithSplitStreamingMethod_SubscribeFlightInformation<Service > SplitStreamedService;
-  typedef WithStreamedUnaryMethod_GetFlightInformation<WithStreamedUnaryMethod_GetIdentification<WithStreamedUnaryMethod_GetProduct<WithStreamedUnaryMethod_GetVersion<WithStreamedUnaryMethod_GetSpeedFactor<WithSplitStreamingMethod_SubscribeFlightInformation<Service > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_GetIdentification<WithStreamedUnaryMethod_GetProduct<WithStreamedUnaryMethod_GetVersion<WithStreamedUnaryMethod_GetSpeedFactor<WithSplitStreamingMethod_SubscribeFlightInformation<Service > > > > > StreamedService;
 };
 
 }  // namespace info

--- a/cpp/src/mavsdk_server/src/generated/info/info.pb.cc
+++ b/cpp/src/mavsdk_server/src/generated/info/info.pb.cc
@@ -245,24 +245,6 @@ struct GetIdentificationRequestDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 GetIdentificationRequestDefaultTypeInternal _GetIdentificationRequest_default_instance_;
-              template <typename>
-PROTOBUF_CONSTEXPR GetFlightInformationRequest::GetFlightInformationRequest(::_pbi::ConstantInitialized)
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-    : ::google::protobuf::internal::ZeroFieldsBase(_class_data_.base()){}
-#else   // PROTOBUF_CUSTOM_VTABLE
-    : ::google::protobuf::internal::ZeroFieldsBase() {
-}
-#endif  // PROTOBUF_CUSTOM_VTABLE
-struct GetFlightInformationRequestDefaultTypeInternal {
-  PROTOBUF_CONSTEXPR GetFlightInformationRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
-  ~GetFlightInformationRequestDefaultTypeInternal() {}
-  union {
-    GetFlightInformationRequest _instance;
-  };
-};
-
-PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
-    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 GetFlightInformationRequestDefaultTypeInternal _GetFlightInformationRequest_default_instance_;
 
 inline constexpr FlightInfo::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -396,32 +378,6 @@ struct GetIdentificationResponseDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 GetIdentificationResponseDefaultTypeInternal _GetIdentificationResponse_default_instance_;
 
-inline constexpr GetFlightInformationResponse::Impl_::Impl_(
-    ::_pbi::ConstantInitialized) noexcept
-      : _cached_size_{0},
-        info_result_{nullptr},
-        flight_info_{nullptr} {}
-
-template <typename>
-PROTOBUF_CONSTEXPR GetFlightInformationResponse::GetFlightInformationResponse(::_pbi::ConstantInitialized)
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-    : ::google::protobuf::Message(_class_data_.base()),
-#else   // PROTOBUF_CUSTOM_VTABLE
-    : ::google::protobuf::Message(),
-#endif  // PROTOBUF_CUSTOM_VTABLE
-      _impl_(::_pbi::ConstantInitialized()) {
-}
-struct GetFlightInformationResponseDefaultTypeInternal {
-  PROTOBUF_CONSTEXPR GetFlightInformationResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
-  ~GetFlightInformationResponseDefaultTypeInternal() {}
-  union {
-    GetFlightInformationResponse _instance;
-  };
-};
-
-PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
-    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 GetFlightInformationResponseDefaultTypeInternal _GetFlightInformationResponse_default_instance_;
-
 inline constexpr FlightInformationResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : _cached_size_{0},
@@ -455,26 +411,6 @@ static constexpr const ::_pb::ServiceDescriptor**
 const ::uint32_t
     TableStruct_info_2finfo_2eproto::offsets[] ABSL_ATTRIBUTE_SECTION_VARIABLE(
         protodesc_cold) = {
-        ~0u,  // no _has_bits_
-        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::info::GetFlightInformationRequest, _internal_metadata_),
-        ~0u,  // no _extensions_
-        ~0u,  // no _oneof_case_
-        ~0u,  // no _weak_field_map_
-        ~0u,  // no _inlined_string_donated_
-        ~0u,  // no _split_
-        ~0u,  // no sizeof(Split)
-        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::info::GetFlightInformationResponse, _impl_._has_bits_),
-        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::info::GetFlightInformationResponse, _internal_metadata_),
-        ~0u,  // no _extensions_
-        ~0u,  // no _oneof_case_
-        ~0u,  // no _weak_field_map_
-        ~0u,  // no _inlined_string_donated_
-        ~0u,  // no _split_
-        ~0u,  // no sizeof(Split)
-        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::info::GetFlightInformationResponse, _impl_.info_result_),
-        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::info::GetFlightInformationResponse, _impl_.flight_info_),
-        0,
-        1,
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::info::GetIdentificationRequest, _internal_metadata_),
         ~0u,  // no _extensions_
@@ -641,27 +577,23 @@ const ::uint32_t
 
 static const ::_pbi::MigrationSchema
     schemas[] ABSL_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-        {0, -1, -1, sizeof(::mavsdk::rpc::info::GetFlightInformationRequest)},
-        {8, 18, -1, sizeof(::mavsdk::rpc::info::GetFlightInformationResponse)},
-        {20, -1, -1, sizeof(::mavsdk::rpc::info::GetIdentificationRequest)},
-        {28, 38, -1, sizeof(::mavsdk::rpc::info::GetIdentificationResponse)},
-        {40, -1, -1, sizeof(::mavsdk::rpc::info::GetProductRequest)},
-        {48, 58, -1, sizeof(::mavsdk::rpc::info::GetProductResponse)},
-        {60, -1, -1, sizeof(::mavsdk::rpc::info::GetVersionRequest)},
-        {68, 78, -1, sizeof(::mavsdk::rpc::info::GetVersionResponse)},
-        {80, -1, -1, sizeof(::mavsdk::rpc::info::GetSpeedFactorRequest)},
-        {88, 98, -1, sizeof(::mavsdk::rpc::info::GetSpeedFactorResponse)},
-        {100, -1, -1, sizeof(::mavsdk::rpc::info::SubscribeFlightInformationRequest)},
-        {108, 117, -1, sizeof(::mavsdk::rpc::info::FlightInformationResponse)},
-        {118, -1, -1, sizeof(::mavsdk::rpc::info::FlightInfo)},
-        {130, -1, -1, sizeof(::mavsdk::rpc::info::Identification)},
-        {140, -1, -1, sizeof(::mavsdk::rpc::info::Product)},
-        {152, -1, -1, sizeof(::mavsdk::rpc::info::Version)},
-        {172, -1, -1, sizeof(::mavsdk::rpc::info::InfoResult)},
+        {0, -1, -1, sizeof(::mavsdk::rpc::info::GetIdentificationRequest)},
+        {8, 18, -1, sizeof(::mavsdk::rpc::info::GetIdentificationResponse)},
+        {20, -1, -1, sizeof(::mavsdk::rpc::info::GetProductRequest)},
+        {28, 38, -1, sizeof(::mavsdk::rpc::info::GetProductResponse)},
+        {40, -1, -1, sizeof(::mavsdk::rpc::info::GetVersionRequest)},
+        {48, 58, -1, sizeof(::mavsdk::rpc::info::GetVersionResponse)},
+        {60, -1, -1, sizeof(::mavsdk::rpc::info::GetSpeedFactorRequest)},
+        {68, 78, -1, sizeof(::mavsdk::rpc::info::GetSpeedFactorResponse)},
+        {80, -1, -1, sizeof(::mavsdk::rpc::info::SubscribeFlightInformationRequest)},
+        {88, 97, -1, sizeof(::mavsdk::rpc::info::FlightInformationResponse)},
+        {98, -1, -1, sizeof(::mavsdk::rpc::info::FlightInfo)},
+        {110, -1, -1, sizeof(::mavsdk::rpc::info::Identification)},
+        {120, -1, -1, sizeof(::mavsdk::rpc::info::Product)},
+        {132, -1, -1, sizeof(::mavsdk::rpc::info::Version)},
+        {152, -1, -1, sizeof(::mavsdk::rpc::info::InfoResult)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
-    &::mavsdk::rpc::info::_GetFlightInformationRequest_default_instance_._instance,
-    &::mavsdk::rpc::info::_GetFlightInformationResponse_default_instance_._instance,
     &::mavsdk::rpc::info::_GetIdentificationRequest_default_instance_._instance,
     &::mavsdk::rpc::info::_GetIdentificationResponse_default_instance_._instance,
     &::mavsdk::rpc::info::_GetProductRequest_default_instance_._instance,
@@ -681,74 +613,67 @@ static const ::_pb::Message* const file_default_instances[] = {
 const char descriptor_table_protodef_info_2finfo_2eproto[] ABSL_ATTRIBUTE_SECTION_VARIABLE(
     protodesc_cold) = {
     "\n\017info/info.proto\022\017mavsdk.rpc.info\032\024mavs"
-    "dk_options.proto\"\035\n\033GetFlightInformation"
-    "Request\"\202\001\n\034GetFlightInformationResponse"
+    "dk_options.proto\"\032\n\030GetIdentificationReq"
+    "uest\"\206\001\n\031GetIdentificationResponse\0220\n\013in"
+    "fo_result\030\001 \001(\0132\033.mavsdk.rpc.info.InfoRe"
+    "sult\0227\n\016identification\030\002 \001(\0132\037.mavsdk.rp"
+    "c.info.Identification\"\023\n\021GetProductReque"
+    "st\"q\n\022GetProductResponse\0220\n\013info_result\030"
+    "\001 \001(\0132\033.mavsdk.rpc.info.InfoResult\022)\n\007pr"
+    "oduct\030\002 \001(\0132\030.mavsdk.rpc.info.Product\"\023\n"
+    "\021GetVersionRequest\"q\n\022GetVersionResponse"
     "\0220\n\013info_result\030\001 \001(\0132\033.mavsdk.rpc.info."
-    "InfoResult\0220\n\013flight_info\030\002 \001(\0132\033.mavsdk"
-    ".rpc.info.FlightInfo\"\032\n\030GetIdentificatio"
-    "nRequest\"\206\001\n\031GetIdentificationResponse\0220"
-    "\n\013info_result\030\001 \001(\0132\033.mavsdk.rpc.info.In"
-    "foResult\0227\n\016identification\030\002 \001(\0132\037.mavsd"
-    "k.rpc.info.Identification\"\023\n\021GetProductR"
-    "equest\"q\n\022GetProductResponse\0220\n\013info_res"
-    "ult\030\001 \001(\0132\033.mavsdk.rpc.info.InfoResult\022)"
-    "\n\007product\030\002 \001(\0132\030.mavsdk.rpc.info.Produc"
-    "t\"\023\n\021GetVersionRequest\"q\n\022GetVersionResp"
-    "onse\0220\n\013info_result\030\001 \001(\0132\033.mavsdk.rpc.i"
-    "nfo.InfoResult\022)\n\007version\030\002 \001(\0132\030.mavsdk"
-    ".rpc.info.Version\"\027\n\025GetSpeedFactorReque"
-    "st\"`\n\026GetSpeedFactorResponse\0220\n\013info_res"
-    "ult\030\001 \001(\0132\033.mavsdk.rpc.info.InfoResult\022\024"
-    "\n\014speed_factor\030\002 \001(\001\"#\n!SubscribeFlightI"
-    "nformationRequest\"M\n\031FlightInformationRe"
-    "sponse\0220\n\013flight_info\030\001 \001(\0132\033.mavsdk.rpc"
-    ".info.FlightInfo\"{\n\nFlightInfo\022\024\n\014time_b"
-    "oot_ms\030\001 \001(\r\022\022\n\nflight_uid\030\002 \001(\004\022 \n\030dura"
-    "tion_since_arming_ms\030\003 \001(\r\022!\n\031duration_s"
-    "ince_takeoff_ms\030\004 \001(\r\":\n\016Identification\022"
-    "\024\n\014hardware_uid\030\001 \001(\t\022\022\n\nlegacy_uid\030\002 \001("
-    "\004\"[\n\007Product\022\021\n\tvendor_id\030\001 \001(\005\022\023\n\013vendo"
-    "r_name\030\002 \001(\t\022\022\n\nproduct_id\030\003 \001(\005\022\024\n\014prod"
-    "uct_name\030\004 \001(\t\"\207\005\n\007Version\022\027\n\017flight_sw_"
-    "major\030\001 \001(\005\022\027\n\017flight_sw_minor\030\002 \001(\005\022\027\n\017"
-    "flight_sw_patch\030\003 \001(\005\022\036\n\026flight_sw_vendo"
-    "r_major\030\004 \001(\005\022\036\n\026flight_sw_vendor_minor\030"
-    "\005 \001(\005\022\036\n\026flight_sw_vendor_patch\030\006 \001(\005\022\023\n"
-    "\013os_sw_major\030\007 \001(\005\022\023\n\013os_sw_minor\030\010 \001(\005\022"
-    "\023\n\013os_sw_patch\030\t \001(\005\022\032\n\022flight_sw_git_ha"
-    "sh\030\n \001(\t\022\026\n\016os_sw_git_hash\030\013 \001(\t\022R\n\026flig"
-    "ht_sw_version_type\030\014 \001(\01622.mavsdk.rpc.in"
-    "fo.Version.FlightSoftwareVersionType\"\211\002\n"
-    "\031FlightSoftwareVersionType\022(\n$FLIGHT_SOF"
-    "TWARE_VERSION_TYPE_UNKNOWN\020\000\022$\n FLIGHT_S"
-    "OFTWARE_VERSION_TYPE_DEV\020\001\022&\n\"FLIGHT_SOF"
-    "TWARE_VERSION_TYPE_ALPHA\020\002\022%\n!FLIGHT_SOF"
-    "TWARE_VERSION_TYPE_BETA\020\003\022#\n\037FLIGHT_SOFT"
-    "WARE_VERSION_TYPE_RC\020\004\022(\n$FLIGHT_SOFTWAR"
-    "E_VERSION_TYPE_RELEASE\020\005\"\305\001\n\nInfoResult\022"
-    "2\n\006result\030\001 \001(\0162\".mavsdk.rpc.info.InfoRe"
-    "sult.Result\022\022\n\nresult_str\030\002 \001(\t\"o\n\006Resul"
-    "t\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCCESS\020"
-    "\001\022\'\n#RESULT_INFORMATION_NOT_RECEIVED_YET"
-    "\020\002\022\024\n\020RESULT_NO_SYSTEM\020\0032\244\005\n\013InfoService"
-    "\022y\n\024GetFlightInformation\022,.mavsdk.rpc.in"
-    "fo.GetFlightInformationRequest\032-.mavsdk."
-    "rpc.info.GetFlightInformationResponse\"\004\200"
-    "\265\030\001\022p\n\021GetIdentification\022).mavsdk.rpc.in"
-    "fo.GetIdentificationRequest\032*.mavsdk.rpc"
-    ".info.GetIdentificationResponse\"\004\200\265\030\001\022[\n"
-    "\nGetProduct\022\".mavsdk.rpc.info.GetProduct"
-    "Request\032#.mavsdk.rpc.info.GetProductResp"
-    "onse\"\004\200\265\030\001\022[\n\nGetVersion\022\".mavsdk.rpc.in"
-    "fo.GetVersionRequest\032#.mavsdk.rpc.info.G"
-    "etVersionResponse\"\004\200\265\030\001\022g\n\016GetSpeedFacto"
-    "r\022&.mavsdk.rpc.info.GetSpeedFactorReques"
-    "t\032\'.mavsdk.rpc.info.GetSpeedFactorRespon"
-    "se\"\004\200\265\030\001\022\204\001\n\032SubscribeFlightInformation\022"
-    "2.mavsdk.rpc.info.SubscribeFlightInforma"
-    "tionRequest\032*.mavsdk.rpc.info.FlightInfo"
-    "rmationResponse\"\004\200\265\030\0000\001B\033\n\016io.mavsdk.inf"
-    "oB\tInfoProtob\006proto3"
+    "InfoResult\022)\n\007version\030\002 \001(\0132\030.mavsdk.rpc"
+    ".info.Version\"\027\n\025GetSpeedFactorRequest\"`"
+    "\n\026GetSpeedFactorResponse\0220\n\013info_result\030"
+    "\001 \001(\0132\033.mavsdk.rpc.info.InfoResult\022\024\n\014sp"
+    "eed_factor\030\002 \001(\001\"#\n!SubscribeFlightInfor"
+    "mationRequest\"M\n\031FlightInformationRespon"
+    "se\0220\n\013flight_info\030\001 \001(\0132\033.mavsdk.rpc.inf"
+    "o.FlightInfo\"{\n\nFlightInfo\022\024\n\014time_boot_"
+    "ms\030\001 \001(\r\022\022\n\nflight_uid\030\002 \001(\004\022 \n\030duration"
+    "_since_arming_ms\030\003 \001(\r\022!\n\031duration_since"
+    "_takeoff_ms\030\004 \001(\r\":\n\016Identification\022\024\n\014h"
+    "ardware_uid\030\001 \001(\t\022\022\n\nlegacy_uid\030\002 \001(\004\"[\n"
+    "\007Product\022\021\n\tvendor_id\030\001 \001(\005\022\023\n\013vendor_na"
+    "me\030\002 \001(\t\022\022\n\nproduct_id\030\003 \001(\005\022\024\n\014product_"
+    "name\030\004 \001(\t\"\207\005\n\007Version\022\027\n\017flight_sw_majo"
+    "r\030\001 \001(\005\022\027\n\017flight_sw_minor\030\002 \001(\005\022\027\n\017flig"
+    "ht_sw_patch\030\003 \001(\005\022\036\n\026flight_sw_vendor_ma"
+    "jor\030\004 \001(\005\022\036\n\026flight_sw_vendor_minor\030\005 \001("
+    "\005\022\036\n\026flight_sw_vendor_patch\030\006 \001(\005\022\023\n\013os_"
+    "sw_major\030\007 \001(\005\022\023\n\013os_sw_minor\030\010 \001(\005\022\023\n\013o"
+    "s_sw_patch\030\t \001(\005\022\032\n\022flight_sw_git_hash\030\n"
+    " \001(\t\022\026\n\016os_sw_git_hash\030\013 \001(\t\022R\n\026flight_s"
+    "w_version_type\030\014 \001(\01622.mavsdk.rpc.info.V"
+    "ersion.FlightSoftwareVersionType\"\211\002\n\031Fli"
+    "ghtSoftwareVersionType\022(\n$FLIGHT_SOFTWAR"
+    "E_VERSION_TYPE_UNKNOWN\020\000\022$\n FLIGHT_SOFTW"
+    "ARE_VERSION_TYPE_DEV\020\001\022&\n\"FLIGHT_SOFTWAR"
+    "E_VERSION_TYPE_ALPHA\020\002\022%\n!FLIGHT_SOFTWAR"
+    "E_VERSION_TYPE_BETA\020\003\022#\n\037FLIGHT_SOFTWARE"
+    "_VERSION_TYPE_RC\020\004\022(\n$FLIGHT_SOFTWARE_VE"
+    "RSION_TYPE_RELEASE\020\005\"\305\001\n\nInfoResult\0222\n\006r"
+    "esult\030\001 \001(\0162\".mavsdk.rpc.info.InfoResult"
+    ".Result\022\022\n\nresult_str\030\002 \001(\t\"o\n\006Result\022\022\n"
+    "\016RESULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\'\n"
+    "#RESULT_INFORMATION_NOT_RECEIVED_YET\020\002\022\024"
+    "\n\020RESULT_NO_SYSTEM\020\0032\251\004\n\013InfoService\022p\n\021"
+    "GetIdentification\022).mavsdk.rpc.info.GetI"
+    "dentificationRequest\032*.mavsdk.rpc.info.G"
+    "etIdentificationResponse\"\004\200\265\030\001\022[\n\nGetPro"
+    "duct\022\".mavsdk.rpc.info.GetProductRequest"
+    "\032#.mavsdk.rpc.info.GetProductResponse\"\004\200"
+    "\265\030\001\022[\n\nGetVersion\022\".mavsdk.rpc.info.GetV"
+    "ersionRequest\032#.mavsdk.rpc.info.GetVersi"
+    "onResponse\"\004\200\265\030\001\022g\n\016GetSpeedFactor\022&.mav"
+    "sdk.rpc.info.GetSpeedFactorRequest\032\'.mav"
+    "sdk.rpc.info.GetSpeedFactorResponse\"\004\200\265\030"
+    "\001\022\204\001\n\032SubscribeFlightInformation\0222.mavsd"
+    "k.rpc.info.SubscribeFlightInformationReq"
+    "uest\032*.mavsdk.rpc.info.FlightInformation"
+    "Response\"\004\200\265\030\0000\001B\033\n\016io.mavsdk.infoB\tInfo"
+    "Protob\006proto3"
 };
 static const ::_pbi::DescriptorTable* const descriptor_table_info_2finfo_2eproto_deps[1] =
     {
@@ -758,13 +683,13 @@ static ::absl::once_flag descriptor_table_info_2finfo_2eproto_once;
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_info_2finfo_2eproto = {
     false,
     false,
-    2740,
+    2453,
     descriptor_table_protodef_info_2finfo_2eproto,
     "info/info.proto",
     &descriptor_table_info_2finfo_2eproto_once,
     descriptor_table_info_2finfo_2eproto_deps,
     1,
-    17,
+    15,
     schemas,
     file_default_instances,
     TableStruct_info_2finfo_2eproto::offsets,
@@ -820,410 +745,6 @@ constexpr int InfoResult::Result_ARRAYSIZE;
 
 #endif  // (__cplusplus < 201703) &&
         // (!defined(_MSC_VER) || (_MSC_VER >= 1900 && _MSC_VER < 1912))
-// ===================================================================
-
-class GetFlightInformationRequest::_Internal {
- public:
-};
-
-GetFlightInformationRequest::GetFlightInformationRequest(::google::protobuf::Arena* arena)
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
-#else   // PROTOBUF_CUSTOM_VTABLE
-    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
-#endif  // PROTOBUF_CUSTOM_VTABLE
-  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.info.GetFlightInformationRequest)
-}
-GetFlightInformationRequest::GetFlightInformationRequest(
-    ::google::protobuf::Arena* arena,
-    const GetFlightInformationRequest& from)
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
-#else   // PROTOBUF_CUSTOM_VTABLE
-    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
-#endif  // PROTOBUF_CUSTOM_VTABLE
-  GetFlightInformationRequest* const _this = this;
-  (void)_this;
-  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
-      from._internal_metadata_);
-
-  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.info.GetFlightInformationRequest)
-}
-
-inline void* GetFlightInformationRequest::PlacementNew_(const void*, void* mem,
-                                        ::google::protobuf::Arena* arena) {
-  return ::new (mem) GetFlightInformationRequest(arena);
-}
-constexpr auto GetFlightInformationRequest::InternalNewImpl_() {
-  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(GetFlightInformationRequest),
-                                            alignof(GetFlightInformationRequest));
-}
-PROTOBUF_CONSTINIT
-PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::google::protobuf::internal::ClassDataFull GetFlightInformationRequest::_class_data_ = {
-    ::google::protobuf::internal::ClassData{
-        &_GetFlightInformationRequest_default_instance_._instance,
-        &_table_.header,
-        nullptr,  // OnDemandRegisterArenaDtor
-        nullptr,  // IsInitialized
-        &GetFlightInformationRequest::MergeImpl,
-        ::google::protobuf::internal::ZeroFieldsBase::GetNewImpl<GetFlightInformationRequest>(),
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-        &GetFlightInformationRequest::SharedDtor,
-        ::google::protobuf::internal::ZeroFieldsBase::GetClearImpl<GetFlightInformationRequest>(), &GetFlightInformationRequest::ByteSizeLong,
-            &GetFlightInformationRequest::_InternalSerialize,
-#endif  // PROTOBUF_CUSTOM_VTABLE
-        PROTOBUF_FIELD_OFFSET(GetFlightInformationRequest, _impl_._cached_size_),
-        false,
-    },
-    &GetFlightInformationRequest::kDescriptorMethods,
-    &descriptor_table_info_2finfo_2eproto,
-    nullptr,  // tracker
-};
-const ::google::protobuf::internal::ClassData* GetFlightInformationRequest::GetClassData() const {
-  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
-  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
-  return _class_data_.base();
-}
-PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<0, 0, 0, 0, 2> GetFlightInformationRequest::_table_ = {
-  {
-    0,  // no _has_bits_
-    0, // no _extensions_
-    0, 0,  // max_field_number, fast_idx_mask
-    offsetof(decltype(_table_), field_lookup_table),
-    4294967295,  // skipmap
-    offsetof(decltype(_table_), field_names),  // no field_entries
-    0,  // num_field_entries
-    0,  // num_aux_entries
-    offsetof(decltype(_table_), field_names),  // no aux_entries
-    _class_data_.base(),
-    nullptr,  // post_loop_handler
-    ::_pbi::TcParser::GenericFallback,  // fallback
-    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
-    ::_pbi::TcParser::GetTable<::mavsdk::rpc::info::GetFlightInformationRequest>(),  // to_prefetch
-    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
-  }, {{
-    {::_pbi::TcParser::MiniParse, {}},
-  }}, {{
-    65535, 65535
-  }},
-  // no field_entries, or aux_entries
-  {{
-  }},
-};
-
-
-
-
-
-
-
-
-::google::protobuf::Metadata GetFlightInformationRequest::GetMetadata() const {
-  return ::google::protobuf::internal::ZeroFieldsBase::GetMetadataImpl(GetClassData()->full());
-}
-// ===================================================================
-
-class GetFlightInformationResponse::_Internal {
- public:
-  using HasBits =
-      decltype(std::declval<GetFlightInformationResponse>()._impl_._has_bits_);
-  static constexpr ::int32_t kHasBitsOffset =
-      8 * PROTOBUF_FIELD_OFFSET(GetFlightInformationResponse, _impl_._has_bits_);
-};
-
-GetFlightInformationResponse::GetFlightInformationResponse(::google::protobuf::Arena* arena)
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-    : ::google::protobuf::Message(arena, _class_data_.base()) {
-#else   // PROTOBUF_CUSTOM_VTABLE
-    : ::google::protobuf::Message(arena) {
-#endif  // PROTOBUF_CUSTOM_VTABLE
-  SharedCtor(arena);
-  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.info.GetFlightInformationResponse)
-}
-inline PROTOBUF_NDEBUG_INLINE GetFlightInformationResponse::Impl_::Impl_(
-    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
-    const Impl_& from, const ::mavsdk::rpc::info::GetFlightInformationResponse& from_msg)
-      : _has_bits_{from._has_bits_},
-        _cached_size_{0} {}
-
-GetFlightInformationResponse::GetFlightInformationResponse(
-    ::google::protobuf::Arena* arena,
-    const GetFlightInformationResponse& from)
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-    : ::google::protobuf::Message(arena, _class_data_.base()) {
-#else   // PROTOBUF_CUSTOM_VTABLE
-    : ::google::protobuf::Message(arena) {
-#endif  // PROTOBUF_CUSTOM_VTABLE
-  GetFlightInformationResponse* const _this = this;
-  (void)_this;
-  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
-      from._internal_metadata_);
-  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
-  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
-  _impl_.info_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::info::InfoResult>(
-                              arena, *from._impl_.info_result_)
-                        : nullptr;
-  _impl_.flight_info_ = (cached_has_bits & 0x00000002u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::info::FlightInfo>(
-                              arena, *from._impl_.flight_info_)
-                        : nullptr;
-
-  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.info.GetFlightInformationResponse)
-}
-inline PROTOBUF_NDEBUG_INLINE GetFlightInformationResponse::Impl_::Impl_(
-    ::google::protobuf::internal::InternalVisibility visibility,
-    ::google::protobuf::Arena* arena)
-      : _cached_size_{0} {}
-
-inline void GetFlightInformationResponse::SharedCtor(::_pb::Arena* arena) {
-  new (&_impl_) Impl_(internal_visibility(), arena);
-  ::memset(reinterpret_cast<char *>(&_impl_) +
-               offsetof(Impl_, info_result_),
-           0,
-           offsetof(Impl_, flight_info_) -
-               offsetof(Impl_, info_result_) +
-               sizeof(Impl_::flight_info_));
-}
-GetFlightInformationResponse::~GetFlightInformationResponse() {
-  // @@protoc_insertion_point(destructor:mavsdk.rpc.info.GetFlightInformationResponse)
-  SharedDtor(*this);
-}
-inline void GetFlightInformationResponse::SharedDtor(MessageLite& self) {
-  GetFlightInformationResponse& this_ = static_cast<GetFlightInformationResponse&>(self);
-  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
-  ABSL_DCHECK(this_.GetArena() == nullptr);
-  delete this_._impl_.info_result_;
-  delete this_._impl_.flight_info_;
-  this_._impl_.~Impl_();
-}
-
-inline void* GetFlightInformationResponse::PlacementNew_(const void*, void* mem,
-                                        ::google::protobuf::Arena* arena) {
-  return ::new (mem) GetFlightInformationResponse(arena);
-}
-constexpr auto GetFlightInformationResponse::InternalNewImpl_() {
-  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(GetFlightInformationResponse),
-                                            alignof(GetFlightInformationResponse));
-}
-PROTOBUF_CONSTINIT
-PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::google::protobuf::internal::ClassDataFull GetFlightInformationResponse::_class_data_ = {
-    ::google::protobuf::internal::ClassData{
-        &_GetFlightInformationResponse_default_instance_._instance,
-        &_table_.header,
-        nullptr,  // OnDemandRegisterArenaDtor
-        nullptr,  // IsInitialized
-        &GetFlightInformationResponse::MergeImpl,
-        ::google::protobuf::Message::GetNewImpl<GetFlightInformationResponse>(),
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-        &GetFlightInformationResponse::SharedDtor,
-        ::google::protobuf::Message::GetClearImpl<GetFlightInformationResponse>(), &GetFlightInformationResponse::ByteSizeLong,
-            &GetFlightInformationResponse::_InternalSerialize,
-#endif  // PROTOBUF_CUSTOM_VTABLE
-        PROTOBUF_FIELD_OFFSET(GetFlightInformationResponse, _impl_._cached_size_),
-        false,
-    },
-    &GetFlightInformationResponse::kDescriptorMethods,
-    &descriptor_table_info_2finfo_2eproto,
-    nullptr,  // tracker
-};
-const ::google::protobuf::internal::ClassData* GetFlightInformationResponse::GetClassData() const {
-  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
-  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
-  return _class_data_.base();
-}
-PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<1, 2, 2, 0, 2> GetFlightInformationResponse::_table_ = {
-  {
-    PROTOBUF_FIELD_OFFSET(GetFlightInformationResponse, _impl_._has_bits_),
-    0, // no _extensions_
-    2, 8,  // max_field_number, fast_idx_mask
-    offsetof(decltype(_table_), field_lookup_table),
-    4294967292,  // skipmap
-    offsetof(decltype(_table_), field_entries),
-    2,  // num_field_entries
-    2,  // num_aux_entries
-    offsetof(decltype(_table_), aux_entries),
-    _class_data_.base(),
-    nullptr,  // post_loop_handler
-    ::_pbi::TcParser::GenericFallback,  // fallback
-    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
-    ::_pbi::TcParser::GetTable<::mavsdk::rpc::info::GetFlightInformationResponse>(),  // to_prefetch
-    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
-  }, {{
-    // .mavsdk.rpc.info.FlightInfo flight_info = 2;
-    {::_pbi::TcParser::FastMtS1,
-     {18, 1, 1, PROTOBUF_FIELD_OFFSET(GetFlightInformationResponse, _impl_.flight_info_)}},
-    // .mavsdk.rpc.info.InfoResult info_result = 1;
-    {::_pbi::TcParser::FastMtS1,
-     {10, 0, 0, PROTOBUF_FIELD_OFFSET(GetFlightInformationResponse, _impl_.info_result_)}},
-  }}, {{
-    65535, 65535
-  }}, {{
-    // .mavsdk.rpc.info.InfoResult info_result = 1;
-    {PROTOBUF_FIELD_OFFSET(GetFlightInformationResponse, _impl_.info_result_), _Internal::kHasBitsOffset + 0, 0,
-    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
-    // .mavsdk.rpc.info.FlightInfo flight_info = 2;
-    {PROTOBUF_FIELD_OFFSET(GetFlightInformationResponse, _impl_.flight_info_), _Internal::kHasBitsOffset + 1, 1,
-    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
-  }}, {{
-    {::_pbi::TcParser::GetTable<::mavsdk::rpc::info::InfoResult>()},
-    {::_pbi::TcParser::GetTable<::mavsdk::rpc::info::FlightInfo>()},
-  }}, {{
-  }},
-};
-
-PROTOBUF_NOINLINE void GetFlightInformationResponse::Clear() {
-// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.info.GetFlightInformationResponse)
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  ::uint32_t cached_has_bits = 0;
-  // Prevent compiler warnings about cached_has_bits being unused
-  (void) cached_has_bits;
-
-  cached_has_bits = _impl_._has_bits_[0];
-  if (cached_has_bits & 0x00000003u) {
-    if (cached_has_bits & 0x00000001u) {
-      ABSL_DCHECK(_impl_.info_result_ != nullptr);
-      _impl_.info_result_->Clear();
-    }
-    if (cached_has_bits & 0x00000002u) {
-      ABSL_DCHECK(_impl_.flight_info_ != nullptr);
-      _impl_.flight_info_->Clear();
-    }
-  }
-  _impl_._has_bits_.Clear();
-  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
-}
-
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-        ::uint8_t* GetFlightInformationResponse::_InternalSerialize(
-            const MessageLite& base, ::uint8_t* target,
-            ::google::protobuf::io::EpsCopyOutputStream* stream) {
-          const GetFlightInformationResponse& this_ = static_cast<const GetFlightInformationResponse&>(base);
-#else   // PROTOBUF_CUSTOM_VTABLE
-        ::uint8_t* GetFlightInformationResponse::_InternalSerialize(
-            ::uint8_t* target,
-            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
-          const GetFlightInformationResponse& this_ = *this;
-#endif  // PROTOBUF_CUSTOM_VTABLE
-          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.info.GetFlightInformationResponse)
-          ::uint32_t cached_has_bits = 0;
-          (void)cached_has_bits;
-
-          cached_has_bits = this_._impl_._has_bits_[0];
-          // .mavsdk.rpc.info.InfoResult info_result = 1;
-          if (cached_has_bits & 0x00000001u) {
-            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
-                1, *this_._impl_.info_result_, this_._impl_.info_result_->GetCachedSize(), target,
-                stream);
-          }
-
-          // .mavsdk.rpc.info.FlightInfo flight_info = 2;
-          if (cached_has_bits & 0x00000002u) {
-            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
-                2, *this_._impl_.flight_info_, this_._impl_.flight_info_->GetCachedSize(), target,
-                stream);
-          }
-
-          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
-            target =
-                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
-                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
-          }
-          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.info.GetFlightInformationResponse)
-          return target;
-        }
-
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-        ::size_t GetFlightInformationResponse::ByteSizeLong(const MessageLite& base) {
-          const GetFlightInformationResponse& this_ = static_cast<const GetFlightInformationResponse&>(base);
-#else   // PROTOBUF_CUSTOM_VTABLE
-        ::size_t GetFlightInformationResponse::ByteSizeLong() const {
-          const GetFlightInformationResponse& this_ = *this;
-#endif  // PROTOBUF_CUSTOM_VTABLE
-          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.info.GetFlightInformationResponse)
-          ::size_t total_size = 0;
-
-          ::uint32_t cached_has_bits = 0;
-          // Prevent compiler warnings about cached_has_bits being unused
-          (void)cached_has_bits;
-
-          ::_pbi::Prefetch5LinesFrom7Lines(&this_);
-          cached_has_bits = this_._impl_._has_bits_[0];
-          if (cached_has_bits & 0x00000003u) {
-            // .mavsdk.rpc.info.InfoResult info_result = 1;
-            if (cached_has_bits & 0x00000001u) {
-              total_size += 1 +
-                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.info_result_);
-            }
-            // .mavsdk.rpc.info.FlightInfo flight_info = 2;
-            if (cached_has_bits & 0x00000002u) {
-              total_size += 1 +
-                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.flight_info_);
-            }
-          }
-          return this_.MaybeComputeUnknownFieldsSize(total_size,
-                                                     &this_._impl_._cached_size_);
-        }
-
-void GetFlightInformationResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
-  auto* const _this = static_cast<GetFlightInformationResponse*>(&to_msg);
-  auto& from = static_cast<const GetFlightInformationResponse&>(from_msg);
-  ::google::protobuf::Arena* arena = _this->GetArena();
-  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.info.GetFlightInformationResponse)
-  ABSL_DCHECK_NE(&from, _this);
-  ::uint32_t cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  cached_has_bits = from._impl_._has_bits_[0];
-  if (cached_has_bits & 0x00000003u) {
-    if (cached_has_bits & 0x00000001u) {
-      ABSL_DCHECK(from._impl_.info_result_ != nullptr);
-      if (_this->_impl_.info_result_ == nullptr) {
-        _this->_impl_.info_result_ =
-            ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::info::InfoResult>(arena, *from._impl_.info_result_);
-      } else {
-        _this->_impl_.info_result_->MergeFrom(*from._impl_.info_result_);
-      }
-    }
-    if (cached_has_bits & 0x00000002u) {
-      ABSL_DCHECK(from._impl_.flight_info_ != nullptr);
-      if (_this->_impl_.flight_info_ == nullptr) {
-        _this->_impl_.flight_info_ =
-            ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::info::FlightInfo>(arena, *from._impl_.flight_info_);
-      } else {
-        _this->_impl_.flight_info_->MergeFrom(*from._impl_.flight_info_);
-      }
-    }
-  }
-  _this->_impl_._has_bits_[0] |= cached_has_bits;
-  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
-}
-
-void GetFlightInformationResponse::CopyFrom(const GetFlightInformationResponse& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.info.GetFlightInformationResponse)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-
-void GetFlightInformationResponse::InternalSwap(GetFlightInformationResponse* PROTOBUF_RESTRICT other) {
-  using std::swap;
-  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
-  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
-  ::google::protobuf::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(GetFlightInformationResponse, _impl_.flight_info_)
-      + sizeof(GetFlightInformationResponse::_impl_.flight_info_)
-      - PROTOBUF_FIELD_OFFSET(GetFlightInformationResponse, _impl_.info_result_)>(
-          reinterpret_cast<char*>(&_impl_.info_result_),
-          reinterpret_cast<char*>(&other->_impl_.info_result_));
-}
-
-::google::protobuf::Metadata GetFlightInformationResponse::GetMetadata() const {
-  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
-}
 // ===================================================================
 
 class GetIdentificationRequest::_Internal {

--- a/cpp/src/mavsdk_server/src/generated/info/info.pb.h
+++ b/cpp/src/mavsdk_server/src/generated/info/info.pb.h
@@ -63,12 +63,6 @@ extern FlightInfoDefaultTypeInternal _FlightInfo_default_instance_;
 class FlightInformationResponse;
 struct FlightInformationResponseDefaultTypeInternal;
 extern FlightInformationResponseDefaultTypeInternal _FlightInformationResponse_default_instance_;
-class GetFlightInformationRequest;
-struct GetFlightInformationRequestDefaultTypeInternal;
-extern GetFlightInformationRequestDefaultTypeInternal _GetFlightInformationRequest_default_instance_;
-class GetFlightInformationResponse;
-struct GetFlightInformationResponseDefaultTypeInternal;
-extern GetFlightInformationResponseDefaultTypeInternal _GetFlightInformationResponse_default_instance_;
 class GetIdentificationRequest;
 struct GetIdentificationRequestDefaultTypeInternal;
 extern GetIdentificationRequestDefaultTypeInternal _GetIdentificationRequest_default_instance_;
@@ -257,7 +251,7 @@ class Version final
     return reinterpret_cast<const Version*>(
         &_Version_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 15;
+  static constexpr int kIndexInFileMessages = 13;
   friend void swap(Version& a, Version& b) { a.Swap(&b); }
   inline void Swap(Version* other) {
     if (other == this) return;
@@ -614,7 +608,7 @@ class SubscribeFlightInformationRequest final
     return reinterpret_cast<const SubscribeFlightInformationRequest*>(
         &_SubscribeFlightInformationRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 10;
+  static constexpr int kIndexInFileMessages = 8;
   friend void swap(SubscribeFlightInformationRequest& a, SubscribeFlightInformationRequest& b) { a.Swap(&b); }
   inline void Swap(SubscribeFlightInformationRequest* other) {
     if (other == this) return;
@@ -761,7 +755,7 @@ class Product final
     return reinterpret_cast<const Product*>(
         &_Product_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 14;
+  static constexpr int kIndexInFileMessages = 12;
   friend void swap(Product& a, Product& b) { a.Swap(&b); }
   inline void Swap(Product* other) {
     if (other == this) return;
@@ -1000,7 +994,7 @@ class InfoResult final
     return reinterpret_cast<const InfoResult*>(
         &_InfoResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 16;
+  static constexpr int kIndexInFileMessages = 14;
   friend void swap(InfoResult& a, InfoResult& b) { a.Swap(&b); }
   inline void Swap(InfoResult* other) {
     if (other == this) return;
@@ -1230,7 +1224,7 @@ class Identification final
     return reinterpret_cast<const Identification*>(
         &_Identification_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 13;
+  static constexpr int kIndexInFileMessages = 11;
   friend void swap(Identification& a, Identification& b) { a.Swap(&b); }
   inline void Swap(Identification* other) {
     if (other == this) return;
@@ -1438,7 +1432,7 @@ class GetVersionRequest final
     return reinterpret_cast<const GetVersionRequest*>(
         &_GetVersionRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 6;
+  static constexpr int kIndexInFileMessages = 4;
   friend void swap(GetVersionRequest& a, GetVersionRequest& b) { a.Swap(&b); }
   inline void Swap(GetVersionRequest* other) {
     if (other == this) return;
@@ -1584,7 +1578,7 @@ class GetSpeedFactorRequest final
     return reinterpret_cast<const GetSpeedFactorRequest*>(
         &_GetSpeedFactorRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 8;
+  static constexpr int kIndexInFileMessages = 6;
   friend void swap(GetSpeedFactorRequest& a, GetSpeedFactorRequest& b) { a.Swap(&b); }
   inline void Swap(GetSpeedFactorRequest* other) {
     if (other == this) return;
@@ -1730,7 +1724,7 @@ class GetProductRequest final
     return reinterpret_cast<const GetProductRequest*>(
         &_GetProductRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 4;
+  static constexpr int kIndexInFileMessages = 2;
   friend void swap(GetProductRequest& a, GetProductRequest& b) { a.Swap(&b); }
   inline void Swap(GetProductRequest* other) {
     if (other == this) return;
@@ -1876,7 +1870,7 @@ class GetIdentificationRequest final
     return reinterpret_cast<const GetIdentificationRequest*>(
         &_GetIdentificationRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 2;
+  static constexpr int kIndexInFileMessages = 0;
   friend void swap(GetIdentificationRequest& a, GetIdentificationRequest& b) { a.Swap(&b); }
   inline void Swap(GetIdentificationRequest* other) {
     if (other == this) return;
@@ -1963,152 +1957,6 @@ class GetIdentificationRequest final
 };
 // -------------------------------------------------------------------
 
-class GetFlightInformationRequest final
-    : public ::google::protobuf::internal::ZeroFieldsBase
-/* @@protoc_insertion_point(class_definition:mavsdk.rpc.info.GetFlightInformationRequest) */ {
- public:
-  inline GetFlightInformationRequest() : GetFlightInformationRequest(nullptr) {}
-
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-  void operator delete(GetFlightInformationRequest* msg, std::destroying_delete_t) {
-    SharedDtor(*msg);
-    ::google::protobuf::internal::SizedDelete(msg, sizeof(GetFlightInformationRequest));
-  }
-#endif
-
-  template <typename = void>
-  explicit PROTOBUF_CONSTEXPR GetFlightInformationRequest(
-      ::google::protobuf::internal::ConstantInitialized);
-
-  inline GetFlightInformationRequest(const GetFlightInformationRequest& from) : GetFlightInformationRequest(nullptr, from) {}
-  inline GetFlightInformationRequest(GetFlightInformationRequest&& from) noexcept
-      : GetFlightInformationRequest(nullptr, std::move(from)) {}
-  inline GetFlightInformationRequest& operator=(const GetFlightInformationRequest& from) {
-    CopyFrom(from);
-    return *this;
-  }
-  inline GetFlightInformationRequest& operator=(GetFlightInformationRequest&& from) noexcept {
-    if (this == &from) return *this;
-    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
-      InternalSwap(&from);
-    } else {
-      CopyFrom(from);
-    }
-    return *this;
-  }
-
-  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
-      ABSL_ATTRIBUTE_LIFETIME_BOUND {
-    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
-  }
-  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
-      ABSL_ATTRIBUTE_LIFETIME_BOUND {
-    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
-  }
-
-  static const ::google::protobuf::Descriptor* descriptor() {
-    return GetDescriptor();
-  }
-  static const ::google::protobuf::Descriptor* GetDescriptor() {
-    return default_instance().GetMetadata().descriptor;
-  }
-  static const ::google::protobuf::Reflection* GetReflection() {
-    return default_instance().GetMetadata().reflection;
-  }
-  static const GetFlightInformationRequest& default_instance() {
-    return *internal_default_instance();
-  }
-  static inline const GetFlightInformationRequest* internal_default_instance() {
-    return reinterpret_cast<const GetFlightInformationRequest*>(
-        &_GetFlightInformationRequest_default_instance_);
-  }
-  static constexpr int kIndexInFileMessages = 0;
-  friend void swap(GetFlightInformationRequest& a, GetFlightInformationRequest& b) { a.Swap(&b); }
-  inline void Swap(GetFlightInformationRequest* other) {
-    if (other == this) return;
-    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
-      InternalSwap(other);
-    } else {
-      ::google::protobuf::internal::GenericSwap(this, other);
-    }
-  }
-  void UnsafeArenaSwap(GetFlightInformationRequest* other) {
-    if (other == this) return;
-    ABSL_DCHECK(GetArena() == other->GetArena());
-    InternalSwap(other);
-  }
-
-  // implements Message ----------------------------------------------
-
-  GetFlightInformationRequest* New(::google::protobuf::Arena* arena = nullptr) const {
-    return ::google::protobuf::internal::ZeroFieldsBase::DefaultConstruct<GetFlightInformationRequest>(arena);
-  }
-  using ::google::protobuf::internal::ZeroFieldsBase::CopyFrom;
-  inline void CopyFrom(const GetFlightInformationRequest& from) {
-    ::google::protobuf::internal::ZeroFieldsBase::CopyImpl(*this, from);
-  }
-  using ::google::protobuf::internal::ZeroFieldsBase::MergeFrom;
-  void MergeFrom(const GetFlightInformationRequest& from) {
-    ::google::protobuf::internal::ZeroFieldsBase::MergeImpl(*this, from);
-  }
-
-  public:
-  bool IsInitialized() const {
-    return true;
-  }
- private:
-  template <typename T>
-  friend ::absl::string_view(
-      ::google::protobuf::internal::GetAnyMessageName)();
-  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.info.GetFlightInformationRequest"; }
-
- protected:
-  explicit GetFlightInformationRequest(::google::protobuf::Arena* arena);
-  GetFlightInformationRequest(::google::protobuf::Arena* arena, const GetFlightInformationRequest& from);
-  GetFlightInformationRequest(::google::protobuf::Arena* arena, GetFlightInformationRequest&& from) noexcept
-      : GetFlightInformationRequest(arena) {
-    *this = ::std::move(from);
-  }
-  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
-  static void* PlacementNew_(const void*, void* mem,
-                             ::google::protobuf::Arena* arena);
-  static constexpr auto InternalNewImpl_();
-  static const ::google::protobuf::internal::ClassDataFull _class_data_;
-
- public:
-  ::google::protobuf::Metadata GetMetadata() const;
-  // nested types ----------------------------------------------------
-
-  // accessors -------------------------------------------------------
-  // @@protoc_insertion_point(class_scope:mavsdk.rpc.info.GetFlightInformationRequest)
- private:
-  class _Internal;
-  friend class ::google::protobuf::internal::TcParser;
-  static const ::google::protobuf::internal::TcParseTable<
-      0, 0, 0,
-      0, 2>
-      _table_;
-
-  friend class ::google::protobuf::MessageLite;
-  friend class ::google::protobuf::Arena;
-  template <typename T>
-  friend class ::google::protobuf::Arena::InternalHelper;
-  using InternalArenaConstructable_ = void;
-  using DestructorSkippable_ = void;
-  struct Impl_ {
-    inline explicit constexpr Impl_(
-        ::google::protobuf::internal::ConstantInitialized) noexcept;
-    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
-                          ::google::protobuf::Arena* arena);
-    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
-                          ::google::protobuf::Arena* arena, const Impl_& from,
-                          const GetFlightInformationRequest& from_msg);
-    PROTOBUF_TSAN_DECLARE_MEMBER
-  };
-  friend struct ::TableStruct_info_2finfo_2eproto;
-};
-// -------------------------------------------------------------------
-
 class FlightInfo final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.info.FlightInfo) */ {
@@ -2169,7 +2017,7 @@ class FlightInfo final
     return reinterpret_cast<const FlightInfo*>(
         &_FlightInfo_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 12;
+  static constexpr int kIndexInFileMessages = 10;
   friend void swap(FlightInfo& a, FlightInfo& b) { a.Swap(&b); }
   inline void Swap(FlightInfo* other) {
     if (other == this) return;
@@ -2396,7 +2244,7 @@ class GetVersionResponse final
     return reinterpret_cast<const GetVersionResponse*>(
         &_GetVersionResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 7;
+  static constexpr int kIndexInFileMessages = 5;
   friend void swap(GetVersionResponse& a, GetVersionResponse& b) { a.Swap(&b); }
   inline void Swap(GetVersionResponse* other) {
     if (other == this) return;
@@ -2610,7 +2458,7 @@ class GetSpeedFactorResponse final
     return reinterpret_cast<const GetSpeedFactorResponse*>(
         &_GetSpeedFactorResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 9;
+  static constexpr int kIndexInFileMessages = 7;
   friend void swap(GetSpeedFactorResponse& a, GetSpeedFactorResponse& b) { a.Swap(&b); }
   inline void Swap(GetSpeedFactorResponse* other) {
     if (other == this) return;
@@ -2819,7 +2667,7 @@ class GetProductResponse final
     return reinterpret_cast<const GetProductResponse*>(
         &_GetProductResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 5;
+  static constexpr int kIndexInFileMessages = 3;
   friend void swap(GetProductResponse& a, GetProductResponse& b) { a.Swap(&b); }
   inline void Swap(GetProductResponse* other) {
     if (other == this) return;
@@ -3033,7 +2881,7 @@ class GetIdentificationResponse final
     return reinterpret_cast<const GetIdentificationResponse*>(
         &_GetIdentificationResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 3;
+  static constexpr int kIndexInFileMessages = 1;
   friend void swap(GetIdentificationResponse& a, GetIdentificationResponse& b) { a.Swap(&b); }
   inline void Swap(GetIdentificationResponse* other) {
     if (other == this) return;
@@ -3187,220 +3035,6 @@ class GetIdentificationResponse final
 };
 // -------------------------------------------------------------------
 
-class GetFlightInformationResponse final
-    : public ::google::protobuf::Message
-/* @@protoc_insertion_point(class_definition:mavsdk.rpc.info.GetFlightInformationResponse) */ {
- public:
-  inline GetFlightInformationResponse() : GetFlightInformationResponse(nullptr) {}
-  ~GetFlightInformationResponse() PROTOBUF_FINAL;
-
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-  void operator delete(GetFlightInformationResponse* msg, std::destroying_delete_t) {
-    SharedDtor(*msg);
-    ::google::protobuf::internal::SizedDelete(msg, sizeof(GetFlightInformationResponse));
-  }
-#endif
-
-  template <typename = void>
-  explicit PROTOBUF_CONSTEXPR GetFlightInformationResponse(
-      ::google::protobuf::internal::ConstantInitialized);
-
-  inline GetFlightInformationResponse(const GetFlightInformationResponse& from) : GetFlightInformationResponse(nullptr, from) {}
-  inline GetFlightInformationResponse(GetFlightInformationResponse&& from) noexcept
-      : GetFlightInformationResponse(nullptr, std::move(from)) {}
-  inline GetFlightInformationResponse& operator=(const GetFlightInformationResponse& from) {
-    CopyFrom(from);
-    return *this;
-  }
-  inline GetFlightInformationResponse& operator=(GetFlightInformationResponse&& from) noexcept {
-    if (this == &from) return *this;
-    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
-      InternalSwap(&from);
-    } else {
-      CopyFrom(from);
-    }
-    return *this;
-  }
-
-  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
-      ABSL_ATTRIBUTE_LIFETIME_BOUND {
-    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
-  }
-  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
-      ABSL_ATTRIBUTE_LIFETIME_BOUND {
-    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
-  }
-
-  static const ::google::protobuf::Descriptor* descriptor() {
-    return GetDescriptor();
-  }
-  static const ::google::protobuf::Descriptor* GetDescriptor() {
-    return default_instance().GetMetadata().descriptor;
-  }
-  static const ::google::protobuf::Reflection* GetReflection() {
-    return default_instance().GetMetadata().reflection;
-  }
-  static const GetFlightInformationResponse& default_instance() {
-    return *internal_default_instance();
-  }
-  static inline const GetFlightInformationResponse* internal_default_instance() {
-    return reinterpret_cast<const GetFlightInformationResponse*>(
-        &_GetFlightInformationResponse_default_instance_);
-  }
-  static constexpr int kIndexInFileMessages = 1;
-  friend void swap(GetFlightInformationResponse& a, GetFlightInformationResponse& b) { a.Swap(&b); }
-  inline void Swap(GetFlightInformationResponse* other) {
-    if (other == this) return;
-    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
-      InternalSwap(other);
-    } else {
-      ::google::protobuf::internal::GenericSwap(this, other);
-    }
-  }
-  void UnsafeArenaSwap(GetFlightInformationResponse* other) {
-    if (other == this) return;
-    ABSL_DCHECK(GetArena() == other->GetArena());
-    InternalSwap(other);
-  }
-
-  // implements Message ----------------------------------------------
-
-  GetFlightInformationResponse* New(::google::protobuf::Arena* arena = nullptr) const {
-    return ::google::protobuf::Message::DefaultConstruct<GetFlightInformationResponse>(arena);
-  }
-  using ::google::protobuf::Message::CopyFrom;
-  void CopyFrom(const GetFlightInformationResponse& from);
-  using ::google::protobuf::Message::MergeFrom;
-  void MergeFrom(const GetFlightInformationResponse& from) { GetFlightInformationResponse::MergeImpl(*this, from); }
-
-  private:
-  static void MergeImpl(
-      ::google::protobuf::MessageLite& to_msg,
-      const ::google::protobuf::MessageLite& from_msg);
-
-  public:
-  bool IsInitialized() const {
-    return true;
-  }
-  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
-  #if defined(PROTOBUF_CUSTOM_VTABLE)
-  private:
-  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
-  static ::uint8_t* _InternalSerialize(
-      const MessageLite& msg, ::uint8_t* target,
-      ::google::protobuf::io::EpsCopyOutputStream* stream);
-
-  public:
-  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
-  ::uint8_t* _InternalSerialize(
-      ::uint8_t* target,
-      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
-    return _InternalSerialize(*this, target, stream);
-  }
-  #else   // PROTOBUF_CUSTOM_VTABLE
-  ::size_t ByteSizeLong() const final;
-  ::uint8_t* _InternalSerialize(
-      ::uint8_t* target,
-      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
-  #endif  // PROTOBUF_CUSTOM_VTABLE
-  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
-
-  private:
-  void SharedCtor(::google::protobuf::Arena* arena);
-  static void SharedDtor(MessageLite& self);
-  void InternalSwap(GetFlightInformationResponse* other);
- private:
-  template <typename T>
-  friend ::absl::string_view(
-      ::google::protobuf::internal::GetAnyMessageName)();
-  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.info.GetFlightInformationResponse"; }
-
- protected:
-  explicit GetFlightInformationResponse(::google::protobuf::Arena* arena);
-  GetFlightInformationResponse(::google::protobuf::Arena* arena, const GetFlightInformationResponse& from);
-  GetFlightInformationResponse(::google::protobuf::Arena* arena, GetFlightInformationResponse&& from) noexcept
-      : GetFlightInformationResponse(arena) {
-    *this = ::std::move(from);
-  }
-  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
-  static void* PlacementNew_(const void*, void* mem,
-                             ::google::protobuf::Arena* arena);
-  static constexpr auto InternalNewImpl_();
-  static const ::google::protobuf::internal::ClassDataFull _class_data_;
-
- public:
-  ::google::protobuf::Metadata GetMetadata() const;
-  // nested types ----------------------------------------------------
-
-  // accessors -------------------------------------------------------
-  enum : int {
-    kInfoResultFieldNumber = 1,
-    kFlightInfoFieldNumber = 2,
-  };
-  // .mavsdk.rpc.info.InfoResult info_result = 1;
-  bool has_info_result() const;
-  void clear_info_result() ;
-  const ::mavsdk::rpc::info::InfoResult& info_result() const;
-  PROTOBUF_NODISCARD ::mavsdk::rpc::info::InfoResult* release_info_result();
-  ::mavsdk::rpc::info::InfoResult* mutable_info_result();
-  void set_allocated_info_result(::mavsdk::rpc::info::InfoResult* value);
-  void unsafe_arena_set_allocated_info_result(::mavsdk::rpc::info::InfoResult* value);
-  ::mavsdk::rpc::info::InfoResult* unsafe_arena_release_info_result();
-
-  private:
-  const ::mavsdk::rpc::info::InfoResult& _internal_info_result() const;
-  ::mavsdk::rpc::info::InfoResult* _internal_mutable_info_result();
-
-  public:
-  // .mavsdk.rpc.info.FlightInfo flight_info = 2;
-  bool has_flight_info() const;
-  void clear_flight_info() ;
-  const ::mavsdk::rpc::info::FlightInfo& flight_info() const;
-  PROTOBUF_NODISCARD ::mavsdk::rpc::info::FlightInfo* release_flight_info();
-  ::mavsdk::rpc::info::FlightInfo* mutable_flight_info();
-  void set_allocated_flight_info(::mavsdk::rpc::info::FlightInfo* value);
-  void unsafe_arena_set_allocated_flight_info(::mavsdk::rpc::info::FlightInfo* value);
-  ::mavsdk::rpc::info::FlightInfo* unsafe_arena_release_flight_info();
-
-  private:
-  const ::mavsdk::rpc::info::FlightInfo& _internal_flight_info() const;
-  ::mavsdk::rpc::info::FlightInfo* _internal_mutable_flight_info();
-
-  public:
-  // @@protoc_insertion_point(class_scope:mavsdk.rpc.info.GetFlightInformationResponse)
- private:
-  class _Internal;
-  friend class ::google::protobuf::internal::TcParser;
-  static const ::google::protobuf::internal::TcParseTable<
-      1, 2, 2,
-      0, 2>
-      _table_;
-
-  friend class ::google::protobuf::MessageLite;
-  friend class ::google::protobuf::Arena;
-  template <typename T>
-  friend class ::google::protobuf::Arena::InternalHelper;
-  using InternalArenaConstructable_ = void;
-  using DestructorSkippable_ = void;
-  struct Impl_ {
-    inline explicit constexpr Impl_(
-        ::google::protobuf::internal::ConstantInitialized) noexcept;
-    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
-                          ::google::protobuf::Arena* arena);
-    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
-                          ::google::protobuf::Arena* arena, const Impl_& from,
-                          const GetFlightInformationResponse& from_msg);
-    ::google::protobuf::internal::HasBits<1> _has_bits_;
-    ::google::protobuf::internal::CachedSize _cached_size_;
-    ::mavsdk::rpc::info::InfoResult* info_result_;
-    ::mavsdk::rpc::info::FlightInfo* flight_info_;
-    PROTOBUF_TSAN_DECLARE_MEMBER
-  };
-  union { Impl_ _impl_; };
-  friend struct ::TableStruct_info_2finfo_2eproto;
-};
-// -------------------------------------------------------------------
-
 class FlightInformationResponse final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.info.FlightInformationResponse) */ {
@@ -3461,7 +3095,7 @@ class FlightInformationResponse final
     return reinterpret_cast<const FlightInformationResponse*>(
         &_FlightInformationResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 11;
+  static constexpr int kIndexInFileMessages = 9;
   friend void swap(FlightInformationResponse& a, FlightInformationResponse& b) { a.Swap(&b); }
   inline void Swap(FlightInformationResponse* other) {
     if (other == this) return;
@@ -3609,206 +3243,6 @@ class FlightInformationResponse final
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif  // __GNUC__
-// -------------------------------------------------------------------
-
-// GetFlightInformationRequest
-
-// -------------------------------------------------------------------
-
-// GetFlightInformationResponse
-
-// .mavsdk.rpc.info.InfoResult info_result = 1;
-inline bool GetFlightInformationResponse::has_info_result() const {
-  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
-  PROTOBUF_ASSUME(!value || _impl_.info_result_ != nullptr);
-  return value;
-}
-inline void GetFlightInformationResponse::clear_info_result() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  if (_impl_.info_result_ != nullptr) _impl_.info_result_->Clear();
-  _impl_._has_bits_[0] &= ~0x00000001u;
-}
-inline const ::mavsdk::rpc::info::InfoResult& GetFlightInformationResponse::_internal_info_result() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  const ::mavsdk::rpc::info::InfoResult* p = _impl_.info_result_;
-  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::info::InfoResult&>(::mavsdk::rpc::info::_InfoResult_default_instance_);
-}
-inline const ::mavsdk::rpc::info::InfoResult& GetFlightInformationResponse::info_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.info.GetFlightInformationResponse.info_result)
-  return _internal_info_result();
-}
-inline void GetFlightInformationResponse::unsafe_arena_set_allocated_info_result(::mavsdk::rpc::info::InfoResult* value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  if (GetArena() == nullptr) {
-    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.info_result_);
-  }
-  _impl_.info_result_ = reinterpret_cast<::mavsdk::rpc::info::InfoResult*>(value);
-  if (value != nullptr) {
-    _impl_._has_bits_[0] |= 0x00000001u;
-  } else {
-    _impl_._has_bits_[0] &= ~0x00000001u;
-  }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.info.GetFlightInformationResponse.info_result)
-}
-inline ::mavsdk::rpc::info::InfoResult* GetFlightInformationResponse::release_info_result() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-
-  _impl_._has_bits_[0] &= ~0x00000001u;
-  ::mavsdk::rpc::info::InfoResult* released = _impl_.info_result_;
-  _impl_.info_result_ = nullptr;
-  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
-    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
-    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
-    if (GetArena() == nullptr) {
-      delete old;
-    }
-  } else {
-    if (GetArena() != nullptr) {
-      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
-    }
-  }
-  return released;
-}
-inline ::mavsdk::rpc::info::InfoResult* GetFlightInformationResponse::unsafe_arena_release_info_result() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  // @@protoc_insertion_point(field_release:mavsdk.rpc.info.GetFlightInformationResponse.info_result)
-
-  _impl_._has_bits_[0] &= ~0x00000001u;
-  ::mavsdk::rpc::info::InfoResult* temp = _impl_.info_result_;
-  _impl_.info_result_ = nullptr;
-  return temp;
-}
-inline ::mavsdk::rpc::info::InfoResult* GetFlightInformationResponse::_internal_mutable_info_result() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  if (_impl_.info_result_ == nullptr) {
-    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::info::InfoResult>(GetArena());
-    _impl_.info_result_ = reinterpret_cast<::mavsdk::rpc::info::InfoResult*>(p);
-  }
-  return _impl_.info_result_;
-}
-inline ::mavsdk::rpc::info::InfoResult* GetFlightInformationResponse::mutable_info_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  _impl_._has_bits_[0] |= 0x00000001u;
-  ::mavsdk::rpc::info::InfoResult* _msg = _internal_mutable_info_result();
-  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.info.GetFlightInformationResponse.info_result)
-  return _msg;
-}
-inline void GetFlightInformationResponse::set_allocated_info_result(::mavsdk::rpc::info::InfoResult* value) {
-  ::google::protobuf::Arena* message_arena = GetArena();
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  if (message_arena == nullptr) {
-    delete (_impl_.info_result_);
-  }
-
-  if (value != nullptr) {
-    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
-    if (message_arena != submessage_arena) {
-      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
-    }
-    _impl_._has_bits_[0] |= 0x00000001u;
-  } else {
-    _impl_._has_bits_[0] &= ~0x00000001u;
-  }
-
-  _impl_.info_result_ = reinterpret_cast<::mavsdk::rpc::info::InfoResult*>(value);
-  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.info.GetFlightInformationResponse.info_result)
-}
-
-// .mavsdk.rpc.info.FlightInfo flight_info = 2;
-inline bool GetFlightInformationResponse::has_flight_info() const {
-  bool value = (_impl_._has_bits_[0] & 0x00000002u) != 0;
-  PROTOBUF_ASSUME(!value || _impl_.flight_info_ != nullptr);
-  return value;
-}
-inline void GetFlightInformationResponse::clear_flight_info() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  if (_impl_.flight_info_ != nullptr) _impl_.flight_info_->Clear();
-  _impl_._has_bits_[0] &= ~0x00000002u;
-}
-inline const ::mavsdk::rpc::info::FlightInfo& GetFlightInformationResponse::_internal_flight_info() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  const ::mavsdk::rpc::info::FlightInfo* p = _impl_.flight_info_;
-  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::info::FlightInfo&>(::mavsdk::rpc::info::_FlightInfo_default_instance_);
-}
-inline const ::mavsdk::rpc::info::FlightInfo& GetFlightInformationResponse::flight_info() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_get:mavsdk.rpc.info.GetFlightInformationResponse.flight_info)
-  return _internal_flight_info();
-}
-inline void GetFlightInformationResponse::unsafe_arena_set_allocated_flight_info(::mavsdk::rpc::info::FlightInfo* value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  if (GetArena() == nullptr) {
-    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.flight_info_);
-  }
-  _impl_.flight_info_ = reinterpret_cast<::mavsdk::rpc::info::FlightInfo*>(value);
-  if (value != nullptr) {
-    _impl_._has_bits_[0] |= 0x00000002u;
-  } else {
-    _impl_._has_bits_[0] &= ~0x00000002u;
-  }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.info.GetFlightInformationResponse.flight_info)
-}
-inline ::mavsdk::rpc::info::FlightInfo* GetFlightInformationResponse::release_flight_info() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-
-  _impl_._has_bits_[0] &= ~0x00000002u;
-  ::mavsdk::rpc::info::FlightInfo* released = _impl_.flight_info_;
-  _impl_.flight_info_ = nullptr;
-  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
-    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
-    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
-    if (GetArena() == nullptr) {
-      delete old;
-    }
-  } else {
-    if (GetArena() != nullptr) {
-      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
-    }
-  }
-  return released;
-}
-inline ::mavsdk::rpc::info::FlightInfo* GetFlightInformationResponse::unsafe_arena_release_flight_info() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  // @@protoc_insertion_point(field_release:mavsdk.rpc.info.GetFlightInformationResponse.flight_info)
-
-  _impl_._has_bits_[0] &= ~0x00000002u;
-  ::mavsdk::rpc::info::FlightInfo* temp = _impl_.flight_info_;
-  _impl_.flight_info_ = nullptr;
-  return temp;
-}
-inline ::mavsdk::rpc::info::FlightInfo* GetFlightInformationResponse::_internal_mutable_flight_info() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  if (_impl_.flight_info_ == nullptr) {
-    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::info::FlightInfo>(GetArena());
-    _impl_.flight_info_ = reinterpret_cast<::mavsdk::rpc::info::FlightInfo*>(p);
-  }
-  return _impl_.flight_info_;
-}
-inline ::mavsdk::rpc::info::FlightInfo* GetFlightInformationResponse::mutable_flight_info() ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  _impl_._has_bits_[0] |= 0x00000002u;
-  ::mavsdk::rpc::info::FlightInfo* _msg = _internal_mutable_flight_info();
-  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.info.GetFlightInformationResponse.flight_info)
-  return _msg;
-}
-inline void GetFlightInformationResponse::set_allocated_flight_info(::mavsdk::rpc::info::FlightInfo* value) {
-  ::google::protobuf::Arena* message_arena = GetArena();
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  if (message_arena == nullptr) {
-    delete (_impl_.flight_info_);
-  }
-
-  if (value != nullptr) {
-    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
-    if (message_arena != submessage_arena) {
-      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
-    }
-    _impl_._has_bits_[0] |= 0x00000002u;
-  } else {
-    _impl_._has_bits_[0] &= ~0x00000002u;
-  }
-
-  _impl_.flight_info_ = reinterpret_cast<::mavsdk::rpc::info::FlightInfo*>(value);
-  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.info.GetFlightInformationResponse.flight_info)
-}
-
 // -------------------------------------------------------------------
 
 // GetIdentificationRequest

--- a/cpp/src/mavsdk_server/src/plugins/info/info_service_impl.hpp
+++ b/cpp/src/mavsdk_server/src/plugins/info/info_service_impl.hpp
@@ -389,35 +389,6 @@ public:
 
 
 
-    grpc::Status GetFlightInformation(
-        grpc::ServerContext* /* context */,
-        const rpc::info::GetFlightInformationRequest* /* request */,
-        rpc::info::GetFlightInformationResponse* response) override
-    {
-        if (_lazy_plugin.maybe_plugin() == nullptr) {
-            
-            if (response != nullptr) {
-                auto result = mavsdk::Info::Result::NoSystem;
-                fillResponseWithResult(response, result);
-            }
-            
-            return grpc::Status::OK;
-        }
-
-        
-
-        auto result = _lazy_plugin.maybe_plugin()->get_flight_information();
-
-        if (response != nullptr) {
-            fillResponseWithResult(response, result.first);
-            
-            response->set_allocated_flight_info(translateToRpcFlightInfo(result.second ).release());
-             }
-
-
-        return grpc::Status::OK;
-    }
-
     grpc::Status GetIdentification(
         grpc::ServerContext* /* context */,
         const rpc::info::GetIdentificationRequest* /* request */,

--- a/py/aiomavsdk/aiomavsdk/plugins/info/info.py
+++ b/py/aiomavsdk/aiomavsdk/plugins/info/info.py
@@ -42,23 +42,6 @@ class InfoAsync:
         self._subscription_handles: dict = {}
         self._plugin = Info(system._system)
 
-    async def get_flight_information(self):
-        """
-        Get flight information of the system.
-
-        Returns
-        -------
-        flight_info : FlightInfo
-        Raises
-        ------
-        InfoError
-            If the request fails. The error contains the reason for the failure.
-        """
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(
-            None, lambda: self._plugin.get_flight_information()
-        )
-
     async def get_identification(self):
         """
         Get the identification of the system.

--- a/py/mavsdk/mavsdk/plugins/info/info.py
+++ b/py/mavsdk/mavsdk/plugins/info/info.py
@@ -334,22 +334,6 @@ class Info:
 
         atexit.register(self.destroy)
 
-    def get_flight_information(self):
-        """Get get_flight_information (blocking)"""
-
-        result_out = FlightInfoCStruct()
-
-        result_code = self._lib.mavsdk_info_get_flight_information(
-            self._handle, ctypes.byref(result_out)
-        )
-        result = InfoResult(result_code)
-        if result != InfoResult.SUCCESS:
-            raise Exception(f"get_flight_information failed: {result}")
-
-        py_result = FlightInfo.from_c_struct(result_out)
-        self._lib.mavsdk_info_flight_info_destroy(ctypes.byref(result_out))
-        return py_result
-
     def get_identification(self):
         """Get get_identification (blocking)"""
 
@@ -473,13 +457,6 @@ _cmavsdk_lib.mavsdk_info_product_destroy.restype = None
 _cmavsdk_lib.mavsdk_info_version_destroy.argtypes = [ctypes.POINTER(VersionCStruct)]
 _cmavsdk_lib.mavsdk_info_version_destroy.restype = None
 
-
-_cmavsdk_lib.mavsdk_info_get_flight_information.argtypes = [
-    ctypes.c_void_p,
-    ctypes.POINTER(FlightInfoCStruct),
-]
-
-_cmavsdk_lib.mavsdk_info_get_flight_information.restype = ctypes.c_int
 
 _cmavsdk_lib.mavsdk_info_get_identification.argtypes = [
     ctypes.c_void_p,


### PR DESCRIPTION
Updates the proto submodule to the latest (removes `GetFlightInformation` sync RPC which conflicted with Java codegen), regenerates C++ and C code, fixes style, and regenerates docs.

Proto change: mavlink/MAVSDK-Proto#411