### PR TITLE
Join sending_tracking_status thread before destruction

### DIFF
--- a/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
+++ b/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
@@ -16,6 +16,7 @@ CameraServerImpl::CameraServerImpl(std::shared_ptr<ServerComponent> server_compo
 
 CameraServerImpl::~CameraServerImpl()
 {
+    stop_sending_tracking_status();
     _server_component_impl->unregister_plugin(this);
 }
 


### PR DESCRIPTION
Issue:
Destructor does not join the live threat created by `start_sending_tracking_status()`, causing std::terminate whenever a `SET_MESSAGE_INTERVAL` starts it.

Fix:
Join the thread before unregistering the plugin