### PR TITLE
core: confine MavlinkMessageHandler to the io_context

### DIFF
--- a/cpp/src/mavsdk/core/mavlink_message_handler.cpp
+++ b/cpp/src/mavsdk/core/mavlink_message_handler.cpp
@@ -1,11 +1,13 @@
 #include <algorithm>
-#include <mutex>
+#include <future>
+#include <utility>
+#include <asio/post.hpp>
 #include "mavlink_message_handler.hpp"
 #include "log.hpp"
 
 namespace mavsdk {
 
-MavlinkMessageHandler::MavlinkMessageHandler()
+MavlinkMessageHandler::MavlinkMessageHandler(asio::io_context& io_context) : _io_context(io_context)
 {
     if (const char* env_p = std::getenv("MAVSDK_MESSAGE_HANDLER_DEBUGGING")) {
         if (std::string(env_p) == "1") {
@@ -34,14 +36,9 @@ void MavlinkMessageHandler::register_one_impl(
     const void* cookie)
 {
     Entry entry = {msg_id, maybe_component_id, callback, cookie};
-
-    std::unique_lock<std::mutex> lock(_mutex, std::try_to_lock);
-    if (lock.owns_lock()) {
-        _table.push_back(entry);
-    } else {
-        std::lock_guard<std::mutex> register_later_lock(_register_later_mutex);
-        _register_later_table.push_back(entry);
-    }
+    asio::post(_io_context, [this, entry = std::move(entry)]() mutable {
+        _table.push_back(std::move(entry));
+    });
 }
 
 void MavlinkMessageHandler::unregister_one(uint16_t msg_id, const void* cookie)
@@ -54,114 +51,62 @@ void MavlinkMessageHandler::unregister_all(const void* cookie)
     unregister_impl({}, cookie);
 }
 
-void MavlinkMessageHandler::unregister_all_blocking(const void* cookie)
-{
-    // Blocking version for use in destructors - waits for any in-flight callbacks to complete.
-    // WARNING: Do NOT call this from within a message handler callback - it will deadlock.
-
-    // Also purge any deferred registrations for this cookie from _register_later_table.
-    // If register_one() was called while process_message() held _mutex, the entries land in
-    // _register_later_table instead of _table.  Without this step, check_register_later()
-    // would later promote those stale entries into _table and fire callbacks on a
-    // destroyed object (heap-use-after-free).
-    {
-        std::lock_guard<std::mutex> register_later_lock(_register_later_mutex);
-        _register_later_table.erase(
-            std::remove_if(
-                _register_later_table.begin(),
-                _register_later_table.end(),
-                [&](const auto& entry) { return entry.cookie == cookie; }),
-            _register_later_table.end());
-    }
-
-    std::lock_guard<std::mutex> lock(_mutex);
-    _table.erase(
-        std::remove_if(
-            _table.begin(), _table.end(), [&](auto& entry) { return entry.cookie == cookie; }),
-        _table.end());
-}
-
 void MavlinkMessageHandler::unregister_impl(
     std::optional<uint16_t> maybe_msg_id, const void* cookie)
 {
-    std::unique_lock<std::mutex> lock(_mutex, std::try_to_lock);
-    if (lock.owns_lock()) {
-        _table.erase(
-            std::remove_if(
-                _table.begin(),
-                _table.end(),
-                [&](auto& entry) {
-                    if (maybe_msg_id) {
-                        return (entry.msg_id == maybe_msg_id.value() && entry.cookie == cookie);
-                    } else {
-                        return (entry.cookie == cookie);
-                    }
-                }),
-            _table.end());
-    } else {
-        std::lock_guard<std::mutex> unregister_later_lock(_unregister_later_mutex);
-        _unregister_later_table.push_back(UnregisterEntry{maybe_msg_id, cookie});
-    }
+    asio::post(
+        _io_context, [this, maybe_msg_id, cookie]() { erase_from_table(maybe_msg_id, cookie); });
 }
 
-void MavlinkMessageHandler::check_register_later()
+void MavlinkMessageHandler::unregister_all_on_io_thread(const void* cookie)
 {
-    std::lock_guard<std::mutex> _register_later_lock(_register_later_mutex);
+    // Direct, synchronous removal. MUST be called on the io_context thread (e.g. from an
+    // owner that is itself created and destroyed on the io thread, like a work-queue item).
+    // The table is only touched on the io thread, so this is race-free, and removing the
+    // entry before the owner is freed avoids any fire-after-free without a posted round-trip.
+    erase_from_table({}, cookie);
+}
 
-    // We could probably just grab the lock here, but it's safer not to
-    // acquire both locks to avoid deadlocks.
-    std::unique_lock<std::mutex> lock(_mutex, std::try_to_lock);
-    if (!lock.owns_lock()) {
-        // Try again later.
+void MavlinkMessageHandler::unregister_all_blocking(const void* cookie)
+{
+    // Synchronous removal for callers that are NOT on the io_context thread (e.g. plugin
+    // destructors on the user thread). MUST NOT be called from the io thread -- it would
+    // post a task and then wait on the very thread that needs to run it. io-thread owners
+    // use unregister_all_on_io_thread() instead.
+    if (_io_context.stopped()) {
+        // The io_context thread is dead -- safe to access the table directly.
+        erase_from_table({}, cookie);
         return;
     }
 
-    for (const auto& entry : _register_later_table) {
-        _table.push_back(entry);
-    }
-
-    _register_later_table.clear();
+    std::promise<void> done;
+    asio::post(_io_context, [this, cookie, &done]() {
+        erase_from_table({}, cookie);
+        done.set_value();
+    });
+    done.get_future().wait();
 }
 
-void MavlinkMessageHandler::check_unregister_later()
+void MavlinkMessageHandler::erase_from_table(
+    std::optional<uint16_t> maybe_msg_id, const void* cookie)
 {
-    std::lock_guard<std::mutex> _unregister_later_lock(_unregister_later_mutex);
-
-    // We could probably just grab the lock here, but it's safer not to
-    // acquire both locks to avoid deadlocks.
-    std::unique_lock<std::mutex> lock(_mutex, std::try_to_lock);
-    if (!lock.owns_lock()) {
-        // Try again later.
-        return;
-    }
-
-    for (const auto& unregister_entry : _unregister_later_table) {
-        _table.erase(
-            std::remove_if(
-                _table.begin(),
-                _table.end(),
-                [&](auto& entry) {
-                    if (unregister_entry.maybe_msg_id) {
-                        return (
-                            entry.msg_id == unregister_entry.maybe_msg_id.value() &&
-                            entry.cookie == unregister_entry.cookie);
-                    } else {
-                        return (entry.cookie == unregister_entry.cookie);
-                    }
-                }),
-            _table.end());
-    }
-
-    _unregister_later_table.clear();
+    _table.erase(
+        std::remove_if(
+            _table.begin(),
+            _table.end(),
+            [&](auto& entry) {
+                if (maybe_msg_id) {
+                    return (entry.msg_id == maybe_msg_id.value() && entry.cookie == cookie);
+                } else {
+                    return (entry.cookie == cookie);
+                }
+            }),
+        _table.end());
 }
 
 void MavlinkMessageHandler::process_message(const mavlink_message_t& message)
 {
-    check_register_later();
-    check_unregister_later();
-
-    std::lock_guard<std::mutex> lock(_mutex);
-
+    // Runs on the io_context thread; _table is only touched there, so no lock is needed.
     bool forwarded = false;
 
     if (_debugging) {
@@ -196,16 +141,13 @@ void MavlinkMessageHandler::process_message(const mavlink_message_t& message)
 void MavlinkMessageHandler::update_component_id(
     uint16_t msg_id, uint8_t component_id, const void* cookie)
 {
-    check_register_later();
-    check_unregister_later();
-
-    std::lock_guard<std::mutex> lock(_mutex);
-
-    for (auto& entry : _table) {
-        if (entry.msg_id == msg_id && entry.cookie == cookie) {
-            entry.component_id = component_id;
+    asio::post(_io_context, [this, msg_id, component_id, cookie]() {
+        for (auto& entry : _table) {
+            if (entry.msg_id == msg_id && entry.cookie == cookie) {
+                entry.component_id = component_id;
+            }
         }
-    }
+    });
 }
 
 } // namespace mavsdk

--- a/cpp/src/mavsdk/core/mavlink_message_handler.hpp
+++ b/cpp/src/mavsdk/core/mavlink_message_handler.hpp
@@ -2,17 +2,25 @@
 
 #include <cstdint>
 #include <functional>
-#include <mutex>
 #include <vector>
 #include <optional>
+#include <asio/io_context.hpp>
 #include "mavlink_include.hpp"
 #include "mavsdk_export.h"
 
 namespace mavsdk {
 
+// Dispatches received MAVLink messages to registered handlers.
+//
+// Threading: the handler table is only ever touched on the io_context thread.
+// process_message() runs there (it is driven by the connection receive path, which
+// posts onto the io_context), and register/unregister post their mutation onto the
+// same io_context. That keeps everything single-threaded without locks, and post()
+// also makes it safe to (un)register from inside a callback (the mutation runs after
+// the current dispatch returns), with ordering preserved by post FIFO.
 class MAVSDK_TEST_EXPORT MavlinkMessageHandler {
 public:
-    MavlinkMessageHandler();
+    explicit MavlinkMessageHandler(asio::io_context& io_context);
 
     using Callback = std::function<void(const mavlink_message_t&)>;
 
@@ -28,6 +36,12 @@ public:
         uint16_t msg_id, uint8_t component_id, const Callback& callback, const void* cookie);
     void unregister_one(uint16_t msg_id, const void* cookie);
     void unregister_all(const void* cookie);
+    // Direct, synchronous unregister for owners that live and die ON the io_context thread
+    // (e.g. work-queue items). Must be called on the io thread.
+    void unregister_all_on_io_thread(const void* cookie);
+    // Synchronous unregister for owners destroyed OFF the io_context thread (e.g. plugins
+    // on the user thread): posts the removal to the io thread and waits for it, so no
+    // callback for this cookie can fire afterwards. Must NOT be called from the io thread.
     void unregister_all_blocking(const void* cookie);
     void process_message(const mavlink_message_t& message);
     void update_component_id(uint16_t msg_id, uint8_t cmp_id, const void* cookie);
@@ -41,22 +55,12 @@ private:
 
     void unregister_impl(std::optional<uint16_t> maybe_msg_id, const void* cookie);
 
-    void check_register_later();
-    void check_unregister_later();
+    // Erase entries matching cookie (and optionally msg_id) from the table.
+    // Must be called on the io_context thread.
+    void erase_from_table(std::optional<uint16_t> maybe_msg_id, const void* cookie);
 
-    std::mutex _mutex{};
+    asio::io_context& _io_context;
     std::vector<Entry> _table{};
-
-    std::mutex _register_later_mutex{};
-    std::vector<Entry> _register_later_table{};
-
-    struct UnregisterEntry {
-        std::optional<uint16_t> maybe_msg_id;
-        const void* cookie;
-    };
-
-    std::mutex _unregister_later_mutex{};
-    std::vector<UnregisterEntry> _unregister_later_table{};
 
     bool _debugging{false};
 };

--- a/cpp/src/mavsdk/core/mavlink_mission_transfer_client.cpp
+++ b/cpp/src/mavsdk/core/mavlink_mission_transfer_client.cpp
@@ -237,7 +237,7 @@ MavlinkMissionTransferClient::UploadWorkItem::UploadWorkItem(
 
 MavlinkMissionTransferClient::UploadWorkItem::~UploadWorkItem()
 {
-    _message_handler.unregister_all_blocking(this);
+    _message_handler.unregister_all_on_io_thread(this);
     _timeout_handler.remove(_cookie);
 }
 
@@ -625,7 +625,7 @@ MavlinkMissionTransferClient::DownloadWorkItem::DownloadWorkItem(
 
 MavlinkMissionTransferClient::DownloadWorkItem::~DownloadWorkItem()
 {
-    _message_handler.unregister_all_blocking(this);
+    _message_handler.unregister_all_on_io_thread(this);
     _timeout_handler.remove(_cookie);
 }
 
@@ -866,7 +866,7 @@ MavlinkMissionTransferClient::ClearWorkItem::ClearWorkItem(
 
 MavlinkMissionTransferClient::ClearWorkItem::~ClearWorkItem()
 {
-    _message_handler.unregister_all_blocking(this);
+    _message_handler.unregister_all_on_io_thread(this);
     _timeout_handler.remove(_cookie);
 }
 
@@ -1015,7 +1015,7 @@ MavlinkMissionTransferClient::SetCurrentWorkItem::SetCurrentWorkItem(
 
 MavlinkMissionTransferClient::SetCurrentWorkItem::~SetCurrentWorkItem()
 {
-    _message_handler.unregister_all_blocking(this);
+    _message_handler.unregister_all_on_io_thread(this);
     _timeout_handler.remove(_cookie);
 }
 

--- a/cpp/src/mavsdk/core/mavlink_mission_transfer_client_test.cpp
+++ b/cpp/src/mavsdk/core/mavlink_mission_transfer_client_test.cpp
@@ -61,33 +61,34 @@ protected:
 
     void TearDown() override
     {
-        // Drain any pending io_context posts (e.g. enqueue lambdas holding shared_ptr<WorkItem>)
-        // so that WorkItem destructors run while message_handler and timeout_handler are still
-        // alive. Without this, io_context (declared first, destroyed last) would destroy those
-        // lambdas after message_handler is already gone, causing heap-use-after-free in
-        // unregister_all_blocking.
-        //
-        // io_context::poll() calls stop() internally when outstanding_work_ == 0, setting
-        // stopped_=true. A do_work() call on an idle queue will trigger this. restart() clears
-        // stopped_ so the subsequent poll() loop can actually execute any handlers still queued
-        // (e.g. the enqueue lambda that holds the last shared_ptr<WorkItem> reference).
+        // Drain any pending posts (handler registrations/removals, WorkItem destructors)
+        // on this thread while message_handler is still alive.
         io_context.restart();
         while (io_context.poll()) {
         }
     }
 
-    // Flush any io_context posts (e.g. the enqueue lambda) then drive the state machine.
-    // Tests call this instead of mmt.do_work() directly so that work posted via
-    // asio::post() from user-thread enqueue calls is processed before do_work() runs.
+    // The message handler posts its table mutations onto the io_context, so poll() first to
+    // apply any pending registrations before driving the state machine / delivering a message.
     void do_work()
     {
         io_context.poll();
         mmt.do_work();
     }
 
+    void process_message(const mavlink_message_t& message)
+    {
+        io_context.poll();
+        message_handler.process_message(message);
+    }
+
+    void run_timeouts() { timeout_handler.run_once(); }
+
+    bool is_idle() { return mmt.is_idle(); }
+
     asio::io_context io_context;
     MockSender mock_sender;
-    MavlinkMessageHandler message_handler;
+    MavlinkMessageHandler message_handler{io_context};
     FakeTime time;
     TimeoutHandler timeout_handler;
     MavlinkMissionTransferClient mmt;
@@ -147,7 +148,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionDoesComplainAboutNoItems)
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionDoesComplainAboutWrongSequence)
@@ -170,7 +171,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionDoesComplainAboutWrongSequ
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(
@@ -195,7 +196,7 @@ TEST_F(
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(
@@ -220,7 +221,7 @@ TEST_F(
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionDoesComplainAboutNoCurrent)
@@ -246,7 +247,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionDoesComplainAboutNoCurrent
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionDoesComplainAboutTwoCurrents)
@@ -272,7 +273,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionDoesComplainAboutTwoCurren
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionDoesNotCrashIfCallbackIsNull)
@@ -296,7 +297,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionDoesNotCrashIfCallbackIsNu
     do_work();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionReturnsConnectionErrorWhenSendMessageFails)
@@ -322,10 +323,10 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionReturnsConnectionErrorWhen
 
     // We want to be sure a timeout is not still triggered later.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 static bool
@@ -395,7 +396,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionResendsCount)
     do_work();
 
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionTimeoutAfterSendCount)
@@ -431,7 +432,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionTimeoutAfterSendCount)
     // After the specified retries we should give up with a timeout.
     for (unsigned i = 0; i < MavlinkMissionTransferClient::retries; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
@@ -520,7 +521,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionSendsMissionItems)
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -529,20 +530,19 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionSendsMissionItems)
             return is_the_same_mission_item_int(items[1], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 1));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 1));
 
-    message_handler.process_message(
-        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     // We do not expect a timeout later though.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionResendsMissionItems)
@@ -571,7 +571,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionResendsMissionItems)
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -581,7 +581,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionResendsMissionItems)
         })));
 
     // Request 0 again in case it had not arrived.
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -591,16 +591,15 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionResendsMissionItems)
         })));
 
     // Request 1 finally.
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 1));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 1));
 
