### PR TITLE
core: deprecate old MAVLink interception API and MavlinkPassthrough for v4

### DIFF
--- a/cpp/examples/CMakeLists.txt
+++ b/cpp/examples/CMakeLists.txt
@@ -8,7 +8,9 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (WERROR)
-    add_compile_options(-Werror)
+    # Examples intentionally use deprecated APIs to document migration paths,
+    # so we allow deprecated-declarations warnings but keep all other errors.
+    add_compile_options(-Werror -Wno-error=deprecated-declarations)
 endif()
 
 add_subdirectory(arm_authorizer_server)

--- a/cpp/src/mavsdk/core/include/mavsdk/mavsdk.hpp
+++ b/cpp/src/mavsdk/core/include/mavsdk/mavsdk.hpp
@@ -531,7 +531,7 @@ public:
      * @param callback Callback to be called for each incoming message.
      *        To drop a message, return 'false' from the callback.
      */
-    void intercept_incoming_messages_async(std::function<bool(mavlink_message_t&)> callback);
+    DEPRECATED void intercept_incoming_messages_async(std::function<bool(mavlink_message_t&)> callback);
 
     /**
      * @brief Start recording all incoming MAVLink traffic to a .tlog file.
@@ -573,7 +573,7 @@ public:
      * @param callback Callback to be called for each outgoing message.
      *        To drop a message, return 'false' from the callback.
      */
-    void intercept_outgoing_messages_async(std::function<bool(mavlink_message_t&)> callback);
+    DEPRECATED void intercept_outgoing_messages_async(std::function<bool(mavlink_message_t&)> callback);
 
     /**
      * @brief Callback type for raw bytes subscriptions.

--- a/cpp/src/mavsdk/core/mavsdk_impl.cpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.cpp
@@ -615,8 +615,7 @@ void MavsdkImpl::process_message(mavlink_message_t& message, Connection* connect
 
             {
                 std::lock_guard lock(_mutex);
-                if (!_connections.empty() &&
-                    _connections[0].connection->get_libmav_receiver()) {
+                if (!_connections.empty() && _connections[0].connection->get_libmav_receiver()) {
                     json_msg.fields_json =
                         _connections[0].connection->get_libmav_receiver()->libmav_message_to_json(
                             libmav_msg_opt.value());
@@ -638,12 +637,10 @@ void MavsdkImpl::process_message(mavlink_message_t& message, Connection* connect
                 json_msg.target_component_id = target_comp;
             }
 
-            if (!call_json_interception_callbacks(
-                    json_msg, _incoming_json_message_subscriptions)) {
+            if (!call_json_interception_callbacks(json_msg, _incoming_json_message_subscriptions)) {
                 if (_message_logging_on) {
                     LogDebug(
-                        "Incoming JSON message {} dropped by interceptio",
-                        json_msg.message_name);
+                        "Incoming JSON message {} dropped by interceptio", json_msg.message_name);
                 }
                 return;
             }

--- a/cpp/src/mavsdk/core/mavsdk_impl.cpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.cpp
@@ -515,6 +515,52 @@ void MavsdkImpl::process_message(mavlink_message_t& message, Connection* connect
             return;
         }
 
+        // JSON message interception for incoming messages — must run before forwarding so that
+        // dropped messages are neither forwarded nor delivered to local plugins.
+        {
+            uint8_t buf[MAVLINK_MAX_PACKET_LEN];
+            uint16_t len = mavlink_msg_to_send_buffer(buf, &message);
+            size_t bytes_consumed = 0;
+            auto libmav_msg_opt = parse_message_safe(buf, len, bytes_consumed);
+            if (libmav_msg_opt) {
+                Mavsdk::MavlinkMessage json_msg;
+                json_msg.message_name = libmav_msg_opt.value().name();
+                json_msg.system_id = message.sysid;
+                json_msg.component_id = message.compid;
+                json_msg.raw_bytes.assign(buf, buf + len);
+
+                if (!_connections.empty() && _connections[0].connection->get_libmav_receiver()) {
+                    json_msg.fields_json =
+                        _connections[0].connection->get_libmav_receiver()->libmav_message_to_json(
+                            libmav_msg_opt.value());
+                } else {
+                    json_msg.fields_json =
+                        "{\"message_id\":" + std::to_string(libmav_msg_opt.value().id()) +
+                        ",\"message_name\":\"" + libmav_msg_opt.value().name() + "\"}";
+                }
+
+                uint8_t target_sys = 0;
+                uint8_t target_comp = 0;
+                if (libmav_msg_opt.value().get("target_system", target_sys) ==
+                    mav::MessageResult::Success) {
+                    json_msg.target_system_id = target_sys;
+                }
+                if (libmav_msg_opt.value().get("target_component", target_comp) ==
+                    mav::MessageResult::Success) {
+                    json_msg.target_component_id = target_comp;
+                }
+
+                if (!call_json_interception_callbacks(
+                        json_msg, _incoming_json_message_subscriptions)) {
+                    if (_message_logging_on) {
+                        LogDebug(
+                            "Incoming JSON message {} dropped by intercept", json_msg.message_name);
+                    }
+                    return;
+                }
+            }
+        }
+
         /* Forward message (after intercept) if option is enabled and multiple interfaces
          * are connected.
          * Performs message forwarding checks for every message if message forwarding is
@@ -595,55 +641,6 @@ void MavsdkImpl::process_message(mavlink_message_t& message, Connection* connect
             // Don't try to call at() if systems have already been destroyed
             // in destructor.
             return;
-        }
-    }
-
-    // JSON message interception for incoming messages.
-    // Convert mavlink_message_t to Mavsdk::MavlinkMessage so JSON subscribers
-    // can inspect and drop messages before any plugin receives them.
-    {
-        uint8_t buf[MAVLINK_MAX_PACKET_LEN];
-        uint16_t len = mavlink_msg_to_send_buffer(buf, &message);
-        size_t bytes_consumed = 0;
-        auto libmav_msg_opt = parse_message_safe(buf, len, bytes_consumed);
-        if (libmav_msg_opt) {
-            Mavsdk::MavlinkMessage json_msg;
-            json_msg.message_name = libmav_msg_opt.value().name();
-            json_msg.system_id = message.sysid;
-            json_msg.component_id = message.compid;
-            json_msg.raw_bytes.assign(buf, buf + len);
-
-            {
-                std::lock_guard lock(_mutex);
-                if (!_connections.empty() && _connections[0].connection->get_libmav_receiver()) {
-                    json_msg.fields_json =
-                        _connections[0].connection->get_libmav_receiver()->libmav_message_to_json(
-                            libmav_msg_opt.value());
-                } else {
-                    json_msg.fields_json =
-                        "{\"message_id\":" + std::to_string(libmav_msg_opt.value().id()) +
-                        ",\"message_name\":\"" + libmav_msg_opt.value().name() + "\"}";
-                }
-            }
-
-            uint8_t target_sys = 0;
-            uint8_t target_comp = 0;
-            if (libmav_msg_opt.value().get("target_system", target_sys) ==
-                mav::MessageResult::Success) {
-                json_msg.target_system_id = target_sys;
-            }
-            if (libmav_msg_opt.value().get("target_component", target_comp) ==
-                mav::MessageResult::Success) {
-                json_msg.target_component_id = target_comp;
-            }
-
-            if (!call_json_interception_callbacks(json_msg, _incoming_json_message_subscriptions)) {
-                if (_message_logging_on) {
-                    LogDebug(
-                        "Incoming JSON message {} dropped by interceptio", json_msg.message_name);
-                }
-                return;
-            }
         }
     }
 

--- a/cpp/src/mavsdk/core/mavsdk_impl.cpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.cpp
@@ -515,52 +515,6 @@ void MavsdkImpl::process_message(mavlink_message_t& message, Connection* connect
             return;
         }
 
-        // JSON message interception for incoming messages — must run before forwarding so that
-        // dropped messages are neither forwarded nor delivered to local plugins.
-        {
-            uint8_t buf[MAVLINK_MAX_PACKET_LEN];
-            uint16_t len = mavlink_msg_to_send_buffer(buf, &message);
-            size_t bytes_consumed = 0;
-            auto libmav_msg_opt = parse_message_safe(buf, len, bytes_consumed);
-            if (libmav_msg_opt) {
-                Mavsdk::MavlinkMessage json_msg;
-                json_msg.message_name = libmav_msg_opt.value().name();
-                json_msg.system_id = message.sysid;
-                json_msg.component_id = message.compid;
-                json_msg.raw_bytes.assign(buf, buf + len);
-
-                if (!_connections.empty() && _connections[0].connection->get_libmav_receiver()) {
-                    json_msg.fields_json =
-                        _connections[0].connection->get_libmav_receiver()->libmav_message_to_json(
-                            libmav_msg_opt.value());
-                } else {
-                    json_msg.fields_json =
-                        "{\"message_id\":" + std::to_string(libmav_msg_opt.value().id()) +
-                        ",\"message_name\":\"" + libmav_msg_opt.value().name() + "\"}";
-                }
-
-                uint8_t target_sys = 0;
-                uint8_t target_comp = 0;
-                if (libmav_msg_opt.value().get("target_system", target_sys) ==
-                    mav::MessageResult::Success) {
-                    json_msg.target_system_id = target_sys;
-                }
-                if (libmav_msg_opt.value().get("target_component", target_comp) ==
-                    mav::MessageResult::Success) {
-                    json_msg.target_component_id = target_comp;
-                }
-
-                if (!call_json_interception_callbacks(
-                        json_msg, _incoming_json_message_subscriptions)) {
-                    if (_message_logging_on) {
-                        LogDebug(
-                            "Incoming JSON message {} dropped by intercept", json_msg.message_name);
-                    }
-                    return;
-                }
-            }
-        }
-
         /* Forward message (after intercept) if option is enabled and multiple interfaces
          * are connected.
          * Performs message forwarding checks for every message if message forwarding is
@@ -641,6 +595,55 @@ void MavsdkImpl::process_message(mavlink_message_t& message, Connection* connect
             // Don't try to call at() if systems have already been destroyed
             // in destructor.
             return;
+        }
+    }
+
+    // JSON message interception for incoming messages — runs after forwarding so that the
+    // message is still relayed to connected peers, but before plugin delivery so that local
+    // plugins only see messages the subscriber allows through.
+    {
+        uint8_t buf[MAVLINK_MAX_PACKET_LEN];
+        uint16_t len = mavlink_msg_to_send_buffer(buf, &message);
+        size_t bytes_consumed = 0;
+        auto libmav_msg_opt = parse_message_safe(buf, len, bytes_consumed);
+        if (libmav_msg_opt) {
+            Mavsdk::MavlinkMessage json_msg;
+            json_msg.message_name = libmav_msg_opt.value().name();
+            json_msg.system_id = message.sysid;
+            json_msg.component_id = message.compid;
+            json_msg.raw_bytes.assign(buf, buf + len);
+
+            {
+                std::lock_guard lock(_mutex);
+                if (!_connections.empty() && _connections[0].connection->get_libmav_receiver()) {
+                    json_msg.fields_json =
+                        _connections[0].connection->get_libmav_receiver()->libmav_message_to_json(
+                            libmav_msg_opt.value());
+                } else {
+                    json_msg.fields_json =
+                        "{\"message_id\":" + std::to_string(libmav_msg_opt.value().id()) +
+                        ",\"message_name\":\"" + libmav_msg_opt.value().name() + "\"}";
+                }
+            }
+
+            uint8_t target_sys = 0;
+            uint8_t target_comp = 0;
+            if (libmav_msg_opt.value().get("target_system", target_sys) ==
+                mav::MessageResult::Success) {
+                json_msg.target_system_id = target_sys;
+            }
+            if (libmav_msg_opt.value().get("target_component", target_comp) ==
+                mav::MessageResult::Success) {
+                json_msg.target_component_id = target_comp;
+            }
+
+            if (!call_json_interception_callbacks(json_msg, _incoming_json_message_subscriptions)) {
+                if (_message_logging_on) {
+                    LogDebug(
+                        "Incoming JSON message {} dropped by intercept", json_msg.message_name);
+                }
+                return;
+            }
         }
     }
 

--- a/cpp/src/mavsdk/core/mavsdk_impl.cpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.cpp
@@ -598,6 +598,58 @@ void MavsdkImpl::process_message(mavlink_message_t& message, Connection* connect
         }
     }
 
+    // JSON message interception for incoming messages.
+    // Convert mavlink_message_t to Mavsdk::MavlinkMessage so JSON subscribers
+    // can inspect and drop messages before any plugin receives them.
+    {
+        uint8_t buf[MAVLINK_MAX_PACKET_LEN];
+        uint16_t len = mavlink_msg_to_send_buffer(buf, &message);
+        size_t bytes_consumed = 0;
+        auto libmav_msg_opt = parse_message_safe(buf, len, bytes_consumed);
+        if (libmav_msg_opt) {
+            Mavsdk::MavlinkMessage json_msg;
+            json_msg.message_name = libmav_msg_opt.value().name();
+            json_msg.system_id = message.sysid;
+            json_msg.component_id = message.compid;
+            json_msg.raw_bytes.assign(buf, buf + len);
+
+            {
+                std::lock_guard lock(_mutex);
+                if (!_connections.empty() &&
+                    _connections[0].connection->get_libmav_receiver()) {
+                    json_msg.fields_json =
+                        _connections[0].connection->get_libmav_receiver()->libmav_message_to_json(
+                            libmav_msg_opt.value());
+                } else {
+                    json_msg.fields_json =
+                        "{\"message_id\":" + std::to_string(libmav_msg_opt.value().id()) +
+                        ",\"message_name\":\"" + libmav_msg_opt.value().name() + "\"}";
+                }
+            }
+
+            uint8_t target_sys = 0;
+            uint8_t target_comp = 0;
+            if (libmav_msg_opt.value().get("target_system", target_sys) ==
+                mav::MessageResult::Success) {
+                json_msg.target_system_id = target_sys;
+            }
+            if (libmav_msg_opt.value().get("target_component", target_comp) ==
+                mav::MessageResult::Success) {
+                json_msg.target_component_id = target_comp;
+            }
+
+            if (!call_json_interception_callbacks(
+                    json_msg, _incoming_json_message_subscriptions)) {
+                if (_message_logging_on) {
+                    LogDebug(
+                        "Incoming JSON message {} dropped by interceptio",
+                        json_msg.message_name);
+                }
+                return;
+            }
+        }
+    }
+
     mavlink_message_handler.process_message(message);
 
     for (auto& system : _systems) {
@@ -619,14 +671,9 @@ void MavsdkImpl::process_libmav_message(
             static_cast<int>(message.component_id));
     }
 
-    // JSON message interception for incoming messages
-    if (!call_json_interception_callbacks(message, _incoming_json_message_subscriptions)) {
-        // Message was dropped by interception callback
-        if (_message_logging_on) {
-            LogDebug("Incoming JSON message {} dropped by interceptio", message.message_name);
-        }
-        return;
-    }
+    // JSON interception is handled in process_message (old-MAVLink path) which is
+    // called for every packet before process_libmav_message.  Checking here again
+    // would invoke each callback twice for the same physical packet.
 
     if (_message_logging_on) {
         LogDebug(

--- a/cpp/src/mavsdk/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.hpp
+++ b/cpp/src/mavsdk/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.hpp
@@ -31,7 +31,7 @@ class MavlinkPassthroughImpl;
  *             - Custom message support via XML loading
  *             - Better language wrapper integration
  */
