### PR TITLE
py: redirect all debug output to stderr

### DIFF
--- a/py/mavsdk/mavsdk/cmavsdk_loader.py
+++ b/py/mavsdk/mavsdk/cmavsdk_loader.py
@@ -27,7 +27,7 @@ def _find_library() -> ctypes.CDLL:
         Path.cwd() / "lib",  # fallback
     ]
 
-    print(f"Searching for library on {platform}...")
+    print(f"Searching for library on {platform}...", file=sys.stderr)
 
     for path in search_paths:
         for name in names:
@@ -35,10 +35,10 @@ def _find_library() -> ctypes.CDLL:
             if lib_path.exists():
                 try:
                     lib = ctypes.CDLL(str(lib_path))
-                    print(f"✓ Loaded library: {lib_path}")
+                    print(f"✓ Loaded library: {lib_path}", file=sys.stderr)
                     return lib
                 except OSError as e:
-                    print(f"✗ Failed to load {lib_path}: {e}")
+                    print(f"✗ Failed to load {lib_path}: {e}", file=sys.stderr)
                     continue
 
     raise LibraryNotFoundError(f"Could not find cmavsdk library. Tried: {names}")

--- a/py/mavsdk/mavsdk/logging.py
+++ b/py/mavsdk/mavsdk/logging.py
@@ -1,6 +1,7 @@
 """Logging support for cmavsdk"""
 
 import ctypes
+import sys
 
 from enum import IntEnum
 from typing import Optional, Callable
@@ -40,9 +41,9 @@ def log_subscribe(callback: Callable[[LogLevel, str, Optional[str], int], bool])
 
     Example:
         def my_log_handler(level, message, file, line):
-            print(f"[{level.name}] {message}")
+            print(f"[{level.name}] {message}", file=sys.stderr)
             if file:
-                print(f"  at {file}:{line}")
+                print(f"  at {file}:{line}", file=sys.stderr)
             return True  # Suppress default logging
 
         log_subscribe(my_log_handler)
@@ -59,7 +60,7 @@ def log_subscribe(callback: Callable[[LogLevel, str, Optional[str], int], bool])
 
             return callback(level_enum, msg_str, file_str, line)
         except Exception as e:
-            print(f"Error in log callback: {e}")
+            print(f"Error in log callback: {e}", file=sys.stderr)
             return False
 
     # Keep reference to prevent garbage collection

--- a/py/mavsdk/mavsdk/plugins/action/action.py
+++ b/py/mavsdk/mavsdk/plugins/action/action.py
@@ -10,6 +10,7 @@ Enable simple actions such as arming, taking off, and landing.
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -100,7 +101,7 @@ class Action:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in arm callback: {e}")
+                print(f"Error in arm callback: {e}", file=sys.stderr)
 
         cb = ArmCallback(c_callback)
         self._callbacks.append(cb)
@@ -134,7 +135,7 @@ class Action:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in arm_force callback: {e}")
+                print(f"Error in arm_force callback: {e}", file=sys.stderr)
 
         cb = ArmForceCallback(c_callback)
         self._callbacks.append(cb)
@@ -166,7 +167,7 @@ class Action:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in disarm callback: {e}")
+                print(f"Error in disarm callback: {e}", file=sys.stderr)
 
         cb = DisarmCallback(c_callback)
         self._callbacks.append(cb)
@@ -200,7 +201,7 @@ class Action:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in takeoff callback: {e}")
+                print(f"Error in takeoff callback: {e}", file=sys.stderr)
 
         cb = TakeoffCallback(c_callback)
         self._callbacks.append(cb)
@@ -231,7 +232,7 @@ class Action:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in land callback: {e}")
+                print(f"Error in land callback: {e}", file=sys.stderr)
 
         cb = LandCallback(c_callback)
         self._callbacks.append(cb)
@@ -262,7 +263,7 @@ class Action:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in reboot callback: {e}")
+                print(f"Error in reboot callback: {e}", file=sys.stderr)
 
         cb = RebootCallback(c_callback)
         self._callbacks.append(cb)
@@ -295,7 +296,7 @@ class Action:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in shutdown callback: {e}")
+                print(f"Error in shutdown callback: {e}", file=sys.stderr)
 
         cb = ShutdownCallback(c_callback)
         self._callbacks.append(cb)
@@ -326,7 +327,7 @@ class Action:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in terminate callback: {e}")
+                print(f"Error in terminate callback: {e}", file=sys.stderr)
 
         cb = TerminateCallback(c_callback)
         self._callbacks.append(cb)
@@ -358,7 +359,7 @@ class Action:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in kill callback: {e}")
+                print(f"Error in kill callback: {e}", file=sys.stderr)
 
         cb = KillCallback(c_callback)
         self._callbacks.append(cb)
@@ -391,7 +392,7 @@ class Action:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in return_to_launch callback: {e}")
+                print(f"Error in return_to_launch callback: {e}", file=sys.stderr)
 
         cb = ReturnToLaunchCallback(c_callback)
         self._callbacks.append(cb)
@@ -433,7 +434,7 @@ class Action:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in goto_location callback: {e}")
+                print(f"Error in goto_location callback: {e}", file=sys.stderr)
 
         cb = GotoLocationCallback(c_callback)
         self._callbacks.append(cb)
@@ -486,7 +487,7 @@ class Action:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in do_orbit callback: {e}")
+                print(f"Error in do_orbit callback: {e}", file=sys.stderr)
 
         cb = DoOrbitCallback(c_callback)
         self._callbacks.append(cb)
@@ -545,7 +546,7 @@ class Action:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in hold callback: {e}")
+                print(f"Error in hold callback: {e}", file=sys.stderr)
 
         cb = HoldCallback(c_callback)
         self._callbacks.append(cb)
@@ -578,7 +579,7 @@ class Action:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_actuator callback: {e}")
+                print(f"Error in set_actuator callback: {e}", file=sys.stderr)
 
         cb = SetActuatorCallback(c_callback)
         self._callbacks.append(cb)
@@ -614,7 +615,7 @@ class Action:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_relay callback: {e}")
+                print(f"Error in set_relay callback: {e}", file=sys.stderr)
 
         cb = SetRelayCallback(c_callback)
         self._callbacks.append(cb)
@@ -649,7 +650,7 @@ class Action:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in transition_to_fixedwing callback: {e}")
+                print(f"Error in transition_to_fixedwing callback: {e}", file=sys.stderr)
 
         cb = TransitionToFixedwingCallback(c_callback)
         self._callbacks.append(cb)
@@ -684,7 +685,7 @@ class Action:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in transition_to_multicopter callback: {e}")
+                print(f"Error in transition_to_multicopter callback: {e}", file=sys.stderr)
 
         cb = TransitionToMulticopterCallback(c_callback)
         self._callbacks.append(cb)
@@ -715,7 +716,7 @@ class Action:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in get_takeoff_altitude callback: {e}")
+                print(f"Error in get_takeoff_altitude callback: {e}", file=sys.stderr)
 
         cb = GetTakeoffAltitudeCallback(c_callback)
         self._callbacks.append(cb)
@@ -748,7 +749,7 @@ class Action:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_takeoff_altitude callback: {e}")
+                print(f"Error in set_takeoff_altitude callback: {e}", file=sys.stderr)
 
         cb = SetTakeoffAltitudeCallback(c_callback)
         self._callbacks.append(cb)
@@ -784,7 +785,7 @@ class Action:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in get_return_to_launch_altitude callback: {e}")
+                print(f"Error in get_return_to_launch_altitude callback: {e}", file=sys.stderr)
 
         cb = GetReturnToLaunchAltitudeCallback(c_callback)
         self._callbacks.append(cb)
@@ -819,7 +820,7 @@ class Action:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_return_to_launch_altitude callback: {e}")
+                print(f"Error in set_return_to_launch_altitude callback: {e}", file=sys.stderr)
 
         cb = SetReturnToLaunchAltitudeCallback(c_callback)
         self._callbacks.append(cb)
