### PR TITLE
examples: fix log_streaming header comment grammar

### DIFF
--- a/cpp/examples/log_streaming/log_streaming.cpp
+++ b/cpp/examples/log_streaming/log_streaming.cpp
@@ -1,5 +1,5 @@
 //
-// Example how to stream logs from PX4 or ArduPilot with MAVSDK.
+// Example of how to stream logs from PX4 or ArduPilot with MAVSDK.
 //
 
 #include <mavsdk/mavsdk.hpp>


### PR DESCRIPTION
## Summary
Grammar polish on the log_streaming example header comment.

## Verification
Comment-only.

AI-assisted; human-reviewed.