### PR TITLE
examples: fix sniffer header comment grammar

### DIFF
--- a/cpp/examples/sniffer/sniffer.cpp
+++ b/cpp/examples/sniffer/sniffer.cpp
@@ -1,5 +1,5 @@
 //
-// Example how to intercept and display MAVLink messages in JSON format.
+// Example of how to intercept and display MAVLink messages in JSON format.
 //
 
 #include <mavsdk/mavsdk.hpp>


### PR DESCRIPTION
## Summary
Header comment: “Example how to…” → “Example of how to…” for the sniffer example.

## Verification
Comment-only.

AI-assisted; human-reviewed.