### PR TITLE
core: fix teardown use-after-free in MavlinkDirect libmav callback

### DIFF
--- a/cpp/src/mavsdk/core/callback_list.hpp
+++ b/cpp/src/mavsdk/core/callback_list.hpp
@@ -26,6 +26,7 @@ public:
 
     Handle<Args...> subscribe(const std::function<void(Args...)>& callback);
     void unsubscribe(Handle<Args...> handle);
+    void unsubscribe_blocking(Handle<Args...> handle);
     void subscribe_conditional(const std::function<bool(Args...)>& callback);
     void operator()(Args... args);
     [[nodiscard]] bool empty();

--- a/cpp/src/mavsdk/core/callback_list.tpp
+++ b/cpp/src/mavsdk/core/callback_list.tpp
@@ -24,6 +24,11 @@ template<typename... Args> void CallbackList<Args...>::unsubscribe(Handle<Args..
     _impl->unsubscribe(handle);
 }
 
+template<typename... Args> void CallbackList<Args...>::unsubscribe_blocking(Handle<Args...> handle)
+{
+    _impl->unsubscribe_blocking(handle);
+}
+
 template<typename... Args>
 void CallbackList<Args...>::subscribe_conditional(const std::function<bool(Args...)>& callback)
 {

--- a/cpp/src/mavsdk/core/callback_list_impl.hpp
+++ b/cpp/src/mavsdk/core/callback_list_impl.hpp
@@ -89,6 +89,43 @@ public:
         });
     }
 
