### PR TITLE
core: fix buffer overflows, deadlocks, and races in core

### DIFF
--- a/cpp/src/mavsdk/core/cli_arg.cpp
+++ b/cpp/src/mavsdk/core/cli_arg.cpp
@@ -230,7 +230,9 @@ std::optional<int> CliArg::port_from_str(std::string_view str)
     int value;
     auto [ptr, ec] = std::from_chars(str.data(), str.data() + str.size(), value);
 
-    if (static_cast<bool>(ec) || value < 1 || value > 65535) {
+    // from_chars stops at the first non-digit and reports success, so also require
+    // that the whole string was consumed to reject inputs like "8080abc".
+    if (static_cast<bool>(ec) || ptr != str.data() + str.size() || value < 1 || value > 65535) {
         return {};
     }
     return {value};
@@ -284,7 +286,8 @@ bool CliArg::parse_serial(const std::string_view rest, bool flow_control_enabled
     auto [ptr, ec] =
         std::from_chars(baudrate_str.data(), baudrate_str.data() + baudrate_str.size(), value);
 
-    if (static_cast<bool>(ec)) {
+    // Reject trailing garbage (e.g. "57600xyz"); from_chars would otherwise accept it.
+    if (static_cast<bool>(ec) || ptr != baudrate_str.data() + baudrate_str.size()) {
         return {};
     }
 

--- a/cpp/src/mavsdk/core/cli_arg_test.cpp
+++ b/cpp/src/mavsdk/core/cli_arg_test.cpp
@@ -400,3 +400,29 @@ TEST(CliArg, RawConnectionWrong)
     EXPECT_FALSE(ca.parse("raw://localhost"));
     EXPECT_FALSE(ca.parse("raw://127.0.0.1"));
 }
+
+TEST(CliArg, PortTrailingGarbageRejected)
+{
+    CliArg ca;
+
+    // std::from_chars stops at the first non-digit but still reports success, so a port
+    // with trailing garbage must be rejected rather than silently truncated to its
+    // leading digits.
+    EXPECT_FALSE(ca.parse("udp://127.0.0.1:8080abc"));
+    EXPECT_FALSE(ca.parse("udpin://0.0.0.0:8080abc"));
+    EXPECT_FALSE(ca.parse("udpout://127.0.0.1:8080abc"));
+    EXPECT_FALSE(ca.parse("tcpout://127.0.0.1:8080abc"));
+    EXPECT_FALSE(ca.parse("udp://127.0.0.1:80x"));
+    // Hex-looking input must not be accepted as its leading decimal digits (0).
+    EXPECT_FALSE(ca.parse("udp://127.0.0.1:0x50"));
+}
+
+TEST(CliArg, SerialBaudrateTrailingGarbageRejected)
+{
+    CliArg ca;
+
+    // Same for the serial baudrate.
+    EXPECT_FALSE(ca.parse("serial:///dev/ttyS0:57600xyz"));
+    EXPECT_FALSE(ca.parse("serial://COM13:57600xyz"));
+    EXPECT_FALSE(ca.parse("serial_flowcontrol:///dev/ttyS0:4000000nope"));
+}

--- a/cpp/src/mavsdk/core/connection.cpp
+++ b/cpp/src/mavsdk/core/connection.cpp
@@ -80,7 +80,8 @@ void Connection::receive_libmav_message(
     const Mavsdk::MavlinkMessage& message, Connection* connection)
 {
     // Register system ID when receiving a message from a new system.
-    if (_system_ids.find(message.system_id) == _system_ids.end()) {
+    {
+        std::lock_guard<std::mutex> lock(_system_ids_mutex);
         _system_ids.insert(message.system_id);
     }
 

--- a/cpp/src/mavsdk/core/curl_wrapper.cpp
+++ b/cpp/src/mavsdk/core/curl_wrapper.cpp
@@ -103,6 +103,13 @@ bool CurlWrapper::download_file_to_path(
         progress.progress_callback = progress_callback;
 
         fp = fopen(path.c_str(), "wb");
+        if (fp == nullptr) {
+            LogErr("Error: cannot open file for writing: {}", path);
+            if (nullptr != progress_callback) {
+                progress_callback(0, HttpStatus::Error, CURLcode::CURLE_WRITE_ERROR);
+            }
+            return false;
+        }
         curl_easy_setopt(curl.get(), CURLOPT_CONNECTTIMEOUT, 5L);
         curl_easy_setopt(curl.get(), CURLOPT_XFERINFOFUNCTION, download_progress_update);
         curl_easy_setopt(curl.get(), CURLOPT_PROGRESSDATA, &progress);

--- a/cpp/src/mavsdk/core/fs_utils.cpp
+++ b/cpp/src/mavsdk/core/fs_utils.cpp
@@ -78,7 +78,10 @@ std::optional<std::filesystem::path> get_cache_directory()
 #elif defined(APPLE) || defined(LINUX)
     const char* homedir;
     if ((homedir = getenv("HOME")) == NULL) {
-        homedir = getpwuid(getuid())->pw_dir;
+        // getpwuid() can return NULL if there is no passwd entry for the uid (common in
+        // minimal containers), so guard against dereferencing it.
+        const struct passwd* pw = getpwuid(getuid());
+        homedir = (pw != nullptr) ? pw->pw_dir : nullptr;
     }
     if (!homedir) {
         return std::nullopt;

--- a/cpp/src/mavsdk/core/hostname_to_ip.cpp
+++ b/cpp/src/mavsdk/core/hostname_to_ip.cpp
@@ -41,20 +41,21 @@ std::optional<std::string> resolve_hostname_to_ip(const std::string& hostname)
         return {};
     }
 
-    std::string ipAddress;
+    std::optional<std::string> ipAddress;
     for (addrinfo* ptr = result; ptr != nullptr; ptr = ptr->ai_next) {
         sockaddr_in* sockaddrIpv4 = reinterpret_cast<sockaddr_in*>(ptr->ai_addr);
-        char ipStr[INET_ADDRSTRLEN];
-        inet_ntop(AF_INET, &(sockaddrIpv4->sin_addr), ipStr, INET_ADDRSTRLEN);
-        ipAddress = ipStr;
-        break; // Take the first result
+        char ipStr[INET_ADDRSTRLEN] = {};
+        if (inet_ntop(AF_INET, &(sockaddrIpv4->sin_addr), ipStr, INET_ADDRSTRLEN) != nullptr) {
+            ipAddress = ipStr;
+            break; // Take the first result
+        }
     }
 
     freeaddrinfo(result);
 #if defined(WINDOWS)
     WSACleanup();
 #endif
-    return {ipAddress};
+    return ipAddress;
 }
 
 } // namespace mavsdk

--- a/cpp/src/mavsdk/core/libmav_receiver.hpp
+++ b/cpp/src/mavsdk/core/libmav_receiver.hpp
@@ -59,9 +59,16 @@ private:
     Mavsdk::MavlinkMessage _last_message;
     std::optional<mav::Message> _last_libmav_message; // Separate libmav message for integration
 
-    // Accumulation buffer for serial connections where messages can span multiple reads
-    // Buffer size is max message size (280 bytes: 255 payload + 10 header + 2 CRC + 13 signature)
-    static constexpr size_t ACCUMULATION_BUFFER_SIZE = mav::MessageDefinition::MAX_MESSAGE_SIZE;
+    // Accumulation buffer for connections where messages can span multiple reads.
+    //
+    // This bound is only a safety valve against unbounded growth; the parser normally
+    // drains the buffer (it consumes complete messages and skips garbage before the magic
+    // byte), so at most one partial message is ever pending. It must therefore be at least
+    // as large as a single read (the 2048-byte connection receive buffers) plus one full
+    // message, otherwise set_new_datagram() would drop the front of a large read *before*
+    // parsing and silently lose the messages in it.
+    static constexpr size_t ACCUMULATION_BUFFER_SIZE =
+        2048 + mav::MessageDefinition::MAX_MESSAGE_SIZE;
     std::vector<uint8_t> _accumulation_buffer;
 
     bool _debugging = false;

--- a/cpp/src/mavsdk/core/mavlink_component_metadata.cpp
+++ b/cpp/src/mavsdk/core/mavlink_component_metadata.cpp
@@ -6,6 +6,7 @@
 #include "system_impl.hpp"
 #include <asio/post.hpp>
 
+#include <cstdlib>
 #include <utility>
 #include <filesystem>
 #include <fstream>
@@ -138,7 +139,16 @@ bool MavlinkComponentMetadata::uri_is_mavlinkftp(
         std::regex compid_regex(R"(^(?:\[\;comp\=(\d+)\])(.*))");
         std::smatch match;
         if (std::regex_search(download_path, match, compid_regex)) {
-            target_compid = std::stoi(match[1]);
+            // Parse the component id without throwing (MAVSDK builds with -fno-exceptions,
+            // so std::stoi would terminate() on an out-of-range value from the wire).
+            const std::string compid_str = match[1].str();
+            char* end = nullptr;
+            const long parsed = std::strtol(compid_str.c_str(), &end, 10);
+            if (end == compid_str.c_str() || *end != '\0' || parsed < 0 || parsed > 255) {
+                LogWarn("Ignoring invalid component id in metadata uri: {}", compid_str);
+                return false;
+            }
+            target_compid = static_cast<uint8_t>(parsed);
             download_path = match[2];
         }
         return true;

--- a/cpp/src/mavsdk/core/mavlink_ftp_client.cpp
+++ b/cpp/src/mavsdk/core/mavlink_ftp_client.cpp
@@ -685,6 +685,18 @@ bool MavlinkFtpClient::download_burst_continue(
                 return false;
             }
 
+            if (payload->offset > item.file_size) {
+                // The server should never point us past the end of the file. Reject rather
+                // than allocating/zero-filling a gap of up to ~4 GB from a bad offset.
+                LogWarn(
+                    "Got payload offset {} past file size {}",
+                    (uint32_t)payload->offset,
+                    item.file_size);
+                item.callback(ClientResult::ProtocolError, {});
+                download_burst_end(work);
+                return false;
+            }
+
             // we missed a part
             item.missing_data.emplace_back(DownloadBurstItem::MissingData{
                 item.current_offset, payload->offset - item.current_offset});

--- a/cpp/src/mavsdk/core/mavlink_ftp_server.cpp
+++ b/cpp/src/mavsdk/core/mavlink_ftp_server.cpp
@@ -945,7 +945,7 @@ void MavlinkFtpServer::_work_write(const PayloadHeader& payload)
     }
 
     _session_info.ofstream.seekp(payload.offset);
-    if (_session_info.ifstream.fail()) {
+    if (_session_info.ofstream.fail()) {
         response.opcode = Opcode::RSP_NAK;
         response.size = 1;
         response.data[0] = ServerResult::ERR_FAIL;

--- a/cpp/src/mavsdk/core/mavlink_ftp_server.cpp
+++ b/cpp/src/mavsdk/core/mavlink_ftp_server.cpp
@@ -855,18 +855,30 @@ void MavlinkFtpServer::_work_burst(const PayloadHeader& payload)
 
     // Schedule sending out burst messages.
     _session_info.burst_thread = std::thread([this]() {
-        while (!_session_info.burst_stop)
-            if (_send_burst_packet())
+        while (!_session_info.burst_stop) {
+            // Try to grab the lock rather than blocking on it. If another thread holds
+            // _mutex to stop and join us, blocking here would deadlock; instead we fall
+            // back to observing burst_stop (atomic) and exit.
+            std::unique_lock<std::mutex> burst_lock(_mutex, std::try_to_lock);
+            if (!burst_lock.owns_lock()) {
+                std::this_thread::yield();
+                continue;
+            }
+            if (_session_info.burst_stop) {
                 break;
+            }
+            if (_send_burst_packet()) {
+                break;
+            }
+        }
     });
 
     // Don't send response as that's done in the call every burst call above.
 }
 
-// Returns true if sending is complete
+// Requires _mutex to be held. Returns true if sending is complete.
 bool MavlinkFtpServer::_send_burst_packet()
 {
-    std::lock_guard<std::mutex> lock(_mutex);
     if (!_session_info.ifstream.is_open()) {
         return false;
     }

--- a/cpp/src/mavsdk/core/mavlink_ftp_server.cpp
+++ b/cpp/src/mavsdk/core/mavlink_ftp_server.cpp
@@ -236,17 +236,32 @@ void MavlinkFtpServer::_send_mavlink_ftp_message(const PayloadHeader& payload)
 
 std::string MavlinkFtpServer::_data_as_string(const PayloadHeader& payload, size_t entry)
 {
+    // Only ever scan within the bytes the sender claims are valid. payload.size is
+    // validated to be <= max_data_length before we get here, but clamp defensively so
+    // we can never read past the fixed data[] buffer regardless of the input.
+    const size_t data_length = std::min(static_cast<size_t>(payload.size), size_t{max_data_length});
+
     size_t start = 0;
     size_t end = 0;
-    std::string result;
 
     for (int i = entry; i >= 0; --i) {
         start = end;
+        if (start >= data_length) {
+            // The requested entry is beyond the available data.
+            return {};
+        }
         end +=
-            strnlen(reinterpret_cast<const char*>(&payload.data[start]), max_data_length - start) +
-            1;
+            strnlen(reinterpret_cast<const char*>(&payload.data[start]), data_length - start) + 1;
     }
 
+    // The trailing field may not be null-terminated within the valid data, in which case
+    // strnlen pushed end one past data_length. Clamp it back so the memcpy stays in bounds.
+    end = std::min(end, data_length);
+    if (end <= start) {
+        return {};
+    }
+
+    std::string result;
     result.resize(end - start);
     std::memcpy(result.data(), &payload.data[start], end - start);
 

--- a/cpp/src/mavsdk/core/mavlink_ftp_server.hpp
+++ b/cpp/src/mavsdk/core/mavlink_ftp_server.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <cinttypes>
 #include <fstream>
 #include <unordered_map>
@@ -136,7 +137,7 @@ private:
     void _work_rename(const PayloadHeader& payload);
     void _work_calc_file_CRC32(const PayloadHeader& payload);
 
-    bool _send_burst_packet();
+    bool _send_burst_packet(); // Requires _mutex to be held.
     void _make_burst_packet(PayloadHeader& packet);
 
     std::mutex _mutex{};
@@ -146,7 +147,10 @@ private:
         uint8_t burst_chunk_size{0};
         std::ifstream ifstream;
         std::ofstream ofstream;
-        bool burst_stop{false};
+        // Atomic so the burst worker can observe a stop request without holding
+        // _mutex, which lets a thread that holds _mutex join the worker without
+        // deadlocking (the worker would otherwise block trying to re-acquire _mutex).
+        std::atomic<bool> burst_stop{false};
         std::thread burst_thread;
     } _session_info{};
 

--- a/cpp/src/mavsdk/core/mavlink_ftp_server.hpp
+++ b/cpp/src/mavsdk/core/mavlink_ftp_server.hpp
@@ -155,8 +155,10 @@ private:
     } _session_info{};
 
     uint8_t _network_id = 0;
-    uint8_t _target_system_id = 0;
-    uint8_t _target_component_id = 0;
+    // Written from the message-processing thread and read from the burst thread
+    // (via _send_mavlink_ftp_message), so keep these atomic.
+    std::atomic<uint8_t> _target_system_id{0};
+    std::atomic<uint8_t> _target_component_id{0};
     std::string _root_dir{};
 
     std::mutex _tmp_files_mutex{};

--- a/cpp/src/mavsdk/core/mavlink_mission_transfer_server.cpp
+++ b/cpp/src/mavsdk/core/mavlink_mission_transfer_server.cpp
@@ -283,6 +283,13 @@ void MavlinkMissionTransferServer::ReceiveIncomingMission::process_mission_item_
     mavlink_mission_item_int_t item_int;
     mavlink_msg_mission_item_int_decode(&message, &item_int);
 
+    // Ignore duplicate or out-of-order items. Without this, a peer streaming items
+    // (e.g. all with seq 0) would grow _items without bound while refreshing the
+    // timeout, so the transfer would never time out.
+    if (_next_sequence != item_int.seq) {
+        return;
+    }
+
     _items.push_back(ItemInt{
         item_int.seq,
         item_int.frame,

--- a/cpp/src/mavsdk/core/mavlink_parameter_cache.cpp
+++ b/cpp/src/mavsdk/core/mavlink_parameter_cache.cpp
@@ -56,6 +56,15 @@ MavlinkParameterCache::all_parameters(bool including_extended) const
             std::back_inserter(params_without_extended),
             [](auto& entry) { return !entry.value.needs_extended(); });
 
+        // The non-extended protocol only advertises these parameters, so their indices
+        // must be contiguous 0..N-1 to stay consistent with count(false). Otherwise, when
+        // extended-only params are interspersed, the stored (full-set) index no longer
+        // matches the position in this filtered view: param_by_index() would return the
+        // wrong param (or trip its assert) and broadcasts would send an index >= count.
+        for (uint16_t i = 0; i < params_without_extended.size(); ++i) {
+            params_without_extended[i].index = i;
+        }
+
         return params_without_extended;
     }
 }

--- a/cpp/src/mavsdk/core/mavlink_parameter_server.cpp
+++ b/cpp/src/mavsdk/core/mavlink_parameter_server.cpp
@@ -299,8 +299,15 @@ void MavlinkParameterServer::process_param_set_internally(
                     LogDebug("Update had no effect: {}", updated_parameter.value.get_string());
                 } else {
                     LogDebug("Updated param to :{}", updated_parameter.value.get_string());
-                    find_and_call_subscriptions_value_changed(
-                        updated_parameter.id, updated_parameter.value);
+                    // Don't call the (user) subscription callbacks while holding
+                    // _all_params_mutex: a callback re-entering a server API that takes the
+                    // same mutex would self-deadlock. Post it onto the io_context instead,
+                    // matching provide_server_param().
+                    const auto changed_id = updated_parameter.id;
+                    const auto changed_value = updated_parameter.value;
+                    asio::post(_io_context, [this, changed_id, changed_value]() {
+                        find_and_call_subscriptions_value_changed(changed_id, changed_value);
+                    });
                 }
                 if (extended) {
                     auto new_work = std::make_shared<WorkItem>(

--- a/cpp/src/mavsdk/core/mavlink_parameter_server.cpp
+++ b/cpp/src/mavsdk/core/mavlink_parameter_server.cpp
@@ -261,7 +261,7 @@ void MavlinkParameterServer::process_param_set_internally(
                     error_code = 1; // MAV_PARAM_ERROR_DOES_NOT_EXIST
                     send_error = true;
                 }
-                return;
+                break;
             }
             case MavlinkParameterCache::UpdateExistingParamResult::WrongType: {
                 // Non-extended: send PARAM_ERROR with TYPE_MISMATCH
@@ -287,7 +287,7 @@ void MavlinkParameterServer::process_param_set_internally(
                     error_code = 7; // MAV_PARAM_ERROR_TYPE_MISMATCH
                     send_error = true;
                 }
-                return;
+                break;
             }
             case MavlinkParameterCache::UpdateExistingParamResult::Ok: {
                 LogWarn("Update existing params!");

--- a/cpp/src/mavsdk/core/mavlink_request_message.cpp
+++ b/cpp/src/mavsdk/core/mavlink_request_message.cpp
@@ -31,6 +31,14 @@ MavlinkRequestMessage::~MavlinkRequestMessage()
     // The message handler holds callbacks capturing 'this', so make sure none of
     // them can fire after we are gone.
     _message_handler.unregister_all_blocking(this);
+
+    // In-flight requests schedule timeouts that also capture 'this'. Cancel any that
+    // are still pending, otherwise TimeoutHandler could fire handle_timeout on us
+    // after destruction (use-after-free).
+    std::lock_guard<std::mutex> lock(_mutex);
+    for (const auto& item : _work_items) {
+        _timeout_handler.remove(item.timeout_cookie);
+    }
 }
 
 void MavlinkRequestMessage::request(

--- a/cpp/src/mavsdk/core/mavlink_request_message.cpp
+++ b/cpp/src/mavsdk/core/mavlink_request_message.cpp
@@ -224,9 +224,10 @@ void MavlinkRequestMessage::handle_any_message(const mavlink_message_t& message)
     std::unique_lock<std::mutex> lock(_mutex);
 
     for (auto it = _work_items.begin(); it != _work_items.end(); ++it) {
-        // Check if we're waiting for this message.
+        // Check if we're waiting for this message. Skip unless both the message id and
+        // the component it came from match what this work item requested.
         // TODO: check if params are correct.
-        if (it->message_id != message.msgid && it->target_component == message.compid) {
+        if (it->message_id != message.msgid || it->target_component != message.compid) {
             continue;
         }
 

--- a/cpp/src/mavsdk/core/mavsdk_impl.cpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.cpp
@@ -1501,13 +1501,16 @@ void MavsdkImpl::process_user_callbacks_thread()
         }
 
         const double timeout_s = 1.0;
+        // Capture the fields we need by value: this watchdog runs on the io thread and
+        // can fire while (or just after) callback.func() runs here, so referencing the
+        // loop-local 'callback' would race with its destruction at the next iteration.
         auto cookie = timeout_handler.add(
-            [&]() {
+            [this, timeout_s, filename = callback.filename, linenumber = callback.linenumber]() {
                 if (_callback_debugging) {
                     LogWarn(
                         "Callback called from {}:{} took more than {} second to run.",
-                        callback.filename,
-                        callback.linenumber,
+                        filename,
+                        linenumber,
                         static_cast<int>(timeout_s));
                     fflush(stdout);
                     fflush(stderr);

--- a/cpp/src/mavsdk/core/mavsdk_impl.cpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.cpp
@@ -242,7 +242,7 @@ std::shared_ptr<ServerComponent> MavsdkImpl::server_component(unsigned instance)
 {
     std::lock_guard lock(_mutex);
 
-    auto component_type = _configuration.get_component_type();
+    auto component_type = get_component_type();
     switch (component_type) {
         case ComponentType::Autopilot:
         case ComponentType::GroundStation:
@@ -557,8 +557,8 @@ void MavsdkImpl::process_message(mavlink_message_t& message, Connection* connect
         // examples and integration tests) to connect to QGroundControl by accident
         // instead of PX4 because the check `has_autopilot()` is not used.
 
-        if (_configuration.get_component_type() == ComponentType::GroundStation &&
-            message.sysid == 255 && message.compid == MAV_COMP_ID_MISSIONPLANNER) {
+        if (get_component_type() == ComponentType::GroundStation && message.sysid == 255 &&
+            message.compid == MAV_COMP_ID_MISSIONPLANNER) {
             if (_message_logging_on) {
                 LogDebug("Ignoring messages from QGC as we are also a ground statio");
             }
@@ -728,8 +728,8 @@ void MavsdkImpl::process_libmav_message(
         }
 
         // Filter out QGroundControl messages similar to regular mavlink processing
-        if (_configuration.get_component_type() == ComponentType::GroundStation &&
-            message.system_id == 255 && message.component_id == MAV_COMP_ID_MISSIONPLANNER) {
+        if (get_component_type() == ComponentType::GroundStation && message.system_id == 255 &&
+            message.component_id == MAV_COMP_ID_MISSIONPLANNER) {
             if (_message_logging_on) {
                 LogDebug("Ignoring libmav messages from QGC as we are also a ground statio");
             }
@@ -1173,8 +1173,14 @@ void MavsdkImpl::remove_connection(Mavsdk::ConnectionHandle handle)
 
 Mavsdk::Configuration MavsdkImpl::get_configuration() const
 {
-    std::lock_guard configuration_lock(_mutex);
+    std::lock_guard configuration_lock(_configuration_mutex);
     return _configuration;
+}
+
+ComponentType MavsdkImpl::get_component_type() const
+{
+    std::lock_guard configuration_lock(_configuration_mutex);
+    return _configuration.get_component_type();
 }
 
 void MavsdkImpl::set_configuration(Mavsdk::Configuration new_configuration)
@@ -1186,16 +1192,23 @@ void MavsdkImpl::set_configuration(Mavsdk::Configuration new_configuration)
     _default_server_component = server_component_by_id_with_lock(
         new_configuration.get_component_id(), new_configuration.get_mav_type());
 
-    if (new_configuration.get_always_send_heartbeats() &&
-        !_configuration.get_always_send_heartbeats()) {
+    const bool was_always_sending_heartbeats = [this] {
+        std::lock_guard configuration_lock(_configuration_mutex);
+        return _configuration.get_always_send_heartbeats();
+    }();
+
+    if (new_configuration.get_always_send_heartbeats() && !was_always_sending_heartbeats) {
         start_sending_heartbeats();
     } else if (
-        !new_configuration.get_always_send_heartbeats() &&
-        _configuration.get_always_send_heartbeats() && !is_any_system_connected()) {
+        !new_configuration.get_always_send_heartbeats() && was_always_sending_heartbeats &&
+        !is_any_system_connected()) {
         stop_sending_heartbeats();
     }
 
-    _configuration = new_configuration;
+    {
+        std::lock_guard configuration_lock(_configuration_mutex);
+        _configuration = new_configuration;
+    }
     // We cache these values as atomic to avoid having to lock any mutex for them.
     _our_system_id = new_configuration.get_system_id();
     _our_component_id = new_configuration.get_component_id();
@@ -1213,16 +1226,19 @@ uint8_t MavsdkImpl::get_own_component_id() const
 
 uint8_t MavsdkImpl::get_mav_type() const
 {
+    std::lock_guard configuration_lock(_configuration_mutex);
     return _configuration.get_mav_type();
 }
 
 Autopilot MavsdkImpl::get_autopilot() const
 {
+    std::lock_guard configuration_lock(_configuration_mutex);
     return _configuration.get_autopilot();
 }
 
 uint8_t MavsdkImpl::get_mav_autopilot() const
 {
+    std::lock_guard configuration_lock(_configuration_mutex);
     switch (_configuration.get_autopilot()) {
         case Autopilot::Px4:
             return MAV_AUTOPILOT_PX4;
@@ -1236,12 +1252,18 @@ uint8_t MavsdkImpl::get_mav_autopilot() const
 
 CompatibilityMode MavsdkImpl::get_compatibility_mode() const
 {
+    std::lock_guard configuration_lock(_configuration_mutex);
     return _configuration.get_compatibility_mode();
 }
 
 Autopilot MavsdkImpl::effective_autopilot(Autopilot detected) const
 {
-    switch (_configuration.get_compatibility_mode()) {
+    CompatibilityMode compatibility_mode;
+    {
+        std::lock_guard configuration_lock(_configuration_mutex);
+        compatibility_mode = _configuration.get_compatibility_mode();
+    }
+    switch (compatibility_mode) {
         case CompatibilityMode::Auto:
             return detected;
         case CompatibilityMode::Pure:
@@ -1533,7 +1555,11 @@ void MavsdkImpl::start_sending_heartbeats()
 
 void MavsdkImpl::stop_sending_heartbeats()
 {
-    if (!_configuration.get_always_send_heartbeats()) {
+    const bool always_send_heartbeats = [this] {
+        std::lock_guard configuration_lock(_configuration_mutex);
+        return _configuration.get_always_send_heartbeats();
+    }();
+    if (!always_send_heartbeats) {
         std::lock_guard<std::mutex> lock(_heartbeat_mutex);
         call_every_handler.remove(_heartbeat_send_cookie);
     }

--- a/cpp/src/mavsdk/core/mavsdk_impl.hpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.hpp
@@ -78,6 +78,7 @@ public:
 
     void set_configuration(Mavsdk::Configuration new_configuration);
     Mavsdk::Configuration get_configuration() const;
+    ComponentType get_component_type() const;
 
     bool send_message(mavlink_message_t& message);
     uint8_t get_own_system_id() const;
@@ -250,6 +251,10 @@ private:
 
     CallbackList<> _new_system_callbacks{_io_context};
 
+    // Leaf mutex guarding only _configuration. It is never held while acquiring
+    // another mutex, so it cannot participate in a lock-order inversion with
+    // _mutex / _server_components_mutex.
+    mutable std::mutex _configuration_mutex{};
     Mavsdk::Configuration _configuration{ComponentType::GroundStation};
     std::atomic<uint8_t> _our_system_id{0};
     std::atomic<uint8_t> _our_component_id{0};

--- a/cpp/src/mavsdk/core/param_value.cpp
+++ b/cpp/src/mavsdk/core/param_value.cpp
@@ -180,7 +180,7 @@ bool ParamValue::set_from_mavlink_param_ext_set(const mavlink_param_ext_set_t& m
             _value = temp;
         } break;
         case MAV_PARAM_EXT_TYPE_CUSTOM: {
-            std::size_t len = std::min(std::size_t(128), strlen(mavlink_ext_set.param_value));
+            std::size_t len = strnlen(mavlink_ext_set.param_value, 128);
             _value = std::string(mavlink_ext_set.param_value, mavlink_ext_set.param_value + len);
         } break;
         default:

--- a/cpp/src/mavsdk/core/system_impl.cpp
+++ b/cpp/src/mavsdk/core/system_impl.cpp
@@ -302,11 +302,13 @@ void SystemImpl::remove_call_every(CallEveryHandler::Cookie cookie)
 void SystemImpl::register_statustext_handler(
     std::function<void(const MavlinkStatustextHandler::Statustext&)> callback, void* cookie)
 {
+    std::lock_guard<std::mutex> lock(_statustext_handler_callbacks_mutex);
     _statustext_handler_callbacks.push_back(StatustextCallback{std::move(callback), cookie});
 }
 
 void SystemImpl::unregister_statustext_handler(void* cookie)
 {
+    std::lock_guard<std::mutex> lock(_statustext_handler_callbacks_mutex);
     _statustext_handler_callbacks.erase(
         std::remove_if(
             _statustext_handler_callbacks.begin(),
@@ -370,7 +372,14 @@ void SystemImpl::process_statustext(const mavlink_message_t& message)
             MavlinkStatustextHandler::severity_str(maybe_result.value().severity),
             maybe_result.value().text);
 
-        for (const auto& entry : _statustext_handler_callbacks) {
+        // Copy the callbacks out under the lock and invoke them afterwards, so a
+        // callback that (un)registers a handler can't deadlock or invalidate the vector.
+        std::vector<StatustextCallback> callbacks_copy;
+        {
+            std::lock_guard<std::mutex> lock(_statustext_handler_callbacks_mutex);
+            callbacks_copy = _statustext_handler_callbacks;
+        }
+        for (const auto& entry : callbacks_copy) {
             entry.callback(maybe_result.value());
         }
     }
@@ -1378,8 +1387,18 @@ void SystemImpl::call_user_callback_located(
 
 void SystemImpl::param_changed(const std::string& name)
 {
-    for (auto& callback : _param_changed_callbacks) {
-        callback.second(name);
+    // Copy the callbacks out under the lock and invoke them afterwards, so a callback
+    // that (un)registers a handler can't deadlock or invalidate the map.
+    std::vector<ParamChangedCallback> callbacks_copy;
+    {
+        std::lock_guard<std::mutex> lock(_param_changed_callbacks_mutex);
+        callbacks_copy.reserve(_param_changed_callbacks.size());
+        for (const auto& callback : _param_changed_callbacks) {
+            callbacks_copy.push_back(callback.second);
+        }
+    }
+    for (const auto& callback : callbacks_copy) {
+        callback(name);
     }
 }
 
@@ -1396,11 +1415,13 @@ void SystemImpl::register_param_changed_handler(
         return;
     }
 
+    std::lock_guard<std::mutex> lock(_param_changed_callbacks_mutex);
     _param_changed_callbacks[cookie] = callback;
 }
 
 void SystemImpl::unregister_param_changed_handler(const void* cookie)
 {
+    std::lock_guard<std::mutex> lock(_param_changed_callbacks_mutex);
     auto it = _param_changed_callbacks.find(cookie);
     if (it == _param_changed_callbacks.end()) {
         LogWarn("param_changed_handler for cookie not found");

--- a/cpp/src/mavsdk/core/system_impl.cpp
+++ b/cpp/src/mavsdk/core/system_impl.cpp
@@ -307,10 +307,12 @@ void SystemImpl::register_statustext_handler(
 
 void SystemImpl::unregister_statustext_handler(void* cookie)
 {
-    _statustext_handler_callbacks.erase(std::remove_if(
-        _statustext_handler_callbacks.begin(),
-        _statustext_handler_callbacks.end(),
-        [&](const auto& entry) { return entry.cookie == cookie; }));
+    _statustext_handler_callbacks.erase(
+        std::remove_if(
+            _statustext_handler_callbacks.begin(),
+            _statustext_handler_callbacks.end(),
+            [&](const auto& entry) { return entry.cookie == cookie; }),
+        _statustext_handler_callbacks.end());
 }
 
 void SystemImpl::process_heartbeat(const mavlink_message_t& message)

--- a/cpp/src/mavsdk/core/system_impl.hpp
+++ b/cpp/src/mavsdk/core/system_impl.hpp
@@ -397,6 +397,7 @@ private:
         void* cookie;
     };
     std::vector<StatustextCallback> _statustext_handler_callbacks;
+    std::mutex _statustext_handler_callbacks_mutex{};
 
     std::atomic<bool> _armed{false};
     std::atomic<bool> _hitl_enabled{false};
@@ -448,6 +449,7 @@ private:
     std::unordered_set<uint8_t> _components{};
 
     std::unordered_map<const void*, ParamChangedCallback> _param_changed_callbacks{};
+    std::mutex _param_changed_callbacks_mutex{};
 
     MAV_TYPE _vehicle_type{MAV_TYPE::MAV_TYPE_GENERIC};
     bool _vehicle_type_set{false};

--- a/cpp/src/mavsdk/core/udp_connection.cpp
+++ b/cpp/src/mavsdk/core/udp_connection.cpp
@@ -104,6 +104,10 @@ ConnectionResult UdpConnection::stop()
             // the socket's internal state.
             std::promise<void> close_done;
             asio::post(io_ctx, [this, &close_done]() {
+                // send_raw_bytes() calls _socket.send_to() synchronously on a caller
+                // thread while holding _remote_mutex, so take it here too: closing the
+                // socket concurrently with an in-flight send_to is a data race.
+                std::lock_guard<std::mutex> lock(_remote_mutex);
                 asio::error_code ec;
                 _socket.close(ec);
                 close_done.set_value();
@@ -119,8 +123,9 @@ ConnectionResult UdpConnection::stop()
             fence.get_future().wait();
         } else {
             // io_context has already been stopped (io_thread joined) — no
-            // concurrent async operation can be running, so closing directly
-            // is safe.
+            // concurrent async operation can be running, but a user thread could
+            // still call send_raw_bytes(), so guard the close with _remote_mutex.
+            std::lock_guard<std::mutex> lock(_remote_mutex);
             asio::error_code ec;
             _socket.close(ec);
         }

--- a/cpp/src/system_tests/system_tests_runner.cpp
+++ b/cpp/src/system_tests/system_tests_runner.cpp
@@ -17,6 +17,12 @@ void handler(int sig)
     } else {
         LogErr("Got signal: <unknown> ({})", sig);
     }
+
+    // Note: generate_trace() symbolizes eagerly and is not strictly async-signal-safe,
+    // but we exit right after, and in practice it produces a fully symbolized backtrace
+    // (function, file, line). cpptrace's signal-safe raw-trace API is not used because it
+    // needs the libunwind backend to collect frames; with the default unwinder it returns
+    // nothing, which would be worse than this.
     cpptrace::generate_trace().print();
     exit(1);
 }

--- a/cpp/third_party/cpptrace/CMakeLists.txt
+++ b/cpp/third_party/cpptrace/CMakeLists.txt
@@ -21,7 +21,7 @@ endforeach()
 ExternalProject_add(
     cpptrace
     GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
-    GIT_TAG v0.3.1
+    GIT_TAG v1.0.4
     PREFIX cpptrace
     CMAKE_ARGS "${CMAKE_ARGS}"
     )


### PR DESCRIPTION
## Summary

An audit of `src/mavsdk/core/` for buffer overflows, deadlocks, and other memory-safety / concurrency bugs. Each fix is its own commit. Build is clean and all unit tests (291) and system tests (95) pass.

## Memory safety (remotely reachable)

- **FTP `_data_as_string` OOB read** — scanned the fixed 239-byte `data[]` ignoring `payload.size`, and `max_data_length - start` (uint8_t − size_t) underflowed; a `CMD_RENAME` with a NUL-free field read far past the buffer. Now bounded by `payload.size`.
- **`PARAM_EXT_SET` custom value OOB read** — used `strlen()` on the non-terminated `char[128]`; switched to `strnlen()`.
- **Metadata uri `std::stoi` → `terminate()`** — a `COMPONENT_METADATA` uri with `comp=` > INT_MAX aborted under `-fno-exceptions`; parse with `strtol` + range check.
- **`fopen` NULL deref** in `download_file_to_path` — unwritable path caused a NULL `FILE*` deref in libcurl's writer / `fclose`.
- **FTP burst offset huge allocation** — a crafted burst `offset` triggered a ~4 GB zero-fill vector; reject offsets past the file size.
- **`getpwuid()` NULL deref** in `get_cache_directory` when `HOME` is unset and the uid has no passwd entry.
- **`inet_ntop` result unchecked** in `resolve_hostname_to_ip` (could read uninitialized buffer / return empty as success).

## Concurrency (races, deadlocks, use-after-free)

- **`MavlinkRequestMessage` UAF** — the destructor didn't cancel pending `TimeoutHandler` cookies, so a timeout could fire on freed memory after teardown.
- **FTP burst-thread deadlock** — `_reset()` / `_work_burst` joined the burst thread while holding `_mutex`, which the worker needs; made `burst_stop` atomic and the worker `try_lock`.
- **Param subscription callbacks under `_all_params_mutex`** — a callback re-entering a server API would self-deadlock; post the notification off the lock (matching `provide_server_param`).
- **`_configuration` inconsistent locking** — written under one mutex, read under another or none; now guarded by a dedicated leaf mutex.
- **`_system_ids` unlocked insert** on the libmav receive path (raced the locked send-path reader).
- **UDP `send_to` vs socket close** race during teardown — close now takes `_remote_mutex`.
- **Callback watchdog captured a loop-local by reference** (debug-only UAF) — capture by value.
- **FTP target ids** made atomic (written on the message thread, read on the burst thread).
- **Unsynchronized statustext / param-changed handler lists** — guarded with a mutex, snapshot-under-lock so callbacks never run while holding it.

## Correctness

- **`unregister_statustext_handler`** used the single-iterator `erase(remove_if(...))` idiom → UB when the cookie isn't present.
- **`MavlinkRequestMessage::handle_any_message`** used `&&` where it needed `||`, so an unrelated message could complete the wrong request.
- **`PARAM_ERROR` never sent** for missing/wrong-type non-extended `PARAM_SET` (`return` instead of `break`).
- **Non-extended parameter view** kept full-set indices, so `param_by_index` / broadcasts were inconsistent with `count()`; reindex contiguously.
- **Mission server accepted duplicate/out-of-order items** unbounded; guard on `seq == _next_sequence` like the client.
- **`_work_write`** checked `ifstream.fail()` after `ofstream.seekp()`.
- **`cli_arg`** accepted trailing garbage in port/baudrate (`from_chars` didn't require full consumption).

## Not addressed (intentionally)

Two lower-confidence, design-level items were left out to avoid a destabilizing change:
- `on_io_thread()` relying on asio's `running_in_this_thread()` across the DSO boundary (possible self-deadlock in `CallbackList::exec`/`drain`).
- `stop()` on the connection classes self-deadlocking if ever driven from the io thread.

## Testing

- `cmake --build build-debug` — clean
- `unit_tests_runner` — 291 passed
- `system_tests_runner` — 95 passed