@@ -856,7 +857,7 @@ class Action:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_current_speed callback: {e}")
+                print(f"Error in set_current_speed callback: {e}", file=sys.stderr)
 
         cb = SetCurrentSpeedCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/action_server/action_server.py
+++ b/py/mavsdk/mavsdk/plugins/action_server/action_server.py
@@ -10,6 +10,7 @@ Provide vehicle actions (as a server) such as arming, taking off, and landing.
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -222,7 +223,7 @@ class ActionServer:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in arm_disarm callback: {e}")
+                print(f"Error in arm_disarm callback: {e}", file=sys.stderr)
 
         cb = ArmDisarmCallback(c_callback)
         self._callbacks.append(cb)
@@ -247,7 +248,7 @@ class ActionServer:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in flight_mode_change callback: {e}")
+                print(f"Error in flight_mode_change callback: {e}", file=sys.stderr)
 
         cb = FlightModeChangeCallback(c_callback)
         self._callbacks.append(cb)
@@ -274,7 +275,7 @@ class ActionServer:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in takeoff callback: {e}")
+                print(f"Error in takeoff callback: {e}", file=sys.stderr)
 
         cb = TakeoffCallback(c_callback)
         self._callbacks.append(cb)
@@ -297,7 +298,7 @@ class ActionServer:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in land callback: {e}")
+                print(f"Error in land callback: {e}", file=sys.stderr)
 
         cb = LandCallback(c_callback)
         self._callbacks.append(cb)
@@ -320,7 +321,7 @@ class ActionServer:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in reboot callback: {e}")
+                print(f"Error in reboot callback: {e}", file=sys.stderr)
 
         cb = RebootCallback(c_callback)
         self._callbacks.append(cb)
@@ -343,7 +344,7 @@ class ActionServer:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in shutdown callback: {e}")
+                print(f"Error in shutdown callback: {e}", file=sys.stderr)
 
         cb = ShutdownCallback(c_callback)
         self._callbacks.append(cb)
@@ -366,7 +367,7 @@ class ActionServer:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in terminate callback: {e}")
+                print(f"Error in terminate callback: {e}", file=sys.stderr)
 
         cb = TerminateCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/arm_authorizer_server/arm_authorizer_server.py
+++ b/py/mavsdk/mavsdk/plugins/arm_authorizer_server/arm_authorizer_server.py
@@ -10,6 +10,7 @@ Use arm authorization.
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -79,7 +80,7 @@ class ArmAuthorizerServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in arm_authorization callback: {e}")
+                print(f"Error in arm_authorization callback: {e}", file=sys.stderr)
 
         cb = ArmAuthorizationCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/calibration/calibration.py
+++ b/py/mavsdk/mavsdk/plugins/calibration/calibration.py
@@ -10,6 +10,7 @@ Enable to calibrate sensors of a drone such as gyro, accelerometer, and magnetom
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -137,7 +138,7 @@ class Calibration:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in calibrate_gyro callback: {e}")
+                print(f"Error in calibrate_gyro callback: {e}", file=sys.stderr)
 
         cb = CalibrateGyroCallback(c_callback)
         self._callbacks.append(cb)
@@ -158,7 +159,7 @@ class Calibration:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in calibrate_accelerometer callback: {e}")
+                print(f"Error in calibrate_accelerometer callback: {e}", file=sys.stderr)
 
         cb = CalibrateAccelerometerCallback(c_callback)
         self._callbacks.append(cb)
@@ -181,7 +182,7 @@ class Calibration:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in calibrate_magnetometer callback: {e}")
+                print(f"Error in calibrate_magnetometer callback: {e}", file=sys.stderr)
 
         cb = CalibrateMagnetometerCallback(c_callback)
         self._callbacks.append(cb)
@@ -204,7 +205,7 @@ class Calibration:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in calibrate_level_horizon callback: {e}")
+                print(f"Error in calibrate_level_horizon callback: {e}", file=sys.stderr)
 
         cb = CalibrateLevelHorizonCallback(c_callback)
         self._callbacks.append(cb)
@@ -229,7 +230,7 @@ class Calibration:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in calibrate_gimbal_accelerometer callback: {e}")
+                print(f"Error in calibrate_gimbal_accelerometer callback: {e}", file=sys.stderr)
 
         cb = CalibrateGimbalAccelerometerCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/camera/camera.py
+++ b/py/mavsdk/mavsdk/plugins/camera/camera.py
@@ -16,6 +16,7 @@ Can be used to manage cameras that implement the MAVLink
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -1174,7 +1175,7 @@ class Camera:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in take_photo callback: {e}")
+                print(f"Error in take_photo callback: {e}", file=sys.stderr)
 
         cb = TakePhotoCallback(c_callback)
         self._callbacks.append(cb)
@@ -1206,7 +1207,7 @@ class Camera:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in start_photo_interval callback: {e}")
+                print(f"Error in start_photo_interval callback: {e}", file=sys.stderr)
 
         cb = StartPhotoIntervalCallback(c_callback)
         self._callbacks.append(cb)
@@ -1241,7 +1242,7 @@ class Camera:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in stop_photo_interval callback: {e}")
+                print(f"Error in stop_photo_interval callback: {e}", file=sys.stderr)
 
         cb = StopPhotoIntervalCallback(c_callback)
         self._callbacks.append(cb)
@@ -1275,7 +1276,7 @@ class Camera:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in start_video callback: {e}")
+                print(f"Error in start_video callback: {e}", file=sys.stderr)
 
         cb = StartVideoCallback(c_callback)
         self._callbacks.append(cb)
@@ -1305,7 +1306,7 @@ class Camera:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in stop_video callback: {e}")
+                print(f"Error in stop_video callback: {e}", file=sys.stderr)
 
         cb = StopVideoCallback(c_callback)
         self._callbacks.append(cb)
@@ -1365,7 +1366,7 @@ class Camera:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_mode callback: {e}")
+                print(f"Error in set_mode callback: {e}", file=sys.stderr)
 
         cb = SetModeCallback(c_callback)
         self._callbacks.append(cb)
@@ -1411,7 +1412,7 @@ class Camera:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in list_photos callback: {e}")
+                print(f"Error in list_photos callback: {e}", file=sys.stderr)
 
         cb = ListPhotosCallback(c_callback)
         self._callbacks.append(cb)
@@ -1458,7 +1459,7 @@ class Camera:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in camera_list callback: {e}")
+                print(f"Error in camera_list callback: {e}", file=sys.stderr)
 
         cb = CameraListCallback(c_callback)
         self._callbacks.append(cb)
@@ -1492,7 +1493,7 @@ class Camera:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in mode callback: {e}")
+                print(f"Error in mode callback: {e}", file=sys.stderr)
 
         cb = ModeCallback(c_callback)
         self._callbacks.append(cb)
@@ -1531,7 +1532,7 @@ class Camera:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in video_stream_info callback: {e}")
+                print(f"Error in video_stream_info callback: {e}", file=sys.stderr)
 
         cb = VideoStreamInfoCallback(c_callback)
         self._callbacks.append(cb)
@@ -1572,7 +1573,7 @@ class Camera:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in capture_info callback: {e}")
+                print(f"Error in capture_info callback: {e}", file=sys.stderr)
 
         cb = CaptureInfoCallback(c_callback)
         self._callbacks.append(cb)
@@ -1595,7 +1596,7 @@ class Camera:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in storage callback: {e}")
+                print(f"Error in storage callback: {e}", file=sys.stderr)
 
         cb = StorageCallback(c_callback)
         self._callbacks.append(cb)
@@ -1636,7 +1637,7 @@ class Camera:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in current_settings callback: {e}")
+                print(f"Error in current_settings callback: {e}", file=sys.stderr)
 
         cb = CurrentSettingsCallback(c_callback)
         self._callbacks.append(cb)
