### PR TITLE
docs: fix MissionRaw QGC import link in general usage guide

### DIFF
--- a/docs/en/cpp/guide/general_usage.md
+++ b/docs/en/cpp/guide/general_usage.md
@@ -140,5 +140,5 @@ Not every mission command behaviour supported by the protocol and PX4 will be su
 
 In order to access the full mission API, the [MissionRaw](../api_reference/classmavsdk_1_1_mission_raw.md) plugin can be used instead.
 
-The MissionRaw also allows to [import QGC mission files](https://mavsdk.mavlink.io/main/en/cpp/api_reference/classmavsdk_1_1_mission_raw.md#classmavsdk_1_1_mission_raw_1a2a4ca261c37737e691c6954693d6d0a5).
+The MissionRaw also allows [importing QGC mission plan files](../api_reference/classmavsdk_1_1_mission_raw.md) via `import_qgroundcontrol_mission` / `import_qgroundcontrol_mission_from_string`.
 


### PR DESCRIPTION
## Summary
- `general_usage.md` used an absolute mavsdk.mavlink.io deep-link that 404s for QGC plan import.
- Link the in-tree MissionRaw API reference and name `import_qgroundcontrol_mission` / `_from_string`.

## Motivation
Guide readers hit a dead hash when diving from Mission → MissionRaw.

## Verification
- Old absolute URL returned 404; relative `../api_reference/classmavsdk_1_1_mission_raw.md` resolves in-tree
- Methods exist on `MissionRaw` in current sources