+    // Blocking variant of unsubscribe(): does not return until the io thread has actually
+    // removed the callback. Because the io thread runs handlers in order, once this returns
+    // any dispatch that was already invoking the callback has finished and no future dispatch
+    // can invoke it -- so it is safe to destroy the object that owns the callback right after.
+    // Only call this off the io thread and while holding no lock the io thread needs (the
+    // plugin deinit path satisfies both); the guards below otherwise avoid a self-deadlock.
+    void unsubscribe_blocking(Handle<Args...> handle)
+    {
+        // Ignore null handle.
+        if (!handle.valid()) {
+            LogErr("Invalid null handle");
+            return;
+        }
+
+        auto erase = [this, handle]() {
+            _list.erase(
+                std::remove_if(
+                    _list.begin(), _list.end(), [&](auto& pair) { return pair.first == handle; }),
+                _list.end());
+            update_size();
+        };
+
+        // Same guards as read_on_io()/drain(): if the io thread is gone (stopped) or we are
+        // already on it, apply inline -- posting and waiting would hang or self-deadlock.
+        if (_io_context.stopped() || on_io_thread()) {
+            erase();
+            return;
+        }
+
+        std::promise<void> done;
+        asio::post(_io_context, [&]() {
+            erase();
+            done.set_value();
+        });
+        done.get_future().wait();
+    }
+
     void exec(Args... args)
     {
         read_on_io([&]() {

--- a/cpp/src/mavsdk/core/server_component_impl.cpp
+++ b/cpp/src/mavsdk/core/server_component_impl.cpp
@@ -148,7 +148,10 @@ Handle<Mavsdk::MavlinkMessage> ServerComponentImpl::register_libmav_message_hand
 
 void ServerComponentImpl::unregister_libmav_message_handler(Handle<Mavsdk::MavlinkMessage> handle)
 {
-    _libmav_message_callbacks.unsubscribe(handle);
+    // Blocking: once this returns the io thread can no longer invoke the callback. Plugin
+    // deinit() relies on that to destroy the object that owns the callback (which captures
+    // its 'this') without a use-after-free on the io thread.
+    _libmav_message_callbacks.unsubscribe_blocking(handle);
 }
 
 void ServerComponentImpl::process_libmav_message(const Mavsdk::MavlinkMessage& message)

--- a/cpp/src/mavsdk/core/system_impl.cpp
+++ b/cpp/src/mavsdk/core/system_impl.cpp
@@ -228,7 +228,10 @@ Handle<Mavsdk::MavlinkMessage> SystemImpl::register_libmav_message_handler_with_
 
 void SystemImpl::unregister_libmav_message_handler(Handle<Mavsdk::MavlinkMessage> handle)
 {
-    _libmav_message_callbacks.unsubscribe(handle);
+    // Blocking: once this returns the io thread can no longer invoke the callback. Plugin
+    // deinit() relies on that to destroy the object that owns the callback (which captures
+    // its 'this') without a use-after-free on the io thread.
+    _libmav_message_callbacks.unsubscribe_blocking(handle);
 
     if (_message_debugging) {
         LogDebug("Unregistered libmav handler");

--- a/cpp/src/mavsdk/plugins/mavlink_direct/mavlink_direct_impl.cpp
+++ b/cpp/src/mavsdk/plugins/mavlink_direct/mavlink_direct_impl.cpp
@@ -58,13 +58,15 @@ void MavlinkDirectImpl::init()
 
 void MavlinkDirectImpl::deinit()
 {
-    // Synchronise with any in-flight I/O-thread dispatch: _callbacks()/exec() holds
-    // the CallbackList's internal mutex, and clear() acquires the same mutex, so
-    // clear() blocks until the current exec() finishes.  After clear() the list is
-    // empty; subsequent exec() calls are no-ops, making it safe to destroy the
-    // CallbackList.  This also prevents any further user callbacks from being enqueued.
+    // Stop dispatching to our own subscribers.
     _callbacks.clear();
 
+    // Crucially, unregister our handler from the system BEFORE this object is destroyed.
+    // The registered callback captures 'this' and reaches into _callbacks, and it runs on
+    // the io thread. unregister_libmav_message_handler() is blocking: once it returns the
+    // io thread can no longer invoke that callback, so it can't touch a freed
+    // MavlinkDirectImpl (previously a teardown use-after-free, only visible as a rare
+    // io-thread crash).
     if (_system_subscription.valid()) {
         _system_impl->unregister_libmav_message_handler(_system_subscription);
         _system_subscription = {};

--- a/cpp/src/mavsdk/plugins/mavlink_direct_server/mavlink_direct_server_impl.cpp
+++ b/cpp/src/mavsdk/plugins/mavlink_direct_server/mavlink_direct_server_impl.cpp
@@ -51,10 +51,13 @@ void MavlinkDirectServerImpl::init()
 
 void MavlinkDirectServerImpl::deinit()
 {
-    // Synchronise with any in-flight dispatch (see MavlinkDirectImpl::deinit for details):
-    // clear() blocks until the current exec() finishes and prevents further callbacks.
+    // Stop dispatching to our own subscribers.
     _callbacks.clear();
 
+    // Unregister from the server component BEFORE this object is destroyed. The registered
+    // callback captures 'this' and reaches into _callbacks on the io thread;
+    // unregister_libmav_message_handler() is blocking, so once it returns the io thread can
+    // no longer invoke it against a freed MavlinkDirectServerImpl (see MavlinkDirectImpl).
     if (_server_subscription.valid()) {
         _server_component_impl->unregister_libmav_message_handler(_server_subscription);
         _server_subscription = {};


### PR DESCRIPTION
## Summary

Fixes a rare teardown use-after-free in the MavlinkDirect / libmav callback path — the segfault that has been intermittently failing macOS CI (on `main`, so pre-existing).

## Root cause

`MavlinkDirectImpl` (and `MavlinkDirectServerImpl`) register a libmav-message callback on `SystemImpl`/`ServerComponentImpl`. That callback captures `this` and, when a message arrives **on the io thread**, reaches into the plugin's own `CallbackList`.

`deinit()` unregistered the callback via `CallbackList::unsubscribe()`, which only *posts* the removal to the io thread and returns immediately (`CallbackListImpl::post_mutation` → `asio::post`, no wait). So `deinit()` — and therefore `~MavlinkDirectImpl` — could complete while the io thread was still about to invoke, or in the middle of invoking, that callback, dereferencing a freed object.

The upgraded cpptrace (v1.0.4) finally produced a fully symbolized backtrace that pinned it precisely:

```
SystemImpl::process_libmav_message()
  CallbackList<Mavsdk::MavlinkMessage>::queue()          ← io thread
    MavlinkDirectImpl::init()::$_0                        ← our registered callback
      CallbackList<MavlinkDirect::MavlinkMessage>::operator()()   ← SEGV: freed MavlinkDirectImpl
```

The prior code comments claimed `_callbacks.clear()` "blocks until the current exec() finishes" — it doesn't; `clear()` also just posts.

## Fix

Add `CallbackList::unsubscribe_blocking()`, which posts the removal and then waits until the io thread has applied it. Since the io thread runs handlers in order, once it returns the callback is removed **and** any in-flight dispatch has finished — so it's safe to destroy the owner immediately after.

It uses the same guards as the existing `read_on_io()`/`drain()` fences — run inline when the io_context is `stopped()` or when already `on_io_thread()` — so it can't hang on a stopped context or self-deadlock. Both plugins' `unregister_libmav_message_handler` paths now go through it (both are called only from `deinit()`, on the main thread, holding no lock the io thread needs).

## Testing

- `unit_tests_runner` — 296 passed
- `system_tests_runner` — 95 passed
- `--gtest_filter='*MavlinkDirect*'` looped 8× — all green, no hangs (verifying the blocking unregister doesn't deadlock)

The crash itself is timing/arch-dependent and I couldn't reproduce it on Linux, so the definitive confirmation is that it stops reproducing under the macOS lldb loop that was catching it.
