### PR TITLE
docs(api): point ActuatorControl PX4 v1.9 note at PX4-Autopilot

### DIFF
--- a/docs/en/cpp/api_reference/structmavsdk_1_1_offboard_1_1_actuator_control.md
+++ b/docs/en/cpp/api_reference/structmavsdk_1_1_offboard_1_1_actuator_control.md
@@ -16,7 +16,7 @@ One group support eight controls.
 Up to 16 actuator controls can be set. To ignore an output group, set all it controls to NaN. If one or more controls in group is not NaN, then all NaN controls will sent as zero. The first 8 actuator controls internally map to control group 0, the latter 8 actuator controls map to control group 1. Depending on what controls are set (instead of NaN) 1 or 2 MAVLink messages are actually sent.
 
 
-In PX4 v1.9.0 Only first four Control Groups are supported ([https://github.com/PX4/Firmware/blob/v1.9.0/src/modules/mavlink/mavlink_receiver.cpp#L980](https://github.com/PX4/Firmware/blob/v1.9.0/src/modules/mavlink/mavlink_receiver.cpp#L980)). 
+In PX4 v1.9.0 Only first four Control Groups are supported ([https://github.com/PX4/PX4-Autopilot/blob/v1.9.0/src/modules/mavlink/mavlink_receiver.cpp#L980](https://github.com/PX4/PX4-Autopilot/blob/v1.9.0/src/modules/mavlink/mavlink_receiver.cpp#L980)). 
 
 
 ## Data Fields


### PR DESCRIPTION
## Summary
Refresh the historical PX4 tree name in the Offboard `ActuatorControl` API note (`Firmware` → `PX4-Autopilot`, same v1.9.0 tag).

## Why
GitHub redirects the old org path; linking the canonical tree avoids stale documentation.

Published API markdown only (not a hand-edit of autogen `.hpp` sources).