### PR TITLE
core: move hand-rolled thread-safety to the asio executor model

### DIFF
--- a/cpp/src/mavsdk/core/callback_list.hpp
+++ b/cpp/src/mavsdk/core/callback_list.hpp
@@ -9,13 +9,19 @@
 #include "handle.hpp"
 #include "mavsdk_export.h"
 
+// Forward-declared so this header (the public face of the CallbackList pair) does not pull
+// asio in; the full include lives in callback_list_impl.hpp.
+namespace asio {
+class io_context;
+}
+
 namespace mavsdk {
 
 template<typename... Args> class CallbackListImpl;
 
 template<typename... Args> class MAVSDK_PUBLIC CallbackList {
 public:
-    CallbackList();
+    explicit CallbackList(asio::io_context& io_context);
     ~CallbackList();
 
     Handle<Args...> subscribe(const std::function<void(Args...)>& callback);

--- a/cpp/src/mavsdk/core/callback_list.tpp
+++ b/cpp/src/mavsdk/core/callback_list.tpp
@@ -7,12 +7,11 @@
 namespace mavsdk {
 
 template<typename... Args>
-CallbackList<Args...>::CallbackList() :
-    _impl(std::make_unique<CallbackListImpl<Args...>>())
+CallbackList<Args...>::CallbackList(asio::io_context& io_context) :
+    _impl(std::make_unique<CallbackListImpl<Args...>>(io_context))
 {}
 
-template<typename... Args>
-CallbackList<Args...>::~CallbackList() = default;
+template<typename... Args> CallbackList<Args...>::~CallbackList() = default;
 
 template<typename... Args>
 Handle<Args...> CallbackList<Args...>::subscribe(const std::function<void(Args...)>& callback)
@@ -46,7 +45,9 @@ template<typename... Args> void CallbackList<Args...>::clear()
     _impl->clear();
 }
 
-template<typename... Args> void CallbackList<Args...>::queue(Args... args, const std::function<void(const std::function<void()>&)>& queue_func)
+template<typename... Args>
+void CallbackList<Args...>::queue(
+    Args... args, const std::function<void(const std::function<void()>&)>& queue_func)
 {
     _impl->queue(args..., queue_func);
 }

--- a/cpp/src/mavsdk/core/callback_list_impl.hpp
+++ b/cpp/src/mavsdk/core/callback_list_impl.hpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <functional>
 #include <future>
+#include <memory>
 #include <utility>
 #include <vector>
 #include <asio/io_context.hpp>
@@ -20,16 +21,21 @@ namespace mavsdk {
 // - exec()/queue() iterate the list; they run inline when already on the io thread (the
 //   common case, driven by received-message handlers and timers) and otherwise post the
 //   access and wait for it.
-// - subscribe()/subscribe_conditional() post their insertion onto the io_context. The
-//   handle is created and returned synchronously (the handle factory is thread-safe); the
-//   list insertion lands on the next io turn.
-// - unsubscribe()/clear() mutate the list. They post the mutation rather than running it
-//   inline so they never mutate the list while exec() is iterating it (which is what makes
-//   it safe to unsubscribe from inside a callback). When called off the io thread they wait
-//   until the mutation has been applied, so no callback can fire afterwards.
+// - subscribe()/subscribe_conditional()/unsubscribe()/clear() post their list mutation
+//   without waiting. Posting (rather than running inline) means they never mutate the list
+//   while exec() is iterating it, so it is safe to (un)subscribe from inside a callback; not
+//   waiting means they never block, so it is also safe to call them while holding a lock (a
+//   blocking round-trip onto the io thread would deadlock if the io thread needed that same
+//   lock). The mutation lands on the next io turn.
+//
+// The list is owned by a plugin, which the user may destroy while the io thread is still
+// running. The posted mutations capture `this`, so the destructor waits (once) for the
+// io_context to flush any that are still queued before the list is torn down.
 template<typename... Args> class CallbackListImpl {
 public:
     explicit CallbackListImpl(asio::io_context& io_context) : _io_context(io_context) {}
+
+    ~CallbackListImpl() { drain(); }
 
     Handle<Args...> subscribe(const std::function<void(Args...)>& callback)
     {
@@ -38,7 +44,7 @@ public:
         auto handle = _handle_factory.create();
 
         if (callback != nullptr) {
-            asio::post(_io_context, [this, handle, callback]() {
+            post_mutation([this, handle, callback]() {
                 _list.emplace_back(handle, callback);
                 update_size();
             });
@@ -54,7 +60,7 @@ public:
     void subscribe_conditional(const std::function<bool(Args...)>& callback)
     {
         if (callback != nullptr) {
-            asio::post(_io_context, [this, callback]() {
+            post_mutation([this, callback]() {
                 _cond_cb_list.emplace_back(callback);
                 update_size();
             });
@@ -71,7 +77,7 @@ public:
             return;
         }
 
-        mutate_on_io([this, handle]() {
+        post_mutation([this, handle]() {
             _list.erase(
                 std::remove_if(
                     _list.begin(), _list.end(), [&](auto& pair) { return pair.first == handle; }),
@@ -113,7 +119,7 @@ public:
 
     void clear()
     {
-        mutate_on_io([this]() {
+        post_mutation([this]() {
             _list.clear();
             _cond_cb_list.clear();
             update_size();
@@ -129,8 +135,10 @@ private:
 
     bool on_io_thread() const { return _io_context.get_executor().running_in_this_thread(); }
 
-    // Run a list read/iteration on the io thread: inline when already there, otherwise
-    // posted and waited for. Safe to run inline because reads don't mutate the list.
+    // Run a list read/iteration on the io thread: inline when already there, otherwise posted
+    // and waited for. Safe to run inline because reads don't mutate the list, and safe to
+    // capture by reference because we block until the posted access has run (which also keeps
+    // the arguments, e.g. a borrowed buffer, alive for the duration).
     template<typename Func> void read_on_io(Func&& func)
     {
         if (_io_context.stopped() || on_io_thread()) {
@@ -145,25 +153,30 @@ private:
         done.get_future().wait();
     }
 
-    // Run a list mutation on the io thread. Never inline: if we are on the io thread we may
-    // be inside an exec() iteration, so the mutation is posted to run after it. Off the io
-    // thread we post and wait so the mutation has been applied by the time we return.
-    template<typename Func> void mutate_on_io(Func&& func)
+    // Post a list mutation onto the io thread, without waiting (see the class comment). When
+    // the io_context is already stopped (teardown) the io thread is gone, so we apply the
+    // mutation directly.
+    template<typename Func> void post_mutation(Func&& func)
     {
         if (_io_context.stopped()) {
-            // The io thread is gone (teardown); accessing the list directly is safe.
             func();
             return;
         }
-        if (on_io_thread()) {
-            asio::post(_io_context, std::forward<Func>(func));
+        asio::post(_io_context, std::forward<Func>(func));
+    }
+
+    // Wait until the io_context has run every mutation posted so far. Used by the destructor:
+    // the posted mutations capture `this`, so they must not outlive the object. If the
+    // io_context is stopped the io thread is gone and nothing will run; if we are on the io
+    // thread we cannot wait on ourselves (and this would only happen if a callback destroyed
+    // its own list, which we don't support).
+    void drain()
+    {
+        if (_io_context.stopped() || on_io_thread()) {
             return;
         }
         std::promise<void> done;
-        asio::post(_io_context, [&]() {
-            func();
-            done.set_value();
-        });
+        asio::post(_io_context, [&done]() { done.set_value(); });
         done.get_future().wait();
     }
 

--- a/cpp/src/mavsdk/core/callback_list_impl.hpp
+++ b/cpp/src/mavsdk/core/callback_list_impl.hpp
@@ -18,8 +18,11 @@ namespace mavsdk {
 // Threading: the callback list is only ever touched on the io_context thread.
 //
 // - exec()/queue() iterate the list; they run inline when already on the io thread (the
-//   common case, driven by received-message handlers and timers) and otherwise post the
-//   access and wait for it.
+//   common case, driven by received-message handlers and timers). Off it, queue() posts the
+//   access without waiting (it only hands callbacks to a queue, so it need not be
+//   synchronous), while exec() posts and waits (it invokes the callbacks directly, so the
+//   caller's arguments must stay alive until they have run). exec() must therefore not be
+//   called off the io thread while holding a lock that the io thread needs.
 // - subscribe()/subscribe_conditional()/unsubscribe()/clear() post their list mutation
 //   without waiting. Posting (rather than running inline) means they never mutate the list
 //   while exec() is iterating it, so it is safe to (un)subscribe from inside a callback; not
@@ -107,7 +110,17 @@ public:
 
     void queue(Args... args, const std::function<void(const std::function<void()>&)>& queue_func)
     {
-        read_on_io([&]() {
+        // queue() only hands the callbacks to queue_func (which enqueues them to run later), so
+        // unlike exec() it never needs to run synchronously. Posting it without waiting (rather
+        // than blocking on the io thread) means it is safe to call while holding a lock that the
+        // io thread also needs -- a blocking round-trip there would deadlock.
+        if (_io_context.stopped() || on_io_thread()) {
+            for (const auto& pair : _list) {
+                queue_func([callback = pair.second, args...]() { callback(args...); });
+            }
+            return;
+        }
+        asio::post(_io_context, [this, args..., queue_func]() {
             for (const auto& pair : _list) {
                 queue_func([callback = pair.second, args...]() { callback(args...); });
             }

--- a/cpp/src/mavsdk/core/callback_list_impl.hpp
+++ b/cpp/src/mavsdk/core/callback_list_impl.hpp
@@ -5,7 +5,6 @@
 #include <cstddef>
 #include <functional>
 #include <future>
-#include <memory>
 #include <utility>
 #include <vector>
 #include <asio/io_context.hpp>

--- a/cpp/src/mavsdk/core/callback_list_impl.hpp
+++ b/cpp/src/mavsdk/core/callback_list_impl.hpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cassert>
 #include <cstddef>
 #include <functional>
 #include <future>
@@ -151,6 +152,12 @@ private:
     // and waited for. Safe to run inline because reads don't mutate the list, and safe to
     // capture by reference because we block until the posted access has run (which also keeps
     // the arguments, e.g. a borrowed buffer, alive for the duration).
+    //
+    // Waiting relies on the io_context staying alive and running: it is only stopped in
+    // ~MavsdkImpl, after which the stopped() fast path applies. The stopped() check is not
+    // synchronized with that teardown, so using or destroying a plugin concurrently with the
+    // Mavsdk instance itself is not supported -- the posted access could then never run and
+    // this wait would hang. The same applies to drain() below.
     template<typename Func> void read_on_io(Func&& func)
     {
         if (_io_context.stopped() || on_io_thread()) {
@@ -184,7 +191,14 @@ private:
     // its own list, which we don't support).
     void drain()
     {
-        if (_io_context.stopped() || on_io_thread()) {
+        if (_io_context.stopped()) {
+            return;
+        }
+        // Destroying the list from the io thread (i.e. from within a callback) is not
+        // supported: we cannot wait on ourselves, and any still-queued mutations capturing
+        // `this` would then run after the list is gone.
+        assert(!on_io_thread());
+        if (on_io_thread()) {
             return;
         }
         std::promise<void> done;

--- a/cpp/src/mavsdk/core/callback_list_impl.hpp
+++ b/cpp/src/mavsdk/core/callback_list_impl.hpp
@@ -1,49 +1,66 @@
 #pragma once
 
 #include <algorithm>
-#include <cstdint>
-#include <functional>
 #include <atomic>
-#include <memory>
-#include <mutex>
+#include <cstddef>
+#include <functional>
+#include <future>
 #include <utility>
 #include <vector>
+#include <asio/io_context.hpp>
+#include <asio/post.hpp>
 #include "log.hpp"
 #include "callback_list.hpp"
 #include "handle_factory.hpp"
 
 namespace mavsdk {
 
+// Threading: the callback list is only ever touched on the io_context thread.
+//
+// - exec()/queue() iterate the list; they run inline when already on the io thread (the
+//   common case, driven by received-message handlers and timers) and otherwise post the
+//   access and wait for it.
+// - subscribe()/subscribe_conditional() post their insertion onto the io_context. The
+//   handle is created and returned synchronously (the handle factory is thread-safe); the
+//   list insertion lands on the next io turn.
+// - unsubscribe()/clear() mutate the list. They post the mutation rather than running it
+//   inline so they never mutate the list while exec() is iterating it (which is what makes
+//   it safe to unsubscribe from inside a callback). When called off the io thread they wait
+//   until the mutation has been applied, so no callback can fire afterwards.
 template<typename... Args> class CallbackListImpl {
 public:
+    explicit CallbackListImpl(asio::io_context& io_context) : _io_context(io_context) {}
+
     Handle<Args...> subscribe(const std::function<void(Args...)>& callback)
     {
-        check_removals();
-        process_subscriptions();
-
-        // We need to return a handle, even if the callback is nullptr to
-        // unsubscribe. That's fine, the handle just won't remove anything
-        // when/if used later.
+        // The handle factory is thread-safe, so hand out the handle synchronously and
+        // apply the actual insertion on the io thread.
         auto handle = _handle_factory.create();
 
         if (callback != nullptr) {
-            if (_mutex.try_lock()) {
-                // We've acquired the lock without blocking, so we can modify the list.
+            asio::post(_io_context, [this, handle, callback]() {
                 _list.emplace_back(handle, callback);
-                _mutex.unlock();
-            } else {
-                // We couldn't acquire the lock because we're likely in a callback.
-                // Defer the subscription.
-                std::lock_guard<std::mutex> lock(_subscribe_later_mutex);
-                _subscribe_later.emplace_back(handle, callback);
-            }
+                update_size();
+            });
         } else {
             LogErr("Use new unsubscribe methods instead of subscribe(nullptr). "
                    "See: https://mavsdk.mavlink.io/main/en/cpp/api_changes.html#unsubscribe");
-            try_clear();
+            clear();
         }
 
         return handle;
+    }
+
+    void subscribe_conditional(const std::function<bool(Args...)>& callback)
+    {
+        if (callback != nullptr) {
+            asio::post(_io_context, [this, callback]() {
+                _cond_cb_list.emplace_back(callback);
+                update_size();
+            });
+        } else {
+            clear();
+        }
     }
 
     void unsubscribe(Handle<Args...> handle)
@@ -54,178 +71,107 @@ public:
             return;
         }
 
-        // We want to allow unsubscribing while in a callback. This would
-        // normally lead to a deadlock. Therefore, we just try to grab the
-        // lock here, and if it's already taken, we schedule the removal
-        // for later.
-        std::unique_lock<std::mutex> lock(_mutex, std::try_to_lock);
-        if (lock.owns_lock()) {
+        mutate_on_io([this, handle]() {
             _list.erase(
                 std::remove_if(
                     _list.begin(), _list.end(), [&](auto& pair) { return pair.first == handle; }),
                 _list.end());
-        } else {
-            std::lock_guard<std::mutex> remove_later_lock(_remove_later_mutex);
-            _remove_later.push_back(handle);
-        }
-
-        // check and remove from deferred lock list if present
-        std::lock_guard<std::mutex> later_lock(_subscribe_later_mutex);
-        _subscribe_later.erase(
-            std::remove_if(
-                _subscribe_later.begin(),
-                _subscribe_later.end(),
-                [&](const auto& pair) { return pair.first == handle; }),
-            _subscribe_later.end());
-    }
-
-    /**
-     * @brief Subscribe a new conditional callback to the list. Conditional callbacks
-     * automatically unsubscribe if the callback evaluates to true, so the user does not
-     * have to manage a handle for 'one-shot' callbacks.
-     *
-     * @param callback The callback function to subscribe.
-     * @return void Since removal is handled internally, we dont need to expose the Handle.
-     */
-    void subscribe_conditional(const std::function<bool(Args...)>& callback)
-    {
-        check_removals();
-        process_subscriptions();
-
-        if (callback != nullptr) {
-            if (_mutex.try_lock()) {
-                _cond_cb_list.emplace_back(callback);
-                _mutex.unlock();
-            } else {
-                // We couldn't acquire the lock because we're likely in a callback.
-                // Defer the subscription.
-                std::lock_guard<std::mutex> lock(_subscribe_later_mutex);
-                _subscribe_later_cond.emplace_back(callback);
-            }
-        } else {
-            try_clear();
-        }
+            update_size();
+        });
     }
 
     void exec(Args... args)
     {
-        check_removals();
-        process_subscriptions();
-
-        std::lock_guard<std::mutex> lock(_mutex);
-        for (const auto& pair : _list) {
-            pair.second(args...);
-        }
-
-        for (auto it = _cond_cb_list.begin(); it != _cond_cb_list.end();) {
-            if ((*it)(args...)) {
-                // If the callback returns true, remove it based on the iterator
-                it = _cond_cb_list.erase(it);
-            } else {
-                // Otherwise, move to the next element
-                ++it;
+        read_on_io([&]() {
+            for (const auto& pair : _list) {
+                pair.second(args...);
             }
-        }
+
+            for (auto it = _cond_cb_list.begin(); it != _cond_cb_list.end();) {
+                if ((*it)(args...)) {
+                    // If the callback returns true, remove it based on the iterator.
+                    it = _cond_cb_list.erase(it);
+                } else {
+                    // Otherwise, move to the next element.
+                    ++it;
+                }
+            }
+            update_size();
+        });
     }
 
     void queue(Args... args, const std::function<void(const std::function<void()>&)>& queue_func)
     {
-        check_removals();
-        process_subscriptions();
-
-        std::lock_guard<std::mutex> lock(_mutex);
-
-        for (const auto& pair : _list) {
-            queue_func([callback = pair.second, args...]() { callback(args...); });
-        }
+        read_on_io([&]() {
+            for (const auto& pair : _list) {
+                queue_func([callback = pair.second, args...]() { callback(args...); });
+            }
+        });
     }
 
-    bool empty()
-    {
-        check_removals();
-        process_subscriptions();
-
-        std::lock_guard<std::mutex> lock(_mutex);
-        return _list.empty() && _cond_cb_list.empty();
-    }
+    bool empty() { return _size.load(std::memory_order_acquire) == 0; }
 
     void clear()
     {
-        std::lock_guard<std::mutex> lock(_mutex);
-        _list.clear();
-        _cond_cb_list.clear();
+        mutate_on_io([this]() {
+            _list.clear();
+            _cond_cb_list.clear();
+            update_size();
+        });
     }
 
 private:
-    void check_removals()
+    // Always called on the io thread, where the list is mutated.
+    void update_size()
     {
-        std::lock_guard<std::mutex> remove_later_lock(_remove_later_mutex);
-
-        // We could probably just grab the lock here, but it's safer not to
-        // acquire both locks to avoid deadlocks.
-        if (_mutex.try_lock()) {
-            if (_remove_all_later) {
-                _remove_all_later = false;
-                _list.clear();
-                _cond_cb_list.clear();
-                _remove_later.clear();
-            }
-
-            for (const auto& handle : _remove_later) {
-                _list.erase(
-                    std::remove_if(
-                        _list.begin(),
-                        _list.end(),
-                        [&](auto& pair) { return pair.first == handle; }),
-                    _list.end());
-            }
-            _mutex.unlock();
-        }
+        _size.store(_list.size() + _cond_cb_list.size(), std::memory_order_release);
     }
 
-    void process_subscriptions()
+    bool on_io_thread() const { return _io_context.get_executor().running_in_this_thread(); }
+
+    // Run a list read/iteration on the io thread: inline when already there, otherwise
+    // posted and waited for. Safe to run inline because reads don't mutate the list.
+    template<typename Func> void read_on_io(Func&& func)
     {
-        std::lock_guard<std::mutex> subscribe_later_lock(_subscribe_later_mutex);
-
-        if (_mutex.try_lock()) {
-            for (const auto& sub : _subscribe_later) {
-                _list.emplace_back(sub);
-            }
-            _subscribe_later.clear();
-
-            // add conditional callbacks
-            for (const auto& sub : _subscribe_later_cond) {
-                _cond_cb_list.emplace_back(sub);
-            }
-            _subscribe_later_cond.clear();
-            _mutex.unlock();
+        if (_io_context.stopped() || on_io_thread()) {
+            func();
+            return;
         }
+        std::promise<void> done;
+        asio::post(_io_context, [&]() {
+            func();
+            done.set_value();
+        });
+        done.get_future().wait();
     }
 
-    void try_clear()
+    // Run a list mutation on the io thread. Never inline: if we are on the io thread we may
+    // be inside an exec() iteration, so the mutation is posted to run after it. Off the io
+    // thread we post and wait so the mutation has been applied by the time we return.
+    template<typename Func> void mutate_on_io(Func&& func)
     {
-        std::unique_lock<std::mutex> lock(_mutex, std::try_to_lock);
-        if (lock.owns_lock()) {
-            _list.clear();
-        } else {
-            std::lock_guard<std::mutex> remove_later_lock(_remove_later_mutex);
-            _remove_all_later = true;
+        if (_io_context.stopped()) {
+            // The io thread is gone (teardown); accessing the list directly is safe.
+            func();
+            return;
         }
+        if (on_io_thread()) {
+            asio::post(_io_context, std::forward<Func>(func));
+            return;
+        }
+        std::promise<void> done;
+        asio::post(_io_context, [&]() {
+            func();
+            done.set_value();
+        });
+        done.get_future().wait();
     }
 
-    mutable std::mutex _mutex{};
+    asio::io_context& _io_context;
     HandleFactory<Args...> _handle_factory;
     std::vector<std::pair<Handle<Args...>, std::function<void(Args...)>>> _list{};
     std::vector<std::function<bool(Args...)>> _cond_cb_list{};
-
-    mutable std::mutex _remove_later_mutex{};
-    std::vector<Handle<Args...>> _remove_later{};
-
-    std::mutex _subscribe_later_mutex;
-    std::vector<std::pair<Handle<Args...>, std::function<void(Args...)>>> _subscribe_later;
-    std::vector<std::function<bool(Args...)>> _subscribe_later_cond;
-
-    bool _remove_all_later{false};
+    std::atomic<std::size_t> _size{0};
 };
 
 } // namespace mavsdk

--- a/cpp/src/mavsdk/core/callback_list_test.cpp
+++ b/cpp/src/mavsdk/core/callback_list_test.cpp
@@ -12,6 +12,8 @@
 #include <optional>
 #include <memory>
 #include <vector>
+#include <asio/executor_work_guard.hpp>
+#include <asio/io_context.hpp>
 #include <gtest/gtest.h>
 
 #include "callback_list.hpp"
@@ -27,13 +29,37 @@ template class CallbackList<>;
 } // namespace mavsdk
 
 using namespace mavsdk;
-TEST(CallbackList, SubscribeCallUnsubscribe)
+
+// CallbackList now confines its list to an io_context: subscribe/unsubscribe post their
+// mutation, and exec()/queue() run on the io thread. The fixture runs the io_context on a
+// background thread so that the (synchronous) test calls behave as they would in the SDK.
+class CallbackListTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        _thread = std::thread([this]() { _io_context.run(); });
+    }
+
+    void TearDown() override
+    {
+        _work_guard.reset();
+        _io_context.stop();
+        _thread.join();
+    }
+
+    asio::io_context _io_context{};
+    asio::executor_work_guard<asio::io_context::executor_type> _work_guard{
+        _io_context.get_executor()};
+    std::thread _thread;
+};
+
+TEST_F(CallbackListTest, SubscribeCallUnsubscribe)
 {
     unsigned first_called = 0;
     unsigned second_called = 0;
     unsigned conditional_called = 0;
 
-    CallbackList<int, double> cl;
+    CallbackList<int, double> cl{_io_context};
     auto first_handle = cl.subscribe([&](int i, double d) {
         ++first_called;
         EXPECT_GE(i, 42);
@@ -107,11 +133,11 @@ TEST(CallbackList, SubscribeCallUnsubscribe)
     EXPECT_TRUE(cl.empty());
 }
 
-TEST(CallbackList, UnsubscribeFromCallback)
+TEST_F(CallbackListTest, UnsubscribeFromCallback)
 {
     unsigned called = 0;
 
-    CallbackList<> cl;
+    CallbackList<> cl{_io_context};
     Handle<> handle = cl.subscribe([&]() {
         cl.unsubscribe(handle);
         ++called;
@@ -123,13 +149,13 @@ TEST(CallbackList, UnsubscribeFromCallback)
     EXPECT_EQ(called, 1);
 }
 
-TEST(CallbackList, UnsubscribeAllWithNullptr)
+TEST_F(CallbackListTest, UnsubscribeAllWithNullptr)
 {
     // This is to deal with the previous API where nullptr would
     // unsubscribe the callback.
     unsigned num_called = 0;
 
-    CallbackList<> cl;
+    CallbackList<> cl{_io_context};
     cl.subscribe([&]() { ++num_called; });
 
     // Call once.
@@ -145,14 +171,14 @@ TEST(CallbackList, UnsubscribeAllWithNullptr)
     EXPECT_EQ(num_called, 1);
 }
 
-TEST(CallbackList, UnsubscribeAllWithClear)
+TEST_F(CallbackListTest, UnsubscribeAllWithClear)
 {
     // This is to deal with the previous API where nullptr would
     // unsubscribe the callback.
     unsigned num_called = 0;
     unsigned num_called_other = 0;
 
-    CallbackList<> cl;
+    CallbackList<> cl{_io_context};
     cl.subscribe([&]() { ++num_called; });
     cl.subscribe([&]() { ++num_called_other; });
 
@@ -170,7 +196,7 @@ TEST(CallbackList, UnsubscribeAllWithClear)
     EXPECT_EQ(num_called_other, 1);
 }
 
-TEST(CallbackList, SubscribeAndUnsubscribeWithinCallbacks)
+TEST_F(CallbackListTest, SubscribeAndUnsubscribeWithinCallbacks)
 {
     const int test_value1 = 42;
     const double test_value2 = 3.14;
@@ -178,7 +204,7 @@ TEST(CallbackList, SubscribeAndUnsubscribeWithinCallbacks)
     std::atomic<int> callback_count{0};
     std::atomic<int> nested_callback_count{0};
 
-    CallbackList<int, double> cl;
+    CallbackList<int, double> cl{_io_context};
 
     // Lambda function for subscribing within a callback
     auto subscribeCallback = [test_value1, test_value2, unsub_value, &nested_callback_count, &cl](
@@ -239,13 +265,13 @@ TEST(CallbackList, SubscribeAndUnsubscribeWithinCallbacks)
     EXPECT_TRUE(cl.empty());
 }
 
-TEST(CallbackList, SubscribeAndUnsubscribeWithinCallbacks2)
+TEST_F(CallbackListTest, SubscribeAndUnsubscribeWithinCallbacks2)
 {
     const int test_value1 = 42;
     const double test_value2 = 3.14;
     const int thread_count = 50000;
     std::atomic<int> nested_callback_count{0};
-    CallbackList<int, double> cl;
+    CallbackList<int, double> cl{_io_context};
 
     // Define the vector type
     using HandleType = Handle<int, double>;

--- a/cpp/src/mavsdk/core/callback_list_test.cpp
+++ b/cpp/src/mavsdk/core/callback_list_test.cpp
@@ -6,6 +6,7 @@
 #endif
 
 #include <atomic>
+#include <future>
 #include <mutex>
 #include <thread>
 #include <set>
@@ -45,6 +46,16 @@ protected:
         _work_guard.reset();
         _io_context.stop();
         _thread.join();
+    }
+
+    // Wait until the io_context has run everything posted so far. subscribe/unsubscribe are
+    // applied on the io thread, so a deferred (un)subscribe made from inside a callback is
+    // only observable via empty() after a round-trip.
+    void flush()
+    {
+        std::promise<void> done;
+        asio::post(_io_context, [&done]() { done.set_value(); });
+        done.get_future().wait();
     }
 
     asio::io_context _io_context{};
@@ -130,6 +141,7 @@ TEST_F(CallbackListTest, SubscribeCallUnsubscribe)
     EXPECT_EQ(conditional_called, 4);
 
     // Both handles are manually removed and conditional callback is autoremoved
+    flush();
     EXPECT_TRUE(cl.empty());
 }
 
@@ -261,7 +273,8 @@ TEST_F(CallbackListTest, SubscribeAndUnsubscribeWithinCallbacks)
     EXPECT_EQ(callback_count, 3);
     EXPECT_EQ(nested_callback_count, 4);
 
-    // List is now empty
+    // List is now empty (after the deferred in-callback unsubscribe has been applied).
+    flush();
     EXPECT_TRUE(cl.empty());
 }
 

--- a/cpp/src/mavsdk/core/mavlink_component_metadata.cpp
+++ b/cpp/src/mavsdk/core/mavlink_component_metadata.cpp
@@ -21,7 +21,8 @@ namespace mavsdk {
 namespace fs = std::filesystem;
 
 MavlinkComponentMetadata::MavlinkComponentMetadata(SystemImpl& system_impl) :
-    _system_impl(system_impl)
+    _system_impl(system_impl),
+    _notification_callbacks(system_impl.io_context())
 {
     if (const char* env_p = std::getenv("MAVSDK_COMPONENT_METADATA_DEBUGGING")) {
         if (std::string(env_p) == "1") {

--- a/cpp/src/mavsdk/core/mavlink_component_metadata.cpp
+++ b/cpp/src/mavsdk/core/mavlink_component_metadata.cpp
@@ -312,7 +312,6 @@ void MavlinkComponentMetadata::handle_metadata_type_completed(
     if (component.json_metadata()) {
         auto metadata_type = get_metadata_type(type);
         if (metadata_type) {
-            const std::lock_guard lg_callbacks{_notification_callbacks_mutex};
             _notification_callbacks.queue(
                 MetadataUpdate{compid, metadata_type.value(), component.json_metadata().value()},
                 [this](const auto& func) { _system_impl.call_user_callback(func); });
@@ -466,14 +465,12 @@ void MavlinkComponentMetadata::parse_component_metadata_general(
 }
 void MavlinkComponentMetadata::unsubscribe_metadata_available(MetadataAvailableHandle handle)
 {
-    const std::lock_guard lg{_notification_callbacks_mutex};
     _notification_callbacks.unsubscribe(handle);
 }
 MavlinkComponentMetadata::MetadataAvailableHandle
 MavlinkComponentMetadata::subscribe_metadata_available(const MetadataAvailableCallback& callback)
 {
     const std::lock_guard lg_components{_mavlink_components_mutex}; // Take this mutex first
-    const std::lock_guard lg_callbacks{_notification_callbacks_mutex};
     const auto handle = _notification_callbacks.subscribe(callback);
 
     // Immediately call the callback for all already existing metadata (with the mutexes locked)
@@ -500,7 +497,6 @@ MavlinkComponentMetadata::subscribe_metadata_available(const MetadataAvailableCa
 
 void MavlinkComponentMetadata::on_all_types_completed(uint8_t compid)
 {
-    const std::lock_guard lg_callbacks{_notification_callbacks_mutex};
     _notification_callbacks.queue(
         MetadataUpdate{compid, MetadataType::AllCompleted, ""},
         [this](const auto& func) { _system_impl.call_user_callback(func); });

--- a/cpp/src/mavsdk/core/mavlink_component_metadata.hpp
+++ b/cpp/src/mavsdk/core/mavlink_component_metadata.hpp
@@ -156,7 +156,6 @@ private:
 
     SystemImpl& _system_impl;
 
-    std::mutex _notification_callbacks_mutex{}; ///< Protects access to _notification_callbacks
     CallbackList<MetadataUpdate> _notification_callbacks;
 
     const std::optional<std::string>

--- a/cpp/src/mavsdk/core/mavlink_message_handler.cpp
+++ b/cpp/src/mavsdk/core/mavlink_message_handler.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cassert>
 #include <future>
 #include <utility>
 #include <asio/post.hpp>
@@ -37,6 +38,7 @@ void MavlinkMessageHandler::register_one_impl(
 {
     Entry entry = {msg_id, maybe_component_id, callback, cookie};
     asio::post(_io_context, [this, entry = std::move(entry)]() mutable {
+        note_table_thread();
         _table.push_back(std::move(entry));
     });
 }
@@ -64,21 +66,38 @@ void MavlinkMessageHandler::unregister_all_on_io_thread(const void* cookie)
     // owner that is itself created and destroyed on the io thread, like a work-queue item).
     // The table is only touched on the io thread, so this is race-free, and removing the
     // entry before the owner is freed avoids any fire-after-free without a posted round-trip.
+    // Removing directly from within a message callback would invalidate the iteration in
+    // process_message(); use the posted unregister_all() there instead.
+    assert(!_processing);
     erase_from_table({}, cookie);
 }
 
 void MavlinkMessageHandler::unregister_all_blocking(const void* cookie)
 {
-    // Synchronous removal for callers that are NOT on the io_context thread (e.g. plugin
-    // destructors on the user thread). MUST NOT be called from the io thread -- it would
-    // post a task and then wait on the very thread that needs to run it. io-thread owners
-    // use unregister_all_on_io_thread() instead.
+    // Synchronous removal: once this returns, no callback for this cookie can fire
+    // anymore. Used by owners that are about to be destroyed (e.g. plugins, whose
+    // destructor runs on the user thread but whose deinit can also run on the io thread
+    // on disconnect).
     if (_io_context.stopped()) {
         // The io_context thread is dead -- safe to access the table directly.
         erase_from_table({}, cookie);
         return;
     }
 
+    if (on_io_thread()) {
+        // Already on the io thread: remove directly, we cannot post and then wait on
+        // ourselves. Same caveat as unregister_all_on_io_thread(): this must not happen
+        // from within a message callback.
+        assert(!_processing);
+        erase_from_table({}, cookie);
+        return;
+    }
+
+    // Waiting here relies on the io_context staying alive and running: it is only stopped
+    // in ~MavsdkImpl, after which the stopped() branch above applies. The stopped() check
+    // is not synchronized with that teardown, so destroying an owner concurrently with the
+    // Mavsdk instance itself is not supported -- the posted removal could then never run
+    // and this wait would hang.
     std::promise<void> done;
     asio::post(_io_context, [this, cookie, &done]() {
         erase_from_table({}, cookie);
@@ -90,6 +109,7 @@ void MavlinkMessageHandler::unregister_all_blocking(const void* cookie)
 void MavlinkMessageHandler::erase_from_table(
     std::optional<uint16_t> maybe_msg_id, const void* cookie)
 {
+    note_table_thread();
     _table.erase(
         std::remove_if(
             _table.begin(),
@@ -107,6 +127,9 @@ void MavlinkMessageHandler::erase_from_table(
 void MavlinkMessageHandler::process_message(const mavlink_message_t& message)
 {
     // Runs on the io_context thread; _table is only touched there, so no lock is needed.
+    note_table_thread();
+    _processing = true;
+
     bool forwarded = false;
 
     if (_debugging) {
@@ -133,15 +156,37 @@ void MavlinkMessageHandler::process_message(const mavlink_message_t& message)
         }
     }
 
+    _processing = false;
+
     if (_debugging && !forwarded) {
         LogDebug("Ignoring msg {}", int(message.msgid));
     }
+}
+
+bool MavlinkMessageHandler::on_io_thread() const
+{
+    return _io_context.get_executor().running_in_this_thread();
+}
+
+void MavlinkMessageHandler::note_table_thread()
+{
+    // All accesses to _table must be serialized: normally they all happen on the io
+    // thread; once the io_context is stopped (teardown), the teardown thread accesses the
+    // table directly instead. We track the accessing thread ourselves rather than
+    // asserting on_io_thread(), because asio's running_in_this_thread() relies on
+    // thread-locals that are not shared with a test binary that polls the io_context from
+    // outside the mavsdk shared library.
+    const auto this_id = std::this_thread::get_id();
+    const auto previous_id = _table_thread_id.exchange(this_id, std::memory_order_relaxed);
+    assert(previous_id == std::thread::id() || previous_id == this_id || _io_context.stopped());
+    (void)previous_id;
 }
 
 void MavlinkMessageHandler::update_component_id(
     uint16_t msg_id, uint8_t component_id, const void* cookie)
 {
     asio::post(_io_context, [this, msg_id, component_id, cookie]() {
+        note_table_thread();
         for (auto& entry : _table) {
             if (entry.msg_id == msg_id && entry.cookie == cookie) {
                 entry.component_id = component_id;

--- a/cpp/src/mavsdk/core/mavlink_message_handler.cpp
+++ b/cpp/src/mavsdk/core/mavlink_message_handler.cpp
@@ -1,11 +1,13 @@
 #include <algorithm>
-#include <mutex>
+#include <future>
+#include <utility>
+#include <asio/post.hpp>
 #include "mavlink_message_handler.hpp"
 #include "log.hpp"
 
 namespace mavsdk {
 
-MavlinkMessageHandler::MavlinkMessageHandler()
+MavlinkMessageHandler::MavlinkMessageHandler(asio::io_context& io_context) : _io_context(io_context)
 {
     if (const char* env_p = std::getenv("MAVSDK_MESSAGE_HANDLER_DEBUGGING")) {
         if (std::string(env_p) == "1") {
@@ -34,14 +36,9 @@ void MavlinkMessageHandler::register_one_impl(
     const void* cookie)
 {
     Entry entry = {msg_id, maybe_component_id, callback, cookie};
-
-    std::unique_lock<std::mutex> lock(_mutex, std::try_to_lock);
-    if (lock.owns_lock()) {
-        _table.push_back(entry);
-    } else {
-        std::lock_guard<std::mutex> register_later_lock(_register_later_mutex);
-        _register_later_table.push_back(entry);
-    }
+    asio::post(_io_context, [this, entry = std::move(entry)]() mutable {
+        _table.push_back(std::move(entry));
+    });
 }
 
 void MavlinkMessageHandler::unregister_one(uint16_t msg_id, const void* cookie)
@@ -54,114 +51,62 @@ void MavlinkMessageHandler::unregister_all(const void* cookie)
     unregister_impl({}, cookie);
 }
 
-void MavlinkMessageHandler::unregister_all_blocking(const void* cookie)
-{
-    // Blocking version for use in destructors - waits for any in-flight callbacks to complete.
-    // WARNING: Do NOT call this from within a message handler callback - it will deadlock.
-
-    // Also purge any deferred registrations for this cookie from _register_later_table.
-    // If register_one() was called while process_message() held _mutex, the entries land in
-    // _register_later_table instead of _table.  Without this step, check_register_later()
-    // would later promote those stale entries into _table and fire callbacks on a
-    // destroyed object (heap-use-after-free).
-    {
-        std::lock_guard<std::mutex> register_later_lock(_register_later_mutex);
-        _register_later_table.erase(
-            std::remove_if(
-                _register_later_table.begin(),
-                _register_later_table.end(),
-                [&](const auto& entry) { return entry.cookie == cookie; }),
-            _register_later_table.end());
-    }
-
-    std::lock_guard<std::mutex> lock(_mutex);
-    _table.erase(
-        std::remove_if(
-            _table.begin(), _table.end(), [&](auto& entry) { return entry.cookie == cookie; }),
-        _table.end());
-}
-
 void MavlinkMessageHandler::unregister_impl(
     std::optional<uint16_t> maybe_msg_id, const void* cookie)
 {
-    std::unique_lock<std::mutex> lock(_mutex, std::try_to_lock);
-    if (lock.owns_lock()) {
-        _table.erase(
-            std::remove_if(
-                _table.begin(),
-                _table.end(),
-                [&](auto& entry) {
-                    if (maybe_msg_id) {
-                        return (entry.msg_id == maybe_msg_id.value() && entry.cookie == cookie);
-                    } else {
-                        return (entry.cookie == cookie);
-                    }
-                }),
-            _table.end());
-    } else {
-        std::lock_guard<std::mutex> unregister_later_lock(_unregister_later_mutex);
-        _unregister_later_table.push_back(UnregisterEntry{maybe_msg_id, cookie});
-    }
+    asio::post(
+        _io_context, [this, maybe_msg_id, cookie]() { erase_from_table(maybe_msg_id, cookie); });
 }
 
-void MavlinkMessageHandler::check_register_later()
+void MavlinkMessageHandler::unregister_all_on_io_thread(const void* cookie)
 {
-    std::lock_guard<std::mutex> _register_later_lock(_register_later_mutex);
+    // Direct, synchronous removal. MUST be called on the io_context thread (e.g. from an
+    // owner that is itself created and destroyed on the io thread, like a work-queue item).
+    // The table is only touched on the io thread, so this is race-free, and removing the
+    // entry before the owner is freed avoids any fire-after-free without a posted round-trip.
+    erase_from_table({}, cookie);
+}
 
-    // We could probably just grab the lock here, but it's safer not to
-    // acquire both locks to avoid deadlocks.
-    std::unique_lock<std::mutex> lock(_mutex, std::try_to_lock);
-    if (!lock.owns_lock()) {
-        // Try again later.
+void MavlinkMessageHandler::unregister_all_blocking(const void* cookie)
+{
+    // Synchronous removal for callers that are NOT on the io_context thread (e.g. plugin
+    // destructors on the user thread). MUST NOT be called from the io thread -- it would
+    // post a task and then wait on the very thread that needs to run it. io-thread owners
+    // use unregister_all_on_io_thread() instead.
+    if (_io_context.stopped()) {
+        // The io_context thread is dead -- safe to access the table directly.
+        erase_from_table({}, cookie);
         return;
     }
 
-    for (const auto& entry : _register_later_table) {
-        _table.push_back(entry);
-    }
-
-    _register_later_table.clear();
+    std::promise<void> done;
+    asio::post(_io_context, [this, cookie, &done]() {
+        erase_from_table({}, cookie);
+        done.set_value();
+    });
+    done.get_future().wait();
 }
 
-void MavlinkMessageHandler::check_unregister_later()
+void MavlinkMessageHandler::erase_from_table(
+    std::optional<uint16_t> maybe_msg_id, const void* cookie)
 {
-    std::lock_guard<std::mutex> _unregister_later_lock(_unregister_later_mutex);
-
-    // We could probably just grab the lock here, but it's safer not to
-    // acquire both locks to avoid deadlocks.
-    std::unique_lock<std::mutex> lock(_mutex, std::try_to_lock);
-    if (!lock.owns_lock()) {
-        // Try again later.
-        return;
-    }
-
-    for (const auto& unregister_entry : _unregister_later_table) {
-        _table.erase(
-            std::remove_if(
-                _table.begin(),
-                _table.end(),
-                [&](auto& entry) {
-                    if (unregister_entry.maybe_msg_id) {
-                        return (
-                            entry.msg_id == unregister_entry.maybe_msg_id.value() &&
-                            entry.cookie == unregister_entry.cookie);
-                    } else {
-                        return (entry.cookie == unregister_entry.cookie);
-                    }
-                }),
-            _table.end());
-    }
-
-    _unregister_later_table.clear();
+    _table.erase(
+        std::remove_if(
+            _table.begin(),
+            _table.end(),
+            [&](auto& entry) {
+                if (maybe_msg_id) {
+                    return (entry.msg_id == maybe_msg_id.value() && entry.cookie == cookie);
+                } else {
+                    return (entry.cookie == cookie);
+                }
+            }),
+        _table.end());
 }
 
 void MavlinkMessageHandler::process_message(const mavlink_message_t& message)
 {
-    check_register_later();
-    check_unregister_later();
-
-    std::lock_guard<std::mutex> lock(_mutex);
-
+    // Runs on the io_context thread; _table is only touched there, so no lock is needed.
     bool forwarded = false;
 
     if (_debugging) {
@@ -196,16 +141,13 @@ void MavlinkMessageHandler::process_message(const mavlink_message_t& message)
 void MavlinkMessageHandler::update_component_id(
     uint16_t msg_id, uint8_t component_id, const void* cookie)
 {
-    check_register_later();
-    check_unregister_later();
-
-    std::lock_guard<std::mutex> lock(_mutex);
-
-    for (auto& entry : _table) {
-        if (entry.msg_id == msg_id && entry.cookie == cookie) {
-            entry.component_id = component_id;
+    asio::post(_io_context, [this, msg_id, component_id, cookie]() {
+        for (auto& entry : _table) {
+            if (entry.msg_id == msg_id && entry.cookie == cookie) {
+                entry.component_id = component_id;
+            }
         }
-    }
+    });
 }
 
 } // namespace mavsdk

--- a/cpp/src/mavsdk/core/mavlink_message_handler.hpp
+++ b/cpp/src/mavsdk/core/mavlink_message_handler.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <functional>
+#include <thread>
 #include <vector>
 #include <optional>
 #include <asio/io_context.hpp>
@@ -37,11 +39,14 @@ public:
     void unregister_one(uint16_t msg_id, const void* cookie);
     void unregister_all(const void* cookie);
     // Direct, synchronous unregister for owners that live and die ON the io_context thread
-    // (e.g. work-queue items). Must be called on the io thread.
+    // (e.g. work-queue items). Must be called on the io thread, but not from within a
+    // message callback (the removal would invalidate the dispatch in process_message()).
     void unregister_all_on_io_thread(const void* cookie);
-    // Synchronous unregister for owners destroyed OFF the io_context thread (e.g. plugins
-    // on the user thread): posts the removal to the io thread and waits for it, so no
-    // callback for this cookie can fire afterwards. Must NOT be called from the io thread.
+    // Synchronous unregister for owners about to be destroyed: once this returns, no
+    // callback for this cookie can fire anymore. Callable from any thread -- on the io
+    // thread it removes directly, off it it posts the removal and waits for it. The one
+    // exception: it must not be called from within a message callback (see
+    // unregister_all_on_io_thread above); use the posted unregister_all() there instead.
     void unregister_all_blocking(const void* cookie);
     void process_message(const mavlink_message_t& message);
     void update_component_id(uint16_t msg_id, uint8_t cmp_id, const void* cookie);
@@ -59,8 +64,25 @@ private:
     // Must be called on the io_context thread.
     void erase_from_table(std::optional<uint16_t> maybe_msg_id, const void* cookie);
 
+    bool on_io_thread() const;
+
+    // Record -- and in debug builds check -- which thread accesses _table; called by every
+    // code path that touches the table. See the implementation for why this exists in
+    // addition to on_io_thread().
+    void note_table_thread();
+
     asio::io_context& _io_context;
     std::vector<Entry> _table{};
+
+    // The single thread that is allowed to touch _table: the io thread while the
+    // io_context runs, the teardown thread once it is stopped. Only used by
+    // note_table_thread().
+    std::atomic<std::thread::id> _table_thread_id{};
+
+    // True while process_message() dispatches to the callbacks; only touched on the io
+    // thread. Used to assert that no callback removes entries from the table directly
+    // underneath the dispatch loop.
+    bool _processing{false};
 
     bool _debugging{false};
 };

--- a/cpp/src/mavsdk/core/mavlink_message_handler.hpp
+++ b/cpp/src/mavsdk/core/mavlink_message_handler.hpp
@@ -2,17 +2,25 @@
 
 #include <cstdint>
 #include <functional>
-#include <mutex>
 #include <vector>
 #include <optional>
+#include <asio/io_context.hpp>
 #include "mavlink_include.hpp"
 #include "mavsdk_export.h"
 
 namespace mavsdk {
 
+// Dispatches received MAVLink messages to registered handlers.
+//
+// Threading: the handler table is only ever touched on the io_context thread.
+// process_message() runs there (it is driven by the connection receive path, which
+// posts onto the io_context), and register/unregister post their mutation onto the
+// same io_context. That keeps everything single-threaded without locks, and post()
+// also makes it safe to (un)register from inside a callback (the mutation runs after
+// the current dispatch returns), with ordering preserved by post FIFO.
 class MAVSDK_TEST_EXPORT MavlinkMessageHandler {
 public:
-    MavlinkMessageHandler();
+    explicit MavlinkMessageHandler(asio::io_context& io_context);
 
     using Callback = std::function<void(const mavlink_message_t&)>;
 
@@ -28,6 +36,12 @@ public:
         uint16_t msg_id, uint8_t component_id, const Callback& callback, const void* cookie);
     void unregister_one(uint16_t msg_id, const void* cookie);
     void unregister_all(const void* cookie);
+    // Direct, synchronous unregister for owners that live and die ON the io_context thread
+    // (e.g. work-queue items). Must be called on the io thread.
+    void unregister_all_on_io_thread(const void* cookie);
+    // Synchronous unregister for owners destroyed OFF the io_context thread (e.g. plugins
+    // on the user thread): posts the removal to the io thread and waits for it, so no
+    // callback for this cookie can fire afterwards. Must NOT be called from the io thread.
     void unregister_all_blocking(const void* cookie);
     void process_message(const mavlink_message_t& message);
     void update_component_id(uint16_t msg_id, uint8_t cmp_id, const void* cookie);
@@ -41,22 +55,12 @@ private:
 
     void unregister_impl(std::optional<uint16_t> maybe_msg_id, const void* cookie);
 
-    void check_register_later();
-    void check_unregister_later();
+    // Erase entries matching cookie (and optionally msg_id) from the table.
+    // Must be called on the io_context thread.
+    void erase_from_table(std::optional<uint16_t> maybe_msg_id, const void* cookie);
 
-    std::mutex _mutex{};
+    asio::io_context& _io_context;
     std::vector<Entry> _table{};
-
-    std::mutex _register_later_mutex{};
-    std::vector<Entry> _register_later_table{};
-
-    struct UnregisterEntry {
-        std::optional<uint16_t> maybe_msg_id;
-        const void* cookie;
-    };
-
-    std::mutex _unregister_later_mutex{};
-    std::vector<UnregisterEntry> _unregister_later_table{};
 
     bool _debugging{false};
 };

--- a/cpp/src/mavsdk/core/mavlink_mission_transfer_client.cpp
+++ b/cpp/src/mavsdk/core/mavlink_mission_transfer_client.cpp
@@ -237,7 +237,7 @@ MavlinkMissionTransferClient::UploadWorkItem::UploadWorkItem(
 
 MavlinkMissionTransferClient::UploadWorkItem::~UploadWorkItem()
 {
-    _message_handler.unregister_all_blocking(this);
+    _message_handler.unregister_all_on_io_thread(this);
     _timeout_handler.remove(_cookie);
 }
 
@@ -625,7 +625,7 @@ MavlinkMissionTransferClient::DownloadWorkItem::DownloadWorkItem(
 
 MavlinkMissionTransferClient::DownloadWorkItem::~DownloadWorkItem()
 {
-    _message_handler.unregister_all_blocking(this);
+    _message_handler.unregister_all_on_io_thread(this);
     _timeout_handler.remove(_cookie);
 }
 
@@ -866,7 +866,7 @@ MavlinkMissionTransferClient::ClearWorkItem::ClearWorkItem(
 
 MavlinkMissionTransferClient::ClearWorkItem::~ClearWorkItem()
 {
-    _message_handler.unregister_all_blocking(this);
+    _message_handler.unregister_all_on_io_thread(this);
     _timeout_handler.remove(_cookie);
 }
 
@@ -1015,7 +1015,7 @@ MavlinkMissionTransferClient::SetCurrentWorkItem::SetCurrentWorkItem(
 
 MavlinkMissionTransferClient::SetCurrentWorkItem::~SetCurrentWorkItem()
 {
-    _message_handler.unregister_all_blocking(this);
+    _message_handler.unregister_all_on_io_thread(this);
     _timeout_handler.remove(_cookie);
 }
 

--- a/cpp/src/mavsdk/core/mavlink_mission_transfer_client_test.cpp
+++ b/cpp/src/mavsdk/core/mavlink_mission_transfer_client_test.cpp
@@ -61,33 +61,34 @@ protected:
 
     void TearDown() override
     {
-        // Drain any pending io_context posts (e.g. enqueue lambdas holding shared_ptr<WorkItem>)
-        // so that WorkItem destructors run while message_handler and timeout_handler are still
-        // alive. Without this, io_context (declared first, destroyed last) would destroy those
-        // lambdas after message_handler is already gone, causing heap-use-after-free in
-        // unregister_all_blocking.
-        //
-        // io_context::poll() calls stop() internally when outstanding_work_ == 0, setting
-        // stopped_=true. A do_work() call on an idle queue will trigger this. restart() clears
-        // stopped_ so the subsequent poll() loop can actually execute any handlers still queued
-        // (e.g. the enqueue lambda that holds the last shared_ptr<WorkItem> reference).
+        // Drain any pending posts (handler registrations/removals, WorkItem destructors)
+        // on this thread while message_handler is still alive.
         io_context.restart();
         while (io_context.poll()) {
         }
     }
 
-    // Flush any io_context posts (e.g. the enqueue lambda) then drive the state machine.
-    // Tests call this instead of mmt.do_work() directly so that work posted via
-    // asio::post() from user-thread enqueue calls is processed before do_work() runs.
+    // The message handler posts its table mutations onto the io_context, so poll() first to
+    // apply any pending registrations before driving the state machine / delivering a message.
     void do_work()
     {
         io_context.poll();
         mmt.do_work();
     }
 
+    void process_message(const mavlink_message_t& message)
+    {
+        io_context.poll();
+        message_handler.process_message(message);
+    }
+
+    void run_timeouts() { timeout_handler.run_once(); }
+
+    bool is_idle() { return mmt.is_idle(); }
+
     asio::io_context io_context;
     MockSender mock_sender;
-    MavlinkMessageHandler message_handler;
+    MavlinkMessageHandler message_handler{io_context};
     FakeTime time;
     TimeoutHandler timeout_handler;
     MavlinkMissionTransferClient mmt;
@@ -147,7 +148,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionDoesComplainAboutNoItems)
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionDoesComplainAboutWrongSequence)
@@ -170,7 +171,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionDoesComplainAboutWrongSequ
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(
@@ -195,7 +196,7 @@ TEST_F(
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(
@@ -220,7 +221,7 @@ TEST_F(
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionDoesComplainAboutNoCurrent)
@@ -246,7 +247,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionDoesComplainAboutNoCurrent
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionDoesComplainAboutTwoCurrents)
@@ -272,7 +273,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionDoesComplainAboutTwoCurren
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionDoesNotCrashIfCallbackIsNull)
@@ -296,7 +297,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionDoesNotCrashIfCallbackIsNu
     do_work();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionReturnsConnectionErrorWhenSendMessageFails)
@@ -322,10 +323,10 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionReturnsConnectionErrorWhen
 
     // We want to be sure a timeout is not still triggered later.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 static bool
@@ -395,7 +396,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionResendsCount)
     do_work();
 
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionTimeoutAfterSendCount)
@@ -431,7 +432,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionTimeoutAfterSendCount)
     // After the specified retries we should give up with a timeout.
     for (unsigned i = 0; i < MavlinkMissionTransferClient::retries; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
@@ -520,7 +521,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionSendsMissionItems)
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -529,20 +530,19 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionSendsMissionItems)
             return is_the_same_mission_item_int(items[1], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 1));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 1));
 
-    message_handler.process_message(
-        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     // We do not expect a timeout later though.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionResendsMissionItems)
@@ -571,7 +571,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionResendsMissionItems)
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -581,7 +581,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionResendsMissionItems)
         })));
 
     // Request 0 again in case it had not arrived.
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -591,16 +591,15 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionResendsMissionItems)
         })));
 
     // Request 1 finally.
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 1));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 1));
 
-    message_handler.process_message(
-        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionResendsMissionItemsButGivesUpAfterSomeRetries)
@@ -631,18 +630,18 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionResendsMissionItemsButGive
         .Times(MavlinkMissionTransferClient::retries);
 
     for (unsigned i = 0; i < MavlinkMissionTransferClient::retries; ++i) {
-        message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+        process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(0)), std::future_status::timeout);
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionAckArrivesTooEarly)
@@ -671,16 +670,15 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionAckArrivesTooEarly)
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
 
     // Don't request item 1 but already send ack.
-    message_handler.process_message(
-        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 class MavlinkMissionTransferClientNack
@@ -718,15 +716,15 @@ TEST_P(MavlinkMissionTransferClientNack, UploadMissionNackAreHandled)
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
 
     // Send nack now.
-    message_handler.process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, mavlink_nack));
+    process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, mavlink_nack));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -776,11 +774,11 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionTimeoutNotTriggeredDuringT
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
 
     // We almost use up the max timeout in each cycle.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 0.8 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     EXPECT_CALL(
         mock_sender,
@@ -789,10 +787,10 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionTimeoutNotTriggeredDuringT
             return is_the_same_mission_item_int(items[1], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 1));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 1));
 
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 0.8 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     EXPECT_CALL(
         mock_sender,
@@ -801,19 +799,18 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionTimeoutNotTriggeredDuringT
             return is_the_same_mission_item_int(items[2], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 2));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 2));
 
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 0.8 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
-    message_handler.process_message(
-        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionTimeoutAfterSendMissionItem)
@@ -842,42 +839,40 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionTimeoutAfterSendMissionIte
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
 
     // Make sure single timeout does not trigger it yet.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1000. + 250)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     EXPECT_EQ(fut.wait_for(std::chrono::milliseconds(50)), std::future_status::timeout);
 
     // But multiple do.
     for (unsigned i = 0; i < (MavlinkMissionTransferClient::retries - 1); ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     // Ignore later (wrong) ack.
-    message_handler.process_message(
-        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionDoesNotCrashOnRandomMessages)
 {
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
 
-    message_handler.process_message(
-        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
 
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 bool is_correct_mission_ack(uint8_t type, uint8_t result, const mavlink_message_t& message)
@@ -914,7 +909,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionCanBeCancelled)
         });
     do_work();
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -937,10 +932,10 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionCanBeCancelled)
 
     // We do not expect a timeout later though.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 mavlink_message_t make_mission_request(uint8_t type, int sequence)
@@ -985,7 +980,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionNacksNonIntCase)
         .Times(1);
 
     // First the non-int wrong case comes in.
-    message_handler.process_message(make_mission_request(MAV_MISSION_TYPE_FENCE, 0));
+    process_message(make_mission_request(MAV_MISSION_TYPE_FENCE, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -994,18 +989,18 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionNacksNonIntCase)
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_FENCE, 0));
-    message_handler.process_message(make_mission_ack(MAV_MISSION_TYPE_FENCE, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_FENCE, 0));
+    process_message(make_mission_ack(MAV_MISSION_TYPE_FENCE, MAV_MISSION_ACCEPTED));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     // We do not expect a timeout later though.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionWithProgress)
@@ -1042,10 +1037,9 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionWithProgress)
         });
     do_work();
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 1));
-    message_handler.process_message(
-        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 1));
+    process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
@@ -1056,10 +1050,10 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionWithProgress)
 
     // We do not expect a timeout later though.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, DownloadMissionSendsRequestList)
@@ -1134,7 +1128,7 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionResendsRequestList)
     do_work();
 
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 }
 
 TEST_F(
@@ -1168,13 +1162,13 @@ TEST_F(
 
     for (unsigned i = 0; i < MavlinkMissionTransferClient::retries; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 bool is_correct_mission_request_int(
@@ -1219,7 +1213,7 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionSendsMissionRequests)
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
 
-    message_handler.process_message(make_mission_count(items.size()));
+    process_message(make_mission_count(items.size()));
 }
 
 TEST_F(MavlinkMissionTransferClientTest, DownloadMissionResendsMissionRequestsAndTimesOutEventually)
@@ -1251,20 +1245,20 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionResendsMissionRequestsAn
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
 
-    message_handler.process_message(make_mission_count(items.size()));
+    process_message(make_mission_count(items.size()));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(0)), std::future_status::timeout);
 
     // After the specified retries we should give up with a timeout.
     for (unsigned i = 0; i < MavlinkMissionTransferClient::retries; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 mavlink_message_t make_mission_item(const std::vector<ItemInt>& item_ints, std::size_t index)
@@ -1321,7 +1315,7 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionSendsAllMissionRequestsA
                 MAV_MISSION_TYPE_MISSION, 0, fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_count(real_items.size()));
+    process_message(make_mission_count(real_items.size()));
 
     EXPECT_CALL(
         mock_sender,
@@ -1331,7 +1325,7 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionSendsAllMissionRequestsA
                 MAV_MISSION_TYPE_MISSION, 1, fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_item(real_items, 0));
+    process_message(make_mission_item(real_items, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -1341,7 +1335,7 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionSendsAllMissionRequestsA
                 MAV_MISSION_TYPE_MISSION, 2, fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_item(real_items, 1));
+    process_message(make_mission_item(real_items, 1));
 
     EXPECT_CALL(
         mock_sender,
@@ -1351,12 +1345,12 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionSendsAllMissionRequestsA
                 MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED, fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_item(real_items, 2));
+    process_message(make_mission_item(real_items, 2));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, DownloadMissionResendsRequestItemAgainForSecondItem)
@@ -1390,11 +1384,11 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionResendsRequestItemAgainF
         })))
         .Times(MavlinkMissionTransferClient::retries - 1);
 
-    message_handler.process_message(make_mission_count(items.size()));
+    process_message(make_mission_count(items.size()));
 
     for (unsigned i = 0; i < MavlinkMissionTransferClient::retries - 2; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     // This time we go over the retry limit.
@@ -1407,17 +1401,17 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionResendsRequestItemAgainF
         })))
         .Times(MavlinkMissionTransferClient::retries);
 
-    message_handler.process_message(make_mission_item(items, 0));
+    process_message(make_mission_item(items, 0));
 
     for (unsigned i = 0; i < MavlinkMissionTransferClient::retries; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, DownloadMissionDoesntHaveDuplicates)
@@ -1449,7 +1443,7 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionDoesntHaveDuplicates)
                 MAV_MISSION_TYPE_MISSION, 0, fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_count(real_items.size()));
+    process_message(make_mission_count(real_items.size()));
 
     EXPECT_CALL(
         mock_sender,
@@ -1459,7 +1453,7 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionDoesntHaveDuplicates)
                 MAV_MISSION_TYPE_MISSION, 1, fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_item(real_items, 0));
+    process_message(make_mission_item(real_items, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -1470,7 +1464,7 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionDoesntHaveDuplicates)
         })));
 
     // Send a message 3 times, it should just get ignored.
-    message_handler.process_message(make_mission_item(real_items, 1));
+    process_message(make_mission_item(real_items, 1));
 
     EXPECT_CALL(
         mock_sender,
@@ -1480,15 +1474,15 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionDoesntHaveDuplicates)
                 MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED, fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_item(real_items, 1));
-    message_handler.process_message(make_mission_item(real_items, 1));
+    process_message(make_mission_item(real_items, 1));
+    process_message(make_mission_item(real_items, 1));
 
-    message_handler.process_message(make_mission_item(real_items, 2));
+    process_message(make_mission_item(real_items, 2));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, DownloadMissionEmptyList)
@@ -1515,16 +1509,16 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionEmptyList)
                 MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED, fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_count(0));
+    process_message(make_mission_count(0));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     // We want to be sure a timeout is not still triggered later.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, DownloadMissionTimeoutNotTriggeredDuringTransfer)
@@ -1551,32 +1545,32 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionTimeoutNotTriggeredDurin
     // We almost use up the max timeout in each cycle.
     time.sleep_for(std::chrono::milliseconds(
         static_cast<int>(timeout_s * MavlinkMissionTransferClient::retries * 0.8 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
-    message_handler.process_message(make_mission_count(real_items.size()));
-
-    time.sleep_for(std::chrono::milliseconds(
-        static_cast<int>(timeout_s * MavlinkMissionTransferClient::retries * 0.8 * 1000.)));
-    timeout_handler.run_once();
-
-    message_handler.process_message(make_mission_item(real_items, 0));
+    process_message(make_mission_count(real_items.size()));
 
     time.sleep_for(std::chrono::milliseconds(
         static_cast<int>(timeout_s * MavlinkMissionTransferClient::retries * 0.8 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
-    message_handler.process_message(make_mission_item(real_items, 1));
+    process_message(make_mission_item(real_items, 0));
 
     time.sleep_for(std::chrono::milliseconds(
         static_cast<int>(timeout_s * MavlinkMissionTransferClient::retries * 0.8 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
-    message_handler.process_message(make_mission_item(real_items, 2));
+    process_message(make_mission_item(real_items, 1));
+
+    time.sleep_for(std::chrono::milliseconds(
+        static_cast<int>(timeout_s * MavlinkMissionTransferClient::retries * 0.8 * 1000.)));
+    run_timeouts();
+
+    process_message(make_mission_item(real_items, 2));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, DownloadMissionCanBeCancelled)
@@ -1600,8 +1594,8 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionCanBeCancelled)
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 2));
 
-    message_handler.process_message(make_mission_count(items.size()));
-    message_handler.process_message(make_mission_item(items, 0));
+    process_message(make_mission_count(items.size()));
+    process_message(make_mission_item(items, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -1622,7 +1616,7 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionCanBeCancelled)
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, DownloadMissionWithProgress)
@@ -1659,10 +1653,10 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionWithProgress)
         });
     do_work();
 
-    message_handler.process_message(make_mission_count(real_items.size()));
-    message_handler.process_message(make_mission_item(real_items, 0));
-    message_handler.process_message(make_mission_item(real_items, 1));
-    message_handler.process_message(make_mission_item(real_items, 2));
+    process_message(make_mission_count(real_items.size()));
+    process_message(make_mission_item(real_items, 0));
+    process_message(make_mission_item(real_items, 1));
+    process_message(make_mission_item(real_items, 2));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
@@ -1671,7 +1665,7 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionWithProgress)
     EXPECT_LE(num_progress_received, 10);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 bool is_correct_mission_clear_all(uint8_t type, const mavlink_message_t& message)
@@ -1710,13 +1704,12 @@ TEST_F(MavlinkMissionTransferClientTest, ClearMissionSendsClear)
         });
     do_work();
 
