### PR TITLE
Time sync API in Python wrappers

### DIFF
--- a/py/aiomavsdk/aiomavsdk/system.py
+++ b/py/aiomavsdk/aiomavsdk/system.py
@@ -46,6 +46,10 @@ class System:
         """Get system ID."""
         return self._system.get_system_id()
 
+    async def enable_timesync(self) -> None:
+        """Enable time synchronization using the TIMESYNC messages."""
+        self._system.enable_timesync()
+
     # ------------------------------------------------------------------
     # Potentially blocking accessors — offloaded to executor
     # ------------------------------------------------------------------

--- a/py/mavsdk/mavsdk/system.py
+++ b/py/mavsdk/mavsdk/system.py
@@ -60,6 +60,10 @@ class System:
         )
         self._callbacks.append(c_callback)
 
+    def enable_timesync(self) -> None:
+        """Enable time synchronization using the TIMESYNC messages."""
+        self._lib.mavsdk_system_enable_timesync(self._handle)
+
 
 IsConnectedCallback = ctypes.CFUNCTYPE(None, ctypes.c_bool, ctypes.c_void_p)
 


### PR DESCRIPTION
C function `mavsdk_system_enable_timesync()` was defined in `mavsdk/system.py`'s, but was not exposed through the `System` class. Exposed this function as `enable_timesync()` and mirrored functionality in `aiomavsdk` to allow time synchronization to be used from Python scripts.