### PR TITLE
test(core): cover flight_mode PX4 and ArduPilot mappings

### DIFF
--- a/cpp/src/mavsdk/core/CMakeLists.txt
+++ b/cpp/src/mavsdk/core/CMakeLists.txt
@@ -284,6 +284,7 @@ list(APPEND UNIT_TEST_SOURCES
     ${PROJECT_SOURCE_DIR}/mavsdk/core/string_utils_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/base64_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/crc32_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/flight_mode_test.cpp
 )
 
 if (NOT BUILD_WITHOUT_CURL)

--- a/cpp/src/mavsdk/core/flight_mode.hpp
+++ b/cpp/src/mavsdk/core/flight_mode.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include "mavlink_include.hpp"
 #include "autopilot.hpp"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -28,11 +29,11 @@ enum class FlightMode {
     Stabilized,
 };
 
-FlightMode
+MAVSDK_TEST_EXPORT FlightMode
 to_flight_mode_from_custom_mode(Autopilot autopilot, MAV_TYPE mav_type, uint32_t custom_mode);
-FlightMode to_flight_mode_from_px4_mode(uint32_t custom_mode);
-FlightMode to_flight_mode_from_ardupilot_rover_mode(uint32_t custom_mode);
-FlightMode to_flight_mode_from_ardupilot_copter_mode(uint32_t custom_mode);
-FlightMode to_flight_mode_from_ardupilot_plane_mode(uint32_t custom_mode);
+MAVSDK_TEST_EXPORT FlightMode to_flight_mode_from_px4_mode(uint32_t custom_mode);
+MAVSDK_TEST_EXPORT FlightMode to_flight_mode_from_ardupilot_rover_mode(uint32_t custom_mode);
+MAVSDK_TEST_EXPORT FlightMode to_flight_mode_from_ardupilot_copter_mode(uint32_t custom_mode);
+MAVSDK_TEST_EXPORT FlightMode to_flight_mode_from_ardupilot_plane_mode(uint32_t custom_mode);
 
 } // namespace mavsdk

