### PR TITLE
examples: fix logfile_download header comment grammar

### DIFF
--- a/cpp/examples/logfile_download/logfile_download.cpp
+++ b/cpp/examples/logfile_download/logfile_download.cpp
@@ -1,5 +1,5 @@
 //
-// Example how to download logfiles with MAVSDK.
+// Example of how to download logfiles with MAVSDK.
 //
 
 #include <mavsdk/mavsdk.hpp>


### PR DESCRIPTION
## Summary
Adds the missing “of” so the logfile download example header reads as natural English.

## Motivation
Matches the clearer style used in newer example headers without changing code.

## Verification
- Comment-only

AI-assisted; human-reviewed.