### PR TITLE
test(core): add Crc32 unit coverage for MAVLink polynomial

### DIFF
--- a/cpp/src/mavsdk/core/CMakeLists.txt
+++ b/cpp/src/mavsdk/core/CMakeLists.txt
@@ -283,6 +283,7 @@ list(APPEND UNIT_TEST_SOURCES
     ${PROJECT_SOURCE_DIR}/mavsdk/core/mavlink_parameter_cache_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/string_utils_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/base64_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/crc32_test.cpp
 )
 
 if (NOT BUILD_WITHOUT_CURL)

--- a/cpp/src/mavsdk/core/crc32.hpp
+++ b/cpp/src/mavsdk/core/crc32.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
 #include <cstdint>
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
 // For more information about the CRC algorithm used, check the comment in the
 // source file.
 
-class Crc32 {
+class MAVSDK_TEST_EXPORT Crc32 {
 public:
     uint32_t add(const uint8_t* src, uint32_t len);
 

--- a/cpp/src/mavsdk/core/crc32_test.cpp
+++ b/cpp/src/mavsdk/core/crc32_test.cpp
@@ -9,7 +9,9 @@ TEST(Crc32, EmptyIsZero)
 {
     Crc32 crc;
     EXPECT_EQ(crc.get(), 0u);
-    EXPECT_EQ(crc.add(nullptr, 0), 0u);
+    const uint8_t* empty = nullptr;
+    // Zero-length add must not read bytes even if src is null.
+    EXPECT_EQ(crc.add(empty, 0), 0u);
     EXPECT_EQ(crc.get(), 0u);
 }
 

--- a/cpp/src/mavsdk/core/crc32_test.cpp
+++ b/cpp/src/mavsdk/core/crc32_test.cpp
@@ -1,0 +1,47 @@
+#include "crc32.hpp"
+#include <gtest/gtest.h>
+#include <vector>
+#include <cstdint>
+
+using namespace mavsdk;
+
+TEST(Crc32, EmptyIsZero)
+{
+    Crc32 crc;
+    EXPECT_EQ(crc.get(), 0u);
+    EXPECT_EQ(crc.add(nullptr, 0), 0u);
+    EXPECT_EQ(crc.get(), 0u);
+}
+
+TEST(Crc32, KnownVector123456789)
+{
+    // MAVLink-style CRC32 (start 0, no final XOR) of ASCII "123456789"
+    const uint8_t data[] = {'1', '2', '3', '4', '5', '6', '7', '8', '9'};
+    Crc32 crc;
+    EXPECT_EQ(crc.add(data, sizeof(data)), 0x2dfd2d88u);
+    EXPECT_EQ(crc.get(), 0x2dfd2d88u);
+}
+
+TEST(Crc32, IncrementalMatchesOneShot)
+{
+    const uint8_t part1[] = {'a', 'b'};
+    const uint8_t part2[] = {'c'};
+    const uint8_t all[] = {'a', 'b', 'c'};
+
+    Crc32 stepwise;
+    stepwise.add(part1, sizeof(part1));
+    stepwise.add(part2, sizeof(part2));
+
+    Crc32 oneshot;
+    oneshot.add(all, sizeof(all));
+
+    EXPECT_EQ(stepwise.get(), oneshot.get());
+    EXPECT_EQ(oneshot.get(), 0xca6598d0u);
+}
+
+TEST(Crc32, Single0xFF)
+{
+    const uint8_t data[] = {0xff};
+    Crc32 crc;
+    EXPECT_EQ(crc.add(data, 1), 0x2d02ef8du);
+}


### PR DESCRIPTION
## Summary
`Crc32` (Gary Brown / MAVLink flavor: init 0, no final XOR) had **no** dedicated unit tests despite shipping in core.

## Changes
- New `crc32_test.cpp`: empty, known vector `123456789` → `0x2dfd2d88`, incremental vs one-shot, single `0xFF`.
- Register source in core `UNIT_TEST_SOURCES`.

No production logic change.

## Verification
Vectors cross-checked against an independent Python replay of the same table polynomial.