-    message_handler.process_message(
-        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_RESULT_ACCEPTED));
+    process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_RESULT_ACCEPTED));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 bool is_correct_mission_set_current(uint16_t seq, const mavlink_message_t& message)
@@ -1761,12 +1754,12 @@ TEST_F(MavlinkMissionTransferClientTest, SetCurrentSendsSetCurrent)
     });
     do_work();
 
-    message_handler.process_message(make_mission_current(2));
+    process_message(make_mission_current(2));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, SetCurrentWithRetransmissionAndTimeout)
@@ -1791,13 +1784,13 @@ TEST_F(MavlinkMissionTransferClientTest, SetCurrentWithRetransmissionAndTimeout)
 
     for (unsigned i = 0; i < MavlinkMissionTransferClient::retries; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, SetCurrentWithRetransmissionAndSuccess)
@@ -1822,16 +1815,16 @@ TEST_F(MavlinkMissionTransferClientTest, SetCurrentWithRetransmissionAndSuccess)
 
     for (unsigned i = 0; i < MavlinkMissionTransferClient::retries - 2; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
-    message_handler.process_message(make_mission_current(2));
+    process_message(make_mission_current(2));
     do_work();
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, SetCurrentWithInvalidInput)
@@ -1850,7 +1843,7 @@ TEST_F(MavlinkMissionTransferClientTest, SetCurrentWithInvalidInput)
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, SetCurrentWithRetransmissionWhenWrong)
@@ -1879,13 +1872,13 @@ TEST_F(MavlinkMissionTransferClientTest, SetCurrentWithRetransmissionWhenWrong)
             [](std::function<mavlink_message_t(MavlinkAddress mavlink_address, uint8_t channel)>
                    fun) { return is_correct_mission_set_current(2, fun(own_address, channel)); })));
 
