### PR TITLE
test(core): cover string_utils full-match and longer-prefix edges

### DIFF
--- a/cpp/src/mavsdk/core/string_utils_test.cpp
+++ b/cpp/src/mavsdk/core/string_utils_test.cpp
@@ -22,3 +22,21 @@ TEST(StringUtils, StripPrefix)
     EXPECT_EQ(strip_prefix("", "b"), "");
     EXPECT_EQ(strip_prefix("f", ""), "f");
 }
+
+TEST(StringUtils, StartsWithFullString)
+{
+    EXPECT_TRUE(starts_with("mavsdk", "mavsdk"));
+    EXPECT_FALSE(starts_with("mav", "mavsdk"));
+}
+
+TEST(StringUtils, StripPrefixFullString)
+{
+    EXPECT_EQ(strip_prefix("mavsdk", "mavsdk"), "");
+    EXPECT_EQ(strip_prefix("prefix", "prefixx"), "prefix");
+}
+
+TEST(StringUtils, StartsWithLongerPrefixRejected)
+{
+    EXPECT_FALSE(starts_with("ab", "abc"));
+    EXPECT_EQ(strip_prefix("ab", "abc"), "ab");
+}


### PR DESCRIPTION
## Summary
Adds edges for `starts_with` / `strip_prefix`: full-string match, prefix longer than haystack, strip-to-empty.

Tiny pure unit coverage; no behavior change.