### PR TITLE
core, plugins: capitalize log message casing

### DIFF
--- a/cpp/src/mavsdk/core/cli_arg.cpp
+++ b/cpp/src/mavsdk/core/cli_arg.cpp
@@ -276,7 +276,7 @@ bool CliArg::parse_serial(const std::string_view rest, bool flow_control_enabled
             return false;
         }
     } else {
-        LogErr("serial port needs to start with / or COM on Windows");
+        LogErr("Serial port needs to start with / or COM on Windows");
         return false;
     }
 
@@ -305,7 +305,7 @@ bool CliArg::parse_raw(const std::string_view rest)
 {
     // raw:// connection has no parameters
     if (!rest.empty()) {
-        LogErr("raw:// connection should not have parameters");
+        LogErr("A raw:// connection should not have parameters");
         return false;
     }
 

--- a/cpp/src/mavsdk/core/hostname_to_ip.cpp
+++ b/cpp/src/mavsdk/core/hostname_to_ip.cpp
@@ -33,10 +33,10 @@ std::optional<std::string> resolve_hostname_to_ip(const std::string& hostname)
     int res = getaddrinfo(hostname.c_str(), nullptr, &hints, &result);
     if (res != 0) {
 #if defined(WINDOWS)
-        LogErr("getaddrinfo failed: {}", WSAGetLastError());
+        LogErr("Call getaddrinfo failed: {}", WSAGetLastError());
         WSACleanup();
 #else
-        LogErr("getaddrinfo failed: {}", gai_strerror(res));
+        LogErr("Call getaddrinfo failed: {}", gai_strerror(res));
 #endif
         return {};
     }

--- a/cpp/src/mavsdk/core/mavlink_command_sender.cpp
+++ b/cpp/src/mavsdk/core/mavlink_command_sender.cpp
@@ -227,7 +227,7 @@ void MavlinkCommandSender::receive_command_ack(const mavlink_message_t& message)
 
             case MAV_RESULT_DENIED:
                 if (_command_debugging) {
-                    LogDebug("command denied ({}).", work->identification.command);
+                    LogDebug("Command denied ({}).", work->identification.command);
                     if (work->identification.command == 512) {
                         LogDebug("(message {})", work->identification.maybe_param1);
                     }
@@ -239,7 +239,7 @@ void MavlinkCommandSender::receive_command_ack(const mavlink_message_t& message)
 
             case MAV_RESULT_UNSUPPORTED:
                 if (_command_debugging) {
-                    LogDebug("command unsupported ({}).", work->identification.command);
+                    LogDebug("Command unsupported ({}).", work->identification.command);
                 }
                 _system_impl.unregister_timeout_handler(work->timeout_cookie);
                 temp_result = {Result::Unsupported, NAN};
@@ -248,7 +248,7 @@ void MavlinkCommandSender::receive_command_ack(const mavlink_message_t& message)
 
             case MAV_RESULT_TEMPORARILY_REJECTED:
                 if (_command_debugging) {
-                    LogDebug("command temporarily rejected ({}).", work->identification.command);
+                    LogDebug("Command temporarily rejected ({}).", work->identification.command);
                 }
                 _system_impl.unregister_timeout_handler(work->timeout_cookie);
                 temp_result = {Result::TemporarilyRejected, NAN};
@@ -257,7 +257,7 @@ void MavlinkCommandSender::receive_command_ack(const mavlink_message_t& message)
 
             case MAV_RESULT_FAILED:
                 if (_command_debugging) {
-                    LogDebug("command failed ({}).", work->identification.command);
+                    LogDebug("Command failed ({}).", work->identification.command);
                 }
                 _system_impl.unregister_timeout_handler(work->timeout_cookie);
                 temp_result = {Result::Failed, NAN};
@@ -289,7 +289,7 @@ void MavlinkCommandSender::receive_command_ack(const mavlink_message_t& message)
 
             case MAV_RESULT_CANCELLED:
                 if (_command_debugging) {
-                    LogDebug("command cancelled ({}).", work->identification.command);
+                    LogDebug("Command cancelled ({}).", work->identification.command);
                 }
                 _system_impl.unregister_timeout_handler(work->timeout_cookie);
                 temp_result = {Result::Cancelled, NAN};
@@ -360,7 +360,7 @@ void MavlinkCommandSender::receive_timeout(const CommandIdentification& identifi
             }
 
             if (!send_mavlink_message(work->command)) {
-                LogErr("connection send error in retransmit ({}).", work->identification.command);
+                LogErr("Connection send error in retransmit ({}).", work->identification.command);
                 temp_callback = work->callback;
                 temp_result = {Result::ConnectionError, NAN};
                 _work_queue.erase(it);
@@ -455,7 +455,7 @@ void MavlinkCommandSender::do_work()
 
         {
             if (!send_mavlink_message(work->command)) {
-                LogErr("connection send error ({})", work->identification.command);
+                LogErr("Connection send error ({})", work->identification.command);
                 // In this case we try again after the timeout. Chances are slim it will work next
                 // time though.
             } else {

--- a/cpp/src/mavsdk/core/mavlink_component_metadata.cpp
+++ b/cpp/src/mavsdk/core/mavlink_component_metadata.cpp
@@ -55,7 +55,7 @@ MavlinkComponentMetadata::~MavlinkComponentMetadata()
     std::error_code ec;
     std::filesystem::remove_all(_tmp_download_path, ec);
     if (ec) {
-        LogErr("failed to remove directory: {}", ec.message());
+        LogErr("Failed to remove directory: {}", ec.message());
     }
 }
 
@@ -439,34 +439,34 @@ void MavlinkComponentMetadata::parse_component_metadata_general(
     }
 
     if (!metadata.contains("version") || !metadata["version"].is_number_integer()) {
-        LogErr("version not found");
+        LogErr("Version not found");
         return;
     }
 
     if (metadata["version"].get<int>() != 1) {
-        LogWarn("version {} not supported", metadata["version"].get<int>());
+        LogWarn("Version {} not supported", metadata["version"].get<int>());
         return;
     }
 
     if (!metadata.contains("metadataTypes") || !metadata["metadataTypes"].is_array()) {
-        LogErr("metadataTypes not found");
+        LogErr("Field metadataTypes not found");
         return;
     }
 
     for (const auto& metadata_type : metadata["metadataTypes"]) {
         if (!metadata_type.is_object() || !metadata_type.contains("type") ||
             !metadata_type["type"].is_number_integer()) {
-            LogErr("type missing");
+            LogErr("Type missing");
             continue;
         }
         auto type = static_cast<COMP_METADATA_TYPE>(metadata_type["type"].get<int>());
         auto& components = _mavlink_components[compid].components;
         if (components.find(type) != components.end()) {
-            LogErr("component type already added: {}", static_cast<int>(type));
+            LogErr("Component type already added: {}", static_cast<int>(type));
             continue;
         }
         if (!metadata_type.contains("uri")) {
-            LogErr("uri missing");
+            LogErr("URI missing");
             continue;
         }
 
@@ -625,7 +625,7 @@ std::optional<std::filesystem::path>& MetadataComponent::current_metadata_path()
         case State::Init:
             break;
     }
-    LogErr("current_metadata_path() called in invalid state");
+    LogErr("Function current_metadata_path() called in invalid state");
     return _metadata;
 }
 } // namespace mavsdk

--- a/cpp/src/mavsdk/core/mavlink_ftp_client.cpp
+++ b/cpp/src/mavsdk/core/mavlink_ftp_client.cpp
@@ -1187,7 +1187,7 @@ bool MavlinkFtpClient::list_dir_continue(Work& work, ListDirItem& item, PayloadH
         ++item.offset;
 
         if (_debugging) {
-            LogDebug("list_dir raw entry: '{}'", entry);
+            LogDebug("Raw entry from list_dir: '{}'", entry);
         }
 
         if (entry.empty()) {

--- a/cpp/src/mavsdk/core/mavlink_ftp_server.cpp
+++ b/cpp/src/mavsdk/core/mavlink_ftp_server.cpp
@@ -1045,7 +1045,7 @@ void MavlinkFtpServer::_work_remove_directory(const PayloadHeader& payload)
         return;
     }
     if (ec) {
-        LogErr("fs::exists for {} returned error: {}", path.string(), ec.message());
+        LogErr("Call fs::exists for {} returned error: {}", path.string(), ec.message());
         response.opcode = Opcode::RSP_NAK;
         response.size = 1;
         response.data[0] = ServerResult::ERR_FAIL;
@@ -1054,7 +1054,7 @@ void MavlinkFtpServer::_work_remove_directory(const PayloadHeader& payload)
     }
 
     if (!fs::remove(path, ec)) {
-        LogErr("fs::remove returned error: {}", ec.message());
+        LogErr("Call fs::remove returned error: {}", ec.message());
         response.opcode = Opcode::RSP_NAK;
         response.size = 1;
         response.data[0] = ServerResult::ERR_FAIL;
@@ -1192,7 +1192,8 @@ void MavlinkFtpServer::_work_rename(const PayloadHeader& payload)
 
     fs::rename(old_name, new_name, ec);
     if (ec) {
-        LogErr("fs::rename from {} to {} returned error: {}", old_name, new_name, ec.message());
+        LogErr(
+            "Call fs::rename from {} to {} returned error: {}", old_name, new_name, ec.message());
         response.opcode = Opcode::RSP_NAK;
         response.size = 1;
         response.data[0] = ServerResult::ERR_FAIL;

--- a/cpp/src/mavsdk/core/mavlink_mission_transfer_client.cpp
+++ b/cpp/src/mavsdk/core/mavlink_mission_transfer_client.cpp
@@ -417,13 +417,13 @@ void MavlinkMissionTransferClient::UploadWorkItem::process_mission_request_int(
     if (_next_sequence < request_int.seq) {
         // We should not go back to a previous one.
         // TODO: figure out if we should error here.
-        LogWarn("mission_request_int: sequence incorrect");
+        LogWarn("In mission_request_int: sequence incorrect");
         return;
 
     } else if (_next_sequence > request_int.seq) {
         // We have already sent that one before.
         if (_retries_done >= retries) {
-            LogWarn("mission_request_int: retries exceeded");
+            LogWarn("In mission_request_int: retries exceeded");
             _timeout_handler.remove(_cookie);
             callback_and_reset(Result::Timeout);
             return;
@@ -447,7 +447,7 @@ void MavlinkMissionTransferClient::UploadWorkItem::process_mission_request_int(
 void MavlinkMissionTransferClient::UploadWorkItem::send_mission_item()
 {
     if (_next_sequence >= _items.size()) {
-        LogErr("send_mission_item: sequence out of bounds");
+        LogErr("In send_mission_item: sequence out of bounds");
         return;
     }
 
@@ -561,7 +561,7 @@ void MavlinkMissionTransferClient::UploadWorkItem::process_timeout()
     }
 
     if (_retries_done >= retries) {
-        LogWarn("timeout: retries exceeded");
+        LogWarn("Timeout: retries exceeded");
         callback_and_reset(Result::Timeout);
         return;
     }

--- a/cpp/src/mavsdk/core/mavlink_mission_transfer_server.cpp
+++ b/cpp/src/mavsdk/core/mavlink_mission_transfer_server.cpp
@@ -501,13 +501,13 @@ void MavlinkMissionTransferServer::SendOutgoingMission::process_mission_request_
     if (_next_sequence < request_int.seq) {
         // We should not go back to a previous one.
         // TODO: figure out if we should error here.
-        LogWarn("mission_request_int: sequence incorrect");
+        LogWarn("In mission_request_int: sequence incorrect");
         return;
 
     } else if (_next_sequence > request_int.seq) {
         // We have already sent that one before.
         if (_retries_done >= retries) {
-            LogWarn("mission_request_int: retries exceeded");
+            LogWarn("In mission_request_int: retries exceeded");
             _timeout_handler.remove(_cookie);
             callback_and_reset(Result::Timeout);
             return;
@@ -528,7 +528,7 @@ void MavlinkMissionTransferServer::SendOutgoingMission::process_mission_request_
 void MavlinkMissionTransferServer::SendOutgoingMission::send_mission_item()
 {
     if (_next_sequence >= _items.size()) {
-        LogErr("send_mission_item: sequence out of bounds");
+        LogErr("In send_mission_item: sequence out of bounds");
         return;
     }
 
@@ -641,7 +641,7 @@ void MavlinkMissionTransferServer::SendOutgoingMission::process_timeout()
     }
 
     if (_retries_done >= retries) {
-        LogWarn("timeout: retries exceeded");
+        LogWarn("Timeout: retries exceeded");
         callback_and_reset(Result::Timeout);
         return;
     }

--- a/cpp/src/mavsdk/core/mavlink_parameter_cache.cpp
+++ b/cpp/src/mavsdk/core/mavlink_parameter_cache.cpp
@@ -109,7 +109,7 @@ MavlinkParameterCache::param_by_index(uint16_t param_index, bool including_exten
 {
     const auto& params = all_parameters(including_extended);
     if (param_index >= params.size()) {
-        LogErr("param at {} out of bounds ({})", (int)param_index, params.size());
+        LogErr("Param at {} out of bounds ({})", (int)param_index, params.size());
         return {};
     }
 

--- a/cpp/src/mavsdk/core/mavlink_parameter_client.cpp
+++ b/cpp/src/mavsdk/core/mavlink_parameter_client.cpp
@@ -820,7 +820,7 @@ void MavlinkParameterClient::process_param_value(const mavlink_message_t& messag
                             item.param_name);
 
                         if (!send_set_param_message(item)) {
-                            LogErr("connection send error in retransmit ({}).", item.param_name);
+                            LogErr("Connection send error in retransmit ({}).", item.param_name);
                             _work_queue.pop_front();
                             if (!_work_queue.empty()) {
                                 asio::post(_io_context, [this] { do_work(); });
@@ -965,7 +965,7 @@ void MavlinkParameterClient::process_param_ext_value(const mavlink_message_t& me
     }
 
     if (_parameter_debugging) {
-        LogDebug("process param_ext_value: {} {}", safe_param_id, received_value.get_string());
+        LogDebug("Process param_ext_value: {} {}", safe_param_id, received_value.get_string());
     }
 
     if (_work_queue.empty()) {
@@ -1068,7 +1068,7 @@ void MavlinkParameterClient::process_param_ext_ack(const mavlink_message_t& mess
     const auto safe_param_id = extract_safe_param_id(param_ext_ack.param_id);
 
     if (_parameter_debugging) {
-        LogDebug("process param_ext_ack: {} {}", safe_param_id, (int)param_ext_ack.param_result);
+        LogDebug("Process param_ext_ack: {} {}", safe_param_id, (int)param_ext_ack.param_result);
     }
 
     if (_work_queue.empty()) {
@@ -1141,7 +1141,7 @@ void MavlinkParameterClient::process_param_error(const mavlink_message_t& messag
     const auto safe_param_id = extract_safe_param_id(param_error.param_id);
 
     if (_parameter_debugging) {
-        LogDebug("process param_error: {} error code: {}", safe_param_id, (int)param_error.error);
+        LogDebug("Process param_error: {} error code: {}", safe_param_id, (int)param_error.error);
     }
 
     if (_work_queue.empty()) {
@@ -1241,7 +1241,7 @@ void MavlinkParameterClient::receive_timeout()
                         item.param_name);
 
                     if (!send_set_param_message(item)) {
-                        LogErr("connection send error in retransmit ({}).", item.param_name);
+                        LogErr("Connection send error in retransmit ({}).", item.param_name);
                         _work_queue.pop_front();
                         if (!_work_queue.empty()) {
                             asio::post(_io_context, [this] { do_work(); });
@@ -1269,9 +1269,9 @@ void MavlinkParameterClient::receive_timeout()
             [&](WorkItemGet& item) {
                 if (work->retries_to_do > 0) {
                     // We're not sure the command arrived, let's retransmit.
-                    LogWarn("sending again, retries to do: {}", work->retries_to_do);
+                    LogWarn("Sending again, retries to do: {}", work->retries_to_do);
                     if (!send_get_param_message(item)) {
-                        LogErr("connection send error in retransmit ");
+                        LogErr("Connection send error in retransmit ");
                         _work_queue.pop_front();
                         if (!_work_queue.empty()) {
                             asio::post(_io_context, [this] { do_work(); });
@@ -1286,7 +1286,7 @@ void MavlinkParameterClient::receive_timeout()
                     }
                 } else {
                     // We have tried retransmitting, giving up now.
-                    LogErr("retrying failed");
+                    LogErr("Retrying failed");
                     _work_queue.pop_front();
                     if (!_work_queue.empty()) {
                         asio::post(_io_context, [this] { do_work(); });
@@ -1372,7 +1372,7 @@ bool MavlinkParameterClient::request_next_missing(uint16_t count)
 
     auto next_missing_indices = _param_cache.next_missing_indices(count, chunk_size);
     if (next_missing_indices.empty()) {
-        LogErr("logic error, there should a missing index");
+        LogErr("Logic error, there should a missing index");
         return false;
     }
 

--- a/cpp/src/mavsdk/core/mavlink_parameter_server.cpp
+++ b/cpp/src/mavsdk/core/mavlink_parameter_server.cpp
@@ -392,7 +392,7 @@ void MavlinkParameterServer::process_param_ext_set(const mavlink_message_t& mess
 void MavlinkParameterServer::process_param_request_read(const mavlink_message_t& message)
 {
     if (_parameter_debugging) {
-        LogDebug("process param_request_read");
+        LogDebug("Process param_request_read");
     }
     mavlink_param_request_read_t read_request{};
     mavlink_msg_param_request_read_decode(&message, &read_request);
@@ -409,13 +409,13 @@ void MavlinkParameterServer::process_param_request_read(const mavlink_message_t&
             [&](std::monostate) { LogWarn("Ill-formed param_request_read message"); },
             [&](std::uint16_t index) {
                 if (_parameter_debugging) {
-                    LogDebug("found index: {}", index);
+                    LogDebug("Found index: {}", index);
                 }
                 internal_process_param_request_read_by_index(index, false);
             },
             [&](const std::string& id) {
                 if (_parameter_debugging) {
-                    LogDebug("found id: {}", id);
+                    LogDebug("Found id: {}", id);
                 }
                 internal_process_param_request_read_by_id(id, false);
             }},
@@ -438,13 +438,13 @@ void MavlinkParameterServer::process_param_ext_request_read(const mavlink_messag
             [&](std::monostate) { LogWarn("Ill-formed param_request_read message"); },
             [&](std::uint16_t index) {
                 if (_parameter_debugging) {
-                    LogDebug("found index: {}", index);
+                    LogDebug("Found index: {}", index);
                 }
                 internal_process_param_request_read_by_index(index, true);
             },
             [&](const std::string& id) {
                 if (_parameter_debugging) {
-                    LogDebug("found id: {}", id);
+                    LogDebug("Found id: {}", id);
                 }
                 internal_process_param_request_read_by_id(id, true);
             }},
@@ -537,7 +537,7 @@ void MavlinkParameterServer::process_param_request_list(const mavlink_message_t&
 void MavlinkParameterServer::process_param_ext_request_list(const mavlink_message_t& message)
 {
     if (_parameter_debugging) {
-        LogDebug("process param_ext_request_list");
+        LogDebug("Process param_ext_request_list");
     }
 
     mavlink_param_ext_request_list_t ext_list_request{};
@@ -565,7 +565,7 @@ void MavlinkParameterServer::broadcast_all_parameters(const bool extended)
     const bool was_empty = _work_queue.empty();
     for (const auto& parameter : all_params) {
         if (_parameter_debugging) {
-            LogDebug("sending param:{}", parameter.id);
+            LogDebug("Sending param:{}", parameter.id);
         }
         auto new_work = std::make_shared<WorkItem>(
             parameter.id,
@@ -614,7 +614,7 @@ void MavlinkParameterServer::do_work()
                         return;
                     }
                 } else {
-                    LogWarn("sending not extended message");
+                    LogWarn("Sending not extended message");
                     float param_value;
                     if (_sender.compatibility_mode() == CompatibilityMode::ArduPilot) {
                         param_value = work->param_value.get_4_float_bytes_cast();

--- a/cpp/src/mavsdk/core/mavlink_request_message_handler.cpp
+++ b/cpp/src/mavsdk/core/mavlink_request_message_handler.cpp
@@ -36,7 +36,7 @@ bool MavlinkRequestMessageHandler::register_handler(
     if (std::find_if(_table.begin(), _table.end(), [message_id](const Entry& entry) {
             return entry.message_id == message_id;
         }) != _table.end()) {
-        LogErr("message id {} already registered, registration ignored", message_id);
+        LogErr("Message id {} already registered, registration ignored", message_id);
         return false;
     }
 

--- a/cpp/src/mavsdk/core/mavsdk_impl.cpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.cpp
@@ -483,7 +483,7 @@ void MavsdkImpl::process_message(mavlink_message_t& message, Connection* connect
             _tlog_file->stream.flush();
 
             if (!_tlog_file->stream.good()) {
-                LogErr("tlog: write failed, stopping recording");
+                LogErr("Tlog: write failed, stopping recording");
                 _tlog_file.reset();
             }
         }
@@ -710,7 +710,7 @@ void MavsdkImpl::process_libmav_message(
             _tlog_file->stream.flush();
 
             if (!_tlog_file->stream.good()) {
-                LogErr("tlog: write failed, stopping recording");
+                LogErr("Tlog: write failed, stopping recording");
                 _tlog_file.reset();
             }
         }

--- a/cpp/src/mavsdk/core/serial_connection.cpp
+++ b/cpp/src/mavsdk/core/serial_connection.cpp
@@ -112,7 +112,7 @@ ConnectionResult SerialConnection::setup_port()
     asio::error_code ec;
     _serial_port.open(_serial_node, ec);
     if (ec) {
-        LogErr("open failed: {}", ec.message());
+        LogErr("Call open failed: {}", ec.message());
         return ConnectionResult::ConnectionError;
     }
 
@@ -125,7 +125,7 @@ ConnectionResult SerialConnection::setup_port()
     const int fd = _serial_port.native_handle();
 
     if (tcgetattr(fd, &tc) != 0) {
-        LogErr("tcgetattr failed: {}", GET_ERROR());
+        LogErr("Call tcgetattr failed: {}", GET_ERROR());
         _serial_port.close(ec);
         return ConnectionResult::ConnectionError;
     }
@@ -157,19 +157,19 @@ ConnectionResult SerialConnection::setup_port()
     }
 
     if (cfsetispeed(&tc, baudrate_or_define) != 0) {
-        LogErr("cfsetispeed failed: {}", GET_ERROR());
+        LogErr("Call cfsetispeed failed: {}", GET_ERROR());
         _serial_port.close(ec);
         return ConnectionResult::ConnectionError;
     }
 
     if (cfsetospeed(&tc, baudrate_or_define) != 0) {
-        LogErr("cfsetospeed failed: {}", GET_ERROR());
+        LogErr("Call cfsetospeed failed: {}", GET_ERROR());
         _serial_port.close(ec);
         return ConnectionResult::ConnectionError;
     }
 
     if (tcsetattr(fd, TCSANOW, &tc) != 0) {
-        LogErr("tcsetattr failed: {}", GET_ERROR());
+        LogErr("Call tcsetattr failed: {}", GET_ERROR());
         _serial_port.close(ec);
         return ConnectionResult::ConnectionError;
     }
@@ -318,7 +318,7 @@ void SerialConnection::do_receive()
             }
 
             if (ec) {
-                LogErr("read failure: {}", ec.message());
+                LogErr("Read failure: {}", ec.message());
                 // Do not re-arm on hard errors (port removed, etc.).
                 return;
             }

--- a/cpp/src/mavsdk/core/system_impl.cpp
+++ b/cpp/src/mavsdk/core/system_impl.cpp
@@ -332,7 +332,7 @@ void SystemImpl::process_heartbeat(const mavlink_message_t& message)
     // This check only works if the MAV_TYPE::MAV_TYPE_ENUM_END is actually the
     // last enumerator.
     if (MAV_TYPE::MAV_TYPE_ENUM_END < heartbeat.type) {
-        LogErr("type received in HEARTBEAT was not recognized");
+        LogErr("Type received in HEARTBEAT was not recognized");
     } else {
         const auto new_vehicle_type = static_cast<MAV_TYPE>(heartbeat.type);
         if (heartbeat.autopilot != MAV_AUTOPILOT_INVALID && new_vehicle_type != MAV_TYPE_GENERIC) {
@@ -396,7 +396,7 @@ void SystemImpl::process_autopilot_version(const mavlink_message_t& message)
 
 void SystemImpl::heartbeats_timed_out()
 {
-    LogInfo("heartbeats from system {} timed out", int(get_system_id()));
+    LogInfo("Heartbeats from system {} timed out", int(get_system_id()));
     set_disconnected();
 }
 
@@ -1425,7 +1425,7 @@ void SystemImpl::unregister_param_changed_handler(const void* cookie)
     std::lock_guard<std::mutex> lock(_param_changed_callbacks_mutex);
     auto it = _param_changed_callbacks.find(cookie);
     if (it == _param_changed_callbacks.end()) {
-        LogWarn("param_changed_handler for cookie not found");
+        LogWarn("Handler param_changed_handler for cookie not found");
         return;
     }
     _param_changed_callbacks.erase(it);

--- a/cpp/src/mavsdk/core/tcp_server_connection.cpp
+++ b/cpp/src/mavsdk/core/tcp_server_connection.cpp
@@ -62,7 +62,7 @@ ConnectionResult TcpServerConnection::start()
 
     _acceptor.open(asio::ip::tcp::v4(), ec);
     if (ec) {
-        LogErr("socket open error: {}", ec.message());
+        LogErr("Socket open error: {}", ec.message());
         return ConnectionResult::SocketError;
     }
 
@@ -70,13 +70,13 @@ ConnectionResult TcpServerConnection::start()
 
     _acceptor.bind(local_endpoint, ec);
     if (ec) {
-        LogErr("bind error: {}", ec.message());
+        LogErr("Bind error: {}", ec.message());
         return ConnectionResult::SocketError;
     }
 
     _acceptor.listen(asio::socket_base::max_listen_connections, ec);
     if (ec) {
-        LogErr("listen error: {}", ec.message());
+        LogErr("Listen error: {}", ec.message());
         return ConnectionResult::SocketError;
     }
 
@@ -195,7 +195,7 @@ void TcpServerConnection::do_accept()
             return;
         }
         if (ec) {
-            LogErr("accept error: {}", ec.message());
+            LogErr("Accept error: {}", ec.message());
             // Re-arm so the server keeps listening (unless we're shutting down).
             if (!_stopping) {
                 do_accept();

--- a/cpp/src/mavsdk/core/udp_connection.cpp
+++ b/cpp/src/mavsdk/core/udp_connection.cpp
@@ -75,7 +75,7 @@ ConnectionResult UdpConnection::setup_port()
 
     _socket.open(asio::ip::udp::v4(), ec);
     if (ec) {
-        LogErr("socket open error: {}", ec.message());
+        LogErr("Socket open error: {}", ec.message());
         return ConnectionResult::SocketError;
     }
 
@@ -83,7 +83,7 @@ ConnectionResult UdpConnection::setup_port()
 
     _socket.bind(local_endpoint, ec);
     if (ec) {
-        LogErr("bind error: {}", ec.message());
+        LogErr("Bind error: {}", ec.message());
         return ConnectionResult::BindError;
     }
 
@@ -270,7 +270,7 @@ void UdpConnection::do_receive()
             if (ec) {
                 // operation_aborted happens when the socket is closed (stop()), which is normal.
                 if (ec != asio::error::operation_aborted) {
-                    LogErr("async_receive_from error: {}", ec.message());
+                    LogErr("Error from async_receive_from: {}", ec.message());
                 }
                 // Do NOT re-post — the connection is being torn down.
                 return;

--- a/cpp/src/mavsdk/plugins/camera/camera_definition.cpp
+++ b/cpp/src/mavsdk/plugins/camera/camera_definition.cpp
@@ -7,7 +7,7 @@ bool CameraDefinition::load_file(const std::string& filepath)
 {
     tinyxml2::XMLError xml_error = _doc.LoadFile(filepath.c_str());
     if (xml_error != tinyxml2::XML_SUCCESS) {
-        LogErr("tinyxml2::LoadFile failed: {}", _doc.ErrorStr());
+        LogErr("Call tinyxml2::LoadFile failed: {}", _doc.ErrorStr());
         return false;
     }
 
@@ -18,7 +18,7 @@ bool CameraDefinition::load_string(const std::string& content)
 {
     tinyxml2::XMLError xml_error = _doc.Parse(content.c_str());
     if (xml_error != tinyxml2::XML_SUCCESS) {
-        LogErr("tinyxml2::Parse failed: {}", _doc.ErrorStr());
+        LogErr("Call tinyxml2::Parse failed: {}", _doc.ErrorStr());
         return false;
     }
 
@@ -45,13 +45,13 @@ bool CameraDefinition::parse_xml()
 
     auto e_definition = e_mavlinkcamera->FirstChildElement("definition");
     if (!e_definition) {
-        LogErr("definition not found");
+        LogErr("Definition not found");
         return false;
     }
 
     auto e_model = e_definition->FirstChildElement("model");
     if (!e_model) {
-        LogErr("model not found");
+        LogErr("Model not found");
         return false;
     }
 
@@ -59,7 +59,7 @@ bool CameraDefinition::parse_xml()
 
     auto e_vendor = e_definition->FirstChildElement("vendor");
     if (!e_vendor) {
-        LogErr("vendor not found");
+        LogErr("Vendor not found");
         return false;
     }
 
@@ -77,13 +77,13 @@ bool CameraDefinition::parse_xml()
          e_parameter = e_parameter->NextSiblingElement("parameter")) {
         const char* param_name = e_parameter->Attribute("name");
         if (!param_name) {
-            LogErr("name attribute missing");
+            LogErr("Name attribute missing");
             return false;
         }
 
         const char* type_str = e_parameter->Attribute("type");
         if (!type_str) {
-            LogErr("type attribute missing");
+            LogErr("Type attribute missing");
             return false;
         }
 
@@ -96,13 +96,13 @@ bool CameraDefinition::parse_xml()
 
         const char* param_name = e_parameter->Attribute("name");
         if (!param_name) {
-            LogErr("name attribute missing");
+            LogErr("Name attribute missing");
             return false;
         }
 
         const char* type_str_res = e_parameter->Attribute("type");
         if (!type_str_res) {
-            LogErr("type attribute missing for {}", param_name);
+            LogErr("Type attribute missing for {}", param_name);
             return false;
         }
 
@@ -148,7 +148,7 @@ bool CameraDefinition::parse_xml()
         }
 
         if (new_parameter->is_readonly && new_parameter->is_writeonly) {
-            LogErr("parameter can't be readonly and writeonly");
+            LogErr("Parameter can't be readonly and writeonly");
             return false;
         }
 
@@ -263,13 +263,13 @@ CameraDefinition::parse_options(
          e_option = e_option->NextSiblingElement("option")) {
         const char* option_name = e_option->Attribute("name");
         if (!option_name) {
-            LogErr("no option name give");
+            LogErr("No option name give");
             return std::make_pair<>(false, options);
         }
 
         const char* option_value = e_option->Attribute("value");
         if (!option_value) {
-            LogErr("no option value give");
+            LogErr("No option value give");
             return std::make_pair<>(false, options);
         }
 
@@ -297,7 +297,7 @@ CameraDefinition::parse_options(
                  e_parameterrange = e_parameterrange->NextSiblingElement("parameterrange")) {
                 const char* roption_parameter_str = e_parameterrange->Attribute("parameter");
                 if (!roption_parameter_str) {
-                    LogErr("missing roption parameter name");
+                    LogErr("Missing roption parameter name");
                     return std::make_pair<>(false, options);
                 }
 
@@ -308,18 +308,18 @@ CameraDefinition::parse_options(
                      e_roption = e_roption->NextSiblingElement("roption")) {
                     const char* roption_name_str = e_roption->Attribute("name");
                     if (!roption_name_str) {
-                        LogErr("missing roption name attribute");
+                        LogErr("Missing roption name attribute");
                         return std::make_pair<>(false, options);
                     }
 
                     const char* roption_value_str = e_roption->Attribute("value");
                     if (!roption_value_str) {
-                        LogErr("missing roption value attribute");
+                        LogErr("Missing roption value attribute");
                         return std::make_pair<>(false, options);
                     }
 
                     if (type_map.find(roption_parameter_str) == type_map.end()) {
-                        LogErr("unknown roption type");
+                        LogErr("Unknown roption type");
                         return std::make_pair<>(false, options);
                     }
 
@@ -357,7 +357,7 @@ CameraDefinition::parse_range_options(
 
     const char* min_str = param_handle->Attribute("min");
     if (!min_str) {
-        LogDebug("min range missing for {}", param_name);
+        LogDebug("Min range missing for {}", param_name);
         return std::make_tuple<>(false, options, default_option);
     }
 
@@ -366,7 +366,7 @@ CameraDefinition::parse_range_options(
 
     const char* max_str = param_handle->Attribute("max");
     if (!max_str) {
-        LogDebug("max range missing for {}", param_name);
+        LogDebug("Max range missing for {}", param_name);
         return std::make_tuple<>(false, options, default_option);
     }
 
@@ -383,7 +383,7 @@ CameraDefinition::parse_range_options(
 
     const char* step_str = param_handle->Attribute("step");
     if (!step_str) {
-        LogDebug("step range missing for {}", param_name);
+        LogDebug("Step range missing for {}", param_name);
     }
 
     if (step_str) {
@@ -404,7 +404,7 @@ CameraDefinition::parse_range_options(
 
     const char* default_str = param_handle->Attribute("default");
     if (!default_str) {
-        LogDebug("default range missing for {}", param_name);
+        LogDebug("Default range missing for {}", param_name);
         return std::make_tuple<>(false, options, default_option);
     }
 

--- a/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
+++ b/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
@@ -259,7 +259,7 @@ bool CameraServerImpl::parse_version_string(const std::string& version_str, uint
 CameraServer::Result CameraServerImpl::set_information(CameraServer::Information information)
 {
     if (!parse_version_string(information.firmware_version)) {
-        LogDebug("incorrectly formatted firmware version string: {}", information.firmware_version);
+        LogDebug("Incorrectly formatted firmware version string: {}", information.firmware_version);
         return CameraServer::Result::WrongArgument;
     }
 
@@ -404,7 +404,7 @@ CameraServer::Result CameraServerImpl::respond_take_photo(
                 capture_info.file_url.c_str());
             return message;
         });
-        LogDebug("sent camera image captured msg - index: {}", +capture_info.index);
+        LogDebug("Sent camera image captured msg - index: {}", +capture_info.index);
 
     } // Release mutex
 
@@ -1091,7 +1091,7 @@ void CameraServerImpl::start_image_capture_interval(float interval_s, int32_t co
     _last_interval_index = index;
     _image_capture_timer_cookie = _server_component_impl->add_call_every(
         [this, remaining]() {
-            LogDebug("capture image timer triggered");
+            LogDebug("Capture image timer triggered");
 
             if (!_take_photo_callbacks.empty()) {
                 _take_photo_callbacks.queue(_last_interval_index++, [this](const auto& func) {
@@ -1257,7 +1257,7 @@ std::optional<mavlink_command_ack_t> CameraServerImpl::process_camera_settings_r
     auto command_ack =
         _server_component_impl->make_command_ack_message(command, MAV_RESULT::MAV_RESULT_ACCEPTED);
     _server_component_impl->send_command_ack(command_ack);
-    LogDebug("sent settings ack");
+    LogDebug("Sent settings ack");
 
     // unsupported
     const auto mode_id = CAMERA_MODE::CAMERA_MODE_IMAGE;
@@ -1278,7 +1278,7 @@ std::optional<mavlink_command_ack_t> CameraServerImpl::process_camera_settings_r
             0);
         return message;
     });
-    LogDebug("sent settings msg");
+    LogDebug("Sent settings msg");
 
     // ack was already sent
     return std::nullopt;
@@ -1328,7 +1328,7 @@ CameraServerImpl::process_storage_format(const MavlinkCommandReceiver::CommandLo
     std::lock_guard<std::mutex> lg{_mutex};
 
     if (_format_storage_callbacks.empty()) {
-        LogDebug("process storage format requested with no storage format subscriber");
+        LogDebug("Process storage format requested with no storage format subscriber");
         return _server_component_impl->make_command_ack_message(
             command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
     }
@@ -1353,7 +1353,7 @@ std::optional<mavlink_command_ack_t> CameraServerImpl::process_camera_capture_st
 
     std::lock_guard<std::mutex> lg{_mutex};
     if (_capture_status_callbacks.empty()) {
-        LogDebug("process camera capture status requested with no capture status subscriber");
+        LogDebug("Process camera capture status requested with no capture status subscriber");
         return _server_component_impl->make_command_ack_message(
             command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
     }
@@ -1439,7 +1439,7 @@ CameraServerImpl::process_reset_camera_settings(const MavlinkCommandReceiver::Co
     std::lock_guard<std::mutex> lg{_mutex};
 
     if (_reset_settings_callbacks.empty()) {
-        LogDebug("reset camera settings requested with no camera settings subscriber");
+        LogDebug("Reset camera settings requested with no camera settings subscriber");
         return _server_component_impl->make_command_ack_message(
             command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
     }
@@ -1502,7 +1502,7 @@ CameraServerImpl::process_set_camera_zoom(const MavlinkCommandReceiver::CommandL
     }
 
     auto unsupported = [&]() {
-        LogWarn("unsupported set camera zoom type ({}) request", (int)zoom_type);
+        LogWarn("Unsupported set camera zoom type ({}) request", (int)zoom_type);
     };
 
     switch (zoom_type) {
@@ -1588,7 +1588,7 @@ CameraServerImpl::process_set_camera_focus(const MavlinkCommandReceiver::Command
     UNUSED(focus_type);
     UNUSED(focus_value);
 
-    LogDebug("unsupported set camera focus request");
+    LogDebug("Unsupported set camera focus request");
 
     return _server_component_impl->make_command_ack_message(
         command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
@@ -1603,7 +1603,7 @@ CameraServerImpl::process_set_storage_usage(const MavlinkCommandReceiver::Comman
     UNUSED(storage_id);
     UNUSED(usage);
 
-    LogDebug("unsupported set storage usage request");
+    LogDebug("Unsupported set storage usage request");
 
     return _server_component_impl->make_command_ack_message(
         command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
@@ -1629,7 +1629,7 @@ CameraServerImpl::process_image_start_capture(const MavlinkCommandReceiver::Comm
     std::lock_guard<std::mutex> lg{_mutex};
 
     if (_take_photo_callbacks.empty()) {
-        LogDebug("image capture requested with no take photo subscriber");
+        LogDebug("Image capture requested with no take photo subscriber");
         return _server_component_impl->make_command_ack_message(
             command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
     }
@@ -1659,7 +1659,7 @@ CameraServerImpl::process_image_start_capture(const MavlinkCommandReceiver::Comm
 std::optional<mavlink_command_ack_t>
 CameraServerImpl::process_image_stop_capture(const MavlinkCommandReceiver::CommandLong& command)
 {
-    LogDebug("received image stop capture request");
+    LogDebug("Received image stop capture request");
 
     // REVISIT: should we return something other that MAV_RESULT_ACCEPTED if
     // there is not currently a capture interval active?
@@ -1676,7 +1676,7 @@ std::optional<mavlink_command_ack_t> CameraServerImpl::process_camera_image_capt
 
     UNUSED(seq_number);
 
-    LogDebug("unsupported image capture request");
+    LogDebug("Unsupported image capture request");
 
     return _server_component_impl->make_command_ack_message(
         command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
@@ -1693,7 +1693,7 @@ CameraServerImpl::process_video_start_capture(const MavlinkCommandReceiver::Comm
     std::lock_guard<std::mutex> lg{_mutex};
 
     if (_start_video_callbacks.empty()) {
-        LogDebug("video start capture requested with no video start capture subscriber");
+        LogDebug("Video start capture requested with no video start capture subscriber");
         return _server_component_impl->make_command_ack_message(
             command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
     }
@@ -1713,7 +1713,7 @@ CameraServerImpl::process_video_stop_capture(const MavlinkCommandReceiver::Comma
     std::lock_guard<std::mutex> lg{_mutex};
 
     if (_stop_video_callbacks.empty()) {
-        LogDebug("video stop capture requested with no video stop capture subscriber");
+        LogDebug("Video stop capture requested with no video stop capture subscriber");
         return _server_component_impl->make_command_ack_message(
             command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
     }
@@ -1733,7 +1733,7 @@ CameraServerImpl::process_video_start_streaming(const MavlinkCommandReceiver::Co
     std::lock_guard<std::mutex> lg{_mutex};
 
     if (_start_video_streaming_callbacks.empty()) {
-        LogDebug("video start streaming requested with no video start streaming subscriber");
+        LogDebug("Video start streaming requested with no video start streaming subscriber");
         return _server_component_impl->make_command_ack_message(
             command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
     }
@@ -1753,7 +1753,7 @@ CameraServerImpl::process_video_stop_streaming(const MavlinkCommandReceiver::Com
     std::lock_guard<std::mutex> lg{_mutex};
 
     if (_stop_video_streaming_callbacks.empty()) {
-        LogDebug("video stop streaming requested with no video stop streaming subscriber");
+        LogDebug("Video stop streaming requested with no video stop streaming subscriber");
         return _server_component_impl->make_command_ack_message(
             command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
     }
@@ -1778,7 +1778,7 @@ std::optional<mavlink_command_ack_t> CameraServerImpl::process_video_stream_info
         auto command_ack = _server_component_impl->make_command_ack_message(
             command, MAV_RESULT::MAV_RESULT_ACCEPTED);
         _server_component_impl->send_command_ack(command_ack);
-        LogDebug("sent video streaming ack");
+        LogDebug("Sent video streaming ack");
 
         const char name[32] = "";
 
@@ -1834,7 +1834,7 @@ std::optional<mavlink_command_ack_t> CameraServerImpl::process_video_stream_stat
     auto command_ack =
         _server_component_impl->make_command_ack_message(command, MAV_RESULT::MAV_RESULT_ACCEPTED);
     _server_component_impl->send_command_ack(command_ack);
-    LogDebug("sent video streaming ack");
+    LogDebug("Sent video streaming ack");
 
     _server_component_impl->queue_message([&](MavlinkAddress mavlink_address, uint8_t channel) {
         mavlink_message_t msg{};

--- a/cpp/src/mavsdk/plugins/component_metadata_server/component_metadata_server_impl.cpp
+++ b/cpp/src/mavsdk/plugins/component_metadata_server/component_metadata_server_impl.cpp
@@ -90,7 +90,7 @@ void ComponentMetadataServerImpl::set_metadata(
 {
     const std::lock_guard lg{_mutex};
     if (_metadata_set) {
-        LogErr("metadata already set");
+        LogErr("Metadata already set");
         return;
     }
 

--- a/cpp/src/mavsdk/plugins/events/events_impl.cpp
+++ b/cpp/src/mavsdk/plugins/events/events_impl.cpp
@@ -111,7 +111,7 @@ void EventsImpl::set_metadata(uint8_t compid, const std::string& metadata_json)
         _system_impl->send_command_async(
             command, [this](MavlinkCommandSender::Result result, float) {
                 if (result != MavlinkCommandSender::Result::Success) {
-                    LogWarn("command MAV_CMD_RUN_PREARM_CHECKS failed");
+                    LogWarn("Command MAV_CMD_RUN_PREARM_CHECKS failed");
                 }
             });
     }

--- a/cpp/src/mavsdk/plugins/log_files/log_files_impl.cpp
+++ b/cpp/src/mavsdk/plugins/log_files/log_files_impl.cpp
@@ -310,7 +310,7 @@ void LogFilesImpl::download_log_file_async(
                  fs::is_directory(fs::path(file_path)) || fs::exists(file_path);
 
     if (error) {
-        LogErr("error: download_log_file_async failed");
+        LogErr("Call download_log_file_async failed");
 
         if (callback) {
             _system_impl->call_user_callback([callback]() {

--- a/cpp/src/mavsdk/plugins/mission/mission_impl.cpp
+++ b/cpp/src/mavsdk/plugins/mission/mission_impl.cpp
@@ -1011,7 +1011,7 @@ void MissionImpl::report_progress_locked()
     if (should_report) {
         _mission_data.mission_progress_callbacks.queue(
             {current, total}, [this](const auto& func) { _system_impl->call_user_callback(func); });
-        LogDebug("current: {}, total: {}", current, total);
+        LogDebug("Current: {}, total: {}", current, total);
     }
 }
 

--- a/cpp/src/mavsdk/plugins/mission_raw/mission_import.cpp
+++ b/cpp/src/mavsdk/plugins/mission_raw/mission_import.cpp
@@ -376,13 +376,13 @@ MissionImport::import_complex_mission_items(const nlohmann::json& json_item)
     }
 
     if (complex_item_type != "survey") {
-        LogErr("complexItemType: {} not supported", json_to_string(complex_item_type));
+        LogErr("Field complexItemType: {} not supported", json_to_string(complex_item_type));
         return std::nullopt;
     }
 
     const auto& version = json_at(json_item, "version");
     if (version.empty()) {
-        LogErr("version of complexItem not found");
+        LogErr("Version of complexItem not found");
         return std::nullopt;
     }
 


### PR DESCRIPTION
## Summary

Makes all log lines in the library start with a capital letter for consistency (following the `Heartbeats from system ... timed out` fix).

Where a line began with a bare identifier — a syscall, function, message, or field name — I prepended a descriptive word rather than capitalizing the identifier itself, so the token stays intact:

- `"getaddrinfo failed"` → `"Call getaddrinfo failed"` (also `tcgetattr`, `cfsetispeed`, `fs::exists`, `tinyxml2::LoadFile`, ...)
- `"mission_request_int: ..."` → `"In mission_request_int: ..."`
- `"metadataTypes not found"` → `"Field metadataTypes not found"`
- `"current_metadata_path() called ..."` → `"Function current_metadata_path() ..."`

Plain-English messages were simply capitalized (`"command denied"` → `"Command denied"`, `"version not found"` → `"Version not found"`, etc.).

## Notes

- Pure log-string changes across 24 files; no behavioral change.
- Grep confirms no lowercase-starting `Log*(...)` lines remain in `src/mavsdk`.