-    message_handler.process_message(
-        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionResendsMissionItemsButGivesUpAfterSomeRetries)
@@ -631,18 +630,18 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionResendsMissionItemsButGive
         .Times(MavlinkMissionTransferClient::retries);
 
     for (unsigned i = 0; i < MavlinkMissionTransferClient::retries; ++i) {
-        message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+        process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(0)), std::future_status::timeout);
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionAckArrivesTooEarly)
@@ -671,16 +670,15 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionAckArrivesTooEarly)
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
 
     // Don't request item 1 but already send ack.
-    message_handler.process_message(
-        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 class MavlinkMissionTransferClientNack
@@ -718,15 +716,15 @@ TEST_P(MavlinkMissionTransferClientNack, UploadMissionNackAreHandled)
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
 
     // Send nack now.
-    message_handler.process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, mavlink_nack));
+    process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, mavlink_nack));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -776,11 +774,11 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionTimeoutNotTriggeredDuringT
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
 
     // We almost use up the max timeout in each cycle.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 0.8 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     EXPECT_CALL(
         mock_sender,
@@ -789,10 +787,10 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionTimeoutNotTriggeredDuringT
             return is_the_same_mission_item_int(items[1], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 1));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 1));
 
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 0.8 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     EXPECT_CALL(
         mock_sender,
@@ -801,19 +799,18 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionTimeoutNotTriggeredDuringT
             return is_the_same_mission_item_int(items[2], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 2));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 2));
 
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 0.8 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
-    message_handler.process_message(
-        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionTimeoutAfterSendMissionItem)
@@ -842,42 +839,40 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionTimeoutAfterSendMissionIte
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
 
     // Make sure single timeout does not trigger it yet.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1000. + 250)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     EXPECT_EQ(fut.wait_for(std::chrono::milliseconds(50)), std::future_status::timeout);
 
     // But multiple do.
     for (unsigned i = 0; i < (MavlinkMissionTransferClient::retries - 1); ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     // Ignore later (wrong) ack.
-    message_handler.process_message(
-        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionDoesNotCrashOnRandomMessages)
 {
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
 
-    message_handler.process_message(
-        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
 
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 bool is_correct_mission_ack(uint8_t type, uint8_t result, const mavlink_message_t& message)
@@ -914,7 +909,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionCanBeCancelled)
         });
     do_work();
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -937,10 +932,10 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionCanBeCancelled)
 
     // We do not expect a timeout later though.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 mavlink_message_t make_mission_request(uint8_t type, int sequence)
