### PR TITLE
examples: fix ftp_client header comment grammar

### DIFF
--- a/cpp/examples/ftp_client/ftp_client.cpp
+++ b/cpp/examples/ftp_client/ftp_client.cpp
@@ -1,5 +1,5 @@
 //
-// Example how to use an FTP client with MAVSDK.
+// Example of how to use an FTP client with MAVSDK.
 //
 
 #include <mavsdk/mavsdk.hpp>


### PR DESCRIPTION
## Summary
Grammar polish on the FTP client example file header (“Example of how to…”).

## Verification
Comment-only.

AI-assisted; human-reviewed.