### PR TITLE
docs: fix misplaced parenthesis in connections ground station note

### DIFF
--- a/docs/en/cpp/guide/connections.md
+++ b/docs/en/cpp/guide/connections.md
@@ -78,7 +78,7 @@ if (connection_result != ConnectionResult::Success) {
 
 ::: info
 The connection string used above (`udpin://0.0.0.0:14540`) is the [standard PX4 UDP port](https://docs.px4.io/main/en/simulation/#default-px4-mavlink-udp-ports) for off-board APIs (14540) used with SITL.
-  The standard way to talk to a ground station (e.g. QGC is on port 14550).
+  The standard way to talk to a ground station (e.g. QGC) is on port 14550.
 :::
 
 #### Behave like a client


### PR DESCRIPTION
In the connections guide, the ground-station note has a misplaced closing parenthesis:

Before:
```
The standard way to talk to a ground station (e.g. QGC is on port 14550).
```
After:
```
The standard way to talk to a ground station (e.g. QGC) is on port 14550.
```

The parenthetical was meant to gloss the example (QGC), not swallow the whole clause. Docs-only.