@@ -985,7 +980,7 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionNacksNonIntCase)
         .Times(1);
 
     // First the non-int wrong case comes in.
-    message_handler.process_message(make_mission_request(MAV_MISSION_TYPE_FENCE, 0));
+    process_message(make_mission_request(MAV_MISSION_TYPE_FENCE, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -994,18 +989,18 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionNacksNonIntCase)
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_FENCE, 0));
-    message_handler.process_message(make_mission_ack(MAV_MISSION_TYPE_FENCE, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_FENCE, 0));
+    process_message(make_mission_ack(MAV_MISSION_TYPE_FENCE, MAV_MISSION_ACCEPTED));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     // We do not expect a timeout later though.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, UploadMissionWithProgress)
@@ -1042,10 +1037,9 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionWithProgress)
         });
     do_work();
 
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
-    message_handler.process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 1));
-    message_handler.process_message(
-        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 0));
+    process_message(make_mission_request_int(MAV_MISSION_TYPE_MISSION, 1));
+    process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
@@ -1056,10 +1050,10 @@ TEST_F(MavlinkMissionTransferClientTest, UploadMissionWithProgress)
 
     // We do not expect a timeout later though.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, DownloadMissionSendsRequestList)
@@ -1134,7 +1128,7 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionResendsRequestList)
     do_work();
 
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 }
 
 TEST_F(
@@ -1168,13 +1162,13 @@ TEST_F(
 
     for (unsigned i = 0; i < MavlinkMissionTransferClient::retries; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 bool is_correct_mission_request_int(
@@ -1219,7 +1213,7 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionSendsMissionRequests)
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
 
-    message_handler.process_message(make_mission_count(items.size()));
+    process_message(make_mission_count(items.size()));
 }
 
 TEST_F(MavlinkMissionTransferClientTest, DownloadMissionResendsMissionRequestsAndTimesOutEventually)
@@ -1251,20 +1245,20 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionResendsMissionRequestsAn
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 0));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
 