-    message_handler.process_message(make_mission_current(1));
+    process_message(make_mission_current(1));
     do_work();
 
-    message_handler.process_message(make_mission_current(2));
+    process_message(make_mission_current(2));
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, IntMessagesNotSupported)
@@ -1909,7 +1902,7 @@ TEST_F(MavlinkMissionTransferClientTest, IntMessagesNotSupported)
     }
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 
     {
         std::promise<void> prom;
@@ -1930,5 +1923,5 @@ TEST_F(MavlinkMissionTransferClientTest, IntMessagesNotSupported)
     }
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }

--- a/cpp/src/mavsdk/core/mavlink_mission_transfer_server.cpp
+++ b/cpp/src/mavsdk/core/mavlink_mission_transfer_server.cpp
@@ -159,7 +159,7 @@ MavlinkMissionTransferServer::ReceiveIncomingMission::ReceiveIncomingMission(
 
 MavlinkMissionTransferServer::ReceiveIncomingMission::~ReceiveIncomingMission()
 {
-    _message_handler.unregister_all_blocking(this);
+    _message_handler.unregister_all_on_io_thread(this);
     _timeout_handler.remove(_cookie);
 }
 
@@ -366,7 +366,7 @@ MavlinkMissionTransferServer::SendOutgoingMission::SendOutgoingMission(
 
 MavlinkMissionTransferServer::SendOutgoingMission::~SendOutgoingMission()
 {
-    _message_handler.unregister_all_blocking(this);
+    _message_handler.unregister_all_on_io_thread(this);
     _timeout_handler.remove(_cookie);
 }
 

--- a/cpp/src/mavsdk/core/mavlink_mission_transfer_server_test.cpp
+++ b/cpp/src/mavsdk/core/mavlink_mission_transfer_server_test.cpp
@@ -66,27 +66,30 @@ protected:
 
     void TearDown() override
     {
-        // Drain any pending io_context posts (e.g. enqueue lambdas holding shared_ptr<WorkItem>)
-        // so that WorkItem destructors run while message_handler and timeout_handler are still
-        // alive. Without this, io_context (declared first, destroyed last) would destroy those
-        // lambdas after message_handler is already gone, causing heap-use-after-free in
-        // unregister_all_blocking.
-        //
-        // io_context::poll() calls stop() internally when outstanding_work_ == 0, setting
-        // stopped_=true. A do_work() call on an idle queue will trigger this. restart() clears
-        // stopped_ so the subsequent poll() loop can actually execute any handlers still queued
-        // (e.g. the enqueue lambda that holds the last shared_ptr<WorkItem> reference).
+        // Drain any pending posts (handler registrations/removals, WorkItem destructors)
+        // on this thread while message_handler is still alive.
         io_context.restart();
         while (io_context.poll()) {
         }
     }
 
-    // Flush any io_context posts (e.g. the enqueue lambda) then drive the state machine.
+    // The message handler posts its table mutations onto the io_context, so poll() first to
+    // apply any pending registrations before driving the state machine / delivering a message.
     void do_work()
     {
         io_context.poll();
         mmt.do_work();
     }
+
+    void process_message(const mavlink_message_t& message)
+    {
+        io_context.poll();
+        message_handler.process_message(message);
+    }
+
+    void run_timeouts() { timeout_handler.run_once(); }
+
+    bool is_idle() { return mmt.is_idle(); }
 
     asio::io_context io_context;
 
@@ -303,7 +306,7 @@ protected:
     }
 
     MockSender mock_sender;
-    MavlinkMessageHandler message_handler;
+    MavlinkMessageHandler message_handler{io_context};
     FakeTime time;
     TimeoutHandler timeout_handler;
     MavlinkMissionTransferServer mmt;
@@ -352,7 +355,7 @@ TEST_P(MavlinkMissionTransferServerFixture, ReceiveIncomingMissionSendsMissionRe
 
     do_work();
 
-    message_handler.process_message(make_mission_count(items.size(), mission_type));
+    process_message(make_mission_count(items.size(), mission_type));
 }
 
 TEST_P(
@@ -395,13 +398,13 @@ TEST_P(
     // After the specified retries we should give up with a timeout.
     for (unsigned i = 0; i < MavlinkMissionTransferServer::retries; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(
@@ -442,7 +445,7 @@ TEST_P(
 
     for (unsigned i = 0; i < MavlinkMissionTransferServer::retries - 2; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     // This time we go over the retry limit.
@@ -455,17 +458,17 @@ TEST_P(
         })))
         .Times(MavlinkMissionTransferServer::retries);
 
-    message_handler.process_message(make_mission_item(items, 0));
+    process_message(make_mission_item(items, 0));
 
     for (unsigned i = 0; i < MavlinkMissionTransferServer::retries; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, ReceiveIncomingMissionEmptyList)
@@ -503,10 +506,10 @@ TEST_P(MavlinkMissionTransferServerFixture, ReceiveIncomingMissionEmptyList)
 
     // We want to be sure a timeout is not still triggered later.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, ReceiveIncomingMissionCanBeCancelled)
@@ -533,7 +536,7 @@ TEST_P(MavlinkMissionTransferServerFixture, ReceiveIncomingMissionCanBeCancelled
         });
     do_work();
 
-    message_handler.process_message(make_mission_item(items, 0));
+    process_message(make_mission_item(items, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -555,7 +558,7 @@ TEST_P(MavlinkMissionTransferServerFixture, ReceiveIncomingMissionCanBeCancelled
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionEmptyMission)
@@ -580,12 +583,12 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionEmptyMission)
     do_work();
 
     // empty mission should just send a zero count and be done
-    message_handler.process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionDoesNotCrashIfCallbackIsNull)
@@ -612,7 +615,7 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionDoesNotCrashIfCal
     do_work();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(
@@ -644,10 +647,10 @@ TEST_P(
 
     // We want to be sure a timeout is not still triggered later.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionSendsCount)
@@ -707,7 +710,7 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionResendsCount)
     do_work();
 
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionTimeoutAfterSendCount)
@@ -747,7 +750,7 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionTimeoutAfterSendC
     // After the specified retries we should give up with a timeout.
     for (unsigned i = 0; i < MavlinkMissionTransferServer::retries; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
@@ -783,7 +786,7 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionSendsMissionItems
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_request_int(mission_type, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -792,19 +795,19 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionSendsMissionItems
             return is_the_same_mission_item_int(items[1], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(mission_type, 1));
+    process_message(make_mission_request_int(mission_type, 1));
 
-    message_handler.process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     // We do not expect a timeout later though.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionResendsMissionItems)
@@ -837,7 +840,7 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionResendsMissionIte
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_request_int(mission_type, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -847,7 +850,7 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionResendsMissionIte
         })));
 
     // Request 0 again in case it had not arrived.
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_request_int(mission_type, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -857,15 +860,15 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionResendsMissionIte
         })));
 
     // Request 1 finally.
