### PR TITLE
docs(python): use HTTPS for hosted API documentation links

### DIFF
--- a/docs/en/python/index.md
+++ b/docs/en/python/index.md
@@ -1,4 +1,4 @@
 # MAVSDK-Python
 
 * [Python QuickStart](quickstart.md)
-* [API documentation](http://mavsdk-python-docs.s3-website.eu-central-1.amazonaws.com/)
+* [API documentation](https://mavsdk-python-docs.s3-website.eu-central-1.amazonaws.com/)

--- a/docs/en/python/quickstart.md
+++ b/docs/en/python/quickstart.md
@@ -118,4 +118,4 @@ We do have a [number of examples](https://github.com/mavlink/MAVSDK-Python/tree/
 
 Once MAVSDK is installed we recommend you:
 - Try the [other examples](https://github.com/mavlink/MAVSDK-Python/tree/main/examples)
-- Browse the [API reference](http://mavsdk-python-docs.s3-website.eu-central-1.amazonaws.com/) to get an overview of the functionality.
+- Browse the [API reference](https://mavsdk-python-docs.s3-website.eu-central-1.amazonaws.com/) to get an overview of the functionality.


### PR DESCRIPTION
## Summary
Python guide still linked the S3 website API docs over plain **http://**. Prefer HTTPS where the host accepts it (not part of the C++ docs consolidate in #2972).

## Changes
- `docs/en/python/index.md`
- `docs/en/python/quickstart.md`

Verified: not overlapping the files in #2972.