-    message_handler.process_message(make_mission_count(items.size()));
+    process_message(make_mission_count(items.size()));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(0)), std::future_status::timeout);
 
     // After the specified retries we should give up with a timeout.
     for (unsigned i = 0; i < MavlinkMissionTransferClient::retries; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 mavlink_message_t make_mission_item(const std::vector<ItemInt>& item_ints, std::size_t index)
@@ -1321,7 +1315,7 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionSendsAllMissionRequestsA
                 MAV_MISSION_TYPE_MISSION, 0, fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_count(real_items.size()));
+    process_message(make_mission_count(real_items.size()));
 
     EXPECT_CALL(
         mock_sender,
@@ -1331,7 +1325,7 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionSendsAllMissionRequestsA
                 MAV_MISSION_TYPE_MISSION, 1, fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_item(real_items, 0));
+    process_message(make_mission_item(real_items, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -1341,7 +1335,7 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionSendsAllMissionRequestsA
                 MAV_MISSION_TYPE_MISSION, 2, fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_item(real_items, 1));
+    process_message(make_mission_item(real_items, 1));
 
     EXPECT_CALL(
         mock_sender,
@@ -1351,12 +1345,12 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionSendsAllMissionRequestsA
                 MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED, fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_item(real_items, 2));
+    process_message(make_mission_item(real_items, 2));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, DownloadMissionResendsRequestItemAgainForSecondItem)
@@ -1390,11 +1384,11 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionResendsRequestItemAgainF
         })))
         .Times(MavlinkMissionTransferClient::retries - 1);
 