-    message_handler.process_message(make_mission_request_int(mission_type, 1));
+    process_message(make_mission_request_int(mission_type, 1));
 
-    message_handler.process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(
@@ -902,18 +905,18 @@ TEST_P(
         .Times(MavlinkMissionTransferServer::retries);
 
     for (unsigned i = 0; i < MavlinkMissionTransferServer::retries; ++i) {
-        message_handler.process_message(make_mission_request_int(mission_type, 0));
+        process_message(make_mission_request_int(mission_type, 0));
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(0)), std::future_status::timeout);
 
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_request_int(mission_type, 0));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionAckArrivesTooEarly)
@@ -946,15 +949,15 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionAckArrivesTooEarl
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_request_int(mission_type, 0));
 
     // Don't request item 1 but already send ack.
-    message_handler.process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 class MavlinkMissionTransferServerNack
@@ -994,15 +997,15 @@ TEST_P(MavlinkMissionTransferServerNack, SendOutgoingMissionNackAreHandled)
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_request_int(mission_type, 0));
 
     // Send nack now.
-    message_handler.process_message(make_mission_ack(mission_type, mavlink_nack));
+    process_message(make_mission_ack(mission_type, mavlink_nack));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1060,11 +1063,11 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionTimeoutNotTrigger
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_request_int(mission_type, 0));
 
     // We almost use up the max timeout in each cycle.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 0.8 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     EXPECT_CALL(
         mock_sender,
@@ -1073,10 +1076,10 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionTimeoutNotTrigger
             return is_the_same_mission_item_int(items[1], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(mission_type, 1));
+    process_message(make_mission_request_int(mission_type, 1));
 
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 0.8 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     EXPECT_CALL(
         mock_sender,
@@ -1085,18 +1088,18 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionTimeoutNotTrigger
             return is_the_same_mission_item_int(items[2], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(mission_type, 2));
+    process_message(make_mission_request_int(mission_type, 2));
 
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 0.8 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
-    message_handler.process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionTimeoutAfterSendMissionItem)
@@ -1129,40 +1132,40 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionTimeoutAfterSendM
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_request_int(mission_type, 0));
 
     // Make sure single timeout does not trigger it yet.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1000. + 250)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     EXPECT_EQ(fut.wait_for(std::chrono::milliseconds(50)), std::future_status::timeout);
 
     // But multiple do.
     for (unsigned i = 0; i < (MavlinkMissionTransferServer::retries - 1); ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     // Ignore later (wrong) ack.
-    message_handler.process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionDoesNotCrashOnRandomMessages)
 {
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_request_int(mission_type, 0));
 
-    message_handler.process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
 
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionCanBeCancelled)
@@ -1188,7 +1191,7 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionCanBeCancelled)
         });
     do_work();
 
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_request_int(mission_type, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -1209,10 +1212,10 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionCanBeCancelled)
 
     // We do not expect a timeout later though.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionNacksNonIntCase)
@@ -1247,7 +1250,7 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionNacksNonIntCase)
         .Times(1);
 
     // First the non-int wrong case comes in.
