### PR TITLE
docs(contributing): use canonical MAVSDK-Proto GitHub path casing

### DIFF
--- a/docs/en/cpp/contributing/autogen.md
+++ b/docs/en/cpp/contributing/autogen.md
@@ -28,7 +28,7 @@ Those parts are maintained manually:
 * New plugins need to be added to `mavsdk_server` (this may be automated in future)
 * The `System` wrapper in language bindings usually needs to be updated whenever a new plugin is added (this may be automated in future)
 
-The heart of the autogeneration system is the [MAVSDK-Proto](https://github.com/mavlink/mavsdk-proto) repository which is described [below](#mechanisms).
+The heart of the autogeneration system is the [MAVSDK-Proto](https://github.com/mavlink/MAVSDK-Proto) repository which is described [below](#mechanisms).
 
 ## Autogeneration Mechanisms {#mechanisms}
 


### PR DESCRIPTION
## Summary
Normalize the MAVSDK-Proto repository URL casing in the autogen contributor guide (`mavsdk-proto` → `MAVSDK-Proto`).

GitHub is case-insensitive for redirects, but docs should match the canonical repo name maintainers ship elsewhere.