### PR TITLE
core: fix deleting of callback on rapid requests of messages

### DIFF
--- a/cpp/src/mavsdk/core/mavlink_request_message.cpp
+++ b/cpp/src/mavsdk/core/mavlink_request_message.cpp
@@ -34,10 +34,16 @@ void MavlinkRequestMessage::request(
     std::unique_lock<std::mutex> lock(_mutex);
 
     // Cleanup previous requests.
-    for (const auto id : _deferred_message_cleanup) {
-        _message_handler.unregister_one(id, this);
+    bool handler_still_registered = false;
+    for (auto it = _deferred_message_cleanup.begin(); it != _deferred_message_cleanup.end();) {
+        if (*it == message_id) {
+            handler_still_registered = true;
+            it = _deferred_message_cleanup.erase(it);
+        } else {
+            _message_handler.unregister_one(*it, this);
+            it = _deferred_message_cleanup.erase(it);
+        }
     }
-    _deferred_message_cleanup.clear();
 
     // Respond with 'Busy' if already in progress.
     for (auto& item : _work_items) {
@@ -57,11 +63,13 @@ void MavlinkRequestMessage::request(
     // Otherwise, schedule it.
     _work_items.emplace_back(WorkItem{message_id, target_component, callback, param2});
 
-    // Register for message
-    _message_handler.register_one(
-        message_id,
-        [this](const mavlink_message_t& message) { handle_any_message(message); },
-        this);
+    // Register for message ONLY if an active lower-level hook doesn't exist
+    if (!handler_still_registered) {
+        _message_handler.register_one(
+            message_id,
+            [this](const mavlink_message_t& message) { handle_any_message(message); },
+            this);
+    }
 
     // And send off command
     send_request(_work_items.back());

--- a/cpp/src/mavsdk/core/mavlink_request_message.cpp
+++ b/cpp/src/mavsdk/core/mavlink_request_message.cpp
@@ -2,6 +2,7 @@
 #include "log.hpp"
 #include "mavlink_request_message.hpp"
 #include "system_impl.hpp"
+#include <algorithm>
 #include <cstdint>
 #include <string>
 
@@ -25,6 +26,13 @@ MavlinkRequestMessage::MavlinkRequestMessage(
     }
 }
 
+MavlinkRequestMessage::~MavlinkRequestMessage()
+{
+    // The message handler holds callbacks capturing 'this', so make sure none of
+    // them can fire after we are gone.
+    _message_handler.unregister_all_blocking(this);
+}
+
 void MavlinkRequestMessage::request(
     uint32_t message_id,
     uint8_t target_component,
@@ -32,18 +40,6 @@ void MavlinkRequestMessage::request(
     uint32_t param2)
 {
     std::unique_lock<std::mutex> lock(_mutex);
-
-    // Cleanup previous requests.
-    bool handler_still_registered = false;
-    for (auto it = _deferred_message_cleanup.begin(); it != _deferred_message_cleanup.end();) {
-        if (*it == message_id) {
-            handler_still_registered = true;
-            it = _deferred_message_cleanup.erase(it);
-        } else {
-            _message_handler.unregister_one(*it, this);
-            it = _deferred_message_cleanup.erase(it);
-        }
-    }
 
     // Respond with 'Busy' if already in progress.
     for (auto& item : _work_items) {
@@ -63,8 +59,13 @@ void MavlinkRequestMessage::request(
     // Otherwise, schedule it.
     _work_items.emplace_back(WorkItem{message_id, target_component, callback, param2});
 
-    // Register for message ONLY if an active lower-level hook doesn't exist
-    if (!handler_still_registered) {
+    // Register a handler for this message id if we don't have one yet. We keep
+    // it registered for our lifetime; handle_any_message is a no-op when no work
+    // item is waiting, and this avoids the races of registering and
+    // unregistering per request.
+    if (std::find(_registered_message_ids.begin(), _registered_message_ids.end(), message_id) ==
+        _registered_message_ids.end()) {
+        _registered_message_ids.push_back(message_id);
         _message_handler.register_one(
             message_id,
             [this](const mavlink_message_t& message) { handle_any_message(message); },
@@ -227,10 +228,9 @@ void MavlinkRequestMessage::handle_any_message(const mavlink_message_t& message)
         // of the command later, we ignore it, and we fake the result to be successful
         // anyway.
         auto temp_callback = it->callback;
-        // We can now get rid of the entry now.
+        // We can now get rid of the entry now. We keep the message handler
+        // registered for next time.
         _work_items.erase(it);
-        // We have to clean up later outside this callback, otherwise we lock ourselves out.
-        _deferred_message_cleanup.push_back(message.msgid);
         lock.unlock();
 
         if (temp_callback) {
@@ -275,7 +275,6 @@ void MavlinkRequestMessage::handle_command_result(
                 if (++it->retries > RETRIES) {
                     // We have already retried, let's give up.
                     auto temp_callback = it->callback;
-                    _message_handler.unregister_one(it->message_id, this);
                     _work_items.erase(it);
                     lock.unlock();
                     if (temp_callback) {
@@ -298,7 +297,6 @@ void MavlinkRequestMessage::handle_command_result(
                 // It looks like this did not work, and we can report the error
                 // No need to try again.
                 auto temp_callback = it->callback;
-                _message_handler.unregister_one(it->message_id, this);
                 _work_items.erase(it);
                 lock.unlock();
                 if (temp_callback) {
@@ -327,7 +325,6 @@ void MavlinkRequestMessage::handle_timeout(uint32_t message_id, uint8_t target_c
         if (++it->retries > RETRIES) {
             // We have already retried, let's give up.
             auto temp_callback = it->callback;
-            _message_handler.unregister_one(it->message_id, this);
             _work_items.erase(it);
             lock.unlock();
             if (temp_callback) {

--- a/cpp/src/mavsdk/core/mavlink_request_message.hpp
+++ b/cpp/src/mavsdk/core/mavlink_request_message.hpp
@@ -4,6 +4,7 @@
 #include "mavlink_message_handler.hpp"
 #include "timeout_handler.hpp"
 #include "mavlink_include.hpp"
+#include <cstdint>
 #include <functional>
 #include <mutex>
 #include <optional>
@@ -20,6 +21,7 @@ public:
         MavlinkCommandSender& command_sender,
         MavlinkMessageHandler& message_handler,
         TimeoutHandler& timeout_handler);
+    ~MavlinkRequestMessage();
     MavlinkRequestMessage() = delete;
 
     using MavlinkRequestMessageCallback =
@@ -58,7 +60,11 @@ private:
 
     std::mutex _mutex{};
     std::vector<WorkItem> _work_items{};
-    std::vector<int> _deferred_message_cleanup{};
+    // Message ids we have registered a handler for. We register lazily on first
+    // request and keep the handler until destruction, so there is never an
+    // unregister racing a register. This stays tiny (a handful of message ids),
+    // so a flat vector is faster than a node-based set.
+    std::vector<uint32_t> _registered_message_ids{};
 
     bool _debugging{false};
 };

--- a/cpp/src/system_tests/CMakeLists.txt
+++ b/cpp/src/system_tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(system_tests_runner
     telemetry_rc_status.cpp
     geofence_download.cpp
     telemetry_home_position.cpp
+    request_message_rapid.cpp
     fs_helpers.cpp
     ftp_download_file.cpp
     ftp_download_file_burst.cpp

--- a/cpp/src/system_tests/request_message_rapid.cpp
+++ b/cpp/src/system_tests/request_message_rapid.cpp
@@ -4,6 +4,7 @@
 #include "plugins/mavlink_direct/mavlink_direct.hpp"
 #include <atomic>
 #include <chrono>
+#include <memory>
 #include <string>
 #include <thread>
 #include <vector>
@@ -56,12 +57,21 @@ TEST(SystemTest, RequestMessageRapid)
     auto gs_system = mavsdk_autopilot.systems().at(0);
 
     auto telemetry = Telemetry{system};
-    auto autopilot_direct = MavlinkDirect{gs_system};
+    // Held by shared_ptr so the COMMAND_LONG callback (which runs on the
+    // autopilot's user-callback thread, outliving this scope) can hold a
+    // weak_ptr and safely no-op if we have already been torn down.
+    auto autopilot_direct = std::make_shared<MavlinkDirect>(gs_system);
+    std::weak_ptr<MavlinkDirect> autopilot_direct_weak = autopilot_direct;
 
     // The autopilot acks any REQUEST_MESSAGE command so the command queue does
     // not fill up with unacked, retrying commands over many iterations.
-    autopilot_direct.subscribe_message(
-        "COMMAND_LONG", [&autopilot_direct](MavlinkDirect::MavlinkMessage command) {
+    autopilot_direct->subscribe_message(
+        "COMMAND_LONG", [autopilot_direct_weak](MavlinkDirect::MavlinkMessage command) {
+            auto direct = autopilot_direct_weak.lock();
+            if (!direct) {
+                return;
+            }
+
             Json::Value root;
             Json::Reader reader;
             if (!reader.parse(command.fields_json, root)) {
@@ -78,7 +88,7 @@ TEST(SystemTest, RequestMessageRapid)
             ack.fields_json = R"({"command":)" + std::to_string(command_id) +
                               R"(,"result":0,"progress":0,"result_param2":0,)" +
                               R"("target_system":0,"target_component":0})";
-            autopilot_direct.send_message(ack);
+            direct->send_message(ack);
         });
 
     // Stream GPS_GLOBAL_ORIGIN at a high rate. This keeps the ground station's
@@ -96,7 +106,7 @@ TEST(SystemTest, RequestMessageRapid)
     std::atomic<bool> keep_streaming{true};
     std::thread streamer([&]() {
         while (keep_streaming) {
-            autopilot_direct.send_message(gps);
+            autopilot_direct->send_message(gps);
             std::this_thread::sleep_for(std::chrono::microseconds(200));
         }
     });

--- a/cpp/src/system_tests/request_message_rapid.cpp
+++ b/cpp/src/system_tests/request_message_rapid.cpp
@@ -1,0 +1,141 @@
+#include "log.hpp"
+#include "mavsdk.hpp"
+#include "plugins/telemetry/telemetry.hpp"
+#include "plugins/mavlink_direct/mavlink_direct.hpp"
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+#include <vector>
+#include <gtest/gtest.h>
+#include <json/json.h>
+
+using namespace mavsdk;
+
+// Reproduces a race when the same message is requested in rapid succession via
+// MAV_CMD_REQUEST_MESSAGE.
+//
+// MavlinkRequestMessage registers a message handler for each request and defers
+// the corresponding unregister to the next request() call (the unregister can't
+// happen from inside the message handler callback). The deferred unregister
+// removes *all* handler entries for that message id and, in the message handler,
+// deferred registrations are applied before deferred unregistrations. So if a
+// request for a message comes in while a previous unregister for the same id is
+// still deferred -- and the receive thread is holding the message handler mutex
+// (deferring both the unregister and the new register) -- the deferred
+// unregister deletes the handler that the new request just registered. That
+// request then never receives its message and times out.
+//
+// A single sequential requester never hits this: the cleanup runs when no one
+// holds the message handler mutex. To reproduce we hammer the same request from
+// several threads at once while the autopilot streams the response message at a
+// high rate (keeping the ground station receive thread inside process_message,
+// holding the mutex). Note that even a request that ends up returning Busy first
+// runs the cleanup loop, so it too can unregister the in-flight winner's handler.
+//
+// Expected results are only Success (the winning request) or Busy (losing,
+// overlapping requests). The bug shows up as a Timeout.
+TEST(SystemTest, RequestMessageRapid)
+{
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{ComponentType::GroundStation}};
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{ComponentType::Autopilot}};
+
+    ASSERT_EQ(
+        mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:15230"),
+        ConnectionResult::Success);
+    ASSERT_EQ(
+        mavsdk_autopilot.add_any_connection("udpout://127.0.0.1:15230"), ConnectionResult::Success);
+
+    auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
+    ASSERT_TRUE(maybe_system);
+    auto system = maybe_system.value();
+
+    while (mavsdk_autopilot.systems().size() == 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    auto gs_system = mavsdk_autopilot.systems().at(0);
+
+    auto telemetry = Telemetry{system};
+    auto autopilot_direct = MavlinkDirect{gs_system};
+
+    // The autopilot acks any REQUEST_MESSAGE command so the command queue does
+    // not fill up with unacked, retrying commands over many iterations.
+    autopilot_direct.subscribe_message(
+        "COMMAND_LONG", [&autopilot_direct](MavlinkDirect::MavlinkMessage command) {
+            Json::Value root;
+            Json::Reader reader;
+            if (!reader.parse(command.fields_json, root)) {
+                return;
+            }
+            const int command_id = root["command"].asInt();
+
+            MavlinkDirect::MavlinkMessage ack;
+            ack.message_name = "COMMAND_ACK";
+            ack.system_id = 1;
+            ack.component_id = 1;
+            ack.target_system_id = 0;
+            ack.target_component_id = 0;
+            ack.fields_json = R"({"command":)" + std::to_string(command_id) +
+                              R"(,"result":0,"progress":0,"result_param2":0,)" +
+                              R"("target_system":0,"target_component":0})";
+            autopilot_direct.send_message(ack);
+        });
+
+    // Stream GPS_GLOBAL_ORIGIN at a high rate. This keeps the ground station's
+    // receive thread inside process_message (holding the message handler mutex)
+    // and also serves as the response to each request.
+    MavlinkDirect::MavlinkMessage gps;
+    gps.message_name = "GPS_GLOBAL_ORIGIN";
+    gps.system_id = 1;
+    gps.component_id = 1;
+    gps.target_system_id = 0;
+    gps.target_component_id = 0;
+    gps.fields_json =
+        R"({"latitude":473977418,"longitude":85455938,"altitude":488000,"time_usec":0})";
+
+    std::atomic<bool> keep_streaming{true};
+    std::thread streamer([&]() {
+        while (keep_streaming) {
+            autopilot_direct.send_message(gps);
+            std::this_thread::sleep_for(std::chrono::microseconds(200));
+        }
+    });
+
+    // Let discovery and streaming settle.
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    // Hammer the same request from several threads. Stop as soon as any thread
+    // sees an unexpected result (the bug manifests as a Timeout).
+    const unsigned num_threads = 8;
+    const int iterations_per_thread = 1000;
+
+    std::atomic<bool> bad_result{false};
+    std::atomic<int> success_count{0};
+
+    std::vector<std::thread> requesters;
+    for (unsigned t = 0; t < num_threads; ++t) {
+        requesters.emplace_back([&]() {
+            for (int i = 0; i < iterations_per_thread && !bad_result; ++i) {
+                auto result = telemetry.get_gps_global_origin();
+                if (result.first == Telemetry::Result::Success) {
+                    ++success_count;
+                } else if (result.first == Telemetry::Result::Busy) {
+                    // Expected: another request for the same message was in flight.
+                } else {
+                    LogErr("Unexpected result: {}", static_cast<int>(result.first));
+                    bad_result = true;
+                }
+            }
+        });
+    }
+
+    for (auto& requester : requesters) {
+        requester.join();
+    }
+
+    keep_streaming = false;
+    streamer.join();
+
+    EXPECT_FALSE(bad_result) << "A request lost its handler and did not complete.";
+    EXPECT_GT(success_count, 0) << "No request ever succeeded; test did not exercise the path.";
+}


### PR DESCRIPTION
When calling `MavlinkRequestMessage::request()` two times in rapid succession, the second call intermittently ends with a timeout, even though the requested message seems to get delivered. What appears to happen is:
1. Request 1 adds one entry in the `_work_items` list and another in the `_message_handler._table` list
2. On message received, ` MavlinkRequestMessage::handle_any_message()` triggers the user callback
3. `_work_items` entry is removed, and `_message_handler._table` entry is marked as **to-be-removed**
4. Request 2 comes in, and cleanup from previous message is started
5. The old `_message_handler._table` entry is attempted to be removed with calling `_message_handler.unregister_one()`
6. :red_circle: The entry is now **assumed** to be gone, but unregistration was deferred due to handler being busy with other message, and a new entry is added with the same ID, and two identical entries are in `_message_handler._table`
7. On second message received, clean up the handler by removing all entries from `_message_handler._table` which matches `_message_handler._unregister_later_table` (deleting both entries)
8. Look through `_message_handler._table` for callback. Nothing found. Timeout

This change attempts to fix this issue by checking if the requested message is of the same type as an existing entry marked for removal, and if it is, skip the unregister-register step, which is vulnerable to being deleted. 