-    message_handler.process_message(make_mission_request(mission_type, 0));
+    process_message(make_mission_request(mission_type, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -1256,18 +1259,18 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionNacksNonIntCase)
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
-    message_handler.process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     // We do not expect a timeout later though.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/src/mavsdk/core/mavlink_parameter_client.cpp
+++ b/cpp/src/mavsdk/core/mavlink_parameter_client.cpp
@@ -7,6 +7,7 @@
 #include <future>
 #include <limits>
 #include <utility>
+#include <asio/dispatch.hpp>
 
 namespace mavsdk {
 
@@ -19,6 +20,7 @@ MavlinkParameterClient::MavlinkParameterClient(
     uint8_t target_system_id,
     uint8_t target_component_id,
     bool use_extended) :
+    MavlinkParameterSubscription(sender.io_context()),
     _sender(sender),
     _message_handler(message_handler),
     _timeout_handler(timeout_handler),
@@ -453,8 +455,10 @@ void MavlinkParameterClient::cancel_all_param(const void* cookie)
         unsubscribe_all_params_changed(cookie);
         return;
     }
+    // dispatch() runs inline if we're already on the io_context thread (avoiding a
+    // self-deadlock on the wait below) and posts otherwise.
     std::promise<void> done;
-    asio::post(_io_context, [this, cookie, &done]() {
+    asio::dispatch(_io_context, [this, cookie, &done]() {
         _work_queue.erase(
             std::remove_if(
                 _work_queue.begin(),

--- a/cpp/src/mavsdk/core/mavlink_parameter_client.cpp
+++ b/cpp/src/mavsdk/core/mavlink_parameter_client.cpp
@@ -78,7 +78,10 @@ MavlinkParameterClient::~MavlinkParameterClient()
             (_use_extended ? "extended" : "not extended"));
     }
 
-    _message_handler.unregister_all(this);
+    // Blocking, so that no message callback can fire into this object after destruction.
+    // (Today this runs during teardown with the io thread already stopped, in which case
+    // it degrades to a direct erase.)
+    _message_handler.unregister_all_blocking(this);
 }
 
 MavlinkParameterClient::Result

--- a/cpp/src/mavsdk/core/mavlink_parameter_server.cpp
+++ b/cpp/src/mavsdk/core/mavlink_parameter_server.cpp
@@ -4,6 +4,7 @@
 #include "overloaded.hpp"
 #include <cassert>
 #include <limits>
+#include <asio/post.hpp>
 
 namespace mavsdk {
 
@@ -12,6 +13,7 @@ MavlinkParameterServer::MavlinkParameterServer(
     MavlinkMessageHandler& message_handler,
     asio::io_context& io_context,
     std::optional<std::map<std::string, ParamValue>> optional_param_values) :
+    MavlinkParameterSubscription(io_context),
     _sender(sender),
     _message_handler(message_handler),
     _io_context(io_context)
@@ -106,7 +108,12 @@ MavlinkParameterServer::provide_server_param(const std::string& name, const Para
             // then, to not change the public api behaviour, try updating its value.
             switch (_param_cache.update_existing_param(name, param_value)) {
                 case MavlinkParameterCache::UpdateExistingParamResult::Ok:
-                    find_and_call_subscriptions_value_changed(name, param_value);
+                    // provide_server_param() is part of the user-facing API and runs on the
+                    // user thread, so post the notification onto the io_context thread where
+                    // the subscription list is owned.
+                    asio::post(_io_context, [this, name, param_value]() {
+                        find_and_call_subscriptions_value_changed(name, param_value);
+                    });
                     // Notify clients of the changed value on the protocol(s) that can carry it and
                     // that a client is actually using. The extended protocol can represent any
                     // parameter; the non-extended protocol only those that don't need_extended.

--- a/cpp/src/mavsdk/core/mavlink_parameter_server.cpp
+++ b/cpp/src/mavsdk/core/mavlink_parameter_server.cpp
@@ -73,7 +73,10 @@ MavlinkParameterServer::MavlinkParameterServer(
 
 MavlinkParameterServer::~MavlinkParameterServer()
 {
-    _message_handler.unregister_all(this);
+    // Blocking, so that no message callback can fire into this object after destruction.
+    // (Today this runs during teardown with the io thread already stopped, in which case
+    // it degrades to a direct erase.)
+    _message_handler.unregister_all_blocking(this);
 }
 
 MavlinkParameterServer::Result

--- a/cpp/src/mavsdk/core/mavlink_parameter_subscription.cpp
+++ b/cpp/src/mavsdk/core/mavlink_parameter_subscription.cpp
@@ -1,8 +1,8 @@
 #include "mavlink_parameter_subscription.hpp"
 
 #include <algorithm>
+#include <cassert>
 #include <future>
-#include <asio/dispatch.hpp>
 
 namespace mavsdk {
 
@@ -29,6 +29,9 @@ void MavlinkParameterSubscription::find_and_call_subscriptions_value_changed(
 {
     // Runs on the io_context thread; _param_changed_subscriptions is only touched there,
     // so no locking is needed.
+    note_list_thread();
+    _iterating = true;
+
     for (const auto& subscription : _param_changed_subscriptions) {
         if (subscription.param_name != param_name) {
             continue;
@@ -49,12 +52,19 @@ void MavlinkParameterSubscription::find_and_call_subscriptions_value_changed(
             LogErr("Type and callback mismatch");
         }
     }
+
+    _iterating = false;
 }
 
 void MavlinkParameterSubscription::unsubscribe_all_params_changed(const void* cookie)
 {
     // Must be called on the io_context thread (or while it is stopped); the list is only
     // touched there.
+    note_list_thread();
+    // Removing directly from within a subscription callback would invalidate the iteration
+    // in find_and_call_subscriptions_value_changed(); use the posted
+    // subscribe_param_changed(nullptr, ...) path there instead.
+    assert(!_iterating);
     _param_changed_subscriptions.erase(
         std::remove_if(
             _param_changed_subscriptions.begin(),
@@ -65,16 +75,29 @@ void MavlinkParameterSubscription::unsubscribe_all_params_changed(const void* co
 
 void MavlinkParameterSubscription::unsubscribe_all_params_changed_blocking(const void* cookie)
 {
+    // Synchronous removal: once this returns, no callback for this cookie can fire
+    // anymore. Same shape as MavlinkMessageHandler::unregister_all_blocking().
     if (_io_context.stopped()) {
         // The io_context thread is dead — safe to access directly.
         unsubscribe_all_params_changed(cookie);
         return;
     }
 
-    // dispatch() runs the handler inline if we are already on the io_context thread
-    // (so we never wait on ourselves and deadlock), and posts it otherwise.
+    if (on_io_thread()) {
+        // Already on the io thread: remove directly, we cannot post and then wait on
+        // ourselves. Not supported from within a subscription callback (see the assert in
+        // unsubscribe_all_params_changed).
+        unsubscribe_all_params_changed(cookie);
+        return;
+    }
+
+    // Waiting here relies on the io_context staying alive and running: it is only stopped
+    // in ~MavsdkImpl, after which the stopped() branch above applies. The stopped() check
+    // is not synchronized with that teardown, so destroying an owner concurrently with the
+    // Mavsdk instance itself is not supported -- the posted removal could then never run
+    // and this wait would hang.
     std::promise<void> done;
-    asio::dispatch(_io_context, [this, cookie, &done]() {
+    asio::post(_io_context, [this, cookie, &done]() {
         unsubscribe_all_params_changed(cookie);
         done.set_value();
     });

--- a/cpp/src/mavsdk/core/mavlink_parameter_subscription.cpp
+++ b/cpp/src/mavsdk/core/mavlink_parameter_subscription.cpp
@@ -1,6 +1,8 @@
 #include "mavlink_parameter_subscription.hpp"
 
 #include <algorithm>
+#include <future>
+#include <asio/dispatch.hpp>
 
 namespace mavsdk {
 
@@ -25,11 +27,8 @@ void MavlinkParameterSubscription::subscribe_param_custom_changed(
 void MavlinkParameterSubscription::find_and_call_subscriptions_value_changed(
     const std::string& param_name, const ParamValue& value)
 {
-    // Process any deferred operations before calling subscriptions
-    process_deferred_operations();
-
-    // Now lock the mutex and call the subscriptions
-    std::lock_guard<std::mutex> lock(_param_changed_subscriptions_mutex);
+    // Runs on the io_context thread; _param_changed_subscriptions is only touched there,
+    // so no locking is needed.
     for (const auto& subscription : _param_changed_subscriptions) {
         if (subscription.param_name != param_name) {
             continue;
@@ -54,26 +53,32 @@ void MavlinkParameterSubscription::find_and_call_subscriptions_value_changed(
 
 void MavlinkParameterSubscription::unsubscribe_all_params_changed(const void* cookie)
 {
-    // Process any deferred operations first
-    process_deferred_operations();
+    // Must be called on the io_context thread (or while it is stopped); the list is only
+    // touched there.
+    _param_changed_subscriptions.erase(
+        std::remove_if(
+            _param_changed_subscriptions.begin(),
+            _param_changed_subscriptions.end(),
+            [&](const auto& subscription) { return subscription.cookie == cookie; }),
+        _param_changed_subscriptions.end());
+}
 
-    // Try to lock the mutex, if it fails we're likely in a callback
-    if (_param_changed_subscriptions_mutex.try_lock()) {
-        // We've acquired the lock without blocking, so we can modify the list
-        _param_changed_subscriptions.erase(
-            std::remove_if(
-                _param_changed_subscriptions.begin(),
-                _param_changed_subscriptions.end(),
-                [&](const auto& subscription) { return subscription.cookie == cookie; }),
-            _param_changed_subscriptions.end());
-        _param_changed_subscriptions_mutex.unlock();
-    } else {
-        // We couldn't acquire the lock because we're likely in a callback
-        // Defer the unsubscription of all params for this cookie
-        std::lock_guard<std::mutex> lock(_deferred_unsubscriptions_mutex);
-        // Add a special marker for unsubscribe_all (empty param_name)
-        _deferred_unsubscriptions.push_back({"", cookie});
+void MavlinkParameterSubscription::unsubscribe_all_params_changed_blocking(const void* cookie)
+{
+    if (_io_context.stopped()) {
+        // The io_context thread is dead — safe to access directly.
+        unsubscribe_all_params_changed(cookie);
+        return;
     }
+
+    // dispatch() runs the handler inline if we are already on the io_context thread
+    // (so we never wait on ourselves and deadlock), and posts it otherwise.
+    std::promise<void> done;
+    asio::dispatch(_io_context, [this, cookie, &done]() {
+        unsubscribe_all_params_changed(cookie);
+        done.set_value();
+    });
+    done.get_future().wait();
 }
 
 } // namespace mavsdk

--- a/cpp/src/mavsdk/core/mavlink_parameter_subscription.hpp
+++ b/cpp/src/mavsdk/core/mavlink_parameter_subscription.hpp
@@ -3,10 +3,11 @@
 #include "param_value.hpp"
 #include <algorithm>
 #include <functional>
-#include <mutex>
 #include <string>
 #include <variant>
 #include <vector>
+#include <asio/io_context.hpp>
+#include <asio/post.hpp>
 
 namespace mavsdk {
 
@@ -16,8 +17,19 @@ namespace mavsdk {
 // But for now, I don't want to go down that route yet since I don't know if that isn't too much of
 // inheritance. NOTE: r.n the inherited class still needs to remember to call
 // find_and_call_subscriptions_value_changed() When a value is changed.
+//
+// Threading: the subscription list is only ever touched on the io_context thread.
+// find_and_call_subscriptions_value_changed() runs there (it is driven by received
+// param messages), and subscribe/unsubscribe post their mutation onto the same
+// io_context. That keeps everything single-threaded without locks, and post() also
+// makes it safe to (un)subscribe from inside a subscription callback (the mutation
+// runs after the current dispatch returns).
 class MavlinkParameterSubscription {
 public:
+    explicit MavlinkParameterSubscription(asio::io_context& io_context) :
+        _io_context(io_context)
+    {}
+
     template<class T> using ParamChangedCallback = std::function<void(T value)>;
 
     using ParamChangedCallbacks = std::variant<
@@ -55,38 +67,20 @@ public:
     {
         if (callback != nullptr) {
             ParamChangedSubscription subscription{name, callback, cookie};
-
-            // Try to lock the mutex, if it fails we're likely in a callback
-            if (_param_changed_subscriptions_mutex.try_lock()) {
-                // We've acquired the lock without blocking, so we can modify the list
-                _param_changed_subscriptions.push_back(subscription);
-                _param_changed_subscriptions_mutex.unlock();
-            } else {
-                // We couldn't acquire the lock because we're likely in a callback
-                // Defer the subscription
-                std::lock_guard<std::mutex> lock(_deferred_subscriptions_mutex);
-                _deferred_subscriptions.push_back(subscription);
-            }
+            asio::post(_io_context, [this, subscription = std::move(subscription)]() mutable {
+                _param_changed_subscriptions.push_back(std::move(subscription));
+            });
         } else {
-            // For unsubscribing, we also need to handle the case where we're in a callback
-            if (_param_changed_subscriptions_mutex.try_lock()) {
-                // We've acquired the lock without blocking, so we can modify the list
-                for (auto it = _param_changed_subscriptions.begin();
-                     it != _param_changed_subscriptions.end();
-                     /* ++it */) {
-                    if (it->param_name == name && it->cookie == cookie) {
-                        it = _param_changed_subscriptions.erase(it);
-                    } else {
-                        ++it;
-                    }
-                }
-                _param_changed_subscriptions_mutex.unlock();
-            } else {
-                // We couldn't acquire the lock because we're likely in a callback
-                // Defer the unsubscription
-                std::lock_guard<std::mutex> lock(_deferred_unsubscriptions_mutex);
-                _deferred_unsubscriptions.push_back({name, cookie});
-            }
+            asio::post(_io_context, [this, name, cookie]() {
+                _param_changed_subscriptions.erase(
+                    std::remove_if(
+                        _param_changed_subscriptions.begin(),
+                        _param_changed_subscriptions.end(),
+                        [&](const auto& subscription) {
+                            return subscription.param_name == name && subscription.cookie == cookie;
+                        }),
+                    _param_changed_subscriptions.end());
+            });
         }
     }
 
@@ -101,81 +95,30 @@ public:
     void subscribe_param_custom_changed(
         const std::string& name, const ParamCustomChangedCallback& callback, const void* cookie);
 
+    // Remove all subscriptions for the given cookie. Must be called on the io_context
+    // thread (or while it is stopped), e.g. from within a handler already posted there.
     void unsubscribe_all_params_changed(const void* cookie);
+
+    // Same, but synchronous and callable from any thread: the removal is run on the
+    // io_context thread and this returns only once it has completed, so no callback for
+    // this cookie can fire afterwards. Safe to call from the io_context thread too (the
+    // removal then runs inline rather than waiting on itself).
+    void unsubscribe_all_params_changed_blocking(const void* cookie);
 
 protected:
     /**
      * Find all the subscriptions for the given @param param_name,
      * check their type and call them when matching. This does not check if the given param actually
      * was changed, but it is safe to call with mismatching types.
+     *
+     * Must be called on the io_context thread.
      */
     void find_and_call_subscriptions_value_changed(
         const std::string& param_name, const ParamValue& new_param_value);
 
 private:
-    // Process any deferred subscriptions or unsubscriptions
-    void process_deferred_operations()
-    {
-        // Process deferred subscriptions
-        {
-            std::lock_guard<std::mutex> lock(_deferred_subscriptions_mutex);
-            if (!_deferred_subscriptions.empty() && _param_changed_subscriptions_mutex.try_lock()) {
-                for (const auto& subscription : _deferred_subscriptions) {
-                    _param_changed_subscriptions.push_back(subscription);
-                }
-                _deferred_subscriptions.clear();
-                _param_changed_subscriptions_mutex.unlock();
-            }
-        }
-
-        // Process deferred unsubscriptions
-        {
-            std::lock_guard<std::mutex> lock(_deferred_unsubscriptions_mutex);
-            if (!_deferred_unsubscriptions.empty() &&
-                _param_changed_subscriptions_mutex.try_lock()) {
-                for (const auto& unsub : _deferred_unsubscriptions) {
-                    if (unsub.param_name.empty()) {
-                        // This is a special marker for unsubscribe_all_params_changed
-                        _param_changed_subscriptions.erase(
-                            std::remove_if(
-                                _param_changed_subscriptions.begin(),
-                                _param_changed_subscriptions.end(),
-                                [&](const auto& subscription) {
-                                    return subscription.cookie == unsub.cookie;
-                                }),
-                            _param_changed_subscriptions.end());
-                    } else {
-                        // This is a normal unsubscription for a specific parameter
-                        for (auto it = _param_changed_subscriptions.begin();
-                             it != _param_changed_subscriptions.end();
-                             /* ++it */) {
-                            if (it->param_name == unsub.param_name && it->cookie == unsub.cookie) {
-                                it = _param_changed_subscriptions.erase(it);
-                            } else {
-                                ++it;
-                            }
-                        }
-                    }
-                }
-                _deferred_unsubscriptions.clear();
-                _param_changed_subscriptions_mutex.unlock();
-            }
-        }
-    }
-
-    struct DeferredUnsubscription {
-        std::string param_name;
-        const void* cookie;
-    };
-
-    std::mutex _param_changed_subscriptions_mutex{};
+    asio::io_context& _io_context;
     std::vector<ParamChangedSubscription> _param_changed_subscriptions{};
-
-    std::mutex _deferred_subscriptions_mutex{};
-    std::vector<ParamChangedSubscription> _deferred_subscriptions{};
-
-    std::mutex _deferred_unsubscriptions_mutex{};
-    std::vector<DeferredUnsubscription> _deferred_unsubscriptions{};
 };
 
 } // namespace mavsdk

--- a/cpp/src/mavsdk/core/mavlink_parameter_subscription.hpp
+++ b/cpp/src/mavsdk/core/mavlink_parameter_subscription.hpp
@@ -2,8 +2,11 @@
 
 #include "param_value.hpp"
 #include <algorithm>
+#include <atomic>
+#include <cassert>
 #include <functional>
 #include <string>
+#include <thread>
 #include <variant>
 #include <vector>
 #include <asio/io_context.hpp>
@@ -68,10 +71,12 @@ public:
         if (callback != nullptr) {
             ParamChangedSubscription subscription{name, callback, cookie};
             asio::post(_io_context, [this, subscription = std::move(subscription)]() mutable {
+                note_list_thread();
                 _param_changed_subscriptions.push_back(std::move(subscription));
             });
         } else {
             asio::post(_io_context, [this, name, cookie]() {
+                note_list_thread();
                 _param_changed_subscriptions.erase(
                     std::remove_if(
                         _param_changed_subscriptions.begin(),
@@ -96,13 +101,15 @@ public:
         const std::string& name, const ParamCustomChangedCallback& callback, const void* cookie);
 
     // Remove all subscriptions for the given cookie. Must be called on the io_context
-    // thread (or while it is stopped), e.g. from within a handler already posted there.
+    // thread (or while it is stopped), e.g. from within a handler already posted there --
+    // but not from within a subscription callback (the removal would invalidate the
+    // iteration in find_and_call_subscriptions_value_changed()).
     void unsubscribe_all_params_changed(const void* cookie);
 
-    // Same, but synchronous and callable from any thread: the removal is run on the
-    // io_context thread and this returns only once it has completed, so no callback for
-    // this cookie can fire afterwards. Safe to call from the io_context thread too (the
-    // removal then runs inline rather than waiting on itself).
+    // Same, but synchronous and callable from any thread: once this returns, no callback
+    // for this cookie can fire anymore. On the io thread it removes directly, off it it
+    // posts the removal and waits for it. Like unsubscribe_all_params_changed(), it must
+    // not be called from within a subscription callback.
     void unsubscribe_all_params_changed_blocking(const void* cookie);
 
 protected:
@@ -117,8 +124,35 @@ protected:
         const std::string& param_name, const ParamValue& new_param_value);
 
 private:
+    bool on_io_thread() const { return _io_context.get_executor().running_in_this_thread(); }
+
+    // Record -- and in debug builds check -- which thread accesses the subscription list:
+    // normally always the io thread; once the io_context is stopped (teardown), the
+    // teardown thread accesses it directly instead. We track the accessing thread
+    // ourselves rather than asserting on_io_thread(), because asio's
+    // running_in_this_thread() relies on thread-locals that are not shared with a test
+    // binary that polls the io_context from outside the mavsdk shared library.
+    void note_list_thread()
+    {
+        const auto this_id = std::this_thread::get_id();
+        const auto previous_id = _list_thread_id.exchange(this_id, std::memory_order_relaxed);
+        assert(
+            previous_id == std::thread::id() || previous_id == this_id ||
+            _io_context.stopped());
+        (void)previous_id;
+    }
+
     asio::io_context& _io_context;
     std::vector<ParamChangedSubscription> _param_changed_subscriptions{};
+
+    // The single thread that is allowed to touch the subscription list; only used by
+    // note_list_thread().
+    std::atomic<std::thread::id> _list_thread_id{};
+
+    // True while find_and_call_subscriptions_value_changed() dispatches to the callbacks;
+    // only touched on the io thread. Used to assert that no callback removes subscriptions
+    // directly underneath the dispatch loop.
+    bool _iterating{false};
 };
 
 } // namespace mavsdk

--- a/cpp/src/mavsdk/core/mavsdk_impl.hpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.hpp
@@ -143,7 +143,7 @@ public:
     void set_heartbeat_timeout_s(double timeout_s) { _heartbeat_timeout_s = timeout_s; }
     double heartbeat_timeout_s() const { return _heartbeat_timeout_s; }
 
-    MavlinkMessageHandler mavlink_message_handler{};
+    MavlinkMessageHandler mavlink_message_handler{_io_context};
 
     ServerComponentImpl& default_server_component_impl();
 

--- a/cpp/src/mavsdk/core/mavsdk_impl.hpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.hpp
@@ -240,7 +240,7 @@ private:
         Handle<> handle;
     };
     std::vector<ConnectionEntry> _connections{};
-    CallbackList<Mavsdk::ConnectionError> _connections_errors_subscriptions{};
+    CallbackList<Mavsdk::ConnectionError> _connections_errors_subscriptions{_io_context};
 
     std::vector<std::pair<uint8_t, std::shared_ptr<System>>> _systems{};
 
@@ -248,7 +248,7 @@ private:
     std::vector<std::pair<uint8_t, std::shared_ptr<ServerComponent>>> _server_components{};
     std::shared_ptr<ServerComponent> _default_server_component{nullptr};
 
-    CallbackList<> _new_system_callbacks{};
+    CallbackList<> _new_system_callbacks{_io_context};
 
     Mavsdk::Configuration _configuration{ComponentType::GroundStation};
     std::atomic<uint8_t> _our_system_id{0};
@@ -292,7 +292,7 @@ private:
     HandleFactory<bool(Mavsdk::MavlinkMessage)> _json_handle_factory{};
 
     // Raw bytes subscriptions
-    CallbackList<const char*, size_t> _raw_bytes_subscriptions{};
+    CallbackList<const char*, size_t> _raw_bytes_subscriptions{_io_context};
 
     std::atomic<double> _timeout_s{DEFAULT_TIMEOUT_S};
     std::atomic<double> _heartbeat_timeout_s{DEFAULT_HEARTBEAT_TIMEOUT_S};

--- a/cpp/src/mavsdk/core/mavsdk_impl.hpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.hpp
@@ -44,6 +44,16 @@ class RawConnection;
 struct TlogFile;
 
 class MavsdkImpl {
+    // The Asio io_context must outlive every member that posts onto it during teardown
+    // (the message handler, parameter subscriptions, connections, systems, and server
+    // components). Declaring it first means it is destroyed last, so those members'
+    // destructors can still safely post/erase. It runs on its own dedicated thread; see
+    // _io_thread, which is stopped and joined explicitly in ~MavsdkImpl.
+    asio::io_context _io_context{};
+    // Keep io_context::run() from returning when there are momentarily no async ops pending.
+    asio::executor_work_guard<asio::io_context::executor_type> _io_work_guard{
+        _io_context.get_executor()};
+
 public:
     MavsdkImpl(const Mavsdk::Configuration& configuration);
     ~MavsdkImpl();
@@ -299,11 +309,8 @@ private:
 
     std::atomic<bool> _should_exit{false};
 
-    // Asio event loop — runs on its own dedicated thread.
-    asio::io_context _io_context{};
-    // Keep io_context::run() from returning when there are momentarily no async ops pending.
-    asio::executor_work_guard<asio::io_context::executor_type> _io_work_guard{
-        _io_context.get_executor()};
+    // _io_context and _io_work_guard are declared at the very top of the class so that the
+    // io_context outlives every member that posts onto it during teardown.
     // Recurring timer that drives TimeoutHandler::run_once() and
     // CallEveryHandler::run_once() on the io_context thread.
     asio::steady_timer _timers_poll_timer{_io_context};

--- a/cpp/src/mavsdk/core/server_component_impl.cpp
+++ b/cpp/src/mavsdk/core/server_component_impl.cpp
@@ -487,4 +487,9 @@ asio::io_context& ServerComponentImpl::OurSender::io_context()
     return _server_component_impl._mavsdk_impl.io_context();
 }
 
+asio::io_context& ServerComponentImpl::io_context()
+{
+    return _mavsdk_impl.io_context();
+}
+
 } // namespace mavsdk

--- a/cpp/src/mavsdk/core/server_component_impl.hpp
+++ b/cpp/src/mavsdk/core/server_component_impl.hpp
@@ -185,6 +185,8 @@ public:
 
     Sender& sender();
 
+    asio::io_context& io_context();
+
 private:
     MavsdkImpl& _mavsdk_impl;
     uint8_t _own_component_id{MAV_COMP_ID_AUTOPILOT1};

--- a/cpp/src/mavsdk/core/server_component_impl.hpp
+++ b/cpp/src/mavsdk/core/server_component_impl.hpp
@@ -196,7 +196,7 @@ private:
     uint8_t _channel{0};
 
     // Incoming libmav (JSON) message handling, used by the MavlinkDirectServer plugin.
-    CallbackList<Mavsdk::MavlinkMessage> _libmav_message_callbacks{};
+    CallbackList<Mavsdk::MavlinkMessage> _libmav_message_callbacks{io_context()};
 
     std::atomic<MAV_STATE> _system_status{MAV_STATE_UNINIT};
     std::atomic<uint8_t> _base_mode{0};

--- a/cpp/src/mavsdk/core/system_impl.cpp
+++ b/cpp/src/mavsdk/core/system_impl.cpp
@@ -24,6 +24,9 @@ template class MAVSDK_TEMPL_INST CallbackList<ComponentType>;
 template class MAVSDK_TEMPL_INST CallbackList<ComponentType, uint8_t>;
 
 SystemImpl::SystemImpl(MavsdkImpl& mavsdk_impl) :
+    // Declared before _mavsdk_impl, so init it first (in declaration order) using the
+    // ctor parameter rather than the not-yet-bound _mavsdk_impl reference.
+    _mavlink_message_handler(mavsdk_impl.io_context()),
     _mavsdk_impl(mavsdk_impl),
     _system_work_timer(mavsdk_impl.io_context()),
     _command_sender(*this),

--- a/cpp/src/mavsdk/core/system_impl.hpp
+++ b/cpp/src/mavsdk/core/system_impl.hpp
@@ -382,17 +382,11 @@ private:
         ParamValue value,
         const GetParamIntCallback& callback);
 
-    CallbackList<ComponentType> _component_discovered_callbacks{};
-    CallbackList<ComponentType, uint8_t> _component_discovered_id_callbacks{};
-
     MavlinkAddress _target_address{};
 
     AutopilotTime _autopilot_time{};
 
     MavlinkMessageHandler _mavlink_message_handler;
-
-    // Libmav message handling using CallbackList for thread safety
-    CallbackList<Mavsdk::MavlinkMessage> _libmav_message_callbacks{};
 
     bool _message_debugging = false;
 
@@ -411,12 +405,18 @@ private:
 
     MavsdkImpl& _mavsdk_impl;
 
+    // Declared after _mavsdk_impl so the default member initializers can use its io_context.
+    CallbackList<ComponentType> _component_discovered_callbacks{io_context()};
+    CallbackList<ComponentType, uint8_t> _component_discovered_id_callbacks{io_context()};
+    // Libmav message handling using CallbackList for thread safety
+    CallbackList<Mavsdk::MavlinkMessage> _libmav_message_callbacks{io_context()};
+
     asio::steady_timer _system_work_timer;
     SteadyTimePoint _last_ping_time{};
     std::atomic<bool> _should_exit{false};
 
     std::atomic<bool> _connected{false};
-    CallbackList<bool> _is_connected_callbacks{};
+    CallbackList<bool> _is_connected_callbacks{io_context()};
     TimeoutHandler::Cookie _heartbeat_timeout_cookie{};
 
     std::atomic<bool> _autopilot_version_pending{false};

--- a/cpp/src/mavsdk/core/system_impl.hpp
+++ b/cpp/src/mavsdk/core/system_impl.hpp
@@ -389,7 +389,7 @@ private:
 
     AutopilotTime _autopilot_time{};
 
-    MavlinkMessageHandler _mavlink_message_handler{};
+    MavlinkMessageHandler _mavlink_message_handler;
 
     // Libmav message handling using CallbackList for thread safety
     CallbackList<Mavsdk::MavlinkMessage> _libmav_message_callbacks{};

--- a/cpp/src/mavsdk/plugins/action_server/action_server_impl.hpp
+++ b/cpp/src/mavsdk/plugins/action_server/action_server_impl.hpp
@@ -70,13 +70,19 @@ private:
     void set_server_armed(bool armed);
 
     std::mutex _callback_mutex;
-    CallbackList<ActionServer::Result, ActionServer::ArmDisarm> _arm_disarm_callbacks{};
-    CallbackList<ActionServer::Result, ActionServer::FlightMode> _flight_mode_change_callbacks{};
-    CallbackList<ActionServer::Result, bool> _takeoff_callbacks{};
-    CallbackList<ActionServer::Result, bool> _land_callbacks{};
-    CallbackList<ActionServer::Result, bool> _reboot_callbacks{};
-    CallbackList<ActionServer::Result, bool> _shutdown_callbacks{};
-    CallbackList<ActionServer::Result, bool> _terminate_callbacks{};
+    CallbackList<ActionServer::Result, ActionServer::ArmDisarm> _arm_disarm_callbacks{
+        _server_component_impl->io_context()};
+    CallbackList<ActionServer::Result, ActionServer::FlightMode> _flight_mode_change_callbacks{
+        _server_component_impl->io_context()};
+    CallbackList<ActionServer::Result, bool> _takeoff_callbacks{
+        _server_component_impl->io_context()};
+    CallbackList<ActionServer::Result, bool> _land_callbacks{_server_component_impl->io_context()};
+    CallbackList<ActionServer::Result, bool> _reboot_callbacks{
+        _server_component_impl->io_context()};
+    CallbackList<ActionServer::Result, bool> _shutdown_callbacks{
+        _server_component_impl->io_context()};
+    CallbackList<ActionServer::Result, bool> _terminate_callbacks{
+        _server_component_impl->io_context()};
 
     std::atomic<bool> _armable = false;
     std::atomic<bool> _force_armable = false;

--- a/cpp/src/mavsdk/plugins/arm_authorizer_server/arm_authorizer_server_impl.hpp
+++ b/cpp/src/mavsdk/plugins/arm_authorizer_server/arm_authorizer_server_impl.hpp
@@ -25,7 +25,7 @@ public:
         bool temporarily, ArmAuthorizerServer::RejectionReason reason, int32_t extra_info) const;
 
 private:
-    CallbackList<uint32_t> _arm_authorization_callbacks{};
+    CallbackList<uint32_t> _arm_authorization_callbacks{_server_component_impl->io_context()};
 
     MavlinkCommandReceiver::CommandLong _last_arm_authorization_request_command;
 

--- a/cpp/src/mavsdk/plugins/camera/camera_impl.hpp
+++ b/cpp/src/mavsdk/plugins/camera/camera_impl.hpp
@@ -373,20 +373,23 @@ private:
     std::mutex& _mutex{*_mutex_keep_alive};
     std::shared_ptr<std::atomic<bool>> _alive{std::make_shared<std::atomic<bool>>(true)};
     std::vector<PotentialCamera> _potential_cameras;
-    CallbackList<Camera::CameraList> _camera_list_subscription_callbacks{};
+    CallbackList<Camera::CameraList> _camera_list_subscription_callbacks{
+        _system_impl->io_context()};
     CallbackList<Camera::PossibleSettingOptionsUpdate>
-        _subscribe_possible_setting_options_callbacks{};
-    CallbackList<Camera::CurrentSettingsUpdate> _subscribe_current_settings_callbacks{};
-    CallbackList<Camera::ModeUpdate> _mode_subscription_callbacks{};
-    CallbackList<Camera::CaptureInfo> _capture_info_callbacks{};
-    CallbackList<Camera::VideoStreamUpdate> _video_stream_info_subscription_callbacks{};
+        _subscribe_possible_setting_options_callbacks{_system_impl->io_context()};
+    CallbackList<Camera::CurrentSettingsUpdate> _subscribe_current_settings_callbacks{
+        _system_impl->io_context()};
+    CallbackList<Camera::ModeUpdate> _mode_subscription_callbacks{_system_impl->io_context()};
+    CallbackList<Camera::CaptureInfo> _capture_info_callbacks{_system_impl->io_context()};
+    CallbackList<Camera::VideoStreamUpdate> _video_stream_info_subscription_callbacks{
+        _system_impl->io_context()};
 
     CallEveryHandler::Cookie _check_potential_cameras_call_every_cookie{};
 
     std::optional<FileCache> _file_cache{};
     std::filesystem::path _tmp_download_path{};
 
-    CallbackList<Camera::StorageUpdate> _storage_subscription_callbacks{};
+    CallbackList<Camera::StorageUpdate> _storage_subscription_callbacks{_system_impl->io_context()};
 
     CallEveryHandler::Cookie _request_slower_call_every_cookie{};
     CallEveryHandler::Cookie _request_faster_call_every_cookie{};

--- a/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.hpp
+++ b/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.hpp
@@ -232,19 +232,21 @@ private:
     CallEveryHandler::Cookie _image_capture_timer_cookie{};
     int32_t _image_capture_count{};
 
-    CallbackList<int32_t> _take_photo_callbacks{};
-    CallbackList<int32_t> _start_video_callbacks{};
-    CallbackList<int32_t> _stop_video_callbacks{};
-    CallbackList<int32_t> _start_video_streaming_callbacks{};
-    CallbackList<int32_t> _stop_video_streaming_callbacks{};
-    CallbackList<CameraServer::Mode> _set_mode_callbacks{};
-    CallbackList<int32_t> _storage_information_callbacks{};
-    CallbackList<int32_t> _capture_status_callbacks{};
-    CallbackList<int32_t> _format_storage_callbacks{};
-    CallbackList<int32_t> _reset_settings_callbacks{};
-    CallbackList<CameraServer::TrackPoint> _tracking_point_callbacks{};
-    CallbackList<CameraServer::TrackRectangle> _tracking_rectangle_callbacks{};
-    CallbackList<int32_t> _tracking_off_callbacks{};
+    CallbackList<int32_t> _take_photo_callbacks{_server_component_impl->io_context()};
+    CallbackList<int32_t> _start_video_callbacks{_server_component_impl->io_context()};
+    CallbackList<int32_t> _stop_video_callbacks{_server_component_impl->io_context()};
+    CallbackList<int32_t> _start_video_streaming_callbacks{_server_component_impl->io_context()};
+    CallbackList<int32_t> _stop_video_streaming_callbacks{_server_component_impl->io_context()};
+    CallbackList<CameraServer::Mode> _set_mode_callbacks{_server_component_impl->io_context()};
+    CallbackList<int32_t> _storage_information_callbacks{_server_component_impl->io_context()};
+    CallbackList<int32_t> _capture_status_callbacks{_server_component_impl->io_context()};
+    CallbackList<int32_t> _format_storage_callbacks{_server_component_impl->io_context()};
+    CallbackList<int32_t> _reset_settings_callbacks{_server_component_impl->io_context()};
+    CallbackList<CameraServer::TrackPoint> _tracking_point_callbacks{
+        _server_component_impl->io_context()};
+    CallbackList<CameraServer::TrackRectangle> _tracking_rectangle_callbacks{
+        _server_component_impl->io_context()};
+    CallbackList<int32_t> _tracking_off_callbacks{_server_component_impl->io_context()};
 
     MavlinkCommandReceiver::CommandLong _last_take_photo_command;
     MavlinkCommandReceiver::CommandLong _last_start_video_command;
@@ -262,10 +264,10 @@ private:
 
     uint8_t _last_storage_id;
 
-    CallbackList<int32_t> _zoom_in_start_callbacks{};
-    CallbackList<int32_t> _zoom_out_start_callbacks{};
-    CallbackList<int32_t> _zoom_stop_callbacks{};
-    CallbackList<float> _zoom_range_callbacks{};
+    CallbackList<int32_t> _zoom_in_start_callbacks{_server_component_impl->io_context()};
+    CallbackList<int32_t> _zoom_out_start_callbacks{_server_component_impl->io_context()};
+    CallbackList<int32_t> _zoom_stop_callbacks{_server_component_impl->io_context()};
+    CallbackList<float> _zoom_range_callbacks{_server_component_impl->io_context()};
 
     MavlinkCommandReceiver::CommandLong _last_zoom_in_start_command;
     MavlinkCommandReceiver::CommandLong _last_zoom_out_start_command;

--- a/cpp/src/mavsdk/plugins/events/events_impl.cpp
+++ b/cpp/src/mavsdk/plugins/events/events_impl.cpp
@@ -5,12 +5,18 @@
 
 namespace mavsdk {
 
-EventsImpl::EventsImpl(System& system) : PluginImplBase(system)
+EventsImpl::EventsImpl(System& system) :
+    PluginImplBase(system),
+    _events_callbacks(_system_impl->io_context()),
+    _health_and_arming_checks_callbacks(_system_impl->io_context())
 {
     _system_impl->register_plugin(this);
 }
 
-EventsImpl::EventsImpl(std::shared_ptr<System> system) : PluginImplBase(std::move(system))
+EventsImpl::EventsImpl(std::shared_ptr<System> system) :
+    PluginImplBase(std::move(system)),
+    _events_callbacks(_system_impl->io_context()),
+    _health_and_arming_checks_callbacks(_system_impl->io_context())
 {
     _system_impl->register_plugin(this);
 }

--- a/cpp/src/mavsdk/plugins/gimbal/gimbal_impl.hpp
+++ b/cpp/src/mavsdk/plugins/gimbal/gimbal_impl.hpp
@@ -159,9 +159,9 @@ private:
     std::optional<GimbalAddress> maybe_address_for_gimbal_id(int32_t gimbal_id) const;
 
     mutable std::mutex _mutex{};
-    CallbackList<Gimbal::GimbalList> _gimbal_list_subscriptions{};
-    CallbackList<Gimbal::ControlStatus> _control_status_subscriptions{};
-    CallbackList<Gimbal::Attitude> _attitude_subscriptions{};
+    CallbackList<Gimbal::GimbalList> _gimbal_list_subscriptions{_system_impl->io_context()};
+    CallbackList<Gimbal::ControlStatus> _control_status_subscriptions{_system_impl->io_context()};
+    CallbackList<Gimbal::Attitude> _attitude_subscriptions{_system_impl->io_context()};
 
     std::vector<GimbalItem> _gimbals;
     std::unordered_map<uint8_t, GimbalDiscovery> _discovery;

--- a/cpp/src/mavsdk/plugins/info/info_impl.hpp
+++ b/cpp/src/mavsdk/plugins/info/info_impl.hpp
@@ -74,7 +74,7 @@ private:
     SteadyTimePoint _last_time_attitude_arrived{};
     uint32_t _last_time_boot_ms{0};
 
-    CallbackList<Info::FlightInfo> _flight_info_subscriptions{};
+    CallbackList<Info::FlightInfo> _flight_info_subscriptions{_system_impl->io_context()};
 
     static const std::string vendor_id_str(uint16_t vendor_id);
     static const std::string product_id_str(uint16_t product_id);

--- a/cpp/src/mavsdk/plugins/log_streaming/log_streaming_backend_ardupilot.cpp
+++ b/cpp/src/mavsdk/plugins/log_streaming/log_streaming_backend_ardupilot.cpp
@@ -36,7 +36,10 @@ void LogStreamingBackendArdupilot::deinit()
     }
 
     if (_system_impl) {
-        _system_impl->unregister_all_mavlink_message_handlers(this);
+        // Blocking, so that no message callback can fire into this backend anymore once
+        // deinit() returns -- the backend is destroyed right afterwards. This is safe from
+        // both the user thread (plugin destructor) and the io thread (disconnect).
+        _system_impl->unregister_all_mavlink_message_handlers_blocking(this);
     }
 }
 

--- a/cpp/src/mavsdk/plugins/log_streaming/log_streaming_backend_px4.cpp
+++ b/cpp/src/mavsdk/plugins/log_streaming/log_streaming_backend_px4.cpp
@@ -38,7 +38,10 @@ void LogStreamingBackendPx4::deinit()
     }
 
     if (_system_impl) {
-        _system_impl->unregister_all_mavlink_message_handlers(this);
+        // Blocking, so that no message callback can fire into this backend anymore once
+        // deinit() returns -- the backend is destroyed right afterwards. This is safe from
+        // both the user thread (plugin destructor) and the io thread (disconnect).
+        _system_impl->unregister_all_mavlink_message_handlers_blocking(this);
     }
 }
 

--- a/cpp/src/mavsdk/plugins/log_streaming/log_streaming_impl.cpp
+++ b/cpp/src/mavsdk/plugins/log_streaming/log_streaming_impl.cpp
@@ -40,18 +40,25 @@ void LogStreamingImpl::init()
 
 void LogStreamingImpl::deinit()
 {
-    std::lock_guard<std::mutex> lock(_mutex);
+    std::unique_ptr<LogStreamingBackend> backend;
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
 
-    // Cancel any pending autopilot type polling
-    if (_check_autopilot_cookie) {
-        _system_impl->remove_call_every(_check_autopilot_cookie);
-        _check_autopilot_cookie = {};
+        // Cancel any pending autopilot type polling
+        if (_check_autopilot_cookie) {
+            _system_impl->remove_call_every(_check_autopilot_cookie);
+            _check_autopilot_cookie = {};
+        }
+        _start_callback = nullptr;
+
+        backend = std::move(_backend);
     }
-    _start_callback = nullptr;
 
-    if (_backend) {
-        _backend->deinit();
-        _backend.reset();
+    // Deinit (and destroy) the backend outside of _mutex: its blocking unregister can wait
+    // for an in-flight message callback to finish, and that callback may be in
+    // process_data() waiting for _mutex.
+    if (backend) {
+        backend->deinit();
     }
 }
 
@@ -59,10 +66,15 @@ void LogStreamingImpl::enable() {}
 
 void LogStreamingImpl::disable()
 {
-    std::lock_guard<std::mutex> lock(_mutex);
-    if (_backend) {
-        _backend->deinit();
-        _backend.reset();
+    std::unique_ptr<LogStreamingBackend> backend;
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+        backend = std::move(_backend);
+    }
+
+    // Deinit (and destroy) the backend outside of _mutex, see deinit() above.
+    if (backend) {
+        backend->deinit();
     }
 }
 

--- a/cpp/src/mavsdk/plugins/log_streaming/log_streaming_impl.hpp
+++ b/cpp/src/mavsdk/plugins/log_streaming/log_streaming_impl.hpp
@@ -44,7 +44,7 @@ private:
 
     std::mutex _mutex{};
     std::unique_ptr<LogStreamingBackend> _backend{};
-    CallbackList<LogStreaming::LogStreamingRaw> _subscription_callbacks{};
+    CallbackList<LogStreaming::LogStreamingRaw> _subscription_callbacks{_system_impl->io_context()};
 
     bool _debugging{false};
 

--- a/cpp/src/mavsdk/plugins/mavlink_direct/mavlink_direct_impl.hpp
+++ b/cpp/src/mavsdk/plugins/mavlink_direct/mavlink_direct_impl.hpp
@@ -31,7 +31,7 @@ public:
 
 private:
     // Internal callback management
-    CallbackList<MavlinkDirect::MavlinkMessage> _callbacks{};
+    CallbackList<MavlinkDirect::MavlinkMessage> _callbacks{_system_impl->io_context()};
     Handle<Mavsdk::MavlinkMessage> _system_subscription{};
 
     bool _debugging = false;

--- a/cpp/src/mavsdk/plugins/mavlink_direct_server/mavlink_direct_server_impl.hpp
+++ b/cpp/src/mavsdk/plugins/mavlink_direct_server/mavlink_direct_server_impl.hpp
@@ -27,7 +27,8 @@ public:
 
 private:
     // Internal callback management
-    CallbackList<MavlinkDirectServer::MavlinkMessage> _callbacks{};
+    CallbackList<MavlinkDirectServer::MavlinkMessage> _callbacks{
+        _server_component_impl->io_context()};
     Handle<Mavsdk::MavlinkMessage> _server_subscription{};
 
     bool _debugging = false;

--- a/cpp/src/mavsdk/plugins/mavlink_passthrough/mavlink_passthrough_impl.cpp
+++ b/cpp/src/mavsdk/plugins/mavlink_passthrough/mavlink_passthrough_impl.cpp
@@ -205,7 +205,8 @@ MavlinkPassthrough::MessageHandle MavlinkPassthroughImpl::subscribe_message(
             this);
     }
 
-    return _message_subscriptions[message_id].subscribe(callback);
+    return _message_subscriptions.try_emplace(message_id, _system_impl->io_context())
+        .first->second.subscribe(callback);
 }
 
 void MavlinkPassthroughImpl::unsubscribe_message(
@@ -219,8 +220,9 @@ void MavlinkPassthroughImpl::unsubscribe_message(
 
 void MavlinkPassthroughImpl::receive_mavlink_message(const mavlink_message_t& message)
 {
-    _message_subscriptions[message.msgid].queue(
-        message, [this](const auto& func) { _system_impl->call_user_callback(func); });
+    _message_subscriptions.try_emplace(message.msgid, _system_impl->io_context())
+        .first->second.queue(
+            message, [this](const auto& func) { _system_impl->call_user_callback(func); });
 }
 
 uint8_t MavlinkPassthroughImpl::get_our_sysid() const

--- a/cpp/src/mavsdk/plugins/mission/mission_impl.cpp
+++ b/cpp/src/mavsdk/plugins/mission/mission_impl.cpp
@@ -14,12 +14,16 @@ using MissionItem = Mission::MissionItem;
 using CameraAction = Mission::MissionItem::CameraAction;
 using VehicleAction = Mission::MissionItem::VehicleAction;
 
-MissionImpl::MissionImpl(System& system) : PluginImplBase(system)
+MissionImpl::MissionImpl(System& system) :
+    PluginImplBase(system),
+    _mission_data(_system_impl->io_context())
 {
     _system_impl->register_plugin(this);
 }
 
-MissionImpl::MissionImpl(std::shared_ptr<System> system) : PluginImplBase(std::move(system))
+MissionImpl::MissionImpl(std::shared_ptr<System> system) :
+    PluginImplBase(std::move(system)),
+    _mission_data(_system_impl->io_context())
 {
     _system_impl->register_plugin(this);
 }

--- a/cpp/src/mavsdk/plugins/mission/mission_impl.hpp
+++ b/cpp/src/mavsdk/plugins/mission/mission_impl.hpp
@@ -117,11 +117,13 @@ private:
         std::vector<MavlinkMissionTransferClient::ItemInt>& int_items, unsigned item_i);
 
     struct MissionData {
+        explicit MissionData(asio::io_context& io_context) : mission_progress_callbacks(io_context)
+        {}
         mutable std::mutex mutex{};
         int last_current_mavlink_mission_item{-1};
         int last_reached_mavlink_mission_item{-1};
         std::vector<int> mavlink_mission_item_to_mission_item_indices{};
-        CallbackList<Mission::MissionProgress> mission_progress_callbacks{};
+        CallbackList<Mission::MissionProgress> mission_progress_callbacks;
         int last_current_reported_mission_item{-1};
         int last_total_reported_mission_item{-1};
         // Separate mutex for last_upload / last_download so their read/write
@@ -133,7 +135,7 @@ private:
         std::weak_ptr<MavlinkMissionTransferClient::WorkItem> last_download{};
         bool gimbal_v2_in_control{false};
         uint8_t mission_state{MISSION_STATE_UNKNOWN};
-    } _mission_data{};
+    } _mission_data;
 
     TimeoutHandler::Cookie _timeout_cookie{};
 

--- a/cpp/src/mavsdk/plugins/mission_raw/mission_raw_impl.cpp
+++ b/cpp/src/mavsdk/plugins/mission_raw/mission_raw_impl.cpp
@@ -16,12 +16,18 @@ template class MAVSDK_TEMPL_INST CallbackList<bool>;
 // This is an empty item that can be sent to ArduPilot to mimic clearing of mission.
 constexpr MissionRaw::MissionItem empty_item{0, 3, 16, 1};
 
-MissionRawImpl::MissionRawImpl(System& system) : PluginImplBase(system)
+MissionRawImpl::MissionRawImpl(System& system) :
+    PluginImplBase(system),
+    _mission_progress(_system_impl->io_context()),
+    _mission_changed(_system_impl->io_context())
 {
     _system_impl->register_plugin(this);
 }
 
-MissionRawImpl::MissionRawImpl(std::shared_ptr<System> system) : PluginImplBase(std::move(system))
+MissionRawImpl::MissionRawImpl(std::shared_ptr<System> system) :
+    PluginImplBase(std::move(system)),
+    _mission_progress(_system_impl->io_context()),
+    _mission_changed(_system_impl->io_context())
 {
     _system_impl->register_plugin(this);
 }

--- a/cpp/src/mavsdk/plugins/mission_raw/mission_raw_impl.hpp
+++ b/cpp/src/mavsdk/plugins/mission_raw/mission_raw_impl.hpp
@@ -131,20 +131,22 @@ private:
     std::weak_ptr<MavlinkMissionTransferClient::WorkItem> _last_upload{};
     std::weak_ptr<MavlinkMissionTransferClient::WorkItem> _last_download{};
 
-    struct {
+    struct MissionProgressData {
+        explicit MissionProgressData(asio::io_context& io_context) : callbacks(io_context) {}
         mutable std::mutex mutex{};
         MissionRaw::MissionProgress last{};
         MissionRaw::MissionProgress last_reported{};
-        CallbackList<MissionRaw::MissionProgress> callbacks{};
+        CallbackList<MissionRaw::MissionProgress> callbacks;
         int32_t last_reached{};
         uint8_t mission_state{MISSION_STATE_UNKNOWN};
-    } _mission_progress{};
+    } _mission_progress;
 
-    struct {
+    struct MissionChangedData {
+        explicit MissionChangedData(asio::io_context& io_context) : callbacks(io_context) {}
         std::mutex mutex{};
-        CallbackList<bool> callbacks{};
+        CallbackList<bool> callbacks;
         uint32_t last_mission_id{0};
-    } _mission_changed{};
+    } _mission_changed;
 };
 
 } // namespace mavsdk

--- a/cpp/src/mavsdk/plugins/mission_raw_server/mission_raw_server_impl.hpp
+++ b/cpp/src/mavsdk/plugins/mission_raw_server/mission_raw_server_impl.hpp
@@ -42,11 +42,12 @@ private:
     get_mission_items(const uint8_t mission_type);
 
     CallbackList<MissionRawServer::Result, MissionRawServer::MissionPlan>
-        _incoming_mission_callbacks{};
+        _incoming_mission_callbacks{_server_component_impl->io_context()};
     CallbackList<MissionRawServer::Result, MissionRawServer::MissionPlan>
-        _outgoing_mission_callbacks{};
-    CallbackList<MissionRawServer::MissionItem> _current_item_changed_callbacks{};
-    CallbackList<uint32_t> _clear_all_callbacks{};
+        _outgoing_mission_callbacks{_server_component_impl->io_context()};
+    CallbackList<MissionRawServer::MissionItem> _current_item_changed_callbacks{
+        _server_component_impl->io_context()};
+    CallbackList<uint32_t> _clear_all_callbacks{_server_component_impl->io_context()};
     std::atomic<int> _target_system_id;
     std::atomic<int> _target_component_id;
     std::atomic<int> _mission_count;

--- a/cpp/src/mavsdk/plugins/param_server/param_server_impl.cpp
+++ b/cpp/src/mavsdk/plugins/param_server/param_server_impl.cpp
@@ -26,13 +26,10 @@ void ParamServerImpl::init() {}
 
 void ParamServerImpl::deinit()
 {
-    // Ensure synchronous cleanup - keep trying until all callbacks are unregistered
+    // Remove our subscriptions synchronously on the io_context thread, so no callback
+    // can fire after we return (and before we clear our callback lists below).
     auto& param_server = _server_component_impl->mavlink_parameter_server();
-    param_server.unsubscribe_all_params_changed(this);
-
-    // Give a brief moment for any deferred unsubscriptions to be processed
-    // This prevents use-after-free if callbacks are still executing
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    param_server.unsubscribe_all_params_changed_blocking(this);
 
     // Clear our callback lists to ensure no pending callbacks exist
     _changed_param_int_callbacks.clear();

--- a/cpp/src/mavsdk/plugins/param_server/param_server_impl.hpp
+++ b/cpp/src/mavsdk/plugins/param_server/param_server_impl.hpp
@@ -47,9 +47,12 @@ public:
     result_from_mavlink_parameter_server_result(MavlinkParameterServer::Result result);
 
 private:
-    CallbackList<ParamServer::IntParam> _changed_param_int_callbacks{};
-    CallbackList<ParamServer::FloatParam> _changed_param_float_callbacks{};
-    CallbackList<ParamServer::CustomParam> _changed_param_custom_callbacks{};
+    CallbackList<ParamServer::IntParam> _changed_param_int_callbacks{
+        _server_component_impl->io_context()};
+    CallbackList<ParamServer::FloatParam> _changed_param_float_callbacks{
+        _server_component_impl->io_context()};
+    CallbackList<ParamServer::CustomParam> _changed_param_custom_callbacks{
+        _server_component_impl->io_context()};
 };
 
 } // namespace mavsdk

--- a/cpp/src/mavsdk/plugins/shell/shell_impl.cpp
+++ b/cpp/src/mavsdk/plugins/shell/shell_impl.cpp
@@ -62,13 +62,11 @@ Shell::Result ShellImpl::send(std::string command)
 
 Shell::ReceiveHandle ShellImpl::subscribe_receive(const Shell::ReceiveCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_receive.mutex);
     return _receive.callbacks.subscribe(callback);
 }
 
 void ShellImpl::unsubscribe_receive(Shell::ReceiveHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_receive.mutex);
     _receive.callbacks.unsubscribe(handle);
 }
 
@@ -101,7 +99,6 @@ bool ShellImpl::send_command_message(std::string command)
     uint8_t flags = 0;
     {
         // We only ask for a response if we have subscribed to a response.
-        std::lock_guard<std::mutex> lock(_receive.mutex);
         if (!_receive.callbacks.empty()) {
             flags |= SERIAL_CONTROL_FLAG_RESPOND;
         }
@@ -150,7 +147,6 @@ void ShellImpl::process_shell_message(const mavlink_message_t& message)
         response.erase(index, 4);
     }
 
-    std::lock_guard<std::mutex> lock(_receive.mutex);
     _receive.callbacks.queue(
         response, [this](const auto& func) { _system_impl->call_user_callback(func); });
 }

--- a/cpp/src/mavsdk/plugins/shell/shell_impl.cpp
+++ b/cpp/src/mavsdk/plugins/shell/shell_impl.cpp
@@ -25,12 +25,14 @@ void ShellImpl::enable() {}
 
 void ShellImpl::disable() {}
 
-ShellImpl::ShellImpl(System& system) : PluginImplBase(system)
+ShellImpl::ShellImpl(System& system) : PluginImplBase(system), _receive(_system_impl->io_context())
 {
     _system_impl->register_plugin(this);
 }
 
-ShellImpl::ShellImpl(std::shared_ptr<System> system) : PluginImplBase(std::move(system))
+ShellImpl::ShellImpl(std::shared_ptr<System> system) :
+    PluginImplBase(std::move(system)),
+    _receive(_system_impl->io_context())
 {
     _system_impl->register_plugin(this);
 }

--- a/cpp/src/mavsdk/plugins/shell/shell_impl.hpp
+++ b/cpp/src/mavsdk/plugins/shell/shell_impl.hpp
@@ -39,7 +39,6 @@ private:
 
     struct Receive {
         explicit Receive(asio::io_context& io_context) : callbacks(io_context) {}
-        std::mutex mutex{};
         CallbackList<std::string> callbacks;
     } _receive;
 };

--- a/cpp/src/mavsdk/plugins/shell/shell_impl.hpp
+++ b/cpp/src/mavsdk/plugins/shell/shell_impl.hpp
@@ -37,9 +37,10 @@ private:
 
     static constexpr uint16_t timeout_ms = 1000;
 
-    struct {
+    struct Receive {
+        explicit Receive(asio::io_context& io_context) : callbacks(io_context) {}
         std::mutex mutex{};
-        CallbackList<std::string> callbacks{};
-    } _receive{};
+        CallbackList<std::string> callbacks;
+    } _receive;
 };
 } // namespace mavsdk

--- a/cpp/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/cpp/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -754,7 +754,6 @@ void TelemetryImpl::process_position_velocity_ned(const mavlink_message_t& messa
 
     set_position_velocity_ned(position_velocity);
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _position_velocity_ned_subscriptions.queue(position_velocity_ned(), [this](const auto& func) {
         _system_impl->call_user_callback(func);
     });
@@ -792,7 +791,6 @@ void TelemetryImpl::process_global_position_int(const mavlink_message_t& message
         set_heading(heading);
     }
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _position_subscriptions.queue(
         position(), [this](const auto& func) { _system_impl->call_user_callback(func); });
 
@@ -829,7 +827,6 @@ void TelemetryImpl::process_home_position(const mavlink_message_t& message)
 
     set_health_home_position(true);
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _home_position_subscriptions.queue(
         home(), [this](const auto& func) { _system_impl->call_user_callback(func); });
 }
@@ -882,7 +879,6 @@ void TelemetryImpl::process_attitude_quaternion(const mavlink_message_t& message
 
     set_attitude_angular_velocity_body(angular_velocity_body);
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _attitude_quaternion_angle_subscriptions.queue(attitude_quaternion(), [this](const auto& func) {
         _system_impl->call_user_callback(func);
     });
@@ -908,7 +904,6 @@ void TelemetryImpl::process_altitude(const mavlink_message_t& message)
 
     set_altitude(new_altitude);
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _altitude_subscriptions.queue(
         altitude(), [this](const auto& func) { _system_impl->call_user_callback(func); });
 }
@@ -930,7 +925,6 @@ void TelemetryImpl::process_wind(const mavlink_message_t& message)
 
     set_wind(new_wind);
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _wind_subscriptions.queue(
         wind(), [this](const auto& func) { _system_impl->call_user_callback(func); });
 }
@@ -954,7 +948,6 @@ void TelemetryImpl::process_imu_reading_ned(const mavlink_message_t& message)
 
     set_imu_reading_ned(new_imu);
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _imu_reading_ned_subscriptions.queue(
         imu(), [this](const auto& func) { _system_impl->call_user_callback(func); });
 }
@@ -981,7 +974,6 @@ void TelemetryImpl::process_scaled_imu(const mavlink_message_t& message)
 
     set_scaled_imu(new_imu);
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _scaled_imu_subscriptions.queue(
         scaled_imu(), [this](const auto& func) { _system_impl->call_user_callback(func); });
 }
@@ -1005,7 +997,6 @@ void TelemetryImpl::process_raw_imu(const mavlink_message_t& message)
 
     set_raw_imu(new_imu);
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _raw_imu_subscriptions.queue(
         raw_imu(), [this](const auto& func) { _system_impl->call_user_callback(func); });
 }
@@ -1068,7 +1059,6 @@ void TelemetryImpl::process_gps_raw_int(const mavlink_message_t& message)
     set_raw_gps(raw_gps_info);
 
     {
-        std::lock_guard<std::mutex> lock(_subscription_mutex);
         _gps_info_subscriptions.queue(
             gps_info(), [this](const auto& func) { _system_impl->call_user_callback(func); });
         _raw_gps_subscriptions.queue(
@@ -1089,7 +1079,6 @@ void TelemetryImpl::process_ground_truth(const mavlink_message_t& message)
 
     set_ground_truth(new_ground_truth);
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _ground_truth_subscriptions.queue(
         ground_truth(), [this](const auto& func) { _system_impl->call_user_callback(func); });
 }
@@ -1107,7 +1096,6 @@ void TelemetryImpl::process_extended_sys_state(const mavlink_message_t& message)
         set_vtol_state(vtol_state);
     }
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _landed_state_subscriptions.queue(
         landed_state(), [this](const auto& func) { _system_impl->call_user_callback(func); });
 
@@ -1141,7 +1129,6 @@ void TelemetryImpl::process_fixedwing_metrics(const mavlink_message_t& message)
 
     set_fixedwing_metrics(new_fixedwing_metrics);
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _fixedwing_metrics_subscriptions.queue(
         fixedwing_metrics(), [this](const auto& func) { _system_impl->call_user_callback(func); });
 }
@@ -1159,7 +1146,6 @@ void TelemetryImpl::process_sys_status(const mavlink_message_t& message)
         set_battery(new_battery);
 
         {
-            std::lock_guard<std::mutex> lock(_subscription_mutex);
             _battery_subscriptions.queue(
                 battery(), [this](const auto& func) { _system_impl->call_user_callback(func); });
         }
@@ -1204,7 +1190,6 @@ void TelemetryImpl::process_sys_status(const mavlink_message_t& message)
 
     set_rc_status({rc_ok}, std::nullopt);
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _rc_status_subscriptions.queue(
         rc_status(), [this](const auto& func) { _system_impl->call_user_callback(func); });
 
@@ -1289,7 +1274,6 @@ void TelemetryImpl::process_battery_status(const mavlink_message_t& message)
     set_battery(new_battery);
 
     {
-        std::lock_guard<std::mutex> lock(_subscription_mutex);
         _battery_subscriptions.queue(
             battery(), [this](const auto& func) { _system_impl->call_user_callback(func); });
     }
@@ -1306,7 +1290,6 @@ void TelemetryImpl::process_heartbeat(const mavlink_message_t& message)
 
     set_armed(((heartbeat.base_mode & MAV_MODE_FLAG_SAFETY_ARMED) ? true : false));
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _armed_subscriptions.queue(
         armed(), [this](const auto& func) { _system_impl->call_user_callback(func); });
 
@@ -1360,7 +1343,6 @@ void TelemetryImpl::receive_statustext(const MavlinkStatustextHandler::Statustex
 
     set_status_text(new_status_text);
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _status_text_subscriptions.queue(
         status_text(), [this](const auto& func) { _system_impl->call_user_callback(func); });
 }
@@ -1374,7 +1356,6 @@ void TelemetryImpl::process_rc_channels(const mavlink_message_t& message)
         set_rc_status(std::nullopt, {rc_channels.rssi});
     }
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _rc_status_subscriptions.queue(
         rc_status(), [this](const auto& func) { _system_impl->call_user_callback(func); });
 }
@@ -1386,7 +1367,6 @@ void TelemetryImpl::process_unix_epoch_time(const mavlink_message_t& message)
 
     set_unix_epoch_time_us(system_time.time_unix_usec);
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _unix_epoch_time_subscriptions.queue(
         unix_epoch_time(), [this](const auto& func) { _system_impl->call_user_callback(func); });
 }
@@ -1407,7 +1387,6 @@ void TelemetryImpl::process_actuator_control_target(const mavlink_message_t& mes
 
     set_actuator_control_target(group, controls);
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _actuator_control_target_subscriptions.queue(
         actuator_control_target(),
         [this](const auto& func) { _system_impl->call_user_callback(func); });
@@ -1429,7 +1408,6 @@ void TelemetryImpl::process_actuator_output_status(const mavlink_message_t& mess
 
     set_actuator_output_status(active, actuators);
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _actuator_output_status_subscriptions.queue(actuator_output_status(), [this](const auto& func) {
         _system_impl->call_user_callback(func);
     });
@@ -1480,7 +1458,6 @@ void TelemetryImpl::process_odometry(const mavlink_message_t& message)
 
     set_odometry(odometry_struct);
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _odometry_subscriptions.queue(
         odometry(), [this](const auto& func) { _system_impl->call_user_callback(func); });
 }
@@ -1502,7 +1479,6 @@ void TelemetryImpl::process_distance_sensor(const mavlink_message_t& message)
 
     set_distance_sensor(distance_sensor_struct);
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _distance_sensor_subscriptions.queue(
         distance_sensor(), [this](const auto& func) { _system_impl->call_user_callback(func); });
 }
@@ -1735,7 +1711,6 @@ void TelemetryImpl::process_scaled_pressure(const mavlink_message_t& message)
 
     set_scaled_pressure(scaled_pressure_struct);
 
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _scaled_pressure_subscriptions.queue(
         scaled_pressure(), [this](const auto& func) { _system_impl->call_user_callback(func); });
 }
