### PR TITLE
docs(examples): align VTOL transition source link label with filename

### DIFF
--- a/docs/en/cpp/examples/transition_vtol_fixed_wing.md
+++ b/docs/en/cpp/examples/transition_vtol_fixed_wing.md
@@ -75,4 +75,4 @@ The operation of the transition code is discussed in the guide: [Takeoff and Lan
 ## Source code {#source_code}
 
 - [CMakeLists.txt](https://github.com/mavlink/MAVSDK/blob/main/cpp/examples/vtol_transition/CMakeLists.txt)
-- [transition_vtol_fixed_wing.cpp](https://github.com/mavlink/MAVSDK/blob/main/cpp/examples/vtol_transition/vtol_transition.cpp)
+- [vtol_transition.cpp](https://github.com/mavlink/MAVSDK/blob/main/cpp/examples/vtol_transition/vtol_transition.cpp)


### PR DESCRIPTION
## Summary
Match the Source code label to `vtol_transition.cpp` (repo path already had the correct blob).