### PR TITLE
ci: update Windows CI to Visual Studio 18 2026

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -72,7 +72,7 @@ jobs:
           Expand-Archive -Path jom.zip -DestinationPath "C:\Program Files\jom"
           echo "C:\Program Files\jom" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: configure
-        run: cmake -G"Visual Studio 17 2022" -A ${{ matrix.platform }}
+        run: cmake -G"Visual Studio 18 2026" -A ${{ matrix.platform }}
           $env:superbuild
           $env:cmake_prefix_path
           -DCMAKE_BUILD_TYPE=RelWithDebInfo
@@ -91,7 +91,7 @@ jobs:
         run: |
           $pluginTargets = "$env:GITHUB_WORKSPACE/cpp/build/third_party/install/lib/cmake/grpc/gRPCPluginTargets.cmake"
           if (-not (Test-Path $pluginTargets)) { New-Item $pluginTargets -Force | Out-Null }
-          cmake -G"Visual Studio 17 2022" -A ${{ matrix.platform }} `
+          cmake -G"Visual Studio 18 2026" -A ${{ matrix.platform }} `
             -DCMAKE_INSTALL_PREFIX=build/install `
             "-DCMAKE_PREFIX_PATH=$env:GITHUB_WORKSPACE/cpp/install;$env:GITHUB_WORKSPACE/cpp/build/third_party/install" `
             -DBUILD_SHARED_LIBS=ON `
@@ -186,7 +186,7 @@ jobs:
           Expand-Archive -Path jom.zip -DestinationPath "C:\Program Files\jom"
           echo "C:\Program Files\jom" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: configure
-        run: cmake -G"Visual Studio 17 2022" -A ${{ matrix.platform }}
+        run: cmake -G"Visual Studio 18 2026" -A ${{ matrix.platform }}
           $env:superbuild
           $env:cmake_prefix_path
           -DCMAKE_BUILD_TYPE=${{ matrix.config }}
@@ -265,7 +265,7 @@ jobs:
         run: |
           rem Build examples in Debug configuration
           cd /d %GITHUB_WORKSPACE%
-          cmake -G"Visual Studio 17 2022" -A ${{ matrix.platform }} ^
+          cmake -G"Visual Studio 18 2026" -A ${{ matrix.platform }} ^
             -DCMAKE_BUILD_TYPE=Debug ^
             -DCMAKE_PREFIX_PATH=%GITHUB_WORKSPACE%\cpp\combined ^
             -Bbuild-examples-debug ^
@@ -277,7 +277,7 @@ jobs:
         run: |
           rem Build examples in RelWithDebInfo configuration
           cd /d %GITHUB_WORKSPACE%
-          cmake -G"Visual Studio 17 2022" -A ${{ matrix.platform }} ^
+          cmake -G"Visual Studio 18 2026" -A ${{ matrix.platform }} ^
             -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
             -DCMAKE_PREFIX_PATH=%GITHUB_WORKSPACE%\cpp\combined ^
             -Bbuild-examples-release ^


### PR DESCRIPTION
The `windows-2025` GitHub Actions runner migrated from Visual Studio 2022 (VS 17) to Visual Studio 2026 (VS 18) in June 2026. This broke the Windows CI jobs because `cmake -G"Visual Studio 17 2022"` can no longer find a Visual Studio installation.

## Changes

Replace all 5 occurrences of `"Visual Studio 17 2022"` with `"Visual Studio 18 2026"` in `.github/workflows/windows.yml`.

## References

- [GitHub Actions: windows-latest and windows-2025 migrating to VS 2026 in June 2026](https://github.com/actions/runner-images/issues/14017)
- [CMake Visual Studio 18 2026 generator docs](https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2018%202026.html)