### PR TITLE
docs: align C++ quickstart QGC install URL with examples index

### DIFF
--- a/docs/en/cpp/quickstart.md
+++ b/docs/en/cpp/quickstart.md
@@ -53,7 +53,7 @@ docker run --rm -it jonasvautherin/px4-gazebo-headless:1.15.3
 You can use *QGroundControl* to connect the simulator and observe vehicle movement and behaviour while the examples are running.
 *QGroundControl* will automatically connect to the PX4 simulation as soon as it is started.
 
-See [QGroundControl > Download and Install](https://docs.qgroundcontrol.com/en/getting_started/download_and_install.html) for information about setting up *QGroundControl* on your platform.
+See [QGroundControl > Download and Install](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/getting_started/download_and_install.html) for information about setting up *QGroundControl* on your platform.
 
 
 ## Build and Try Example {#build_examples}


### PR DESCRIPTION
## Summary
- C++ quickstart used a short QGC docs path.
- Align with the canonical `master/.../qgc-user-guide/getting_started/download_and_install.html` already used in examples index.

## Motivation
One consistent QGC install destination across onboarding docs.

## Verification
- Matches examples/index link shape
- Docs markdown only