### PR TITLE
test(core): hostname_to_ip private dotted and whitespace edges

### DIFF
--- a/cpp/src/mavsdk/core/hostname_to_ip_test.cpp
+++ b/cpp/src/mavsdk/core/hostname_to_ip_test.cpp
@@ -32,3 +32,23 @@ TEST(HostnameToIp, Something)
     auto ip = resolve_hostname_to_ip(host);
     EXPECT_FALSE(ip);
 }
+
+TEST(HostnameToIp, DottedPrivate)
+{
+    auto ip = resolve_hostname_to_ip("192.168.1.10");
+    ASSERT_TRUE(ip);
+    EXPECT_EQ(ip.value(), "192.168.1.10");
+}
+
+TEST(HostnameToIp, ZeroZeroZeroZero)
+{
+    auto ip = resolve_hostname_to_ip("0.0.0.0");
+    ASSERT_TRUE(ip);
+    EXPECT_EQ(ip.value(), "0.0.0.0");
+}
+
+TEST(HostnameToIp, WhitespaceRejected)
+{
+    EXPECT_FALSE(resolve_hostname_to_ip(" "));
+    EXPECT_FALSE(resolve_hostname_to_ip("127.0.0.1 "));
+}


### PR DESCRIPTION
## Summary
Extends `hostname_to_ip` tests for private IPv4 passthrough, `0.0.0.0`, and whitespace-ish invalid hosts.

Pass-through path should not round-trip through DNS for dotted quads.