### PR TITLE
core: fix Android cache directory path null byte handling

### DIFF
--- a/cpp/src/mavsdk/core/fs_utils.cpp
+++ b/cpp/src/mavsdk/core/fs_utils.cpp
@@ -71,11 +71,8 @@ std::optional<std::filesystem::path> get_cache_directory()
     // Read /proc/self/cmdline
     std::ifstream cmdline("/proc/self/cmdline");
     std::string line;
-    if (std::getline(cmdline, line)) {
-        // line might have a trailing \0
-        if (line.length() > 0 && *line.end() == 0) {
-            line.pop_back();
-        }
+    // /proc/self/cmdline stores the package name followed by a NUL byte, which we want to exclude
+    if (std::getline(cmdline, line, '\0')) {
         return "/data/data/" + line + "/mavsdk_cache";
     }
 #elif defined(APPLE) || defined(LINUX)


### PR DESCRIPTION
## Description
On Android, `get_cache_directory()` reads `/proc/self/cmdline` to build the MAVSDK cache path under `/data/data/<package>/mavsdk_cache`.  `/proc/self/cmdline` is NUL-separated.  The current code attempts to strip out the null byte, but does so by de-referencing `line.end()`, which is one byte past the end and undefined. 

This changes the Android path lookup to read only until the first NUL-delimited entry from `/proc/self/cmdline`, so the cache path is built without the embedded null byte.

## Testing
Tested with `mavsdk_server` on Android and verified camera definitions are cached under `/data/data/<package>/mavsdk_cache/...`, and MAVSDK Camera `getCurrentSettings()` no longer returns `UNAVAILABLE`.

## Addresses
https://github.com/mavlink/MAVSDK/issues/2896