### PR TITLE
docs: align toolchain and code style with C++20 library

### DIFF
--- a/docs/en/cpp/guide/code_style.md
+++ b/docs/en/cpp/guide/code_style.md
@@ -33,7 +33,7 @@ tools/run-docker.sh tools/fix_style.py .
 
 The following general guidelines should be used for all code:
 
-* C++17 is encouraged to allow developers to use C++17 features and the C++ STL:
+* The library itself is C++20; new contributions and examples should target C++20. C++17 features and the C++ STL remain welcome when they improve clarity:
   Examples:
 
   * [`std::function`](http://en.cppreference.com/w/cpp/utility/functional/function) and [lambda expressions](http://en.cppreference.com/w/cpp/language/lambda)

--- a/docs/en/cpp/guide/code_style.md
+++ b/docs/en/cpp/guide/code_style.md
@@ -33,7 +33,7 @@ tools/run-docker.sh tools/fix_style.py .
 
 The following general guidelines should be used for all code:
 
-* The library itself is C++20; new contributions and examples should target C++20. C++17 features and the C++ STL remain welcome when they improve clarity:
+* The library is C++20; new contributions and examples should target C++20. The C++ STL is welcome when it improves clarity:
   Examples:
 
   * [`std::function`](http://en.cppreference.com/w/cpp/utility/functional/function) and [lambda expressions](http://en.cppreference.com/w/cpp/language/lambda)

--- a/docs/en/cpp/guide/toolchain.md
+++ b/docs/en/cpp/guide/toolchain.md
@@ -1,6 +1,6 @@
 # Building C++ Apps
 
-The MAVSDK core C++ library is written in C++17 and exposes C++11 interfaces such as `std::function`. Therefore, applications using the library need to be C++11 or later as well.
+The MAVSDK core C++ library is written in **C++20** (see `CMAKE_CXX_STANDARD` in `cpp/src/CMakeLists.txt`) and exposes C++11-friendly interfaces such as `std::function`. Applications using the library should be C++11 or later; shipped examples use C++20.
 
 Applications can be built using your preferred build system, compiler and linker toolchain. The only requirement is that the build system must be able to locate the MAVSDK C++ headers and libraries (installed as described [here](installation.md)).
 
@@ -29,8 +29,8 @@ cmake_minimum_required(VERSION 3.15)
 # Specify your project's name
 project(your_project_name)
 
-# Specify at least C++11, better C++17
-set(CMAKE_CXX_STANDARD 17)
+# Match the library/examples (C++20). C++17 may work for apps that only need older language surface.
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Enable strict handling of warnings


### PR DESCRIPTION
## Summary
- Document that the MAVSDK **core library** is C++20 (`cpp/src/CMakeLists.txt` `CMAKE_CXX_STANDARD 20`, examples already on 20, repo description “C++ 20”).
- Update the sample `CMakeLists.txt` in the toolchain guide to recommend `CMAKE_CXX_STANDARD 20`.
- Soft-update code-style guidance so new contributions/examples prefer C++20 while still welcoming clear C++17/STL usage.

## Why
Docs still said the core was “written in C++17”, which confuses users trying to match the tree.

## Non-overlap
Does **not** touch the Markdown fixes in open #2922 (that PR covers connections fence, quickstart fence, build paths, etc.).

## Test plan
- [x] Docs-only; no C++/CMake library flag changes
- [x] Spot-check relative statements against `cpp/src/CMakeLists.txt` and example CMakeLists