### PR TITLE
docs(mission_raw): point HOLD mode pause docs at PX4 main

### DIFF
--- a/cpp/src/mavsdk/plugins/mission_raw/include/plugins/mission_raw/mission_raw.hpp
+++ b/cpp/src/mavsdk/plugins/mission_raw/include/plugins/mission_raw/mission_raw.hpp
@@ -493,7 +493,7 @@ public:
      * @brief Pause the mission.
      *
      * Pausing the mission puts the vehicle into
-     * [HOLD mode](https://docs.px4.io/en/flight_modes/hold.html).
+     * [HOLD mode](https://docs.px4.io/main/en/flight_modes_mc/hold.html).
      * A multicopter should just hover at the spot while a fixedwing vehicle should loiter
      * around the location where it paused.
      *
@@ -507,7 +507,7 @@ public:
      * @brief Pause the mission.
      *
      * Pausing the mission puts the vehicle into
-     * [HOLD mode](https://docs.px4.io/en/flight_modes/hold.html).
+     * [HOLD mode](https://docs.px4.io/main/en/flight_modes_mc/hold.html).
      * A multicopter should just hover at the spot while a fixedwing vehicle should loiter
      * around the location where it paused.
      *


### PR DESCRIPTION
## Summary
- Mirror of the Mission plugin pause HOLD link refresh for `MissionRaw`.
- Use `docs.px4.io/main/en/flight_modes_mc/hold.html`.

## Motivation
Keep Mission and MissionRaw pause documentation consistent and non-404.

## Verification
- URL check 200 on replacement
- Docstring-only