### PR TITLE
docs(examples): fix follow_me.cpp source link target

### DIFF
--- a/docs/en/cpp/examples/follow_me.md
+++ b/docs/en/cpp/examples/follow_me.md
@@ -115,4 +115,4 @@ The operation of the "SDK-specific" part of this code is discussed in the guide:
 ## Source code {#source_code}
 
 - [CMakeLists.txt](https://github.com/mavlink/MAVSDK/blob/main/cpp/examples/follow_me/CMakeLists.txt)
-- [follow_me.cpp](https://github.com/mavlink/MAVSDK/blob/main/cpp/examples/follow_me/CMakeLists.txt)
+- [follow_me.cpp](https://github.com/mavlink/MAVSDK/blob/main/cpp/examples/follow_me/follow_me.cpp)


### PR DESCRIPTION
## Summary
The follow-me example guide listed `follow_me.cpp` but the href pointed at `CMakeLists.txt`.

## Why
Broken source navigation on the published docs site.

## Notes
Docs-only. AI-assisted research; human-reviewed. No flight-control changes.