### PR TITLE
core: notify param value changes on every used protocol

### DIFF
--- a/cpp/src/mavsdk/core/mavlink_parameter_server.cpp
+++ b/cpp/src/mavsdk/core/mavlink_parameter_server.cpp
@@ -98,21 +98,24 @@ MavlinkParameterServer::provide_server_param(const std::string& name, const Para
             switch (_param_cache.update_existing_param(name, param_value)) {
                 case MavlinkParameterCache::UpdateExistingParamResult::Ok:
                     find_and_call_subscriptions_value_changed(name, param_value);
-                    {
-                        auto new_work = std::make_shared<WorkItem>(
-                            name,
-                            param_value,
-                            WorkItemValue{
-                                std::numeric_limits<std::uint16_t>::max(),
-                                std::numeric_limits<std::uint16_t>::max(),
-                                _last_extended});
-                        asio::post(_io_context, [this, new_work]() {
-                            const bool was_empty = _work_queue.empty();
-                            _work_queue.push_back(new_work);
-                            if (was_empty) {
-                                do_work();
-                            }
-                        });
+                    // Notify clients of the changed value on the protocol(s) that can carry it and
+                    // that a client is actually using. The extended protocol can represent any
+                    // parameter; the non-extended protocol only those that don't need_extended.
+                    if (!_seen_extended && !_seen_non_extended) {
+                        // No request seen yet, so we can't tell which protocol a client uses.
+                        // Fall back to notifying on every protocol the parameter supports to avoid
+                        // silently dropping the change.
+                        enqueue_value_broadcast(name, param_value, true);
+                        if (!param_value.needs_extended()) {
+                            enqueue_value_broadcast(name, param_value, false);
+                        }
+                    } else {
+                        if (_seen_extended) {
+                            enqueue_value_broadcast(name, param_value, true);
+                        }
+                        if (_seen_non_extended && !param_value.needs_extended()) {
+                            enqueue_value_broadcast(name, param_value, false);
+                        }
                     }
                     return Result::OkExistsAlready;
                 case MavlinkParameterCache::UpdateExistingParamResult::MissingParam:
@@ -220,6 +223,7 @@ void MavlinkParameterServer::process_param_set_internally(
 
     {
         std::lock_guard<std::mutex> lock(_all_params_mutex);
+        mark_protocol_seen(extended);
         // for checking if the update actually changed the value
         const auto opt_before_update = _param_cache.param_by_id(param_id, extended);
         const auto result = _param_cache.update_existing_param(param_id, value_to_set);
@@ -426,6 +430,7 @@ void MavlinkParameterServer::internal_process_param_request_read_by_id(
 {
     {
         std::lock_guard<std::mutex> lock(_all_params_mutex);
+        mark_protocol_seen(extended);
         const auto param_opt = _param_cache.param_by_id(id, extended);
 
         if (!param_opt.has_value()) {
@@ -446,7 +451,6 @@ void MavlinkParameterServer::internal_process_param_request_read_by_id(
                 asio::post(_io_context, [this] { do_work(); });
             }
 
-            _last_extended = extended;
             return;
         }
     }
@@ -462,6 +466,7 @@ void MavlinkParameterServer::internal_process_param_request_read_by_index(
 {
     {
         std::lock_guard<std::mutex> lock(_all_params_mutex);
+        mark_protocol_seen(extended);
         const auto param_opt = _param_cache.param_by_index(index, extended);
 
         if (!param_opt.has_value()) {
@@ -521,6 +526,7 @@ void MavlinkParameterServer::process_param_ext_request_list(const mavlink_messag
 void MavlinkParameterServer::broadcast_all_parameters(const bool extended)
 {
     std::lock_guard<std::mutex> lock(_all_params_mutex);
+    mark_protocol_seen(extended);
 
     // Param used with index, we should no longer change the index
     _params_locked_down = true;
@@ -676,6 +682,34 @@ void MavlinkParameterServer::send_param_error(
         })) {
         LogErr("Error: Send PARAM_ERROR message failed");
     }
+}
+
+void MavlinkParameterServer::mark_protocol_seen(bool extended)
+{
+    if (extended) {
+        _seen_extended = true;
+    } else {
+        _seen_non_extended = true;
+    }
+}
+
+void MavlinkParameterServer::enqueue_value_broadcast(
+    const std::string& name, const ParamValue& param_value, bool extended)
+{
+    auto new_work = std::make_shared<WorkItem>(
+        name,
+        param_value,
+        WorkItemValue{
+            std::numeric_limits<std::uint16_t>::max(),
+            std::numeric_limits<std::uint16_t>::max(),
+            extended});
+    asio::post(_io_context, [this, new_work]() {
+        const bool was_empty = _work_queue.empty();
+        _work_queue.push_back(new_work);
+        if (was_empty) {
+            do_work();
+        }
+    });
 }
 
 std::ostream& operator<<(std::ostream& str, const MavlinkParameterServer::Result& result)

--- a/cpp/src/mavsdk/core/mavlink_parameter_server.hpp
+++ b/cpp/src/mavsdk/core/mavlink_parameter_server.hpp
@@ -96,6 +96,14 @@ private:
 
     void send_param_error(const std::string& param_id, int16_t param_index, uint8_t error_code);
 
+    // Remember which parameter protocol(s) clients have actually used, so that a spontaneous
+    // value-change notification is only sent on protocols someone is listening on.
+    // Must be called with _all_params_mutex held.
+    void mark_protocol_seen(bool extended);
+    // Enqueue a spontaneous PARAM_VALUE / PARAM_EXT_VALUE broadcast for a changed value.
+    void enqueue_value_broadcast(
+        const std::string& name, const ParamValue& param_value, bool extended);
+
     static std::variant<std::monostate, std::string, std::uint16_t>
     extract_request_read_param_identifier(int16_t param_index, const char* param_id);
 
@@ -134,7 +142,9 @@ private:
 
     bool _extended_protocol = true;
     bool _parameter_debugging = false;
-    bool _last_extended = true;
+    // Sticky flags tracking which protocol(s) clients have used (guarded by _all_params_mutex).
+    bool _seen_extended = false;
+    bool _seen_non_extended = false;
 
     bool _params_locked_down = false;
 };

--- a/cpp/src/system_tests/CMakeLists.txt
+++ b/cpp/src/system_tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(system_tests_runner
     param_get_all.cpp
     param_custom_set_and_get.cpp
     param_get_all.cpp
+    param_change_notification.cpp
     mission_raw_upload.cpp
     mission_raw_upload_empty.cpp
     telemetry_subscription.cpp

--- a/cpp/src/system_tests/param_change_notification.cpp
+++ b/cpp/src/system_tests/param_change_notification.cpp
@@ -1,0 +1,280 @@
+#include "mavsdk.hpp"
+#include "plugins/mavlink_direct/mavlink_direct.hpp"
+#include "plugins/param_server/param_server.hpp"
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+#include <gtest/gtest.h>
+#include <json/json.h>
+
+using namespace mavsdk;
+
+namespace {
+
+constexpr auto param_name = "TEST_FOO";
+constexpr float initial_value = 42.0f;
+constexpr float changed_value = 43.0f;
+
+// Collects the values seen for a given parameter from PARAM_VALUE / PARAM_EXT_VALUE broadcasts.
+struct ValueCollector {
+    std::mutex mutex{};
+    std::vector<float> param_values{};
+    std::vector<std::string> param_ext_values{};
+
+    void add_param_value(const std::string& json)
+    {
+        Json::Value root;
+        Json::Reader reader;
+        if (!reader.parse(json, root)) {
+            return;
+        }
+        if (root["param_id"].asString().rfind(param_name, 0) != 0) {
+            return;
+        }
+        std::lock_guard<std::mutex> lock(mutex);
+        param_values.push_back(root["param_value"].asFloat());
+    }
+
+    void add_param_ext_value(const std::string& json)
+    {
+        Json::Value root;
+        Json::Reader reader;
+        if (!reader.parse(json, root)) {
+            return;
+        }
+        if (root["param_id"].asString().rfind(param_name, 0) != 0) {
+            return;
+        }
+        std::lock_guard<std::mutex> lock(mutex);
+        param_ext_values.push_back(root["param_value"].asString());
+    }
+};
+
+bool contains_value(ValueCollector& collector, float value)
+{
+    std::lock_guard<std::mutex> lock(collector.mutex);
+    for (const auto& v : collector.param_values) {
+        if (v == value) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Sends a PARAM_(EXT_)REQUEST_READ for our parameter to the autopilot. This makes the server
+// register a client using the given protocol (without locking the parameter set down, which a
+// REQUEST_LIST would) and triggers a value response.
+void request_read(MavlinkDirect& mavlink_direct, bool extended)
+{
+    MavlinkDirect::MavlinkMessage message;
+    message.message_name = extended ? "PARAM_EXT_REQUEST_READ" : "PARAM_REQUEST_READ";
+    message.fields_json = R"({"target_system":1,"target_component":1,"param_id":")" +
+                          std::string(param_name) + R"(","param_index":-1})";
+    EXPECT_EQ(mavlink_direct.send_message(message), MavlinkDirect::Result::Success);
+}
+
+} // namespace
+
+// When only a non-extended client has been seen, a value change to a parameter that is
+// representable in the classic protocol must be broadcast as PARAM_VALUE (not PARAM_EXT_VALUE),
+// otherwise the non-extended client misses the update.
+TEST(ParamChangeNotification, NonExtendedClient)
+{
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{ComponentType::GroundStation}};
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{ComponentType::Autopilot}};
+
+    ASSERT_EQ(
+        mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17010"),
+        ConnectionResult::Success);
+    ASSERT_EQ(
+        mavsdk_autopilot.add_any_connection("udpout://127.0.0.1:17010"), ConnectionResult::Success);
+
+    auto param_server = ParamServer{mavsdk_autopilot.server_component()};
+    ASSERT_EQ(
+        param_server.provide_param_float(param_name, initial_value), ParamServer::Result::Success);
+
+    auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
+    ASSERT_TRUE(maybe_system);
+    auto system = maybe_system.value();
+
+    ValueCollector collector;
+    auto mavlink_direct = MavlinkDirect{system};
+    mavlink_direct.subscribe_message(
+        "PARAM_VALUE", [&collector](MavlinkDirect::MavlinkMessage message) {
+            collector.add_param_value(message.fields_json);
+        });
+    mavlink_direct.subscribe_message(
+        "PARAM_EXT_VALUE", [&collector](MavlinkDirect::MavlinkMessage message) {
+            collector.add_param_ext_value(message.fields_json);
+        });
+
+    // Give the subscriptions a moment to register.
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    // Announce ourselves as a non-extended client and get the initial value.
+    request_read(mavlink_direct, false);
+
+    // Wait for the initial value to arrive via PARAM_VALUE.
+    for (int i = 0; i < 50 && !contains_value(collector, initial_value); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    EXPECT_TRUE(contains_value(collector, initial_value));
+
+    // Change the value on the server.
+    ASSERT_EQ(
+        param_server.provide_param_float(param_name, changed_value), ParamServer::Result::Success);
+
+    // The change must be broadcast as PARAM_VALUE so a non-extended client sees it.
+    for (int i = 0; i < 50 && !contains_value(collector, changed_value); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    EXPECT_TRUE(contains_value(collector, changed_value));
+
+    // And it must not have leaked out as PARAM_EXT_VALUE.
+    std::lock_guard<std::mutex> lock(collector.mutex);
+    EXPECT_TRUE(collector.param_ext_values.empty());
+}
+
+// When only an extended client has been seen, a value change must be broadcast as
+// PARAM_EXT_VALUE, and must not go out as PARAM_VALUE.
+TEST(ParamChangeNotification, ExtendedClient)
+{
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{ComponentType::GroundStation}};
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{ComponentType::Autopilot}};
+
+    ASSERT_EQ(
+        mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17011"),
+        ConnectionResult::Success);
+    ASSERT_EQ(
+        mavsdk_autopilot.add_any_connection("udpout://127.0.0.1:17011"), ConnectionResult::Success);
+
+    auto param_server = ParamServer{mavsdk_autopilot.server_component()};
+    ASSERT_EQ(
+        param_server.provide_param_float(param_name, initial_value), ParamServer::Result::Success);
+
+    auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
+    ASSERT_TRUE(maybe_system);
+    auto system = maybe_system.value();
+
+    ValueCollector collector;
+    auto mavlink_direct = MavlinkDirect{system};
+    mavlink_direct.subscribe_message(
+        "PARAM_VALUE", [&collector](MavlinkDirect::MavlinkMessage message) {
+            collector.add_param_value(message.fields_json);
+        });
+    mavlink_direct.subscribe_message(
+        "PARAM_EXT_VALUE", [&collector](MavlinkDirect::MavlinkMessage message) {
+            collector.add_param_ext_value(message.fields_json);
+        });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    // Announce ourselves as an extended client and get the initial value.
+    request_read(mavlink_direct, true);
+
+    // Wait for the initial value to arrive via PARAM_EXT_VALUE.
+    auto ext_seen = [&collector]() {
+        std::lock_guard<std::mutex> lock(collector.mutex);
+        return !collector.param_ext_values.empty();
+    };
+    for (int i = 0; i < 50 && !ext_seen(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    EXPECT_TRUE(ext_seen());
+
+    const size_t ext_count_before = [&collector]() {
+        std::lock_guard<std::mutex> lock(collector.mutex);
+        return collector.param_ext_values.size();
+    }();
+
+    // Change the value on the server.
+    ASSERT_EQ(
+        param_server.provide_param_float(param_name, changed_value), ParamServer::Result::Success);
+
+    // The change must be broadcast as PARAM_EXT_VALUE.
+    auto ext_grew = [&collector, ext_count_before]() {
+        std::lock_guard<std::mutex> lock(collector.mutex);
+        return collector.param_ext_values.size() > ext_count_before;
+    };
+    for (int i = 0; i < 50 && !ext_grew(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    EXPECT_TRUE(ext_grew());
+
+    // The value change must not have leaked out as PARAM_VALUE.
+    EXPECT_FALSE(contains_value(collector, changed_value));
+}
+
+// When both a non-extended and an extended client have been seen, a value change must be
+// broadcast on both protocols. This is the actual regression: previously the notification went
+// out on only the protocol of the most recent request, so a client on the other protocol missed
+// the update.
+TEST(ParamChangeNotification, BothProtocolsSeen)
+{
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{ComponentType::GroundStation}};
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{ComponentType::Autopilot}};
+
+    ASSERT_EQ(
+        mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17012"),
+        ConnectionResult::Success);
+    ASSERT_EQ(
+        mavsdk_autopilot.add_any_connection("udpout://127.0.0.1:17012"), ConnectionResult::Success);
+
+    auto param_server = ParamServer{mavsdk_autopilot.server_component()};
+    ASSERT_EQ(
+        param_server.provide_param_float(param_name, initial_value), ParamServer::Result::Success);
+
+    auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
+    ASSERT_TRUE(maybe_system);
+    auto system = maybe_system.value();
+
+    ValueCollector collector;
+    auto mavlink_direct = MavlinkDirect{system};
+    mavlink_direct.subscribe_message(
+        "PARAM_VALUE", [&collector](MavlinkDirect::MavlinkMessage message) {
+            collector.add_param_value(message.fields_json);
+        });
+    mavlink_direct.subscribe_message(
+        "PARAM_EXT_VALUE", [&collector](MavlinkDirect::MavlinkMessage message) {
+            collector.add_param_ext_value(message.fields_json);
+        });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    // A non-extended client reads, then an extended client reads. The extended read is last,
+    // which is what used to hide the update from the non-extended client.
+    request_read(mavlink_direct, false);
+    request_read(mavlink_direct, true);
+
+    // Wait for the initial value to be reflected on both protocols.
+    auto both_initial = [&collector]() {
+        std::lock_guard<std::mutex> lock(collector.mutex);
+        return !collector.param_values.empty() && !collector.param_ext_values.empty();
+    };
+    for (int i = 0; i < 50 && !both_initial(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    ASSERT_TRUE(both_initial());
+
+    const size_t ext_count_before = [&collector]() {
+        std::lock_guard<std::mutex> lock(collector.mutex);
+        return collector.param_ext_values.size();
+    }();
+
+    // Change the value on the server.
+    ASSERT_EQ(
+        param_server.provide_param_float(param_name, changed_value), ParamServer::Result::Success);
+
+    // The change must reach both the non-extended and the extended client.
+    auto ext_grew = [&collector, ext_count_before]() {
+        std::lock_guard<std::mutex> lock(collector.mutex);
+        return collector.param_ext_values.size() > ext_count_before;
+    };
+    for (int i = 0; i < 50 && !(contains_value(collector, changed_value) && ext_grew()); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    EXPECT_TRUE(contains_value(collector, changed_value));
+    EXPECT_TRUE(ext_grew());
+}


### PR DESCRIPTION
Alternative fix to https://github.com/mavlink/MAVSDK/pull/2913.

If you don't mind, it would be very helpful if you could test this @bastianhjaeger.