-    message_handler.process_message(make_mission_count(items.size()));
+    process_message(make_mission_count(items.size()));
 
     for (unsigned i = 0; i < MavlinkMissionTransferClient::retries - 2; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     // This time we go over the retry limit.
@@ -1407,17 +1401,17 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionResendsRequestItemAgainF
         })))
         .Times(MavlinkMissionTransferClient::retries);
 
-    message_handler.process_message(make_mission_item(items, 0));
+    process_message(make_mission_item(items, 0));
 
     for (unsigned i = 0; i < MavlinkMissionTransferClient::retries; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, DownloadMissionDoesntHaveDuplicates)
@@ -1449,7 +1443,7 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionDoesntHaveDuplicates)
                 MAV_MISSION_TYPE_MISSION, 0, fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_count(real_items.size()));
+    process_message(make_mission_count(real_items.size()));
 
     EXPECT_CALL(
         mock_sender,
@@ -1459,7 +1453,7 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionDoesntHaveDuplicates)
                 MAV_MISSION_TYPE_MISSION, 1, fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_item(real_items, 0));
+    process_message(make_mission_item(real_items, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -1470,7 +1464,7 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionDoesntHaveDuplicates)
         })));
 
     // Send a message 3 times, it should just get ignored.
-    message_handler.process_message(make_mission_item(real_items, 1));
+    process_message(make_mission_item(real_items, 1));
 
     EXPECT_CALL(
         mock_sender,
@@ -1480,15 +1474,15 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionDoesntHaveDuplicates)
                 MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED, fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_item(real_items, 1));
-    message_handler.process_message(make_mission_item(real_items, 1));
+    process_message(make_mission_item(real_items, 1));
+    process_message(make_mission_item(real_items, 1));
 
-    message_handler.process_message(make_mission_item(real_items, 2));
+    process_message(make_mission_item(real_items, 2));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, DownloadMissionEmptyList)
@@ -1515,16 +1509,16 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionEmptyList)
                 MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED, fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_count(0));
+    process_message(make_mission_count(0));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     // We want to be sure a timeout is not still triggered later.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, DownloadMissionTimeoutNotTriggeredDuringTransfer)
@@ -1551,32 +1545,32 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionTimeoutNotTriggeredDurin
     // We almost use up the max timeout in each cycle.
     time.sleep_for(std::chrono::milliseconds(
         static_cast<int>(timeout_s * MavlinkMissionTransferClient::retries * 0.8 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
-    message_handler.process_message(make_mission_count(real_items.size()));
-
-    time.sleep_for(std::chrono::milliseconds(
-        static_cast<int>(timeout_s * MavlinkMissionTransferClient::retries * 0.8 * 1000.)));
-    timeout_handler.run_once();
-
-    message_handler.process_message(make_mission_item(real_items, 0));
+    process_message(make_mission_count(real_items.size()));
 
     time.sleep_for(std::chrono::milliseconds(
         static_cast<int>(timeout_s * MavlinkMissionTransferClient::retries * 0.8 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
-    message_handler.process_message(make_mission_item(real_items, 1));
+    process_message(make_mission_item(real_items, 0));
 
     time.sleep_for(std::chrono::milliseconds(
         static_cast<int>(timeout_s * MavlinkMissionTransferClient::retries * 0.8 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
-    message_handler.process_message(make_mission_item(real_items, 2));
+    process_message(make_mission_item(real_items, 1));
+
+    time.sleep_for(std::chrono::milliseconds(
+        static_cast<int>(timeout_s * MavlinkMissionTransferClient::retries * 0.8 * 1000.)));
+    run_timeouts();
+
+    process_message(make_mission_item(real_items, 2));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, DownloadMissionCanBeCancelled)
@@ -1600,8 +1594,8 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionCanBeCancelled)
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 1));
     items.push_back(make_item(MAV_MISSION_TYPE_MISSION, 2));
 
-    message_handler.process_message(make_mission_count(items.size()));
-    message_handler.process_message(make_mission_item(items, 0));
+    process_message(make_mission_count(items.size()));
+    process_message(make_mission_item(items, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -1622,7 +1616,7 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionCanBeCancelled)
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, DownloadMissionWithProgress)
@@ -1659,10 +1653,10 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionWithProgress)
         });
     do_work();
 
-    message_handler.process_message(make_mission_count(real_items.size()));
-    message_handler.process_message(make_mission_item(real_items, 0));
-    message_handler.process_message(make_mission_item(real_items, 1));
-    message_handler.process_message(make_mission_item(real_items, 2));
+    process_message(make_mission_count(real_items.size()));
+    process_message(make_mission_item(real_items, 0));
+    process_message(make_mission_item(real_items, 1));
+    process_message(make_mission_item(real_items, 2));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
@@ -1671,7 +1665,7 @@ TEST_F(MavlinkMissionTransferClientTest, DownloadMissionWithProgress)
     EXPECT_LE(num_progress_received, 10);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 bool is_correct_mission_clear_all(uint8_t type, const mavlink_message_t& message)
@@ -1710,13 +1704,12 @@ TEST_F(MavlinkMissionTransferClientTest, ClearMissionSendsClear)
         });
     do_work();
 
