### PR TITLE
examples: fix coming typo in distance_sensor comment

### DIFF
--- a/cpp/examples/distance_sensor/distance_sensor.cpp
+++ b/cpp/examples/distance_sensor/distance_sensor.cpp
@@ -58,7 +58,7 @@ int main(int argc, char** argv)
     // subscribe to distance sensor readings
     subscribe_distance_sensor(telemetry);
 
-    // endless loop so that the sensor readings will keep comming
+    // endless loop so that the sensor readings will keep coming
     // will close only with kill or Ctrl+C
     while (true) {
         std::this_thread::sleep_for(std::chrono::seconds(1));


### PR DESCRIPTION
## Summary
Fixes a spelling error (`comming` → `coming`) in the endless-loop comment of the distance sensor example.

## Motivation
Clearer example comments reduce friction for first-time contributors and match the rest of the tree (Ctrl+C exit comments elsewhere already use clean English).

## Verification
- Comment-only change; no compile path impact
- Local search: no remaining `comming` in this file

AI-assisted; human-reviewed.