@@ -2247,101 +2222,85 @@ void TelemetryImpl::set_scaled_pressure(Telemetry::ScaledPressure& scaled_pressu
 Telemetry::PositionVelocityNedHandle TelemetryImpl::subscribe_position_velocity_ned(
     const Telemetry::PositionVelocityNedCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _position_velocity_ned_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_position_velocity_ned(Telemetry::PositionVelocityNedHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _position_velocity_ned_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::PositionHandle
 TelemetryImpl::subscribe_position(const Telemetry::PositionCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _position_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_position(Telemetry::PositionHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _position_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::HomeHandle TelemetryImpl::subscribe_home(const Telemetry::HomeCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _home_position_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_home(Telemetry::HomeHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _home_position_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::InAirHandle TelemetryImpl::subscribe_in_air(const Telemetry::InAirCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _in_air_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_in_air(Telemetry::InAirHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _in_air_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::StatusTextHandle
 TelemetryImpl::subscribe_status_text(const Telemetry::StatusTextCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _status_text_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_status_text(Handle<Telemetry::StatusText> handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _status_text_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::ArmedHandle TelemetryImpl::subscribe_armed(const Telemetry::ArmedCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _armed_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_armed(Telemetry::ArmedHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _armed_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::AttitudeQuaternionHandle
 TelemetryImpl::subscribe_attitude_quaternion(const Telemetry::AttitudeQuaternionCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _attitude_quaternion_angle_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_attitude_quaternion(Telemetry::AttitudeQuaternionHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _attitude_quaternion_angle_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::AttitudeEulerHandle
 TelemetryImpl::subscribe_attitude_euler(const Telemetry::AttitudeEulerCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _attitude_euler_angle_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_attitude_euler(Telemetry::AttitudeEulerHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _attitude_euler_angle_subscriptions.unsubscribe(handle);
 }
 
@@ -2349,322 +2308,272 @@ Telemetry::AttitudeAngularVelocityBodyHandle
 TelemetryImpl::subscribe_attitude_angular_velocity_body(
     const Telemetry::AttitudeAngularVelocityBodyCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _attitude_angular_velocity_body_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_attitude_angular_velocity_body(
     Telemetry::AttitudeAngularVelocityBodyHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _attitude_angular_velocity_body_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::FixedwingMetricsHandle
 TelemetryImpl::subscribe_fixedwing_metrics(const Telemetry::FixedwingMetricsCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _fixedwing_metrics_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_fixedwing_metrics(Telemetry::FixedwingMetricsHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _fixedwing_metrics_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::GroundTruthHandle
 TelemetryImpl::subscribe_ground_truth(const Telemetry::GroundTruthCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _ground_truth_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_ground_truth(Telemetry::GroundTruthHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _ground_truth_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::VelocityNedHandle
 TelemetryImpl::subscribe_velocity_ned(const Telemetry::VelocityNedCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _velocity_ned_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_velocity_ned(Telemetry::VelocityNedHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _velocity_ned_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::ImuHandle TelemetryImpl::subscribe_imu(const Telemetry::ImuCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _imu_reading_ned_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_imu(Telemetry::ImuHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _imu_reading_ned_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::ScaledImuHandle
 TelemetryImpl::subscribe_scaled_imu(const Telemetry::ScaledImuCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _scaled_imu_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_scaled_imu(Telemetry::ScaledImuHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _scaled_imu_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::RawImuHandle TelemetryImpl::subscribe_raw_imu(const Telemetry::RawImuCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _raw_imu_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_raw_imu(Telemetry::RawImuHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _raw_imu_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::GpsInfoHandle
 TelemetryImpl::subscribe_gps_info(const Telemetry::GpsInfoCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _gps_info_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_gps_info(Telemetry::GpsInfoHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _gps_info_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::RawGpsHandle TelemetryImpl::subscribe_raw_gps(const Telemetry::RawGpsCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _raw_gps_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_raw_gps(Telemetry::RawGpsHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _raw_gps_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::BatteryHandle
 TelemetryImpl::subscribe_battery(const Telemetry::BatteryCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _battery_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_battery(Telemetry::BatteryHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _battery_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::FlightModeHandle
 TelemetryImpl::subscribe_flight_mode(const Telemetry::FlightModeCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _flight_mode_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_flight_mode(Telemetry::FlightModeHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _flight_mode_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::HealthHandle TelemetryImpl::subscribe_health(const Telemetry::HealthCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _health_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_health(Telemetry::HealthHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _health_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::HealthAllOkHandle
 TelemetryImpl::subscribe_health_all_ok(const Telemetry::HealthAllOkCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _health_all_ok_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_health_all_ok(Telemetry::HealthAllOkHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _health_all_ok_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::VtolStateHandle
 TelemetryImpl::subscribe_vtol_state(const Telemetry::VtolStateCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _vtol_state_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_vtol_state(Telemetry::VtolStateHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _vtol_state_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::LandedStateHandle
 TelemetryImpl::subscribe_landed_state(const Telemetry::LandedStateCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _landed_state_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_landed_state(Telemetry::LandedStateHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _landed_state_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::RcStatusHandle
 TelemetryImpl::subscribe_rc_status(const Telemetry::RcStatusCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _rc_status_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_rc_status(Telemetry::RcStatusHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _rc_status_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::UnixEpochTimeHandle
 TelemetryImpl::subscribe_unix_epoch_time(const Telemetry::UnixEpochTimeCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _unix_epoch_time_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_unix_epoch_time(Telemetry::UnixEpochTimeHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _unix_epoch_time_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::ActuatorControlTargetHandle TelemetryImpl::subscribe_actuator_control_target(
     const Telemetry::ActuatorControlTargetCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _actuator_control_target_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_actuator_control_target(
     Telemetry::ActuatorControlTargetHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _actuator_control_target_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::ActuatorOutputStatusHandle TelemetryImpl::subscribe_actuator_output_status(
     const Telemetry::ActuatorOutputStatusCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _actuator_output_status_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_actuator_output_status(Telemetry::ActuatorOutputStatusHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _actuator_output_status_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::OdometryHandle
 TelemetryImpl::subscribe_odometry(const Telemetry::OdometryCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _odometry_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_odometry(Telemetry::OdometryHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _odometry_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::DistanceSensorHandle
 TelemetryImpl::subscribe_distance_sensor(const Telemetry::DistanceSensorCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _distance_sensor_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_distance_sensor(Telemetry::DistanceSensorHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _distance_sensor_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::ScaledPressureHandle
 TelemetryImpl::subscribe_scaled_pressure(const Telemetry::ScaledPressureCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _scaled_pressure_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_scaled_pressure(Telemetry::ScaledPressureHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _scaled_pressure_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::HeadingHandle
 TelemetryImpl::subscribe_heading(const Telemetry::HeadingCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _heading_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_heading(Telemetry::HeadingHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _heading_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::AltitudeHandle
 TelemetryImpl::subscribe_altitude(const Telemetry::AltitudeCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _altitude_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_altitude(Telemetry::AltitudeHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _altitude_subscriptions.unsubscribe(handle);
 }
 
 Telemetry::WindHandle TelemetryImpl::subscribe_wind(const Telemetry::WindCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _wind_subscriptions.subscribe(callback);
 }
 
 void TelemetryImpl::unsubscribe_wind(Telemetry::WindHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _wind_subscriptions.unsubscribe(handle);
 }
 

--- a/cpp/src/mavsdk/plugins/telemetry/telemetry_impl.hpp
+++ b/cpp/src/mavsdk/plugins/telemetry/telemetry_impl.hpp
@@ -381,39 +381,48 @@ private:
     Telemetry::Wind _wind{};
 
     std::mutex _subscription_mutex{};
-    CallbackList<Telemetry::PositionVelocityNed> _position_velocity_ned_subscriptions{};
-    CallbackList<Telemetry::Position> _position_subscriptions{};
-    CallbackList<Telemetry::HomePosition> _home_position_subscriptions{};
-    CallbackList<bool> _in_air_subscriptions{};
-    CallbackList<Telemetry::StatusText> _status_text_subscriptions{};
-    CallbackList<bool> _armed_subscriptions{};
-    CallbackList<Telemetry::Quaternion> _attitude_quaternion_angle_subscriptions{};
-    CallbackList<Telemetry::AngularVelocityBody> _attitude_angular_velocity_body_subscriptions{};
-    CallbackList<Telemetry::GroundTruth> _ground_truth_subscriptions{};
-    CallbackList<Telemetry::FixedwingMetrics> _fixedwing_metrics_subscriptions{};
-    CallbackList<Telemetry::EulerAngle> _attitude_euler_angle_subscriptions{};
-    CallbackList<Telemetry::VelocityNed> _velocity_ned_subscriptions{};
-    CallbackList<Telemetry::Imu> _imu_reading_ned_subscriptions{};
-    CallbackList<Telemetry::Imu> _scaled_imu_subscriptions{};
-    CallbackList<Telemetry::Imu> _raw_imu_subscriptions{};
-    CallbackList<Telemetry::GpsInfo> _gps_info_subscriptions{};
-    CallbackList<Telemetry::RawGps> _raw_gps_subscriptions{};
-    CallbackList<Telemetry::Battery> _battery_subscriptions{};
-    CallbackList<Telemetry::FlightMode> _flight_mode_subscriptions{};
-    CallbackList<Telemetry::Health> _health_subscriptions{};
-    CallbackList<bool> _health_all_ok_subscriptions{};
-    CallbackList<Telemetry::VtolState> _vtol_state_subscriptions{};
-    CallbackList<Telemetry::LandedState> _landed_state_subscriptions{};
-    CallbackList<Telemetry::RcStatus> _rc_status_subscriptions{};
-    CallbackList<uint64_t> _unix_epoch_time_subscriptions{};
-    CallbackList<Telemetry::ActuatorControlTarget> _actuator_control_target_subscriptions{};
-    CallbackList<Telemetry::ActuatorOutputStatus> _actuator_output_status_subscriptions{};
-    CallbackList<Telemetry::Odometry> _odometry_subscriptions{};
-    CallbackList<Telemetry::DistanceSensor> _distance_sensor_subscriptions{};
-    CallbackList<Telemetry::ScaledPressure> _scaled_pressure_subscriptions{};
-    CallbackList<Telemetry::Heading> _heading_subscriptions{};
-    CallbackList<Telemetry::Altitude> _altitude_subscriptions{};
-    CallbackList<Telemetry::Wind> _wind_subscriptions{};
+    CallbackList<Telemetry::PositionVelocityNed> _position_velocity_ned_subscriptions{
+        _system_impl->io_context()};
+    CallbackList<Telemetry::Position> _position_subscriptions{_system_impl->io_context()};
+    CallbackList<Telemetry::HomePosition> _home_position_subscriptions{_system_impl->io_context()};
+    CallbackList<bool> _in_air_subscriptions{_system_impl->io_context()};
+    CallbackList<Telemetry::StatusText> _status_text_subscriptions{_system_impl->io_context()};
+    CallbackList<bool> _armed_subscriptions{_system_impl->io_context()};
+    CallbackList<Telemetry::Quaternion> _attitude_quaternion_angle_subscriptions{
+        _system_impl->io_context()};
+    CallbackList<Telemetry::AngularVelocityBody> _attitude_angular_velocity_body_subscriptions{
+        _system_impl->io_context()};
+    CallbackList<Telemetry::GroundTruth> _ground_truth_subscriptions{_system_impl->io_context()};
+    CallbackList<Telemetry::FixedwingMetrics> _fixedwing_metrics_subscriptions{
+        _system_impl->io_context()};
+    CallbackList<Telemetry::EulerAngle> _attitude_euler_angle_subscriptions{
+        _system_impl->io_context()};
+    CallbackList<Telemetry::VelocityNed> _velocity_ned_subscriptions{_system_impl->io_context()};
+    CallbackList<Telemetry::Imu> _imu_reading_ned_subscriptions{_system_impl->io_context()};
+    CallbackList<Telemetry::Imu> _scaled_imu_subscriptions{_system_impl->io_context()};
+    CallbackList<Telemetry::Imu> _raw_imu_subscriptions{_system_impl->io_context()};
+    CallbackList<Telemetry::GpsInfo> _gps_info_subscriptions{_system_impl->io_context()};
+    CallbackList<Telemetry::RawGps> _raw_gps_subscriptions{_system_impl->io_context()};
+    CallbackList<Telemetry::Battery> _battery_subscriptions{_system_impl->io_context()};
+    CallbackList<Telemetry::FlightMode> _flight_mode_subscriptions{_system_impl->io_context()};
+    CallbackList<Telemetry::Health> _health_subscriptions{_system_impl->io_context()};
+    CallbackList<bool> _health_all_ok_subscriptions{_system_impl->io_context()};
+    CallbackList<Telemetry::VtolState> _vtol_state_subscriptions{_system_impl->io_context()};
+    CallbackList<Telemetry::LandedState> _landed_state_subscriptions{_system_impl->io_context()};
+    CallbackList<Telemetry::RcStatus> _rc_status_subscriptions{_system_impl->io_context()};
+    CallbackList<uint64_t> _unix_epoch_time_subscriptions{_system_impl->io_context()};
+    CallbackList<Telemetry::ActuatorControlTarget> _actuator_control_target_subscriptions{
+        _system_impl->io_context()};
+    CallbackList<Telemetry::ActuatorOutputStatus> _actuator_output_status_subscriptions{
+        _system_impl->io_context()};
+    CallbackList<Telemetry::Odometry> _odometry_subscriptions{_system_impl->io_context()};
+    CallbackList<Telemetry::DistanceSensor> _distance_sensor_subscriptions{
+        _system_impl->io_context()};
+    CallbackList<Telemetry::ScaledPressure> _scaled_pressure_subscriptions{
+        _system_impl->io_context()};
+    CallbackList<Telemetry::Heading> _heading_subscriptions{_system_impl->io_context()};
+    CallbackList<Telemetry::Altitude> _altitude_subscriptions{_system_impl->io_context()};
+    CallbackList<Telemetry::Wind> _wind_subscriptions{_system_impl->io_context()};
     // The velocity (former ground speed) and position are coupled to the same message, therefore,
     // we just use the faster between the two.
     double _velocity_ned_rate_hz{0.0};

--- a/cpp/src/mavsdk/plugins/telemetry/telemetry_impl.hpp
+++ b/cpp/src/mavsdk/plugins/telemetry/telemetry_impl.hpp
@@ -380,7 +380,6 @@ private:
     mutable std::mutex _wind_mutex{};
     Telemetry::Wind _wind{};
 
-    std::mutex _subscription_mutex{};
     CallbackList<Telemetry::PositionVelocityNed> _position_velocity_ned_subscriptions{
         _system_impl->io_context()};
     CallbackList<Telemetry::Position> _position_subscriptions{_system_impl->io_context()};

--- a/cpp/src/mavsdk/plugins/transponder/transponder_impl.cpp
+++ b/cpp/src/mavsdk/plugins/transponder/transponder_impl.cpp
@@ -64,13 +64,11 @@ Transponder::AdsbVehicle TransponderImpl::transponder() const
 Transponder::TransponderHandle
 TransponderImpl::subscribe_transponder(const Transponder::TransponderCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _transponder_subscriptions.subscribe(callback);
 }
 
 void TransponderImpl::unsubscribe_transponder(Transponder::TransponderHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _transponder_subscriptions.unsubscribe(handle);
 }
 

--- a/cpp/src/mavsdk/plugins/transponder/transponder_impl.hpp
+++ b/cpp/src/mavsdk/plugins/transponder/transponder_impl.hpp
@@ -43,7 +43,7 @@ private:
     Transponder::AdsbVehicle _transponder{};
 
     std::mutex _subscription_mutex{};
-    CallbackList<Transponder::AdsbVehicle> _transponder_subscriptions{};
+    CallbackList<Transponder::AdsbVehicle> _transponder_subscriptions{_system_impl->io_context()};
 };
 
 } // namespace mavsdk

--- a/cpp/src/mavsdk/plugins/transponder/transponder_impl.hpp
+++ b/cpp/src/mavsdk/plugins/transponder/transponder_impl.hpp
@@ -42,7 +42,6 @@ private:
     mutable std::mutex _transponder_mutex{};
     Transponder::AdsbVehicle _transponder{};
 
-    std::mutex _subscription_mutex{};
     CallbackList<Transponder::AdsbVehicle> _transponder_subscriptions{_system_impl->io_context()};
 };
 

--- a/cpp/src/mavsdk/plugins/winch/winch_impl.cpp
+++ b/cpp/src/mavsdk/plugins/winch/winch_impl.cpp
@@ -32,13 +32,11 @@ void WinchImpl::init()
 
 Winch::StatusHandle WinchImpl::subscribe_status(const Winch::StatusCallback& callback)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     return _status_subscriptions.subscribe(callback);
 }
 
 void WinchImpl::unsubscribe_status(Winch::StatusHandle handle)
 {
-    std::lock_guard<std::mutex> lock(_subscription_mutex);
     _status_subscriptions.unsubscribe(handle);
 }
 
@@ -102,7 +100,6 @@ void WinchImpl::process_status(const mavlink_message_t& message)
     set_status(new_status);
 
     {
-        std::lock_guard<std::mutex> lock(_subscription_mutex);
         _status_subscriptions.queue(
             status(), [this](const auto& func) { _system_impl->call_user_callback(func); });
     }

--- a/cpp/src/mavsdk/plugins/winch/winch_impl.hpp
+++ b/cpp/src/mavsdk/plugins/winch/winch_impl.hpp
@@ -73,7 +73,7 @@ private:
 
     std::mutex _subscription_mutex{};
 
-    CallbackList<Winch::Status> _status_subscriptions{};
+    CallbackList<Winch::Status> _status_subscriptions{_system_impl->io_context()};
 };
 
 } // namespace mavsdk

--- a/cpp/src/mavsdk/plugins/winch/winch_impl.hpp
+++ b/cpp/src/mavsdk/plugins/winch/winch_impl.hpp
@@ -71,8 +71,6 @@ private:
     mutable std::mutex _status_mutex{};
     Winch::Status _status{};
 
-    std::mutex _subscription_mutex{};
-
     CallbackList<Winch::Status> _status_subscriptions{_system_impl->io_context()};
 };
 

--- a/cpp/src/mavsdk_server/test/telemetry_service_impl_test.cpp
+++ b/cpp/src/mavsdk_server/test/telemetry_service_impl_test.cpp
@@ -5,7 +5,10 @@
 #include <grpc++/server_builder.h>
 #include <memory>
 #include <random>
+#include <thread>
 #include <vector>
+#include <asio/executor_work_guard.hpp>
+#include <asio/io_context.hpp>
 
 #include "telemetry/mocks/telemetry_mock.hpp"
 #include "telemetry/telemetry_service_impl.hpp"
@@ -79,6 +82,8 @@ protected:
         auto channel = _server->InProcessChannel(channel_args);
         _stub = TelemetryService::NewStub(channel);
 
+        _io_thread = std::thread([this]() { _io_context.run(); });
+
         initRandomGenerator();
 
         testing::DefaultValue<mavsdk::Telemetry::PositionHandle>::SetFactory(
@@ -115,7 +120,13 @@ protected:
             [] { return mavsdk::FakeHandle<mavsdk::Telemetry::RcStatus>::create(); });
     }
 
-    virtual void TearDown() { _server->Shutdown(); }
+    virtual void TearDown()
+    {
+        _server->Shutdown();
+        _work_guard.reset();
+        _io_context.stop();
+        _io_thread.join();
+    }
 
     std::future<void> subscribePositionAsync(std::vector<Position>& positions);
     Position createPosition(
@@ -191,6 +202,13 @@ protected:
     ActuatorOutputStatus createActuatorOutputStatus(const std::vector<float>& actuators) const;
     std::future<void> subscribeActuatorOutputStatusAsync(
         std::vector<ActuatorOutputStatus>& actuator_output_status_events) const;
+
+    // The fake CallbackLists used in the tests are confined to this io_context, run on a
+    // background thread for the duration of each test.
+    asio::io_context _io_context{};
+    asio::executor_work_guard<asio::io_context::executor_type> _work_guard{
+        _io_context.get_executor()};
+    std::thread _io_thread{};
 
     std::unique_ptr<MockLazyPlugin> _lazy_plugin{};
     std::unique_ptr<grpc::Server> _server{};
@@ -280,7 +298,7 @@ void TelemetryServiceImplTest::checkSendsPositions(const std::vector<Position>& 
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::Position> position_callbacks;
+    mavsdk::CallbackList<mavsdk::Telemetry::Position> position_callbacks{_io_context};
     EXPECT_CALL(*_telemetry, subscribe_position(_))
         .WillOnce(SaveCallback(&position_callbacks, &subscription_promise));
 
@@ -390,7 +408,7 @@ void TelemetryServiceImplTest::checkSendsHealths(const std::vector<Health>& heal
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::Health> health_callbacks;
+    mavsdk::CallbackList<mavsdk::Telemetry::Health> health_callbacks{_io_context};
     EXPECT_CALL(*_telemetry, subscribe_health(_))
         .WillOnce(SaveCallback(&health_callbacks, &subscription_promise));
 
@@ -499,7 +517,7 @@ void TelemetryServiceImplTest::checkSendsHomePositions(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::HomePosition> home_callbacks;
+    mavsdk::CallbackList<mavsdk::Telemetry::HomePosition> home_callbacks{_io_context};
     EXPECT_CALL(*_telemetry, subscribe_home(_))
         .WillOnce(SaveCallback(&home_callbacks, &subscription_promise));
 
@@ -595,7 +613,7 @@ void TelemetryServiceImplTest::checkSendsInAirEvents(const std::vector<bool>& in
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<bool> in_air_callbacks;
+    mavsdk::CallbackList<bool> in_air_callbacks{_io_context};
     EXPECT_CALL(*_telemetry, subscribe_in_air(_))
         .WillOnce(SaveCallback(&in_air_callbacks, &subscription_promise));
 
@@ -677,7 +695,7 @@ void TelemetryServiceImplTest::checkSendsArmedEvents(const std::vector<bool>& ar
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<bool> armed_callbacks;
+    mavsdk::CallbackList<bool> armed_callbacks{_io_context};
     EXPECT_CALL(*_telemetry, subscribe_armed(_))
         .WillOnce(SaveCallback(&armed_callbacks, &subscription_promise));
 
@@ -787,7 +805,7 @@ void TelemetryServiceImplTest::checkSendsGpsInfoEvents(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::GpsInfo> gps_info_callbacks;
+    mavsdk::CallbackList<mavsdk::Telemetry::GpsInfo> gps_info_callbacks{_io_context};
     EXPECT_CALL(*_telemetry, subscribe_gps_info(_))
         .WillOnce(SaveCallback(&gps_info_callbacks, &subscription_promise));
 
@@ -901,7 +919,7 @@ void TelemetryServiceImplTest::checkSendsBatteryEvents(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::Battery> battery_callbacks;
+    mavsdk::CallbackList<mavsdk::Telemetry::Battery> battery_callbacks{_io_context};
     EXPECT_CALL(*_telemetry, subscribe_battery(_))
         .WillOnce(SaveCallback(&battery_callbacks, &subscription_promise));
 
@@ -1011,7 +1029,7 @@ void TelemetryServiceImplTest::checkSendsFlightModeEvents(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::FlightMode> flight_mode_callbacks;
+    mavsdk::CallbackList<mavsdk::Telemetry::FlightMode> flight_mode_callbacks{_io_context};
     EXPECT_CALL(*_telemetry, subscribe_flight_mode(_))
         .WillOnce(SaveCallback(&flight_mode_callbacks, &subscription_promise));
 
@@ -1187,7 +1205,7 @@ void TelemetryServiceImplTest::checkSendsAttitudeQuaternions(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::Quaternion> attitude_quaternion_callbacks;
+    mavsdk::CallbackList<mavsdk::Telemetry::Quaternion> attitude_quaternion_callbacks{_io_context};
     EXPECT_CALL(*_telemetry, subscribe_attitude_quaternion(_))
         .WillOnce(SaveCallback(&attitude_quaternion_callbacks, &subscription_promise));
 
@@ -1212,7 +1230,7 @@ void TelemetryServiceImplTest::checkSendsAttitudeAngularVelocitiesBody(
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
     mavsdk::CallbackList<mavsdk::Telemetry::AngularVelocityBody>
-        attitude_angular_velocity_body_callbacks;
+        attitude_angular_velocity_body_callbacks{_io_context};
     EXPECT_CALL(*_telemetry, subscribe_attitude_angular_velocity_body(_))
         .WillOnce(SaveCallback(&attitude_angular_velocity_body_callbacks, &subscription_promise));
 
@@ -1322,7 +1340,7 @@ void TelemetryServiceImplTest::checkSendsAttitudeEulerAngles(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::EulerAngle> attitude_euler_angle_callbacks;
+    mavsdk::CallbackList<mavsdk::Telemetry::EulerAngle> attitude_euler_angle_callbacks{_io_context};
     EXPECT_CALL(*_telemetry, subscribe_attitude_euler(_))
         .WillOnce(SaveCallback(&attitude_euler_angle_callbacks, &subscription_promise));
 
@@ -1422,7 +1440,7 @@ void TelemetryServiceImplTest::checkSendsVelocityEvents(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::VelocityNed> velocity_ned_callbacks;
+    mavsdk::CallbackList<mavsdk::Telemetry::VelocityNed> velocity_ned_callbacks{_io_context};
     EXPECT_CALL(*_telemetry, subscribe_velocity_ned(_))
         .WillOnce(SaveCallback(&velocity_ned_callbacks, &subscription_promise));
 
@@ -1524,7 +1542,7 @@ void TelemetryServiceImplTest::checkSendsRcStatusEvents(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::RcStatus> rc_status_callbacks;
+    mavsdk::CallbackList<mavsdk::Telemetry::RcStatus> rc_status_callbacks{_io_context};
     EXPECT_CALL(*_telemetry, subscribe_rc_status(_))
         .WillOnce(SaveCallback(&rc_status_callbacks, &subscription_promise));
 
@@ -1637,7 +1655,7 @@ void TelemetryServiceImplTest::checkSendsActuatorControlTargetEvents(
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
     mavsdk::CallbackList<mavsdk::Telemetry::ActuatorControlTarget>
-        actuator_control_target_callbacks;
+        actuator_control_target_callbacks{_io_context};
     EXPECT_CALL(*_telemetry, subscribe_actuator_control_target(_))
         .WillOnce(SaveCallback(&actuator_control_target_callbacks, &subscription_promise));
 
@@ -1665,7 +1683,8 @@ void TelemetryServiceImplTest::checkSendsActuatorOutputStatusEvents(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::ActuatorOutputStatus> actuator_output_status_callbacks;
+    mavsdk::CallbackList<mavsdk::Telemetry::ActuatorOutputStatus> actuator_output_status_callbacks{
+        _io_context};
     EXPECT_CALL(*_telemetry, subscribe_actuator_output_status(_))
         .WillOnce(SaveCallback(&actuator_output_status_callbacks, &subscription_promise));
 

--- a/cpp/src/mavsdk_server/test/telemetry_service_impl_test.cpp
+++ b/cpp/src/mavsdk_server/test/telemetry_service_impl_test.cpp
@@ -1,3 +1,4 @@
+#include <functional>
 #include <future>
 #include <gmock/gmock.h>
 #include <grpc++/grpc++.h>
@@ -5,20 +6,39 @@
 #include <grpc++/server_builder.h>
 #include <memory>
 #include <random>
-#include <thread>
+#include <utility>
 #include <vector>
-#include <asio/executor_work_guard.hpp>
-#include <asio/io_context.hpp>
 
 #include "telemetry/mocks/telemetry_mock.hpp"
 #include "telemetry/telemetry_service_impl.hpp"
 #include "mocks/lazy_plugin_mock.hpp"
-#include "callback_list.hpp"
+#include "handle.hpp"
 
 namespace mavsdk {
 template<typename... Args> class FakeHandle {
 public:
     static mavsdk::Handle<Args...> create() { return mavsdk::Handle<Args...>(0); }
+};
+
+// Minimal stand-in for CallbackList: captures a service's subscription callback and replays
+// it. Used so the mavsdk_server tests don't pull the io_context (and asio) in, which the real
+// CallbackList now needs.
+template<typename... Args> class FakeCallbackList {
+public:
+    mavsdk::Handle<Args...> subscribe(std::function<void(Args...)> callback)
+    {
+        _callback = std::move(callback);
+        return FakeHandle<Args...>::create();
+    }
+    void operator()(Args... args) const
+    {
+        if (_callback) {
+            _callback(args...);
+        }
+    }
+
+private:
+    std::function<void(Args...)> _callback{};
 };
 } // namespace mavsdk
 
@@ -82,8 +102,6 @@ protected:
         auto channel = _server->InProcessChannel(channel_args);
         _stub = TelemetryService::NewStub(channel);
 
-        _io_thread = std::thread([this]() { _io_context.run(); });
-
         initRandomGenerator();
 
         testing::DefaultValue<mavsdk::Telemetry::PositionHandle>::SetFactory(
@@ -120,13 +138,7 @@ protected:
             [] { return mavsdk::FakeHandle<mavsdk::Telemetry::RcStatus>::create(); });
     }
 
-    virtual void TearDown()
-    {
-        _server->Shutdown();
-        _work_guard.reset();
-        _io_context.stop();
-        _io_thread.join();
-    }
+    virtual void TearDown() { _server->Shutdown(); }
 
     std::future<void> subscribePositionAsync(std::vector<Position>& positions);
     Position createPosition(
@@ -202,13 +214,6 @@ protected:
     ActuatorOutputStatus createActuatorOutputStatus(const std::vector<float>& actuators) const;
     std::future<void> subscribeActuatorOutputStatusAsync(
         std::vector<ActuatorOutputStatus>& actuator_output_status_events) const;
-
-    // The fake CallbackLists used in the tests are confined to this io_context, run on a
-    // background thread for the duration of each test.
-    asio::io_context _io_context{};
-    asio::executor_work_guard<asio::io_context::executor_type> _work_guard{
-        _io_context.get_executor()};
-    std::thread _io_thread{};
 
     std::unique_ptr<MockLazyPlugin> _lazy_plugin{};
     std::unique_ptr<grpc::Server> _server{};
@@ -298,7 +303,7 @@ void TelemetryServiceImplTest::checkSendsPositions(const std::vector<Position>& 
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::Position> position_callbacks{_io_context};
+    mavsdk::FakeCallbackList<mavsdk::Telemetry::Position> position_callbacks;
     EXPECT_CALL(*_telemetry, subscribe_position(_))
         .WillOnce(SaveCallback(&position_callbacks, &subscription_promise));
 
@@ -408,7 +413,7 @@ void TelemetryServiceImplTest::checkSendsHealths(const std::vector<Health>& heal
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::Health> health_callbacks{_io_context};
+    mavsdk::FakeCallbackList<mavsdk::Telemetry::Health> health_callbacks;
     EXPECT_CALL(*_telemetry, subscribe_health(_))
         .WillOnce(SaveCallback(&health_callbacks, &subscription_promise));
 
@@ -517,7 +522,7 @@ void TelemetryServiceImplTest::checkSendsHomePositions(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::HomePosition> home_callbacks{_io_context};
+    mavsdk::FakeCallbackList<mavsdk::Telemetry::HomePosition> home_callbacks;
     EXPECT_CALL(*_telemetry, subscribe_home(_))
         .WillOnce(SaveCallback(&home_callbacks, &subscription_promise));
 
@@ -613,7 +618,7 @@ void TelemetryServiceImplTest::checkSendsInAirEvents(const std::vector<bool>& in
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<bool> in_air_callbacks{_io_context};
+    mavsdk::FakeCallbackList<bool> in_air_callbacks;
     EXPECT_CALL(*_telemetry, subscribe_in_air(_))
         .WillOnce(SaveCallback(&in_air_callbacks, &subscription_promise));
 
@@ -695,7 +700,7 @@ void TelemetryServiceImplTest::checkSendsArmedEvents(const std::vector<bool>& ar
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<bool> armed_callbacks{_io_context};
+    mavsdk::FakeCallbackList<bool> armed_callbacks;
     EXPECT_CALL(*_telemetry, subscribe_armed(_))
         .WillOnce(SaveCallback(&armed_callbacks, &subscription_promise));
 
@@ -805,7 +810,7 @@ void TelemetryServiceImplTest::checkSendsGpsInfoEvents(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::GpsInfo> gps_info_callbacks{_io_context};
+    mavsdk::FakeCallbackList<mavsdk::Telemetry::GpsInfo> gps_info_callbacks;
     EXPECT_CALL(*_telemetry, subscribe_gps_info(_))
         .WillOnce(SaveCallback(&gps_info_callbacks, &subscription_promise));
 
@@ -919,7 +924,7 @@ void TelemetryServiceImplTest::checkSendsBatteryEvents(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::Battery> battery_callbacks{_io_context};
+    mavsdk::FakeCallbackList<mavsdk::Telemetry::Battery> battery_callbacks;
     EXPECT_CALL(*_telemetry, subscribe_battery(_))
         .WillOnce(SaveCallback(&battery_callbacks, &subscription_promise));
 
@@ -1029,7 +1034,7 @@ void TelemetryServiceImplTest::checkSendsFlightModeEvents(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::FlightMode> flight_mode_callbacks{_io_context};
+    mavsdk::FakeCallbackList<mavsdk::Telemetry::FlightMode> flight_mode_callbacks;
     EXPECT_CALL(*_telemetry, subscribe_flight_mode(_))
         .WillOnce(SaveCallback(&flight_mode_callbacks, &subscription_promise));
 
@@ -1205,7 +1210,7 @@ void TelemetryServiceImplTest::checkSendsAttitudeQuaternions(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::Quaternion> attitude_quaternion_callbacks{_io_context};
+    mavsdk::FakeCallbackList<mavsdk::Telemetry::Quaternion> attitude_quaternion_callbacks;
     EXPECT_CALL(*_telemetry, subscribe_attitude_quaternion(_))
         .WillOnce(SaveCallback(&attitude_quaternion_callbacks, &subscription_promise));
 
@@ -1229,8 +1234,8 @@ void TelemetryServiceImplTest::checkSendsAttitudeAngularVelocitiesBody(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::AngularVelocityBody>
-        attitude_angular_velocity_body_callbacks{_io_context};
+    mavsdk::FakeCallbackList<mavsdk::Telemetry::AngularVelocityBody>
+        attitude_angular_velocity_body_callbacks;
     EXPECT_CALL(*_telemetry, subscribe_attitude_angular_velocity_body(_))
         .WillOnce(SaveCallback(&attitude_angular_velocity_body_callbacks, &subscription_promise));
 
@@ -1340,7 +1345,7 @@ void TelemetryServiceImplTest::checkSendsAttitudeEulerAngles(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::EulerAngle> attitude_euler_angle_callbacks{_io_context};
+    mavsdk::FakeCallbackList<mavsdk::Telemetry::EulerAngle> attitude_euler_angle_callbacks;
     EXPECT_CALL(*_telemetry, subscribe_attitude_euler(_))
         .WillOnce(SaveCallback(&attitude_euler_angle_callbacks, &subscription_promise));
 
@@ -1440,7 +1445,7 @@ void TelemetryServiceImplTest::checkSendsVelocityEvents(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::VelocityNed> velocity_ned_callbacks{_io_context};
+    mavsdk::FakeCallbackList<mavsdk::Telemetry::VelocityNed> velocity_ned_callbacks;
     EXPECT_CALL(*_telemetry, subscribe_velocity_ned(_))
         .WillOnce(SaveCallback(&velocity_ned_callbacks, &subscription_promise));
 
@@ -1542,7 +1547,7 @@ void TelemetryServiceImplTest::checkSendsRcStatusEvents(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::RcStatus> rc_status_callbacks{_io_context};
+    mavsdk::FakeCallbackList<mavsdk::Telemetry::RcStatus> rc_status_callbacks;
     EXPECT_CALL(*_telemetry, subscribe_rc_status(_))
         .WillOnce(SaveCallback(&rc_status_callbacks, &subscription_promise));
 
@@ -1654,8 +1659,8 @@ void TelemetryServiceImplTest::checkSendsActuatorControlTargetEvents(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::ActuatorControlTarget>
-        actuator_control_target_callbacks{_io_context};
+    mavsdk::FakeCallbackList<mavsdk::Telemetry::ActuatorControlTarget>
+        actuator_control_target_callbacks;
     EXPECT_CALL(*_telemetry, subscribe_actuator_control_target(_))
         .WillOnce(SaveCallback(&actuator_control_target_callbacks, &subscription_promise));
 
@@ -1683,8 +1688,8 @@ void TelemetryServiceImplTest::checkSendsActuatorOutputStatusEvents(
 {
     std::promise<void> subscription_promise;
     auto subscription_future = subscription_promise.get_future();
-    mavsdk::CallbackList<mavsdk::Telemetry::ActuatorOutputStatus> actuator_output_status_callbacks{
-        _io_context};
+    mavsdk::FakeCallbackList<mavsdk::Telemetry::ActuatorOutputStatus>
+        actuator_output_status_callbacks;
     EXPECT_CALL(*_telemetry, subscribe_actuator_output_status(_))
         .WillOnce(SaveCallback(&actuator_output_status_callbacks, &subscription_promise));
 


### PR DESCRIPTION
Replace core's hand-rolled thread-safety (a mutex plus deferred side-tables and try_lock-or-defer) with the executor model already used elsewhere: the shared state is only ever touched on the io_context thread. Reads run there directly (inline when already on the io thread); mutations `asio::post()` onto the io_context, so they're serialized and safe to call from inside a callback.

Converted:
- `MavlinkParameterSubscription` — subscription list confined to the io_context.
- `MavlinkMessageHandler` — handler table confined to the io_context.
- `CallbackList` — subscription list confined to the io_context; `empty()` is an atomic. The dedicated mutexes that only guarded a subscription list are removed.

Two things the strand model has to get right:

- **Lifetime.** Owners post onto the io_context during their own destruction (e.g. `~ServerComponentImpl`), so the io_context must outlive them. `_io_context`/`_io_work_guard` are now the first members of `MavsdkImpl`, so it's destroyed last; otherwise those posts hit a freed io_context (use-after-free + a leaked op). A `CallbackList` also drains the io_context in its destructor, since plugins can be destroyed mid-run while posts are still queued.

- **No blocking onto the io thread.** subscribe/unsubscribe/clear and `CallbackList::queue()` post without waiting, so they can't deadlock when called from inside a callback or while holding a lock the io thread also needs (`queue()` is used that way from `subscribe_on_new_system` and `subscribe_component_discovered`).
