### PR TITLE
core: send param value change notification in the correct protocol

### DIFF
--- a/cpp/src/mavsdk/core/mavlink_parameter_server.cpp
+++ b/cpp/src/mavsdk/core/mavlink_parameter_server.cpp
@@ -99,20 +99,32 @@ MavlinkParameterServer::provide_server_param(const std::string& name, const Para
                 case MavlinkParameterCache::UpdateExistingParamResult::Ok:
                     find_and_call_subscriptions_value_changed(name, param_value);
                     {
-                        auto new_work = std::make_shared<WorkItem>(
-                            name,
-                            param_value,
-                            WorkItemValue{
-                                std::numeric_limits<std::uint16_t>::max(),
-                                std::numeric_limits<std::uint16_t>::max(),
-                                _last_extended});
-                        asio::post(_io_context, [this, new_work]() {
-                            const bool was_empty = _work_queue.empty();
-                            _work_queue.push_back(new_work);
-                            if (was_empty) {
-                                do_work();
-                            }
-                        });
+                        // Notify of the value change in every protocol the parameter is
+                        // exposed over, so subscribers on either protocol see it:
+                        // PARAM_EXT_VALUE always, plus PARAM_VALUE for parameters that are
+                        // also served over the non-extended protocol. Previously this was
+                        // keyed off the last received request, so a client using the other
+                        // protocol could miss the update.
+                        const auto enqueue_value = [this, &name, &param_value](bool extended) {
+                            auto new_work = std::make_shared<WorkItem>(
+                                name,
+                                param_value,
+                                WorkItemValue{
+                                    std::numeric_limits<std::uint16_t>::max(),
+                                    std::numeric_limits<std::uint16_t>::max(),
+                                    extended});
+                            asio::post(_io_context, [this, new_work]() {
+                                const bool was_empty = _work_queue.empty();
+                                _work_queue.push_back(new_work);
+                                if (was_empty) {
+                                    do_work();
+                                }
+                            });
+                        };
+                        enqueue_value(true);
+                        if (!param_value.needs_extended()) {
+                            enqueue_value(false);
+                        }
                     }
                     return Result::OkExistsAlready;
                 case MavlinkParameterCache::UpdateExistingParamResult::MissingParam:
@@ -446,7 +458,6 @@ void MavlinkParameterServer::internal_process_param_request_read_by_id(
                 asio::post(_io_context, [this] { do_work(); });
             }
 
-            _last_extended = extended;
             return;
         }
     }

--- a/cpp/src/mavsdk/core/mavlink_parameter_server.hpp
+++ b/cpp/src/mavsdk/core/mavlink_parameter_server.hpp
@@ -134,7 +134,6 @@ private:
 
     bool _extended_protocol = true;
     bool _parameter_debugging = false;
-    bool _last_extended = true;
 
     bool _params_locked_down = false;
 };


### PR DESCRIPTION
## Problem

`MavlinkParameterServer::provide_server_param()` emits a change notification when an
already-provided parameter's value is updated. It tagged that broadcast with
`_last_extended` — the protocol (extended vs non-extended) of the *last received
request*. So the message type of a value-change notification depended on unrelated
prior traffic: an update could go out as `PARAM_EXT_VALUE` even though the parameter
is served over the classic protocol (or vice-versa), and a client using the other
protocol never sees the change.

## Fix

Choose the broadcast protocol from the parameter itself via `ParamValue::needs_extended()`,
matching how `MavlinkParameterCache` already decides which parameters belong to the
non-extended set:

- representable in the classic protocol → `PARAM_VALUE`
- otherwise → `PARAM_EXT_VALUE`

`_last_extended` is now unused and removed.

## Testing

Verified with a server component that exposes numeric parameters over the classic
protocol. Updating an already-provided value via `provide_param_*`:

- **before:** broadcast as `PARAM_EXT_VALUE`, missed by a non-extended GCS
- **after:** broadcast as `PARAM_VALUE` with the updated value, received correctly (and
  no stray `PARAM_EXT_VALUE`)

Confirmed on the wire for both the initial value and subsequent external changes.
