### PR TITLE
Expose MavLink forwarding options in Python wrappers

### DIFF
--- a/py/aiomavsdk/aiomavsdk/mavsdk.py
+++ b/py/aiomavsdk/aiomavsdk/mavsdk.py
@@ -8,6 +8,7 @@ from mavsdk.mavsdk import Mavsdk as _Mavsdk, Configuration
 from mavsdk.component_type import ComponentType
 from mavsdk.server_component import ServerComponent
 from .system import System
+from .enums import ForwardingOption
 from .exceptions import MavsdkConnectionError
 
 
@@ -61,7 +62,11 @@ class Mavsdk:
     # Potentially blocking calls — offloaded to executor
     # ------------------------------------------------------------------
 
-    async def add_any_connection(self, connection_url: str) -> None:
+    async def add_any_connection(
+        self,
+        connection_url: str,
+        forwarding_option: ForwardingOption = ForwardingOption.OFF,
+    ) -> None:
         """
         Add a connection.
 
@@ -69,6 +74,9 @@ class Mavsdk:
         ----------
         connection_url : str
             Connection URL, e.g. ``"udp://:14540"`` or ``"serial:///dev/ttyUSB0:57600"``.
+
+        forwarding_option : ForwardingOption
+            Enables or disables forwarding. By default, it is disabled.
 
         Raises
         ------
@@ -78,7 +86,9 @@ class Mavsdk:
         loop = asyncio.get_running_loop()
         try:
             await loop.run_in_executor(
-                None, self._mavsdk.add_any_connection_with_handle, connection_url
+                None,
+                self._mavsdk.add_any_connection_with_handle_and_forwarding,
+                *(connection_url, forwarding_option),
             )
         except Exception as e:
             raise MavsdkConnectionError(str(e)) from e

--- a/py/mavsdk/mavsdk/mavsdk.py
+++ b/py/mavsdk/mavsdk/mavsdk.py
@@ -9,6 +9,7 @@ from .cmavsdk_loader import _cmavsdk_lib
 from .connection_result import ConnectionResult
 from .component_type import ComponentType
 from .exceptions import ConnectionError
+from .enums import ForwardingOption
 from .server_component import ServerComponent
 from .system import System
 from .types import (
@@ -101,10 +102,36 @@ class Mavsdk:
         )
         return ConnectionResult(result)
 
+    def add_any_connection_with_forwarding(
+        self, connection_url: str, forwarding_option: ForwardingOption
+    ) -> ConnectionResult:
+        """Add a connection with forwarding option"""
+        result = self._lib.mavsdk_add_any_connection_with_forwarding(
+            self._handle,
+            connection_url.encode("utf-8"),
+            ctypes.c_int(forwarding_option.value),
+        )
+        return ConnectionResult(result)
+
     def add_any_connection_with_handle(self, connection_url: str):
         """Add a connection and get handle"""
         result = self._lib.mavsdk_add_any_connection_with_handle(
             self._handle, connection_url.encode("utf-8")
+        )
+        if result.result != ConnectionResult.SUCCESS:
+            raise ConnectionError(
+                f"Connection failed: {ConnectionResult(result.result).name}"
+            )
+        return result.handle
+
+    def add_any_connection_with_handle_and_forwarding(
+        self, connection_url: str, forwarding_option: ForwardingOption
+    ):
+        """Add a connection with forwarding option and get handle"""
+        result = self._lib.mavsdk_add_any_connection_with_handle_and_forwarding(
+            self._handle,
+            connection_url.encode("utf-8"),
+            ctypes.c_int(forwarding_option.value),
         )
         if result.result != ConnectionResult.SUCCESS:
             raise ConnectionError(
@@ -289,11 +316,27 @@ _cmavsdk_lib.mavsdk_version.restype = ctypes.c_char_p
 _cmavsdk_lib.mavsdk_add_any_connection.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
 _cmavsdk_lib.mavsdk_add_any_connection.restype = ctypes.c_int
 
+_cmavsdk_lib.mavsdk_add_any_connection_with_forwarding.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_char_p,
+    ctypes.c_int,
+]
+_cmavsdk_lib.mavsdk_add_any_connection_with_forwarding.restype = ctypes.c_int
+
 _cmavsdk_lib.mavsdk_add_any_connection_with_handle.argtypes = [
     ctypes.c_void_p,
     ctypes.c_char_p,
 ]
 _cmavsdk_lib.mavsdk_add_any_connection_with_handle.restype = ConnectionResultWithHandle
+
+_cmavsdk_lib.mavsdk_add_any_connection_with_handle_and_forwarding.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_char_p,
+    ctypes.c_int,
+]
+_cmavsdk_lib.mavsdk_add_any_connection_with_handle_and_forwarding.restype = (
+    ConnectionResultWithHandle
+)
 
 _cmavsdk_lib.mavsdk_remove_connection.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
 _cmavsdk_lib.mavsdk_remove_connection.restype = None


### PR DESCRIPTION
Python wrappers do not expose options for MavLink forwarding and only contain unused definitions for `ForwardingOption`s. Extended `py/mavsdk` to import C forwarding-related functions and made use of them in `Mavsdk` class.

`aiomavsdk/mavsdk.py` was also modified to achieve feature parity with `py/mavsdk`. Took some inspiration from MavSDK's C++ API and made use of `forwarding_option` parameter with a default value.