-    message_handler.process_message(
-        make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_RESULT_ACCEPTED));
+    process_message(make_mission_ack(MAV_MISSION_TYPE_MISSION, MAV_RESULT_ACCEPTED));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 bool is_correct_mission_set_current(uint16_t seq, const mavlink_message_t& message)
@@ -1761,12 +1754,12 @@ TEST_F(MavlinkMissionTransferClientTest, SetCurrentSendsSetCurrent)
     });
     do_work();
 
-    message_handler.process_message(make_mission_current(2));
+    process_message(make_mission_current(2));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, SetCurrentWithRetransmissionAndTimeout)
@@ -1791,13 +1784,13 @@ TEST_F(MavlinkMissionTransferClientTest, SetCurrentWithRetransmissionAndTimeout)
 
     for (unsigned i = 0; i < MavlinkMissionTransferClient::retries; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, SetCurrentWithRetransmissionAndSuccess)
@@ -1822,16 +1815,16 @@ TEST_F(MavlinkMissionTransferClientTest, SetCurrentWithRetransmissionAndSuccess)
 
     for (unsigned i = 0; i < MavlinkMissionTransferClient::retries - 2; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
-    message_handler.process_message(make_mission_current(2));
+    process_message(make_mission_current(2));
     do_work();
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, SetCurrentWithInvalidInput)
@@ -1850,7 +1843,7 @@ TEST_F(MavlinkMissionTransferClientTest, SetCurrentWithInvalidInput)
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, SetCurrentWithRetransmissionWhenWrong)
@@ -1879,13 +1872,13 @@ TEST_F(MavlinkMissionTransferClientTest, SetCurrentWithRetransmissionWhenWrong)
             [](std::function<mavlink_message_t(MavlinkAddress mavlink_address, uint8_t channel)>
                    fun) { return is_correct_mission_set_current(2, fun(own_address, channel)); })));
 
-    message_handler.process_message(make_mission_current(1));
+    process_message(make_mission_current(1));
     do_work();
 
-    message_handler.process_message(make_mission_current(2));
+    process_message(make_mission_current(2));
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_F(MavlinkMissionTransferClientTest, IntMessagesNotSupported)
@@ -1909,7 +1902,7 @@ TEST_F(MavlinkMissionTransferClientTest, IntMessagesNotSupported)
     }
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 
     {
         std::promise<void> prom;
@@ -1930,5 +1923,5 @@ TEST_F(MavlinkMissionTransferClientTest, IntMessagesNotSupported)
     }
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }

