### PR TITLE
docs(core): update px4_custom_mode.h source attribution URL

### DIFF
--- a/cpp/src/mavsdk/core/px4_custom_mode.hpp
+++ b/cpp/src/mavsdk/core/px4_custom_mode.hpp
@@ -36,7 +36,7 @@
  * PX4 custom flight modes
  *
  * This file has been copied from
- * https://github.com/PX4/Firmware/blob/master/src/modules/commander/px4_custom_mode.h
+ * https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/commander/px4_custom_mode.h
  *
  *
  */


### PR DESCRIPTION
## Summary
- `px4_custom_mode.hpp` still cited `github.com/PX4/Firmware/...`.
- Point the “copied from” note at `PX4-Autopilot` main commander header.

## Motivation
PX4 renamed the primary tree years ago; attribution should match today’s sources.

## Verification
- New URL 200
- Comment-only; no enum/value changes