### PR TITLE
docs(geometry): point geo inspiration link at PX4-Autopilot

### DIFF
--- a/cpp/src/mavsdk/core/include/mavsdk/geometry.hpp
+++ b/cpp/src/mavsdk/core/include/mavsdk/geometry.hpp
@@ -11,7 +11,7 @@ namespace mavsdk::geometry {
  * coordinates are taken from:
  * http://mathworld.wolfram.com/AzimuthalEquidistantProjection.html
  * and inspired by the implementations in:
- * https://github.com/PX4/ecl/blob/master/geo/geo.cpp
+ * https://github.com/PX4/PX4-Autopilot/blob/main/src/lib/geo/geo.cpp
  */
 class MAVSDK_PUBLIC CoordinateTransformation {
 public:

--- a/docs/en/cpp/api_reference/classmavsdk_1_1geometry_1_1_coordinate_transformation.md
+++ b/docs/en/cpp/api_reference/classmavsdk_1_1geometry_1_1_coordinate_transformation.md
@@ -7,7 +7,7 @@
 This is a utility class for coordinate transformations. 
 
 
-The projections used to transform from global (lat/lon) to local (meter) coordinates are taken from: [http://mathworld.wolfram.com/AzimuthalEquidistantProjection.html](http://mathworld.wolfram.com/AzimuthalEquidistantProjection.html) and inspired by the implementations in: [https://github.com/PX4/ecl/blob/master/geo/geo.cpp](https://github.com/PX4/ecl/blob/master/geo/geo.cpp) 
+The projections used to transform from global (lat/lon) to local (meter) coordinates are taken from: [http://mathworld.wolfram.com/AzimuthalEquidistantProjection.html](http://mathworld.wolfram.com/AzimuthalEquidistantProjection.html) and inspired by the implementations in: [https://github.com/PX4/PX4-Autopilot/blob/main/src/lib/geo/geo.cpp](https://github.com/PX4/PX4-Autopilot/blob/main/src/lib/geo/geo.cpp) 
 
 
 ## Data Structures


### PR DESCRIPTION
## Summary
- `geometry.hpp` credited `PX4/ecl` `geo/geo.cpp`.
- Retarget to `PX4-Autopilot` `src/lib/geo/geo.cpp` on main.

## Motivation
ecl was absorbed into PX4-Autopilot; the old tree link is a confusing dead-end for implementors.

## Verification
- New blob URL 200
- Comment-only in public geometry header