### PR TITLE
docs: fix Mission API reference links and messages typo

### DIFF
--- a/docs/en/cpp/guide/general_usage.md
+++ b/docs/en/cpp/guide/general_usage.md
@@ -115,11 +115,11 @@ The implication is that developers will need to separately monitor the completio
 
 ### Missions
 
-The [Mission](../api_reference/classmavsdk_1_1_mission.html) and [MissionItem](../api_reference/structmavsdk_1_1_mission_1_1_mission_item.html) APIs provide a simplified but often useful *subset* of MAVLink mission commands as a developer-friendly API.
+The [Mission](../api_reference/classmavsdk_1_1_mission.md) and [MissionItem](../api_reference/structmavsdk_1_1_mission_1_1_mission_item.md) APIs provide a simplified but often useful *subset* of MAVLink mission commands as a developer-friendly API.
 
 Not every mission command behaviour supported by the protocol and PX4 will be supported by the Mission plugins.
 
-In order to access the full mission API, the [MissionRaw](../api_reference/classmavsdk_1_1_mission_raw.html) plugin can be used instead.
+In order to access the full mission API, the [MissionRaw](../api_reference/classmavsdk_1_1_mission_raw.md) plugin can be used instead.
 
-The MissionRaw also allows to [import QGC mission files](https://mavsdk.mavlink.io/main/en/cpp/api_reference/classmavsdk_1_1_mission_raw.html#classmavsdk_1_1_mission_raw_1a2a4ca261c37737e691c6954693d6d0a5).
+The MissionRaw also allows to [import QGC mission files](https://mavsdk.mavlink.io/main/en/cpp/api_reference/classmavsdk_1_1_mission_raw.md#classmavsdk_1_1_mission_raw_1a2a4ca261c37737e691c6954693d6d0a5).
 

--- a/docs/en/cpp/guide/mavlink_direct.md
+++ b/docs/en/cpp/guide/mavlink_direct.md
@@ -41,7 +41,7 @@ MavlinkDirect works at runtime instead of compile-time, so instead of having the
 
 ## Load custom MAVLink XML/ MAVLink dialects
 
-By default all messsages from the [common.xml](https://mavlink.io/en/messages/common.html) MAVLink dialect are available, loaded in.
+By default all messages from the [common.xml](https://mavlink.io/en/messages/common.html) MAVLink dialect are available, loaded in.
 
 MavlinkDirect allows to load your own/custom MAVLink messages or other dialects.
 


### PR DESCRIPTION
## Summary
- Fix relative API links in `docs/en/cpp/guide/general_usage.md` § Missions: `Mission` / `MissionItem` / `MissionRaw` pointed at non-existent `../api_reference/*.html`; in-tree files are `.md` (same pattern as the rest of the guides).
- Fix typo in `docs/en/cpp/guide/mavlink_direct.md`: `messsages` → `messages`.

## Non-overlap
Complementary to maintainer/bot docs PR #2922 (does not edit these link lines / this typo).

## Test plan
- [x] Confirmed `docs/en/cpp/api_reference/classmavsdk_1_1_mission.md` (and MissionItem / MissionRaw) exist
- [x] Docs-only micro-diff