@@ -1682,7 +1683,7 @@ class Camera:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in possible_setting_options callback: {e}")
+                print(f"Error in possible_setting_options callback: {e}", file=sys.stderr)
 
         cb = PossibleSettingOptionsCallback(c_callback)
         self._callbacks.append(cb)
@@ -1730,7 +1731,7 @@ class Camera:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_setting callback: {e}")
+                print(f"Error in set_setting callback: {e}", file=sys.stderr)
 
         cb = SetSettingCallback(c_callback)
         self._callbacks.append(cb)
@@ -1771,7 +1772,7 @@ class Camera:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in get_setting callback: {e}")
+                print(f"Error in get_setting callback: {e}", file=sys.stderr)
 
         cb = GetSettingCallback(c_callback)
         self._callbacks.append(cb)
@@ -1810,7 +1811,7 @@ class Camera:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in format_storage callback: {e}")
+                print(f"Error in format_storage callback: {e}", file=sys.stderr)
 
         cb = FormatStorageCallback(c_callback)
         self._callbacks.append(cb)
@@ -1847,7 +1848,7 @@ class Camera:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in reset_settings callback: {e}")
+                print(f"Error in reset_settings callback: {e}", file=sys.stderr)
 
         cb = ResetSettingsCallback(c_callback)
         self._callbacks.append(cb)
@@ -1881,7 +1882,7 @@ class Camera:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in zoom_in_start callback: {e}")
+                print(f"Error in zoom_in_start callback: {e}", file=sys.stderr)
 
         cb = ZoomInStartCallback(c_callback)
         self._callbacks.append(cb)
@@ -1915,7 +1916,7 @@ class Camera:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in zoom_out_start callback: {e}")
+                print(f"Error in zoom_out_start callback: {e}", file=sys.stderr)
 
         cb = ZoomOutStartCallback(c_callback)
         self._callbacks.append(cb)
@@ -1947,7 +1948,7 @@ class Camera:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in zoom_stop callback: {e}")
+                print(f"Error in zoom_stop callback: {e}", file=sys.stderr)
 
         cb = ZoomStopCallback(c_callback)
         self._callbacks.append(cb)
@@ -1979,7 +1980,7 @@ class Camera:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in zoom_range callback: {e}")
+                print(f"Error in zoom_range callback: {e}", file=sys.stderr)
 
         cb = ZoomRangeCallback(c_callback)
         self._callbacks.append(cb)
@@ -2020,7 +2021,7 @@ class Camera:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in track_point callback: {e}")
+                print(f"Error in track_point callback: {e}", file=sys.stderr)
 
         cb = TrackPointCallback(c_callback)
         self._callbacks.append(cb)
@@ -2064,7 +2065,7 @@ class Camera:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in track_rectangle callback: {e}")
+                print(f"Error in track_rectangle callback: {e}", file=sys.stderr)
 
         cb = TrackRectangleCallback(c_callback)
         self._callbacks.append(cb)
@@ -2109,7 +2110,7 @@ class Camera:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in track_stop callback: {e}")
+                print(f"Error in track_stop callback: {e}", file=sys.stderr)
 
         cb = TrackStopCallback(c_callback)
         self._callbacks.append(cb)
@@ -2141,7 +2142,7 @@ class Camera:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in focus_in_start callback: {e}")
+                print(f"Error in focus_in_start callback: {e}", file=sys.stderr)
 
         cb = FocusInStartCallback(c_callback)
         self._callbacks.append(cb)
@@ -2175,7 +2176,7 @@ class Camera:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in focus_out_start callback: {e}")
+                print(f"Error in focus_out_start callback: {e}", file=sys.stderr)
 
         cb = FocusOutStartCallback(c_callback)
         self._callbacks.append(cb)
@@ -2207,7 +2208,7 @@ class Camera:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in focus_stop callback: {e}")
+                print(f"Error in focus_stop callback: {e}", file=sys.stderr)
 
         cb = FocusStopCallback(c_callback)
         self._callbacks.append(cb)
@@ -2239,7 +2240,7 @@ class Camera:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in focus_range callback: {e}")
+                print(f"Error in focus_range callback: {e}", file=sys.stderr)
 
         cb = FocusRangeCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/camera_server/camera_server.py
+++ b/py/mavsdk/mavsdk/plugins/camera_server/camera_server.py
@@ -10,6 +10,7 @@ Provides handling of camera interface
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -774,7 +775,7 @@ class CameraServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in take_photo callback: {e}")
+                print(f"Error in take_photo callback: {e}", file=sys.stderr)
 
         cb = TakePhotoCallback(c_callback)
         self._callbacks.append(cb)
@@ -811,7 +812,7 @@ class CameraServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in start_video callback: {e}")
+                print(f"Error in start_video callback: {e}", file=sys.stderr)
 
         cb = StartVideoCallback(c_callback)
         self._callbacks.append(cb)
@@ -847,7 +848,7 @@ class CameraServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in stop_video callback: {e}")
+                print(f"Error in stop_video callback: {e}", file=sys.stderr)
 
         cb = StopVideoCallback(c_callback)
         self._callbacks.append(cb)
@@ -885,7 +886,7 @@ class CameraServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in start_video_streaming callback: {e}")
+                print(f"Error in start_video_streaming callback: {e}", file=sys.stderr)
 
         cb = StartVideoStreamingCallback(c_callback)
         self._callbacks.append(cb)
@@ -923,7 +924,7 @@ class CameraServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in stop_video_streaming callback: {e}")
+                print(f"Error in stop_video_streaming callback: {e}", file=sys.stderr)
 
         cb = StopVideoStreamingCallback(c_callback)
         self._callbacks.append(cb)
@@ -961,7 +962,7 @@ class CameraServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in set_mode callback: {e}")
+                print(f"Error in set_mode callback: {e}", file=sys.stderr)
 
         cb = SetModeCallback(c_callback)
         self._callbacks.append(cb)
@@ -995,7 +996,7 @@ class CameraServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in storage_information callback: {e}")
+                print(f"Error in storage_information callback: {e}", file=sys.stderr)
 
         cb = StorageInformationCallback(c_callback)
         self._callbacks.append(cb)
@@ -1036,7 +1037,7 @@ class CameraServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in capture_status callback: {e}")
+                print(f"Error in capture_status callback: {e}", file=sys.stderr)
 
         cb = CaptureStatusCallback(c_callback)
         self._callbacks.append(cb)
@@ -1073,7 +1074,7 @@ class CameraServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in format_storage callback: {e}")
+                print(f"Error in format_storage callback: {e}", file=sys.stderr)
 
         cb = FormatStorageCallback(c_callback)
         self._callbacks.append(cb)
@@ -1109,7 +1110,7 @@ class CameraServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in reset_settings callback: {e}")
+                print(f"Error in reset_settings callback: {e}", file=sys.stderr)
 
         cb = ResetSettingsCallback(c_callback)
         self._callbacks.append(cb)
@@ -1145,7 +1146,7 @@ class CameraServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in zoom_in_start callback: {e}")
+                print(f"Error in zoom_in_start callback: {e}", file=sys.stderr)
 
         cb = ZoomInStartCallback(c_callback)
         self._callbacks.append(cb)
@@ -1181,7 +1182,7 @@ class CameraServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in zoom_out_start callback: {e}")
+                print(f"Error in zoom_out_start callback: {e}", file=sys.stderr)
 
         cb = ZoomOutStartCallback(c_callback)
         self._callbacks.append(cb)
@@ -1217,7 +1218,7 @@ class CameraServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in zoom_stop callback: {e}")
+                print(f"Error in zoom_stop callback: {e}", file=sys.stderr)
 
         cb = ZoomStopCallback(c_callback)
         self._callbacks.append(cb)