--- a/cpp/src/mavsdk/core/flight_mode_test.cpp
+++ b/cpp/src/mavsdk/core/flight_mode_test.cpp
@@ -1,0 +1,151 @@
+#include "flight_mode.hpp"
+#include "ardupilot_custom_mode.hpp"
+#include "px4_custom_mode.hpp"
+#include "autopilot.hpp"
+#include <gtest/gtest.h>
+
+using namespace mavsdk;
+
+static uint32_t px4_mode(uint8_t main_mode, uint8_t sub_mode = 0)
+{
+    px4::px4_custom_mode m{};
+    m.main_mode = main_mode;
+    m.sub_mode = sub_mode;
+    return m.data;
+}
+
+TEST(FlightMode, Px4MainModes)
+{
+    EXPECT_EQ(
+        to_flight_mode_from_px4_mode(px4_mode(px4::PX4_CUSTOM_MAIN_MODE_MANUAL)),
+        FlightMode::Manual);
+    EXPECT_EQ(
+        to_flight_mode_from_px4_mode(px4_mode(px4::PX4_CUSTOM_MAIN_MODE_ALTCTL)),
+        FlightMode::Altctl);
+    EXPECT_EQ(
+        to_flight_mode_from_px4_mode(px4_mode(px4::PX4_CUSTOM_MAIN_MODE_POSCTL)),
+        FlightMode::Posctl);
+    EXPECT_EQ(
+        to_flight_mode_from_px4_mode(px4_mode(px4::PX4_CUSTOM_MAIN_MODE_ACRO)), FlightMode::Acro);
+    EXPECT_EQ(
+        to_flight_mode_from_px4_mode(px4_mode(px4::PX4_CUSTOM_MAIN_MODE_OFFBOARD)),
+        FlightMode::Offboard);
+    EXPECT_EQ(
+        to_flight_mode_from_px4_mode(px4_mode(px4::PX4_CUSTOM_MAIN_MODE_STABILIZED)),
+        FlightMode::Stabilized);
+    EXPECT_EQ(
+        to_flight_mode_from_px4_mode(px4_mode(px4::PX4_CUSTOM_MAIN_MODE_RATTITUDE)),
+        FlightMode::Rattitude);
+}
+
+TEST(FlightMode, Px4AutoSubModes)
+{
+    EXPECT_EQ(
+        to_flight_mode_from_px4_mode(
+            px4_mode(px4::PX4_CUSTOM_MAIN_MODE_AUTO, px4::PX4_CUSTOM_SUB_MODE_AUTO_READY)),
+        FlightMode::Ready);
+    EXPECT_EQ(
+        to_flight_mode_from_px4_mode(
+            px4_mode(px4::PX4_CUSTOM_MAIN_MODE_AUTO, px4::PX4_CUSTOM_SUB_MODE_AUTO_TAKEOFF)),
+        FlightMode::Takeoff);
+    EXPECT_EQ(
+        to_flight_mode_from_px4_mode(
+            px4_mode(px4::PX4_CUSTOM_MAIN_MODE_AUTO, px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER)),
+        FlightMode::Hold);
+    EXPECT_EQ(
+        to_flight_mode_from_px4_mode(
+            px4_mode(px4::PX4_CUSTOM_MAIN_MODE_AUTO, px4::PX4_CUSTOM_SUB_MODE_AUTO_MISSION)),
+        FlightMode::Mission);
+    EXPECT_EQ(
+        to_flight_mode_from_px4_mode(
+            px4_mode(px4::PX4_CUSTOM_MAIN_MODE_AUTO, px4::PX4_CUSTOM_SUB_MODE_AUTO_RTL)),
+        FlightMode::ReturnToLaunch);
+    EXPECT_EQ(
+        to_flight_mode_from_px4_mode(
+            px4_mode(px4::PX4_CUSTOM_MAIN_MODE_AUTO, px4::PX4_CUSTOM_SUB_MODE_AUTO_LAND)),
+        FlightMode::Land);
+    EXPECT_EQ(
+        to_flight_mode_from_px4_mode(
+            px4_mode(px4::PX4_CUSTOM_MAIN_MODE_AUTO, px4::PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET)),
+        FlightMode::FollowMe);
+}
+
+TEST(FlightMode, ArduCopter)
+{
+    EXPECT_EQ(
+        to_flight_mode_from_ardupilot_copter_mode(static_cast<uint32_t>(ardupilot::CopterMode::Auto)),
+        FlightMode::Mission);
+    EXPECT_EQ(
+        to_flight_mode_from_ardupilot_copter_mode(static_cast<uint32_t>(ardupilot::CopterMode::Land)),
+        FlightMode::Land);
+    EXPECT_EQ(
+        to_flight_mode_from_ardupilot_copter_mode(static_cast<uint32_t>(ardupilot::CopterMode::Rtl)),
+        FlightMode::ReturnToLaunch);
+    EXPECT_EQ(
+        to_flight_mode_from_ardupilot_copter_mode(
+            static_cast<uint32_t>(ardupilot::CopterMode::Guided)),
+        FlightMode::Offboard);
+    EXPECT_EQ(
+        to_flight_mode_from_ardupilot_copter_mode(
+            static_cast<uint32_t>(ardupilot::CopterMode::Unknown)),
+        FlightMode::Unknown);
+}
+
+TEST(FlightMode, ArduPlane)
+{
+    EXPECT_EQ(
+        to_flight_mode_from_ardupilot_plane_mode(static_cast<uint32_t>(ardupilot::PlaneMode::Fbwa)),
+        FlightMode::FBWA);
+    EXPECT_EQ(
+        to_flight_mode_from_ardupilot_plane_mode(static_cast<uint32_t>(ardupilot::PlaneMode::Fbwb)),
+        FlightMode::FBWB);
+    EXPECT_EQ(
+        to_flight_mode_from_ardupilot_plane_mode(static_cast<uint32_t>(ardupilot::PlaneMode::Takeoff)),
+        FlightMode::Takeoff);
+    EXPECT_EQ(
+        to_flight_mode_from_ardupilot_plane_mode(static_cast<uint32_t>(ardupilot::PlaneMode::Auto)),
+        FlightMode::Mission);
+}
+
+TEST(FlightMode, ArduRover)
+{
+    EXPECT_EQ(
+        to_flight_mode_from_ardupilot_rover_mode(static_cast<uint32_t>(ardupilot::RoverMode::Hold)),
+        FlightMode::Hold);
+    EXPECT_EQ(
+        to_flight_mode_from_ardupilot_rover_mode(static_cast<uint32_t>(ardupilot::RoverMode::RTL)),
+        FlightMode::ReturnToLaunch);
+    EXPECT_EQ(
+        to_flight_mode_from_ardupilot_rover_mode(static_cast<uint32_t>(ardupilot::RoverMode::Manual)),
+        FlightMode::Manual);
+}
+
+TEST(FlightMode, CustomModeDispatch)
+{
+    // Unknown autopilot path uses PX4 decoder.
+    EXPECT_EQ(
+        to_flight_mode_from_custom_mode(
+            Autopilot::Px4, MAV_TYPE_QUADROTOR, px4_mode(px4::PX4_CUSTOM_MAIN_MODE_MANUAL)),
+        FlightMode::Manual);
+
+    EXPECT_EQ(
+        to_flight_mode_from_custom_mode(
+            Autopilot::ArduPilot,
+            MAV_TYPE_QUADROTOR,
+            static_cast<uint32_t>(ardupilot::CopterMode::Land)),
+        FlightMode::Land);
+
+    EXPECT_EQ(
+        to_flight_mode_from_custom_mode(
+            Autopilot::ArduPilot,
+            MAV_TYPE_FIXED_WING,
+            static_cast<uint32_t>(ardupilot::PlaneMode::Fbwa)),
+        FlightMode::FBWA);
+
+    EXPECT_EQ(
+        to_flight_mode_from_custom_mode(
+            Autopilot::ArduPilot,
+            MAV_TYPE_GROUND_ROVER,
+            static_cast<uint32_t>(ardupilot::RoverMode::Hold)),
+        FlightMode::Hold);
+}

