### PR TITLE
docs(swift): use HTTPS for Swift API documentation link

### DIFF
--- a/docs/en/swift/index.md
+++ b/docs/en/swift/index.md
@@ -1,3 +1,3 @@
 # MAVSDK-Swift
 
-* [API documentation](http://mavsdk-swift-docs.s3.eu-central-1.amazonaws.com/main/index.html)
+* [API documentation](https://mavsdk-swift-docs.s3.eu-central-1.amazonaws.com/main/index.html)


### PR DESCRIPTION
## Summary
Swift index linked API docs via `http://` S3. Switch to HTTPS.

Orthogonal to C++ docs consolidate #2972 and python HTTPS PR.