--- a/cpp/src/mavsdk/core/mavlink_mission_transfer_server.cpp
+++ b/cpp/src/mavsdk/core/mavlink_mission_transfer_server.cpp
@@ -159,7 +159,7 @@ MavlinkMissionTransferServer::ReceiveIncomingMission::ReceiveIncomingMission(
 
 MavlinkMissionTransferServer::ReceiveIncomingMission::~ReceiveIncomingMission()
 {
-    _message_handler.unregister_all_blocking(this);
+    _message_handler.unregister_all_on_io_thread(this);
     _timeout_handler.remove(_cookie);
 }
 
@@ -366,7 +366,7 @@ MavlinkMissionTransferServer::SendOutgoingMission::SendOutgoingMission(
 
 MavlinkMissionTransferServer::SendOutgoingMission::~SendOutgoingMission()
 {
-    _message_handler.unregister_all_blocking(this);
+    _message_handler.unregister_all_on_io_thread(this);
     _timeout_handler.remove(_cookie);
 }
 

--- a/cpp/src/mavsdk/core/mavlink_mission_transfer_server_test.cpp
+++ b/cpp/src/mavsdk/core/mavlink_mission_transfer_server_test.cpp
@@ -66,27 +66,30 @@ protected:
 
     void TearDown() override
     {
-        // Drain any pending io_context posts (e.g. enqueue lambdas holding shared_ptr<WorkItem>)
-        // so that WorkItem destructors run while message_handler and timeout_handler are still
-        // alive. Without this, io_context (declared first, destroyed last) would destroy those
-        // lambdas after message_handler is already gone, causing heap-use-after-free in
-        // unregister_all_blocking.
-        //
-        // io_context::poll() calls stop() internally when outstanding_work_ == 0, setting
-        // stopped_=true. A do_work() call on an idle queue will trigger this. restart() clears
-        // stopped_ so the subsequent poll() loop can actually execute any handlers still queued
-        // (e.g. the enqueue lambda that holds the last shared_ptr<WorkItem> reference).
+        // Drain any pending posts (handler registrations/removals, WorkItem destructors)
+        // on this thread while message_handler is still alive.
         io_context.restart();
         while (io_context.poll()) {
         }
     }
 
-    // Flush any io_context posts (e.g. the enqueue lambda) then drive the state machine.
+    // The message handler posts its table mutations onto the io_context, so poll() first to
+    // apply any pending registrations before driving the state machine / delivering a message.
     void do_work()
     {
         io_context.poll();
         mmt.do_work();
     }
+
+    void process_message(const mavlink_message_t& message)
+    {
+        io_context.poll();
+        message_handler.process_message(message);
+    }
+
+    void run_timeouts() { timeout_handler.run_once(); }
+
+    bool is_idle() { return mmt.is_idle(); }
 
     asio::io_context io_context;
 
@@ -303,7 +306,7 @@ protected:
     }
 
     MockSender mock_sender;
-    MavlinkMessageHandler message_handler;
+    MavlinkMessageHandler message_handler{io_context};
     FakeTime time;
     TimeoutHandler timeout_handler;
     MavlinkMissionTransferServer mmt;
@@ -352,7 +355,7 @@ TEST_P(MavlinkMissionTransferServerFixture, ReceiveIncomingMissionSendsMissionRe
 
     do_work();
 
-    message_handler.process_message(make_mission_count(items.size(), mission_type));
+    process_message(make_mission_count(items.size(), mission_type));
 }
 
 TEST_P(
@@ -395,13 +398,13 @@ TEST_P(
     // After the specified retries we should give up with a timeout.
     for (unsigned i = 0; i < MavlinkMissionTransferServer::retries; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(
@@ -442,7 +445,7 @@ TEST_P(
 
     for (unsigned i = 0; i < MavlinkMissionTransferServer::retries - 2; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     // This time we go over the retry limit.
@@ -455,17 +458,17 @@ TEST_P(
         })))
         .Times(MavlinkMissionTransferServer::retries);
 
-    message_handler.process_message(make_mission_item(items, 0));
+    process_message(make_mission_item(items, 0));
 
     for (unsigned i = 0; i < MavlinkMissionTransferServer::retries; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, ReceiveIncomingMissionEmptyList)
@@ -503,10 +506,10 @@ TEST_P(MavlinkMissionTransferServerFixture, ReceiveIncomingMissionEmptyList)
 
     // We want to be sure a timeout is not still triggered later.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, ReceiveIncomingMissionCanBeCancelled)
@@ -533,7 +536,7 @@ TEST_P(MavlinkMissionTransferServerFixture, ReceiveIncomingMissionCanBeCancelled
         });
     do_work();
 
-    message_handler.process_message(make_mission_item(items, 0));
+    process_message(make_mission_item(items, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -555,7 +558,7 @@ TEST_P(MavlinkMissionTransferServerFixture, ReceiveIncomingMissionCanBeCancelled
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionEmptyMission)
@@ -580,12 +583,12 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionEmptyMission)
     do_work();
 
     // empty mission should just send a zero count and be done
-    message_handler.process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionDoesNotCrashIfCallbackIsNull)
@@ -612,7 +615,7 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionDoesNotCrashIfCal
     do_work();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(
@@ -644,10 +647,10 @@ TEST_P(
 
     // We want to be sure a timeout is not still triggered later.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionSendsCount)
@@ -707,7 +710,7 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionResendsCount)
     do_work();
 
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionTimeoutAfterSendCount)
@@ -747,7 +750,7 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionTimeoutAfterSendC
     // After the specified retries we should give up with a timeout.
     for (unsigned i = 0; i < MavlinkMissionTransferServer::retries; ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
@@ -783,7 +786,7 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionSendsMissionItems
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_request_int(mission_type, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -792,19 +795,19 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionSendsMissionItems
             return is_the_same_mission_item_int(items[1], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(mission_type, 1));
+    process_message(make_mission_request_int(mission_type, 1));
 
-    message_handler.process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     // We do not expect a timeout later though.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionResendsMissionItems)
@@ -837,7 +840,7 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionResendsMissionIte
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_request_int(mission_type, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -847,7 +850,7 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionResendsMissionIte
         })));
 
     // Request 0 again in case it had not arrived.
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_request_int(mission_type, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -857,15 +860,15 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionResendsMissionIte
         })));
 
     // Request 1 finally.
-    message_handler.process_message(make_mission_request_int(mission_type, 1));
+    process_message(make_mission_request_int(mission_type, 1));
 
-    message_handler.process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(
@@ -902,18 +905,18 @@ TEST_P(
         .Times(MavlinkMissionTransferServer::retries);
 
     for (unsigned i = 0; i < MavlinkMissionTransferServer::retries; ++i) {
-        message_handler.process_message(make_mission_request_int(mission_type, 0));
+        process_message(make_mission_request_int(mission_type, 0));
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(0)), std::future_status::timeout);
 
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_request_int(mission_type, 0));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionAckArrivesTooEarly)
@@ -946,15 +949,15 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionAckArrivesTooEarl
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_request_int(mission_type, 0));
 
     // Don't request item 1 but already send ack.
-    message_handler.process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 class MavlinkMissionTransferServerNack
@@ -994,15 +997,15 @@ TEST_P(MavlinkMissionTransferServerNack, SendOutgoingMissionNackAreHandled)
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_request_int(mission_type, 0));
 
     // Send nack now.
-    message_handler.process_message(make_mission_ack(mission_type, mavlink_nack));
+    process_message(make_mission_ack(mission_type, mavlink_nack));
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1060,11 +1063,11 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionTimeoutNotTrigger
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_request_int(mission_type, 0));
 
     // We almost use up the max timeout in each cycle.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 0.8 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     EXPECT_CALL(
         mock_sender,
@@ -1073,10 +1076,10 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionTimeoutNotTrigger
             return is_the_same_mission_item_int(items[1], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(mission_type, 1));
+    process_message(make_mission_request_int(mission_type, 1));
 
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 0.8 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     EXPECT_CALL(
         mock_sender,
@@ -1085,18 +1088,18 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionTimeoutNotTrigger
             return is_the_same_mission_item_int(items[2], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(mission_type, 2));
+    process_message(make_mission_request_int(mission_type, 2));
 
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 0.8 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
-    message_handler.process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionTimeoutAfterSendMissionItem)
@@ -1129,40 +1132,40 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionTimeoutAfterSendM
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_request_int(mission_type, 0));
 
     // Make sure single timeout does not trigger it yet.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1000. + 250)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     EXPECT_EQ(fut.wait_for(std::chrono::milliseconds(50)), std::future_status::timeout);
 
     // But multiple do.
     for (unsigned i = 0; i < (MavlinkMissionTransferServer::retries - 1); ++i) {
         time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1000.)));