@@ -1253,7 +1254,7 @@ class CameraServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in zoom_range callback: {e}")
+                print(f"Error in zoom_range callback: {e}", file=sys.stderr)
 
         cb = ZoomRangeCallback(c_callback)
         self._callbacks.append(cb)
@@ -1308,7 +1309,7 @@ class CameraServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in tracking_point_command callback: {e}")
+                print(f"Error in tracking_point_command callback: {e}", file=sys.stderr)
 
         cb = TrackingPointCommandCallback(c_callback)
         self._callbacks.append(cb)
@@ -1339,7 +1340,7 @@ class CameraServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in tracking_rectangle_command callback: {e}")
+                print(f"Error in tracking_rectangle_command callback: {e}", file=sys.stderr)
 
         cb = TrackingRectangleCommandCallback(c_callback)
         self._callbacks.append(cb)
@@ -1364,7 +1365,7 @@ class CameraServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in tracking_off_command callback: {e}")
+                print(f"Error in tracking_off_command callback: {e}", file=sys.stderr)
 
         cb = TrackingOffCommandCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/component_metadata/component_metadata.py
+++ b/py/mavsdk/mavsdk/plugins/component_metadata/component_metadata.py
@@ -10,6 +10,7 @@ Access component metadata json definitions, such as parameters.
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -185,7 +186,7 @@ class ComponentMetadata:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in metadata_available callback: {e}")
+                print(f"Error in metadata_available callback: {e}", file=sys.stderr)
 
         cb = MetadataAvailableCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/events/events.py
+++ b/py/mavsdk/mavsdk/plugins/events/events.py
@@ -10,6 +10,7 @@ Get event notifications, such as takeoff, or arming checks
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -414,7 +415,7 @@ class Events:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in events callback: {e}")
+                print(f"Error in events callback: {e}", file=sys.stderr)
 
         cb = EventsCallback(c_callback)
         self._callbacks.append(cb)
@@ -441,7 +442,7 @@ class Events:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in health_and_arming_checks callback: {e}")
+                print(f"Error in health_and_arming_checks callback: {e}", file=sys.stderr)
 
         cb = HealthAndArmingChecksCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/ftp/ftp.py
+++ b/py/mavsdk/mavsdk/plugins/ftp/ftp.py
@@ -10,6 +10,7 @@ Implements file transfer functionality using MAVLink FTP.
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -176,7 +177,7 @@ class Ftp:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in download callback: {e}")
+                print(f"Error in download callback: {e}", file=sys.stderr)
 
         cb = DownloadCallback(c_callback)
         self._callbacks.append(cb)
@@ -208,7 +209,7 @@ class Ftp:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in upload callback: {e}")
+                print(f"Error in upload callback: {e}", file=sys.stderr)
 
         cb = UploadCallback(c_callback)
         self._callbacks.append(cb)
@@ -239,7 +240,7 @@ class Ftp:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in list_directory callback: {e}")
+                print(f"Error in list_directory callback: {e}", file=sys.stderr)
 
         cb = ListDirectoryCallback(c_callback)
         self._callbacks.append(cb)
@@ -281,7 +282,7 @@ class Ftp:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in create_directory callback: {e}")
+                print(f"Error in create_directory callback: {e}", file=sys.stderr)
 
         cb = CreateDirectoryCallback(c_callback)
         self._callbacks.append(cb)
@@ -318,7 +319,7 @@ class Ftp:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in remove_directory callback: {e}")
+                print(f"Error in remove_directory callback: {e}", file=sys.stderr)
 
         cb = RemoveDirectoryCallback(c_callback)
         self._callbacks.append(cb)
@@ -355,7 +356,7 @@ class Ftp:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in remove_file callback: {e}")
+                print(f"Error in remove_file callback: {e}", file=sys.stderr)
 
         cb = RemoveFileCallback(c_callback)
         self._callbacks.append(cb)
@@ -400,7 +401,7 @@ class Ftp:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in rename callback: {e}")
+                print(f"Error in rename callback: {e}", file=sys.stderr)
 
         cb = RenameCallback(c_callback)
         self._callbacks.append(cb)
@@ -453,7 +454,7 @@ class Ftp:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in are_files_identical callback: {e}")
+                print(f"Error in are_files_identical callback: {e}", file=sys.stderr)
 
         cb = AreFilesIdenticalCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/geofence/geofence.py
+++ b/py/mavsdk/mavsdk/plugins/geofence/geofence.py
@@ -10,6 +10,7 @@ Enable setting a geofence.
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -295,7 +296,7 @@ class Geofence:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in upload_geofence callback: {e}")
+                print(f"Error in upload_geofence callback: {e}", file=sys.stderr)
 
         cb = UploadGeofenceCallback(c_callback)
         self._callbacks.append(cb)
@@ -327,7 +328,7 @@ class Geofence:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in clear_geofence callback: {e}")
+                print(f"Error in clear_geofence callback: {e}", file=sys.stderr)
 
         cb = ClearGeofenceCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/gimbal/gimbal.py
+++ b/py/mavsdk/mavsdk/plugins/gimbal/gimbal.py
@@ -11,6 +11,7 @@ Provide control over a gimbal within the MAVLink
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -548,7 +549,7 @@ class Gimbal:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_angles callback: {e}")
+                print(f"Error in set_angles callback: {e}", file=sys.stderr)
 
         cb = SetAnglesCallback(c_callback)
         self._callbacks.append(cb)
@@ -611,7 +612,7 @@ class Gimbal:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_angular_rates callback: {e}")
+                print(f"Error in set_angular_rates callback: {e}", file=sys.stderr)
 
         cb = SetAngularRatesCallback(c_callback)
         self._callbacks.append(cb)
@@ -678,7 +679,7 @@ class Gimbal:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_roi_location callback: {e}")
+                print(f"Error in set_roi_location callback: {e}", file=sys.stderr)
 
         cb = SetRoiLocationCallback(c_callback)
         self._callbacks.append(cb)
@@ -723,7 +724,7 @@ class Gimbal:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in take_control callback: {e}")
+                print(f"Error in take_control callback: {e}", file=sys.stderr)
 
         cb = TakeControlCallback(c_callback)
         self._callbacks.append(cb)
@@ -760,7 +761,7 @@ class Gimbal:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in release_control callback: {e}")
+                print(f"Error in release_control callback: {e}", file=sys.stderr)
 
         cb = ReleaseControlCallback(c_callback)
         self._callbacks.append(cb)
@@ -795,7 +796,7 @@ class Gimbal:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in gimbal_list callback: {e}")
+                print(f"Error in gimbal_list callback: {e}", file=sys.stderr)
 
         cb = GimbalListCallback(c_callback)
         self._callbacks.append(cb)
@@ -833,7 +834,7 @@ class Gimbal:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in control_status callback: {e}")
+                print(f"Error in control_status callback: {e}", file=sys.stderr)
 
         cb = ControlStatusCallback(c_callback)
         self._callbacks.append(cb)
@@ -874,7 +875,7 @@ class Gimbal:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in attitude callback: {e}")
+                print(f"Error in attitude callback: {e}", file=sys.stderr)
 
         cb = AttitudeCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/gripper/gripper.py
+++ b/py/mavsdk/mavsdk/plugins/gripper/gripper.py
@@ -10,6 +10,7 @@ Allows users to send gripper actions.
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -82,7 +83,7 @@ class Gripper:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in grab callback: {e}")
+                print(f"Error in grab callback: {e}", file=sys.stderr)
 
         cb = GrabCallback(c_callback)
         self._callbacks.append(cb)
@@ -112,7 +113,7 @@ class Gripper:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in release callback: {e}")
+                print(f"Error in release callback: {e}", file=sys.stderr)
 
         cb = ReleaseCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/info/info.py
