### PR TITLE
docs(action): point Return mode docs at current PX4 main guide

### DIFF
--- a/cpp/src/mavsdk/plugins/action/include/plugins/action/action.hpp
+++ b/cpp/src/mavsdk/plugins/action/include/plugins/action/action.hpp
@@ -427,7 +427,7 @@ public:
     /**
      * @brief Send command to return to the launch (takeoff) position and land.
      *
-     * This switches the drone into [Return mode](https://docs.px4.io/master/en/flight_modes/return.html) which
+     * This switches the drone into [Return mode](https://docs.px4.io/main/en/flight_modes_mc/return.html) which
      * generally means it will rise up to a certain altitude to clear any obstacles before heading
      * back to the launch (takeoff) position and land there.
      *
@@ -440,7 +440,7 @@ public:
     /**
      * @brief Send command to return to the launch (takeoff) position and land.
      *
-     * This switches the drone into [Return mode](https://docs.px4.io/master/en/flight_modes/return.html) which
+     * This switches the drone into [Return mode](https://docs.px4.io/main/en/flight_modes_mc/return.html) which
      * generally means it will rise up to a certain altitude to clear any obstacles before heading
      * back to the launch (takeoff) position and land there.
      *


### PR DESCRIPTION
## Summary
- `Action::return_to_launch*` docs referenced `docs.px4.io/master/en/flight_modes/return.html`.
- Update to `main/en/flight_modes_mc/return.html`.

## Motivation
Legacy `/master/` flight mode paths no longer land on useful content after PX4 docs restructure.

## Verification
- New URL 200; old master path does not serve the intended page
- Docstring-only; no API behaviour change