### PR TITLE
docs: fix generate_markdown script path and Doxygen URL in build_docs

### DIFF
--- a/docs/en/cpp/guide/build_docs.md
+++ b/docs/en/cpp/guide/build_docs.md
@@ -4,7 +4,7 @@ The [API reference docs for C++](../api_reference/index.md) are already pre-gene
 
 ## Build API Reference Documentation {#build_api_reference}
 
-The C++ source code is annotated using comments using [Doxygen](http://doxygen.nl/manual/index.html) syntax.
+The C++ source code is annotated using comments using [Doxygen](https://www.doxygen.nl/manual/index.html) syntax.
 
 Extract the documentation to markdown files (one per class) on macOS or Linux using the commands:
 ```bash
@@ -19,5 +19,5 @@ Extracting the API reference does not yet work automatically on Windows.
 
 ::: info
 The *generate_docs.sh* script [builds the library](build.md), installs it locally to **/install**, and then uses *DOxygen* to create XML documentation in **/install/docs/xml**.
-The [generate_markdown_from_doxygen_xml.py](https://github.com/mavlink/MAVSDK/blob/main/tools/generate_markdown_from_doxygen_xml.py) script is then run on all files in the */xml* directory to generate markdown files in **/install/docs/markdown**.
+The [generate_markdown_from_doxygen_xml.py](https://github.com/mavlink/MAVSDK/blob/main/cpp/tools/generate_markdown_from_doxygen_xml.py) script is then run on all files in the */xml* directory to generate markdown files in **/install/docs/markdown**.
 :::


### PR DESCRIPTION
## Summary
- Point the documented Doxygen→markdown helper at `cpp/tools/generate_markdown_from_doxygen_xml.py` (repo root `tools/` path was wrong).
- Prefer HTTPS for the Doxygen manual link.

## Verification
Script exists under `cpp/tools/` on main.