--- a/cpp/src/mavsdk/core/flight_mode_test.cpp
+++ b/cpp/src/mavsdk/core/flight_mode_test.cpp
@@ -73,13 +73,16 @@ TEST(FlightMode, Px4AutoSubModes)
 TEST(FlightMode, ArduCopter)
 {
     EXPECT_EQ(
-        to_flight_mode_from_ardupilot_copter_mode(static_cast<uint32_t>(ardupilot::CopterMode::Auto)),
+        to_flight_mode_from_ardupilot_copter_mode(
+            static_cast<uint32_t>(ardupilot::CopterMode::Auto)),
         FlightMode::Mission);
     EXPECT_EQ(
-        to_flight_mode_from_ardupilot_copter_mode(static_cast<uint32_t>(ardupilot::CopterMode::Land)),
+        to_flight_mode_from_ardupilot_copter_mode(
+            static_cast<uint32_t>(ardupilot::CopterMode::Land)),
         FlightMode::Land);
     EXPECT_EQ(
-        to_flight_mode_from_ardupilot_copter_mode(static_cast<uint32_t>(ardupilot::CopterMode::Rtl)),
+        to_flight_mode_from_ardupilot_copter_mode(
+            static_cast<uint32_t>(ardupilot::CopterMode::Rtl)),
         FlightMode::ReturnToLaunch);
     EXPECT_EQ(
         to_flight_mode_from_ardupilot_copter_mode(
@@ -100,7 +103,8 @@ TEST(FlightMode, ArduPlane)
         to_flight_mode_from_ardupilot_plane_mode(static_cast<uint32_t>(ardupilot::PlaneMode::Fbwb)),
         FlightMode::FBWB);
     EXPECT_EQ(
-        to_flight_mode_from_ardupilot_plane_mode(static_cast<uint32_t>(ardupilot::PlaneMode::Takeoff)),
+        to_flight_mode_from_ardupilot_plane_mode(
+            static_cast<uint32_t>(ardupilot::PlaneMode::Takeoff)),
         FlightMode::Takeoff);
     EXPECT_EQ(
         to_flight_mode_from_ardupilot_plane_mode(static_cast<uint32_t>(ardupilot::PlaneMode::Auto)),
@@ -116,7 +120,8 @@ TEST(FlightMode, ArduRover)
         to_flight_mode_from_ardupilot_rover_mode(static_cast<uint32_t>(ardupilot::RoverMode::RTL)),
         FlightMode::ReturnToLaunch);
     EXPECT_EQ(
-        to_flight_mode_from_ardupilot_rover_mode(static_cast<uint32_t>(ardupilot::RoverMode::Manual)),
+        to_flight_mode_from_ardupilot_rover_mode(
+            static_cast<uint32_t>(ardupilot::RoverMode::Manual)),
         FlightMode::Manual);
 }
 


### PR DESCRIPTION
## Summary
Adds unit coverage for `flight_mode` mappers used when decoding vehicle custom modes.

## Why
These tables gate RTL/hold/offboard interpretation for PX4 and ArduPilot vehicle types; they previously had no dedicated unit tests.

## Changes
- New `flight_mode_test.cpp` exercising PX4 main modes, AUTO sub-modes, ArduPilot copter/plane/rover helpers, and `to_flight_mode_from_custom_mode` dispatch.
- Register test in core `CMakeLists.txt`.

## Test plan
- [ ] CI unit tests
- Local: build `unit_tests` target and run flight_mode fixture when convenient

Human-authored; AI-assisted draft aren't present as co-authors.