### PR TITLE
docs(offboard): refresh Hold mode and PX4 Autopilot links

### DIFF
--- a/cpp/src/mavsdk/plugins/offboard/include/plugins/offboard/offboard.hpp
+++ b/cpp/src/mavsdk/plugins/offboard/include/plugins/offboard/offboard.hpp
@@ -142,7 +142,7 @@ public:
      * MAVLink messages are actually sent.
      *
      * In PX4 v1.9.0 Only first four Control Groups are supported
-     * (https://github.com/PX4/Firmware/blob/v1.9.0/src/modules/mavlink/mavlink_receiver.cpp#L980).
+     * (https://github.com/PX4/PX4-Autopilot/blob/v1.9.0/src/modules/mavlink/mavlink_receiver.cpp#L980).
      */
     struct ActuatorControl {
         
@@ -424,7 +424,7 @@ public:
     /**
      * @brief Stop offboard control.
      *
-     * The vehicle will be put into Hold mode: https://docs.px4.io/en/flight_modes/hold.html
+     * The vehicle will be put into Hold mode: https://docs.px4.io/main/en/flight_modes_mc/hold.html
      *
      * This function is non-blocking. See 'stop' for the blocking counterpart.
      */
@@ -435,7 +435,7 @@ public:
     /**
      * @brief Stop offboard control.
      *
-     * The vehicle will be put into Hold mode: https://docs.px4.io/en/flight_modes/hold.html
+     * The vehicle will be put into Hold mode: https://docs.px4.io/main/en/flight_modes_mc/hold.html
      *
      * This function is blocking. See 'stop_async' for the non-blocking counterpart.
      *


### PR DESCRIPTION
## Summary
- `Offboard::stop*` Hold-mode docs used legacy `docs.px4.io/en/flight_modes/hold.html`.
- Point at `docs.px4.io/main/en/flight_modes_mc/hold.html`.
- Rename historical PX4 `Firmware` blob URL to `PX4-Autopilot` for the v1.9 actuator-control note.

## Motivation
Header Doxygen is what becomes the published API reference; stale Hold URLs 404 after redirect collapse.

## Verification
- Confirmed redirect/404 behaviour on old Hold path; 200 on main multicopter Hold page
- PX4-Autopilot v1.9.0 blob path returns 200
- Docs comments only — no flight-control logic change