### PR TITLE
test(core): cover replace_non_ascii_and_whitespace

### DIFF
--- a/cpp/src/mavsdk/core/CMakeLists.txt
+++ b/cpp/src/mavsdk/core/CMakeLists.txt
@@ -285,6 +285,7 @@ list(APPEND UNIT_TEST_SOURCES
     ${PROJECT_SOURCE_DIR}/mavsdk/core/base64_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/crc32_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/flight_mode_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/fs_utils_test.cpp
 )
 
 if (NOT BUILD_WITHOUT_CURL)

--- a/cpp/src/mavsdk/core/fs_utils.hpp
+++ b/cpp/src/mavsdk/core/fs_utils.hpp
@@ -19,7 +19,7 @@ MAVSDK_TEST_EXPORT std::optional<std::filesystem::path> get_cache_directory();
 MAVSDK_TEST_EXPORT std::optional<std::filesystem::path>
 create_tmp_directory(const std::string& prefix);
 
-std::string replace_non_ascii_and_whitespace(const std::string& input);
+MAVSDK_TEST_EXPORT std::string replace_non_ascii_and_whitespace(const std::string& input);
 
 #ifdef ANDROID
 extern "C" {

--- a/cpp/src/mavsdk/core/fs_utils_test.cpp
+++ b/cpp/src/mavsdk/core/fs_utils_test.cpp
@@ -1,0 +1,23 @@
+#include "fs_utils.hpp"
+#include <gtest/gtest.h>
+
+using namespace mavsdk;
+
+TEST(FsUtils, ReplaceAsciiUnchanged)
+{
+    EXPECT_EQ(replace_non_ascii_and_whitespace("cache-tag_v1"), "cache-tag_v1");
+    EXPECT_EQ(replace_non_ascii_and_whitespace(""), "");
+}
+
+TEST(FsUtils, ReplaceWhitespace)
+{
+    EXPECT_EQ(replace_non_ascii_and_whitespace("a b\tc"), "a_b_c");
+    EXPECT_EQ(replace_non_ascii_and_whitespace(" \n"), "__");
+}
+
+TEST(FsUtils, ReplaceNonAscii)
+{
+    // UTF-8 multi-byte bytes are >127 and must become underscores.
+    const std::string input = std::string("id-") + "\xC3\xA9" + "-x"; // "é"
+    EXPECT_EQ(replace_non_ascii_and_whitespace(input), "id-__-x");
+}


### PR DESCRIPTION
## What
Unit tests for `replace_non_ascii_and_whitespace` in `fs_utils`.

## Why
Helper sanitizes cache tags / path fragments. Previously untested pure string transform.

## Coverage
- ASCII passthrough / empty
- space and tab → `_`
- multi-byte non-ASCII bytes → `_`

No production behavior change.