### PR TITLE
docs(telemetry): point FlightMode docs link at PX4 main

### DIFF
--- a/cpp/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.hpp
+++ b/cpp/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.hpp
@@ -121,7 +121,7 @@ public:
      * @brief Flight modes.
      *
      * For more information about flight modes, check out
-     * https://docs.px4.io/master/en/config/flight_mode.html.
+     * https://docs.px4.io/main/en/config/flight_mode.html.
      */
     enum class FlightMode {
         Unknown, /**< @brief Mode not known. */


### PR DESCRIPTION
## Summary
- `Telemetry::FlightMode` doc comment used `docs.px4.io/master/...`.
- Prefer the stable `/main/` flight mode configuration guide.

## Motivation
Keep enum docs aligned with current PX4 documentation tree.

## Verification
- Target URL returns 200
- Comment-only change in public header