-        timeout_handler.run_once();
+        run_timeouts();
     }
 
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     // Ignore later (wrong) ack.
-    message_handler.process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionDoesNotCrashOnRandomMessages)
 {
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_request_int(mission_type, 0));
 
-    message_handler.process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
 
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionCanBeCancelled)
@@ -1188,7 +1191,7 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionCanBeCancelled)
         });
     do_work();
 
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_request_int(mission_type, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -1209,10 +1212,10 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionCanBeCancelled)
 
     // We do not expect a timeout later though.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionNacksNonIntCase)
@@ -1247,7 +1250,7 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionNacksNonIntCase)
         .Times(1);
 
     // First the non-int wrong case comes in.
-    message_handler.process_message(make_mission_request(mission_type, 0));
+    process_message(make_mission_request(mission_type, 0));
 
     EXPECT_CALL(
         mock_sender,
@@ -1256,18 +1259,18 @@ TEST_P(MavlinkMissionTransferServerFixture, SendOutgoingMissionNacksNonIntCase)
             return is_the_same_mission_item_int(items[0], fun(own_address, channel));
         })));
 
-    message_handler.process_message(make_mission_request_int(mission_type, 0));
-    message_handler.process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
+    process_message(make_mission_request_int(mission_type, 0));
+    process_message(make_mission_ack(mission_type, MAV_MISSION_ACCEPTED));
 
     // We are finished and should have received the successful result.
     EXPECT_EQ(fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 
     // We do not expect a timeout later though.
     time.sleep_for(std::chrono::milliseconds(static_cast<int>(timeout_s * 1.1 * 1000.)));
-    timeout_handler.run_once();
+    run_timeouts();
 
     do_work();
-    EXPECT_TRUE(mmt.is_idle());
+    EXPECT_TRUE(is_idle());
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/src/mavsdk/core/mavsdk_impl.hpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.hpp
@@ -143,7 +143,7 @@ public:
     void set_heartbeat_timeout_s(double timeout_s) { _heartbeat_timeout_s = timeout_s; }
     double heartbeat_timeout_s() const { return _heartbeat_timeout_s; }
 
-    MavlinkMessageHandler mavlink_message_handler{};
+    MavlinkMessageHandler mavlink_message_handler{_io_context};
 
     ServerComponentImpl& default_server_component_impl();
 

--- a/cpp/src/mavsdk/core/system_impl.cpp
+++ b/cpp/src/mavsdk/core/system_impl.cpp
@@ -24,6 +24,9 @@ template class MAVSDK_TEMPL_INST CallbackList<ComponentType>;
 template class MAVSDK_TEMPL_INST CallbackList<ComponentType, uint8_t>;
 
 SystemImpl::SystemImpl(MavsdkImpl& mavsdk_impl) :
+    // Declared before _mavsdk_impl, so init it first (in declaration order) using the
+    // ctor parameter rather than the not-yet-bound _mavsdk_impl reference.
+    _mavlink_message_handler(mavsdk_impl.io_context()),
     _mavsdk_impl(mavsdk_impl),
     _system_work_timer(mavsdk_impl.io_context()),
     _command_sender(*this),

--- a/cpp/src/mavsdk/core/system_impl.hpp
+++ b/cpp/src/mavsdk/core/system_impl.hpp
@@ -389,7 +389,7 @@ private:
 
     AutopilotTime _autopilot_time{};
 
-    MavlinkMessageHandler _mavlink_message_handler{};
+    MavlinkMessageHandler _mavlink_message_handler;
 
     // Libmav message handling using CallbackList for thread safety
     CallbackList<Mavsdk::MavlinkMessage> _libmav_message_callbacks{};


### PR DESCRIPTION
Replace MavlinkMessageHandler's hand-rolled thread-safety (a mutex plus two deferred side-tables and try_lock-or-defer, applying registers before unregisters) with the executor model the rest of core now uses: the handler table is only ever touched on the io_context thread.

- process_message() already runs on the io thread (it is driven by the connection receive path, which posts onto the io_context), so it iterates the table directly with no lock.
- register/unregister asio::post() their mutation onto the io_context, so they are safe from any thread and from inside a callback (the mutation runs after the current dispatch), with ordering preserved by post FIFO.

Teardown is split by where the owner is destroyed, which the caller always knows by construction, so no run-time "am I on the io thread" detection is needed (asio's running_in_this_thread() is unreliable during destructor cleanup anyway):

- unregister_all_on_io_thread(): direct synchronous erase, for owners that live and die ON the io thread (mission-transfer WorkItems). They are only ever destroyed from do_work(), never mid process_message() iteration, so the direct erase is race-free and avoids a fire-after-free without a round-trip.
- unregister_all_blocking(): posts the removal and waits, for owners destroyed OFF the io thread (plugin destructors on the user thread). Plugins are documented to be destroyed before Mavsdk, so the io thread is alive and the wait completes.

Shutdown is covered by the existing ~MavsdkImpl top-level stop()+join(): the io thread is gone before systems/core objects destruct, so their unregister_all() posts are harmless no-ops and no callback can fire on freed memory.

MavlinkMessageHandler now takes the io_context by reference; wire it through MavsdkImpl and SystemImpl. The mission-transfer unit tests now run the io_context on a dedicated thread (as in production) and route their interactions through an on_io() helper, instead of manual poll()-gating.

Full unit (291) and system (85) suites pass.