### PR TITLE
docs: fix issues from MAVSDK-docs tracker

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -148,6 +148,10 @@ export default defineConfig({
             text: "v2",
             link: "https://mavsdk.mavlink.io/v2.0/en/",
           },
+          {
+            text: "v1",
+            link: "https://mavsdk.mavlink.io/v1.4/en/",
+          },
         ],
       },
     ],

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -138,19 +138,15 @@ export default defineConfig({
         items: [
           {
             text: "main / v4",
-            link: "https://mavsdk.mavlink.io/main/en/cpp/api_changes.html",
+            link: "https://mavsdk.mavlink.io/main/en/",
           },
           {
             text: "v3",
-            link: "https://mavsdk.mavlink.io/v3/en/cpp/api_changes.html",
+            link: "https://mavsdk.mavlink.io/v3/en/",
           },
           {
             text: "v2",
-            link: "https://mavsdk.mavlink.io/v2.0/en/cpp/api_changes.html",
-          },
-          {
-            text: "v1.4",
-            link: "https://mavsdk.mavlink.io/v1.4/en/cpp/api_changes.html",
+            link: "https://mavsdk.mavlink.io/v2.0/en/",
           },
         ],
       },

--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -21,7 +21,7 @@
         * [Plugin/Test Logging](cpp/guide/dev_logging.md)
         * [Testing](cpp/guide/test.md)
         * [Build on Linux](cpp/guide/build_linux.md)
-        * [Building on macOS](cpp/guide/build.md)
+        * [Building on macOS](cpp/guide/build_macos.md)
         * [Building on Windows](cpp/guide/build_windows.md)
         * [Building using Dockcross](cpp/guide/build_dockcross.md)
         * [Generate API docs from Source](cpp/guide/build_docs.md)

--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -14,6 +14,8 @@
         * [Missions](cpp/guide/missions.md)
         * [Offboard Control](cpp/guide/offboard.md)
         * [Follow Me](cpp/guide/follow_me.md)
+        * [Camera](cpp/guide/camera.md)
+        * [Gimbal](cpp/guide/gimbal.md)
         * [VTOL Support](cpp/guide/vtol.md)
         * [MavlinkDirect](cpp/guide/mavlink_direct.md)
         * [Building C++ Apps](cpp/guide/toolchain.md)

--- a/docs/en/cpp/contributing/documentation.md
+++ b/docs/en/cpp/contributing/documentation.md
@@ -9,10 +9,10 @@ You will need a [Github](https://github.com/) login to make and submit changes t
 
 ## Overview
 
-This guide is written in [markdown](https://github.com/GitbookIO/gitbook/blob/master/docs/syntax/markdown.md) wiki syntax and stored in the Github [mavlink/MAVSDK-docs](https://github.com/mavlink/MAVSDK-docs) repo.
+This guide is written in [markdown](https://vitepress.dev/guide/markdown) and stored in the Github [mavlink/MAVSDK](https://github.com/mavlink/MAVSDK) repository under the `docs/` folder.
 
-The [API Reference](../api_reference/index.md) section is compiled from source code into markdown using a [separate toolchain](#api-reference) and then copied into Github.
-Updates to the reference should be made in the [source code repository](https://github.com/mavlink/MAVSDK) (see [API Reference](#api-reference) below for more information).
+The [API Reference](../api_reference/index.md) section is compiled from source code into markdown using a [separate toolchain](#api-reference) and then checked in.
+Updates to the reference should be made in the [source code](https://github.com/mavlink/MAVSDK) (see [API Reference](#api-reference) below for more information).
 
 The guide is licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) - if you make any changes then they will be made available under the same license.
 
@@ -21,38 +21,28 @@ The guide is licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/
 
 Simple fixes to an existing page can be made directly on Github:
 
-1. Click the **Edit** button in the top toolbar to open the page
-
-   ![Edit page](../../../assets/site/gitbook_toolbar_edit.png)
-
-1. Make required changes in the editor section near the top of the page.
-2. At the bottom of the page, add a comment and select the second radio button to create a new branch.
-
-   ![Edit page](../../../assets/site/github_edit.png)
-
-3. Follow the on-screen instructions to create a pull request with your change.
+1. Navigate to the relevant file in the [docs/en/](https://github.com/mavlink/MAVSDK/tree/main/docs/en) folder.
+1. Click the pencil (edit) icon to open the file editor.
+1. Make the required changes.
+1. At the bottom of the page, enter a commit message and select **Create a new branch** to open a pull request.
 
 
 ## Raising an Issue
 
-To raise an issue against the documentation:
-
-1. Open the page with problem content.
-1. Click the **Bug** button in the top toolbar.
-
-   ![Raise bug](../../../assets/site/gitbook_toolbar_bug.png)
-
-   This will open a bug in Github, seeded with the URL/name for the current page.
-1. Enter enough information for someone to understand the problem, and ideally to fix it.
-
-TODO: still valid?
+To raise an issue against the documentation, open a [Github issue](https://github.com/mavlink/MAVSDK/issues) and include the page URL and a description of the problem.
 
 
-## Making a Big Change
+## Building the Docs Locally
 
-If you want to make more significant changes or additions to the documentation you will need to set up *Git* and the *Gitbook* toolchain (this allows you to render the documentation and check that links work).
+The docs use [VitePress](https://vitepress.dev/). To build and preview locally:
 
-For setup information see: [Gitbook toolchain](https://github.com/GitbookIO/gitbook/blob/master/docs/setup.md).
+```bash
+cd docs
+npm install
+npm run dev
+```
+
+This starts a local dev server at `http://localhost:5173`.
 
 
 ## API Reference
@@ -60,6 +50,6 @@ For setup information see: [Gitbook toolchain](https://github.com/GitbookIO/gitb
 The C++ public header files are annotated using docstrings using [Doxygen](http://doxygen.nl/manual/index.html) syntax.
 You can extract the documentation to markdown files (one per class) on macOS or Linux using the instructions in [Build API Reference Documentation](../guide/build_docs.md).
 
-In order to include new API reference in the *SDK Documentation* it must be manually added to the [Github repository](https://github.com/mavlink/MAVSDK-docs):
-- Copy the files into the [/en/cpp/api_reference](https://github.com/mavlink/MAVSDK-docs/tree/main/en/cpp/api_reference) folder
-- *New* APIs should be added to appropriate sections in the [MAVSDK-docs/en/SUMMARY.md](https://github.com/mavlink/MAVSDK-docs/blob/main/en/SUMMARY.md) and [/en/cpp/api_reference/README.md](https://github.com/mavlink/MAVSDK-docs/blob/main/en/cpp/api_reference/README.md).
+In order to include new API reference in the documentation:
+- Copy the generated files into the [docs/en/cpp/api_reference](https://github.com/mavlink/MAVSDK/tree/main/docs/en/cpp/api_reference) folder
+- *New* APIs should be added to the appropriate sections in [docs/en/SUMMARY.md](https://github.com/mavlink/MAVSDK/tree/main/docs/en/SUMMARY.md) and [docs/en/cpp/api_reference/index.md](https://github.com/mavlink/MAVSDK/tree/main/docs/en/cpp/api_reference/index.md).

--- a/docs/en/cpp/contributing/plugins.md
+++ b/docs/en/cpp/contributing/plugins.md
@@ -182,7 +182,7 @@ Once the proto file has been created, you can generate all files required for th
 
 1. Run the configure step to prepare the tools required:
    ```
-   cmake -DBUILD_MAVSDK_SERVER=ON -Bbuild/default -S.
+   cmake -DBUILD_MAVSDK_SERVER=ON -B build/default -S.
    ```
 1. Install `protoc_gen_mavsdk` which is required for the auto-generation:
    ```

--- a/docs/en/cpp/contributing/plugins.md
+++ b/docs/en/cpp/contributing/plugins.md
@@ -182,7 +182,7 @@ Once the proto file has been created, you can generate all files required for th
 
 1. Run the configure step to prepare the tools required:
    ```
-   cmake -DBUILD_MAVSDK_SERVER=ON -B build/default -S.
+   cmake -DBUILD_MAVSDK_SERVER=ON -B build/default -S .
    ```
 1. Install `protoc_gen_mavsdk` which is required for the auto-generation:
    ```

--- a/docs/en/cpp/contributing/release.md
+++ b/docs/en/cpp/contributing/release.md
@@ -32,23 +32,12 @@ The idea is of course to automate this as much as possible.
    - `brew bump-formula-pr mavsdk --tag=vX.Y.Z --revision=<GIT HASH>`
    - This should then open the browser with the pull request already created.
 
-## MAVSDK-docs part
+## Documentation part
 
-1. [Generate the docs](../guide/build_docs.md) and update the reference docs.
-1. Check or update the examples in the docs.
-1. Create a branch off `main` for the release
-   - Create the branch
-     ```
-     git switch main
-     git pull
-     git switch -c vX.Y
-     ```
-   - Modify **book.json** in the vX.Y branch to change the value of `github_branch` to match the new branch: `"github_branch": "vX.Y"`
-   - Push the branch to the upstream repo
-     ```
-     git push origin vX.Y
-     ```
-1. Add the branch to the version checker in main branch [book.json](https://github.com/mavlink/MAVSDK-docs/blob/main/book.json) (see pattern below `versions`).
+Documentation is now in-tree under the `docs/` folder in this repository, so it is released together with the code.
+
+1. [Generate the API reference docs](../guide/build_docs.md) and commit any changes to `docs/en/cpp/api_reference/`.
+1. Check or update the examples and guides in `docs/en/` as needed.
 
 ## Other
 

--- a/docs/en/cpp/examples/index.md
+++ b/docs/en/cpp/examples/index.md
@@ -75,7 +75,7 @@ See [installation guide](../guide/installation.md) if that is not already the ca
 Then build the example:
 ```sh
 cd cpp/examples/takeoff_and_land/
-cmake -B build -S.
+cmake -B build -S .
 cmake --build build -j4
 ```
 

--- a/docs/en/cpp/examples/index.md
+++ b/docs/en/cpp/examples/index.md
@@ -75,7 +75,7 @@ See [installation guide](../guide/installation.md) if that is not already the ca
 Then build the example:
 ```sh
 cd cpp/examples/takeoff_and_land/
-cmake -Bbuild -S.
+cmake -B build -S.
 cmake --build build -j4
 ```
 
@@ -83,7 +83,7 @@ cmake --build build -j4
 if MAVSDK is installed locally (e.g. on Windows) you need to pass the location to cmake:
 
 ```
-cmake -Bbuild -DCMAKE_PREFIX_PATH=wherever_mavsdk_is_locally_installed
+cmake -B build -DCMAKE_PREFIX_PATH=wherever_mavsdk_is_locally_installed
 ```
 :::
 

--- a/docs/en/cpp/examples/transition_vtol_fixed_wing.md
+++ b/docs/en/cpp/examples/transition_vtol_fixed_wing.md
@@ -74,5 +74,5 @@ The operation of the transition code is discussed in the guide: [Takeoff and Lan
 
 ## Source code {#source_code}
 
-- [CMakeLists.txt](https://github.com/JoC2000/MAVSDK/blob/main/cpp/examples/vtol_transition/CMakeLists.txt)
-- [transition_vtol_fixed_wing.cpp](https://github.com/JoC2000/MAVSDK/blob/main/cpp/examples/vtol_transition/vtol_transition.cpp)
+- [CMakeLists.txt](https://github.com/mavlink/MAVSDK/blob/main/cpp/examples/vtol_transition/CMakeLists.txt)
+- [transition_vtol_fixed_wing.cpp](https://github.com/mavlink/MAVSDK/blob/main/cpp/examples/vtol_transition/vtol_transition.cpp)

--- a/docs/en/cpp/guide/build_dockcross.md
+++ b/docs/en/cpp/guide/build_dockcross.md
@@ -32,7 +32,7 @@ docker run --rm dockcross/linux-armv7 > ./dockcross-linux-armv7
 chmod +x ./dockcross-linux-armv7
 
 # Use the script to run cmake and build
-./dockcross-linux-armv7 bash -c 'cmake -DCMAKE_BUILD_TYPE=Release -Bbuild -S. && cmake --build build'
+./dockcross-linux-armv7 bash -c 'cmake -DCMAKE_BUILD_TYPE=Release -B build -S. && cmake --build build'
 ```
 
 ## Building for Android
@@ -77,7 +77,7 @@ cmake \
     -DANDROID_ABI=arm64-v8a \
     -DANDROID_PLATFORM=android-28 \
     -DCMAKE_BUILD_TYPE=Release \
-    -Bbuild/android \
+    -B build/android \
     -S.
 
 cmake --build build/android

--- a/docs/en/cpp/guide/build_dockcross.md
+++ b/docs/en/cpp/guide/build_dockcross.md
@@ -32,7 +32,7 @@ docker run --rm dockcross/linux-armv7 > ./dockcross-linux-armv7
 chmod +x ./dockcross-linux-armv7
 
 # Use the script to run cmake and build
-./dockcross-linux-armv7 bash -c 'cmake -DCMAKE_BUILD_TYPE=Release -B build -S. && cmake --build build'
+./dockcross-linux-armv7 bash -c 'cmake -DCMAKE_BUILD_TYPE=Release -B build -S . && cmake --build build'
 ```
 
 ## Building for Android
@@ -78,7 +78,7 @@ cmake \
     -DANDROID_PLATFORM=android-28 \
     -DCMAKE_BUILD_TYPE=Release \
     -B build/android \
-    -S.
+    -S .
 
 cmake --build build/android
 ```

--- a/docs/en/cpp/guide/build_linux.md
+++ b/docs/en/cpp/guide/build_linux.md
@@ -35,7 +35,7 @@ cd cpp
 
 For development, use the debug build:
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Debug -B build -S.
+cmake -DCMAKE_BUILD_TYPE=Debug -B build -S .
 cmake --build build -j8
 ```
 
@@ -43,7 +43,7 @@ cmake --build build -j8
 
 For production use, build with optimizations enabled:
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Release -B build -S.
+cmake -DCMAKE_BUILD_TYPE=Release -B build -S .
 cmake --build build -j8
 ```
 
@@ -62,7 +62,7 @@ sudo ldconfig  # Update linker cache
 To install to a custom location, e.g. `install`
 
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -B build -S.
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -B build -S .
 cmake --build build --target install
 ```
 
@@ -75,7 +75,7 @@ For more information about the architecture, also see [how the auto-generation w
 In order to include the mavsdk_server in the build, add `-DBUILD_MAVSDK_SERVER=ON`:
 
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_MAVSDK_SERVER=ON -B build -S.
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_MAVSDK_SERVER=ON -B build -S .
 cmake --build build -j8
 ```
 
@@ -110,18 +110,18 @@ Examples:
 
 ```bash
 # Build with development dialect
-cmake -DCMAKE_BUILD_TYPE=Debug -DMAVLINK_DIALECT=development -B build -S.
+cmake -DCMAKE_BUILD_TYPE=Debug -DMAVLINK_DIALECT=development -B build -S .
 
 # Use a custom MAVLink repository fork
 cmake -DCMAKE_BUILD_TYPE=Debug \
     -DMAVLINK_URL=https://github.com/yourfork/mavlink \
     -DMAVLINK_HASH=abc123def456 \
-    -B build -S.
+    -B build -S .
 
 # Use local MAVLink XML files
 cmake -DCMAKE_BUILD_TYPE=Debug \
     -DMAVLINK_XML_PATH=/path/to/mavlink/message_definitions/v1.0 \
-    -B build -S.
+    -B build -S .
 ```
 
 ## Building without Superbuild

--- a/docs/en/cpp/guide/build_linux.md
+++ b/docs/en/cpp/guide/build_linux.md
@@ -35,7 +35,7 @@ cd cpp
 
 For development, use the debug build:
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Debug -Bbuild -S.
+cmake -DCMAKE_BUILD_TYPE=Debug -B build -S.
 cmake --build build -j8
 ```
 
@@ -43,7 +43,7 @@ cmake --build build -j8
 
 For production use, build with optimizations enabled:
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Release -Bbuild -S.
+cmake -DCMAKE_BUILD_TYPE=Release -B build -S.
 cmake --build build -j8
 ```
 
@@ -62,7 +62,7 @@ sudo ldconfig  # Update linker cache
 To install to a custom location, e.g. `install`
 
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -Bbuild -S.
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -B build -S.
 cmake --build build --target install
 ```
 
@@ -75,7 +75,7 @@ For more information about the architecture, also see [how the auto-generation w
 In order to include the mavsdk_server in the build, add `-DBUILD_MAVSDK_SERVER=ON`:
 
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_MAVSDK_SERVER=ON -Bbuild -S.
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_MAVSDK_SERVER=ON -B build -S.
 cmake --build build -j8
 ```
 
@@ -110,18 +110,18 @@ Examples:
 
 ```bash
 # Build with development dialect
-cmake -DCMAKE_BUILD_TYPE=Debug -DMAVLINK_DIALECT=development -Bbuild -S.
+cmake -DCMAKE_BUILD_TYPE=Debug -DMAVLINK_DIALECT=development -B build -S.
 
 # Use a custom MAVLink repository fork
 cmake -DCMAKE_BUILD_TYPE=Debug \
     -DMAVLINK_URL=https://github.com/yourfork/mavlink \
     -DMAVLINK_HASH=abc123def456 \
-    -Bbuild -S.
+    -B build -S.
 
 # Use local MAVLink XML files
 cmake -DCMAKE_BUILD_TYPE=Debug \
     -DMAVLINK_XML_PATH=/path/to/mavlink/message_definitions/v1.0 \
-    -Bbuild -S.
+    -B build -S.
 ```
 
 ## Building without Superbuild

--- a/docs/en/cpp/guide/build_macos.md
+++ b/docs/en/cpp/guide/build_macos.md
@@ -38,7 +38,7 @@ cd cpp
 
 For development, use the debug build:
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Debug -B build -S.
+cmake -DCMAKE_BUILD_TYPE=Debug -B build -S .
 cmake --build build -j8
 ```
 
@@ -46,7 +46,7 @@ cmake --build build -j8
 
 For production use, build with optimizations enabled:
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Release -B build -S.
+cmake -DCMAKE_BUILD_TYPE=Release -B build -S .
 cmake --build build -j8
 ```
 
@@ -63,7 +63,7 @@ sudo cmake --build build --target install
 
 To install to a local folder, e.g. `install`:
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -B build -S.
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -B build -S .
 cmake --build build --target install
 ```
 
@@ -72,14 +72,14 @@ cmake --build build --target install
 To build for real iOS devices on macOS:
 
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_MAVSDK_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_TOOLCHAIN_FILE=tools/ios.toolchain.cmake -DPLATFORM=OS -B build/ios -S.
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_MAVSDK_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_TOOLCHAIN_FILE=tools/ios.toolchain.cmake -DPLATFORM=OS -B build/ios -S .
 cmake --build build/ios
 ```
 
 Build for the iOS simulator on macOS:
 
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_MAVSDK_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_TOOLCHAIN_FILE=tools/ios.toolchain.cmake -DPLATFORM=SIMULATOR64 -B build/ios_simulator -S.
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_MAVSDK_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_TOOLCHAIN_FILE=tools/ios.toolchain.cmake -DPLATFORM=SIMULATOR64 -B build/ios_simulator -S .
 ```
 
 ## Build Options

--- a/docs/en/cpp/guide/build_macos.md
+++ b/docs/en/cpp/guide/build_macos.md
@@ -38,7 +38,7 @@ cd cpp
 
 For development, use the debug build:
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Debug -Bbuild -S.
+cmake -DCMAKE_BUILD_TYPE=Debug -B build -S.
 cmake --build build -j8
 ```
 
@@ -46,7 +46,7 @@ cmake --build build -j8
 
 For production use, build with optimizations enabled:
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Release -Bbuild -S.
+cmake -DCMAKE_BUILD_TYPE=Release -B build -S.
 cmake --build build -j8
 ```
 
@@ -63,7 +63,7 @@ sudo cmake --build build --target install
 
 To install to a local folder, e.g. `install`:
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -Bbuild -S.
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -B build -S.
 cmake --build build --target install
 ```
 
@@ -72,14 +72,14 @@ cmake --build build --target install
 To build for real iOS devices on macOS:
 
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_MAVSDK_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_TOOLCHAIN_FILE=tools/ios.toolchain.cmake -DPLATFORM=OS -Bbuild/ios -S.
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_MAVSDK_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_TOOLCHAIN_FILE=tools/ios.toolchain.cmake -DPLATFORM=OS -B build/ios -S.
 cmake --build build/ios
 ```
 
 Build for the iOS simulator on macOS:
 
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_MAVSDK_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_TOOLCHAIN_FILE=tools/ios.toolchain.cmake -DPLATFORM=SIMULATOR64 -Bbuild/ios_simulator -S.
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_MAVSDK_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_TOOLCHAIN_FILE=tools/ios.toolchain.cmake -DPLATFORM=SIMULATOR64 -B build/ios_simulator -S.
 ```
 
 ## Build Options

--- a/docs/en/cpp/guide/build_windows.md
+++ b/docs/en/cpp/guide/build_windows.md
@@ -56,7 +56,7 @@ Make sure to run this within the Visual Studio environment to access Ninja. You 
 
 For development, use the debug build:
 ```bash
-cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -Bbuild -S.
+cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -B build -S.
 cmake --build build --config Debug
 ```
 
@@ -65,7 +65,7 @@ cmake --build build --config Debug
 For production use, build with optimizations enabled:
 
 ```bash
-cmake -GNinja -DCMAKE_BUILD_TYPE=Release -S. -Bbuild
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release -S. -B build
 cmake --build build --config Release
 ```
 
@@ -87,7 +87,7 @@ Note that a `mavsdk.lib` built this way does not "contain" the dependencies it w
 For instance, to build the examples, it looks like this:
 
 ```bash
-cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install -DBUILD_MAVSDK_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DWERROR=ON -Bbuild -S.
+cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install -DBUILD_MAVSDK_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DWERROR=ON -B build -S.
 cmake --build build --config RelWithDebInfo --target install
 ```
 
@@ -95,7 +95,7 @@ And now the examples need both dependencies: mavsdk.lib but also its transitive 
 
 ```bash
 cd examples
-cmake -G"Ninja" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH="../install;../build/third_party/install" -DCMAKE_INSTALL_PREFIX=install -Bbuild -S.
+cmake -G"Ninja" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH="../install;../build/third_party/install" -DCMAKE_INSTALL_PREFIX=install -B build -S.
 cmake --build build
 ```
 
@@ -113,7 +113,7 @@ cmake --build build --target install
 
 To install to a custom location:
 ```bash
-cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -Bbuild -S.
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -B build -S.
 cmake --build build --target install
 ```
 
@@ -126,7 +126,7 @@ For more information about the architecture, also see [how the auto-generation w
 In order to include the mavsdk_server in the build, add `-DBUILD_MAVSDK_SERVER=ON`. In order to avoid a linking issue on Windows (where more than 65535 objects are present, we need to build all static libraries like so:
 
 ```bash
-cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_MAVSDK_SERVER=ON -Bbuild -S.
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_MAVSDK_SERVER=ON -B build -S.
 cmake --build build
 ```
 
@@ -157,7 +157,7 @@ rm -rf build
 
 If you don't need http/https downloads for camera definition files or other component definition files, and you're not building the MAVSDK server (`BUILD_MAVSDK_SERVER=OFF`), you can exclude CURL and OpenSSL using:
 ```bash
-cmake -GNinja -DBUILD_WITHOUT_CURL=ON -Bbuild -S.
+cmake -GNinja -DBUILD_WITHOUT_CURL=ON -B build -S.
 ```
 
 This eliminates the need for Perl/OpenSSL setup.
@@ -183,10 +183,10 @@ Ensure your application build configuration matches the MAVSDK library configura
 2. **When building from source**: Use the same `CMAKE_BUILD_TYPE` for both MAVSDK and your application:
    ```bash
    # For Debug applications
-   cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -Bbuild -S.
+   cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -B build -S.
 
    # For Release applications
-   cmake -GNinja -DCMAKE_BUILD_TYPE=Release -Bbuild -S.
+   cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build -S.
    ```
 
 3. **Mixed configurations are not supported**: Never link a Debug application against a Release MAVSDK library or vice versa on Windows.

--- a/docs/en/cpp/guide/build_windows.md
+++ b/docs/en/cpp/guide/build_windows.md
@@ -56,7 +56,7 @@ Make sure to run this within the Visual Studio environment to access Ninja. You 
 
 For development, use the debug build:
 ```bash
-cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -B build -S.
+cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -B build -S .
 cmake --build build --config Debug
 ```
 
@@ -65,7 +65,7 @@ cmake --build build --config Debug
 For production use, build with optimizations enabled:
 
 ```bash
-cmake -GNinja -DCMAKE_BUILD_TYPE=Release -S. -B build
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release -S . -B build
 cmake --build build --config Release
 ```
 
@@ -87,7 +87,7 @@ Note that a `mavsdk.lib` built this way does not "contain" the dependencies it w
 For instance, to build the examples, it looks like this:
 
 ```bash
-cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install -DBUILD_MAVSDK_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DWERROR=ON -B build -S.
+cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install -DBUILD_MAVSDK_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DWERROR=ON -B build -S .
 cmake --build build --config RelWithDebInfo --target install
 ```
 
@@ -95,7 +95,7 @@ And now the examples need both dependencies: mavsdk.lib but also its transitive 
 
 ```bash
 cd examples
-cmake -G"Ninja" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH="../install;../build/third_party/install" -DCMAKE_INSTALL_PREFIX=install -B build -S.
+cmake -G"Ninja" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH="../install;../build/third_party/install" -DCMAKE_INSTALL_PREFIX=install -B build -S .
 cmake --build build
 ```
 
@@ -113,7 +113,7 @@ cmake --build build --target install
 
 To install to a custom location:
 ```bash
-cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -B build -S.
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -B build -S .
 cmake --build build --target install
 ```
 
@@ -126,7 +126,7 @@ For more information about the architecture, also see [how the auto-generation w
 In order to include the mavsdk_server in the build, add `-DBUILD_MAVSDK_SERVER=ON`. In order to avoid a linking issue on Windows (where more than 65535 objects are present, we need to build all static libraries like so:
 
 ```bash
-cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_MAVSDK_SERVER=ON -B build -S.
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_MAVSDK_SERVER=ON -B build -S .
 cmake --build build
 ```
 
@@ -157,7 +157,7 @@ rm -rf build
 
 If you don't need http/https downloads for camera definition files or other component definition files, and you're not building the MAVSDK server (`BUILD_MAVSDK_SERVER=OFF`), you can exclude CURL and OpenSSL using:
 ```bash
-cmake -GNinja -DBUILD_WITHOUT_CURL=ON -B build -S.
+cmake -GNinja -DBUILD_WITHOUT_CURL=ON -B build -S .
 ```
 
 This eliminates the need for Perl/OpenSSL setup.
@@ -183,10 +183,10 @@ Ensure your application build configuration matches the MAVSDK library configura
 2. **When building from source**: Use the same `CMAKE_BUILD_TYPE` for both MAVSDK and your application:
    ```bash
    # For Debug applications
-   cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -B build -S.
+   cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -B build -S .
 
    # For Release applications
-   cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build -S.
+   cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build -S .
    ```
 
 3. **Mixed configurations are not supported**: Never link a Debug application against a Release MAVSDK library or vice versa on Windows.

--- a/docs/en/cpp/guide/camera.md
+++ b/docs/en/cpp/guide/camera.md
@@ -1,0 +1,64 @@
+# Camera
+
+The [Camera](../api_reference/classmavsdk_1_1_camera.md) plugin provides control over cameras that implement the [MAVLink Camera Protocol](https://mavlink.io/en/services/camera.html).
+
+## Create the Plugin
+
+```cpp
+#include <mavsdk/plugins/camera/camera.h>
+auto camera = Camera{system};
+```
+
+## Discover Cameras
+
+Cameras announce themselves as MAVLink components. Subscribe to the camera list to be notified when a camera appears:
+
+```cpp
+camera.subscribe_camera_list([](Camera::CameraList list) {
+    for (auto& item : list.cameras) {
+        std::cout << "Camera found: component id " << item.component_id << '\n';
+    }
+});
+```
+
+## Set Mode and Take Photos
+
+Switch to photo mode and capture a single image (using the `component_id` from discovery):
+
+```cpp
+camera.set_mode(component_id, Camera::Mode::Photo);
+camera.take_photo(component_id);
+```
+
+Subscribe to `capture_info` to receive the result (file URL, position, timestamp):
+
+```cpp
+camera.subscribe_capture_info([](Camera::CaptureInfo info) {
+    std::cout << "Photo saved to: " << info.file_url << '\n';
+});
+```
+
+## Record Video
+
+```cpp
+camera.set_mode(component_id, Camera::Mode::Video);
+camera.start_video(component_id);
+// ... fly around ...
+camera.stop_video(component_id);
+```
+
+## Zoom and Focus
+
+```cpp
+camera.zoom_range(component_id, 2.0f);   // 2× zoom
+camera.focus_range(component_id, 70.0f); // 70% focus position
+```
+
+## Further Information
+
+- [API Reference: Camera](../api_reference/classmavsdk_1_1_camera.md)
+- [Example: Camera](https://github.com/mavlink/MAVSDK/tree/main/cpp/examples/camera)
+- [Example: Camera settings](https://github.com/mavlink/MAVSDK/tree/main/cpp/examples/camera_settings)
+- [Example: Camera zoom](https://github.com/mavlink/MAVSDK/tree/main/cpp/examples/camera_zoom)
+- [Example: Camera server](https://github.com/mavlink/MAVSDK/tree/main/cpp/examples/camera_server) (implementing a camera component)
+- [MAVLink Camera Protocol](https://mavlink.io/en/services/camera.html)

--- a/docs/en/cpp/guide/connections.md
+++ b/docs/en/cpp/guide/connections.md
@@ -200,7 +200,7 @@ To forward only in one direction, e.g to send messages arriving on serial over U
 ```cpp
 Mavsdk mavsdk;
 mavsdk.add_any_connection("udpin://0.0.0.0:14540", ForwardingOption::ForwardingOn);
-mavsdk.add_any_connection("serial:///dev/serial/by-id/usb-FTDI_FT232R_USB_UART_XXXXXXXX-if00-port0:57600", `ForwardingOption::ForwardingOff`);
+mavsdk.add_any_connection("serial:///dev/serial/by-id/usb-FTDI_FT232R_USB_UART_XXXXXXXX-if00-port0:57600", ForwardingOption::ForwardingOff);
 ```
 
 Note that the default function overload is `ForwardingOption::ForwardingOff`.

--- a/docs/en/cpp/guide/dev_logging.md
+++ b/docs/en/cpp/guide/dev_logging.md
@@ -15,7 +15,7 @@ It is not exported, or intended, for use in SDK apps (and we do not commit to ma
 
 ### Usage
 
-The API is defined in [src/core/log.h](https://github.com/JoC2000/MAVSDK/blob/main/cpp/src/mavsdk/core/log.h).
+The API is defined in [src/core/log.h](https://github.com/mavlink/MAVSDK/blob/main/cpp/src/mavsdk/core/log.h).
 
 The API methods are called as shown below for `LogDebug()`, with the insertion operator (`<<`) used to append the message-specific text.
 
@@ -40,6 +40,6 @@ Function | Description | Example
 Basic logging is defined in source for both incoming (handled/ignored) and sent MAVLink messages.
 
 This functionality is disabled by default, and available only in debug build when built from source.
-To enable the logs, set `#define MESSAGE_DEBUGGING 1` in [src/core/system.cpp](https://github.com/JoC2000/MAVSDK/blob/main/cpp/src/mavsdk/core/system.cpp)
+To enable the logs, set `#define MESSAGE_DEBUGGING 1` in [src/core/system.cpp](https://github.com/mavlink/MAVSDK/blob/main/cpp/src/mavsdk/core/system.cpp)
 
 <!-- Added: https://github.com/mavlink/MAVSDK/pull/194 -->

--- a/docs/en/cpp/guide/general_usage.md
+++ b/docs/en/cpp/guide/general_usage.md
@@ -89,7 +89,26 @@ MAVSDK monitors a specified port for vehicles, see [Connecting to Systems (Vehic
 
 ### Connection Status
 
-A system is considered to be disconnected (timed-out) if its heartbeat message is not detected within 3 seconds.
+A system is considered to be disconnected if its heartbeat is not received within the heartbeat timeout (default: 3 seconds). See [Timeouts](#timeouts) below.
+
+### Timeouts {#timeouts}
+
+MAVSDK has two configurable timeouts on the `Mavsdk` object:
+
+**MAVLink transfer timeout** — how long to wait for an acknowledgment to a MAVLink command or request (default: 0.5 s). Increase this for high-latency links; decrease it when MAVSDK and the autopilot are on the same host:
+
+```cpp
+mavsdk.set_timeout_s(1.0); // wait up to 1 second for acknowledgments
+```
+
+**Heartbeat timeout** — how long to wait without a heartbeat before a system is considered disconnected (default: 3 s):
+
+```cpp
+mavsdk.set_heartbeat_timeout_s(5.0); // allow up to 5 seconds between heartbeats
+double current = mavsdk.get_heartbeat_timeout_s();
+```
+
+Both methods are on [class Mavsdk](../api_reference/classmavsdk_1_1_mavsdk.md) and can be called at any time before or after adding connections.
 
 ### Telemetry/Information
 

--- a/docs/en/cpp/guide/gimbal.md
+++ b/docs/en/cpp/guide/gimbal.md
@@ -1,0 +1,70 @@
+# Gimbal
+
+The [Gimbal](../api_reference/classmavsdk_1_1_gimbal.md) plugin controls gimbals that implement [MAVLink Gimbal Protocol v2](https://mavlink.io/en/services/gimbal_v2.html).
+
+::: tip
+This page covers real-time gimbal control from a ground station or companion computer. For gimbal actions within a mission (e.g. camera angle at a waypoint), see the [Mission](missions.md) guide.
+:::
+
+## Create the Plugin
+
+```cpp
+#include <mavsdk/plugins/gimbal/gimbal.h>
+auto gimbal = Gimbal{system};
+```
+
+## Discover Gimbals
+
+Gimbals are identified by a gimbal id. Subscribe to the gimbal list to be notified when one connects:
+
+```cpp
+gimbal.subscribe_gimbal_list([](Gimbal::GimbalList list) {
+    for (auto& item : list.gimbals) {
+        std::cout << "Gimbal id: " << item.gimbal_id << '\n';
+    }
+});
+```
+
+## Take Control
+
+Claim primary control before sending commands; release it when done:
+
+```cpp
+gimbal.take_control(gimbal_id, Gimbal::ControlMode::Primary);
+// ... control gimbal ...
+gimbal.release_control(gimbal_id);
+```
+
+## Set Angles
+
+Point the gimbal at a fixed roll/pitch/yaw (in degrees):
+
+```cpp
+gimbal.set_angles(gimbal_id, 0.0f, -30.0f, 0.0f,
+                  Gimbal::GimbalMode::YawFollow,
+                  Gimbal::SendMode::Once);
+```
+
+`YawFollow` keeps the gimbal yaw locked to the vehicle body; `YawLock` holds a fixed world heading.
+
+## Point at a Location
+
+```cpp
+gimbal.set_roi_location(gimbal_id, latitude_deg, longitude_deg, altitude_m);
+```
+
+## Monitor Attitude
+
+```cpp
+gimbal.subscribe_attitude([](Gimbal::Attitude attitude) {
+    std::cout << "Pitch: " << attitude.euler_angle_forward.pitch_deg << '\n';
+});
+```
+
+## Further Information
+
+- [API Reference: Gimbal](../api_reference/classmavsdk_1_1_gimbal.md)
+- [Example: Gimbal](https://github.com/mavlink/MAVSDK/tree/main/cpp/examples/gimbal)
+- [Example: Gimbal full control](https://github.com/mavlink/MAVSDK/tree/main/cpp/examples/gimbal_full_control)
+- [Example: Gimbal device tester](https://github.com/mavlink/MAVSDK/tree/main/cpp/examples/gimbal_device_tester)
+- [MAVLink Gimbal Protocol v2](https://mavlink.io/en/services/gimbal_v2.html)

--- a/docs/en/cpp/guide/missions.md
+++ b/docs/en/cpp/guide/missions.md
@@ -51,7 +51,7 @@ The main steps are:
    Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
    ConnectionResult conn_result = mavsdk.add_udp_connection();
    // Wait for the system to connect via heartbeat
-   while (mavsdk.system().size() == 0) {
+   while (mavsdk.systems().size() == 0) {
       sleep_for(seconds(1));
    }
    // System got discovered.
@@ -90,11 +90,10 @@ The example below shows how you might set the other options on a second `Mission
 ```cpp
 std::shared_ptr<MissionItem> new_item2(new MissionItem());
 new_item2->latitude_deg = 47.40;
-new_item2->longitude_deg = 8.5455360114574432);
+new_item2->longitude_deg = 8.5455360114574432;
 new_item2->relative_altitude_m = 2.0f;
 new_item2->speed_m_s = 5.0f;
 new_item2->is_fly_through = true;
-new_item2->gimbal_pitch_deg = 20.0f;
 new_item2->gimbal_pitch_deg = 20.0f;
 new_item2->gimbal_yaw_deg = 60.0f;
 new_item2->camera_action = MissionItem::CameraAction::TakePhoto;
@@ -211,7 +210,7 @@ which receives a regular callback with the current `MissionItem` number and the 
 The code fragment just takes a lambda function that reports the current status.
 
 ```cpp
-mission.subscribe_mission_progress( [](Mission::MissionProgress mission_progress)) {
+mission.subscribe_mission_progress( [](Mission::MissionProgress mission_progress) {
        std::cout << "Mission status update: " << mission_progress.current << " / " << mission_progress.total << '\n';
     });
 ```

--- a/docs/en/cpp/guide/taking_off_landing.md
+++ b/docs/en/cpp/guide/taking_off_landing.md
@@ -217,7 +217,7 @@ This mode is invoked from `Action` using the [return_to_launch()](../api_referen
 The code below shows how to use the synchronous method:
 
 ```cpp
-const Action::Result rtl_result = telemetry.return_to_launch();
+const Action::Result rtl_result = action.return_to_launch();
 if (rtl_result != Action::Result::Success) {
     //RTL failed, so exit (in reality might send kill command.)
     return 1;

--- a/docs/en/cpp/guide/test.md
+++ b/docs/en/cpp/guide/test.md
@@ -54,7 +54,7 @@ MAVSDK includes a MAVLink fuzzer using libfuzzer to find bugs through randomized
 ### Building the Fuzzer
 
 ```bash
-cmake -Bbuild-fuzz -S. -GNinja -DBUILD_FUZZ_TESTS=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+cmake -B build-fuzz -S. -GNinja -DBUILD_FUZZ_TESTS=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
 cmake --build build-fuzz
 ```
 

--- a/docs/en/cpp/guide/test.md
+++ b/docs/en/cpp/guide/test.md
@@ -54,7 +54,7 @@ MAVSDK includes a MAVLink fuzzer using libfuzzer to find bugs through randomized
 ### Building the Fuzzer
 
 ```bash
-cmake -B build-fuzz -S. -GNinja -DBUILD_FUZZ_TESTS=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+cmake -B build-fuzz -S . -GNinja -DBUILD_FUZZ_TESTS=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
 cmake --build build-fuzz
 ```
 

--- a/docs/en/cpp/guide/toolchain.md
+++ b/docs/en/cpp/guide/toolchain.md
@@ -74,7 +74,7 @@ For this case `find_package(MAVSDK REQUIRED)` as used in `CMakeLists.txt` above 
 To build the example we would do:
 
 ```bash
-   cmake -B build -H.
+   cmake -B build -S.
    cmake --build build -j8
 ```
 
@@ -89,7 +89,7 @@ For the case where the library is installed in some local directory, you need to
 E.g. here there would be a directory called mavsdk just one directory up:
 
 ```bash
-cmake -B build -DCMAKE_PREFIX_PATH=../mavsdk -H.
+cmake -B build -DCMAKE_PREFIX_PATH=../mavsdk -S.
 cmake --build build -j8
 ```
 
@@ -112,14 +112,14 @@ In order to build in Release mode where the file size is smaller and optimizatio
 
 **macOS/Linux:**
 ```
-cmake -B build -DCMAKE_BUILD_TYPE=Release -H.
+cmake -B build -DCMAKE_BUILD_TYPE=Release -S.
 cmake --build build -j8
 ```
 
 **Windows:**
 
 ```
-cmake -B build -H.
+cmake -B build -S.
 cmake --build build -j8 --config Release
 ```
 

--- a/docs/en/cpp/guide/toolchain.md
+++ b/docs/en/cpp/guide/toolchain.md
@@ -74,7 +74,7 @@ For this case `find_package(MAVSDK REQUIRED)` as used in `CMakeLists.txt` above 
 To build the example we would do:
 
 ```bash
-   cmake -Bbuild -H.
+   cmake -B build -H.
    cmake --build build -j8
 ```
 
@@ -89,7 +89,7 @@ For the case where the library is installed in some local directory, you need to
 E.g. here there would be a directory called mavsdk just one directory up:
 
 ```bash
-cmake -Bbuild -DCMAKE_PREFIX_PATH=../mavsdk -H.
+cmake -B build -DCMAKE_PREFIX_PATH=../mavsdk -H.
 cmake --build build -j8
 ```
 
@@ -112,14 +112,14 @@ In order to build in Release mode where the file size is smaller and optimizatio
 
 **macOS/Linux:**
 ```
-cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -H.
+cmake -B build -DCMAKE_BUILD_TYPE=Release -H.
 cmake --build build -j8
 ```
 
 **Windows:**
 
 ```
-cmake -Bbuild -H.
+cmake -B build -H.
 cmake --build build -j8 --config Release
 ```
 

--- a/docs/en/cpp/guide/toolchain.md
+++ b/docs/en/cpp/guide/toolchain.md
@@ -74,7 +74,7 @@ For this case `find_package(MAVSDK REQUIRED)` as used in `CMakeLists.txt` above 
 To build the example we would do:
 
 ```bash
-   cmake -B build -S.
+   cmake -B build -S .
    cmake --build build -j8
 ```
 
@@ -89,7 +89,7 @@ For the case where the library is installed in some local directory, you need to
 E.g. here there would be a directory called mavsdk just one directory up:
 
 ```bash
-cmake -B build -DCMAKE_PREFIX_PATH=../mavsdk -S.
+cmake -B build -DCMAKE_PREFIX_PATH=../mavsdk -S .
 cmake --build build -j8
 ```
 
@@ -112,14 +112,14 @@ In order to build in Release mode where the file size is smaller and optimizatio
 
 **macOS/Linux:**
 ```
-cmake -B build -DCMAKE_BUILD_TYPE=Release -S.
+cmake -B build -DCMAKE_BUILD_TYPE=Release -S .
 cmake --build build -j8
 ```
 
 **Windows:**
 
 ```
-cmake -B build -S.
+cmake -B build -S .
 cmake --build build -j8 --config Release
 ```
 

--- a/docs/en/cpp/quickstart.md
+++ b/docs/en/cpp/quickstart.md
@@ -80,7 +80,7 @@ cmake --build build -j4
 
 ::: info
 The examples match the MAVSDK version from your current branch. If you have another MAVSDK version installed, you should checkout the examples from that version. For example, if you have installed MAVSDK v2.x.y, you need to switch to the branch `v2`.
-"""
+:::
 
 ## Running an Example {#running_the_examples}
 

--- a/docs/en/cpp/quickstart.md
+++ b/docs/en/cpp/quickstart.md
@@ -74,7 +74,7 @@ To build the takeoff and land example, you can do:
 
 ```sh
 cd takeoff_and_land/
-cmake -Bbuild -S.
+cmake -B build -S.
 cmake --build build -j4
 ```
 

--- a/docs/en/cpp/quickstart.md
+++ b/docs/en/cpp/quickstart.md
@@ -74,7 +74,7 @@ To build the takeoff and land example, you can do:
 
 ```sh
 cd takeoff_and_land/
-cmake -B build -S.
+cmake -B build -S .
 cmake --build build -j4
 ```
 

--- a/docs/en/cpp/troubleshooting.md
+++ b/docs/en/cpp/troubleshooting.md
@@ -53,7 +53,7 @@ If you really want to do something that takes longer inside a callback, the work
 void my_callback(Telemetry::Position position)
 {
     std::thread([position]() {
-        std::this_thread_sleep_for(std::chrono::seconds(3));
+        std::this_thread::sleep_for(std::chrono::seconds(3));
         my_delayed_action(position);
     }).detach();
 }

--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -105,7 +105,7 @@ There are multiple ways to support multiple programming languages all with their
 3. Direct language bindings manually written, or based on various tools like [pybind11](https://github.com/pybind/pybind11).
    `+` Some languages "almost for free".
    `-` Varies on the language. If done manually likely to have bugs.
-   `-` Requires linking to nan-native dependencies.
+   `-` Requires linking to non-native dependencies.
 4. Language bindings based on proto definitions (protobuf) and gRPC.
    `+` Nice native APIs can be auto-generated from proto files.
    `+` No non-native dependencies in language wrappers.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -40,7 +40,7 @@ If you have specific questions that are not answered by the documentation, these
 Use Github for bug reports/enhancement requests:
 
 * [C++ API](https://github.com/mavlink/MAVSDK/issues)
-* [C++ Documentation](https://github.com/mavlink/MAVSDK-docs/issues)
+* [C++ Documentation](https://github.com/mavlink/MAVSDK/issues)
 * [Swift API and docs](https://github.com/mavlink/MAVSDK-Swift/issues)
 * [Python API and docs](https://github.com/mavlink/MAVSDK-Python/issues)
 <!-- Add info about where other API issues are reported). -->


### PR DESCRIPTION
Fixes open issues from https://github.com/mavlink/MAVSDK-docs/issues applied to the in-tree docs, plus new Camera and Gimbal guide pages.

## Test plan
- [x] Review commits
- [ ] Build docs locally: `cd docs && npm install && npm run dev`