+++ b/py/mavsdk/mavsdk/plugins/info/info.py
@@ -10,6 +10,7 @@ Provide information about the hardware and/or software of a system.
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -424,7 +425,7 @@ class Info:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in flight_information callback: {e}")
+                print(f"Error in flight_information callback: {e}", file=sys.stderr)
 
         cb = FlightInformationCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/log_files/log_files.py
+++ b/py/mavsdk/mavsdk/plugins/log_files/log_files.py
@@ -11,6 +11,7 @@ Allow to download log files from the vehicle after a flight is complete.
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -167,7 +168,7 @@ class LogFiles:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in get_entries callback: {e}")
+                print(f"Error in get_entries callback: {e}", file=sys.stderr)
 
         cb = GetEntriesCallback(c_callback)
         self._callbacks.append(cb)
@@ -207,7 +208,7 @@ class LogFiles:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in download_log_file callback: {e}")
+                print(f"Error in download_log_file callback: {e}", file=sys.stderr)
 
         cb = DownloadLogFileCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/log_streaming/log_streaming.py
+++ b/py/mavsdk/mavsdk/plugins/log_streaming/log_streaming.py
@@ -10,6 +10,7 @@ Provide log streaming data.
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -110,7 +111,7 @@ class LogStreaming:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in start_log_streaming callback: {e}")
+                print(f"Error in start_log_streaming callback: {e}", file=sys.stderr)
 
         cb = StartLogStreamingCallback(c_callback)
         self._callbacks.append(cb)
@@ -139,7 +140,7 @@ class LogStreaming:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in stop_log_streaming callback: {e}")
+                print(f"Error in stop_log_streaming callback: {e}", file=sys.stderr)
 
         cb = StopLogStreamingCallback(c_callback)
         self._callbacks.append(cb)
@@ -172,7 +173,7 @@ class LogStreaming:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in log_streaming_raw callback: {e}")
+                print(f"Error in log_streaming_raw callback: {e}", file=sys.stderr)
 
         cb = LogStreamingRawCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/manual_control/manual_control.py
+++ b/py/mavsdk/mavsdk/plugins/manual_control/manual_control.py
@@ -10,6 +10,7 @@ Enable manual control using e.g. a joystick or gamepad.
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -79,7 +80,7 @@ class ManualControl:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in start_position_control callback: {e}")
+                print(f"Error in start_position_control callback: {e}", file=sys.stderr)
 
         cb = StartPositionControlCallback(c_callback)
         self._callbacks.append(cb)
@@ -113,7 +114,7 @@ class ManualControl:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in start_altitude_control callback: {e}")
+                print(f"Error in start_altitude_control callback: {e}", file=sys.stderr)
 
         cb = StartAltitudeControlCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/mavlink_direct/mavlink_direct.py
+++ b/py/mavsdk/mavsdk/plugins/mavlink_direct/mavlink_direct.py
@@ -10,6 +10,7 @@ Enable direct MAVLink communication using libmav.
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -166,7 +167,7 @@ class MavlinkDirect:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in message callback: {e}")
+                print(f"Error in message callback: {e}", file=sys.stderr)
 
         cb = MessageCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/mission/mission.py
+++ b/py/mavsdk/mavsdk/plugins/mission/mission.py
@@ -10,6 +10,7 @@ Enable waypoint missions.
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -418,7 +419,7 @@ class Mission:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in upload_mission callback: {e}")
+                print(f"Error in upload_mission callback: {e}", file=sys.stderr)
 
         cb = UploadMissionCallback(c_callback)
         self._callbacks.append(cb)
@@ -459,7 +460,7 @@ class Mission:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in upload_mission_with_progress callback: {e}")
+                print(f"Error in upload_mission_with_progress callback: {e}", file=sys.stderr)
 
         cb = UploadMissionWithProgressCallback(c_callback)
         self._callbacks.append(cb)
@@ -497,7 +498,7 @@ class Mission:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in download_mission callback: {e}")
+                print(f"Error in download_mission callback: {e}", file=sys.stderr)
 
         cb = DownloadMissionCallback(c_callback)
         self._callbacks.append(cb)
@@ -541,7 +542,7 @@ class Mission:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in download_mission_with_progress callback: {e}")
+                print(f"Error in download_mission_with_progress callback: {e}", file=sys.stderr)
 
         cb = DownloadMissionWithProgressCallback(c_callback)
         self._callbacks.append(cb)
@@ -574,7 +575,7 @@ class Mission:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in start_mission callback: {e}")
+                print(f"Error in start_mission callback: {e}", file=sys.stderr)
 
         cb = StartMissionCallback(c_callback)
         self._callbacks.append(cb)
@@ -608,7 +609,7 @@ class Mission:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in pause_mission callback: {e}")
+                print(f"Error in pause_mission callback: {e}", file=sys.stderr)
 
         cb = PauseMissionCallback(c_callback)
         self._callbacks.append(cb)
@@ -637,7 +638,7 @@ class Mission:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in clear_mission callback: {e}")
+                print(f"Error in clear_mission callback: {e}", file=sys.stderr)
 
         cb = ClearMissionCallback(c_callback)
         self._callbacks.append(cb)
@@ -674,7 +675,7 @@ class Mission:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_current_mission_item callback: {e}")
+                print(f"Error in set_current_mission_item callback: {e}", file=sys.stderr)
 
         cb = SetCurrentMissionItemCallback(c_callback)
         self._callbacks.append(cb)
@@ -722,7 +723,7 @@ class Mission:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in mission_progress callback: {e}")
+                print(f"Error in mission_progress callback: {e}", file=sys.stderr)
 
         cb = MissionProgressCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/mission_raw/mission_raw.py
+++ b/py/mavsdk/mavsdk/plugins/mission_raw/mission_raw.py
@@ -10,6 +10,7 @@ Enable raw missions as exposed by MAVLink.
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -334,7 +335,7 @@ class MissionRaw:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in upload_mission callback: {e}")
+                print(f"Error in upload_mission callback: {e}", file=sys.stderr)
 
         cb = UploadMissionCallback(c_callback)
         self._callbacks.append(cb)
@@ -368,7 +369,7 @@ class MissionRaw:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in upload_geofence callback: {e}")
+                print(f"Error in upload_geofence callback: {e}", file=sys.stderr)
 
         cb = UploadGeofenceCallback(c_callback)
         self._callbacks.append(cb)
@@ -402,7 +403,7 @@ class MissionRaw:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in upload_rally_points callback: {e}")
+                print(f"Error in upload_rally_points callback: {e}", file=sys.stderr)
 
         cb = UploadRallyPointsCallback(c_callback)
         self._callbacks.append(cb)
@@ -453,7 +454,7 @@ class MissionRaw:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in download_mission callback: {e}")
+                print(f"Error in download_mission callback: {e}", file=sys.stderr)
 
         cb = DownloadMissionCallback(c_callback)
         self._callbacks.append(cb)
@@ -496,7 +497,7 @@ class MissionRaw:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in download_geofence callback: {e}")
+                print(f"Error in download_geofence callback: {e}", file=sys.stderr)
 
         cb = DownloadGeofenceCallback(c_callback)
         self._callbacks.append(cb)
@@ -539,7 +540,7 @@ class MissionRaw:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in download_rallypoints callback: {e}")
+                print(f"Error in download_rallypoints callback: {e}", file=sys.stderr)
 
         cb = DownloadRallypointsCallback(c_callback)
         self._callbacks.append(cb)
@@ -589,7 +590,7 @@ class MissionRaw:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in start_mission callback: {e}")
+                print(f"Error in start_mission callback: {e}", file=sys.stderr)
 
         cb = StartMissionCallback(c_callback)
         self._callbacks.append(cb)
@@ -623,7 +624,7 @@ class MissionRaw:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in pause_mission callback: {e}")
+                print(f"Error in pause_mission callback: {e}", file=sys.stderr)
 
         cb = PauseMissionCallback(c_callback)
         self._callbacks.append(cb)