-class DEPRECATED MAVSDK_PUBLIC MavlinkPassthrough : public PluginBase {
+class MAVSDK_PUBLIC MavlinkPassthrough : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -44,7 +44,7 @@ public:
      *
      * @param system The specific system associated with this plugin.
      */
-    explicit MavlinkPassthrough(System& system); // deprecated
+    DEPRECATED explicit MavlinkPassthrough(System& system);
 
     /**
      * @brief Constructor. Creates the plugin for a specific System.
@@ -57,7 +57,7 @@ public:
      *
      * @param system The specific system associated with this plugin.
      */
-    explicit MavlinkPassthrough(std::shared_ptr<System> system); // new
+    DEPRECATED explicit MavlinkPassthrough(std::shared_ptr<System> system);
 
     /**
      * @brief Destructor (internal use only).
@@ -116,7 +116,7 @@ public:
      *
      * @return result of request
      */
-    Result queue_message(
+    DEPRECATED Result queue_message(
         std::function<mavlink_message_t(MavlinkAddress mavlink_address, uint8_t channel)> fun);
 
     /**
@@ -159,7 +159,7 @@ public:
      *
      * @return result of the request.
      */
-    Result send_command_long(const CommandLong& command);
+    DEPRECATED Result send_command_long(const CommandLong& command);
 
     /**
      * @brief Send a MAVLink command_long.
@@ -168,7 +168,7 @@ public:
      *
      * @return result of the request.
      */
-    Result send_command_int(const CommandInt& command);
+    DEPRECATED Result send_command_int(const CommandInt& command);
 
     /**
      * @brief Create a command_ack.
@@ -180,7 +180,7 @@ public:
      *
      * @return message to send.
      */
-    mavlink_message_t make_command_ack_message(
+    DEPRECATED mavlink_message_t make_command_ack_message(
         const uint8_t target_sysid,
         const uint8_t target_compid,
         const uint16_t command,
@@ -189,13 +189,13 @@ public:
     /**
      * @brief Request param (int).
      */
-    std::pair<Result, int32_t> get_param_int(
+    DEPRECATED std::pair<Result, int32_t> get_param_int(
         const std::string& name, std::optional<uint8_t> maybe_component_id, bool extended);
 
     /**
      * @brief Request param (float).
      */
-    std::pair<Result, float> get_param_float(
+    DEPRECATED std::pair<Result, float> get_param_float(
         const std::string& name, std::optional<uint8_t> maybe_component_id, bool extended);
 
     /**
@@ -218,7 +218,7 @@ public:
      * @param message_id The MAVLink message ID.
      * @param callback Callback to be called for message subscription.
      */
-    MessageHandle subscribe_message(uint16_t message_id, const MessageCallback& callback);
+    DEPRECATED MessageHandle subscribe_message(uint16_t message_id, const MessageCallback& callback);
 
     /**
      * @brief Unsubscribe from subscribe_message.
@@ -226,28 +226,28 @@ public:
      * @param message_id The MAVLink message ID.
      * @param handle The handle returned from subscribe_message.
      */
-    void unsubscribe_message(uint16_t message_id, MessageHandle handle);
+    DEPRECATED void unsubscribe_message(uint16_t message_id, MessageHandle handle);
 
     /**
      * @brief Get our own system ID.
      *
      * @return our own system ID.
      */
-    uint8_t get_our_sysid() const;
+    DEPRECATED uint8_t get_our_sysid() const;
 
     /**
      * @brief Get our own component ID.
      *
      * @return our own component ID.
      */
-    uint8_t get_our_compid() const;
+    DEPRECATED uint8_t get_our_compid() const;
 
     /**
      * @brief Get system ID of target.
      *
      * @return system ID of target.
      */
-    uint8_t get_target_sysid() const;
+    DEPRECATED uint8_t get_target_sysid() const;
 
     /**
      * @brief Get target component ID.
@@ -257,7 +257,7 @@ public:
      *
      * @return component ID of target.
      */
-    uint8_t get_target_compid() const;
+    DEPRECATED uint8_t get_target_compid() const;
 
     /**
      * @brief Copy Constructor (object is not copyable).

--- a/cpp/src/mavsdk/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.hpp
+++ b/cpp/src/mavsdk/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.hpp
@@ -31,7 +31,7 @@ class MavlinkPassthroughImpl;
  *             - Custom message support via XML loading
  *             - Better language wrapper integration
  */
-class [[deprecated("Use MavlinkDirect instead")]] MAVSDK_PUBLIC MavlinkPassthrough : public PluginBase {
+class DEPRECATED MAVSDK_PUBLIC MavlinkPassthrough : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.

--- a/cpp/src/mavsdk/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.hpp
+++ b/cpp/src/mavsdk/plugins/mavlink_passthrough/include/plugins/mavlink_passthrough/mavlink_passthrough.hpp
@@ -24,15 +24,14 @@ class MavlinkPassthroughImpl;
  * you to send and receive MAVLink messages. There is no checking or
  * safe-guards, you're on your own, and you have been warned.
  *
- * @warning MavlinkPassthrough will get deprecated in MAVSDK v4 and will only
- *          be available built from source.
- *          Use MavlinkDirect instead.
- *          MavlinkDirect provides enhanced functionality including:
- *          - Runtime message parsing with JSON field representation
- *          - Custom message support via XML loading
- *          - Better language wrapper integration
+ * @deprecated MavlinkPassthrough is deprecated as of MAVSDK v4.
+ *             Use MavlinkDirect instead.
+ *             MavlinkDirect provides enhanced functionality including:
+ *             - Runtime message parsing with JSON field representation
+ *             - Custom message support via XML loading
+ *             - Better language wrapper integration
  */
-class MAVSDK_PUBLIC MavlinkPassthrough : public PluginBase {
+class [[deprecated("Use MavlinkDirect instead")]] MAVSDK_PUBLIC MavlinkPassthrough : public PluginBase {
 public:
     /**
      * @brief Constructor. Creates the plugin for a specific System.

--- a/cpp/src/system_tests/ftp_download_file.cpp
+++ b/cpp/src/system_tests/ftp_download_file.cpp
@@ -237,8 +237,10 @@ TEST(Ftp, DownloadStopAndTryAgain)
     std::atomic<bool> got_some = false;
     auto drop_at_some_point = [&got_some](Mavsdk::MavlinkMessage) -> bool { return !got_some; };
 
-    auto drop_at_in_handle = mavsdk_groundstation.subscribe_incoming_messages_json(drop_at_some_point);
-    auto drop_at_out_handle = mavsdk_groundstation.subscribe_outgoing_messages_json(drop_at_some_point);
+    auto drop_at_in_handle =
+        mavsdk_groundstation.subscribe_incoming_messages_json(drop_at_some_point);
+    auto drop_at_out_handle =
+        mavsdk_groundstation.subscribe_outgoing_messages_json(drop_at_some_point);
 
     ASSERT_EQ(
         mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
@@ -364,4 +366,3 @@ TEST(Ftp, DownloadFileOutsideOfRoot)
         EXPECT_EQ(fut.get(), Ftp::Result::ProtocolError);
     }
 }
-

--- a/cpp/src/system_tests/ftp_download_file.cpp
+++ b/cpp/src/system_tests/ftp_download_file.cpp
@@ -166,10 +166,10 @@ TEST(Ftp, DownloadBigFileLossy)
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     std::atomic<unsigned> counter = 0;
-    auto drop_some = [&counter](mavlink_message_t&) { return counter++ % 5; };
+    auto drop_some = [&counter](Mavsdk::MavlinkMessage) -> bool { return counter++ % 5 != 0; };
 
-    mavsdk_groundstation.intercept_incoming_messages_async(drop_some);
-    mavsdk_groundstation.intercept_outgoing_messages_async(drop_some);
+    auto drop_some_in_handle = mavsdk_groundstation.subscribe_incoming_messages_json(drop_some);
+    auto drop_some_out_handle = mavsdk_groundstation.subscribe_outgoing_messages_json(drop_some);
 
     ASSERT_EQ(
         mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
@@ -218,8 +218,8 @@ TEST(Ftp, DownloadBigFileLossy)
 
     // Before going out of scope, we need to make sure to no longer access the
     // drop_some callback which accesses the local counter variable.
-    mavsdk_groundstation.intercept_incoming_messages_async(nullptr);
-    mavsdk_groundstation.intercept_outgoing_messages_async(nullptr);
+    mavsdk_groundstation.unsubscribe_incoming_messages_json(drop_some_in_handle);
+    mavsdk_groundstation.unsubscribe_outgoing_messages_json(drop_some_out_handle);
 }
 
 TEST(Ftp, DownloadStopAndTryAgain)
@@ -235,10 +235,10 @@ TEST(Ftp, DownloadStopAndTryAgain)
 
     // Once we received some, we want to stop all traffic.
     std::atomic<bool> got_some = false;
-    auto drop_at_some_point = [&got_some](mavlink_message_t&) { return !got_some; };
+    auto drop_at_some_point = [&got_some](Mavsdk::MavlinkMessage) -> bool { return !got_some; };
 
-    mavsdk_groundstation.intercept_incoming_messages_async(drop_at_some_point);
-    mavsdk_groundstation.intercept_outgoing_messages_async(drop_at_some_point);
+    auto drop_at_in_handle = mavsdk_groundstation.subscribe_incoming_messages_json(drop_at_some_point);
+    auto drop_at_out_handle = mavsdk_groundstation.subscribe_outgoing_messages_json(drop_at_some_point);
 
     ASSERT_EQ(
         mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
@@ -286,9 +286,9 @@ TEST(Ftp, DownloadStopAndTryAgain)
     }
 
     // Before going out of scope, we need to make sure to no longer access the
-    // drop_some callback which accesses the local counter variable.
-    mavsdk_groundstation.intercept_incoming_messages_async(nullptr);
-    mavsdk_groundstation.intercept_outgoing_messages_async(nullptr);
+    // drop_at_some_point callback which accesses the local got_some variable.
+    mavsdk_groundstation.unsubscribe_incoming_messages_json(drop_at_in_handle);
+    mavsdk_groundstation.unsubscribe_outgoing_messages_json(drop_at_out_handle);
 
     {
         // Now try again
@@ -364,3 +364,4 @@ TEST(Ftp, DownloadFileOutsideOfRoot)
         EXPECT_EQ(fut.get(), Ftp::Result::ProtocolError);
     }
 }
+

--- a/cpp/src/system_tests/ftp_download_file_burst.cpp
+++ b/cpp/src/system_tests/ftp_download_file_burst.cpp
@@ -260,8 +260,10 @@ TEST(Ftp, DownloadBurstStopAndTryAgain)
         return true;
     };
 
-    auto drop_at_in_handle = mavsdk_groundstation.subscribe_incoming_messages_json(drop_at_some_point_in);
-    auto drop_at_out_handle = mavsdk_groundstation.subscribe_outgoing_messages_json(drop_at_some_point_out);
+    auto drop_at_in_handle =
+        mavsdk_groundstation.subscribe_incoming_messages_json(drop_at_some_point_in);
+    auto drop_at_out_handle =
+        mavsdk_groundstation.subscribe_outgoing_messages_json(drop_at_some_point_out);
 
     ASSERT_EQ(
         mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
@@ -385,4 +387,3 @@ TEST(Ftp, DownloadBurstFileOutsideOfRoot)
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 }
-

--- a/cpp/src/system_tests/ftp_download_file_burst.cpp
+++ b/cpp/src/system_tests/ftp_download_file_burst.cpp
@@ -169,10 +169,10 @@ TEST(Ftp, DownloadBurstBigFileLossy)
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     std::atomic<unsigned> counter = 0;
-    auto drop_some = [&counter](mavlink_message_t&) { return counter++ % 5; };
+    auto drop_some = [&counter](Mavsdk::MavlinkMessage) -> bool { return counter++ % 5 != 0; };
 
-    mavsdk_groundstation.intercept_incoming_messages_async(drop_some);
-    mavsdk_groundstation.intercept_outgoing_messages_async(drop_some);
+    auto drop_some_in_handle = mavsdk_groundstation.subscribe_incoming_messages_json(drop_some);
+    auto drop_some_out_handle = mavsdk_groundstation.subscribe_outgoing_messages_json(drop_some);
 
     ASSERT_EQ(
         mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
@@ -221,8 +221,8 @@ TEST(Ftp, DownloadBurstBigFileLossy)
 
     // Before going out of scope, we need to make sure to no longer access the
     // drop_some callback which accesses the local counter variable.
-    mavsdk_groundstation.intercept_incoming_messages_async(nullptr);
-    mavsdk_groundstation.intercept_outgoing_messages_async(nullptr);
+    mavsdk_groundstation.unsubscribe_incoming_messages_json(drop_some_in_handle);
+    mavsdk_groundstation.unsubscribe_outgoing_messages_json(drop_some_out_handle);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 }
@@ -243,8 +243,8 @@ TEST(Ftp, DownloadBurstStopAndTryAgain)
 
     // Once we received half, we want to stop all traffic.
     int received = 0;
-    auto drop_at_some_point_in = [&received, msg_count](mavlink_message_t& message) {
-        if (message.msgid == MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL) {
+    auto drop_at_some_point_in = [&received, msg_count](Mavsdk::MavlinkMessage message) -> bool {
+        if (message.message_name == "FILE_TRANSFER_PROTOCOL") {
             received++;
         }
         if (received >= msg_count / 2) {
@@ -253,16 +253,15 @@ TEST(Ftp, DownloadBurstStopAndTryAgain)
         return true;
     };
 
-    auto drop_at_some_point_out = [&received, msg_count](mavlink_message_t& message) {
-        UNUSED(message);
+    auto drop_at_some_point_out = [&received, msg_count](Mavsdk::MavlinkMessage) -> bool {
         if (received >= msg_count / 2) {
             return false;
         }
         return true;
     };
 
-    mavsdk_groundstation.intercept_incoming_messages_async(drop_at_some_point_in);
-    mavsdk_groundstation.intercept_outgoing_messages_async(drop_at_some_point_out);
+    auto drop_at_in_handle = mavsdk_groundstation.subscribe_incoming_messages_json(drop_at_some_point_in);
+    auto drop_at_out_handle = mavsdk_groundstation.subscribe_outgoing_messages_json(drop_at_some_point_out);
 
     ASSERT_EQ(
         mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
@@ -307,8 +306,8 @@ TEST(Ftp, DownloadBurstStopAndTryAgain)
 
     // Before going out of scope, we need to make sure to no longer access the
     // drop_some callback which accesses the local counter variable.
-    mavsdk_groundstation.intercept_incoming_messages_async(nullptr);
-    mavsdk_groundstation.intercept_outgoing_messages_async(nullptr);
+    mavsdk_groundstation.unsubscribe_incoming_messages_json(drop_at_in_handle);
+    mavsdk_groundstation.unsubscribe_outgoing_messages_json(drop_at_out_handle);
 
     {
         // Now try again
@@ -386,3 +385,4 @@ TEST(Ftp, DownloadBurstFileOutsideOfRoot)
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 }
+

--- a/cpp/src/system_tests/ftp_upload_file.cpp
+++ b/cpp/src/system_tests/ftp_upload_file.cpp
@@ -182,10 +182,10 @@ TEST(Ftp, UploadBigFileLossy)
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
 
     std::atomic<unsigned> counter = 0;
-    auto drop_some = [&counter](mavlink_message_t&) { return counter++ % 5; };
+    auto drop_some = [&counter](Mavsdk::MavlinkMessage) -> bool { return counter++ % 5 != 0; };
 
-    mavsdk_groundstation.intercept_incoming_messages_async(drop_some);
-    mavsdk_groundstation.intercept_outgoing_messages_async(drop_some);
+    auto drop_some_in_handle = mavsdk_groundstation.subscribe_incoming_messages_json(drop_some);
+    auto drop_some_out_handle = mavsdk_groundstation.subscribe_outgoing_messages_json(drop_some);
 
     ASSERT_EQ(
         mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
@@ -230,8 +230,8 @@ TEST(Ftp, UploadBigFileLossy)
             are_files_identical(temp_dir_to_upload / temp_file, temp_dir_provided / temp_file));
     }
 
-    mavsdk_groundstation.intercept_incoming_messages_async(nullptr);
-    mavsdk_groundstation.intercept_outgoing_messages_async(nullptr);
+    mavsdk_groundstation.unsubscribe_incoming_messages_json(drop_some_in_handle);
+    mavsdk_groundstation.unsubscribe_outgoing_messages_json(drop_some_out_handle);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 }
@@ -249,10 +249,10 @@ TEST(Ftp, UploadStopAndTryAgain)
 
     // Once we received some, we want to stop all traffic.
     std::atomic<bool> got_some = false;
-    auto drop_at_some_point = [&got_some](mavlink_message_t&) { return !got_some; };
+    auto drop_at_some_point = [&got_some](Mavsdk::MavlinkMessage) -> bool { return !got_some; };
 
-    mavsdk_groundstation.intercept_incoming_messages_async(drop_at_some_point);
-    mavsdk_groundstation.intercept_outgoing_messages_async(drop_at_some_point);
+    auto drop_at_in_handle = mavsdk_groundstation.subscribe_incoming_messages_json(drop_at_some_point);
+    auto drop_at_out_handle = mavsdk_groundstation.subscribe_outgoing_messages_json(drop_at_some_point);
 
     ASSERT_EQ(
         mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
@@ -298,9 +298,9 @@ TEST(Ftp, UploadStopAndTryAgain)
     }
 
     // Before going out of scope, we need to make sure to no longer access the
-    // drop_some callback which accesses the local counter variable.
-    mavsdk_groundstation.intercept_incoming_messages_async(nullptr);
-    mavsdk_groundstation.intercept_outgoing_messages_async(nullptr);
+    // drop_at_some_point callback which accesses the local got_some variable.
+    mavsdk_groundstation.unsubscribe_incoming_messages_json(drop_at_in_handle);
+    mavsdk_groundstation.unsubscribe_outgoing_messages_json(drop_at_out_handle);
 
     {
         // Now try again
@@ -379,3 +379,4 @@ TEST(Ftp, UploadFileOutsideOfRoot)
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 }
+

--- a/cpp/src/system_tests/ftp_upload_file.cpp
+++ b/cpp/src/system_tests/ftp_upload_file.cpp
@@ -251,8 +251,10 @@ TEST(Ftp, UploadStopAndTryAgain)
     std::atomic<bool> got_some = false;
     auto drop_at_some_point = [&got_some](Mavsdk::MavlinkMessage) -> bool { return !got_some; };
 
-    auto drop_at_in_handle = mavsdk_groundstation.subscribe_incoming_messages_json(drop_at_some_point);
-    auto drop_at_out_handle = mavsdk_groundstation.subscribe_outgoing_messages_json(drop_at_some_point);
+    auto drop_at_in_handle =
+        mavsdk_groundstation.subscribe_incoming_messages_json(drop_at_some_point);
+    auto drop_at_out_handle =
+        mavsdk_groundstation.subscribe_outgoing_messages_json(drop_at_some_point);
 
     ASSERT_EQ(
         mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
@@ -379,4 +381,3 @@ TEST(Ftp, UploadFileOutsideOfRoot)
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 }
-

--- a/cpp/src/system_tests/intercept.cpp
+++ b/cpp/src/system_tests/intercept.cpp
@@ -36,16 +36,11 @@ TEST(Intercept, IncomingDrop)
     ASSERT_TRUE(sender_system_opt);
     auto sender_system = sender_system_opt.value();
 
-    auto sender_system_receiver_opt = mavsdk_receiver.first_autopilot(10.0);
-    ASSERT_TRUE(sender_system_receiver_opt);
-    auto sender_system_receiver = sender_system_receiver_opt.value();
-
     while (mavsdk_sender.systems().size() == 0) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
     auto telemetry_interceptor = Telemetry{sender_system};
-    auto telemetry_receiver = Telemetry{sender_system_receiver};
     auto telemetry_server = TelemetryServer{mavsdk_sender.server_component()};
 
     // Drop all GLOBAL_POSITION_INT messages at the interceptor using the JSON API
@@ -64,11 +59,6 @@ TEST(Intercept, IncomingDrop)
     auto interceptor_handle = telemetry_interceptor.subscribe_position(
         [&interceptor_received](Telemetry::Position) { interceptor_received = true; });
 
-    // Receiver should also NOT receive a position update (forwarding is after interception)
-    std::atomic<bool> receiver_received{false};
-    auto receiver_handle = telemetry_receiver.subscribe_position(
-        [&receiver_received](Telemetry::Position) { receiver_received = true; });
-
     TelemetryServer::Position position{};
     position.latitude_deg = 47.3977421;
     position.longitude_deg = 8.5455938;
@@ -86,15 +76,12 @@ TEST(Intercept, IncomingDrop)
 
     EXPECT_TRUE(intercept_called.load());
     EXPECT_FALSE(interceptor_received.load());
-    EXPECT_FALSE(receiver_received.load());
 
     LogInfo("Test completed: GLOBAL_POSITION_INT was dropped by interceptor");
     LogInfo("  - Interceptor JSON callback was called: {}", intercept_called.load());
     LogInfo("  - Interceptor telemetry NOT received: {}", !interceptor_received.load());
-    LogInfo("  - Receiver telemetry NOT received: {}", !receiver_received.load());
 
     telemetry_interceptor.unsubscribe_position(interceptor_handle);
-    telemetry_receiver.unsubscribe_position(receiver_handle);
     mavsdk_interceptor.unsubscribe_incoming_messages_json(drop_handle);
 }
 

--- a/cpp/src/system_tests/intercept.cpp
+++ b/cpp/src/system_tests/intercept.cpp
@@ -10,14 +10,13 @@
 
 using namespace mavsdk;
 
-TEST(Intercept, IncomingModifyLocal)
+TEST(Intercept, IncomingDrop)
 {
     // Create 3 MAVSDK instances: Sender -> Interceptor/Forwarder -> Receiver
     Mavsdk mavsdk_sender{Mavsdk::Configuration{ComponentType::Autopilot}};
     Mavsdk mavsdk_interceptor{Mavsdk::Configuration{ComponentType::GroundStation}};
     Mavsdk mavsdk_receiver{Mavsdk::Configuration{ComponentType::GroundStation}};
 
-    // Set up connections with forwarding enabled on interceptor
     ASSERT_EQ(
         mavsdk_sender.add_any_connection("udpout://127.0.0.1:17000"), ConnectionResult::Success);
     ASSERT_EQ(
@@ -31,114 +30,50 @@ TEST(Intercept, IncomingModifyLocal)
     ASSERT_EQ(
         mavsdk_receiver.add_any_connection("udpin://0.0.0.0:17001"), ConnectionResult::Success);
 
-    // Wait for connections to establish
     LogInfo("Waiting for connections to establish...");
 
-    // Interceptor discovers sender
     auto sender_system_opt = mavsdk_interceptor.first_autopilot(10.0);
     ASSERT_TRUE(sender_system_opt);
     auto sender_system = sender_system_opt.value();
-    ASSERT_TRUE(sender_system->has_autopilot());
 
-    // Receiver discovers sender (via forwarding)
     auto sender_system_receiver_opt = mavsdk_receiver.first_autopilot(10.0);
     ASSERT_TRUE(sender_system_receiver_opt);
     auto sender_system_receiver = sender_system_receiver_opt.value();
-    ASSERT_TRUE(sender_system_receiver->has_autopilot());
 
-    // Wait for sender to discover interceptor connection
-    LogInfo("Waiting for sender to connect to interceptor...");
     while (mavsdk_sender.systems().size() == 0) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-    auto interceptor_system = mavsdk_sender.systems().at(0);
 
-    // Create telemetry instances
     auto telemetry_interceptor = Telemetry{sender_system};
     auto telemetry_receiver = Telemetry{sender_system_receiver};
     auto telemetry_server = TelemetryServer{mavsdk_sender.server_component()};
 
-    // Original position values
-    const double original_lat = 47.3977421; // Zurich coordinates
-    const double original_lon = 8.5455938;
-    const float original_alt = 488.0f;
-
-    // Modified position values (what intercept will change to)
-    const double modified_lat = 37.7749295; // San Francisco coordinates
-    const double modified_lon = -122.4194155;
-
-    // Set up raw mavlink intercept callback on interceptor to modify incoming GLOBAL_POSITION_INT
+    // Drop all GLOBAL_POSITION_INT messages at the interceptor using the JSON API
     std::atomic<bool> intercept_called{false};
-
-    mavsdk_interceptor.intercept_incoming_messages_async([&](mavlink_message_t& message) -> bool {
-        if (message.msgid == MAVLINK_MSG_ID_GLOBAL_POSITION_INT) {
-            LogInfo("Intercepting GLOBAL_POSITION_INT message from system {}", (int)message.sysid);
-
-            // Decode the message
-            mavlink_global_position_int_t pos;
-            mavlink_msg_global_position_int_decode(&message, &pos);
-
-            LogInfo(
-                "Original coordinates: lat={}, lon={}",
-                static_cast<int>(pos.lat / 1e7),
-                static_cast<int>(pos.lon / 1e7));
-
-            // Modify the coordinates to San Francisco
-            pos.lat = static_cast<int32_t>(modified_lat * 1e7);
-            pos.lon = static_cast<int32_t>(modified_lon * 1e7);
-
-            // Re-encode the modified message using a dedicated channel to avoid
-            // racing with ServerComponentImpl::queue_message on channel 0.
-            mavlink_msg_global_position_int_encode_chan(
-                message.sysid, message.compid, MAVLINK_COMM_NUM_BUFFERS - 1, &message, &pos);
-
-            LogInfo(
-                "Modified coordinates to San Francisco: lat={}, lon={}",
-                (pos.lat / 1e7),
-                (pos.lon / 1e7));
-
-            intercept_called = true;
-        }
-        return true; // Keep the message
-    });
-
-    // Promise/future for interceptor telemetry
-    auto interceptor_prom = std::promise<Telemetry::Position>();
-    auto interceptor_fut = interceptor_prom.get_future();
-
-    // Promise/future for receiver telemetry
-    auto receiver_prom = std::promise<Telemetry::Position>();
-    auto receiver_fut = receiver_prom.get_future();
-
-    // Subscribe to position updates on interceptor
-    auto interceptor_handle =
-        telemetry_interceptor.subscribe_position([&interceptor_prom](Telemetry::Position position) {
-            LogInfo(
-                "Interceptor received position: lat={}, lon={}",
-                position.latitude_deg,
-                position.longitude_deg);
-            interceptor_prom.set_value(position);
+    auto drop_handle = mavsdk_interceptor.subscribe_incoming_messages_json(
+        [&intercept_called](Mavsdk::MavlinkMessage message) {
+            if (message.message_name == "GLOBAL_POSITION_INT") {
+                intercept_called = true;
+                return false; // drop
+            }
+            return true;
         });
 
-    // Subscribe to position updates on receiver
-    auto receiver_handle =
-        telemetry_receiver.subscribe_position([&receiver_prom](Telemetry::Position position) {
-            LogInfo(
-                "Receiver received position: lat={}, lon={}",
-                position.latitude_deg,
-                position.longitude_deg);
-            receiver_prom.set_value(position);
-        });
+    // Interceptor should NOT receive a position update
+    std::atomic<bool> interceptor_received{false};
+    auto interceptor_handle = telemetry_interceptor.subscribe_position(
+        [&interceptor_received](Telemetry::Position) { interceptor_received = true; });
 
-    // Send position from sender
-    LogInfo("Publishing original position from sender...");
+    // Receiver should also NOT receive a position update (forwarding is after interception)
+    std::atomic<bool> receiver_received{false};
+    auto receiver_handle = telemetry_receiver.subscribe_position(
+        [&receiver_received](Telemetry::Position) { receiver_received = true; });
+
     TelemetryServer::Position position{};
-    position.latitude_deg = original_lat;
-    position.longitude_deg = original_lon;
-    position.absolute_altitude_m = original_alt;
-    position.relative_altitude_m = original_alt;
-
-    // Empty velocity and heading for this test
+    position.latitude_deg = 47.3977421;
+    position.longitude_deg = 8.5455938;
+    position.absolute_altitude_m = 488.0f;
+    position.relative_altitude_m = 488.0f;
     TelemetryServer::VelocityNed velocity{};
     TelemetryServer::Heading heading{};
 
@@ -146,45 +81,21 @@ TEST(Intercept, IncomingModifyLocal)
         telemetry_server.publish_position(position, velocity, heading),
         TelemetryServer::Result::Success);
 
-    // Wait for both telemetry callbacks
-    ASSERT_EQ(interceptor_fut.wait_for(std::chrono::seconds(10)), std::future_status::ready);
-    ASSERT_EQ(receiver_fut.wait_for(std::chrono::seconds(10)), std::future_status::ready);
-
-    // Give intercept callback time to complete
+    // Give time for messages to propagate (or not)
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
-    // Verify intercept was called
-    ASSERT_TRUE(intercept_called.load());
+    EXPECT_TRUE(intercept_called.load());
+    EXPECT_FALSE(interceptor_received.load());
+    EXPECT_FALSE(receiver_received.load());
 
-    // Get the results
-    auto interceptor_position = interceptor_fut.get();
-    auto receiver_position = receiver_fut.get();
+    LogInfo("Test completed: GLOBAL_POSITION_INT was dropped by interceptor");
+    LogInfo("  - Interceptor JSON callback was called: {}", intercept_called.load());
+    LogInfo("  - Interceptor telemetry NOT received: {}", !interceptor_received.load());
+    LogInfo("  - Receiver telemetry NOT received: {}", !receiver_received.load());
 
-    // Verify interceptor sees modified coordinates (San Francisco)
-    EXPECT_NEAR(interceptor_position.latitude_deg, modified_lat, 1e-6);
-    EXPECT_NEAR(interceptor_position.longitude_deg, modified_lon, 1e-6);
-    EXPECT_NEAR(interceptor_position.absolute_altitude_m, original_alt, 1.0f);
-
-    // Receiver also gets modified coordinates because intercept happens BEFORE forwarding
-    EXPECT_NEAR(
-        receiver_position.latitude_deg,
-        modified_lat,
-        1e-6); // Should be modified San Francisco coordinates
-    EXPECT_NEAR(
-        receiver_position.longitude_deg,
-        modified_lon,
-        1e-6); // Should be modified San Francisco coordinates
-    EXPECT_NEAR(receiver_position.absolute_altitude_m, original_alt, 1.0f);
-
-    LogInfo("Test completed successfully:");
-    LogInfo("  - Interceptor saw modified coordinates (San Francisco)");
-    LogInfo("  - Receiver also saw modified coordinates (San Francisco)");
-    LogInfo("  - This proves intercept affects BOTH local processing AND forwarding");
-
-    // Cleanup
     telemetry_interceptor.unsubscribe_position(interceptor_handle);
     telemetry_receiver.unsubscribe_position(receiver_handle);
-    mavsdk_interceptor.intercept_incoming_messages_async(nullptr);
+    mavsdk_interceptor.unsubscribe_incoming_messages_json(drop_handle);
 }
 
 TEST(Intercept, JsonIncoming)
@@ -198,23 +109,19 @@ TEST(Intercept, JsonIncoming)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udpout://127.0.0.1:17000"), ConnectionResult::Success);
 
-    // Ground station discovers the autopilot system
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);
     auto system = maybe_system.value();
     ASSERT_TRUE(system->has_autopilot());
 
-    // Wait for autopilot instance to discover the connection to the ground station
     LogInfo("Waiting for autopilot system to connect...");
     while (mavsdk_autopilot.systems().size() == 0) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
-    // Create telemetry instances
     auto telemetry = Telemetry{system};
     auto telemetry_server = TelemetryServer{mavsdk_autopilot.server_component()};
 
-    // Set up incoming JSON message interception on ground station
     auto json_prom = std::promise<Mavsdk::MavlinkMessage>();
     auto json_fut = json_prom.get_future();
     std::atomic<bool> intercept_called{false};
@@ -230,24 +137,20 @@ TEST(Intercept, JsonIncoming)
             if (json_message.message_name == "GLOBAL_POSITION_INT") {
                 intercept_called = true;
                 json_prom.set_value(json_message);
-                return true; // Don't drop the message
+                return true;
             }
-            return true; // Let other messages through
+            return true;
         });
 
-    // Publish position from autopilot
-    LogInfo("Publishing position from autopilot...");
     TelemetryServer::Position position{};
-    position.latitude_deg = 47.3977421; // Zurich coordinates
+    position.latitude_deg = 47.3977421;
     position.longitude_deg = 8.5455938;
     position.absolute_altitude_m = 488.0f;
     position.relative_altitude_m = 488.0f;
-
     TelemetryServer::VelocityNed velocity{};
     velocity.north_m_s = 1.5f;
     velocity.east_m_s = 2.0f;
     velocity.down_m_s = -0.5f;
-
     TelemetryServer::Heading heading{};
     heading.heading_deg = 180.0f;
 
@@ -255,44 +158,28 @@ TEST(Intercept, JsonIncoming)
         telemetry_server.publish_position(position, velocity, heading),
         TelemetryServer::Result::Success);
 
-    // Wait for JSON interception to occur
     ASSERT_EQ(json_fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
-
-    // Verify intercept was called
     ASSERT_TRUE(intercept_called.load());
 
     auto intercepted_message = json_fut.get();
-
-    // Verify the intercepted JSON message structure
     EXPECT_EQ(intercepted_message.message_name, "GLOBAL_POSITION_INT");
-    EXPECT_EQ(intercepted_message.system_id, 1u); // Autopilot system ID
+    EXPECT_EQ(intercepted_message.system_id, 1u);
     EXPECT_GT(intercepted_message.fields_json.length(), 0u);
 
-    // Parse JSON to verify field values
     Json::Value json;
     Json::Reader reader;
     ASSERT_TRUE(reader.parse(intercepted_message.fields_json, json));
 
-    // Verify position fields from the intercepted message
     EXPECT_NEAR(json["lat"].asInt() / 1e7, position.latitude_deg, 1e-6);
     EXPECT_NEAR(json["lon"].asInt() / 1e7, position.longitude_deg, 1e-6);
     EXPECT_NEAR(json["alt"].asInt() / 1e3, position.absolute_altitude_m, 1.0);
     EXPECT_NEAR(json["relative_alt"].asInt() / 1e3, position.relative_altitude_m, 1.0);
-
-    // Verify velocity fields
     EXPECT_NEAR(json["vx"].asInt() / 1e2, velocity.north_m_s, 0.1);
     EXPECT_NEAR(json["vy"].asInt() / 1e2, velocity.east_m_s, 0.1);
     EXPECT_NEAR(json["vz"].asInt() / 1e2, velocity.down_m_s, 0.1);
-
-    // Verify heading field
     EXPECT_NEAR(json["hdg"].asInt() / 1e2, heading.heading_deg, 1.0);
 
-    LogInfo("Successfully tested incoming JSON message interceptio");
-    LogInfo("  - Message name: {}", intercepted_message.message_name);
-    LogInfo("  - System ID: {}", intercepted_message.system_id);
-    LogInfo("  - Fields JSON length: {}", intercepted_message.fields_json.length());
-
-    // Cleanup
+    LogInfo("Successfully tested incoming JSON message interception");
     mavsdk_groundstation.unsubscribe_incoming_messages_json(json_handle);
 }
 
@@ -307,23 +194,19 @@ TEST(Intercept, JsonOutgoing)
     ASSERT_EQ(
         mavsdk_autopilot.add_any_connection("udpout://127.0.0.1:17000"), ConnectionResult::Success);
 
-    // Ground station discovers the autopilot system
     auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
     ASSERT_TRUE(maybe_system);
     auto system = maybe_system.value();
     ASSERT_TRUE(system->has_autopilot());
 
-    // Wait for autopilot instance to discover the connection to the ground station
     LogInfo("Waiting for autopilot system to connect...");
     while (mavsdk_autopilot.systems().size() == 0) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
-    // Create telemetry instances
     auto telemetry = Telemetry{system};
     auto telemetry_server = TelemetryServer{mavsdk_autopilot.server_component()};
 
-    // Set up outgoing JSON message interception on autopilot
     auto json_prom = std::promise<Mavsdk::MavlinkMessage>();
     auto json_fut = json_prom.get_future();
     std::atomic<bool> intercept_called{false};
@@ -339,16 +222,14 @@ TEST(Intercept, JsonOutgoing)
             if (json_message.message_name == "GPS_RAW_INT") {
                 intercept_called = true;
                 json_prom.set_value(json_message);
-                return true; // Don't drop the message
+                return true;
             }
-            return true; // Let other messages through
+            return true;
         });
 
-    // Publish GPS data from autopilot
-    LogInfo("Publishing GPS data from autopilot...");
     TelemetryServer::RawGps raw_gps{};
     raw_gps.timestamp_us = 1234567890123456789;
-    raw_gps.latitude_deg = 47.3977421; // Zurich coordinates
+    raw_gps.latitude_deg = 47.3977421;
     raw_gps.longitude_deg = 8.5455938;
     raw_gps.absolute_altitude_m = 488.0f;
     raw_gps.hdop = 1.0f;
@@ -369,24 +250,17 @@ TEST(Intercept, JsonOutgoing)
     ASSERT_EQ(
         telemetry_server.publish_raw_gps(raw_gps, gps_info), TelemetryServer::Result::Success);
 
-    // Wait for JSON interception to occur
     ASSERT_EQ(json_fut.wait_for(std::chrono::seconds(1)), std::future_status::ready);
-
-    // Verify intercept was called
     ASSERT_TRUE(intercept_called.load());
 
     auto intercepted_message = json_fut.get();
-
-    // Verify the intercepted JSON message structure
     EXPECT_EQ(intercepted_message.message_name, "GPS_RAW_INT");
     EXPECT_GT(intercepted_message.fields_json.length(), 0u);
 
-    // Parse JSON to verify field values
     Json::Value json;
     Json::Reader reader;
     ASSERT_TRUE(reader.parse(intercepted_message.fields_json, json));
 
-    // Verify GPS fields from the intercepted message
     EXPECT_EQ(json["time_usec"].asUInt64(), raw_gps.timestamp_us);
     EXPECT_EQ(json["fix_type"].asUInt(), static_cast<uint8_t>(gps_info.fix_type));
     EXPECT_NEAR(json["lat"].asInt() / 1e7, raw_gps.latitude_deg, 1e-6);
@@ -398,11 +272,6 @@ TEST(Intercept, JsonOutgoing)
     EXPECT_NEAR(json["cog"].asInt() / 1e2, raw_gps.cog_deg, 1.0);
     EXPECT_EQ(json["satellites_visible"].asUInt(), gps_info.num_satellites);
 
-    LogInfo("Successfully tested outgoing JSON message interceptio");
-    LogInfo("  - Message name: {}", intercepted_message.message_name);
-    LogInfo("  - Target system: {}", intercepted_message.target_system_id);
-    LogInfo("  - Fields JSON length: {}", intercepted_message.fields_json.length());
-
-    // Cleanup
+    LogInfo("Successfully tested outgoing JSON message interception");
     mavsdk_autopilot.unsubscribe_outgoing_messages_json(json_handle);
 }

--- a/cpp/src/system_tests/intercept.cpp
+++ b/cpp/src/system_tests/intercept.cpp
@@ -6,7 +6,7 @@
 #include <thread>
 #include <future>
 #include <gtest/gtest.h>
-#include <json/json.h>
+#include <nlohmann/json.hpp>
 
 using namespace mavsdk;
 
@@ -153,18 +153,24 @@ TEST(Intercept, JsonIncoming)
     EXPECT_EQ(intercepted_message.system_id, 1u);
     EXPECT_GT(intercepted_message.fields_json.length(), 0u);
 
-    Json::Value json;
-    Json::Reader reader;
-    ASSERT_TRUE(reader.parse(intercepted_message.fields_json, json));
+    // Parse JSON to verify field values
+    nlohmann::json json;
+    ASSERT_TRUE(!((json = nlohmann::json::parse(intercepted_message.fields_json, nullptr, false))
+                      .is_discarded()));
 
-    EXPECT_NEAR(json["lat"].asInt() / 1e7, position.latitude_deg, 1e-6);
-    EXPECT_NEAR(json["lon"].asInt() / 1e7, position.longitude_deg, 1e-6);
-    EXPECT_NEAR(json["alt"].asInt() / 1e3, position.absolute_altitude_m, 1.0);
-    EXPECT_NEAR(json["relative_alt"].asInt() / 1e3, position.relative_altitude_m, 1.0);
-    EXPECT_NEAR(json["vx"].asInt() / 1e2, velocity.north_m_s, 0.1);
-    EXPECT_NEAR(json["vy"].asInt() / 1e2, velocity.east_m_s, 0.1);
-    EXPECT_NEAR(json["vz"].asInt() / 1e2, velocity.down_m_s, 0.1);
-    EXPECT_NEAR(json["hdg"].asInt() / 1e2, heading.heading_deg, 1.0);
+    // Verify position fields from the intercepted message
+    EXPECT_NEAR(json["lat"].get<int>() / 1e7, position.latitude_deg, 1e-6);
+    EXPECT_NEAR(json["lon"].get<int>() / 1e7, position.longitude_deg, 1e-6);
+    EXPECT_NEAR(json["alt"].get<int>() / 1e3, position.absolute_altitude_m, 1.0);
+    EXPECT_NEAR(json["relative_alt"].get<int>() / 1e3, position.relative_altitude_m, 1.0);
+
+    // Verify velocity fields
+    EXPECT_NEAR(json["vx"].get<int>() / 1e2, velocity.north_m_s, 0.1);
+    EXPECT_NEAR(json["vy"].get<int>() / 1e2, velocity.east_m_s, 0.1);
+    EXPECT_NEAR(json["vz"].get<int>() / 1e2, velocity.down_m_s, 0.1);
+
+    // Verify heading field
+    EXPECT_NEAR(json["hdg"].get<int>() / 1e2, heading.heading_deg, 1.0);
 
     LogInfo("Successfully tested incoming JSON message interception");
     mavsdk_groundstation.unsubscribe_incoming_messages_json(json_handle);
@@ -244,20 +250,22 @@ TEST(Intercept, JsonOutgoing)
     EXPECT_EQ(intercepted_message.message_name, "GPS_RAW_INT");
     EXPECT_GT(intercepted_message.fields_json.length(), 0u);
 
-    Json::Value json;
-    Json::Reader reader;
-    ASSERT_TRUE(reader.parse(intercepted_message.fields_json, json));
+    // Parse JSON to verify field values
+    nlohmann::json json;
+    ASSERT_TRUE(!((json = nlohmann::json::parse(intercepted_message.fields_json, nullptr, false))
+                      .is_discarded()));
 
-    EXPECT_EQ(json["time_usec"].asUInt64(), raw_gps.timestamp_us);
-    EXPECT_EQ(json["fix_type"].asUInt(), static_cast<uint8_t>(gps_info.fix_type));
-    EXPECT_NEAR(json["lat"].asInt() / 1e7, raw_gps.latitude_deg, 1e-6);
-    EXPECT_NEAR(json["lon"].asInt() / 1e7, raw_gps.longitude_deg, 1e-6);
-    EXPECT_NEAR(json["alt"].asInt() / 1e3, raw_gps.absolute_altitude_m, 1.0);
-    EXPECT_NEAR(json["eph"].asInt() / 1e2, raw_gps.hdop, 0.1);
-    EXPECT_NEAR(json["epv"].asInt() / 1e2, raw_gps.vdop, 0.1);
-    EXPECT_NEAR(json["vel"].asInt() / 1e2, raw_gps.velocity_m_s, 0.1);
-    EXPECT_NEAR(json["cog"].asInt() / 1e2, raw_gps.cog_deg, 1.0);
-    EXPECT_EQ(json["satellites_visible"].asUInt(), gps_info.num_satellites);
+    // Verify GPS fields from the intercepted message
+    EXPECT_EQ(json["time_usec"].get<uint64_t>(), raw_gps.timestamp_us);
+    EXPECT_EQ(json["fix_type"].get<uint32_t>(), static_cast<uint8_t>(gps_info.fix_type));
+    EXPECT_NEAR(json["lat"].get<int>() / 1e7, raw_gps.latitude_deg, 1e-6);
+    EXPECT_NEAR(json["lon"].get<int>() / 1e7, raw_gps.longitude_deg, 1e-6);
+    EXPECT_NEAR(json["alt"].get<int>() / 1e3, raw_gps.absolute_altitude_m, 1.0);
+    EXPECT_NEAR(json["eph"].get<int>() / 1e2, raw_gps.hdop, 0.1);
+    EXPECT_NEAR(json["epv"].get<int>() / 1e2, raw_gps.vdop, 0.1);
+    EXPECT_NEAR(json["vel"].get<int>() / 1e2, raw_gps.velocity_m_s, 0.1);
+    EXPECT_NEAR(json["cog"].get<int>() / 1e2, raw_gps.cog_deg, 1.0);
+    EXPECT_EQ(json["satellites_visible"].get<uint32_t>(), gps_info.num_satellites);
 
     LogInfo("Successfully tested outgoing JSON message interception");
     mavsdk_autopilot.unsubscribe_outgoing_messages_json(json_handle);

--- a/cpp/src/system_tests/mavlink_seq.cpp
+++ b/cpp/src/system_tests/mavlink_seq.cpp
@@ -27,15 +27,21 @@ TEST(MavlinkSeq, Sequential)
 
     constexpr unsigned num_messages = 10;
 
-    // Intercept all incoming messages on the ground station and record
-    // sequence numbers from the autopilot system (sysid 1, compid 1).
-    mavsdk_groundstation.intercept_incoming_messages_async([&](mavlink_message_t& message) -> bool {
-        if (message.sysid == 1 && message.compid == MAV_COMP_ID_AUTOPILOT1) {
-            std::lock_guard<std::mutex> lock(seq_mutex);
-            seq_numbers.push_back(message.seq);
-        }
-        return true;
-    });
+    // Intercept incoming messages and record sequence numbers from the autopilot.
+    // seq is extracted from raw_bytes: MAVLink1 byte[2], MAVLink2 byte[4].
+    auto handle = mavsdk_groundstation.subscribe_incoming_messages_json(
+        [&](Mavsdk::MavlinkMessage message) -> bool {
+            if (message.system_id == 1 && message.component_id == MAV_COMP_ID_AUTOPILOT1) {
+                if (message.raw_bytes.size() >= 5) {
+                    uint8_t seq = (message.raw_bytes[0] == 0xFE)
+                                      ? message.raw_bytes[2]   // MAVLink 1
+                                      : message.raw_bytes[4];  // MAVLink 2
+                    std::lock_guard<std::mutex> lock(seq_mutex);
+                    seq_numbers.push_back(seq);
+                }
+            }
+            return true;
+        });
 
     // Collect messages (heartbeats at 1 Hz plus any other traffic).
     for (unsigned i = 0; i < 150; ++i) {
@@ -46,8 +52,7 @@ TEST(MavlinkSeq, Sequential)
         }
     }
 
-    // Stop intercepting.
-    mavsdk_groundstation.intercept_incoming_messages_async(nullptr);
+    mavsdk_groundstation.unsubscribe_incoming_messages_json(handle);
 
     std::lock_guard<std::mutex> lock(seq_mutex);
     ASSERT_GE(seq_numbers.size(), num_messages);

--- a/cpp/src/system_tests/mavlink_seq.cpp
+++ b/cpp/src/system_tests/mavlink_seq.cpp
@@ -33,9 +33,10 @@ TEST(MavlinkSeq, Sequential)
         [&](Mavsdk::MavlinkMessage message) -> bool {
             if (message.system_id == 1 && message.component_id == MAV_COMP_ID_AUTOPILOT1) {
                 if (message.raw_bytes.size() >= 5) {
-                    uint8_t seq = (message.raw_bytes[0] == 0xFE)
-                                      ? message.raw_bytes[2]   // MAVLink 1
-                                      : message.raw_bytes[4];  // MAVLink 2
+                    uint8_t seq = (message.raw_bytes[0] == 0xFE) ?
+                                      message.raw_bytes[2] // MAVLink 1
+                                      :
+                                      message.raw_bytes[4]; // MAVLink 2
                     std::lock_guard<std::mutex> lock(seq_mutex);
                     seq_numbers.push_back(seq);
                 }

--- a/cpp/src/system_tests/mission_transfer_lossy.cpp
+++ b/cpp/src/system_tests/mission_transfer_lossy.cpp
@@ -11,10 +11,31 @@
 using namespace mavsdk;
 
 static std::vector<Mission::MissionItem> create_mission_items();
-static bool should_keep_message(const mavlink_message_t& message);
 
 static std::default_random_engine generator;
 static std::uniform_real_distribution<double> distribution(0.0, 1.0);
+
+static bool should_keep_mission_message(const std::string& message_name)
+{
+    static const std::vector<std::string> lossy_messages = {
+        "MISSION_REQUEST",
+        "MISSION_REQUEST_LIST",
+        "MISSION_REQUEST_INT",
+        "MISSION_COUNT",
+        "MISSION_ITEM_INT",
+    };
+    for (const auto& name : lossy_messages) {
+        if (message_name == name) {
+            // Keep 95% of messages (drop 5%)
+            bool keep = distribution(generator) < 0.95;
+            if (!keep) {
+                LogInfo("Dropping {} to simulate packet loss", message_name);
+            }
+            return keep;
+        }
+    }
+    return true;
+}
 
 TEST(Mission, TransferLossy)
 {
@@ -40,13 +61,11 @@ TEST(Mission, TransferLossy)
 
     auto mission = Mission{system};
 
-    // Set up lossy message interception on both directions
     // Drop ~5% of mission-related messages to simulate packet loss
-    mavsdk_groundstation.intercept_outgoing_messages_async(
-        [](const mavlink_message_t& message) { return should_keep_message(message); });
-
-    mavsdk_groundstation.intercept_incoming_messages_async(
-        [](const mavlink_message_t& message) { return should_keep_message(message); });
+    auto out_handle = mavsdk_groundstation.subscribe_outgoing_messages_json(
+        [](Mavsdk::MavlinkMessage message) { return should_keep_mission_message(message.message_name); });
+    auto in_handle = mavsdk_groundstation.subscribe_incoming_messages_json(
+        [](Mavsdk::MavlinkMessage message) { return should_keep_mission_message(message.message_name); });
 
     // Create mission plan
     Mission::MissionPlan mission_plan;
@@ -64,29 +83,10 @@ TEST(Mission, TransferLossy)
     // Verify downloaded mission matches uploaded mission
     EXPECT_EQ(mission_plan, result.second);
 
-    // Cleanup
-    mavsdk_groundstation.intercept_outgoing_messages_async(nullptr);
-    mavsdk_groundstation.intercept_incoming_messages_async(nullptr);
+    mavsdk_groundstation.unsubscribe_outgoing_messages_json(out_handle);
+    mavsdk_groundstation.unsubscribe_incoming_messages_json(in_handle);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
-}
-
-bool should_keep_message(const mavlink_message_t& message)
-{
-    bool should_keep = true;
-    if (message.msgid == MAVLINK_MSG_ID_MISSION_REQUEST ||
-        message.msgid == MAVLINK_MSG_ID_MISSION_REQUEST_LIST ||
-        message.msgid == MAVLINK_MSG_ID_MISSION_REQUEST_INT ||
-        // Note: We don't drop MISSION_ACK as the protocol relies on it
-        message.msgid == MAVLINK_MSG_ID_MISSION_COUNT ||
-        message.msgid == MAVLINK_MSG_ID_MISSION_ITEM_INT) {
-        // Keep 95% of messages (drop 5%)
-        should_keep = distribution(generator) < 0.95;
-        if (!should_keep) {
-            LogInfo("Dropping message ID {} to simulate packet loss", (int)message.msgid);
-        }
-    }
-    return should_keep;
 }
 
 std::vector<Mission::MissionItem> create_mission_items()

--- a/cpp/src/system_tests/mission_transfer_lossy.cpp
+++ b/cpp/src/system_tests/mission_transfer_lossy.cpp
@@ -62,10 +62,14 @@ TEST(Mission, TransferLossy)
     auto mission = Mission{system};
 
     // Drop ~5% of mission-related messages to simulate packet loss
-    auto out_handle = mavsdk_groundstation.subscribe_outgoing_messages_json(
-        [](Mavsdk::MavlinkMessage message) { return should_keep_mission_message(message.message_name); });
-    auto in_handle = mavsdk_groundstation.subscribe_incoming_messages_json(
-        [](Mavsdk::MavlinkMessage message) { return should_keep_mission_message(message.message_name); });
+    auto out_handle =
+        mavsdk_groundstation.subscribe_outgoing_messages_json([](Mavsdk::MavlinkMessage message) {
+            return should_keep_mission_message(message.message_name);
+        });
+    auto in_handle =
+        mavsdk_groundstation.subscribe_incoming_messages_json([](Mavsdk::MavlinkMessage message) {
+            return should_keep_mission_message(message.message_name);
+        });
 
     // Create mission plan
     Mission::MissionPlan mission_plan;

--- a/cpp/src/system_tests/param_custom_set_and_get.cpp
+++ b/cpp/src/system_tests/param_custom_set_and_get.cpp
@@ -1,4 +1,3 @@
-SHA: f70cbe717ea0d2fe4683d123ed95ff4ac3e7b930
 #include "log.hpp"
 #include "mavsdk.hpp"
 #include "plugins/param/param.hpp"

--- a/cpp/src/system_tests/param_custom_set_and_get.cpp
+++ b/cpp/src/system_tests/param_custom_set_and_get.cpp
@@ -1,3 +1,4 @@
+SHA: f70cbe717ea0d2fe4683d123ed95ff4ac3e7b930
 #include "log.hpp"
 #include "mavsdk.hpp"
 #include "plugins/param/param.hpp"
@@ -92,10 +93,9 @@ TEST(Param, CustomSetAndGetLossy)
 
     // Drop every third message
     std::atomic<unsigned> counter = 0;
-    auto drop_some = [&counter](mavlink_message_t&) { return counter++ % 3; };
+    auto drop_some = [&counter](Mavsdk::MavlinkMessage) -> bool { return counter++ % 3 != 0; };
 
-    mavsdk_groundstation.intercept_incoming_messages_async(drop_some);
-    mavsdk_groundstation.intercept_incoming_messages_async(drop_some);
+    auto drop_some_handle = mavsdk_groundstation.subscribe_incoming_messages_json(drop_some);
 
     ASSERT_EQ(
         mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
@@ -142,8 +142,7 @@ TEST(Param, CustomSetAndGetLossy)
 
     // Before going out of scope, we need to make sure to no longer access the
     // drop_some callback which accesses the local counter variable.
-    mavsdk_groundstation.intercept_incoming_messages_async(nullptr);
-    mavsdk_groundstation.intercept_incoming_messages_async(nullptr);
+    mavsdk_groundstation.unsubscribe_incoming_messages_json(drop_some_handle);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 }

--- a/cpp/src/system_tests/param_get_all.cpp
+++ b/cpp/src/system_tests/param_get_all.cpp
@@ -128,10 +128,10 @@ TEST(Param, GetAllLossy)
 
     // Drop every third message
     std::atomic<unsigned> counter = 0;
-    auto drop_some = [&counter](mavlink_message_t&) { return counter++ % 5; };
+    auto drop_some = [&counter](Mavsdk::MavlinkMessage) -> bool { return counter++ % 5 != 0; };
 
-    mavsdk_groundstation.intercept_incoming_messages_async(drop_some);
-    mavsdk_groundstation.intercept_outgoing_messages_async(drop_some);
+    auto drop_some_in_handle = mavsdk_groundstation.subscribe_incoming_messages_json(drop_some);
+    auto drop_some_out_handle = mavsdk_groundstation.subscribe_outgoing_messages_json(drop_some);
 
     ASSERT_EQ(
         mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
@@ -183,8 +183,9 @@ TEST(Param, GetAllLossy)
 
     // Before going out of scope, we need to make sure to no longer access the
     // drop_some callback which accesses the local counter variable.
-    mavsdk_groundstation.intercept_incoming_messages_async(nullptr);
-    mavsdk_groundstation.intercept_outgoing_messages_async(nullptr);
+    mavsdk_groundstation.unsubscribe_incoming_messages_json(drop_some_in_handle);
+    mavsdk_groundstation.unsubscribe_outgoing_messages_json(drop_some_out_handle);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 }
+

--- a/cpp/src/system_tests/param_get_all.cpp
+++ b/cpp/src/system_tests/param_get_all.cpp
@@ -188,4 +188,3 @@ TEST(Param, GetAllLossy)
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 }
-

--- a/cpp/src/system_tests/param_set_and_get.cpp
+++ b/cpp/src/system_tests/param_set_and_get.cpp
@@ -102,12 +102,10 @@ TEST(Param, SetAndGetLossy)
     Mavsdk mavsdk_groundstation{Mavsdk::Configuration{ComponentType::GroundStation}};
     mavsdk_groundstation.set_timeout_s(reduced_timeout_s);
 
-    // Drop every third message
+    // Drop every third message to simulate a lossy link
     std::atomic<unsigned> counter = 0;
-    auto drop_some = [&counter](mavlink_message_t&) { return counter++ % 3; };
-
-    mavsdk_groundstation.intercept_incoming_messages_async(drop_some);
-    mavsdk_groundstation.intercept_incoming_messages_async(drop_some);
+    auto drop_handle = mavsdk_groundstation.subscribe_incoming_messages_json(
+        [&counter](Mavsdk::MavlinkMessage) -> bool { return counter++ % 3 != 0; });
 
     Mavsdk mavsdk_autopilot{Mavsdk::Configuration{ComponentType::Autopilot}};
     mavsdk_autopilot.set_timeout_s(reduced_timeout_s);
@@ -175,10 +173,8 @@ TEST(Param, SetAndGetLossy)
     EXPECT_EQ(server_result_all_params.int_params.size(), 1);
     EXPECT_EQ(server_result_all_params.float_params.size(), 1);
 
-    // Before going out of scope, we need to make sure to no longer access the
-    // drop_some callback which accesses the local counter variable.
-    mavsdk_groundstation.intercept_incoming_messages_async(nullptr);
-    mavsdk_groundstation.intercept_incoming_messages_async(nullptr);
+    // Stop dropping before going out of scope
+    mavsdk_groundstation.unsubscribe_incoming_messages_json(drop_handle);
 }
 
 TEST(Param, GetAndChange)

--- a/docs/en/cpp/api_reference/classmavsdk_1_1_mavlink_passthrough.md
+++ b/docs/en/cpp/api_reference/classmavsdk_1_1_mavlink_passthrough.md
@@ -10,17 +10,13 @@ The [MavlinkPassthrough](classmavsdk_1_1_mavlink_passthrough.md) class provides 
 "With great power comes great responsibility." - This plugin allows you to send and receive MAVLink messages. There is no checking or safe-guards, you're on your own, and you have been warned.
 
 
-::: warning
-[MavlinkPassthrough](classmavsdk_1_1_mavlink_passthrough.md) will get deprecated in MAVSDK v4 and will only be available built from source. Use [MavlinkDirect](classmavsdk_1_1_mavlink_direct.md) instead. [MavlinkDirect](classmavsdk_1_1_mavlink_direct.md) provides enhanced functionality including:
-<ul>
-<li><p>Runtime message parsing with JSON field representation</p>
-</li>
-<li><p>Custom message support via XML loading</p>
-</li>
-<li><p>Better language wrapper integration </p>
-</li>
-</ul>
-:::
+<xrefsect id="deprecated_1_deprecated000001"><xreftitle>Deprecated</xreftitle><xrefdescription><para><ref refid="classmavsdk_1_1_mavlink_passthrough" kindref="compound">MavlinkPassthrough</ref> is deprecated as of MAVSDK v4. Use <ref refid="classmavsdk_1_1_mavlink_direct" kindref="compound">MavlinkDirect</ref> instead. <ref refid="classmavsdk_1_1_mavlink_direct" kindref="compound">MavlinkDirect</ref> provides enhanced functionality including:<itemizedlist>
+<listitem><para>Runtime message parsing with JSON field representation</para>
+</listitem><listitem><para>Custom message support via XML loading</para>
+</listitem><listitem><para>Better language wrapper integration </para>
+</listitem></itemizedlist>
+</para>
+</xrefdescription></xrefsect>
 
 
 ## Data Structures
@@ -44,32 +40,32 @@ std::function< void(const mavlink_message_t &)> [MessageCallback](#classmavsdk_1
 
 Type | Name | Description
 ---: | --- | ---
-&nbsp; | [MavlinkPassthrough](#classmavsdk_1_1_mavlink_passthrough_1ad17fc20d2b7c5c6996e0841aaabccb56) ([System](classmavsdk_1_1_system.md) & system) | Constructor. Creates the plugin for a specific [System](classmavsdk_1_1_system.md).
-&nbsp; | [MavlinkPassthrough](#classmavsdk_1_1_mavlink_passthrough_1a9d1fdd3c4aeab8e221ac59612944c299) (std::shared_ptr< [System](classmavsdk_1_1_system.md) > system) | Constructor. Creates the plugin for a specific [System](classmavsdk_1_1_system.md).
+DEPRECATED | [MavlinkPassthrough](#classmavsdk_1_1_mavlink_passthrough_1a3b8db71291e153e753a8a316d58cfaa3) ([System](classmavsdk_1_1_system.md) & system) | Constructor. Creates the plugin for a specific [System](classmavsdk_1_1_system.md).
+DEPRECATED | [MavlinkPassthrough](#classmavsdk_1_1_mavlink_passthrough_1acddc4bdb520f49019f52cdafd74b43f2) (std::shared_ptr< [System](classmavsdk_1_1_system.md) > system) | Constructor. Creates the plugin for a specific [System](classmavsdk_1_1_system.md).
 &nbsp; | [~MavlinkPassthrough](#classmavsdk_1_1_mavlink_passthrough_1a890faef9ad80c3e79e0b785fd07106c8) () | Destructor (internal use only).
 &nbsp; | [MavlinkPassthrough](#classmavsdk_1_1_mavlink_passthrough_1ae4b30f9c2c5e938ab965729e27f50ce5) (const [MavlinkPassthrough](classmavsdk_1_1_mavlink_passthrough.md) &)=delete | Copy Constructor (object is not copyable).
 DEPRECATED [Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793) | [send_message](#classmavsdk_1_1_mavlink_passthrough_1a9bbd09d34f7ae1b6e27bcd5c3d4ba667) (mavlink_message_t & message) | Send message (deprecated).
-[Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793) | [queue_message](#classmavsdk_1_1_mavlink_passthrough_1aa95592bc4da7d56d444b8b5cb5bce814) (std::function< mavlink_message_t([MavlinkAddress](struct_mavlink_address.md) mavlink_address, uint8_t channel)> fun) | Send message by queueing it.
-[Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793) | [send_command_long](#classmavsdk_1_1_mavlink_passthrough_1a7e258aa16b92195e5329e861fb18f8e9) (const [CommandLong](structmavsdk_1_1_mavlink_passthrough_1_1_command_long.md) & command) | Send a MAVLink command_long.
-[Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793) | [send_command_int](#classmavsdk_1_1_mavlink_passthrough_1a654d67a3b136509c76e2ac804a656ada) (const [CommandInt](structmavsdk_1_1_mavlink_passthrough_1_1_command_int.md) & command) | Send a MAVLink command_long.
-mavlink_message_t | [make_command_ack_message](#classmavsdk_1_1_mavlink_passthrough_1aa08cb5d2f9aed795367cf7e05d58bdcc) (const uint8_t target_sysid, const uint8_t target_compid, const uint16_t command, MAV_RESULT result) | Create a command_ack.
-std::pair< [Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793), int32_t > | [get_param_int](#classmavsdk_1_1_mavlink_passthrough_1ad692f8b619f317151831bc53b4f6c168) (const std::string & name, std::optional< uint8_t > maybe_component_id, bool extended) | Request param (int).
-std::pair< [Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793), float > | [get_param_float](#classmavsdk_1_1_mavlink_passthrough_1a347f3921a786865c7bb62817b706c359) (const std::string & name, std::optional< uint8_t > maybe_component_id, bool extended) | Request param (float).
-[MessageHandle](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a2e283239c4429eaeb33deb5821833066) | [subscribe_message](#classmavsdk_1_1_mavlink_passthrough_1ae2ab2426bc0d844e931c266aa26c3607) (uint16_t message_id, const [MessageCallback](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a97f94c54e84fcce94d922fd7f4e3d231) & callback) | Subscribe to messages using message ID.
-void | [unsubscribe_message](#classmavsdk_1_1_mavlink_passthrough_1af4e722ae613e799b60020c30193656be) (uint16_t message_id, [MessageHandle](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a2e283239c4429eaeb33deb5821833066) handle) | Unsubscribe from subscribe_message.
-uint8_t | [get_our_sysid](#classmavsdk_1_1_mavlink_passthrough_1a985b269c1b78ec3e4e9d9468e46e19be) () const | Get our own system ID.
-uint8_t | [get_our_compid](#classmavsdk_1_1_mavlink_passthrough_1a85ddd016ab35d5f3f487b1362723d3cf) () const | Get our own component ID.
-uint8_t | [get_target_sysid](#classmavsdk_1_1_mavlink_passthrough_1a2867d1f37649d62e757bbac0a73b3ebd) () const | Get system ID of target.
-uint8_t | [get_target_compid](#classmavsdk_1_1_mavlink_passthrough_1a22ecab3905237a2f227f77bbab9afd17) () const | Get target component ID.
+DEPRECATED [Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793) | [queue_message](#classmavsdk_1_1_mavlink_passthrough_1a272f72328f6298eb80332edacc0f7d38) (std::function< mavlink_message_t([MavlinkAddress](struct_mavlink_address.md) mavlink_address, uint8_t channel)> fun) | Send message by queueing it.
+DEPRECATED [Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793) | [send_command_long](#classmavsdk_1_1_mavlink_passthrough_1a3c0d1373da35e5812ed1f70215ffa095) (const [CommandLong](structmavsdk_1_1_mavlink_passthrough_1_1_command_long.md) & command) | Send a MAVLink command_long.
+DEPRECATED [Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793) | [send_command_int](#classmavsdk_1_1_mavlink_passthrough_1aaad7aef7c0f7009e31aed0470483db2b) (const [CommandInt](structmavsdk_1_1_mavlink_passthrough_1_1_command_int.md) & command) | Send a MAVLink command_long.
+DEPRECATED mavlink_message_t | [make_command_ack_message](#classmavsdk_1_1_mavlink_passthrough_1ab2ff746c12d2fead5eecb5d9eff5f1bb) (const uint8_t target_sysid, const uint8_t target_compid, const uint16_t command, MAV_RESULT result) | Create a command_ack.
+DEPRECATED std::pair< [Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793), int32_t > | [get_param_int](#classmavsdk_1_1_mavlink_passthrough_1a7abe72a086741674ae6a27d545b4ccc3) (const std::string & name, std::optional< uint8_t > maybe_component_id, bool extended) | Request param (int).
+DEPRECATED std::pair< [Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793), float > | [get_param_float](#classmavsdk_1_1_mavlink_passthrough_1a1d537c9ad28f89fa220c7a1aadf83668) (const std::string & name, std::optional< uint8_t > maybe_component_id, bool extended) | Request param (float).
+DEPRECATED [MessageHandle](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a2e283239c4429eaeb33deb5821833066) | [subscribe_message](#classmavsdk_1_1_mavlink_passthrough_1a1e9e4ef7c75d7b69a863a1aaf4dfd96b) (uint16_t message_id, const [MessageCallback](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a97f94c54e84fcce94d922fd7f4e3d231) & callback) | Subscribe to messages using message ID.
+DEPRECATED void | [unsubscribe_message](#classmavsdk_1_1_mavlink_passthrough_1a419a26941e923a42362c37d5e509ed8d) (uint16_t message_id, [MessageHandle](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a2e283239c4429eaeb33deb5821833066) handle) | Unsubscribe from subscribe_message.
+DEPRECATED uint8_t | [get_our_sysid](#classmavsdk_1_1_mavlink_passthrough_1a92417cb2892173b70b9458f9678bfea9) () const | Get our own system ID.
+DEPRECATED uint8_t | [get_our_compid](#classmavsdk_1_1_mavlink_passthrough_1a260b865afbeadfb6349ce242a4b997da) () const | Get our own component ID.
+DEPRECATED uint8_t | [get_target_sysid](#classmavsdk_1_1_mavlink_passthrough_1a319e2cec657560acb8a6c01175febf65) () const | Get system ID of target.
+DEPRECATED uint8_t | [get_target_compid](#classmavsdk_1_1_mavlink_passthrough_1a7b769a42fabf11c099cc28948ece2903) () const | Get target component ID.
 const [MavlinkPassthrough](classmavsdk_1_1_mavlink_passthrough.md) & | [operator=](#classmavsdk_1_1_mavlink_passthrough_1a39b74b37094511cc5bc910a2233d024e) (const [MavlinkPassthrough](classmavsdk_1_1_mavlink_passthrough.md) &)=delete | Equality operator (object is not copyable).
 
 
 ## Constructor & Destructor Documentation
 
 
-### MavlinkPassthrough() {#classmavsdk_1_1_mavlink_passthrough_1ad17fc20d2b7c5c6996e0841aaabccb56}
+### MavlinkPassthrough() {#classmavsdk_1_1_mavlink_passthrough_1a3b8db71291e153e753a8a316d58cfaa3}
 ```cpp
-mavsdk::MavlinkPassthrough::MavlinkPassthrough(System &system)
+DEPRECATED mavsdk::MavlinkPassthrough::MavlinkPassthrough(System &system)
 ```
 
 
@@ -85,9 +81,13 @@ auto mavlink_passthrough = MavlinkPassthrough(system);
 
 * [System](classmavsdk_1_1_system.md)& **system** - The specific system associated with this plugin.
 
-### MavlinkPassthrough() {#classmavsdk_1_1_mavlink_passthrough_1a9d1fdd3c4aeab8e221ac59612944c299}
+**Returns**
+
+&emsp;DEPRECATED - 
+
+### MavlinkPassthrough() {#classmavsdk_1_1_mavlink_passthrough_1acddc4bdb520f49019f52cdafd74b43f2}
 ```cpp
-mavsdk::MavlinkPassthrough::MavlinkPassthrough(std::shared_ptr< System > system)
+DEPRECATED mavsdk::MavlinkPassthrough::MavlinkPassthrough(std::shared_ptr< System > system)
 ```
 
 
@@ -102,6 +102,10 @@ auto mavlink_passthrough = MavlinkPassthrough(system);
 **Parameters**
 
 * std::shared_ptr< [System](classmavsdk_1_1_system.md) > **system** - The specific system associated with this plugin.
+
+**Returns**
+
+&emsp;DEPRECATED - 
 
 ### ~MavlinkPassthrough() {#classmavsdk_1_1_mavlink_passthrough_1a890faef9ad80c3e79e0b785fd07106c8}
 ```cpp
@@ -187,7 +191,7 @@ DEPRECATED Result mavsdk::MavlinkPassthrough::send_message(mavlink_message_t &me
 Send message (deprecated).
 
 ::: info
-This interface is deprecated. Instead the method [queue_message()](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1aa95592bc4da7d56d444b8b5cb5bce814) should be used.
+This interface is deprecated. Instead the method [queue_message()](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a272f72328f6298eb80332edacc0f7d38) should be used.
 :::
 
 **Parameters**
@@ -198,9 +202,9 @@ This interface is deprecated. Instead the method [queue_message()](classmavsdk_1
 
 &emsp;DEPRECATED [Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793) - result of the request.
 
-### queue_message() {#classmavsdk_1_1_mavlink_passthrough_1aa95592bc4da7d56d444b8b5cb5bce814}
+### queue_message() {#classmavsdk_1_1_mavlink_passthrough_1a272f72328f6298eb80332edacc0f7d38}
 ```cpp
-Result mavsdk::MavlinkPassthrough::queue_message(std::function< mavlink_message_t(MavlinkAddress mavlink_address, uint8_t channel)> fun)
+DEPRECATED Result mavsdk::MavlinkPassthrough::queue_message(std::function< mavlink_message_t(MavlinkAddress mavlink_address, uint8_t channel)> fun)
 ```
 
 
@@ -218,11 +222,11 @@ The interface changed in order to prevent accessing the internal MAVLink status 
 
 **Returns**
 
-&emsp;[Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793) - result of request
+&emsp;DEPRECATED [Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793) - result of request
 
-### send_command_long() {#classmavsdk_1_1_mavlink_passthrough_1a7e258aa16b92195e5329e861fb18f8e9}
+### send_command_long() {#classmavsdk_1_1_mavlink_passthrough_1a3c0d1373da35e5812ed1f70215ffa095}
 ```cpp
-Result mavsdk::MavlinkPassthrough::send_command_long(const CommandLong &command)
+DEPRECATED Result mavsdk::MavlinkPassthrough::send_command_long(const CommandLong &command)
 ```
 
 
@@ -235,11 +239,11 @@ Send a MAVLink command_long.
 
 **Returns**
 
-&emsp;[Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793) - result of the request.
+&emsp;DEPRECATED [Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793) - result of the request.
 
-### send_command_int() {#classmavsdk_1_1_mavlink_passthrough_1a654d67a3b136509c76e2ac804a656ada}
+### send_command_int() {#classmavsdk_1_1_mavlink_passthrough_1aaad7aef7c0f7009e31aed0470483db2b}
 ```cpp
-Result mavsdk::MavlinkPassthrough::send_command_int(const CommandInt &command)
+DEPRECATED Result mavsdk::MavlinkPassthrough::send_command_int(const CommandInt &command)
 ```
 
 
@@ -252,11 +256,11 @@ Send a MAVLink command_long.
 
 **Returns**
 
-&emsp;[Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793) - result of the request.
+&emsp;DEPRECATED [Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793) - result of the request.
 
-### make_command_ack_message() {#classmavsdk_1_1_mavlink_passthrough_1aa08cb5d2f9aed795367cf7e05d58bdcc}
+### make_command_ack_message() {#classmavsdk_1_1_mavlink_passthrough_1ab2ff746c12d2fead5eecb5d9eff5f1bb}
 ```cpp
-mavlink_message_t mavsdk::MavlinkPassthrough::make_command_ack_message(const uint8_t target_sysid, const uint8_t target_compid, const uint16_t command, MAV_RESULT result)
+DEPRECATED mavlink_message_t mavsdk::MavlinkPassthrough::make_command_ack_message(const uint8_t target_sysid, const uint8_t target_compid, const uint16_t command, MAV_RESULT result)
 ```
 
 
@@ -272,11 +276,11 @@ Create a command_ack.
 
 **Returns**
 
-&emsp;mavlink_message_t - message to send.
+&emsp;DEPRECATED mavlink_message_t - message to send.
 
-### get_param_int() {#classmavsdk_1_1_mavlink_passthrough_1ad692f8b619f317151831bc53b4f6c168}
+### get_param_int() {#classmavsdk_1_1_mavlink_passthrough_1a7abe72a086741674ae6a27d545b4ccc3}
 ```cpp
-std::pair< Result, int32_t > mavsdk::MavlinkPassthrough::get_param_int(const std::string &name, std::optional< uint8_t > maybe_component_id, bool extended)
+DEPRECATED std::pair< Result, int32_t > mavsdk::MavlinkPassthrough::get_param_int(const std::string &name, std::optional< uint8_t > maybe_component_id, bool extended)
 ```
 
 
@@ -291,11 +295,11 @@ Request param (int).
 
 **Returns**
 
-&emsp;std::pair< [Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793), int32_t > - 
+&emsp;DEPRECATED std::pair< [Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793), int32_t > - 
 
-### get_param_float() {#classmavsdk_1_1_mavlink_passthrough_1a347f3921a786865c7bb62817b706c359}
+### get_param_float() {#classmavsdk_1_1_mavlink_passthrough_1a1d537c9ad28f89fa220c7a1aadf83668}
 ```cpp
-std::pair< Result, float > mavsdk::MavlinkPassthrough::get_param_float(const std::string &name, std::optional< uint8_t > maybe_component_id, bool extended)
+DEPRECATED std::pair< Result, float > mavsdk::MavlinkPassthrough::get_param_float(const std::string &name, std::optional< uint8_t > maybe_component_id, bool extended)
 ```
 
 
@@ -310,11 +314,11 @@ Request param (float).
 
 **Returns**
 
-&emsp;std::pair< [Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793), float > - 
+&emsp;DEPRECATED std::pair< [Result](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a265eacaeea064a31de3fe16d1e357793), float > - 
 
-### subscribe_message() {#classmavsdk_1_1_mavlink_passthrough_1ae2ab2426bc0d844e931c266aa26c3607}
+### subscribe_message() {#classmavsdk_1_1_mavlink_passthrough_1a1e9e4ef7c75d7b69a863a1aaf4dfd96b}
 ```cpp
-MessageHandle mavsdk::MavlinkPassthrough::subscribe_message(uint16_t message_id, const MessageCallback &callback)
+DEPRECATED MessageHandle mavsdk::MavlinkPassthrough::subscribe_message(uint16_t message_id, const MessageCallback &callback)
 ```
 
 
@@ -329,11 +333,11 @@ This means that all future messages being received will trigger the callback to 
 
 **Returns**
 
-&emsp;[MessageHandle](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a2e283239c4429eaeb33deb5821833066) - 
+&emsp;DEPRECATED [MessageHandle](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a2e283239c4429eaeb33deb5821833066) - 
 
-### unsubscribe_message() {#classmavsdk_1_1_mavlink_passthrough_1af4e722ae613e799b60020c30193656be}
+### unsubscribe_message() {#classmavsdk_1_1_mavlink_passthrough_1a419a26941e923a42362c37d5e509ed8d}
 ```cpp
-void mavsdk::MavlinkPassthrough::unsubscribe_message(uint16_t message_id, MessageHandle handle)
+DEPRECATED void mavsdk::MavlinkPassthrough::unsubscribe_message(uint16_t message_id, MessageHandle handle)
 ```
 
 
@@ -345,9 +349,13 @@ Unsubscribe from subscribe_message.
 * uint16_t **message_id** - The MAVLink message ID.
 * [MessageHandle](classmavsdk_1_1_mavlink_passthrough.md#classmavsdk_1_1_mavlink_passthrough_1a2e283239c4429eaeb33deb5821833066) **handle** - The handle returned from subscribe_message.
 
-### get_our_sysid() {#classmavsdk_1_1_mavlink_passthrough_1a985b269c1b78ec3e4e9d9468e46e19be}
+**Returns**
+
+&emsp;DEPRECATED void - 
+
+### get_our_sysid() {#classmavsdk_1_1_mavlink_passthrough_1a92417cb2892173b70b9458f9678bfea9}
 ```cpp
-uint8_t mavsdk::MavlinkPassthrough::get_our_sysid() const
+DEPRECATED uint8_t mavsdk::MavlinkPassthrough::get_our_sysid() const
 ```
 
 
@@ -356,11 +364,11 @@ Get our own system ID.
 
 **Returns**
 
-&emsp;uint8_t - our own system ID.
+&emsp;DEPRECATED uint8_t - our own system ID.
 
-### get_our_compid() {#classmavsdk_1_1_mavlink_passthrough_1a85ddd016ab35d5f3f487b1362723d3cf}
+### get_our_compid() {#classmavsdk_1_1_mavlink_passthrough_1a260b865afbeadfb6349ce242a4b997da}
 ```cpp
-uint8_t mavsdk::MavlinkPassthrough::get_our_compid() const
+DEPRECATED uint8_t mavsdk::MavlinkPassthrough::get_our_compid() const
 ```
 
 
@@ -369,11 +377,11 @@ Get our own component ID.
 
 **Returns**
 
-&emsp;uint8_t - our own component ID.
+&emsp;DEPRECATED uint8_t - our own component ID.
 
-### get_target_sysid() {#classmavsdk_1_1_mavlink_passthrough_1a2867d1f37649d62e757bbac0a73b3ebd}
+### get_target_sysid() {#classmavsdk_1_1_mavlink_passthrough_1a319e2cec657560acb8a6c01175febf65}
 ```cpp
-uint8_t mavsdk::MavlinkPassthrough::get_target_sysid() const
+DEPRECATED uint8_t mavsdk::MavlinkPassthrough::get_target_sysid() const
 ```
 
 
@@ -382,11 +390,11 @@ Get system ID of target.
 
 **Returns**
 
-&emsp;uint8_t - system ID of target.
+&emsp;DEPRECATED uint8_t - system ID of target.
 
-### get_target_compid() {#classmavsdk_1_1_mavlink_passthrough_1a22ecab3905237a2f227f77bbab9afd17}
+### get_target_compid() {#classmavsdk_1_1_mavlink_passthrough_1a7b769a42fabf11c099cc28948ece2903}
 ```cpp
-uint8_t mavsdk::MavlinkPassthrough::get_target_compid() const
+DEPRECATED uint8_t mavsdk::MavlinkPassthrough::get_target_compid() const
 ```
 
 
@@ -396,7 +404,7 @@ This defaults to the component ID of the autopilot (1) if available and otherwis
 
 **Returns**
 
-&emsp;uint8_t - component ID of target.
+&emsp;DEPRECATED uint8_t - component ID of target.
 
 ### operator=() {#classmavsdk_1_1_mavlink_passthrough_1a39b74b37094511cc5bc910a2233d024e}
 ```cpp

--- a/docs/en/cpp/api_reference/classmavsdk_1_1_mavsdk.md
+++ b/docs/en/cpp/api_reference/classmavsdk_1_1_mavsdk.md
@@ -67,10 +67,10 @@ std::shared_ptr< [ServerComponent](classmavsdk_1_1_server_component.md) > | [ser
 void | [unsubscribe_incoming_messages_json](#classmavsdk_1_1_mavsdk_1a4be244c38939cb517c2061baf4d43386) ([InterceptJsonHandle](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a3b40ae4fd8af4c4419b61f0ad955812f) handle) | Unsubscribe from incoming messages as JSON.
 [InterceptJsonHandle](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a3b40ae4fd8af4c4419b61f0ad955812f) | [subscribe_outgoing_messages_json](#classmavsdk_1_1_mavsdk_1a58f85b2f74a32404a8e975feefed8f47) (const [InterceptJsonCallback](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a17923db3b1504e911487729114b68f48) & callback) | Intercept outgoing messages as JSON.
 void | [unsubscribe_outgoing_messages_json](#classmavsdk_1_1_mavsdk_1aa3a490358db87cfed617cdad902bb753) ([InterceptJsonHandle](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a3b40ae4fd8af4c4419b61f0ad955812f) handle) | Unsubscribe from outgoing messages as JSON.
-void | [intercept_incoming_messages_async](#classmavsdk_1_1_mavsdk_1ac80c8909958533131cbdbc61d061794f) (std::function< bool(mavlink_message_t &)> callback) | Intercept incoming messages.
+DEPRECATED void | [intercept_incoming_messages_async](#classmavsdk_1_1_mavsdk_1a4a6e5997a4e46c965bf287f9350fa44b) (std::function< bool(mavlink_message_t &)> callback) | Intercept incoming messages.
 bool | [start_tlog_recording](#classmavsdk_1_1_mavsdk_1af8ed201951f4b264a864217c5e5db5c1) (const std::string & path) | Start recording all incoming MAVLink traffic to a .tlog file.
 void | [stop_tlog_recording](#classmavsdk_1_1_mavsdk_1a507d9f58439233b5ddd3d5d1ba30bc0c) () | Stop recording and close the .tlog file.
-void | [intercept_outgoing_messages_async](#classmavsdk_1_1_mavsdk_1a040ee5c1d41e71c0d63cf8f76d2db275) (std::function< bool(mavlink_message_t &)> callback) | Intercept outgoing messages.
+DEPRECATED void | [intercept_outgoing_messages_async](#classmavsdk_1_1_mavsdk_1a8c9df4be715d1ec5f8113d232a189e5b) (std::function< bool(mavlink_message_t &)> callback) | Intercept outgoing messages.
 void | [pass_received_raw_bytes](#classmavsdk_1_1_mavsdk_1a65329315ac07bae110839d9e054fbc05) (const char * bytes, size_t length) | Pass received raw MAVLink bytes.
 [RawBytesHandle](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1ac766258f137aa3e8b0dabb5a66435ea1) | [subscribe_raw_bytes_to_be_sent](#classmavsdk_1_1_mavsdk_1a116e9bab0efdf7ec90866107ef517b20) ([RawBytesCallback](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1acb5be9a1be97d251387ffe87ae8b9eb0) callback) | Subscribe to raw bytes to be sent.
 void | [unsubscribe_raw_bytes_to_be_sent](#classmavsdk_1_1_mavsdk_1af6ec813a9728f4258056fa1f5d399eb1) ([RawBytesHandle](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1ac766258f137aa3e8b0dabb5a66435ea1) handle) | Unsubscribe from raw bytes to be sent.
@@ -630,9 +630,9 @@ Unsubscribe from outgoing messages as JSON.
 
 * [InterceptJsonHandle](classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a3b40ae4fd8af4c4419b61f0ad955812f) **handle** - 
 
-### intercept_incoming_messages_async() {#classmavsdk_1_1_mavsdk_1ac80c8909958533131cbdbc61d061794f}
+### intercept_incoming_messages_async() {#classmavsdk_1_1_mavsdk_1a4a6e5997a4e46c965bf287f9350fa44b}
 ```cpp
-void mavsdk::Mavsdk::intercept_incoming_messages_async(std::function< bool(mavlink_message_t &)> callback)
+DEPRECATED void mavsdk::Mavsdk::intercept_incoming_messages_async(std::function< bool(mavlink_message_t &)> callback)
 ```
 
 
@@ -648,6 +648,10 @@ This functionality is provided primarily for testing in order to simulate packet
 **Parameters**
 
 * std::function< bool(mavlink_message_t &)> **callback** - Callback to be called for each incoming message. To drop a message, return 'false' from the callback.
+
+**Returns**
+
+&emsp;DEPRECATED void - 
 
 ### start_tlog_recording() {#classmavsdk_1_1_mavsdk_1af8ed201951f4b264a864217c5e5db5c1}
 ```cpp
@@ -683,9 +687,9 @@ Stop recording and close the .tlog file.
 
 Does nothing if recording is not active. Automatically called on [Mavsdk](classmavsdk_1_1_mavsdk.md) destruction.
 
-### intercept_outgoing_messages_async() {#classmavsdk_1_1_mavsdk_1a040ee5c1d41e71c0d63cf8f76d2db275}
+### intercept_outgoing_messages_async() {#classmavsdk_1_1_mavsdk_1a8c9df4be715d1ec5f8113d232a189e5b}
 ```cpp
-void mavsdk::Mavsdk::intercept_outgoing_messages_async(std::function< bool(mavlink_message_t &)> callback)
+DEPRECATED void mavsdk::Mavsdk::intercept_outgoing_messages_async(std::function< bool(mavlink_message_t &)> callback)
 ```
 
 
@@ -701,6 +705,10 @@ This functionality is provided primarily for testing in order to simulate packet
 **Parameters**
 
 * std::function< bool(mavlink_message_t &)> **callback** - Callback to be called for each outgoing message. To drop a message, return 'false' from the callback.
+
+**Returns**
+
+&emsp;DEPRECATED void - 
 
 ### pass_received_raw_bytes() {#classmavsdk_1_1_mavsdk_1a65329315ac07bae110839d9e054fbc05}
 ```cpp


### PR DESCRIPTION
Marks the old MAVLink APIs as deprecated ahead of v4:

- `Mavsdk::intercept_incoming_messages_async()` — use `subscribe_incoming_messages_json()` instead
- `Mavsdk::intercept_outgoing_messages_async()` — use `subscribe_outgoing_messages_json()` instead
- `MavlinkPassthrough` class — use `MavlinkDirect` instead

The JSON-based replacements were added in #2638, which stated the old API would be replaced "by the next major release". MavlinkPassthrough already had a docstring warning; this adds the machine-readable `[[deprecated]]` attribute so compilers emit warnings at call sites.