### PR TITLE
docs(mission): point HOLD mode pause docs at PX4 main

### DIFF
--- a/cpp/src/mavsdk/plugins/mission/include/plugins/mission/mission.hpp
+++ b/cpp/src/mavsdk/plugins/mission/include/plugins/mission/mission.hpp
@@ -481,7 +481,7 @@ public:
      * @brief Pause the mission.
      *
      * Pausing the mission puts the vehicle into
-     * [HOLD mode](https://docs.px4.io/en/flight_modes/hold.html).
+     * [HOLD mode](https://docs.px4.io/main/en/flight_modes_mc/hold.html).
      * A multicopter should just hover at the spot while a fixedwing vehicle should loiter
      * around the location where it paused.
      *
@@ -495,7 +495,7 @@ public:
      * @brief Pause the mission.
      *
      * Pausing the mission puts the vehicle into
-     * [HOLD mode](https://docs.px4.io/en/flight_modes/hold.html).
+     * [HOLD mode](https://docs.px4.io/main/en/flight_modes_mc/hold.html).
      * A multicopter should just hover at the spot while a fixedwing vehicle should loiter
      * around the location where it paused.
      *


### PR DESCRIPTION
## Summary
- `Mission::pause_mission*` HOLD-mode links used legacy `docs.px4.io/en/flight_modes/hold.html`.
- Point at multicopter Hold docs under `/main/`.

## Motivation
Pause-mission docs should deep-link somewhere that still resolves for operators.

## Verification
- New hold URL 200; legacy path fails after redirect
- Header comments only