@@ -652,7 +653,7 @@ class MissionRaw:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in clear_mission callback: {e}")
+                print(f"Error in clear_mission callback: {e}", file=sys.stderr)
 
         cb = ClearMissionCallback(c_callback)
         self._callbacks.append(cb)
@@ -686,7 +687,7 @@ class MissionRaw:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_current_mission_item callback: {e}")
+                print(f"Error in set_current_mission_item callback: {e}", file=sys.stderr)
 
         cb = SetCurrentMissionItemCallback(c_callback)
         self._callbacks.append(cb)
@@ -722,7 +723,7 @@ class MissionRaw:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in mission_progress callback: {e}")
+                print(f"Error in mission_progress callback: {e}", file=sys.stderr)
 
         cb = MissionProgressCallback(c_callback)
         self._callbacks.append(cb)
@@ -763,7 +764,7 @@ class MissionRaw:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in mission_changed callback: {e}")
+                print(f"Error in mission_changed callback: {e}", file=sys.stderr)
 
         cb = MissionChangedCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/mission_raw_server/mission_raw_server.py
+++ b/py/mavsdk/mavsdk/plugins/mission_raw_server/mission_raw_server.py
@@ -11,6 +11,7 @@ Acts as a vehicle and receives incoming missions from GCS (in raw MAVLINK format
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -293,7 +294,7 @@ class MissionRawServer:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in incoming_mission callback: {e}")
+                print(f"Error in incoming_mission callback: {e}", file=sys.stderr)
 
         cb = IncomingMissionCallback(c_callback)
         self._callbacks.append(cb)
@@ -322,7 +323,7 @@ class MissionRawServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in current_item_changed callback: {e}")
+                print(f"Error in current_item_changed callback: {e}", file=sys.stderr)
 
         cb = CurrentItemChangedCallback(c_callback)
         self._callbacks.append(cb)
@@ -354,7 +355,7 @@ class MissionRawServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in clear_all callback: {e}")
+                print(f"Error in clear_all callback: {e}", file=sys.stderr)
 
         cb = ClearAllCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/offboard/offboard.py
+++ b/py/mavsdk/mavsdk/plugins/offboard/offboard.py
@@ -17,6 +17,7 @@ Control a drone with position, velocity, attitude or motor commands.
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -584,7 +585,7 @@ class Offboard:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in start callback: {e}")
+                print(f"Error in start callback: {e}", file=sys.stderr)
 
         cb = StartCallback(c_callback)
         self._callbacks.append(cb)
@@ -615,7 +616,7 @@ class Offboard:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in stop callback: {e}")
+                print(f"Error in stop callback: {e}", file=sys.stderr)
 
         cb = StopCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/param_server/param_server.py
+++ b/py/mavsdk/mavsdk/plugins/param_server/param_server.py
@@ -10,6 +10,7 @@ Provide raw access to retrieve and provide server parameters.
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -405,7 +406,7 @@ class ParamServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in changed_param_int callback: {e}")
+                print(f"Error in changed_param_int callback: {e}", file=sys.stderr)
 
         cb = ChangedParamIntCallback(c_callback)
         self._callbacks.append(cb)
@@ -432,7 +433,7 @@ class ParamServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in changed_param_float callback: {e}")
+                print(f"Error in changed_param_float callback: {e}", file=sys.stderr)
 
         cb = ChangedParamFloatCallback(c_callback)
         self._callbacks.append(cb)
@@ -459,7 +460,7 @@ class ParamServer:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in changed_param_custom callback: {e}")
+                print(f"Error in changed_param_custom callback: {e}", file=sys.stderr)
 
         cb = ChangedParamCustomCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/shell/shell.py
+++ b/py/mavsdk/mavsdk/plugins/shell/shell.py
@@ -10,6 +10,7 @@ Allow to communicate with the vehicle's system shell.
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -88,7 +89,7 @@ class Shell:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in receive callback: {e}")
+                print(f"Error in receive callback: {e}", file=sys.stderr)
 
         cb = ReceiveCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/telemetry/telemetry.py
+++ b/py/mavsdk/mavsdk/plugins/telemetry/telemetry.py
@@ -12,6 +12,7 @@ Allow users to get vehicle telemetry and state information
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -2027,7 +2028,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in position callback: {e}")
+                print(f"Error in position callback: {e}", file=sys.stderr)
 
         cb = PositionCallback(c_callback)
         self._callbacks.append(cb)
@@ -2061,7 +2062,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in home callback: {e}")
+                print(f"Error in home callback: {e}", file=sys.stderr)
 
         cb = HomeCallback(c_callback)
         self._callbacks.append(cb)
@@ -2093,7 +2094,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in in_air callback: {e}")
+                print(f"Error in in_air callback: {e}", file=sys.stderr)
 
         cb = InAirCallback(c_callback)
         self._callbacks.append(cb)
@@ -2123,7 +2124,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in landed_state callback: {e}")
+                print(f"Error in landed_state callback: {e}", file=sys.stderr)
 
         cb = LandedStateCallback(c_callback)
         self._callbacks.append(cb)
@@ -2153,7 +2154,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in armed callback: {e}")
+                print(f"Error in armed callback: {e}", file=sys.stderr)
 
         cb = ArmedCallback(c_callback)
         self._callbacks.append(cb)
@@ -2183,7 +2184,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in vtol_state callback: {e}")
+                print(f"Error in vtol_state callback: {e}", file=sys.stderr)
 
         cb = VtolStateCallback(c_callback)
         self._callbacks.append(cb)
@@ -2215,7 +2216,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in attitude_quaternion callback: {e}")
+                print(f"Error in attitude_quaternion callback: {e}", file=sys.stderr)
 
         cb = AttitudeQuaternionCallback(c_callback)
         self._callbacks.append(cb)
@@ -2253,7 +2254,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in attitude_euler callback: {e}")
+                print(f"Error in attitude_euler callback: {e}", file=sys.stderr)
 
         cb = AttitudeEulerCallback(c_callback)
         self._callbacks.append(cb)
@@ -2295,7 +2296,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in attitude_angular_velocity_body callback: {e}")
+                print(f"Error in attitude_angular_velocity_body callback: {e}", file=sys.stderr)
 
         cb = AttitudeAngularVelocityBodyCallback(c_callback)
         self._callbacks.append(cb)
@@ -2337,7 +2338,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in velocity_ned callback: {e}")
+                print(f"Error in velocity_ned callback: {e}", file=sys.stderr)
 
         cb = VelocityNedCallback(c_callback)
         self._callbacks.append(cb)
@@ -2371,7 +2372,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in gps_info callback: {e}")
+                print(f"Error in gps_info callback: {e}", file=sys.stderr)
 
         cb = GpsInfoCallback(c_callback)
         self._callbacks.append(cb)
@@ -2405,7 +2406,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in raw_gps callback: {e}")
+                print(f"Error in raw_gps callback: {e}", file=sys.stderr)
 
         cb = RawGpsCallback(c_callback)
         self._callbacks.append(cb)
@@ -2439,7 +2440,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in battery callback: {e}")
+                print(f"Error in battery callback: {e}", file=sys.stderr)
 
         cb = BatteryCallback(c_callback)
         self._callbacks.append(cb)
@@ -2471,7 +2472,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in flight_mode callback: {e}")
+                print(f"Error in flight_mode callback: {e}", file=sys.stderr)
 
         cb = FlightModeCallback(c_callback)
         self._callbacks.append(cb)
@@ -2503,7 +2504,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in health callback: {e}")
+                print(f"Error in health callback: {e}", file=sys.stderr)
 
         cb = HealthCallback(c_callback)
         self._callbacks.append(cb)
@@ -2537,7 +2538,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in rc_status callback: {e}")
+                print(f"Error in rc_status callback: {e}", file=sys.stderr)
 
         cb = RcStatusCallback(c_callback)
         self._callbacks.append(cb)
@@ -2571,7 +2572,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in status_text callback: {e}")
+                print(f"Error in status_text callback: {e}", file=sys.stderr)
 
         cb = StatusTextCallback(c_callback)
         self._callbacks.append(cb)
@@ -2609,7 +2610,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in actuator_control_target callback: {e}")
+                print(f"Error in actuator_control_target callback: {e}", file=sys.stderr)
 
         cb = ActuatorControlTargetCallback(c_callback)
         self._callbacks.append(cb)
@@ -2655,7 +2656,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in actuator_output_status callback: {e}")
+                print(f"Error in actuator_output_status callback: {e}", file=sys.stderr)
 
         cb = ActuatorOutputStatusCallback(c_callback)
         self._callbacks.append(cb)
@@ -2697,7 +2698,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in odometry callback: {e}")
+                print(f"Error in odometry callback: {e}", file=sys.stderr)
 
         cb = OdometryCallback(c_callback)
         self._callbacks.append(cb)
@@ -2735,7 +2736,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in position_velocity_ned callback: {e}")
+                print(f"Error in position_velocity_ned callback: {e}", file=sys.stderr)
 
         cb = PositionVelocityNedCallback(c_callback)
         self._callbacks.append(cb)
@@ -2777,7 +2778,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in ground_truth callback: {e}")
+                print(f"Error in ground_truth callback: {e}", file=sys.stderr)
 
         cb = GroundTruthCallback(c_callback)
         self._callbacks.append(cb)
@@ -2813,7 +2814,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in fixedwing_metrics callback: {e}")
+                print(f"Error in fixedwing_metrics callback: {e}", file=sys.stderr)
 
         cb = FixedwingMetricsCallback(c_callback)
         self._callbacks.append(cb)
@@ -2851,7 +2852,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in imu callback: {e}")
+                print(f"Error in imu callback: {e}", file=sys.stderr)
 
         cb = ImuCallback(c_callback)
         self._callbacks.append(cb)
@@ -2885,7 +2886,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in scaled_imu callback: {e}")
+                print(f"Error in scaled_imu callback: {e}", file=sys.stderr)
 
         cb = ScaledImuCallback(c_callback)
         self._callbacks.append(cb)
@@ -2919,7 +2920,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in raw_imu callback: {e}")
+                print(f"Error in raw_imu callback: {e}", file=sys.stderr)
 
         cb = RawImuCallback(c_callback)
         self._callbacks.append(cb)
@@ -2951,7 +2952,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in health_all_ok callback: {e}")
+                print(f"Error in health_all_ok callback: {e}", file=sys.stderr)
 
         cb = HealthAllOkCallback(c_callback)
         self._callbacks.append(cb)
@@ -2983,7 +2984,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in unix_epoch_time callback: {e}")
+                print(f"Error in unix_epoch_time callback: {e}", file=sys.stderr)
 
         cb = UnixEpochTimeCallback(c_callback)
         self._callbacks.append(cb)
@@ -3019,7 +3020,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in distance_sensor callback: {e}")
+                print(f"Error in distance_sensor callback: {e}", file=sys.stderr)
 
         cb = DistanceSensorCallback(c_callback)
         self._callbacks.append(cb)
@@ -3057,7 +3058,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in scaled_pressure callback: {e}")
+                print(f"Error in scaled_pressure callback: {e}", file=sys.stderr)
 
         cb = ScaledPressureCallback(c_callback)
         self._callbacks.append(cb)
@@ -3095,7 +3096,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in heading callback: {e}")
+                print(f"Error in heading callback: {e}", file=sys.stderr)
 
         cb = HeadingCallback(c_callback)
         self._callbacks.append(cb)
@@ -3129,7 +3130,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in altitude callback: {e}")
+                print(f"Error in altitude callback: {e}", file=sys.stderr)
 
         cb = AltitudeCallback(c_callback)
         self._callbacks.append(cb)
@@ -3163,7 +3164,7 @@ class Telemetry:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in wind callback: {e}")
+                print(f"Error in wind callback: {e}", file=sys.stderr)
 
         cb = WindCallback(c_callback)
         self._callbacks.append(cb)
@@ -3197,7 +3198,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_position callback: {e}")
+                print(f"Error in set_rate_position callback: {e}", file=sys.stderr)
 
         cb = SetRatePositionCallback(c_callback)
         self._callbacks.append(cb)
@@ -3229,7 +3230,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_home callback: {e}")
+                print(f"Error in set_rate_home callback: {e}", file=sys.stderr)
 
         cb = SetRateHomeCallback(c_callback)
         self._callbacks.append(cb)
@@ -3259,7 +3260,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_in_air callback: {e}")
+                print(f"Error in set_rate_in_air callback: {e}", file=sys.stderr)
 
         cb = SetRateInAirCallback(c_callback)
         self._callbacks.append(cb)
@@ -3293,7 +3294,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_landed_state callback: {e}")
+                print(f"Error in set_rate_landed_state callback: {e}", file=sys.stderr)
 
         cb = SetRateLandedStateCallback(c_callback)
         self._callbacks.append(cb)
@@ -3327,7 +3328,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_vtol_state callback: {e}")
+                print(f"Error in set_rate_vtol_state callback: {e}", file=sys.stderr)
 
         cb = SetRateVtolStateCallback(c_callback)
         self._callbacks.append(cb)
@@ -3361,7 +3362,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_attitude_quaternion callback: {e}")
+                print(f"Error in set_rate_attitude_quaternion callback: {e}", file=sys.stderr)
 
         cb = SetRateAttitudeQuaternionCallback(c_callback)
         self._callbacks.append(cb)
@@ -3395,7 +3396,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_attitude_euler callback: {e}")
+                print(f"Error in set_rate_attitude_euler callback: {e}", file=sys.stderr)
 
         cb = SetRateAttitudeEulerCallback(c_callback)
         self._callbacks.append(cb)
@@ -3430,7 +3431,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_velocity_ned callback: {e}")
+                print(f"Error in set_rate_velocity_ned callback: {e}", file=sys.stderr)
 
         cb = SetRateVelocityNedCallback(c_callback)
         self._callbacks.append(cb)
@@ -3464,7 +3465,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_gps_info callback: {e}")
+                print(f"Error in set_rate_gps_info callback: {e}", file=sys.stderr)
 
         cb = SetRateGpsInfoCallback(c_callback)
         self._callbacks.append(cb)
@@ -3498,7 +3499,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_battery callback: {e}")
+                print(f"Error in set_rate_battery callback: {e}", file=sys.stderr)
 
         cb = SetRateBatteryCallback(c_callback)
         self._callbacks.append(cb)
@@ -3532,7 +3533,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_rc_status callback: {e}")
+                print(f"Error in set_rate_rc_status callback: {e}", file=sys.stderr)
 
         cb = SetRateRcStatusCallback(c_callback)
         self._callbacks.append(cb)
@@ -3566,7 +3567,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_actuator_control_target callback: {e}")
+                print(f"Error in set_rate_actuator_control_target callback: {e}", file=sys.stderr)
 
         cb = SetRateActuatorControlTargetCallback(c_callback)
         self._callbacks.append(cb)
@@ -3600,7 +3601,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_actuator_output_status callback: {e}")
+                print(f"Error in set_rate_actuator_output_status callback: {e}", file=sys.stderr)
 
         cb = SetRateActuatorOutputStatusCallback(c_callback)
         self._callbacks.append(cb)
@@ -3634,7 +3635,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_odometry callback: {e}")
+                print(f"Error in set_rate_odometry callback: {e}", file=sys.stderr)
 
         cb = SetRateOdometryCallback(c_callback)
         self._callbacks.append(cb)
@@ -3668,7 +3669,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_position_velocity_ned callback: {e}")
+                print(f"Error in set_rate_position_velocity_ned callback: {e}", file=sys.stderr)
 
         cb = SetRatePositionVelocityNedCallback(c_callback)
         self._callbacks.append(cb)
@@ -3702,7 +3703,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_ground_truth callback: {e}")
+                print(f"Error in set_rate_ground_truth callback: {e}", file=sys.stderr)
 
         cb = SetRateGroundTruthCallback(c_callback)
         self._callbacks.append(cb)
@@ -3736,7 +3737,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_fixedwing_metrics callback: {e}")
+                print(f"Error in set_rate_fixedwing_metrics callback: {e}", file=sys.stderr)
 
         cb = SetRateFixedwingMetricsCallback(c_callback)
         self._callbacks.append(cb)
@@ -3768,7 +3769,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_imu callback: {e}")
+                print(f"Error in set_rate_imu callback: {e}", file=sys.stderr)
 
         cb = SetRateImuCallback(c_callback)
         self._callbacks.append(cb)
@@ -3800,7 +3801,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_scaled_imu callback: {e}")
+                print(f"Error in set_rate_scaled_imu callback: {e}", file=sys.stderr)
 
         cb = SetRateScaledImuCallback(c_callback)
         self._callbacks.append(cb)
@@ -3834,7 +3835,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_raw_imu callback: {e}")
+                print(f"Error in set_rate_raw_imu callback: {e}", file=sys.stderr)
 
         cb = SetRateRawImuCallback(c_callback)
         self._callbacks.append(cb)
@@ -3868,7 +3869,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_unix_epoch_time callback: {e}")
+                print(f"Error in set_rate_unix_epoch_time callback: {e}", file=sys.stderr)
 
         cb = SetRateUnixEpochTimeCallback(c_callback)
         self._callbacks.append(cb)
@@ -3902,7 +3903,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_distance_sensor callback: {e}")
+                print(f"Error in set_rate_distance_sensor callback: {e}", file=sys.stderr)
 
         cb = SetRateDistanceSensorCallback(c_callback)
         self._callbacks.append(cb)
@@ -3936,7 +3937,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_altitude callback: {e}")
+                print(f"Error in set_rate_altitude callback: {e}", file=sys.stderr)
 
         cb = SetRateAltitudeCallback(c_callback)
         self._callbacks.append(cb)
@@ -3968,7 +3969,7 @@ class Telemetry:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_health callback: {e}")
+                print(f"Error in set_rate_health callback: {e}", file=sys.stderr)
 
         cb = SetRateHealthCallback(c_callback)
         self._callbacks.append(cb)
@@ -4006,7 +4007,7 @@ class Telemetry:
                 callback(py_result, py_data, user_data)
 
             except Exception as e:
-                print(f"Error in get_gps_global_origin callback: {e}")
+                print(f"Error in get_gps_global_origin callback: {e}", file=sys.stderr)
 
         cb = GetGpsGlobalOriginCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/transponder/transponder.py
+++ b/py/mavsdk/mavsdk/plugins/transponder/transponder.py
@@ -11,6 +11,7 @@ Allow users to get ADS-B information
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -212,7 +213,7 @@ class Transponder:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in transponder callback: {e}")
+                print(f"Error in transponder callback: {e}", file=sys.stderr)
 
         cb = TransponderCallback(c_callback)
         self._callbacks.append(cb)
@@ -248,7 +249,7 @@ class Transponder:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in set_rate_transponder callback: {e}")
+                print(f"Error in set_rate_transponder callback: {e}", file=sys.stderr)
 
         cb = SetRateTransponderCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/tune/tune.py
+++ b/py/mavsdk/mavsdk/plugins/tune/tune.py
@@ -10,6 +10,7 @@ Enable creating and sending a tune to be played on the system.
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -139,7 +140,7 @@ class Tune:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in play_tune callback: {e}")
+                print(f"Error in play_tune callback: {e}", file=sys.stderr)
 
         cb = PlayTuneCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/mavsdk/plugins/winch/winch.py
+++ b/py/mavsdk/mavsdk/plugins/winch/winch.py
@@ -10,6 +10,7 @@ Allows users to send winch actions, as well as receive status information from w
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -294,7 +295,7 @@ class Winch:
                 callback(py_data, user_data)
 
             except Exception as e:
-                print(f"Error in status callback: {e}")
+                print(f"Error in status callback: {e}", file=sys.stderr)
 
         cb = StatusCallback(c_callback)
         self._callbacks.append(cb)
@@ -326,7 +327,7 @@ class Winch:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in relax callback: {e}")
+                print(f"Error in relax callback: {e}", file=sys.stderr)
 
         cb = RelaxCallback(c_callback)
         self._callbacks.append(cb)
@@ -358,7 +359,7 @@ class Winch:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in relative_length_control callback: {e}")
+                print(f"Error in relative_length_control callback: {e}", file=sys.stderr)
 
         cb = RelativeLengthControlCallback(c_callback)
         self._callbacks.append(cb)
@@ -394,7 +395,7 @@ class Winch:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in rate_control callback: {e}")
+                print(f"Error in rate_control callback: {e}", file=sys.stderr)
 
         cb = RateControlCallback(c_callback)
         self._callbacks.append(cb)
@@ -427,7 +428,7 @@ class Winch:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in lock callback: {e}")
+                print(f"Error in lock callback: {e}", file=sys.stderr)
 
         cb = LockCallback(c_callback)
         self._callbacks.append(cb)
@@ -457,7 +458,7 @@ class Winch:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in deliver callback: {e}")
+                print(f"Error in deliver callback: {e}", file=sys.stderr)
 
         cb = DeliverCallback(c_callback)
         self._callbacks.append(cb)
@@ -487,7 +488,7 @@ class Winch:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in hold callback: {e}")
+                print(f"Error in hold callback: {e}", file=sys.stderr)
 
         cb = HoldCallback(c_callback)
         self._callbacks.append(cb)
@@ -517,7 +518,7 @@ class Winch:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in retract callback: {e}")
+                print(f"Error in retract callback: {e}", file=sys.stderr)
 
         cb = RetractCallback(c_callback)
         self._callbacks.append(cb)
@@ -549,7 +550,7 @@ class Winch:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in load_line callback: {e}")
+                print(f"Error in load_line callback: {e}", file=sys.stderr)
 
         cb = LoadLineCallback(c_callback)
         self._callbacks.append(cb)
@@ -579,7 +580,7 @@ class Winch:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in abandon_line callback: {e}")
+                print(f"Error in abandon_line callback: {e}", file=sys.stderr)
 
         cb = AbandonLineCallback(c_callback)
         self._callbacks.append(cb)
@@ -609,7 +610,7 @@ class Winch:
                 callback(py_result, user_data)
 
             except Exception as e:
-                print(f"Error in load_payload callback: {e}")
+                print(f"Error in load_payload callback: {e}", file=sys.stderr)
 
         cb = LoadPayloadCallback(c_callback)
         self._callbacks.append(cb)

--- a/py/mavsdk/templates/file.py.j2
+++ b/py/mavsdk/templates/file.py.j2
@@ -10,6 +10,7 @@
 
 import atexit
 import ctypes
+import sys
 
 from typing import Callable, Any
 from enum import IntEnum
@@ -283,7 +284,7 @@ class {{ plugin_name.upper_camel_case }}:
                 {% endif %}
 
             except Exception as e:
-                print(f"Error in {{ method.name.lower_snake_case }} callback: {e}")
+                print(f"Error in {{ method.name.lower_snake_case }} callback: {e}", file=sys.stderr)
 
         cb = {{ method.name.upper_camel_case }}Callback(c_callback)
         self._callbacks.append(cb)


### PR DESCRIPTION
Redirects all diagnostic `print()` output in the Python SDK to `stderr`, so callers can use `stdout` for their own program output without capturing SDK noise.

Changes:
- `cmavsdk_loader.py` — library search/load messages
- `logging.py` — log callback error
- All 27 generated plugin files — callback error messages
- `templates/file.py.j2` — so future codegen picks this up automatically