### PR TITLE
docs: fix takeoff_and_land build dir path in quickstart

### DIFF
--- a/docs/en/cpp/quickstart.md
+++ b/docs/en/cpp/quickstart.md
@@ -86,7 +86,7 @@ The examples match the MAVSDK version from your current branch. If you have anot
 
 First start PX4 in SITL (Simulation) and *QGroundControl* as described above.
 
-Then run the example app (from the **cpp/examples/takeoff_land/build** directory) as shown:
+Then run the example app (from the **cpp/examples/takeoff_and_land/build** directory) as shown:
 ```sh
 build/takeoff_and_land udpin://0.0.0.0:14540
 ```


### PR DESCRIPTION
Ports the still-relevant half of mavlink/MAVSDK-docs#294 to this repo, since the docs now live here (per @julianoes).

The quickstart still references the wrong example build directory: `cpp/examples/takeoff_land/build` — the directory is `takeoff_and_land`. The stale GitHub link that #294 also fixed is already correct in this repo, so this is the only remaining change.

Docs-only, one line.