### PR TITLE
camera_server: Add CAMERA_FOV_STATUS request support

### DIFF
--- a/c/src/cmavsdk/plugins/camera_server/camera_server.cpp
+++ b/c/src/cmavsdk/plugins/camera_server/camera_server.cpp
@@ -1957,3 +1957,60 @@ mavsdk_camera_server_respond_tracking_off_command(
 
     return translate_result(ret_value);
 }
+
+
+// SetPosition sync
+mavsdk_camera_server_result_t
+mavsdk_camera_server_set_position(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_position_t position)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto ret_value = wrapper->cpp_plugin->set_position(        translate_position_from_c(position));
+
+    return translate_result(ret_value);
+}
+
+
+// SetAttitudeQuaternion sync
+mavsdk_camera_server_result_t
+mavsdk_camera_server_set_attitude_quaternion(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_quaternion_t attitude_quaternion)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto ret_value = wrapper->cpp_plugin->set_attitude_quaternion(        translate_quaternion_from_c(attitude_quaternion));
+
+    return translate_result(ret_value);
+}
+
+
+// SetZoomFactor sync
+mavsdk_camera_server_result_t
+mavsdk_camera_server_set_zoom_factor(
+    mavsdk_camera_server_t camera_server,
+    float zoom_factor)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto ret_value = wrapper->cpp_plugin->set_zoom_factor(        zoom_factor);
+
+    return translate_result(ret_value);
+}
+
+
+// SetFieldOfView sync
+mavsdk_camera_server_result_t
+mavsdk_camera_server_set_field_of_view(
+    mavsdk_camera_server_t camera_server,
+    float horizontal_fov_deg,
+    float vertical_fov_deg)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto ret_value = wrapper->cpp_plugin->set_field_of_view(        horizontal_fov_deg,        vertical_fov_deg);
+
+    return translate_result(ret_value);
+}

--- a/c/src/cmavsdk/plugins/camera_server/camera_server.h
+++ b/c/src/cmavsdk/plugins/camera_server/camera_server.h
@@ -1466,6 +1466,67 @@ mavsdk_camera_server_respond_tracking_off_command(
     mavsdk_camera_server_camera_feedback_t stop_video_feedback);
 
 
+/**
+ * @brief Get the current set position (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param set_position_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_camera_server_result_t
+mavsdk_camera_server_set_position(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_position_t position);
+
+
+/**
+ * @brief Get the current set attitude quaternion (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param set_attitude_quaternion_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_camera_server_result_t
+mavsdk_camera_server_set_attitude_quaternion(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_quaternion_t attitude_quaternion);
+
+
+/**
+ * @brief Get the current set zoom factor (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param set_zoom_factor_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_camera_server_result_t
+mavsdk_camera_server_set_zoom_factor(
+    mavsdk_camera_server_t camera_server,
+    float zoom_factor);
+
+
+/**
+ * @brief Get the current set field of view (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param set_field_of_view_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_camera_server_result_t
+mavsdk_camera_server_set_field_of_view(
+    mavsdk_camera_server_t camera_server,
+    float horizontal_fov_deg,
+    float vertical_fov_deg);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpp/src/mavsdk/plugins/camera_server/camera_server.cpp
+++ b/cpp/src/mavsdk/plugins/camera_server/camera_server.cpp
@@ -332,6 +332,16 @@ CameraServer::respond_tracking_off_command(CameraFeedback stop_video_feedback) c
     return _impl->respond_tracking_off_command(stop_video_feedback);
 }
 
+CameraServer::Result CameraServer::set_position(Position position) const
+{
+    return _impl->set_position(position);
+}
+
+CameraServer::Result CameraServer::set_attitude_quaternion(Quaternion attitude_quaternion) const
+{
+    return _impl->set_attitude_quaternion(attitude_quaternion);
+}
+
 MAVSDK_PUBLIC bool
 operator==(const CameraServer::Information& lhs, const CameraServer::Information& rhs)
 {

--- a/cpp/src/mavsdk/plugins/camera_server/camera_server.cpp
+++ b/cpp/src/mavsdk/plugins/camera_server/camera_server.cpp
@@ -342,6 +342,17 @@ CameraServer::Result CameraServer::set_attitude_quaternion(Quaternion attitude_q
     return _impl->set_attitude_quaternion(attitude_quaternion);
 }
 
+CameraServer::Result CameraServer::set_zoom_factor(float zoom_factor) const
+{
+    return _impl->set_zoom_factor(zoom_factor);
+}
+
+CameraServer::Result
+CameraServer::set_field_of_view(float horizontal_fov_deg, float vertical_fov_deg) const
+{
+    return _impl->set_field_of_view(horizontal_fov_deg, vertical_fov_deg);
+}
+
 MAVSDK_PUBLIC bool
 operator==(const CameraServer::Information& lhs, const CameraServer::Information& rhs)
 {

--- a/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
+++ b/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
@@ -1449,6 +1449,24 @@ CameraServerImpl::set_attitude_quaternion(CameraServer::Quaternion attitude_quat
     return CameraServer::Result::Success;
 }
 
+CameraServer::Result CameraServerImpl::set_zoom_factor(float zoom_factor)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    _zoom_factor = zoom_factor;
+    _is_zoom_factor_set = true;
+    return CameraServer::Result::Success;
+}
+
+CameraServer::Result
+CameraServerImpl::set_field_of_view(float horizontal_fov_deg, float vertical_fov_deg)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    _horizontal_fov_deg = horizontal_fov_deg;
+    _vertical_fov_deg = vertical_fov_deg;
+    _is_fov_set = true;
+    return CameraServer::Result::Success;
+}
+
 std::optional<mavlink_command_ack_t>
 CameraServerImpl::send_fov_status(const MavlinkCommandReceiver::CommandLong& command)
 {
@@ -1459,14 +1477,32 @@ CameraServerImpl::send_fov_status(const MavlinkCommandReceiver::CommandLong& com
             command, MAV_RESULT::MAV_RESULT_TEMPORARILY_REJECTED);
     }
 
-    const float hfov_deg =
-        2.0f *
-        std::atan2(_information.horizontal_sensor_size_mm, 2.0f * _information.focal_length_mm) *
-        static_cast<float>(180.0 / M_PI);
-    const float vfov_deg =
-        2.0f *
-        std::atan2(_information.vertical_sensor_size_mm, 2.0f * _information.focal_length_mm) *
-        static_cast<float>(180.0 / M_PI);
+    float hfov_deg;
+    float vfov_deg;
+    if (_is_zoom_factor_set) {
+        const float focal_length_mm = _information.focal_length_mm * _zoom_factor;
+        hfov_deg = 2.0f *
+                   std::atan((_information.horizontal_sensor_size_mm / 2.0f) / focal_length_mm) *
+                   (180.0f / static_cast<float>(M_PI));
+        vfov_deg = 2.0f *
+                   std::atan((_information.vertical_sensor_size_mm / 2.0f) / focal_length_mm) *
+                   (180.0f / static_cast<float>(M_PI));
+    } else if (_is_fov_set) {
+        hfov_deg = _horizontal_fov_deg;
+        vfov_deg = _vertical_fov_deg;
+    } else {
+        // Fall back to base FOV derived from camera information (no zoom applied)
+        hfov_deg =
+            2.0f *
+            std::atan(
+                (_information.horizontal_sensor_size_mm / 2.0f) / _information.focal_length_mm) *
+            (180.0f / static_cast<float>(M_PI));
+        vfov_deg =
+            2.0f *
+            std::atan(
+                (_information.vertical_sensor_size_mm / 2.0f) / _information.focal_length_mm) *
+            (180.0f / static_cast<float>(M_PI));
+    }
 
     const int32_t lat_camera =
         _is_position_set ? static_cast<int32_t>(_position.latitude_deg * 1e7) : INT32_MAX;

--- a/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
+++ b/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
@@ -1143,6 +1143,9 @@ CameraServerImpl::process_request_message(const MavlinkCommandReceiver::CommandL
             return _server_component_impl->make_command_ack_message(
                 command, MAV_RESULT::MAV_RESULT_ACCEPTED);
 
+        case MAVLINK_MSG_ID_CAMERA_FOV_STATUS:
+            return send_fov_status(command);
+
         default:
             LogWarn("Got unknown request message!");
             return _server_component_impl->make_command_ack_message(
@@ -1427,6 +1430,84 @@ void CameraServerImpl::send_capture_status()
             0);
         return message;
     });
+}
+
+CameraServer::Result CameraServerImpl::set_position(CameraServer::Position position)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    _position = position;
+    _is_position_set = true;
+    return CameraServer::Result::Success;
+}
+
+CameraServer::Result
+CameraServerImpl::set_attitude_quaternion(CameraServer::Quaternion attitude_quaternion)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    _attitude_quaternion = attitude_quaternion;
+    _is_attitude_quaternion_set = true;
+    return CameraServer::Result::Success;
+}
+
+std::optional<mavlink_command_ack_t>
+CameraServerImpl::send_fov_status(const MavlinkCommandReceiver::CommandLong& command)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+
+    if (!_is_information_set) {
+        return _server_component_impl->make_command_ack_message(
+            command, MAV_RESULT::MAV_RESULT_TEMPORARILY_REJECTED);
+    }
+
+    const float hfov_deg =
+        2.0f *
+        std::atan2(_information.horizontal_sensor_size_mm, 2.0f * _information.focal_length_mm) *
+        static_cast<float>(180.0 / M_PI);
+    const float vfov_deg =
+        2.0f *
+        std::atan2(_information.vertical_sensor_size_mm, 2.0f * _information.focal_length_mm) *
+        static_cast<float>(180.0 / M_PI);
+
+    const int32_t lat_camera =
+        _is_position_set ? static_cast<int32_t>(_position.latitude_deg * 1e7) : INT32_MAX;
+    const int32_t lon_camera =
+        _is_position_set ? static_cast<int32_t>(_position.longitude_deg * 1e7) : INT32_MAX;
+    const int32_t alt_camera =
+        _is_position_set ? static_cast<int32_t>(_position.absolute_altitude_m * 1e3) : INT32_MAX;
+
+    const float q[4] = {
+        _is_attitude_quaternion_set ? _attitude_quaternion.w : 1.0f,
+        _is_attitude_quaternion_set ? _attitude_quaternion.x : 0.0f,
+        _is_attitude_quaternion_set ? _attitude_quaternion.y : 0.0f,
+        _is_attitude_quaternion_set ? _attitude_quaternion.z : 0.0f,
+    };
+
+    auto ack =
+        _server_component_impl->make_command_ack_message(command, MAV_RESULT::MAV_RESULT_ACCEPTED);
+    _server_component_impl->send_command_ack(ack);
+
+    _server_component_impl->queue_message([&](MavlinkAddress mavlink_address, uint8_t channel) {
+        mavlink_message_t message{};
+        mavlink_msg_camera_fov_status_pack_chan(
+            mavlink_address.system_id,
+            mavlink_address.component_id,
+            channel,
+            &message,
+            static_cast<uint32_t>(_server_component_impl->get_time().elapsed_s() * 1e3),
+            lat_camera,
+            lon_camera,
+            alt_camera,
+            INT32_MAX, // lat_image: unknown, requires terrain intersection
+            INT32_MAX, // lon_image: unknown, requires terrain intersection
+            INT32_MAX, // alt_image: unknown, requires terrain intersection
+            q,
+            hfov_deg,
+            vfov_deg,
+            0 /* camera_device_id: 0 = MAVLink camera */);
+        return message;
+    });
+
+    return std::nullopt; // ACK already sent
 }
 
 std::optional<mavlink_command_ack_t>

--- a/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
+++ b/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
@@ -1451,6 +1451,10 @@ CameraServerImpl::set_attitude_quaternion(CameraServer::Quaternion attitude_quat
 
 CameraServer::Result CameraServerImpl::set_zoom_factor(float zoom_factor)
 {
+    if (!std::isfinite(zoom_factor) || zoom_factor < 1.0f) {
+        LogWarn("Invalid zoom factor: {}", zoom_factor);
+        return CameraServer::Result::WrongArgument;
+    }
     std::lock_guard<std::mutex> lg{_mutex};
     _zoom_factor = zoom_factor;
     _is_zoom_factor_set = true;
@@ -1460,6 +1464,18 @@ CameraServer::Result CameraServerImpl::set_zoom_factor(float zoom_factor)
 CameraServer::Result
 CameraServerImpl::set_field_of_view(float horizontal_fov_deg, float vertical_fov_deg)
 {
+    if (!std::isfinite(horizontal_fov_deg) || horizontal_fov_deg <= 0.0f ||
+        horizontal_fov_deg >= 180.0f) {
+        LogWarn("Invalid horizontal FOV: {}", horizontal_fov_deg);
+        return CameraServer::Result::WrongArgument;
+    }
+
+    if (!std::isfinite(vertical_fov_deg) || vertical_fov_deg <= 0.0f ||
+        vertical_fov_deg >= 180.0f) {
+        LogWarn("Invalid vertical FOV: {}", vertical_fov_deg);
+        return CameraServer::Result::WrongArgument;
+    }
+
     std::lock_guard<std::mutex> lg{_mutex};
     _horizontal_fov_deg = horizontal_fov_deg;
     _vertical_fov_deg = vertical_fov_deg;

--- a/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.hpp
+++ b/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.hpp
@@ -26,6 +26,8 @@ public:
     CameraServer::Result set_in_progress(bool in_progress);
     CameraServer::Result set_position(CameraServer::Position position);
     CameraServer::Result set_attitude_quaternion(CameraServer::Quaternion attitude_quaternion);
+    CameraServer::Result set_zoom_factor(float zoom_factor);
+    CameraServer::Result set_field_of_view(float horizontal_fov_deg, float vertical_fov_deg);
 
     CameraServer::TakePhotoHandle
     subscribe_take_photo(const CameraServer::TakePhotoCallback& callback);
@@ -211,6 +213,8 @@ private:
     bool _is_information_set{};
     bool _is_position_set{};
     bool _is_attitude_quaternion_set{};
+    bool _is_zoom_factor_set{};
+    bool _is_fov_set{};
 
     std::mutex _mutex{};
 
@@ -228,6 +232,9 @@ private:
     CameraServer::Information _information{};
     CameraServer::Position _position{};
     CameraServer::Quaternion _attitude_quaternion{};
+    float _zoom_factor{};
+    float _horizontal_fov_deg{};
+    float _vertical_fov_deg{};
     bool _is_video_streaming_set{};
     CameraServer::VideoStreaming _video_streaming{};
 

--- a/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.hpp
+++ b/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.hpp
@@ -24,6 +24,8 @@ public:
     CameraServer::Result set_information(CameraServer::Information information);
     CameraServer::Result set_video_streaming(CameraServer::VideoStreaming video_streaming);
     CameraServer::Result set_in_progress(bool in_progress);
+    CameraServer::Result set_position(CameraServer::Position position);
+    CameraServer::Result set_attitude_quaternion(CameraServer::Quaternion attitude_quaternion);
 
     CameraServer::TakePhotoHandle
     subscribe_take_photo(const CameraServer::TakePhotoCallback& callback);
@@ -203,7 +205,12 @@ private:
 
     void send_capture_status();
 
+    std::optional<mavlink_command_ack_t>
+    send_fov_status(const MavlinkCommandReceiver::CommandLong& command);
+
     bool _is_information_set{};
+    bool _is_position_set{};
+    bool _is_attitude_quaternion_set{};
 
     std::mutex _mutex{};
 
@@ -219,6 +226,8 @@ private:
     CallEveryHandler::Cookie _capture_status_timer_cookie{};
 
     CameraServer::Information _information{};
+    CameraServer::Position _position{};
+    CameraServer::Quaternion _attitude_quaternion{};
     bool _is_video_streaming_set{};
     CameraServer::VideoStreaming _video_streaming{};
 

--- a/cpp/src/mavsdk/plugins/camera_server/include/plugins/camera_server/camera_server.hpp
+++ b/cpp/src/mavsdk/plugins/camera_server/include/plugins/camera_server/camera_server.hpp
@@ -1387,6 +1387,38 @@ public:
 
 
 
+
+
+    /**
+     * @brief Set the camera's zoom factor for CAMERA_FOV_STATUS reporting.
+     *
+     * This function is blocking.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result set_zoom_factor(float zoom_factor) const;
+
+
+
+
+
+
+    /**
+     * @brief Set the field of view explicitly, for cameras that do not report a zoom factor.
+     *
+     * This function is blocking.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result set_field_of_view(float horizontal_fov_deg, float vertical_fov_deg) const;
+
+
+
+
     /**
      * @brief Copy constructor.
      */

--- a/cpp/src/mavsdk/plugins/camera_server/include/plugins/camera_server/camera_server.hpp
+++ b/cpp/src/mavsdk/plugins/camera_server/include/plugins/camera_server/camera_server.hpp
@@ -1355,6 +1355,38 @@ public:
 
 
 
+
+
+    /**
+     * @brief Set the camera's GPS position.
+     *
+     * This function is blocking.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result set_position(Position position) const;
+
+
+
+
+
+
+    /**
+     * @brief Set the camera's attitude quaternion.
+     *
+     * This function is blocking.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result set_attitude_quaternion(Quaternion attitude_quaternion) const;
+
+
+
+
     /**
      * @brief Copy constructor.
      */

--- a/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.grpc.pb.cc
+++ b/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.grpc.pb.cc
@@ -63,6 +63,8 @@ static const char* CameraServerService_method_names[] = {
   "/mavsdk.rpc.camera_server.CameraServerService/RespondTrackingPointCommand",
   "/mavsdk.rpc.camera_server.CameraServerService/RespondTrackingRectangleCommand",
   "/mavsdk.rpc.camera_server.CameraServerService/RespondTrackingOffCommand",
+  "/mavsdk.rpc.camera_server.CameraServerService/SetPosition",
+  "/mavsdk.rpc.camera_server.CameraServerService/SetAttitudeQuaternion",
 };
 
 std::unique_ptr< CameraServerService::Stub> CameraServerService::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
@@ -111,6 +113,8 @@ CameraServerService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>
   , rpcmethod_RespondTrackingPointCommand_(CameraServerService_method_names[36], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_RespondTrackingRectangleCommand_(CameraServerService_method_names[37], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_RespondTrackingOffCommand_(CameraServerService_method_names[38], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetPosition_(CameraServerService_method_names[39], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetAttitudeQuaternion_(CameraServerService_method_names[40], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status CameraServerService::Stub::SetInformation(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetInformationRequest& request, ::mavsdk::rpc::camera_server::SetInformationResponse* response) {
@@ -891,6 +895,52 @@ void CameraServerService::Stub::async::RespondTrackingOffCommand(::grpc::ClientC
   return result;
 }
 
+::grpc::Status CameraServerService::Stub::SetPosition(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest& request, ::mavsdk::rpc::camera_server::SetPositionResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera_server::SetPositionRequest, ::mavsdk::rpc::camera_server::SetPositionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_SetPosition_, context, request, response);
+}
+
+void CameraServerService::Stub::async::SetPosition(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest* request, ::mavsdk::rpc::camera_server::SetPositionResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera_server::SetPositionRequest, ::mavsdk::rpc::camera_server::SetPositionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetPosition_, context, request, response, std::move(f));
+}
+
+void CameraServerService::Stub::async::SetPosition(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest* request, ::mavsdk::rpc::camera_server::SetPositionResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetPosition_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetPositionResponse>* CameraServerService::Stub::PrepareAsyncSetPositionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera_server::SetPositionResponse, ::mavsdk::rpc::camera_server::SetPositionRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_SetPosition_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetPositionResponse>* CameraServerService::Stub::AsyncSetPositionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncSetPositionRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::Status CameraServerService::Stub::SetAttitudeQuaternion(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest& request, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_SetAttitudeQuaternion_, context, request, response);
+}
+
+void CameraServerService::Stub::async::SetAttitudeQuaternion(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* request, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetAttitudeQuaternion_, context, request, response, std::move(f));
+}
+
+void CameraServerService::Stub::async::SetAttitudeQuaternion(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* request, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetAttitudeQuaternion_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>* CameraServerService::Stub::PrepareAsyncSetAttitudeQuaternionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_SetAttitudeQuaternion_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>* CameraServerService::Stub::AsyncSetAttitudeQuaternionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncSetAttitudeQuaternionRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
 CameraServerService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       CameraServerService_method_names[0],
@@ -1282,6 +1332,26 @@ CameraServerService::Service::Service() {
              ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse* resp) {
                return service->RespondTrackingOffCommand(ctx, req, resp);
              }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[39],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SetPositionRequest, ::mavsdk::rpc::camera_server::SetPositionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::SetPositionRequest* req,
+             ::mavsdk::rpc::camera_server::SetPositionResponse* resp) {
+               return service->SetPosition(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[40],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* req,
+             ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* resp) {
+               return service->SetAttitudeQuaternion(ctx, req, resp);
+             }, this)));
 }
 
 CameraServerService::Service::~Service() {
@@ -1554,6 +1624,20 @@ CameraServerService::Service::~Service() {
 }
 
 ::grpc::Status CameraServerService::Service::RespondTrackingOffCommand(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::SetPosition(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest* request, ::mavsdk::rpc::camera_server::SetPositionResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::SetAttitudeQuaternion(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* request, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.grpc.pb.cc
+++ b/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.grpc.pb.cc
@@ -65,6 +65,8 @@ static const char* CameraServerService_method_names[] = {
   "/mavsdk.rpc.camera_server.CameraServerService/RespondTrackingOffCommand",
   "/mavsdk.rpc.camera_server.CameraServerService/SetPosition",
   "/mavsdk.rpc.camera_server.CameraServerService/SetAttitudeQuaternion",
+  "/mavsdk.rpc.camera_server.CameraServerService/SetZoomFactor",
+  "/mavsdk.rpc.camera_server.CameraServerService/SetFieldOfView",
 };
 
 std::unique_ptr< CameraServerService::Stub> CameraServerService::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
@@ -115,6 +117,8 @@ CameraServerService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>
   , rpcmethod_RespondTrackingOffCommand_(CameraServerService_method_names[38], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_SetPosition_(CameraServerService_method_names[39], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_SetAttitudeQuaternion_(CameraServerService_method_names[40], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetZoomFactor_(CameraServerService_method_names[41], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetFieldOfView_(CameraServerService_method_names[42], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status CameraServerService::Stub::SetInformation(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetInformationRequest& request, ::mavsdk::rpc::camera_server::SetInformationResponse* response) {
@@ -941,6 +945,52 @@ void CameraServerService::Stub::async::SetAttitudeQuaternion(::grpc::ClientConte
   return result;
 }
 
+::grpc::Status CameraServerService::Stub::SetZoomFactor(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest& request, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera_server::SetZoomFactorRequest, ::mavsdk::rpc::camera_server::SetZoomFactorResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_SetZoomFactor_, context, request, response);
+}
+
+void CameraServerService::Stub::async::SetZoomFactor(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest* request, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera_server::SetZoomFactorRequest, ::mavsdk::rpc::camera_server::SetZoomFactorResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetZoomFactor_, context, request, response, std::move(f));
+}
+
+void CameraServerService::Stub::async::SetZoomFactor(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest* request, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetZoomFactor_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetZoomFactorResponse>* CameraServerService::Stub::PrepareAsyncSetZoomFactorRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera_server::SetZoomFactorResponse, ::mavsdk::rpc::camera_server::SetZoomFactorRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_SetZoomFactor_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetZoomFactorResponse>* CameraServerService::Stub::AsyncSetZoomFactorRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncSetZoomFactorRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::Status CameraServerService::Stub::SetFieldOfView(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest& request, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera_server::SetFieldOfViewRequest, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_SetFieldOfView_, context, request, response);
+}
+
+void CameraServerService::Stub::async::SetFieldOfView(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* request, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera_server::SetFieldOfViewRequest, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetFieldOfView_, context, request, response, std::move(f));
+}
+
+void CameraServerService::Stub::async::SetFieldOfView(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* request, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetFieldOfView_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>* CameraServerService::Stub::PrepareAsyncSetFieldOfViewRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera_server::SetFieldOfViewResponse, ::mavsdk::rpc::camera_server::SetFieldOfViewRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_SetFieldOfView_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>* CameraServerService::Stub::AsyncSetFieldOfViewRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncSetFieldOfViewRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
 CameraServerService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       CameraServerService_method_names[0],
@@ -1352,6 +1402,26 @@ CameraServerService::Service::Service() {
              ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* resp) {
                return service->SetAttitudeQuaternion(ctx, req, resp);
              }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[41],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SetZoomFactorRequest, ::mavsdk::rpc::camera_server::SetZoomFactorResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::SetZoomFactorRequest* req,
+             ::mavsdk::rpc::camera_server::SetZoomFactorResponse* resp) {
+               return service->SetZoomFactor(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[42],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SetFieldOfViewRequest, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* req,
+             ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* resp) {
+               return service->SetFieldOfView(ctx, req, resp);
+             }, this)));
 }
 
 CameraServerService::Service::~Service() {
@@ -1638,6 +1708,20 @@ CameraServerService::Service::~Service() {
 }
 
 ::grpc::Status CameraServerService::Service::SetAttitudeQuaternion(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* request, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::SetZoomFactor(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest* request, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::SetFieldOfView(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* request, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.grpc.pb.h
+++ b/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.grpc.pb.h
@@ -384,6 +384,22 @@ class CameraServerService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>> PrepareAsyncRespondTrackingOffCommand(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>>(PrepareAsyncRespondTrackingOffCommandRaw(context, request, cq));
     }
+    // Set the camera's GPS position.
+    virtual ::grpc::Status SetPosition(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest& request, ::mavsdk::rpc::camera_server::SetPositionResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetPositionResponse>> AsyncSetPosition(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetPositionResponse>>(AsyncSetPositionRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetPositionResponse>> PrepareAsyncSetPosition(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetPositionResponse>>(PrepareAsyncSetPositionRaw(context, request, cq));
+    }
+    // Set the camera's attitude quaternion.
+    virtual ::grpc::Status SetAttitudeQuaternion(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest& request, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>> AsyncSetAttitudeQuaternion(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>>(AsyncSetAttitudeQuaternionRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>> PrepareAsyncSetAttitudeQuaternion(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>>(PrepareAsyncSetAttitudeQuaternionRaw(context, request, cq));
+    }
     class async_interface {
      public:
       virtual ~async_interface() {}
@@ -487,6 +503,12 @@ class CameraServerService final {
       // Respond to an incoming tracking off command.
       virtual void RespondTrackingOffCommand(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void RespondTrackingOffCommand(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Set the camera's GPS position.
+      virtual void SetPosition(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest* request, ::mavsdk::rpc::camera_server::SetPositionResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void SetPosition(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest* request, ::mavsdk::rpc::camera_server::SetPositionResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Set the camera's attitude quaternion.
+      virtual void SetAttitudeQuaternion(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* request, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void SetAttitudeQuaternion(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* request, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
     };
     typedef class async_interface experimental_async_interface;
     virtual class async_interface* async() { return nullptr; }
@@ -587,6 +609,10 @@ class CameraServerService final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse>* PrepareAsyncRespondTrackingRectangleCommandRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>* AsyncRespondTrackingOffCommandRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>* PrepareAsyncRespondTrackingOffCommandRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetPositionResponse>* AsyncSetPositionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetPositionResponse>* PrepareAsyncSetPositionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>* AsyncSetAttitudeQuaternionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>* PrepareAsyncSetAttitudeQuaternionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest& request, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
@@ -898,6 +924,20 @@ class CameraServerService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>> PrepareAsyncRespondTrackingOffCommand(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>>(PrepareAsyncRespondTrackingOffCommandRaw(context, request, cq));
     }
+    ::grpc::Status SetPosition(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest& request, ::mavsdk::rpc::camera_server::SetPositionResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetPositionResponse>> AsyncSetPosition(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetPositionResponse>>(AsyncSetPositionRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetPositionResponse>> PrepareAsyncSetPosition(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetPositionResponse>>(PrepareAsyncSetPositionRaw(context, request, cq));
+    }
+    ::grpc::Status SetAttitudeQuaternion(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest& request, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>> AsyncSetAttitudeQuaternion(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>>(AsyncSetAttitudeQuaternionRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>> PrepareAsyncSetAttitudeQuaternion(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>>(PrepareAsyncSetAttitudeQuaternionRaw(context, request, cq));
+    }
     class async final :
       public StubInterface::async_interface {
      public:
@@ -962,6 +1002,10 @@ class CameraServerService final {
       void RespondTrackingRectangleCommand(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void RespondTrackingOffCommand(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse* response, std::function<void(::grpc::Status)>) override;
       void RespondTrackingOffCommand(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SetPosition(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest* request, ::mavsdk::rpc::camera_server::SetPositionResponse* response, std::function<void(::grpc::Status)>) override;
+      void SetPosition(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest* request, ::mavsdk::rpc::camera_server::SetPositionResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SetAttitudeQuaternion(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* request, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* response, std::function<void(::grpc::Status)>) override;
+      void SetAttitudeQuaternion(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* request, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
      private:
       friend class Stub;
       explicit async(Stub* stub): stub_(stub) { }
@@ -1068,6 +1112,10 @@ class CameraServerService final {
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse>* PrepareAsyncRespondTrackingRectangleCommandRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>* AsyncRespondTrackingOffCommandRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>* PrepareAsyncRespondTrackingOffCommandRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetPositionResponse>* AsyncSetPositionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetPositionResponse>* PrepareAsyncSetPositionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>* AsyncSetAttitudeQuaternionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>* PrepareAsyncSetAttitudeQuaternionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_SetInformation_;
     const ::grpc::internal::RpcMethod rpcmethod_SetVideoStreaming_;
     const ::grpc::internal::RpcMethod rpcmethod_SetInProgress_;
@@ -1107,6 +1155,8 @@ class CameraServerService final {
     const ::grpc::internal::RpcMethod rpcmethod_RespondTrackingPointCommand_;
     const ::grpc::internal::RpcMethod rpcmethod_RespondTrackingRectangleCommand_;
     const ::grpc::internal::RpcMethod rpcmethod_RespondTrackingOffCommand_;
+    const ::grpc::internal::RpcMethod rpcmethod_SetPosition_;
+    const ::grpc::internal::RpcMethod rpcmethod_SetAttitudeQuaternion_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
 
@@ -1192,6 +1242,10 @@ class CameraServerService final {
     virtual ::grpc::Status RespondTrackingRectangleCommand(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse* response);
     // Respond to an incoming tracking off command.
     virtual ::grpc::Status RespondTrackingOffCommand(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse* response);
+    // Set the camera's GPS position.
+    virtual ::grpc::Status SetPosition(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest* request, ::mavsdk::rpc::camera_server::SetPositionResponse* response);
+    // Set the camera's attitude quaternion.
+    virtual ::grpc::Status SetAttitudeQuaternion(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* request, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* response);
   };
   template <class BaseClass>
   class WithAsyncMethod_SetInformation : public BaseClass {
@@ -1973,7 +2027,47 @@ class CameraServerService final {
       ::grpc::Service::RequestAsyncUnary(38, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_SetInformation<WithAsyncMethod_SetVideoStreaming<WithAsyncMethod_SetInProgress<WithAsyncMethod_SubscribeTakePhoto<WithAsyncMethod_RespondTakePhoto<WithAsyncMethod_SubscribeStartVideo<WithAsyncMethod_RespondStartVideo<WithAsyncMethod_SubscribeStopVideo<WithAsyncMethod_RespondStopVideo<WithAsyncMethod_SubscribeStartVideoStreaming<WithAsyncMethod_RespondStartVideoStreaming<WithAsyncMethod_SubscribeStopVideoStreaming<WithAsyncMethod_RespondStopVideoStreaming<WithAsyncMethod_SubscribeSetMode<WithAsyncMethod_RespondSetMode<WithAsyncMethod_SubscribeStorageInformation<WithAsyncMethod_RespondStorageInformation<WithAsyncMethod_SubscribeCaptureStatus<WithAsyncMethod_RespondCaptureStatus<WithAsyncMethod_SubscribeFormatStorage<WithAsyncMethod_RespondFormatStorage<WithAsyncMethod_SubscribeResetSettings<WithAsyncMethod_RespondResetSettings<WithAsyncMethod_SubscribeZoomInStart<WithAsyncMethod_RespondZoomInStart<WithAsyncMethod_SubscribeZoomOutStart<WithAsyncMethod_RespondZoomOutStart<WithAsyncMethod_SubscribeZoomStop<WithAsyncMethod_RespondZoomStop<WithAsyncMethod_SubscribeZoomRange<WithAsyncMethod_RespondZoomRange<WithAsyncMethod_SetTrackingRectangleStatus<WithAsyncMethod_SetTrackingOffStatus<WithAsyncMethod_SubscribeTrackingPointCommand<WithAsyncMethod_SubscribeTrackingRectangleCommand<WithAsyncMethod_SubscribeTrackingOffCommand<WithAsyncMethod_RespondTrackingPointCommand<WithAsyncMethod_RespondTrackingRectangleCommand<WithAsyncMethod_RespondTrackingOffCommand<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
+  template <class BaseClass>
+  class WithAsyncMethod_SetPosition : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SetPosition() {
+      ::grpc::Service::MarkMethodAsync(39);
+    }
+    ~WithAsyncMethod_SetPosition() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetPosition(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetPositionRequest* /*request*/, ::mavsdk::rpc::camera_server::SetPositionResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetPosition(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SetPositionRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::SetPositionResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(39, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_SetAttitudeQuaternion : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SetAttitudeQuaternion() {
+      ::grpc::Service::MarkMethodAsync(40);
+    }
+    ~WithAsyncMethod_SetAttitudeQuaternion() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetAttitudeQuaternion(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* /*request*/, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetAttitudeQuaternion(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(40, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  typedef WithAsyncMethod_SetInformation<WithAsyncMethod_SetVideoStreaming<WithAsyncMethod_SetInProgress<WithAsyncMethod_SubscribeTakePhoto<WithAsyncMethod_RespondTakePhoto<WithAsyncMethod_SubscribeStartVideo<WithAsyncMethod_RespondStartVideo<WithAsyncMethod_SubscribeStopVideo<WithAsyncMethod_RespondStopVideo<WithAsyncMethod_SubscribeStartVideoStreaming<WithAsyncMethod_RespondStartVideoStreaming<WithAsyncMethod_SubscribeStopVideoStreaming<WithAsyncMethod_RespondStopVideoStreaming<WithAsyncMethod_SubscribeSetMode<WithAsyncMethod_RespondSetMode<WithAsyncMethod_SubscribeStorageInformation<WithAsyncMethod_RespondStorageInformation<WithAsyncMethod_SubscribeCaptureStatus<WithAsyncMethod_RespondCaptureStatus<WithAsyncMethod_SubscribeFormatStorage<WithAsyncMethod_RespondFormatStorage<WithAsyncMethod_SubscribeResetSettings<WithAsyncMethod_RespondResetSettings<WithAsyncMethod_SubscribeZoomInStart<WithAsyncMethod_RespondZoomInStart<WithAsyncMethod_SubscribeZoomOutStart<WithAsyncMethod_RespondZoomOutStart<WithAsyncMethod_SubscribeZoomStop<WithAsyncMethod_RespondZoomStop<WithAsyncMethod_SubscribeZoomRange<WithAsyncMethod_RespondZoomRange<WithAsyncMethod_SetTrackingRectangleStatus<WithAsyncMethod_SetTrackingOffStatus<WithAsyncMethod_SubscribeTrackingPointCommand<WithAsyncMethod_SubscribeTrackingRectangleCommand<WithAsyncMethod_SubscribeTrackingOffCommand<WithAsyncMethod_RespondTrackingPointCommand<WithAsyncMethod_RespondTrackingRectangleCommand<WithAsyncMethod_RespondTrackingOffCommand<WithAsyncMethod_SetPosition<WithAsyncMethod_SetAttitudeQuaternion<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_SetInformation : public BaseClass {
    private:
@@ -2942,7 +3036,61 @@ class CameraServerService final {
     virtual ::grpc::ServerUnaryReactor* RespondTrackingOffCommand(
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_SetInformation<WithCallbackMethod_SetVideoStreaming<WithCallbackMethod_SetInProgress<WithCallbackMethod_SubscribeTakePhoto<WithCallbackMethod_RespondTakePhoto<WithCallbackMethod_SubscribeStartVideo<WithCallbackMethod_RespondStartVideo<WithCallbackMethod_SubscribeStopVideo<WithCallbackMethod_RespondStopVideo<WithCallbackMethod_SubscribeStartVideoStreaming<WithCallbackMethod_RespondStartVideoStreaming<WithCallbackMethod_SubscribeStopVideoStreaming<WithCallbackMethod_RespondStopVideoStreaming<WithCallbackMethod_SubscribeSetMode<WithCallbackMethod_RespondSetMode<WithCallbackMethod_SubscribeStorageInformation<WithCallbackMethod_RespondStorageInformation<WithCallbackMethod_SubscribeCaptureStatus<WithCallbackMethod_RespondCaptureStatus<WithCallbackMethod_SubscribeFormatStorage<WithCallbackMethod_RespondFormatStorage<WithCallbackMethod_SubscribeResetSettings<WithCallbackMethod_RespondResetSettings<WithCallbackMethod_SubscribeZoomInStart<WithCallbackMethod_RespondZoomInStart<WithCallbackMethod_SubscribeZoomOutStart<WithCallbackMethod_RespondZoomOutStart<WithCallbackMethod_SubscribeZoomStop<WithCallbackMethod_RespondZoomStop<WithCallbackMethod_SubscribeZoomRange<WithCallbackMethod_RespondZoomRange<WithCallbackMethod_SetTrackingRectangleStatus<WithCallbackMethod_SetTrackingOffStatus<WithCallbackMethod_SubscribeTrackingPointCommand<WithCallbackMethod_SubscribeTrackingRectangleCommand<WithCallbackMethod_SubscribeTrackingOffCommand<WithCallbackMethod_RespondTrackingPointCommand<WithCallbackMethod_RespondTrackingRectangleCommand<WithCallbackMethod_RespondTrackingOffCommand<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
+  template <class BaseClass>
+  class WithCallbackMethod_SetPosition : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SetPosition() {
+      ::grpc::Service::MarkMethodCallback(39,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetPositionRequest, ::mavsdk::rpc::camera_server::SetPositionResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest* request, ::mavsdk::rpc::camera_server::SetPositionResponse* response) { return this->SetPosition(context, request, response); }));}
+    void SetMessageAllocatorFor_SetPosition(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::SetPositionRequest, ::mavsdk::rpc::camera_server::SetPositionResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(39);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetPositionRequest, ::mavsdk::rpc::camera_server::SetPositionResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_SetPosition() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetPosition(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetPositionRequest* /*request*/, ::mavsdk::rpc::camera_server::SetPositionResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* SetPosition(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetPositionRequest* /*request*/, ::mavsdk::rpc::camera_server::SetPositionResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_SetAttitudeQuaternion : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SetAttitudeQuaternion() {
+      ::grpc::Service::MarkMethodCallback(40,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* request, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* response) { return this->SetAttitudeQuaternion(context, request, response); }));}
+    void SetMessageAllocatorFor_SetAttitudeQuaternion(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(40);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_SetAttitudeQuaternion() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetAttitudeQuaternion(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* /*request*/, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* SetAttitudeQuaternion(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* /*request*/, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* /*response*/)  { return nullptr; }
+  };
+  typedef WithCallbackMethod_SetInformation<WithCallbackMethod_SetVideoStreaming<WithCallbackMethod_SetInProgress<WithCallbackMethod_SubscribeTakePhoto<WithCallbackMethod_RespondTakePhoto<WithCallbackMethod_SubscribeStartVideo<WithCallbackMethod_RespondStartVideo<WithCallbackMethod_SubscribeStopVideo<WithCallbackMethod_RespondStopVideo<WithCallbackMethod_SubscribeStartVideoStreaming<WithCallbackMethod_RespondStartVideoStreaming<WithCallbackMethod_SubscribeStopVideoStreaming<WithCallbackMethod_RespondStopVideoStreaming<WithCallbackMethod_SubscribeSetMode<WithCallbackMethod_RespondSetMode<WithCallbackMethod_SubscribeStorageInformation<WithCallbackMethod_RespondStorageInformation<WithCallbackMethod_SubscribeCaptureStatus<WithCallbackMethod_RespondCaptureStatus<WithCallbackMethod_SubscribeFormatStorage<WithCallbackMethod_RespondFormatStorage<WithCallbackMethod_SubscribeResetSettings<WithCallbackMethod_RespondResetSettings<WithCallbackMethod_SubscribeZoomInStart<WithCallbackMethod_RespondZoomInStart<WithCallbackMethod_SubscribeZoomOutStart<WithCallbackMethod_RespondZoomOutStart<WithCallbackMethod_SubscribeZoomStop<WithCallbackMethod_RespondZoomStop<WithCallbackMethod_SubscribeZoomRange<WithCallbackMethod_RespondZoomRange<WithCallbackMethod_SetTrackingRectangleStatus<WithCallbackMethod_SetTrackingOffStatus<WithCallbackMethod_SubscribeTrackingPointCommand<WithCallbackMethod_SubscribeTrackingRectangleCommand<WithCallbackMethod_SubscribeTrackingOffCommand<WithCallbackMethod_RespondTrackingPointCommand<WithCallbackMethod_RespondTrackingRectangleCommand<WithCallbackMethod_RespondTrackingOffCommand<WithCallbackMethod_SetPosition<WithCallbackMethod_SetAttitudeQuaternion<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_SetInformation : public BaseClass {
@@ -3603,6 +3751,40 @@ class CameraServerService final {
     }
     // disable synchronous version of this method
     ::grpc::Status RespondTrackingOffCommand(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_SetPosition : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SetPosition() {
+      ::grpc::Service::MarkMethodGeneric(39);
+    }
+    ~WithGenericMethod_SetPosition() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetPosition(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetPositionRequest* /*request*/, ::mavsdk::rpc::camera_server::SetPositionResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_SetAttitudeQuaternion : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SetAttitudeQuaternion() {
+      ::grpc::Service::MarkMethodGeneric(40);
+    }
+    ~WithGenericMethod_SetAttitudeQuaternion() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetAttitudeQuaternion(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* /*request*/, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -4385,6 +4567,46 @@ class CameraServerService final {
     }
     void RequestRespondTrackingOffCommand(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(38, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_SetPosition : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SetPosition() {
+      ::grpc::Service::MarkMethodRaw(39);
+    }
+    ~WithRawMethod_SetPosition() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetPosition(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetPositionRequest* /*request*/, ::mavsdk::rpc::camera_server::SetPositionResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetPosition(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(39, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_SetAttitudeQuaternion : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SetAttitudeQuaternion() {
+      ::grpc::Service::MarkMethodRaw(40);
+    }
+    ~WithRawMethod_SetAttitudeQuaternion() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetAttitudeQuaternion(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* /*request*/, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetAttitudeQuaternion(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(40, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -5246,6 +5468,50 @@ class CameraServerService final {
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithRawCallbackMethod_SetPosition : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SetPosition() {
+      ::grpc::Service::MarkMethodRawCallback(39,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetPosition(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_SetPosition() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetPosition(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetPositionRequest* /*request*/, ::mavsdk::rpc::camera_server::SetPositionResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* SetPosition(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_SetAttitudeQuaternion : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SetAttitudeQuaternion() {
+      ::grpc::Service::MarkMethodRawCallback(40,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetAttitudeQuaternion(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_SetAttitudeQuaternion() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetAttitudeQuaternion(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* /*request*/, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* SetAttitudeQuaternion(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_SetInformation : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
@@ -5839,7 +6105,61 @@ class CameraServerService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedRespondTrackingOffCommand(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest,::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_SetInformation<WithStreamedUnaryMethod_SetVideoStreaming<WithStreamedUnaryMethod_SetInProgress<WithStreamedUnaryMethod_RespondTakePhoto<WithStreamedUnaryMethod_RespondStartVideo<WithStreamedUnaryMethod_RespondStopVideo<WithStreamedUnaryMethod_RespondStartVideoStreaming<WithStreamedUnaryMethod_RespondStopVideoStreaming<WithStreamedUnaryMethod_RespondSetMode<WithStreamedUnaryMethod_RespondStorageInformation<WithStreamedUnaryMethod_RespondCaptureStatus<WithStreamedUnaryMethod_RespondFormatStorage<WithStreamedUnaryMethod_RespondResetSettings<WithStreamedUnaryMethod_RespondZoomInStart<WithStreamedUnaryMethod_RespondZoomOutStart<WithStreamedUnaryMethod_RespondZoomStop<WithStreamedUnaryMethod_RespondZoomRange<WithStreamedUnaryMethod_SetTrackingRectangleStatus<WithStreamedUnaryMethod_SetTrackingOffStatus<WithStreamedUnaryMethod_RespondTrackingPointCommand<WithStreamedUnaryMethod_RespondTrackingRectangleCommand<WithStreamedUnaryMethod_RespondTrackingOffCommand<Service > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_SetPosition : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_SetPosition() {
+      ::grpc::Service::MarkMethodStreamed(39,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera_server::SetPositionRequest, ::mavsdk::rpc::camera_server::SetPositionResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera_server::SetPositionRequest, ::mavsdk::rpc::camera_server::SetPositionResponse>* streamer) {
+                       return this->StreamedSetPosition(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_SetPosition() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SetPosition(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetPositionRequest* /*request*/, ::mavsdk::rpc::camera_server::SetPositionResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedSetPosition(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::SetPositionRequest,::mavsdk::rpc::camera_server::SetPositionResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_SetAttitudeQuaternion : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_SetAttitudeQuaternion() {
+      ::grpc::Service::MarkMethodStreamed(40,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>* streamer) {
+                       return this->StreamedSetAttitudeQuaternion(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_SetAttitudeQuaternion() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SetAttitudeQuaternion(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* /*request*/, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedSetAttitudeQuaternion(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest,::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>* server_unary_streamer) = 0;
+  };
+  typedef WithStreamedUnaryMethod_SetInformation<WithStreamedUnaryMethod_SetVideoStreaming<WithStreamedUnaryMethod_SetInProgress<WithStreamedUnaryMethod_RespondTakePhoto<WithStreamedUnaryMethod_RespondStartVideo<WithStreamedUnaryMethod_RespondStopVideo<WithStreamedUnaryMethod_RespondStartVideoStreaming<WithStreamedUnaryMethod_RespondStopVideoStreaming<WithStreamedUnaryMethod_RespondSetMode<WithStreamedUnaryMethod_RespondStorageInformation<WithStreamedUnaryMethod_RespondCaptureStatus<WithStreamedUnaryMethod_RespondFormatStorage<WithStreamedUnaryMethod_RespondResetSettings<WithStreamedUnaryMethod_RespondZoomInStart<WithStreamedUnaryMethod_RespondZoomOutStart<WithStreamedUnaryMethod_RespondZoomStop<WithStreamedUnaryMethod_RespondZoomRange<WithStreamedUnaryMethod_SetTrackingRectangleStatus<WithStreamedUnaryMethod_SetTrackingOffStatus<WithStreamedUnaryMethod_RespondTrackingPointCommand<WithStreamedUnaryMethod_RespondTrackingRectangleCommand<WithStreamedUnaryMethod_RespondTrackingOffCommand<WithStreamedUnaryMethod_SetPosition<WithStreamedUnaryMethod_SetAttitudeQuaternion<Service > > > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
   template <class BaseClass>
   class WithSplitStreamingMethod_SubscribeTakePhoto : public BaseClass {
    private:
@@ -6300,7 +6620,7 @@ class CameraServerService final {
     virtual ::grpc::Status StreamedSubscribeTrackingOffCommand(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::camera_server::SubscribeTrackingOffCommandRequest,::mavsdk::rpc::camera_server::TrackingOffCommandResponse>* server_split_streamer) = 0;
   };
   typedef WithSplitStreamingMethod_SubscribeTakePhoto<WithSplitStreamingMethod_SubscribeStartVideo<WithSplitStreamingMethod_SubscribeStopVideo<WithSplitStreamingMethod_SubscribeStartVideoStreaming<WithSplitStreamingMethod_SubscribeStopVideoStreaming<WithSplitStreamingMethod_SubscribeSetMode<WithSplitStreamingMethod_SubscribeStorageInformation<WithSplitStreamingMethod_SubscribeCaptureStatus<WithSplitStreamingMethod_SubscribeFormatStorage<WithSplitStreamingMethod_SubscribeResetSettings<WithSplitStreamingMethod_SubscribeZoomInStart<WithSplitStreamingMethod_SubscribeZoomOutStart<WithSplitStreamingMethod_SubscribeZoomStop<WithSplitStreamingMethod_SubscribeZoomRange<WithSplitStreamingMethod_SubscribeTrackingPointCommand<WithSplitStreamingMethod_SubscribeTrackingRectangleCommand<WithSplitStreamingMethod_SubscribeTrackingOffCommand<Service > > > > > > > > > > > > > > > > > SplitStreamedService;
-  typedef WithStreamedUnaryMethod_SetInformation<WithStreamedUnaryMethod_SetVideoStreaming<WithStreamedUnaryMethod_SetInProgress<WithSplitStreamingMethod_SubscribeTakePhoto<WithStreamedUnaryMethod_RespondTakePhoto<WithSplitStreamingMethod_SubscribeStartVideo<WithStreamedUnaryMethod_RespondStartVideo<WithSplitStreamingMethod_SubscribeStopVideo<WithStreamedUnaryMethod_RespondStopVideo<WithSplitStreamingMethod_SubscribeStartVideoStreaming<WithStreamedUnaryMethod_RespondStartVideoStreaming<WithSplitStreamingMethod_SubscribeStopVideoStreaming<WithStreamedUnaryMethod_RespondStopVideoStreaming<WithSplitStreamingMethod_SubscribeSetMode<WithStreamedUnaryMethod_RespondSetMode<WithSplitStreamingMethod_SubscribeStorageInformation<WithStreamedUnaryMethod_RespondStorageInformation<WithSplitStreamingMethod_SubscribeCaptureStatus<WithStreamedUnaryMethod_RespondCaptureStatus<WithSplitStreamingMethod_SubscribeFormatStorage<WithStreamedUnaryMethod_RespondFormatStorage<WithSplitStreamingMethod_SubscribeResetSettings<WithStreamedUnaryMethod_RespondResetSettings<WithSplitStreamingMethod_SubscribeZoomInStart<WithStreamedUnaryMethod_RespondZoomInStart<WithSplitStreamingMethod_SubscribeZoomOutStart<WithStreamedUnaryMethod_RespondZoomOutStart<WithSplitStreamingMethod_SubscribeZoomStop<WithStreamedUnaryMethod_RespondZoomStop<WithSplitStreamingMethod_SubscribeZoomRange<WithStreamedUnaryMethod_RespondZoomRange<WithStreamedUnaryMethod_SetTrackingRectangleStatus<WithStreamedUnaryMethod_SetTrackingOffStatus<WithSplitStreamingMethod_SubscribeTrackingPointCommand<WithSplitStreamingMethod_SubscribeTrackingRectangleCommand<WithSplitStreamingMethod_SubscribeTrackingOffCommand<WithStreamedUnaryMethod_RespondTrackingPointCommand<WithStreamedUnaryMethod_RespondTrackingRectangleCommand<WithStreamedUnaryMethod_RespondTrackingOffCommand<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_SetInformation<WithStreamedUnaryMethod_SetVideoStreaming<WithStreamedUnaryMethod_SetInProgress<WithSplitStreamingMethod_SubscribeTakePhoto<WithStreamedUnaryMethod_RespondTakePhoto<WithSplitStreamingMethod_SubscribeStartVideo<WithStreamedUnaryMethod_RespondStartVideo<WithSplitStreamingMethod_SubscribeStopVideo<WithStreamedUnaryMethod_RespondStopVideo<WithSplitStreamingMethod_SubscribeStartVideoStreaming<WithStreamedUnaryMethod_RespondStartVideoStreaming<WithSplitStreamingMethod_SubscribeStopVideoStreaming<WithStreamedUnaryMethod_RespondStopVideoStreaming<WithSplitStreamingMethod_SubscribeSetMode<WithStreamedUnaryMethod_RespondSetMode<WithSplitStreamingMethod_SubscribeStorageInformation<WithStreamedUnaryMethod_RespondStorageInformation<WithSplitStreamingMethod_SubscribeCaptureStatus<WithStreamedUnaryMethod_RespondCaptureStatus<WithSplitStreamingMethod_SubscribeFormatStorage<WithStreamedUnaryMethod_RespondFormatStorage<WithSplitStreamingMethod_SubscribeResetSettings<WithStreamedUnaryMethod_RespondResetSettings<WithSplitStreamingMethod_SubscribeZoomInStart<WithStreamedUnaryMethod_RespondZoomInStart<WithSplitStreamingMethod_SubscribeZoomOutStart<WithStreamedUnaryMethod_RespondZoomOutStart<WithSplitStreamingMethod_SubscribeZoomStop<WithStreamedUnaryMethod_RespondZoomStop<WithSplitStreamingMethod_SubscribeZoomRange<WithStreamedUnaryMethod_RespondZoomRange<WithStreamedUnaryMethod_SetTrackingRectangleStatus<WithStreamedUnaryMethod_SetTrackingOffStatus<WithSplitStreamingMethod_SubscribeTrackingPointCommand<WithSplitStreamingMethod_SubscribeTrackingRectangleCommand<WithSplitStreamingMethod_SubscribeTrackingOffCommand<WithStreamedUnaryMethod_RespondTrackingPointCommand<WithStreamedUnaryMethod_RespondTrackingRectangleCommand<WithStreamedUnaryMethod_RespondTrackingOffCommand<WithStreamedUnaryMethod_SetPosition<WithStreamedUnaryMethod_SetAttitudeQuaternion<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace camera_server

--- a/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.grpc.pb.h
+++ b/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.grpc.pb.h
@@ -400,6 +400,22 @@ class CameraServerService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>> PrepareAsyncSetAttitudeQuaternion(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>>(PrepareAsyncSetAttitudeQuaternionRaw(context, request, cq));
     }
+    // Set the camera's zoom factor for CAMERA_FOV_STATUS reporting.
+    virtual ::grpc::Status SetZoomFactor(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest& request, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetZoomFactorResponse>> AsyncSetZoomFactor(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetZoomFactorResponse>>(AsyncSetZoomFactorRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetZoomFactorResponse>> PrepareAsyncSetZoomFactor(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetZoomFactorResponse>>(PrepareAsyncSetZoomFactorRaw(context, request, cq));
+    }
+    // Set the field of view explicitly, for cameras that do not report a zoom factor.
+    virtual ::grpc::Status SetFieldOfView(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest& request, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>> AsyncSetFieldOfView(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>>(AsyncSetFieldOfViewRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>> PrepareAsyncSetFieldOfView(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>>(PrepareAsyncSetFieldOfViewRaw(context, request, cq));
+    }
     class async_interface {
      public:
       virtual ~async_interface() {}
@@ -509,6 +525,12 @@ class CameraServerService final {
       // Set the camera's attitude quaternion.
       virtual void SetAttitudeQuaternion(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* request, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void SetAttitudeQuaternion(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* request, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Set the camera's zoom factor for CAMERA_FOV_STATUS reporting.
+      virtual void SetZoomFactor(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest* request, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void SetZoomFactor(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest* request, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Set the field of view explicitly, for cameras that do not report a zoom factor.
+      virtual void SetFieldOfView(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* request, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void SetFieldOfView(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* request, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
     };
     typedef class async_interface experimental_async_interface;
     virtual class async_interface* async() { return nullptr; }
@@ -613,6 +635,10 @@ class CameraServerService final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetPositionResponse>* PrepareAsyncSetPositionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>* AsyncSetAttitudeQuaternionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>* PrepareAsyncSetAttitudeQuaternionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetZoomFactorResponse>* AsyncSetZoomFactorRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetZoomFactorResponse>* PrepareAsyncSetZoomFactorRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>* AsyncSetFieldOfViewRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>* PrepareAsyncSetFieldOfViewRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest& request, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
@@ -938,6 +964,20 @@ class CameraServerService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>> PrepareAsyncSetAttitudeQuaternion(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>>(PrepareAsyncSetAttitudeQuaternionRaw(context, request, cq));
     }
+    ::grpc::Status SetZoomFactor(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest& request, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetZoomFactorResponse>> AsyncSetZoomFactor(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetZoomFactorResponse>>(AsyncSetZoomFactorRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetZoomFactorResponse>> PrepareAsyncSetZoomFactor(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetZoomFactorResponse>>(PrepareAsyncSetZoomFactorRaw(context, request, cq));
+    }
+    ::grpc::Status SetFieldOfView(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest& request, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>> AsyncSetFieldOfView(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>>(AsyncSetFieldOfViewRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>> PrepareAsyncSetFieldOfView(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>>(PrepareAsyncSetFieldOfViewRaw(context, request, cq));
+    }
     class async final :
       public StubInterface::async_interface {
      public:
@@ -1006,6 +1046,10 @@ class CameraServerService final {
       void SetPosition(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest* request, ::mavsdk::rpc::camera_server::SetPositionResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void SetAttitudeQuaternion(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* request, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* response, std::function<void(::grpc::Status)>) override;
       void SetAttitudeQuaternion(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* request, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SetZoomFactor(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest* request, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* response, std::function<void(::grpc::Status)>) override;
+      void SetZoomFactor(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest* request, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SetFieldOfView(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* request, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* response, std::function<void(::grpc::Status)>) override;
+      void SetFieldOfView(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* request, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
      private:
       friend class Stub;
       explicit async(Stub* stub): stub_(stub) { }
@@ -1116,6 +1160,10 @@ class CameraServerService final {
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetPositionResponse>* PrepareAsyncSetPositionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>* AsyncSetAttitudeQuaternionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>* PrepareAsyncSetAttitudeQuaternionRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetZoomFactorResponse>* AsyncSetZoomFactorRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetZoomFactorResponse>* PrepareAsyncSetZoomFactorRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>* AsyncSetFieldOfViewRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>* PrepareAsyncSetFieldOfViewRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_SetInformation_;
     const ::grpc::internal::RpcMethod rpcmethod_SetVideoStreaming_;
     const ::grpc::internal::RpcMethod rpcmethod_SetInProgress_;
@@ -1157,6 +1205,8 @@ class CameraServerService final {
     const ::grpc::internal::RpcMethod rpcmethod_RespondTrackingOffCommand_;
     const ::grpc::internal::RpcMethod rpcmethod_SetPosition_;
     const ::grpc::internal::RpcMethod rpcmethod_SetAttitudeQuaternion_;
+    const ::grpc::internal::RpcMethod rpcmethod_SetZoomFactor_;
+    const ::grpc::internal::RpcMethod rpcmethod_SetFieldOfView_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
 
@@ -1246,6 +1296,10 @@ class CameraServerService final {
     virtual ::grpc::Status SetPosition(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest* request, ::mavsdk::rpc::camera_server::SetPositionResponse* response);
     // Set the camera's attitude quaternion.
     virtual ::grpc::Status SetAttitudeQuaternion(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* request, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* response);
+    // Set the camera's zoom factor for CAMERA_FOV_STATUS reporting.
+    virtual ::grpc::Status SetZoomFactor(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest* request, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* response);
+    // Set the field of view explicitly, for cameras that do not report a zoom factor.
+    virtual ::grpc::Status SetFieldOfView(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* request, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* response);
   };
   template <class BaseClass>
   class WithAsyncMethod_SetInformation : public BaseClass {
@@ -2067,7 +2121,47 @@ class CameraServerService final {
       ::grpc::Service::RequestAsyncUnary(40, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_SetInformation<WithAsyncMethod_SetVideoStreaming<WithAsyncMethod_SetInProgress<WithAsyncMethod_SubscribeTakePhoto<WithAsyncMethod_RespondTakePhoto<WithAsyncMethod_SubscribeStartVideo<WithAsyncMethod_RespondStartVideo<WithAsyncMethod_SubscribeStopVideo<WithAsyncMethod_RespondStopVideo<WithAsyncMethod_SubscribeStartVideoStreaming<WithAsyncMethod_RespondStartVideoStreaming<WithAsyncMethod_SubscribeStopVideoStreaming<WithAsyncMethod_RespondStopVideoStreaming<WithAsyncMethod_SubscribeSetMode<WithAsyncMethod_RespondSetMode<WithAsyncMethod_SubscribeStorageInformation<WithAsyncMethod_RespondStorageInformation<WithAsyncMethod_SubscribeCaptureStatus<WithAsyncMethod_RespondCaptureStatus<WithAsyncMethod_SubscribeFormatStorage<WithAsyncMethod_RespondFormatStorage<WithAsyncMethod_SubscribeResetSettings<WithAsyncMethod_RespondResetSettings<WithAsyncMethod_SubscribeZoomInStart<WithAsyncMethod_RespondZoomInStart<WithAsyncMethod_SubscribeZoomOutStart<WithAsyncMethod_RespondZoomOutStart<WithAsyncMethod_SubscribeZoomStop<WithAsyncMethod_RespondZoomStop<WithAsyncMethod_SubscribeZoomRange<WithAsyncMethod_RespondZoomRange<WithAsyncMethod_SetTrackingRectangleStatus<WithAsyncMethod_SetTrackingOffStatus<WithAsyncMethod_SubscribeTrackingPointCommand<WithAsyncMethod_SubscribeTrackingRectangleCommand<WithAsyncMethod_SubscribeTrackingOffCommand<WithAsyncMethod_RespondTrackingPointCommand<WithAsyncMethod_RespondTrackingRectangleCommand<WithAsyncMethod_RespondTrackingOffCommand<WithAsyncMethod_SetPosition<WithAsyncMethod_SetAttitudeQuaternion<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
+  template <class BaseClass>
+  class WithAsyncMethod_SetZoomFactor : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SetZoomFactor() {
+      ::grpc::Service::MarkMethodAsync(41);
+    }
+    ~WithAsyncMethod_SetZoomFactor() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetZoomFactor(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest* /*request*/, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetZoomFactor(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SetZoomFactorRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::SetZoomFactorResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(41, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_SetFieldOfView : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SetFieldOfView() {
+      ::grpc::Service::MarkMethodAsync(42);
+    }
+    ~WithAsyncMethod_SetFieldOfView() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetFieldOfView(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* /*request*/, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetFieldOfView(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(42, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  typedef WithAsyncMethod_SetInformation<WithAsyncMethod_SetVideoStreaming<WithAsyncMethod_SetInProgress<WithAsyncMethod_SubscribeTakePhoto<WithAsyncMethod_RespondTakePhoto<WithAsyncMethod_SubscribeStartVideo<WithAsyncMethod_RespondStartVideo<WithAsyncMethod_SubscribeStopVideo<WithAsyncMethod_RespondStopVideo<WithAsyncMethod_SubscribeStartVideoStreaming<WithAsyncMethod_RespondStartVideoStreaming<WithAsyncMethod_SubscribeStopVideoStreaming<WithAsyncMethod_RespondStopVideoStreaming<WithAsyncMethod_SubscribeSetMode<WithAsyncMethod_RespondSetMode<WithAsyncMethod_SubscribeStorageInformation<WithAsyncMethod_RespondStorageInformation<WithAsyncMethod_SubscribeCaptureStatus<WithAsyncMethod_RespondCaptureStatus<WithAsyncMethod_SubscribeFormatStorage<WithAsyncMethod_RespondFormatStorage<WithAsyncMethod_SubscribeResetSettings<WithAsyncMethod_RespondResetSettings<WithAsyncMethod_SubscribeZoomInStart<WithAsyncMethod_RespondZoomInStart<WithAsyncMethod_SubscribeZoomOutStart<WithAsyncMethod_RespondZoomOutStart<WithAsyncMethod_SubscribeZoomStop<WithAsyncMethod_RespondZoomStop<WithAsyncMethod_SubscribeZoomRange<WithAsyncMethod_RespondZoomRange<WithAsyncMethod_SetTrackingRectangleStatus<WithAsyncMethod_SetTrackingOffStatus<WithAsyncMethod_SubscribeTrackingPointCommand<WithAsyncMethod_SubscribeTrackingRectangleCommand<WithAsyncMethod_SubscribeTrackingOffCommand<WithAsyncMethod_RespondTrackingPointCommand<WithAsyncMethod_RespondTrackingRectangleCommand<WithAsyncMethod_RespondTrackingOffCommand<WithAsyncMethod_SetPosition<WithAsyncMethod_SetAttitudeQuaternion<WithAsyncMethod_SetZoomFactor<WithAsyncMethod_SetFieldOfView<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_SetInformation : public BaseClass {
    private:
@@ -3090,7 +3184,61 @@ class CameraServerService final {
     virtual ::grpc::ServerUnaryReactor* SetAttitudeQuaternion(
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* /*request*/, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_SetInformation<WithCallbackMethod_SetVideoStreaming<WithCallbackMethod_SetInProgress<WithCallbackMethod_SubscribeTakePhoto<WithCallbackMethod_RespondTakePhoto<WithCallbackMethod_SubscribeStartVideo<WithCallbackMethod_RespondStartVideo<WithCallbackMethod_SubscribeStopVideo<WithCallbackMethod_RespondStopVideo<WithCallbackMethod_SubscribeStartVideoStreaming<WithCallbackMethod_RespondStartVideoStreaming<WithCallbackMethod_SubscribeStopVideoStreaming<WithCallbackMethod_RespondStopVideoStreaming<WithCallbackMethod_SubscribeSetMode<WithCallbackMethod_RespondSetMode<WithCallbackMethod_SubscribeStorageInformation<WithCallbackMethod_RespondStorageInformation<WithCallbackMethod_SubscribeCaptureStatus<WithCallbackMethod_RespondCaptureStatus<WithCallbackMethod_SubscribeFormatStorage<WithCallbackMethod_RespondFormatStorage<WithCallbackMethod_SubscribeResetSettings<WithCallbackMethod_RespondResetSettings<WithCallbackMethod_SubscribeZoomInStart<WithCallbackMethod_RespondZoomInStart<WithCallbackMethod_SubscribeZoomOutStart<WithCallbackMethod_RespondZoomOutStart<WithCallbackMethod_SubscribeZoomStop<WithCallbackMethod_RespondZoomStop<WithCallbackMethod_SubscribeZoomRange<WithCallbackMethod_RespondZoomRange<WithCallbackMethod_SetTrackingRectangleStatus<WithCallbackMethod_SetTrackingOffStatus<WithCallbackMethod_SubscribeTrackingPointCommand<WithCallbackMethod_SubscribeTrackingRectangleCommand<WithCallbackMethod_SubscribeTrackingOffCommand<WithCallbackMethod_RespondTrackingPointCommand<WithCallbackMethod_RespondTrackingRectangleCommand<WithCallbackMethod_RespondTrackingOffCommand<WithCallbackMethod_SetPosition<WithCallbackMethod_SetAttitudeQuaternion<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
+  template <class BaseClass>
+  class WithCallbackMethod_SetZoomFactor : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SetZoomFactor() {
+      ::grpc::Service::MarkMethodCallback(41,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetZoomFactorRequest, ::mavsdk::rpc::camera_server::SetZoomFactorResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest* request, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* response) { return this->SetZoomFactor(context, request, response); }));}
+    void SetMessageAllocatorFor_SetZoomFactor(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::SetZoomFactorRequest, ::mavsdk::rpc::camera_server::SetZoomFactorResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(41);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetZoomFactorRequest, ::mavsdk::rpc::camera_server::SetZoomFactorResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_SetZoomFactor() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetZoomFactor(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest* /*request*/, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* SetZoomFactor(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest* /*request*/, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_SetFieldOfView : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SetFieldOfView() {
+      ::grpc::Service::MarkMethodCallback(42,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetFieldOfViewRequest, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* request, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* response) { return this->SetFieldOfView(context, request, response); }));}
+    void SetMessageAllocatorFor_SetFieldOfView(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::SetFieldOfViewRequest, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(42);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetFieldOfViewRequest, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_SetFieldOfView() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetFieldOfView(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* /*request*/, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* SetFieldOfView(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* /*request*/, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* /*response*/)  { return nullptr; }
+  };
+  typedef WithCallbackMethod_SetInformation<WithCallbackMethod_SetVideoStreaming<WithCallbackMethod_SetInProgress<WithCallbackMethod_SubscribeTakePhoto<WithCallbackMethod_RespondTakePhoto<WithCallbackMethod_SubscribeStartVideo<WithCallbackMethod_RespondStartVideo<WithCallbackMethod_SubscribeStopVideo<WithCallbackMethod_RespondStopVideo<WithCallbackMethod_SubscribeStartVideoStreaming<WithCallbackMethod_RespondStartVideoStreaming<WithCallbackMethod_SubscribeStopVideoStreaming<WithCallbackMethod_RespondStopVideoStreaming<WithCallbackMethod_SubscribeSetMode<WithCallbackMethod_RespondSetMode<WithCallbackMethod_SubscribeStorageInformation<WithCallbackMethod_RespondStorageInformation<WithCallbackMethod_SubscribeCaptureStatus<WithCallbackMethod_RespondCaptureStatus<WithCallbackMethod_SubscribeFormatStorage<WithCallbackMethod_RespondFormatStorage<WithCallbackMethod_SubscribeResetSettings<WithCallbackMethod_RespondResetSettings<WithCallbackMethod_SubscribeZoomInStart<WithCallbackMethod_RespondZoomInStart<WithCallbackMethod_SubscribeZoomOutStart<WithCallbackMethod_RespondZoomOutStart<WithCallbackMethod_SubscribeZoomStop<WithCallbackMethod_RespondZoomStop<WithCallbackMethod_SubscribeZoomRange<WithCallbackMethod_RespondZoomRange<WithCallbackMethod_SetTrackingRectangleStatus<WithCallbackMethod_SetTrackingOffStatus<WithCallbackMethod_SubscribeTrackingPointCommand<WithCallbackMethod_SubscribeTrackingRectangleCommand<WithCallbackMethod_SubscribeTrackingOffCommand<WithCallbackMethod_RespondTrackingPointCommand<WithCallbackMethod_RespondTrackingRectangleCommand<WithCallbackMethod_RespondTrackingOffCommand<WithCallbackMethod_SetPosition<WithCallbackMethod_SetAttitudeQuaternion<WithCallbackMethod_SetZoomFactor<WithCallbackMethod_SetFieldOfView<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_SetInformation : public BaseClass {
@@ -3785,6 +3933,40 @@ class CameraServerService final {
     }
     // disable synchronous version of this method
     ::grpc::Status SetAttitudeQuaternion(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* /*request*/, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_SetZoomFactor : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SetZoomFactor() {
+      ::grpc::Service::MarkMethodGeneric(41);
+    }
+    ~WithGenericMethod_SetZoomFactor() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetZoomFactor(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest* /*request*/, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_SetFieldOfView : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SetFieldOfView() {
+      ::grpc::Service::MarkMethodGeneric(42);
+    }
+    ~WithGenericMethod_SetFieldOfView() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetFieldOfView(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* /*request*/, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -4607,6 +4789,46 @@ class CameraServerService final {
     }
     void RequestSetAttitudeQuaternion(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(40, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_SetZoomFactor : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SetZoomFactor() {
+      ::grpc::Service::MarkMethodRaw(41);
+    }
+    ~WithRawMethod_SetZoomFactor() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetZoomFactor(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest* /*request*/, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetZoomFactor(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(41, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_SetFieldOfView : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SetFieldOfView() {
+      ::grpc::Service::MarkMethodRaw(42);
+    }
+    ~WithRawMethod_SetFieldOfView() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetFieldOfView(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* /*request*/, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetFieldOfView(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(42, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -5512,6 +5734,50 @@ class CameraServerService final {
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithRawCallbackMethod_SetZoomFactor : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SetZoomFactor() {
+      ::grpc::Service::MarkMethodRawCallback(41,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetZoomFactor(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_SetZoomFactor() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetZoomFactor(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest* /*request*/, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* SetZoomFactor(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_SetFieldOfView : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SetFieldOfView() {
+      ::grpc::Service::MarkMethodRawCallback(42,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetFieldOfView(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_SetFieldOfView() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetFieldOfView(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* /*request*/, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* SetFieldOfView(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_SetInformation : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
@@ -6159,7 +6425,61 @@ class CameraServerService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedSetAttitudeQuaternion(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest,::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_SetInformation<WithStreamedUnaryMethod_SetVideoStreaming<WithStreamedUnaryMethod_SetInProgress<WithStreamedUnaryMethod_RespondTakePhoto<WithStreamedUnaryMethod_RespondStartVideo<WithStreamedUnaryMethod_RespondStopVideo<WithStreamedUnaryMethod_RespondStartVideoStreaming<WithStreamedUnaryMethod_RespondStopVideoStreaming<WithStreamedUnaryMethod_RespondSetMode<WithStreamedUnaryMethod_RespondStorageInformation<WithStreamedUnaryMethod_RespondCaptureStatus<WithStreamedUnaryMethod_RespondFormatStorage<WithStreamedUnaryMethod_RespondResetSettings<WithStreamedUnaryMethod_RespondZoomInStart<WithStreamedUnaryMethod_RespondZoomOutStart<WithStreamedUnaryMethod_RespondZoomStop<WithStreamedUnaryMethod_RespondZoomRange<WithStreamedUnaryMethod_SetTrackingRectangleStatus<WithStreamedUnaryMethod_SetTrackingOffStatus<WithStreamedUnaryMethod_RespondTrackingPointCommand<WithStreamedUnaryMethod_RespondTrackingRectangleCommand<WithStreamedUnaryMethod_RespondTrackingOffCommand<WithStreamedUnaryMethod_SetPosition<WithStreamedUnaryMethod_SetAttitudeQuaternion<Service > > > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_SetZoomFactor : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_SetZoomFactor() {
+      ::grpc::Service::MarkMethodStreamed(41,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera_server::SetZoomFactorRequest, ::mavsdk::rpc::camera_server::SetZoomFactorResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera_server::SetZoomFactorRequest, ::mavsdk::rpc::camera_server::SetZoomFactorResponse>* streamer) {
+                       return this->StreamedSetZoomFactor(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_SetZoomFactor() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SetZoomFactor(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest* /*request*/, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedSetZoomFactor(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::SetZoomFactorRequest,::mavsdk::rpc::camera_server::SetZoomFactorResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_SetFieldOfView : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_SetFieldOfView() {
+      ::grpc::Service::MarkMethodStreamed(42,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera_server::SetFieldOfViewRequest, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera_server::SetFieldOfViewRequest, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>* streamer) {
+                       return this->StreamedSetFieldOfView(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_SetFieldOfView() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SetFieldOfView(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* /*request*/, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedSetFieldOfView(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::SetFieldOfViewRequest,::mavsdk::rpc::camera_server::SetFieldOfViewResponse>* server_unary_streamer) = 0;
+  };
+  typedef WithStreamedUnaryMethod_SetInformation<WithStreamedUnaryMethod_SetVideoStreaming<WithStreamedUnaryMethod_SetInProgress<WithStreamedUnaryMethod_RespondTakePhoto<WithStreamedUnaryMethod_RespondStartVideo<WithStreamedUnaryMethod_RespondStopVideo<WithStreamedUnaryMethod_RespondStartVideoStreaming<WithStreamedUnaryMethod_RespondStopVideoStreaming<WithStreamedUnaryMethod_RespondSetMode<WithStreamedUnaryMethod_RespondStorageInformation<WithStreamedUnaryMethod_RespondCaptureStatus<WithStreamedUnaryMethod_RespondFormatStorage<WithStreamedUnaryMethod_RespondResetSettings<WithStreamedUnaryMethod_RespondZoomInStart<WithStreamedUnaryMethod_RespondZoomOutStart<WithStreamedUnaryMethod_RespondZoomStop<WithStreamedUnaryMethod_RespondZoomRange<WithStreamedUnaryMethod_SetTrackingRectangleStatus<WithStreamedUnaryMethod_SetTrackingOffStatus<WithStreamedUnaryMethod_RespondTrackingPointCommand<WithStreamedUnaryMethod_RespondTrackingRectangleCommand<WithStreamedUnaryMethod_RespondTrackingOffCommand<WithStreamedUnaryMethod_SetPosition<WithStreamedUnaryMethod_SetAttitudeQuaternion<WithStreamedUnaryMethod_SetZoomFactor<WithStreamedUnaryMethod_SetFieldOfView<Service > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
   template <class BaseClass>
   class WithSplitStreamingMethod_SubscribeTakePhoto : public BaseClass {
    private:
@@ -6620,7 +6940,7 @@ class CameraServerService final {
     virtual ::grpc::Status StreamedSubscribeTrackingOffCommand(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::camera_server::SubscribeTrackingOffCommandRequest,::mavsdk::rpc::camera_server::TrackingOffCommandResponse>* server_split_streamer) = 0;
   };
   typedef WithSplitStreamingMethod_SubscribeTakePhoto<WithSplitStreamingMethod_SubscribeStartVideo<WithSplitStreamingMethod_SubscribeStopVideo<WithSplitStreamingMethod_SubscribeStartVideoStreaming<WithSplitStreamingMethod_SubscribeStopVideoStreaming<WithSplitStreamingMethod_SubscribeSetMode<WithSplitStreamingMethod_SubscribeStorageInformation<WithSplitStreamingMethod_SubscribeCaptureStatus<WithSplitStreamingMethod_SubscribeFormatStorage<WithSplitStreamingMethod_SubscribeResetSettings<WithSplitStreamingMethod_SubscribeZoomInStart<WithSplitStreamingMethod_SubscribeZoomOutStart<WithSplitStreamingMethod_SubscribeZoomStop<WithSplitStreamingMethod_SubscribeZoomRange<WithSplitStreamingMethod_SubscribeTrackingPointCommand<WithSplitStreamingMethod_SubscribeTrackingRectangleCommand<WithSplitStreamingMethod_SubscribeTrackingOffCommand<Service > > > > > > > > > > > > > > > > > SplitStreamedService;
-  typedef WithStreamedUnaryMethod_SetInformation<WithStreamedUnaryMethod_SetVideoStreaming<WithStreamedUnaryMethod_SetInProgress<WithSplitStreamingMethod_SubscribeTakePhoto<WithStreamedUnaryMethod_RespondTakePhoto<WithSplitStreamingMethod_SubscribeStartVideo<WithStreamedUnaryMethod_RespondStartVideo<WithSplitStreamingMethod_SubscribeStopVideo<WithStreamedUnaryMethod_RespondStopVideo<WithSplitStreamingMethod_SubscribeStartVideoStreaming<WithStreamedUnaryMethod_RespondStartVideoStreaming<WithSplitStreamingMethod_SubscribeStopVideoStreaming<WithStreamedUnaryMethod_RespondStopVideoStreaming<WithSplitStreamingMethod_SubscribeSetMode<WithStreamedUnaryMethod_RespondSetMode<WithSplitStreamingMethod_SubscribeStorageInformation<WithStreamedUnaryMethod_RespondStorageInformation<WithSplitStreamingMethod_SubscribeCaptureStatus<WithStreamedUnaryMethod_RespondCaptureStatus<WithSplitStreamingMethod_SubscribeFormatStorage<WithStreamedUnaryMethod_RespondFormatStorage<WithSplitStreamingMethod_SubscribeResetSettings<WithStreamedUnaryMethod_RespondResetSettings<WithSplitStreamingMethod_SubscribeZoomInStart<WithStreamedUnaryMethod_RespondZoomInStart<WithSplitStreamingMethod_SubscribeZoomOutStart<WithStreamedUnaryMethod_RespondZoomOutStart<WithSplitStreamingMethod_SubscribeZoomStop<WithStreamedUnaryMethod_RespondZoomStop<WithSplitStreamingMethod_SubscribeZoomRange<WithStreamedUnaryMethod_RespondZoomRange<WithStreamedUnaryMethod_SetTrackingRectangleStatus<WithStreamedUnaryMethod_SetTrackingOffStatus<WithSplitStreamingMethod_SubscribeTrackingPointCommand<WithSplitStreamingMethod_SubscribeTrackingRectangleCommand<WithSplitStreamingMethod_SubscribeTrackingOffCommand<WithStreamedUnaryMethod_RespondTrackingPointCommand<WithStreamedUnaryMethod_RespondTrackingRectangleCommand<WithStreamedUnaryMethod_RespondTrackingOffCommand<WithStreamedUnaryMethod_SetPosition<WithStreamedUnaryMethod_SetAttitudeQuaternion<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_SetInformation<WithStreamedUnaryMethod_SetVideoStreaming<WithStreamedUnaryMethod_SetInProgress<WithSplitStreamingMethod_SubscribeTakePhoto<WithStreamedUnaryMethod_RespondTakePhoto<WithSplitStreamingMethod_SubscribeStartVideo<WithStreamedUnaryMethod_RespondStartVideo<WithSplitStreamingMethod_SubscribeStopVideo<WithStreamedUnaryMethod_RespondStopVideo<WithSplitStreamingMethod_SubscribeStartVideoStreaming<WithStreamedUnaryMethod_RespondStartVideoStreaming<WithSplitStreamingMethod_SubscribeStopVideoStreaming<WithStreamedUnaryMethod_RespondStopVideoStreaming<WithSplitStreamingMethod_SubscribeSetMode<WithStreamedUnaryMethod_RespondSetMode<WithSplitStreamingMethod_SubscribeStorageInformation<WithStreamedUnaryMethod_RespondStorageInformation<WithSplitStreamingMethod_SubscribeCaptureStatus<WithStreamedUnaryMethod_RespondCaptureStatus<WithSplitStreamingMethod_SubscribeFormatStorage<WithStreamedUnaryMethod_RespondFormatStorage<WithSplitStreamingMethod_SubscribeResetSettings<WithStreamedUnaryMethod_RespondResetSettings<WithSplitStreamingMethod_SubscribeZoomInStart<WithStreamedUnaryMethod_RespondZoomInStart<WithSplitStreamingMethod_SubscribeZoomOutStart<WithStreamedUnaryMethod_RespondZoomOutStart<WithSplitStreamingMethod_SubscribeZoomStop<WithStreamedUnaryMethod_RespondZoomStop<WithSplitStreamingMethod_SubscribeZoomRange<WithStreamedUnaryMethod_RespondZoomRange<WithStreamedUnaryMethod_SetTrackingRectangleStatus<WithStreamedUnaryMethod_SetTrackingOffStatus<WithSplitStreamingMethod_SubscribeTrackingPointCommand<WithSplitStreamingMethod_SubscribeTrackingRectangleCommand<WithSplitStreamingMethod_SubscribeTrackingOffCommand<WithStreamedUnaryMethod_RespondTrackingPointCommand<WithStreamedUnaryMethod_RespondTrackingRectangleCommand<WithStreamedUnaryMethod_RespondTrackingOffCommand<WithStreamedUnaryMethod_SetPosition<WithStreamedUnaryMethod_SetAttitudeQuaternion<WithStreamedUnaryMethod_SetZoomFactor<WithStreamedUnaryMethod_SetFieldOfView<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace camera_server

--- a/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.pb.cc
+++ b/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.pb.cc
@@ -1580,6 +1580,56 @@ struct SetTrackingPointStatusRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetTrackingPointStatusRequestDefaultTypeInternal _SetTrackingPointStatusRequest_default_instance_;
 
+inline constexpr SetPositionResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_server_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR SetPositionResponse::SetPositionResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct SetPositionResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SetPositionResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SetPositionResponseDefaultTypeInternal() {}
+  union {
+    SetPositionResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetPositionResponseDefaultTypeInternal _SetPositionResponse_default_instance_;
+
+inline constexpr SetPositionRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        position_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR SetPositionRequest::SetPositionRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct SetPositionRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SetPositionRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SetPositionRequestDefaultTypeInternal() {}
+  union {
+    SetPositionRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetPositionRequestDefaultTypeInternal _SetPositionRequest_default_instance_;
+
 inline constexpr SetInformationResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : _cached_size_{0},
@@ -1654,6 +1704,56 @@ struct SetInProgressResponseDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetInProgressResponseDefaultTypeInternal _SetInProgressResponse_default_instance_;
+
+inline constexpr SetAttitudeQuaternionResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_server_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR SetAttitudeQuaternionResponse::SetAttitudeQuaternionResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct SetAttitudeQuaternionResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SetAttitudeQuaternionResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SetAttitudeQuaternionResponseDefaultTypeInternal() {}
+  union {
+    SetAttitudeQuaternionResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetAttitudeQuaternionResponseDefaultTypeInternal _SetAttitudeQuaternionResponse_default_instance_;
+
+inline constexpr SetAttitudeQuaternionRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        attitude_quaternion_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR SetAttitudeQuaternionRequest::SetAttitudeQuaternionRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct SetAttitudeQuaternionRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SetAttitudeQuaternionRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SetAttitudeQuaternionRequestDefaultTypeInternal() {}
+  union {
+    SetAttitudeQuaternionRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetAttitudeQuaternionRequestDefaultTypeInternal _SetAttitudeQuaternionRequest_default_instance_;
 
 inline constexpr RespondZoomStopResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -3047,6 +3147,46 @@ const ::uint32_t
         ~0u,  // no sizeof(Split)
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse, _impl_.camera_server_result_),
         0,
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetPositionRequest, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetPositionRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetPositionRequest, _impl_.position_),
+        0,
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetPositionResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetPositionResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetPositionResponse, _impl_.camera_server_result_),
+        0,
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, _impl_.attitude_quaternion_),
+        0,
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse, _impl_.camera_server_result_),
+        0,
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::TrackPoint, _internal_metadata_),
         ~0u,  // no _extensions_
@@ -3162,8 +3302,12 @@ static const ::_pbi::MigrationSchema
         {820, 829, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse)},
         {830, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest)},
         {839, 848, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse)},
-        {849, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackPoint)},
-        {860, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackRectangle)},
+        {849, 858, -1, sizeof(::mavsdk::rpc::camera_server::SetPositionRequest)},
+        {859, 868, -1, sizeof(::mavsdk::rpc::camera_server::SetPositionResponse)},
+        {869, 878, -1, sizeof(::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest)},
+        {879, 888, -1, sizeof(::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse)},
+        {889, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackPoint)},
+        {900, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackRectangle)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::camera_server::_SetInformationRequest_default_instance_._instance,
@@ -3254,6 +3398,10 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::camera_server::_RespondTrackingRectangleCommandResponse_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_RespondTrackingOffCommandRequest_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_RespondTrackingOffCommandResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SetPositionRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SetPositionResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SetAttitudeQuaternionRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SetAttitudeQuaternionResponse_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_TrackPoint_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_TrackRectangle_default_instance_._instance,
 };
@@ -3472,157 +3620,173 @@ const char descriptor_table_protodef_camera_5fserver_2fcamera_5fserver_2eproto[]
     ".CameraFeedback\"o\n!RespondTrackingOffCom"
     "mandResponse\022J\n\024camera_server_result\030\001 \001"
     "(\0132,.mavsdk.rpc.camera_server.CameraServ"
-    "erResult\">\n\nTrackPoint\022\017\n\007point_x\030\001 \001(\002\022"
-    "\017\n\007point_y\030\002 \001(\002\022\016\n\006radius\030\003 \001(\002\"\204\001\n\016Tra"
-    "ckRectangle\022\031\n\021top_left_corner_x\030\001 \001(\002\022\031"
-    "\n\021top_left_corner_y\030\002 \001(\002\022\035\n\025bottom_righ"
-    "t_corner_x\030\003 \001(\002\022\035\n\025bottom_right_corner_"
-    "y\030\004 \001(\002*{\n\016CameraFeedback\022\033\n\027CAMERA_FEED"
-    "BACK_UNKNOWN\020\000\022\026\n\022CAMERA_FEEDBACK_OK\020\001\022\030"
-    "\n\024CAMERA_FEEDBACK_BUSY\020\002\022\032\n\026CAMERA_FEEDB"
-    "ACK_FAILED\020\003*8\n\004Mode\022\020\n\014MODE_UNKNOWN\020\000\022\016"
-    "\n\nMODE_PHOTO\020\001\022\016\n\nMODE_VIDEO\020\0022\270+\n\023Camer"
-    "aServerService\022y\n\016SetInformation\022/.mavsd"
-    "k.rpc.camera_server.SetInformationReques"
-    "t\0320.mavsdk.rpc.camera_server.SetInformat"
-    "ionResponse\"\004\200\265\030\001\022\202\001\n\021SetVideoStreaming\022"
-    "2.mavsdk.rpc.camera_server.SetVideoStrea"
-    "mingRequest\0323.mavsdk.rpc.camera_server.S"
-    "etVideoStreamingResponse\"\004\200\265\030\001\022v\n\rSetInP"
-    "rogress\022..mavsdk.rpc.camera_server.SetIn"
-    "ProgressRequest\032/.mavsdk.rpc.camera_serv"
-    "er.SetInProgressResponse\"\004\200\265\030\001\022~\n\022Subscr"
-    "ibeTakePhoto\0223.mavsdk.rpc.camera_server."
-    "SubscribeTakePhotoRequest\032+.mavsdk.rpc.c"
-    "amera_server.TakePhotoResponse\"\004\200\265\030\0000\001\022\177"
-    "\n\020RespondTakePhoto\0221.mavsdk.rpc.camera_s"
-    "erver.RespondTakePhotoRequest\0322.mavsdk.r"
-    "pc.camera_server.RespondTakePhotoRespons"
-    "e\"\004\200\265\030\001\022\201\001\n\023SubscribeStartVideo\0224.mavsdk"
-    ".rpc.camera_server.SubscribeStartVideoRe"
-    "quest\032,.mavsdk.rpc.camera_server.StartVi"
-    "deoResponse\"\004\200\265\030\0000\001\022\202\001\n\021RespondStartVide"
-    "o\0222.mavsdk.rpc.camera_server.RespondStar"
-    "tVideoRequest\0323.mavsdk.rpc.camera_server"
-    ".RespondStartVideoResponse\"\004\200\265\030\001\022~\n\022Subs"
-    "cribeStopVideo\0223.mavsdk.rpc.camera_serve"
-    "r.SubscribeStopVideoRequest\032+.mavsdk.rpc"
-    ".camera_server.StopVideoResponse\"\004\200\265\030\0000\001"
-    "\022\177\n\020RespondStopVideo\0221.mavsdk.rpc.camera"
-    "_server.RespondStopVideoRequest\0322.mavsdk"
-    ".rpc.camera_server.RespondStopVideoRespo"
-    "nse\"\004\200\265\030\001\022\234\001\n\034SubscribeStartVideoStreami"
-    "ng\022=.mavsdk.rpc.camera_server.SubscribeS"
-    "tartVideoStreamingRequest\0325.mavsdk.rpc.c"
-    "amera_server.StartVideoStreamingResponse"
-    "\"\004\200\265\030\0000\001\022\235\001\n\032RespondStartVideoStreaming\022"
-    ";.mavsdk.rpc.camera_server.RespondStartV"
-    "ideoStreamingRequest\032<.mavsdk.rpc.camera"
-    "_server.RespondStartVideoStreamingRespon"
-    "se\"\004\200\265\030\001\022\231\001\n\033SubscribeStopVideoStreaming"
-    "\022<.mavsdk.rpc.camera_server.SubscribeSto"
-    "pVideoStreamingRequest\0324.mavsdk.rpc.came"
-    "ra_server.StopVideoStreamingResponse\"\004\200\265"
-    "\030\0000\001\022\232\001\n\031RespondStopVideoStreaming\022:.mav"
-    "sdk.rpc.camera_server.RespondStopVideoSt"
-    "reamingRequest\032;.mavsdk.rpc.camera_serve"
-    "r.RespondStopVideoStreamingResponse\"\004\200\265\030"
-    "\001\022x\n\020SubscribeSetMode\0221.mavsdk.rpc.camer"
-    "a_server.SubscribeSetModeRequest\032).mavsd"
-    "k.rpc.camera_server.SetModeResponse\"\004\200\265\030"
-    "\0000\001\022y\n\016RespondSetMode\022/.mavsdk.rpc.camer"
-    "a_server.RespondSetModeRequest\0320.mavsdk."
-    "rpc.camera_server.RespondSetModeResponse"
-    "\"\004\200\265\030\001\022\231\001\n\033SubscribeStorageInformation\022<"
-    ".mavsdk.rpc.camera_server.SubscribeStora"
-    "geInformationRequest\0324.mavsdk.rpc.camera"
-    "_server.StorageInformationResponse\"\004\200\265\030\000"
-    "0\001\022\232\001\n\031RespondStorageInformation\022:.mavsd"
-    "k.rpc.camera_server.RespondStorageInform"
-    "ationRequest\032;.mavsdk.rpc.camera_server."
-    "RespondStorageInformationResponse\"\004\200\265\030\001\022"
-    "\212\001\n\026SubscribeCaptureStatus\0227.mavsdk.rpc."
-    "camera_server.SubscribeCaptureStatusRequ"
-    "est\032/.mavsdk.rpc.camera_server.CaptureSt"
-    "atusResponse\"\004\200\265\030\0000\001\022\213\001\n\024RespondCaptureS"
-    "tatus\0225.mavsdk.rpc.camera_server.Respond"
-    "CaptureStatusRequest\0326.mavsdk.rpc.camera"
-    "_server.RespondCaptureStatusResponse\"\004\200\265"
-    "\030\001\022\212\001\n\026SubscribeFormatStorage\0227.mavsdk.r"
-    "pc.camera_server.SubscribeFormatStorageR"
-    "equest\032/.mavsdk.rpc.camera_server.Format"
-    "StorageResponse\"\004\200\265\030\0000\001\022\213\001\n\024RespondForma"
-    "tStorage\0225.mavsdk.rpc.camera_server.Resp"
-    "ondFormatStorageRequest\0326.mavsdk.rpc.cam"
-    "era_server.RespondFormatStorageResponse\""
-    "\004\200\265\030\001\022\212\001\n\026SubscribeResetSettings\0227.mavsd"
-    "k.rpc.camera_server.SubscribeResetSettin"
-    "gsRequest\032/.mavsdk.rpc.camera_server.Res"
-    "etSettingsResponse\"\004\200\265\030\0000\001\022\213\001\n\024RespondRe"
-    "setSettings\0225.mavsdk.rpc.camera_server.R"
-    "espondResetSettingsRequest\0326.mavsdk.rpc."
-    "camera_server.RespondResetSettingsRespon"
-    "se\"\004\200\265\030\001\022\204\001\n\024SubscribeZoomInStart\0225.mavs"
-    "dk.rpc.camera_server.SubscribeZoomInStar"
-    "tRequest\032-.mavsdk.rpc.camera_server.Zoom"
-    "InStartResponse\"\004\200\265\030\0000\001\022\205\001\n\022RespondZoomI"
-    "nStart\0223.mavsdk.rpc.camera_server.Respon"
-    "dZoomInStartRequest\0324.mavsdk.rpc.camera_"
-    "server.RespondZoomInStartResponse\"\004\200\265\030\001\022"
-    "\207\001\n\025SubscribeZoomOutStart\0226.mavsdk.rpc.c"
-    "amera_server.SubscribeZoomOutStartReques"
-    "t\032..mavsdk.rpc.camera_server.ZoomOutStar"
-    "tResponse\"\004\200\265\030\0000\001\022\210\001\n\023RespondZoomOutStar"
-    "t\0224.mavsdk.rpc.camera_server.RespondZoom"
-    "OutStartRequest\0325.mavsdk.rpc.camera_serv"
-    "er.RespondZoomOutStartResponse\"\004\200\265\030\001\022{\n\021"
-    "SubscribeZoomStop\0222.mavsdk.rpc.camera_se"
-    "rver.SubscribeZoomStopRequest\032*.mavsdk.r"
-    "pc.camera_server.ZoomStopResponse\"\004\200\265\030\0000"
-    "\001\022|\n\017RespondZoomStop\0220.mavsdk.rpc.camera"
-    "_server.RespondZoomStopRequest\0321.mavsdk."
-    "rpc.camera_server.RespondZoomStopRespons"
-    "e\"\004\200\265\030\001\022~\n\022SubscribeZoomRange\0223.mavsdk.r"
-    "pc.camera_server.SubscribeZoomRangeReque"
-    "st\032+.mavsdk.rpc.camera_server.ZoomRangeR"
-    "esponse\"\004\200\265\030\0000\001\022\177\n\020RespondZoomRange\0221.ma"
-    "vsdk.rpc.camera_server.RespondZoomRangeR"
-    "equest\0322.mavsdk.rpc.camera_server.Respon"
-    "dZoomRangeResponse\"\004\200\265\030\001\022\235\001\n\032SetTracking"
-    "RectangleStatus\022;.mavsdk.rpc.camera_serv"
-    "er.SetTrackingRectangleStatusRequest\032<.m"
-    "avsdk.rpc.camera_server.SetTrackingRecta"
-    "ngleStatusResponse\"\004\200\265\030\001\022\213\001\n\024SetTracking"
-    "OffStatus\0225.mavsdk.rpc.camera_server.Set"
-    "TrackingOffStatusRequest\0326.mavsdk.rpc.ca"
-    "mera_server.SetTrackingOffStatusResponse"
-    "\"\004\200\265\030\001\022\237\001\n\035SubscribeTrackingPointCommand"
-    "\022>.mavsdk.rpc.camera_server.SubscribeTra"
-    "ckingPointCommandRequest\0326.mavsdk.rpc.ca"
-    "mera_server.TrackingPointCommandResponse"
-    "\"\004\200\265\030\0000\001\022\253\001\n!SubscribeTrackingRectangleC"
-    "ommand\022B.mavsdk.rpc.camera_server.Subscr"
-    "ibeTrackingRectangleCommandRequest\032:.mav"
-    "sdk.rpc.camera_server.TrackingRectangleC"
-    "ommandResponse\"\004\200\265\030\0000\001\022\231\001\n\033SubscribeTrac"
-    "kingOffCommand\022<.mavsdk.rpc.camera_serve"
-    "r.SubscribeTrackingOffCommandRequest\0324.m"
-    "avsdk.rpc.camera_server.TrackingOffComma"
-    "ndResponse\"\004\200\265\030\0000\001\022\240\001\n\033RespondTrackingPo"
-    "intCommand\022<.mavsdk.rpc.camera_server.Re"
-    "spondTrackingPointCommandRequest\032=.mavsd"
-    "k.rpc.camera_server.RespondTrackingPoint"
-    "CommandResponse\"\004\200\265\030\001\022\254\001\n\037RespondTrackin"
-    "gRectangleCommand\022@.mavsdk.rpc.camera_se"
-    "rver.RespondTrackingRectangleCommandRequ"
-    "est\032A.mavsdk.rpc.camera_server.RespondTr"
-    "ackingRectangleCommandResponse\"\004\200\265\030\001\022\232\001\n"
-    "\031RespondTrackingOffCommand\022:.mavsdk.rpc."
-    "camera_server.RespondTrackingOffCommandR"
-    "equest\032;.mavsdk.rpc.camera_server.Respon"
-    "dTrackingOffCommandResponse\"\004\200\265\030\001B,\n\027io."
-    "mavsdk.camera_serverB\021CameraServerProtob"
-    "\006proto3"
+    "erResult\"J\n\022SetPositionRequest\0224\n\010positi"
+    "on\030\001 \001(\0132\".mavsdk.rpc.camera_server.Posi"
+    "tion\"a\n\023SetPositionResponse\022J\n\024camera_se"
+    "rver_result\030\001 \001(\0132,.mavsdk.rpc.camera_se"
+    "rver.CameraServerResult\"a\n\034SetAttitudeQu"
+    "aternionRequest\022A\n\023attitude_quaternion\030\001"
+    " \001(\0132$.mavsdk.rpc.camera_server.Quaterni"
+    "on\"k\n\035SetAttitudeQuaternionResponse\022J\n\024c"
+    "amera_server_result\030\001 \001(\0132,.mavsdk.rpc.c"
+    "amera_server.CameraServerResult\">\n\nTrack"
+    "Point\022\017\n\007point_x\030\001 \001(\002\022\017\n\007point_y\030\002 \001(\002\022"
+    "\016\n\006radius\030\003 \001(\002\"\204\001\n\016TrackRectangle\022\031\n\021to"
+    "p_left_corner_x\030\001 \001(\002\022\031\n\021top_left_corner"
+    "_y\030\002 \001(\002\022\035\n\025bottom_right_corner_x\030\003 \001(\002\022"
+    "\035\n\025bottom_right_corner_y\030\004 \001(\002*{\n\016Camera"
+    "Feedback\022\033\n\027CAMERA_FEEDBACK_UNKNOWN\020\000\022\026\n"
+    "\022CAMERA_FEEDBACK_OK\020\001\022\030\n\024CAMERA_FEEDBACK"
+    "_BUSY\020\002\022\032\n\026CAMERA_FEEDBACK_FAILED\020\003*8\n\004M"
+    "ode\022\020\n\014MODE_UNKNOWN\020\000\022\016\n\nMODE_PHOTO\020\001\022\016\n"
+    "\nMODE_VIDEO\020\0022\273-\n\023CameraServerService\022y\n"
+    "\016SetInformation\022/.mavsdk.rpc.camera_serv"
+    "er.SetInformationRequest\0320.mavsdk.rpc.ca"
+    "mera_server.SetInformationResponse\"\004\200\265\030\001"
+    "\022\202\001\n\021SetVideoStreaming\0222.mavsdk.rpc.came"
+    "ra_server.SetVideoStreamingRequest\0323.mav"
+    "sdk.rpc.camera_server.SetVideoStreamingR"
+    "esponse\"\004\200\265\030\001\022v\n\rSetInProgress\022..mavsdk."
+    "rpc.camera_server.SetInProgressRequest\032/"
+    ".mavsdk.rpc.camera_server.SetInProgressR"
+    "esponse\"\004\200\265\030\001\022~\n\022SubscribeTakePhoto\0223.ma"
+    "vsdk.rpc.camera_server.SubscribeTakePhot"
+    "oRequest\032+.mavsdk.rpc.camera_server.Take"
+    "PhotoResponse\"\004\200\265\030\0000\001\022\177\n\020RespondTakePhot"
+    "o\0221.mavsdk.rpc.camera_server.RespondTake"
+    "PhotoRequest\0322.mavsdk.rpc.camera_server."
+    "RespondTakePhotoResponse\"\004\200\265\030\001\022\201\001\n\023Subsc"
+    "ribeStartVideo\0224.mavsdk.rpc.camera_serve"
+    "r.SubscribeStartVideoRequest\032,.mavsdk.rp"
+    "c.camera_server.StartVideoResponse\"\004\200\265\030\000"
+    "0\001\022\202\001\n\021RespondStartVideo\0222.mavsdk.rpc.ca"
+    "mera_server.RespondStartVideoRequest\0323.m"
+    "avsdk.rpc.camera_server.RespondStartVide"
+    "oResponse\"\004\200\265\030\001\022~\n\022SubscribeStopVideo\0223."
+    "mavsdk.rpc.camera_server.SubscribeStopVi"
+    "deoRequest\032+.mavsdk.rpc.camera_server.St"
+    "opVideoResponse\"\004\200\265\030\0000\001\022\177\n\020RespondStopVi"
+    "deo\0221.mavsdk.rpc.camera_server.RespondSt"
+    "opVideoRequest\0322.mavsdk.rpc.camera_serve"
+    "r.RespondStopVideoResponse\"\004\200\265\030\001\022\234\001\n\034Sub"
+    "scribeStartVideoStreaming\022=.mavsdk.rpc.c"
+    "amera_server.SubscribeStartVideoStreamin"
+    "gRequest\0325.mavsdk.rpc.camera_server.Star"
+    "tVideoStreamingResponse\"\004\200\265\030\0000\001\022\235\001\n\032Resp"
+    "ondStartVideoStreaming\022;.mavsdk.rpc.came"
+    "ra_server.RespondStartVideoStreamingRequ"
+    "est\032<.mavsdk.rpc.camera_server.RespondSt"
+    "artVideoStreamingResponse\"\004\200\265\030\001\022\231\001\n\033Subs"
+    "cribeStopVideoStreaming\022<.mavsdk.rpc.cam"
+    "era_server.SubscribeStopVideoStreamingRe"
+    "quest\0324.mavsdk.rpc.camera_server.StopVid"
+    "eoStreamingResponse\"\004\200\265\030\0000\001\022\232\001\n\031RespondS"
+    "topVideoStreaming\022:.mavsdk.rpc.camera_se"
+    "rver.RespondStopVideoStreamingRequest\032;."
+    "mavsdk.rpc.camera_server.RespondStopVide"
+    "oStreamingResponse\"\004\200\265\030\001\022x\n\020SubscribeSet"
+    "Mode\0221.mavsdk.rpc.camera_server.Subscrib"
+    "eSetModeRequest\032).mavsdk.rpc.camera_serv"
+    "er.SetModeResponse\"\004\200\265\030\0000\001\022y\n\016RespondSet"
+    "Mode\022/.mavsdk.rpc.camera_server.RespondS"
+    "etModeRequest\0320.mavsdk.rpc.camera_server"
+    ".RespondSetModeResponse\"\004\200\265\030\001\022\231\001\n\033Subscr"
+    "ibeStorageInformation\022<.mavsdk.rpc.camer"
+    "a_server.SubscribeStorageInformationRequ"
+    "est\0324.mavsdk.rpc.camera_server.StorageIn"
+    "formationResponse\"\004\200\265\030\0000\001\022\232\001\n\031RespondSto"
+    "rageInformation\022:.mavsdk.rpc.camera_serv"
+    "er.RespondStorageInformationRequest\032;.ma"
+    "vsdk.rpc.camera_server.RespondStorageInf"
+    "ormationResponse\"\004\200\265\030\001\022\212\001\n\026SubscribeCapt"
+    "ureStatus\0227.mavsdk.rpc.camera_server.Sub"
+    "scribeCaptureStatusRequest\032/.mavsdk.rpc."
+    "camera_server.CaptureStatusResponse\"\004\200\265\030"
+    "\0000\001\022\213\001\n\024RespondCaptureStatus\0225.mavsdk.rp"
+    "c.camera_server.RespondCaptureStatusRequ"
+    "est\0326.mavsdk.rpc.camera_server.RespondCa"
+    "ptureStatusResponse\"\004\200\265\030\001\022\212\001\n\026SubscribeF"
+    "ormatStorage\0227.mavsdk.rpc.camera_server."
+    "SubscribeFormatStorageRequest\032/.mavsdk.r"
+    "pc.camera_server.FormatStorageResponse\"\004"
+    "\200\265\030\0000\001\022\213\001\n\024RespondFormatStorage\0225.mavsdk"
+    ".rpc.camera_server.RespondFormatStorageR"
+    "equest\0326.mavsdk.rpc.camera_server.Respon"
+    "dFormatStorageResponse\"\004\200\265\030\001\022\212\001\n\026Subscri"
+    "beResetSettings\0227.mavsdk.rpc.camera_serv"
+    "er.SubscribeResetSettingsRequest\032/.mavsd"
+    "k.rpc.camera_server.ResetSettingsRespons"
+    "e\"\004\200\265\030\0000\001\022\213\001\n\024RespondResetSettings\0225.mav"
+    "sdk.rpc.camera_server.RespondResetSettin"
+    "gsRequest\0326.mavsdk.rpc.camera_server.Res"
+    "pondResetSettingsResponse\"\004\200\265\030\001\022\204\001\n\024Subs"
+    "cribeZoomInStart\0225.mavsdk.rpc.camera_ser"
+    "ver.SubscribeZoomInStartRequest\032-.mavsdk"
+    ".rpc.camera_server.ZoomInStartResponse\"\004"
+    "\200\265\030\0000\001\022\205\001\n\022RespondZoomInStart\0223.mavsdk.r"
+    "pc.camera_server.RespondZoomInStartReque"
+    "st\0324.mavsdk.rpc.camera_server.RespondZoo"
+    "mInStartResponse\"\004\200\265\030\001\022\207\001\n\025SubscribeZoom"
+    "OutStart\0226.mavsdk.rpc.camera_server.Subs"
+    "cribeZoomOutStartRequest\032..mavsdk.rpc.ca"
+    "mera_server.ZoomOutStartResponse\"\004\200\265\030\0000\001"
+    "\022\210\001\n\023RespondZoomOutStart\0224.mavsdk.rpc.ca"
+    "mera_server.RespondZoomOutStartRequest\0325"
+    ".mavsdk.rpc.camera_server.RespondZoomOut"
+    "StartResponse\"\004\200\265\030\001\022{\n\021SubscribeZoomStop"
+    "\0222.mavsdk.rpc.camera_server.SubscribeZoo"
+    "mStopRequest\032*.mavsdk.rpc.camera_server."
+    "ZoomStopResponse\"\004\200\265\030\0000\001\022|\n\017RespondZoomS"
+    "top\0220.mavsdk.rpc.camera_server.RespondZo"
+    "omStopRequest\0321.mavsdk.rpc.camera_server"
+    ".RespondZoomStopResponse\"\004\200\265\030\001\022~\n\022Subscr"
+    "ibeZoomRange\0223.mavsdk.rpc.camera_server."
+    "SubscribeZoomRangeRequest\032+.mavsdk.rpc.c"
+    "amera_server.ZoomRangeResponse\"\004\200\265\030\0000\001\022\177"
+    "\n\020RespondZoomRange\0221.mavsdk.rpc.camera_s"
+    "erver.RespondZoomRangeRequest\0322.mavsdk.r"
+    "pc.camera_server.RespondZoomRangeRespons"
+    "e\"\004\200\265\030\001\022\235\001\n\032SetTrackingRectangleStatus\022;"
+    ".mavsdk.rpc.camera_server.SetTrackingRec"
+    "tangleStatusRequest\032<.mavsdk.rpc.camera_"
+    "server.SetTrackingRectangleStatusRespons"
+    "e\"\004\200\265\030\001\022\213\001\n\024SetTrackingOffStatus\0225.mavsd"
+    "k.rpc.camera_server.SetTrackingOffStatus"
+    "Request\0326.mavsdk.rpc.camera_server.SetTr"
+    "ackingOffStatusResponse\"\004\200\265\030\001\022\237\001\n\035Subscr"
+    "ibeTrackingPointCommand\022>.mavsdk.rpc.cam"
+    "era_server.SubscribeTrackingPointCommand"
+    "Request\0326.mavsdk.rpc.camera_server.Track"
+    "ingPointCommandResponse\"\004\200\265\030\0000\001\022\253\001\n!Subs"
+    "cribeTrackingRectangleCommand\022B.mavsdk.r"
+    "pc.camera_server.SubscribeTrackingRectan"
+    "gleCommandRequest\032:.mavsdk.rpc.camera_se"
+    "rver.TrackingRectangleCommandResponse\"\004\200"
+    "\265\030\0000\001\022\231\001\n\033SubscribeTrackingOffCommand\022<."
+    "mavsdk.rpc.camera_server.SubscribeTracki"
+    "ngOffCommandRequest\0324.mavsdk.rpc.camera_"
+    "server.TrackingOffCommandResponse\"\004\200\265\030\0000"
+    "\001\022\240\001\n\033RespondTrackingPointCommand\022<.mavs"
+    "dk.rpc.camera_server.RespondTrackingPoin"
+    "tCommandRequest\032=.mavsdk.rpc.camera_serv"
+    "er.RespondTrackingPointCommandResponse\"\004"
+    "\200\265\030\001\022\254\001\n\037RespondTrackingRectangleCommand"
+    "\022@.mavsdk.rpc.camera_server.RespondTrack"
+    "ingRectangleCommandRequest\032A.mavsdk.rpc."
+    "camera_server.RespondTrackingRectangleCo"
+    "mmandResponse\"\004\200\265\030\001\022\232\001\n\031RespondTrackingO"
+    "ffCommand\022:.mavsdk.rpc.camera_server.Res"
+    "pondTrackingOffCommandRequest\032;.mavsdk.r"
+    "pc.camera_server.RespondTrackingOffComma"
+    "ndResponse\"\004\200\265\030\001\022p\n\013SetPosition\022,.mavsdk"
+    ".rpc.camera_server.SetPositionRequest\032-."
+    "mavsdk.rpc.camera_server.SetPositionResp"
+    "onse\"\004\200\265\030\001\022\216\001\n\025SetAttitudeQuaternion\0226.m"
+    "avsdk.rpc.camera_server.SetAttitudeQuate"
+    "rnionRequest\0327.mavsdk.rpc.camera_server."
+    "SetAttitudeQuaternionResponse\"\004\200\265\030\001B,\n\027i"
+    "o.mavsdk.camera_serverB\021CameraServerProt"
+    "ob\006proto3"
 };
 static const ::_pbi::DescriptorTable* const descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_deps[1] =
     {
@@ -3632,13 +3796,13 @@ static ::absl::once_flag descriptor_table_camera_5fserver_2fcamera_5fserver_2epr
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto = {
     false,
     false,
-    14527,
+    15169,
     descriptor_table_protodef_camera_5fserver_2fcamera_5fserver_2eproto,
     "camera_server/camera_server.proto",
     &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_once,
     descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_deps,
     1,
-    90,
+    94,
     schemas,
     file_default_instances,
     TableStruct_camera_5fserver_2fcamera_5fserver_2eproto::offsets,
@@ -22201,6 +22365,1006 @@ void RespondTrackingOffCommandResponse::InternalSwap(RespondTrackingOffCommandRe
 }
 
 ::google::protobuf::Metadata RespondTrackingOffCommandResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SetPositionRequest::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<SetPositionRequest>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(SetPositionRequest, _impl_._has_bits_);
+};
+
+SetPositionRequest::SetPositionRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SetPositionRequest)
+}
+inline PROTOBUF_NDEBUG_INLINE SetPositionRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera_server::SetPositionRequest& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+SetPositionRequest::SetPositionRequest(
+    ::google::protobuf::Arena* arena,
+    const SetPositionRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SetPositionRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.position_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::Position>(
+                              arena, *from._impl_.position_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.SetPositionRequest)
+}
+inline PROTOBUF_NDEBUG_INLINE SetPositionRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void SetPositionRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.position_ = {};
+}
+SetPositionRequest::~SetPositionRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.SetPositionRequest)
+  SharedDtor(*this);
+}
+inline void SetPositionRequest::SharedDtor(MessageLite& self) {
+  SetPositionRequest& this_ = static_cast<SetPositionRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.position_;
+  this_._impl_.~Impl_();
+}
+
+inline void* SetPositionRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SetPositionRequest(arena);
+}
+constexpr auto SetPositionRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SetPositionRequest),
+                                            alignof(SetPositionRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SetPositionRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SetPositionRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SetPositionRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<SetPositionRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SetPositionRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<SetPositionRequest>(), &SetPositionRequest::ByteSizeLong,
+            &SetPositionRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SetPositionRequest, _impl_._cached_size_),
+        false,
+    },
+    &SetPositionRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SetPositionRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> SetPositionRequest::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(SetPositionRequest, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::SetPositionRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.Position position = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(SetPositionRequest, _impl_.position_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.Position position = 1;
+    {PROTOBUF_FIELD_OFFSET(SetPositionRequest, _impl_.position_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::Position>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void SetPositionRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.SetPositionRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.position_ != nullptr);
+    _impl_.position_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* SetPositionRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const SetPositionRequest& this_ = static_cast<const SetPositionRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* SetPositionRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const SetPositionRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.SetPositionRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera_server.Position position = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.position_, this_._impl_.position_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.SetPositionRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t SetPositionRequest::ByteSizeLong(const MessageLite& base) {
+          const SetPositionRequest& this_ = static_cast<const SetPositionRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t SetPositionRequest::ByteSizeLong() const {
+          const SetPositionRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.SetPositionRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.Position position = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.position_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void SetPositionRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<SetPositionRequest*>(&to_msg);
+  auto& from = static_cast<const SetPositionRequest&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.SetPositionRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.position_ != nullptr);
+    if (_this->_impl_.position_ == nullptr) {
+      _this->_impl_.position_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::Position>(arena, *from._impl_.position_);
+    } else {
+      _this->_impl_.position_->MergeFrom(*from._impl_.position_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SetPositionRequest::CopyFrom(const SetPositionRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.SetPositionRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void SetPositionRequest::InternalSwap(SetPositionRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.position_, other->_impl_.position_);
+}
+
+::google::protobuf::Metadata SetPositionRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SetPositionResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<SetPositionResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(SetPositionResponse, _impl_._has_bits_);
+};
+
+SetPositionResponse::SetPositionResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SetPositionResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE SetPositionResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera_server::SetPositionResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+SetPositionResponse::SetPositionResponse(
+    ::google::protobuf::Arena* arena,
+    const SetPositionResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SetPositionResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_server_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(
+                              arena, *from._impl_.camera_server_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.SetPositionResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE SetPositionResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void SetPositionResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_server_result_ = {};
+}
+SetPositionResponse::~SetPositionResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.SetPositionResponse)
+  SharedDtor(*this);
+}
+inline void SetPositionResponse::SharedDtor(MessageLite& self) {
+  SetPositionResponse& this_ = static_cast<SetPositionResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.camera_server_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* SetPositionResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SetPositionResponse(arena);
+}
+constexpr auto SetPositionResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SetPositionResponse),
+                                            alignof(SetPositionResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SetPositionResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SetPositionResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SetPositionResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<SetPositionResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SetPositionResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<SetPositionResponse>(), &SetPositionResponse::ByteSizeLong,
+            &SetPositionResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SetPositionResponse, _impl_._cached_size_),
+        false,
+    },
+    &SetPositionResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SetPositionResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> SetPositionResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(SetPositionResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::SetPositionResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(SetPositionResponse, _impl_.camera_server_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {PROTOBUF_FIELD_OFFSET(SetPositionResponse, _impl_.camera_server_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::CameraServerResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void SetPositionResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.SetPositionResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_server_result_ != nullptr);
+    _impl_.camera_server_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* SetPositionResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const SetPositionResponse& this_ = static_cast<const SetPositionResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* SetPositionResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const SetPositionResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.SetPositionResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.camera_server_result_, this_._impl_.camera_server_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.SetPositionResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t SetPositionResponse::ByteSizeLong(const MessageLite& base) {
+          const SetPositionResponse& this_ = static_cast<const SetPositionResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t SetPositionResponse::ByteSizeLong() const {
+          const SetPositionResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.SetPositionResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.camera_server_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void SetPositionResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<SetPositionResponse*>(&to_msg);
+  auto& from = static_cast<const SetPositionResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.SetPositionResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.camera_server_result_ != nullptr);
+    if (_this->_impl_.camera_server_result_ == nullptr) {
+      _this->_impl_.camera_server_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(arena, *from._impl_.camera_server_result_);
+    } else {
+      _this->_impl_.camera_server_result_->MergeFrom(*from._impl_.camera_server_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SetPositionResponse::CopyFrom(const SetPositionResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.SetPositionResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void SetPositionResponse::InternalSwap(SetPositionResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_server_result_, other->_impl_.camera_server_result_);
+}
+
+::google::protobuf::Metadata SetPositionResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SetAttitudeQuaternionRequest::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<SetAttitudeQuaternionRequest>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(SetAttitudeQuaternionRequest, _impl_._has_bits_);
+};
+
+SetAttitudeQuaternionRequest::SetAttitudeQuaternionRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SetAttitudeQuaternionRequest)
+}
+inline PROTOBUF_NDEBUG_INLINE SetAttitudeQuaternionRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+SetAttitudeQuaternionRequest::SetAttitudeQuaternionRequest(
+    ::google::protobuf::Arena* arena,
+    const SetAttitudeQuaternionRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SetAttitudeQuaternionRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.attitude_quaternion_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::Quaternion>(
+                              arena, *from._impl_.attitude_quaternion_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.SetAttitudeQuaternionRequest)
+}
+inline PROTOBUF_NDEBUG_INLINE SetAttitudeQuaternionRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void SetAttitudeQuaternionRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.attitude_quaternion_ = {};
+}
+SetAttitudeQuaternionRequest::~SetAttitudeQuaternionRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.SetAttitudeQuaternionRequest)
+  SharedDtor(*this);
+}
+inline void SetAttitudeQuaternionRequest::SharedDtor(MessageLite& self) {
+  SetAttitudeQuaternionRequest& this_ = static_cast<SetAttitudeQuaternionRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.attitude_quaternion_;
+  this_._impl_.~Impl_();
+}
+
+inline void* SetAttitudeQuaternionRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SetAttitudeQuaternionRequest(arena);
+}
+constexpr auto SetAttitudeQuaternionRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SetAttitudeQuaternionRequest),
+                                            alignof(SetAttitudeQuaternionRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SetAttitudeQuaternionRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SetAttitudeQuaternionRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SetAttitudeQuaternionRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<SetAttitudeQuaternionRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SetAttitudeQuaternionRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<SetAttitudeQuaternionRequest>(), &SetAttitudeQuaternionRequest::ByteSizeLong,
+            &SetAttitudeQuaternionRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SetAttitudeQuaternionRequest, _impl_._cached_size_),
+        false,
+    },
+    &SetAttitudeQuaternionRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SetAttitudeQuaternionRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> SetAttitudeQuaternionRequest::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(SetAttitudeQuaternionRequest, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.Quaternion attitude_quaternion = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(SetAttitudeQuaternionRequest, _impl_.attitude_quaternion_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.Quaternion attitude_quaternion = 1;
+    {PROTOBUF_FIELD_OFFSET(SetAttitudeQuaternionRequest, _impl_.attitude_quaternion_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::Quaternion>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void SetAttitudeQuaternionRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.SetAttitudeQuaternionRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.attitude_quaternion_ != nullptr);
+    _impl_.attitude_quaternion_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* SetAttitudeQuaternionRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const SetAttitudeQuaternionRequest& this_ = static_cast<const SetAttitudeQuaternionRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* SetAttitudeQuaternionRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const SetAttitudeQuaternionRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.SetAttitudeQuaternionRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera_server.Quaternion attitude_quaternion = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.attitude_quaternion_, this_._impl_.attitude_quaternion_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.SetAttitudeQuaternionRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t SetAttitudeQuaternionRequest::ByteSizeLong(const MessageLite& base) {
+          const SetAttitudeQuaternionRequest& this_ = static_cast<const SetAttitudeQuaternionRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t SetAttitudeQuaternionRequest::ByteSizeLong() const {
+          const SetAttitudeQuaternionRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.SetAttitudeQuaternionRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.Quaternion attitude_quaternion = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.attitude_quaternion_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void SetAttitudeQuaternionRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<SetAttitudeQuaternionRequest*>(&to_msg);
+  auto& from = static_cast<const SetAttitudeQuaternionRequest&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.SetAttitudeQuaternionRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.attitude_quaternion_ != nullptr);
+    if (_this->_impl_.attitude_quaternion_ == nullptr) {
+      _this->_impl_.attitude_quaternion_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::Quaternion>(arena, *from._impl_.attitude_quaternion_);
+    } else {
+      _this->_impl_.attitude_quaternion_->MergeFrom(*from._impl_.attitude_quaternion_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SetAttitudeQuaternionRequest::CopyFrom(const SetAttitudeQuaternionRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.SetAttitudeQuaternionRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void SetAttitudeQuaternionRequest::InternalSwap(SetAttitudeQuaternionRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.attitude_quaternion_, other->_impl_.attitude_quaternion_);
+}
+
+::google::protobuf::Metadata SetAttitudeQuaternionRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SetAttitudeQuaternionResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<SetAttitudeQuaternionResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(SetAttitudeQuaternionResponse, _impl_._has_bits_);
+};
+
+SetAttitudeQuaternionResponse::SetAttitudeQuaternionResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SetAttitudeQuaternionResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE SetAttitudeQuaternionResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+SetAttitudeQuaternionResponse::SetAttitudeQuaternionResponse(
+    ::google::protobuf::Arena* arena,
+    const SetAttitudeQuaternionResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SetAttitudeQuaternionResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_server_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(
+                              arena, *from._impl_.camera_server_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.SetAttitudeQuaternionResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE SetAttitudeQuaternionResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void SetAttitudeQuaternionResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_server_result_ = {};
+}
+SetAttitudeQuaternionResponse::~SetAttitudeQuaternionResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.SetAttitudeQuaternionResponse)
+  SharedDtor(*this);
+}
+inline void SetAttitudeQuaternionResponse::SharedDtor(MessageLite& self) {
+  SetAttitudeQuaternionResponse& this_ = static_cast<SetAttitudeQuaternionResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.camera_server_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* SetAttitudeQuaternionResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SetAttitudeQuaternionResponse(arena);
+}
+constexpr auto SetAttitudeQuaternionResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SetAttitudeQuaternionResponse),
+                                            alignof(SetAttitudeQuaternionResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SetAttitudeQuaternionResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SetAttitudeQuaternionResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SetAttitudeQuaternionResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<SetAttitudeQuaternionResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SetAttitudeQuaternionResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<SetAttitudeQuaternionResponse>(), &SetAttitudeQuaternionResponse::ByteSizeLong,
+            &SetAttitudeQuaternionResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SetAttitudeQuaternionResponse, _impl_._cached_size_),
+        false,
+    },
+    &SetAttitudeQuaternionResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SetAttitudeQuaternionResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> SetAttitudeQuaternionResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(SetAttitudeQuaternionResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(SetAttitudeQuaternionResponse, _impl_.camera_server_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {PROTOBUF_FIELD_OFFSET(SetAttitudeQuaternionResponse, _impl_.camera_server_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::CameraServerResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void SetAttitudeQuaternionResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.SetAttitudeQuaternionResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_server_result_ != nullptr);
+    _impl_.camera_server_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* SetAttitudeQuaternionResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const SetAttitudeQuaternionResponse& this_ = static_cast<const SetAttitudeQuaternionResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* SetAttitudeQuaternionResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const SetAttitudeQuaternionResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.SetAttitudeQuaternionResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.camera_server_result_, this_._impl_.camera_server_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.SetAttitudeQuaternionResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t SetAttitudeQuaternionResponse::ByteSizeLong(const MessageLite& base) {
+          const SetAttitudeQuaternionResponse& this_ = static_cast<const SetAttitudeQuaternionResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t SetAttitudeQuaternionResponse::ByteSizeLong() const {
+          const SetAttitudeQuaternionResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.SetAttitudeQuaternionResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.camera_server_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void SetAttitudeQuaternionResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<SetAttitudeQuaternionResponse*>(&to_msg);
+  auto& from = static_cast<const SetAttitudeQuaternionResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.SetAttitudeQuaternionResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.camera_server_result_ != nullptr);
+    if (_this->_impl_.camera_server_result_ == nullptr) {
+      _this->_impl_.camera_server_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(arena, *from._impl_.camera_server_result_);
+    } else {
+      _this->_impl_.camera_server_result_->MergeFrom(*from._impl_.camera_server_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SetAttitudeQuaternionResponse::CopyFrom(const SetAttitudeQuaternionResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.SetAttitudeQuaternionResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void SetAttitudeQuaternionResponse::InternalSwap(SetAttitudeQuaternionResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_server_result_, other->_impl_.camera_server_result_);
+}
+
+::google::protobuf::Metadata SetAttitudeQuaternionResponse::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================

--- a/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.pb.cc
+++ b/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.pb.cc
@@ -723,6 +723,31 @@ struct StartVideoResponseDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 StartVideoResponseDefaultTypeInternal _StartVideoResponse_default_instance_;
+
+inline constexpr SetZoomFactorRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : zoom_factor_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR SetZoomFactorRequest::SetZoomFactorRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct SetZoomFactorRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SetZoomFactorRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SetZoomFactorRequestDefaultTypeInternal() {}
+  union {
+    SetZoomFactorRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetZoomFactorRequestDefaultTypeInternal _SetZoomFactorRequest_default_instance_;
               template <typename>
 PROTOBUF_CONSTEXPR SetTrackingRectangleStatusResponse::SetTrackingRectangleStatusResponse(::_pbi::ConstantInitialized)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
@@ -845,6 +870,32 @@ struct SetInProgressRequestDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetInProgressRequestDefaultTypeInternal _SetInProgressRequest_default_instance_;
+
+inline constexpr SetFieldOfViewRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : horizontal_fov_deg_{0},
+        vertical_fov_deg_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR SetFieldOfViewRequest::SetFieldOfViewRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct SetFieldOfViewRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SetFieldOfViewRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SetFieldOfViewRequestDefaultTypeInternal() {}
+  union {
+    SetFieldOfViewRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetFieldOfViewRequestDefaultTypeInternal _SetFieldOfViewRequest_default_instance_;
 
 inline constexpr RespondZoomStopRequest::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -1480,6 +1531,31 @@ struct TrackingPointCommandResponseDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 TrackingPointCommandResponseDefaultTypeInternal _TrackingPointCommandResponse_default_instance_;
 
+inline constexpr SetZoomFactorResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_server_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR SetZoomFactorResponse::SetZoomFactorResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct SetZoomFactorResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SetZoomFactorResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SetZoomFactorResponseDefaultTypeInternal() {}
+  union {
+    SetZoomFactorResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetZoomFactorResponseDefaultTypeInternal _SetZoomFactorResponse_default_instance_;
+
 inline constexpr SetVideoStreamingResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : _cached_size_{0},
@@ -1704,6 +1780,31 @@ struct SetInProgressResponseDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetInProgressResponseDefaultTypeInternal _SetInProgressResponse_default_instance_;
+
+inline constexpr SetFieldOfViewResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_server_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR SetFieldOfViewResponse::SetFieldOfViewResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct SetFieldOfViewResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SetFieldOfViewResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SetFieldOfViewResponseDefaultTypeInternal() {}
+  union {
+    SetFieldOfViewResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SetFieldOfViewResponseDefaultTypeInternal _SetFieldOfViewResponse_default_instance_;
 
 inline constexpr SetAttitudeQuaternionResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -3188,6 +3289,45 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse, _impl_.camera_server_result_),
         0,
         ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetZoomFactorRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetZoomFactorRequest, _impl_.zoom_factor_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetZoomFactorResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetZoomFactorResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetZoomFactorResponse, _impl_.camera_server_result_),
+        0,
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetFieldOfViewRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetFieldOfViewRequest, _impl_.horizontal_fov_deg_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetFieldOfViewRequest, _impl_.vertical_fov_deg_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetFieldOfViewResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetFieldOfViewResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SetFieldOfViewResponse, _impl_.camera_server_result_),
+        0,
+        ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::TrackPoint, _internal_metadata_),
         ~0u,  // no _extensions_
         ~0u,  // no _oneof_case_
@@ -3306,8 +3446,12 @@ static const ::_pbi::MigrationSchema
         {859, 868, -1, sizeof(::mavsdk::rpc::camera_server::SetPositionResponse)},
         {869, 878, -1, sizeof(::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest)},
         {879, 888, -1, sizeof(::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse)},
-        {889, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackPoint)},
-        {900, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackRectangle)},
+        {889, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetZoomFactorRequest)},
+        {898, 907, -1, sizeof(::mavsdk::rpc::camera_server::SetZoomFactorResponse)},
+        {908, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetFieldOfViewRequest)},
+        {918, 927, -1, sizeof(::mavsdk::rpc::camera_server::SetFieldOfViewResponse)},
+        {928, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackPoint)},
+        {939, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackRectangle)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::camera_server::_SetInformationRequest_default_instance_._instance,
@@ -3402,6 +3546,10 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::camera_server::_SetPositionResponse_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_SetAttitudeQuaternionRequest_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_SetAttitudeQuaternionResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SetZoomFactorRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SetZoomFactorResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SetFieldOfViewRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SetFieldOfViewResponse_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_TrackPoint_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_TrackRectangle_default_instance_._instance,
 };
@@ -3629,164 +3777,178 @@ const char descriptor_table_protodef_camera_5fserver_2fcamera_5fserver_2eproto[]
     " \001(\0132$.mavsdk.rpc.camera_server.Quaterni"
     "on\"k\n\035SetAttitudeQuaternionResponse\022J\n\024c"
     "amera_server_result\030\001 \001(\0132,.mavsdk.rpc.c"
-    "amera_server.CameraServerResult\">\n\nTrack"
-    "Point\022\017\n\007point_x\030\001 \001(\002\022\017\n\007point_y\030\002 \001(\002\022"
-    "\016\n\006radius\030\003 \001(\002\"\204\001\n\016TrackRectangle\022\031\n\021to"
-    "p_left_corner_x\030\001 \001(\002\022\031\n\021top_left_corner"
-    "_y\030\002 \001(\002\022\035\n\025bottom_right_corner_x\030\003 \001(\002\022"
-    "\035\n\025bottom_right_corner_y\030\004 \001(\002*{\n\016Camera"
-    "Feedback\022\033\n\027CAMERA_FEEDBACK_UNKNOWN\020\000\022\026\n"
-    "\022CAMERA_FEEDBACK_OK\020\001\022\030\n\024CAMERA_FEEDBACK"
-    "_BUSY\020\002\022\032\n\026CAMERA_FEEDBACK_FAILED\020\003*8\n\004M"
-    "ode\022\020\n\014MODE_UNKNOWN\020\000\022\016\n\nMODE_PHOTO\020\001\022\016\n"
-    "\nMODE_VIDEO\020\0022\273-\n\023CameraServerService\022y\n"
-    "\016SetInformation\022/.mavsdk.rpc.camera_serv"
-    "er.SetInformationRequest\0320.mavsdk.rpc.ca"
-    "mera_server.SetInformationResponse\"\004\200\265\030\001"
-    "\022\202\001\n\021SetVideoStreaming\0222.mavsdk.rpc.came"
-    "ra_server.SetVideoStreamingRequest\0323.mav"
-    "sdk.rpc.camera_server.SetVideoStreamingR"
-    "esponse\"\004\200\265\030\001\022v\n\rSetInProgress\022..mavsdk."
-    "rpc.camera_server.SetInProgressRequest\032/"
-    ".mavsdk.rpc.camera_server.SetInProgressR"
-    "esponse\"\004\200\265\030\001\022~\n\022SubscribeTakePhoto\0223.ma"
-    "vsdk.rpc.camera_server.SubscribeTakePhot"
-    "oRequest\032+.mavsdk.rpc.camera_server.Take"
-    "PhotoResponse\"\004\200\265\030\0000\001\022\177\n\020RespondTakePhot"
-    "o\0221.mavsdk.rpc.camera_server.RespondTake"
-    "PhotoRequest\0322.mavsdk.rpc.camera_server."
-    "RespondTakePhotoResponse\"\004\200\265\030\001\022\201\001\n\023Subsc"
-    "ribeStartVideo\0224.mavsdk.rpc.camera_serve"
-    "r.SubscribeStartVideoRequest\032,.mavsdk.rp"
-    "c.camera_server.StartVideoResponse\"\004\200\265\030\000"
-    "0\001\022\202\001\n\021RespondStartVideo\0222.mavsdk.rpc.ca"
-    "mera_server.RespondStartVideoRequest\0323.m"
-    "avsdk.rpc.camera_server.RespondStartVide"
-    "oResponse\"\004\200\265\030\001\022~\n\022SubscribeStopVideo\0223."
-    "mavsdk.rpc.camera_server.SubscribeStopVi"
-    "deoRequest\032+.mavsdk.rpc.camera_server.St"
-    "opVideoResponse\"\004\200\265\030\0000\001\022\177\n\020RespondStopVi"
-    "deo\0221.mavsdk.rpc.camera_server.RespondSt"
-    "opVideoRequest\0322.mavsdk.rpc.camera_serve"
-    "r.RespondStopVideoResponse\"\004\200\265\030\001\022\234\001\n\034Sub"
-    "scribeStartVideoStreaming\022=.mavsdk.rpc.c"
-    "amera_server.SubscribeStartVideoStreamin"
-    "gRequest\0325.mavsdk.rpc.camera_server.Star"
-    "tVideoStreamingResponse\"\004\200\265\030\0000\001\022\235\001\n\032Resp"
-    "ondStartVideoStreaming\022;.mavsdk.rpc.came"
-    "ra_server.RespondStartVideoStreamingRequ"
-    "est\032<.mavsdk.rpc.camera_server.RespondSt"
-    "artVideoStreamingResponse\"\004\200\265\030\001\022\231\001\n\033Subs"
-    "cribeStopVideoStreaming\022<.mavsdk.rpc.cam"
-    "era_server.SubscribeStopVideoStreamingRe"
-    "quest\0324.mavsdk.rpc.camera_server.StopVid"
-    "eoStreamingResponse\"\004\200\265\030\0000\001\022\232\001\n\031RespondS"
-    "topVideoStreaming\022:.mavsdk.rpc.camera_se"
-    "rver.RespondStopVideoStreamingRequest\032;."
-    "mavsdk.rpc.camera_server.RespondStopVide"
-    "oStreamingResponse\"\004\200\265\030\001\022x\n\020SubscribeSet"
-    "Mode\0221.mavsdk.rpc.camera_server.Subscrib"
-    "eSetModeRequest\032).mavsdk.rpc.camera_serv"
-    "er.SetModeResponse\"\004\200\265\030\0000\001\022y\n\016RespondSet"
-    "Mode\022/.mavsdk.rpc.camera_server.RespondS"
-    "etModeRequest\0320.mavsdk.rpc.camera_server"
-    ".RespondSetModeResponse\"\004\200\265\030\001\022\231\001\n\033Subscr"
-    "ibeStorageInformation\022<.mavsdk.rpc.camer"
-    "a_server.SubscribeStorageInformationRequ"
-    "est\0324.mavsdk.rpc.camera_server.StorageIn"
-    "formationResponse\"\004\200\265\030\0000\001\022\232\001\n\031RespondSto"
-    "rageInformation\022:.mavsdk.rpc.camera_serv"
-    "er.RespondStorageInformationRequest\032;.ma"
-    "vsdk.rpc.camera_server.RespondStorageInf"
-    "ormationResponse\"\004\200\265\030\001\022\212\001\n\026SubscribeCapt"
-    "ureStatus\0227.mavsdk.rpc.camera_server.Sub"
-    "scribeCaptureStatusRequest\032/.mavsdk.rpc."
-    "camera_server.CaptureStatusResponse\"\004\200\265\030"
-    "\0000\001\022\213\001\n\024RespondCaptureStatus\0225.mavsdk.rp"
-    "c.camera_server.RespondCaptureStatusRequ"
-    "est\0326.mavsdk.rpc.camera_server.RespondCa"
-    "ptureStatusResponse\"\004\200\265\030\001\022\212\001\n\026SubscribeF"
-    "ormatStorage\0227.mavsdk.rpc.camera_server."
-    "SubscribeFormatStorageRequest\032/.mavsdk.r"
-    "pc.camera_server.FormatStorageResponse\"\004"
-    "\200\265\030\0000\001\022\213\001\n\024RespondFormatStorage\0225.mavsdk"
-    ".rpc.camera_server.RespondFormatStorageR"
-    "equest\0326.mavsdk.rpc.camera_server.Respon"
-    "dFormatStorageResponse\"\004\200\265\030\001\022\212\001\n\026Subscri"
-    "beResetSettings\0227.mavsdk.rpc.camera_serv"
-    "er.SubscribeResetSettingsRequest\032/.mavsd"
-    "k.rpc.camera_server.ResetSettingsRespons"
-    "e\"\004\200\265\030\0000\001\022\213\001\n\024RespondResetSettings\0225.mav"
-    "sdk.rpc.camera_server.RespondResetSettin"
-    "gsRequest\0326.mavsdk.rpc.camera_server.Res"
-    "pondResetSettingsResponse\"\004\200\265\030\001\022\204\001\n\024Subs"
-    "cribeZoomInStart\0225.mavsdk.rpc.camera_ser"
-    "ver.SubscribeZoomInStartRequest\032-.mavsdk"
-    ".rpc.camera_server.ZoomInStartResponse\"\004"
-    "\200\265\030\0000\001\022\205\001\n\022RespondZoomInStart\0223.mavsdk.r"
-    "pc.camera_server.RespondZoomInStartReque"
-    "st\0324.mavsdk.rpc.camera_server.RespondZoo"
-    "mInStartResponse\"\004\200\265\030\001\022\207\001\n\025SubscribeZoom"
-    "OutStart\0226.mavsdk.rpc.camera_server.Subs"
-    "cribeZoomOutStartRequest\032..mavsdk.rpc.ca"
-    "mera_server.ZoomOutStartResponse\"\004\200\265\030\0000\001"
-    "\022\210\001\n\023RespondZoomOutStart\0224.mavsdk.rpc.ca"
-    "mera_server.RespondZoomOutStartRequest\0325"
-    ".mavsdk.rpc.camera_server.RespondZoomOut"
-    "StartResponse\"\004\200\265\030\001\022{\n\021SubscribeZoomStop"
-    "\0222.mavsdk.rpc.camera_server.SubscribeZoo"
-    "mStopRequest\032*.mavsdk.rpc.camera_server."
-    "ZoomStopResponse\"\004\200\265\030\0000\001\022|\n\017RespondZoomS"
-    "top\0220.mavsdk.rpc.camera_server.RespondZo"
-    "omStopRequest\0321.mavsdk.rpc.camera_server"
-    ".RespondZoomStopResponse\"\004\200\265\030\001\022~\n\022Subscr"
-    "ibeZoomRange\0223.mavsdk.rpc.camera_server."
-    "SubscribeZoomRangeRequest\032+.mavsdk.rpc.c"
-    "amera_server.ZoomRangeResponse\"\004\200\265\030\0000\001\022\177"
-    "\n\020RespondZoomRange\0221.mavsdk.rpc.camera_s"
-    "erver.RespondZoomRangeRequest\0322.mavsdk.r"
-    "pc.camera_server.RespondZoomRangeRespons"
-    "e\"\004\200\265\030\001\022\235\001\n\032SetTrackingRectangleStatus\022;"
-    ".mavsdk.rpc.camera_server.SetTrackingRec"
-    "tangleStatusRequest\032<.mavsdk.rpc.camera_"
-    "server.SetTrackingRectangleStatusRespons"
-    "e\"\004\200\265\030\001\022\213\001\n\024SetTrackingOffStatus\0225.mavsd"
-    "k.rpc.camera_server.SetTrackingOffStatus"
-    "Request\0326.mavsdk.rpc.camera_server.SetTr"
-    "ackingOffStatusResponse\"\004\200\265\030\001\022\237\001\n\035Subscr"
-    "ibeTrackingPointCommand\022>.mavsdk.rpc.cam"
-    "era_server.SubscribeTrackingPointCommand"
-    "Request\0326.mavsdk.rpc.camera_server.Track"
-    "ingPointCommandResponse\"\004\200\265\030\0000\001\022\253\001\n!Subs"
-    "cribeTrackingRectangleCommand\022B.mavsdk.r"
-    "pc.camera_server.SubscribeTrackingRectan"
-    "gleCommandRequest\032:.mavsdk.rpc.camera_se"
-    "rver.TrackingRectangleCommandResponse\"\004\200"
-    "\265\030\0000\001\022\231\001\n\033SubscribeTrackingOffCommand\022<."
-    "mavsdk.rpc.camera_server.SubscribeTracki"
-    "ngOffCommandRequest\0324.mavsdk.rpc.camera_"
-    "server.TrackingOffCommandResponse\"\004\200\265\030\0000"
-    "\001\022\240\001\n\033RespondTrackingPointCommand\022<.mavs"
-    "dk.rpc.camera_server.RespondTrackingPoin"
-    "tCommandRequest\032=.mavsdk.rpc.camera_serv"
-    "er.RespondTrackingPointCommandResponse\"\004"
-    "\200\265\030\001\022\254\001\n\037RespondTrackingRectangleCommand"
-    "\022@.mavsdk.rpc.camera_server.RespondTrack"
-    "ingRectangleCommandRequest\032A.mavsdk.rpc."
-    "camera_server.RespondTrackingRectangleCo"
-    "mmandResponse\"\004\200\265\030\001\022\232\001\n\031RespondTrackingO"
-    "ffCommand\022:.mavsdk.rpc.camera_server.Res"
-    "pondTrackingOffCommandRequest\032;.mavsdk.r"
-    "pc.camera_server.RespondTrackingOffComma"
-    "ndResponse\"\004\200\265\030\001\022p\n\013SetPosition\022,.mavsdk"
-    ".rpc.camera_server.SetPositionRequest\032-."
-    "mavsdk.rpc.camera_server.SetPositionResp"
-    "onse\"\004\200\265\030\001\022\216\001\n\025SetAttitudeQuaternion\0226.m"
-    "avsdk.rpc.camera_server.SetAttitudeQuate"
-    "rnionRequest\0327.mavsdk.rpc.camera_server."
-    "SetAttitudeQuaternionResponse\"\004\200\265\030\001B,\n\027i"
-    "o.mavsdk.camera_serverB\021CameraServerProt"
-    "ob\006proto3"
+    "amera_server.CameraServerResult\"+\n\024SetZo"
+    "omFactorRequest\022\023\n\013zoom_factor\030\001 \001(\002\"c\n\025"
+    "SetZoomFactorResponse\022J\n\024camera_server_r"
+    "esult\030\001 \001(\0132,.mavsdk.rpc.camera_server.C"
+    "ameraServerResult\"M\n\025SetFieldOfViewReque"
+    "st\022\032\n\022horizontal_fov_deg\030\001 \001(\002\022\030\n\020vertic"
+    "al_fov_deg\030\002 \001(\002\"d\n\026SetFieldOfViewRespon"
+    "se\022J\n\024camera_server_result\030\001 \001(\0132,.mavsd"
+    "k.rpc.camera_server.CameraServerResult\">"
+    "\n\nTrackPoint\022\017\n\007point_x\030\001 \001(\002\022\017\n\007point_y"
+    "\030\002 \001(\002\022\016\n\006radius\030\003 \001(\002\"\204\001\n\016TrackRectangl"
+    "e\022\031\n\021top_left_corner_x\030\001 \001(\002\022\031\n\021top_left"
+    "_corner_y\030\002 \001(\002\022\035\n\025bottom_right_corner_x"
+    "\030\003 \001(\002\022\035\n\025bottom_right_corner_y\030\004 \001(\002*{\n"
+    "\016CameraFeedback\022\033\n\027CAMERA_FEEDBACK_UNKNO"
+    "WN\020\000\022\026\n\022CAMERA_FEEDBACK_OK\020\001\022\030\n\024CAMERA_F"
+    "EEDBACK_BUSY\020\002\022\032\n\026CAMERA_FEEDBACK_FAILED"
+    "\020\003*8\n\004Mode\022\020\n\014MODE_UNKNOWN\020\000\022\016\n\nMODE_PHO"
+    "TO\020\001\022\016\n\nMODE_VIDEO\020\0022\256/\n\023CameraServerSer"
+    "vice\022y\n\016SetInformation\022/.mavsdk.rpc.came"
+    "ra_server.SetInformationRequest\0320.mavsdk"
+    ".rpc.camera_server.SetInformationRespons"
+    "e\"\004\200\265\030\001\022\202\001\n\021SetVideoStreaming\0222.mavsdk.r"
+    "pc.camera_server.SetVideoStreamingReques"
+    "t\0323.mavsdk.rpc.camera_server.SetVideoStr"
+    "eamingResponse\"\004\200\265\030\001\022v\n\rSetInProgress\022.."
+    "mavsdk.rpc.camera_server.SetInProgressRe"
+    "quest\032/.mavsdk.rpc.camera_server.SetInPr"
+    "ogressResponse\"\004\200\265\030\001\022~\n\022SubscribeTakePho"
+    "to\0223.mavsdk.rpc.camera_server.SubscribeT"
+    "akePhotoRequest\032+.mavsdk.rpc.camera_serv"
+    "er.TakePhotoResponse\"\004\200\265\030\0000\001\022\177\n\020RespondT"
+    "akePhoto\0221.mavsdk.rpc.camera_server.Resp"
+    "ondTakePhotoRequest\0322.mavsdk.rpc.camera_"
+    "server.RespondTakePhotoResponse\"\004\200\265\030\001\022\201\001"
+    "\n\023SubscribeStartVideo\0224.mavsdk.rpc.camer"
+    "a_server.SubscribeStartVideoRequest\032,.ma"
+    "vsdk.rpc.camera_server.StartVideoRespons"
+    "e\"\004\200\265\030\0000\001\022\202\001\n\021RespondStartVideo\0222.mavsdk"
+    ".rpc.camera_server.RespondStartVideoRequ"
+    "est\0323.mavsdk.rpc.camera_server.RespondSt"
+    "artVideoResponse\"\004\200\265\030\001\022~\n\022SubscribeStopV"
+    "ideo\0223.mavsdk.rpc.camera_server.Subscrib"
+    "eStopVideoRequest\032+.mavsdk.rpc.camera_se"
+    "rver.StopVideoResponse\"\004\200\265\030\0000\001\022\177\n\020Respon"
+    "dStopVideo\0221.mavsdk.rpc.camera_server.Re"
+    "spondStopVideoRequest\0322.mavsdk.rpc.camer"
+    "a_server.RespondStopVideoResponse\"\004\200\265\030\001\022"
+    "\234\001\n\034SubscribeStartVideoStreaming\022=.mavsd"
+    "k.rpc.camera_server.SubscribeStartVideoS"
+    "treamingRequest\0325.mavsdk.rpc.camera_serv"
+    "er.StartVideoStreamingResponse\"\004\200\265\030\0000\001\022\235"
+    "\001\n\032RespondStartVideoStreaming\022;.mavsdk.r"
+    "pc.camera_server.RespondStartVideoStream"
+    "ingRequest\032<.mavsdk.rpc.camera_server.Re"
+    "spondStartVideoStreamingResponse\"\004\200\265\030\001\022\231"
+    "\001\n\033SubscribeStopVideoStreaming\022<.mavsdk."
+    "rpc.camera_server.SubscribeStopVideoStre"
+    "amingRequest\0324.mavsdk.rpc.camera_server."
+    "StopVideoStreamingResponse\"\004\200\265\030\0000\001\022\232\001\n\031R"
+    "espondStopVideoStreaming\022:.mavsdk.rpc.ca"
+    "mera_server.RespondStopVideoStreamingReq"
+    "uest\032;.mavsdk.rpc.camera_server.RespondS"
+    "topVideoStreamingResponse\"\004\200\265\030\001\022x\n\020Subsc"
+    "ribeSetMode\0221.mavsdk.rpc.camera_server.S"
+    "ubscribeSetModeRequest\032).mavsdk.rpc.came"
+    "ra_server.SetModeResponse\"\004\200\265\030\0000\001\022y\n\016Res"
+    "pondSetMode\022/.mavsdk.rpc.camera_server.R"
+    "espondSetModeRequest\0320.mavsdk.rpc.camera"
+    "_server.RespondSetModeResponse\"\004\200\265\030\001\022\231\001\n"
+    "\033SubscribeStorageInformation\022<.mavsdk.rp"
+    "c.camera_server.SubscribeStorageInformat"
+    "ionRequest\0324.mavsdk.rpc.camera_server.St"
+    "orageInformationResponse\"\004\200\265\030\0000\001\022\232\001\n\031Res"
+    "pondStorageInformation\022:.mavsdk.rpc.came"
+    "ra_server.RespondStorageInformationReque"
+    "st\032;.mavsdk.rpc.camera_server.RespondSto"
+    "rageInformationResponse\"\004\200\265\030\001\022\212\001\n\026Subscr"
+    "ibeCaptureStatus\0227.mavsdk.rpc.camera_ser"
+    "ver.SubscribeCaptureStatusRequest\032/.mavs"
+    "dk.rpc.camera_server.CaptureStatusRespon"
+    "se\"\004\200\265\030\0000\001\022\213\001\n\024RespondCaptureStatus\0225.ma"
+    "vsdk.rpc.camera_server.RespondCaptureSta"
+    "tusRequest\0326.mavsdk.rpc.camera_server.Re"
+    "spondCaptureStatusResponse\"\004\200\265\030\001\022\212\001\n\026Sub"
+    "scribeFormatStorage\0227.mavsdk.rpc.camera_"
+    "server.SubscribeFormatStorageRequest\032/.m"
+    "avsdk.rpc.camera_server.FormatStorageRes"
+    "ponse\"\004\200\265\030\0000\001\022\213\001\n\024RespondFormatStorage\0225"
+    ".mavsdk.rpc.camera_server.RespondFormatS"
+    "torageRequest\0326.mavsdk.rpc.camera_server"
+    ".RespondFormatStorageResponse\"\004\200\265\030\001\022\212\001\n\026"
+    "SubscribeResetSettings\0227.mavsdk.rpc.came"
+    "ra_server.SubscribeResetSettingsRequest\032"
+    "/.mavsdk.rpc.camera_server.ResetSettings"
+    "Response\"\004\200\265\030\0000\001\022\213\001\n\024RespondResetSetting"
+    "s\0225.mavsdk.rpc.camera_server.RespondRese"
+    "tSettingsRequest\0326.mavsdk.rpc.camera_ser"
+    "ver.RespondResetSettingsResponse\"\004\200\265\030\001\022\204"
+    "\001\n\024SubscribeZoomInStart\0225.mavsdk.rpc.cam"
+    "era_server.SubscribeZoomInStartRequest\032-"
+    ".mavsdk.rpc.camera_server.ZoomInStartRes"
+    "ponse\"\004\200\265\030\0000\001\022\205\001\n\022RespondZoomInStart\0223.m"
+    "avsdk.rpc.camera_server.RespondZoomInSta"
+    "rtRequest\0324.mavsdk.rpc.camera_server.Res"
+    "pondZoomInStartResponse\"\004\200\265\030\001\022\207\001\n\025Subscr"
+    "ibeZoomOutStart\0226.mavsdk.rpc.camera_serv"
+    "er.SubscribeZoomOutStartRequest\032..mavsdk"
+    ".rpc.camera_server.ZoomOutStartResponse\""
+    "\004\200\265\030\0000\001\022\210\001\n\023RespondZoomOutStart\0224.mavsdk"
+    ".rpc.camera_server.RespondZoomOutStartRe"
+    "quest\0325.mavsdk.rpc.camera_server.Respond"
+    "ZoomOutStartResponse\"\004\200\265\030\001\022{\n\021SubscribeZ"
+    "oomStop\0222.mavsdk.rpc.camera_server.Subsc"
+    "ribeZoomStopRequest\032*.mavsdk.rpc.camera_"
+    "server.ZoomStopResponse\"\004\200\265\030\0000\001\022|\n\017Respo"
+    "ndZoomStop\0220.mavsdk.rpc.camera_server.Re"
+    "spondZoomStopRequest\0321.mavsdk.rpc.camera"
+    "_server.RespondZoomStopResponse\"\004\200\265\030\001\022~\n"
+    "\022SubscribeZoomRange\0223.mavsdk.rpc.camera_"
+    "server.SubscribeZoomRangeRequest\032+.mavsd"
+    "k.rpc.camera_server.ZoomRangeResponse\"\004\200"
+    "\265\030\0000\001\022\177\n\020RespondZoomRange\0221.mavsdk.rpc.c"
+    "amera_server.RespondZoomRangeRequest\0322.m"
+    "avsdk.rpc.camera_server.RespondZoomRange"
+    "Response\"\004\200\265\030\001\022\235\001\n\032SetTrackingRectangleS"
+    "tatus\022;.mavsdk.rpc.camera_server.SetTrac"
+    "kingRectangleStatusRequest\032<.mavsdk.rpc."
+    "camera_server.SetTrackingRectangleStatus"
+    "Response\"\004\200\265\030\001\022\213\001\n\024SetTrackingOffStatus\022"
+    "5.mavsdk.rpc.camera_server.SetTrackingOf"
+    "fStatusRequest\0326.mavsdk.rpc.camera_serve"
+    "r.SetTrackingOffStatusResponse\"\004\200\265\030\001\022\237\001\n"
+    "\035SubscribeTrackingPointCommand\022>.mavsdk."
+    "rpc.camera_server.SubscribeTrackingPoint"
+    "CommandRequest\0326.mavsdk.rpc.camera_serve"
+    "r.TrackingPointCommandResponse\"\004\200\265\030\0000\001\022\253"
+    "\001\n!SubscribeTrackingRectangleCommand\022B.m"
+    "avsdk.rpc.camera_server.SubscribeTrackin"
+    "gRectangleCommandRequest\032:.mavsdk.rpc.ca"
+    "mera_server.TrackingRectangleCommandResp"
+    "onse\"\004\200\265\030\0000\001\022\231\001\n\033SubscribeTrackingOffCom"
+    "mand\022<.mavsdk.rpc.camera_server.Subscrib"
+    "eTrackingOffCommandRequest\0324.mavsdk.rpc."
+    "camera_server.TrackingOffCommandResponse"
+    "\"\004\200\265\030\0000\001\022\240\001\n\033RespondTrackingPointCommand"
+    "\022<.mavsdk.rpc.camera_server.RespondTrack"
+    "ingPointCommandRequest\032=.mavsdk.rpc.came"
+    "ra_server.RespondTrackingPointCommandRes"
+    "ponse\"\004\200\265\030\001\022\254\001\n\037RespondTrackingRectangle"
+    "Command\022@.mavsdk.rpc.camera_server.Respo"
+    "ndTrackingRectangleCommandRequest\032A.mavs"
+    "dk.rpc.camera_server.RespondTrackingRect"
+    "angleCommandResponse\"\004\200\265\030\001\022\232\001\n\031RespondTr"
+    "ackingOffCommand\022:.mavsdk.rpc.camera_ser"
+    "ver.RespondTrackingOffCommandRequest\032;.m"
+    "avsdk.rpc.camera_server.RespondTrackingO"
+    "ffCommandResponse\"\004\200\265\030\001\022p\n\013SetPosition\022,"
+    ".mavsdk.rpc.camera_server.SetPositionReq"
+    "uest\032-.mavsdk.rpc.camera_server.SetPosit"
+    "ionResponse\"\004\200\265\030\001\022\216\001\n\025SetAttitudeQuatern"
+    "ion\0226.mavsdk.rpc.camera_server.SetAttitu"
+    "deQuaternionRequest\0327.mavsdk.rpc.camera_"
+    "server.SetAttitudeQuaternionResponse\"\004\200\265"
+    "\030\001\022v\n\rSetZoomFactor\022..mavsdk.rpc.camera_"
+    "server.SetZoomFactorRequest\032/.mavsdk.rpc"
+    ".camera_server.SetZoomFactorResponse\"\004\200\265"
+    "\030\001\022y\n\016SetFieldOfView\022/.mavsdk.rpc.camera"
+    "_server.SetFieldOfViewRequest\0320.mavsdk.r"
+    "pc.camera_server.SetFieldOfViewResponse\""
+    "\004\200\265\030\001B,\n\027io.mavsdk.camera_serverB\021Camera"
+    "ServerProtob\006proto3"
 };
 static const ::_pbi::DescriptorTable* const descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_deps[1] =
     {
@@ -3796,13 +3958,13 @@ static ::absl::once_flag descriptor_table_camera_5fserver_2fcamera_5fserver_2epr
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto = {
     false,
     false,
-    15169,
+    15739,
     descriptor_table_protodef_camera_5fserver_2fcamera_5fserver_2eproto,
     "camera_server/camera_server.proto",
     &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_once,
     descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_deps,
     1,
-    94,
+    98,
     schemas,
     file_default_instances,
     TableStruct_camera_5fserver_2fcamera_5fserver_2eproto::offsets,
@@ -23365,6 +23527,951 @@ void SetAttitudeQuaternionResponse::InternalSwap(SetAttitudeQuaternionResponse* 
 }
 
 ::google::protobuf::Metadata SetAttitudeQuaternionResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SetZoomFactorRequest::_Internal {
+ public:
+};
+
+SetZoomFactorRequest::SetZoomFactorRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SetZoomFactorRequest)
+}
+SetZoomFactorRequest::SetZoomFactorRequest(
+    ::google::protobuf::Arena* arena, const SetZoomFactorRequest& from)
+    : SetZoomFactorRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE SetZoomFactorRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void SetZoomFactorRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.zoom_factor_ = {};
+}
+SetZoomFactorRequest::~SetZoomFactorRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.SetZoomFactorRequest)
+  SharedDtor(*this);
+}
+inline void SetZoomFactorRequest::SharedDtor(MessageLite& self) {
+  SetZoomFactorRequest& this_ = static_cast<SetZoomFactorRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* SetZoomFactorRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SetZoomFactorRequest(arena);
+}
+constexpr auto SetZoomFactorRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SetZoomFactorRequest),
+                                            alignof(SetZoomFactorRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SetZoomFactorRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SetZoomFactorRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SetZoomFactorRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<SetZoomFactorRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SetZoomFactorRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<SetZoomFactorRequest>(), &SetZoomFactorRequest::ByteSizeLong,
+            &SetZoomFactorRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SetZoomFactorRequest, _impl_._cached_size_),
+        false,
+    },
+    &SetZoomFactorRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SetZoomFactorRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> SetZoomFactorRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::SetZoomFactorRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // float zoom_factor = 1;
+    {::_pbi::TcParser::FastF32S1,
+     {13, 63, 0, PROTOBUF_FIELD_OFFSET(SetZoomFactorRequest, _impl_.zoom_factor_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // float zoom_factor = 1;
+    {PROTOBUF_FIELD_OFFSET(SetZoomFactorRequest, _impl_.zoom_factor_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void SetZoomFactorRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.SetZoomFactorRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.zoom_factor_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* SetZoomFactorRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const SetZoomFactorRequest& this_ = static_cast<const SetZoomFactorRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* SetZoomFactorRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const SetZoomFactorRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.SetZoomFactorRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // float zoom_factor = 1;
+          if (::absl::bit_cast<::uint32_t>(this_._internal_zoom_factor()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                1, this_._internal_zoom_factor(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.SetZoomFactorRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t SetZoomFactorRequest::ByteSizeLong(const MessageLite& base) {
+          const SetZoomFactorRequest& this_ = static_cast<const SetZoomFactorRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t SetZoomFactorRequest::ByteSizeLong() const {
+          const SetZoomFactorRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.SetZoomFactorRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // float zoom_factor = 1;
+            if (::absl::bit_cast<::uint32_t>(this_._internal_zoom_factor()) != 0) {
+              total_size += 5;
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void SetZoomFactorRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<SetZoomFactorRequest*>(&to_msg);
+  auto& from = static_cast<const SetZoomFactorRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.SetZoomFactorRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (::absl::bit_cast<::uint32_t>(from._internal_zoom_factor()) != 0) {
+    _this->_impl_.zoom_factor_ = from._impl_.zoom_factor_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SetZoomFactorRequest::CopyFrom(const SetZoomFactorRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.SetZoomFactorRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void SetZoomFactorRequest::InternalSwap(SetZoomFactorRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.zoom_factor_, other->_impl_.zoom_factor_);
+}
+
+::google::protobuf::Metadata SetZoomFactorRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SetZoomFactorResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<SetZoomFactorResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(SetZoomFactorResponse, _impl_._has_bits_);
+};
+
+SetZoomFactorResponse::SetZoomFactorResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SetZoomFactorResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE SetZoomFactorResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera_server::SetZoomFactorResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+SetZoomFactorResponse::SetZoomFactorResponse(
+    ::google::protobuf::Arena* arena,
+    const SetZoomFactorResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SetZoomFactorResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_server_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(
+                              arena, *from._impl_.camera_server_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.SetZoomFactorResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE SetZoomFactorResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void SetZoomFactorResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_server_result_ = {};
+}
+SetZoomFactorResponse::~SetZoomFactorResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.SetZoomFactorResponse)
+  SharedDtor(*this);
+}
+inline void SetZoomFactorResponse::SharedDtor(MessageLite& self) {
+  SetZoomFactorResponse& this_ = static_cast<SetZoomFactorResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.camera_server_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* SetZoomFactorResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SetZoomFactorResponse(arena);
+}
+constexpr auto SetZoomFactorResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SetZoomFactorResponse),
+                                            alignof(SetZoomFactorResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SetZoomFactorResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SetZoomFactorResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SetZoomFactorResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<SetZoomFactorResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SetZoomFactorResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<SetZoomFactorResponse>(), &SetZoomFactorResponse::ByteSizeLong,
+            &SetZoomFactorResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SetZoomFactorResponse, _impl_._cached_size_),
+        false,
+    },
+    &SetZoomFactorResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SetZoomFactorResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> SetZoomFactorResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(SetZoomFactorResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::SetZoomFactorResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(SetZoomFactorResponse, _impl_.camera_server_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {PROTOBUF_FIELD_OFFSET(SetZoomFactorResponse, _impl_.camera_server_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::CameraServerResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void SetZoomFactorResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.SetZoomFactorResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_server_result_ != nullptr);
+    _impl_.camera_server_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* SetZoomFactorResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const SetZoomFactorResponse& this_ = static_cast<const SetZoomFactorResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* SetZoomFactorResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const SetZoomFactorResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.SetZoomFactorResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.camera_server_result_, this_._impl_.camera_server_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.SetZoomFactorResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t SetZoomFactorResponse::ByteSizeLong(const MessageLite& base) {
+          const SetZoomFactorResponse& this_ = static_cast<const SetZoomFactorResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t SetZoomFactorResponse::ByteSizeLong() const {
+          const SetZoomFactorResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.SetZoomFactorResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.camera_server_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void SetZoomFactorResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<SetZoomFactorResponse*>(&to_msg);
+  auto& from = static_cast<const SetZoomFactorResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.SetZoomFactorResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.camera_server_result_ != nullptr);
+    if (_this->_impl_.camera_server_result_ == nullptr) {
+      _this->_impl_.camera_server_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(arena, *from._impl_.camera_server_result_);
+    } else {
+      _this->_impl_.camera_server_result_->MergeFrom(*from._impl_.camera_server_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SetZoomFactorResponse::CopyFrom(const SetZoomFactorResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.SetZoomFactorResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void SetZoomFactorResponse::InternalSwap(SetZoomFactorResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_server_result_, other->_impl_.camera_server_result_);
+}
+
+::google::protobuf::Metadata SetZoomFactorResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SetFieldOfViewRequest::_Internal {
+ public:
+};
+
+SetFieldOfViewRequest::SetFieldOfViewRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SetFieldOfViewRequest)
+}
+SetFieldOfViewRequest::SetFieldOfViewRequest(
+    ::google::protobuf::Arena* arena, const SetFieldOfViewRequest& from)
+    : SetFieldOfViewRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE SetFieldOfViewRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void SetFieldOfViewRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  ::memset(reinterpret_cast<char *>(&_impl_) +
+               offsetof(Impl_, horizontal_fov_deg_),
+           0,
+           offsetof(Impl_, vertical_fov_deg_) -
+               offsetof(Impl_, horizontal_fov_deg_) +
+               sizeof(Impl_::vertical_fov_deg_));
+}
+SetFieldOfViewRequest::~SetFieldOfViewRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.SetFieldOfViewRequest)
+  SharedDtor(*this);
+}
+inline void SetFieldOfViewRequest::SharedDtor(MessageLite& self) {
+  SetFieldOfViewRequest& this_ = static_cast<SetFieldOfViewRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* SetFieldOfViewRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SetFieldOfViewRequest(arena);
+}
+constexpr auto SetFieldOfViewRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SetFieldOfViewRequest),
+                                            alignof(SetFieldOfViewRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SetFieldOfViewRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SetFieldOfViewRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SetFieldOfViewRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<SetFieldOfViewRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SetFieldOfViewRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<SetFieldOfViewRequest>(), &SetFieldOfViewRequest::ByteSizeLong,
+            &SetFieldOfViewRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SetFieldOfViewRequest, _impl_._cached_size_),
+        false,
+    },
+    &SetFieldOfViewRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SetFieldOfViewRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<1, 2, 0, 0, 2> SetFieldOfViewRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    2, 8,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967292,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    2,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::SetFieldOfViewRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // float vertical_fov_deg = 2;
+    {::_pbi::TcParser::FastF32S1,
+     {21, 63, 0, PROTOBUF_FIELD_OFFSET(SetFieldOfViewRequest, _impl_.vertical_fov_deg_)}},
+    // float horizontal_fov_deg = 1;
+    {::_pbi::TcParser::FastF32S1,
+     {13, 63, 0, PROTOBUF_FIELD_OFFSET(SetFieldOfViewRequest, _impl_.horizontal_fov_deg_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // float horizontal_fov_deg = 1;
+    {PROTOBUF_FIELD_OFFSET(SetFieldOfViewRequest, _impl_.horizontal_fov_deg_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+    // float vertical_fov_deg = 2;
+    {PROTOBUF_FIELD_OFFSET(SetFieldOfViewRequest, _impl_.vertical_fov_deg_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void SetFieldOfViewRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.SetFieldOfViewRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  ::memset(&_impl_.horizontal_fov_deg_, 0, static_cast<::size_t>(
+      reinterpret_cast<char*>(&_impl_.vertical_fov_deg_) -
+      reinterpret_cast<char*>(&_impl_.horizontal_fov_deg_)) + sizeof(_impl_.vertical_fov_deg_));
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* SetFieldOfViewRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const SetFieldOfViewRequest& this_ = static_cast<const SetFieldOfViewRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* SetFieldOfViewRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const SetFieldOfViewRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.SetFieldOfViewRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // float horizontal_fov_deg = 1;
+          if (::absl::bit_cast<::uint32_t>(this_._internal_horizontal_fov_deg()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                1, this_._internal_horizontal_fov_deg(), target);
+          }
+
+          // float vertical_fov_deg = 2;
+          if (::absl::bit_cast<::uint32_t>(this_._internal_vertical_fov_deg()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                2, this_._internal_vertical_fov_deg(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.SetFieldOfViewRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t SetFieldOfViewRequest::ByteSizeLong(const MessageLite& base) {
+          const SetFieldOfViewRequest& this_ = static_cast<const SetFieldOfViewRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t SetFieldOfViewRequest::ByteSizeLong() const {
+          const SetFieldOfViewRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.SetFieldOfViewRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+          ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+           {
+            // float horizontal_fov_deg = 1;
+            if (::absl::bit_cast<::uint32_t>(this_._internal_horizontal_fov_deg()) != 0) {
+              total_size += 5;
+            }
+            // float vertical_fov_deg = 2;
+            if (::absl::bit_cast<::uint32_t>(this_._internal_vertical_fov_deg()) != 0) {
+              total_size += 5;
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void SetFieldOfViewRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<SetFieldOfViewRequest*>(&to_msg);
+  auto& from = static_cast<const SetFieldOfViewRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.SetFieldOfViewRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (::absl::bit_cast<::uint32_t>(from._internal_horizontal_fov_deg()) != 0) {
+    _this->_impl_.horizontal_fov_deg_ = from._impl_.horizontal_fov_deg_;
+  }
+  if (::absl::bit_cast<::uint32_t>(from._internal_vertical_fov_deg()) != 0) {
+    _this->_impl_.vertical_fov_deg_ = from._impl_.vertical_fov_deg_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SetFieldOfViewRequest::CopyFrom(const SetFieldOfViewRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.SetFieldOfViewRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void SetFieldOfViewRequest::InternalSwap(SetFieldOfViewRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::google::protobuf::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(SetFieldOfViewRequest, _impl_.vertical_fov_deg_)
+      + sizeof(SetFieldOfViewRequest::_impl_.vertical_fov_deg_)
+      - PROTOBUF_FIELD_OFFSET(SetFieldOfViewRequest, _impl_.horizontal_fov_deg_)>(
+          reinterpret_cast<char*>(&_impl_.horizontal_fov_deg_),
+          reinterpret_cast<char*>(&other->_impl_.horizontal_fov_deg_));
+}
+
+::google::protobuf::Metadata SetFieldOfViewRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SetFieldOfViewResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<SetFieldOfViewResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(SetFieldOfViewResponse, _impl_._has_bits_);
+};
+
+SetFieldOfViewResponse::SetFieldOfViewResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SetFieldOfViewResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE SetFieldOfViewResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera_server::SetFieldOfViewResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+SetFieldOfViewResponse::SetFieldOfViewResponse(
+    ::google::protobuf::Arena* arena,
+    const SetFieldOfViewResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SetFieldOfViewResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_server_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(
+                              arena, *from._impl_.camera_server_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.SetFieldOfViewResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE SetFieldOfViewResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void SetFieldOfViewResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_server_result_ = {};
+}
+SetFieldOfViewResponse::~SetFieldOfViewResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.SetFieldOfViewResponse)
+  SharedDtor(*this);
+}
+inline void SetFieldOfViewResponse::SharedDtor(MessageLite& self) {
+  SetFieldOfViewResponse& this_ = static_cast<SetFieldOfViewResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.camera_server_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* SetFieldOfViewResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SetFieldOfViewResponse(arena);
+}
+constexpr auto SetFieldOfViewResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SetFieldOfViewResponse),
+                                            alignof(SetFieldOfViewResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SetFieldOfViewResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SetFieldOfViewResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SetFieldOfViewResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<SetFieldOfViewResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SetFieldOfViewResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<SetFieldOfViewResponse>(), &SetFieldOfViewResponse::ByteSizeLong,
+            &SetFieldOfViewResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SetFieldOfViewResponse, _impl_._cached_size_),
+        false,
+    },
+    &SetFieldOfViewResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SetFieldOfViewResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> SetFieldOfViewResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(SetFieldOfViewResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::SetFieldOfViewResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(SetFieldOfViewResponse, _impl_.camera_server_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {PROTOBUF_FIELD_OFFSET(SetFieldOfViewResponse, _impl_.camera_server_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::CameraServerResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void SetFieldOfViewResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.SetFieldOfViewResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_server_result_ != nullptr);
+    _impl_.camera_server_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* SetFieldOfViewResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const SetFieldOfViewResponse& this_ = static_cast<const SetFieldOfViewResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* SetFieldOfViewResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const SetFieldOfViewResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.SetFieldOfViewResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.camera_server_result_, this_._impl_.camera_server_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.SetFieldOfViewResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t SetFieldOfViewResponse::ByteSizeLong(const MessageLite& base) {
+          const SetFieldOfViewResponse& this_ = static_cast<const SetFieldOfViewResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t SetFieldOfViewResponse::ByteSizeLong() const {
+          const SetFieldOfViewResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.SetFieldOfViewResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.camera_server_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void SetFieldOfViewResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<SetFieldOfViewResponse*>(&to_msg);
+  auto& from = static_cast<const SetFieldOfViewResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.SetFieldOfViewResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.camera_server_result_ != nullptr);
+    if (_this->_impl_.camera_server_result_ == nullptr) {
+      _this->_impl_.camera_server_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(arena, *from._impl_.camera_server_result_);
+    } else {
+      _this->_impl_.camera_server_result_->MergeFrom(*from._impl_.camera_server_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SetFieldOfViewResponse::CopyFrom(const SetFieldOfViewResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.SetFieldOfViewResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void SetFieldOfViewResponse::InternalSwap(SetFieldOfViewResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_server_result_, other->_impl_.camera_server_result_);
+}
+
+::google::protobuf::Metadata SetFieldOfViewResponse::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================

--- a/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.pb.h
+++ b/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.pb.h
@@ -186,6 +186,12 @@ extern RespondZoomStopRequestDefaultTypeInternal _RespondZoomStopRequest_default
 class RespondZoomStopResponse;
 struct RespondZoomStopResponseDefaultTypeInternal;
 extern RespondZoomStopResponseDefaultTypeInternal _RespondZoomStopResponse_default_instance_;
+class SetAttitudeQuaternionRequest;
+struct SetAttitudeQuaternionRequestDefaultTypeInternal;
+extern SetAttitudeQuaternionRequestDefaultTypeInternal _SetAttitudeQuaternionRequest_default_instance_;
+class SetAttitudeQuaternionResponse;
+struct SetAttitudeQuaternionResponseDefaultTypeInternal;
+extern SetAttitudeQuaternionResponseDefaultTypeInternal _SetAttitudeQuaternionResponse_default_instance_;
 class SetInProgressRequest;
 struct SetInProgressRequestDefaultTypeInternal;
 extern SetInProgressRequestDefaultTypeInternal _SetInProgressRequest_default_instance_;
@@ -201,6 +207,12 @@ extern SetInformationResponseDefaultTypeInternal _SetInformationResponse_default
 class SetModeResponse;
 struct SetModeResponseDefaultTypeInternal;
 extern SetModeResponseDefaultTypeInternal _SetModeResponse_default_instance_;
+class SetPositionRequest;
+struct SetPositionRequestDefaultTypeInternal;
+extern SetPositionRequestDefaultTypeInternal _SetPositionRequest_default_instance_;
+class SetPositionResponse;
+struct SetPositionResponseDefaultTypeInternal;
+extern SetPositionResponseDefaultTypeInternal _SetPositionResponse_default_instance_;
 class SetTrackingOffStatusRequest;
 struct SetTrackingOffStatusRequestDefaultTypeInternal;
 extern SetTrackingOffStatusRequestDefaultTypeInternal _SetTrackingOffStatusRequest_default_instance_;
@@ -1811,7 +1823,7 @@ class TrackRectangle final
     return reinterpret_cast<const TrackRectangle*>(
         &_TrackRectangle_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 89;
+  static constexpr int kIndexInFileMessages = 93;
   friend void swap(TrackRectangle& a, TrackRectangle& b) { a.Swap(&b); }
   inline void Swap(TrackRectangle* other) {
     if (other == this) return;
@@ -2038,7 +2050,7 @@ class TrackPoint final
     return reinterpret_cast<const TrackPoint*>(
         &_TrackPoint_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 88;
+  static constexpr int kIndexInFileMessages = 92;
   friend void swap(TrackPoint& a, TrackPoint& b) { a.Swap(&b); }
   inline void Swap(TrackPoint* other) {
     if (other == this) return;
@@ -12874,6 +12886,400 @@ class SetTrackingPointStatusRequest final
 };
 // -------------------------------------------------------------------
 
+class SetPositionResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SetPositionResponse) */ {
+ public:
+  inline SetPositionResponse() : SetPositionResponse(nullptr) {}
+  ~SetPositionResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SetPositionResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SetPositionResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SetPositionResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SetPositionResponse(const SetPositionResponse& from) : SetPositionResponse(nullptr, from) {}
+  inline SetPositionResponse(SetPositionResponse&& from) noexcept
+      : SetPositionResponse(nullptr, std::move(from)) {}
+  inline SetPositionResponse& operator=(const SetPositionResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetPositionResponse& operator=(SetPositionResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SetPositionResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SetPositionResponse* internal_default_instance() {
+    return reinterpret_cast<const SetPositionResponse*>(
+        &_SetPositionResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 89;
+  friend void swap(SetPositionResponse& a, SetPositionResponse& b) { a.Swap(&b); }
+  inline void Swap(SetPositionResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetPositionResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SetPositionResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<SetPositionResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const SetPositionResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const SetPositionResponse& from) { SetPositionResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(SetPositionResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.SetPositionResponse"; }
+
+ protected:
+  explicit SetPositionResponse(::google::protobuf::Arena* arena);
+  SetPositionResponse(::google::protobuf::Arena* arena, const SetPositionResponse& from);
+  SetPositionResponse(::google::protobuf::Arena* arena, SetPositionResponse&& from) noexcept
+      : SetPositionResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCameraServerResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+  bool has_camera_server_result() const;
+  void clear_camera_server_result() ;
+  const ::mavsdk::rpc::camera_server::CameraServerResult& camera_server_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera_server::CameraServerResult* release_camera_server_result();
+  ::mavsdk::rpc::camera_server::CameraServerResult* mutable_camera_server_result();
+  void set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  void unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  ::mavsdk::rpc::camera_server::CameraServerResult* unsafe_arena_release_camera_server_result();
+
+  private:
+  const ::mavsdk::rpc::camera_server::CameraServerResult& _internal_camera_server_result() const;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _internal_mutable_camera_server_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SetPositionResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SetPositionResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera_server::CameraServerResult* camera_server_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SetPositionRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SetPositionRequest) */ {
+ public:
+  inline SetPositionRequest() : SetPositionRequest(nullptr) {}
+  ~SetPositionRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SetPositionRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SetPositionRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SetPositionRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SetPositionRequest(const SetPositionRequest& from) : SetPositionRequest(nullptr, from) {}
+  inline SetPositionRequest(SetPositionRequest&& from) noexcept
+      : SetPositionRequest(nullptr, std::move(from)) {}
+  inline SetPositionRequest& operator=(const SetPositionRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetPositionRequest& operator=(SetPositionRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SetPositionRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SetPositionRequest* internal_default_instance() {
+    return reinterpret_cast<const SetPositionRequest*>(
+        &_SetPositionRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 88;
+  friend void swap(SetPositionRequest& a, SetPositionRequest& b) { a.Swap(&b); }
+  inline void Swap(SetPositionRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetPositionRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SetPositionRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<SetPositionRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const SetPositionRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const SetPositionRequest& from) { SetPositionRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(SetPositionRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.SetPositionRequest"; }
+
+ protected:
+  explicit SetPositionRequest(::google::protobuf::Arena* arena);
+  SetPositionRequest(::google::protobuf::Arena* arena, const SetPositionRequest& from);
+  SetPositionRequest(::google::protobuf::Arena* arena, SetPositionRequest&& from) noexcept
+      : SetPositionRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kPositionFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.Position position = 1;
+  bool has_position() const;
+  void clear_position() ;
+  const ::mavsdk::rpc::camera_server::Position& position() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera_server::Position* release_position();
+  ::mavsdk::rpc::camera_server::Position* mutable_position();
+  void set_allocated_position(::mavsdk::rpc::camera_server::Position* value);
+  void unsafe_arena_set_allocated_position(::mavsdk::rpc::camera_server::Position* value);
+  ::mavsdk::rpc::camera_server::Position* unsafe_arena_release_position();
+
+  private:
+  const ::mavsdk::rpc::camera_server::Position& _internal_position() const;
+  ::mavsdk::rpc::camera_server::Position* _internal_mutable_position();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SetPositionRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SetPositionRequest& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera_server::Position* position_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
 class SetInformationResponse final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SetInformationResponse) */ {
@@ -13458,6 +13864,400 @@ class SetInProgressResponse final
     ::google::protobuf::internal::HasBits<1> _has_bits_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     ::mavsdk::rpc::camera_server::CameraServerResult* camera_server_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SetAttitudeQuaternionResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SetAttitudeQuaternionResponse) */ {
+ public:
+  inline SetAttitudeQuaternionResponse() : SetAttitudeQuaternionResponse(nullptr) {}
+  ~SetAttitudeQuaternionResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SetAttitudeQuaternionResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SetAttitudeQuaternionResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SetAttitudeQuaternionResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SetAttitudeQuaternionResponse(const SetAttitudeQuaternionResponse& from) : SetAttitudeQuaternionResponse(nullptr, from) {}
+  inline SetAttitudeQuaternionResponse(SetAttitudeQuaternionResponse&& from) noexcept
+      : SetAttitudeQuaternionResponse(nullptr, std::move(from)) {}
+  inline SetAttitudeQuaternionResponse& operator=(const SetAttitudeQuaternionResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetAttitudeQuaternionResponse& operator=(SetAttitudeQuaternionResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SetAttitudeQuaternionResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SetAttitudeQuaternionResponse* internal_default_instance() {
+    return reinterpret_cast<const SetAttitudeQuaternionResponse*>(
+        &_SetAttitudeQuaternionResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 91;
+  friend void swap(SetAttitudeQuaternionResponse& a, SetAttitudeQuaternionResponse& b) { a.Swap(&b); }
+  inline void Swap(SetAttitudeQuaternionResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetAttitudeQuaternionResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SetAttitudeQuaternionResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<SetAttitudeQuaternionResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const SetAttitudeQuaternionResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const SetAttitudeQuaternionResponse& from) { SetAttitudeQuaternionResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(SetAttitudeQuaternionResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.SetAttitudeQuaternionResponse"; }
+
+ protected:
+  explicit SetAttitudeQuaternionResponse(::google::protobuf::Arena* arena);
+  SetAttitudeQuaternionResponse(::google::protobuf::Arena* arena, const SetAttitudeQuaternionResponse& from);
+  SetAttitudeQuaternionResponse(::google::protobuf::Arena* arena, SetAttitudeQuaternionResponse&& from) noexcept
+      : SetAttitudeQuaternionResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCameraServerResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+  bool has_camera_server_result() const;
+  void clear_camera_server_result() ;
+  const ::mavsdk::rpc::camera_server::CameraServerResult& camera_server_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera_server::CameraServerResult* release_camera_server_result();
+  ::mavsdk::rpc::camera_server::CameraServerResult* mutable_camera_server_result();
+  void set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  void unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  ::mavsdk::rpc::camera_server::CameraServerResult* unsafe_arena_release_camera_server_result();
+
+  private:
+  const ::mavsdk::rpc::camera_server::CameraServerResult& _internal_camera_server_result() const;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _internal_mutable_camera_server_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SetAttitudeQuaternionResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SetAttitudeQuaternionResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera_server::CameraServerResult* camera_server_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SetAttitudeQuaternionRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SetAttitudeQuaternionRequest) */ {
+ public:
+  inline SetAttitudeQuaternionRequest() : SetAttitudeQuaternionRequest(nullptr) {}
+  ~SetAttitudeQuaternionRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SetAttitudeQuaternionRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SetAttitudeQuaternionRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SetAttitudeQuaternionRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SetAttitudeQuaternionRequest(const SetAttitudeQuaternionRequest& from) : SetAttitudeQuaternionRequest(nullptr, from) {}
+  inline SetAttitudeQuaternionRequest(SetAttitudeQuaternionRequest&& from) noexcept
+      : SetAttitudeQuaternionRequest(nullptr, std::move(from)) {}
+  inline SetAttitudeQuaternionRequest& operator=(const SetAttitudeQuaternionRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetAttitudeQuaternionRequest& operator=(SetAttitudeQuaternionRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SetAttitudeQuaternionRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SetAttitudeQuaternionRequest* internal_default_instance() {
+    return reinterpret_cast<const SetAttitudeQuaternionRequest*>(
+        &_SetAttitudeQuaternionRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 90;
+  friend void swap(SetAttitudeQuaternionRequest& a, SetAttitudeQuaternionRequest& b) { a.Swap(&b); }
+  inline void Swap(SetAttitudeQuaternionRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetAttitudeQuaternionRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SetAttitudeQuaternionRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<SetAttitudeQuaternionRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const SetAttitudeQuaternionRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const SetAttitudeQuaternionRequest& from) { SetAttitudeQuaternionRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(SetAttitudeQuaternionRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.SetAttitudeQuaternionRequest"; }
+
+ protected:
+  explicit SetAttitudeQuaternionRequest(::google::protobuf::Arena* arena);
+  SetAttitudeQuaternionRequest(::google::protobuf::Arena* arena, const SetAttitudeQuaternionRequest& from);
+  SetAttitudeQuaternionRequest(::google::protobuf::Arena* arena, SetAttitudeQuaternionRequest&& from) noexcept
+      : SetAttitudeQuaternionRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kAttitudeQuaternionFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.Quaternion attitude_quaternion = 1;
+  bool has_attitude_quaternion() const;
+  void clear_attitude_quaternion() ;
+  const ::mavsdk::rpc::camera_server::Quaternion& attitude_quaternion() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera_server::Quaternion* release_attitude_quaternion();
+  ::mavsdk::rpc::camera_server::Quaternion* mutable_attitude_quaternion();
+  void set_allocated_attitude_quaternion(::mavsdk::rpc::camera_server::Quaternion* value);
+  void unsafe_arena_set_allocated_attitude_quaternion(::mavsdk::rpc::camera_server::Quaternion* value);
+  ::mavsdk::rpc::camera_server::Quaternion* unsafe_arena_release_attitude_quaternion();
+
+  private:
+  const ::mavsdk::rpc::camera_server::Quaternion& _internal_attitude_quaternion() const;
+  ::mavsdk::rpc::camera_server::Quaternion* _internal_mutable_attitude_quaternion();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SetAttitudeQuaternionRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SetAttitudeQuaternionRequest& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera_server::Quaternion* attitude_quaternion_;
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
   union { Impl_ _impl_; };
@@ -22900,6 +23700,406 @@ inline void RespondTrackingOffCommandResponse::set_allocated_camera_server_resul
 
   _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
   // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.RespondTrackingOffCommandResponse.camera_server_result)
+}
+
+// -------------------------------------------------------------------
+
+// SetPositionRequest
+
+// .mavsdk.rpc.camera_server.Position position = 1;
+inline bool SetPositionRequest::has_position() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.position_ != nullptr);
+  return value;
+}
+inline void SetPositionRequest::clear_position() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.position_ != nullptr) _impl_.position_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera_server::Position& SetPositionRequest::_internal_position() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera_server::Position* p = _impl_.position_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera_server::Position&>(::mavsdk::rpc::camera_server::_Position_default_instance_);
+}
+inline const ::mavsdk::rpc::camera_server::Position& SetPositionRequest::position() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.SetPositionRequest.position)
+  return _internal_position();
+}
+inline void SetPositionRequest::unsafe_arena_set_allocated_position(::mavsdk::rpc::camera_server::Position* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.position_);
+  }
+  _impl_.position_ = reinterpret_cast<::mavsdk::rpc::camera_server::Position*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera_server.SetPositionRequest.position)
+}
+inline ::mavsdk::rpc::camera_server::Position* SetPositionRequest::release_position() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::Position* released = _impl_.position_;
+  _impl_.position_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera_server::Position* SetPositionRequest::unsafe_arena_release_position() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera_server.SetPositionRequest.position)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::Position* temp = _impl_.position_;
+  _impl_.position_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera_server::Position* SetPositionRequest::_internal_mutable_position() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.position_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera_server::Position>(GetArena());
+    _impl_.position_ = reinterpret_cast<::mavsdk::rpc::camera_server::Position*>(p);
+  }
+  return _impl_.position_;
+}
+inline ::mavsdk::rpc::camera_server::Position* SetPositionRequest::mutable_position() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera_server::Position* _msg = _internal_mutable_position();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera_server.SetPositionRequest.position)
+  return _msg;
+}
+inline void SetPositionRequest::set_allocated_position(::mavsdk::rpc::camera_server::Position* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.position_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.position_ = reinterpret_cast<::mavsdk::rpc::camera_server::Position*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.SetPositionRequest.position)
+}
+
+// -------------------------------------------------------------------
+
+// SetPositionResponse
+
+// .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+inline bool SetPositionResponse::has_camera_server_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_server_result_ != nullptr);
+  return value;
+}
+inline void SetPositionResponse::clear_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ != nullptr) _impl_.camera_server_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& SetPositionResponse::_internal_camera_server_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera_server::CameraServerResult* p = _impl_.camera_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera_server::CameraServerResult&>(::mavsdk::rpc::camera_server::_CameraServerResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& SetPositionResponse::camera_server_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.SetPositionResponse.camera_server_result)
+  return _internal_camera_server_result();
+}
+inline void SetPositionResponse::unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_server_result_);
+  }
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera_server.SetPositionResponse.camera_server_result)
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SetPositionResponse::release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* released = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SetPositionResponse::unsafe_arena_release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera_server.SetPositionResponse.camera_server_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* temp = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SetPositionResponse::_internal_mutable_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(GetArena());
+    _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(p);
+  }
+  return _impl_.camera_server_result_;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SetPositionResponse::mutable_camera_server_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _msg = _internal_mutable_camera_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera_server.SetPositionResponse.camera_server_result)
+  return _msg;
+}
+inline void SetPositionResponse::set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.camera_server_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.SetPositionResponse.camera_server_result)
+}
+
+// -------------------------------------------------------------------
+
+// SetAttitudeQuaternionRequest
+
+// .mavsdk.rpc.camera_server.Quaternion attitude_quaternion = 1;
+inline bool SetAttitudeQuaternionRequest::has_attitude_quaternion() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.attitude_quaternion_ != nullptr);
+  return value;
+}
+inline void SetAttitudeQuaternionRequest::clear_attitude_quaternion() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.attitude_quaternion_ != nullptr) _impl_.attitude_quaternion_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera_server::Quaternion& SetAttitudeQuaternionRequest::_internal_attitude_quaternion() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera_server::Quaternion* p = _impl_.attitude_quaternion_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera_server::Quaternion&>(::mavsdk::rpc::camera_server::_Quaternion_default_instance_);
+}
+inline const ::mavsdk::rpc::camera_server::Quaternion& SetAttitudeQuaternionRequest::attitude_quaternion() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.SetAttitudeQuaternionRequest.attitude_quaternion)
+  return _internal_attitude_quaternion();
+}
+inline void SetAttitudeQuaternionRequest::unsafe_arena_set_allocated_attitude_quaternion(::mavsdk::rpc::camera_server::Quaternion* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.attitude_quaternion_);
+  }
+  _impl_.attitude_quaternion_ = reinterpret_cast<::mavsdk::rpc::camera_server::Quaternion*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera_server.SetAttitudeQuaternionRequest.attitude_quaternion)
+}
+inline ::mavsdk::rpc::camera_server::Quaternion* SetAttitudeQuaternionRequest::release_attitude_quaternion() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::Quaternion* released = _impl_.attitude_quaternion_;
+  _impl_.attitude_quaternion_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera_server::Quaternion* SetAttitudeQuaternionRequest::unsafe_arena_release_attitude_quaternion() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera_server.SetAttitudeQuaternionRequest.attitude_quaternion)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::Quaternion* temp = _impl_.attitude_quaternion_;
+  _impl_.attitude_quaternion_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera_server::Quaternion* SetAttitudeQuaternionRequest::_internal_mutable_attitude_quaternion() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.attitude_quaternion_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera_server::Quaternion>(GetArena());
+    _impl_.attitude_quaternion_ = reinterpret_cast<::mavsdk::rpc::camera_server::Quaternion*>(p);
+  }
+  return _impl_.attitude_quaternion_;
+}
+inline ::mavsdk::rpc::camera_server::Quaternion* SetAttitudeQuaternionRequest::mutable_attitude_quaternion() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera_server::Quaternion* _msg = _internal_mutable_attitude_quaternion();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera_server.SetAttitudeQuaternionRequest.attitude_quaternion)
+  return _msg;
+}
+inline void SetAttitudeQuaternionRequest::set_allocated_attitude_quaternion(::mavsdk::rpc::camera_server::Quaternion* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.attitude_quaternion_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.attitude_quaternion_ = reinterpret_cast<::mavsdk::rpc::camera_server::Quaternion*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.SetAttitudeQuaternionRequest.attitude_quaternion)
+}
+
+// -------------------------------------------------------------------
+
+// SetAttitudeQuaternionResponse
+
+// .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+inline bool SetAttitudeQuaternionResponse::has_camera_server_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_server_result_ != nullptr);
+  return value;
+}
+inline void SetAttitudeQuaternionResponse::clear_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ != nullptr) _impl_.camera_server_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& SetAttitudeQuaternionResponse::_internal_camera_server_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera_server::CameraServerResult* p = _impl_.camera_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera_server::CameraServerResult&>(::mavsdk::rpc::camera_server::_CameraServerResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& SetAttitudeQuaternionResponse::camera_server_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.SetAttitudeQuaternionResponse.camera_server_result)
+  return _internal_camera_server_result();
+}
+inline void SetAttitudeQuaternionResponse::unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_server_result_);
+  }
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera_server.SetAttitudeQuaternionResponse.camera_server_result)
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SetAttitudeQuaternionResponse::release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* released = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SetAttitudeQuaternionResponse::unsafe_arena_release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera_server.SetAttitudeQuaternionResponse.camera_server_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* temp = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SetAttitudeQuaternionResponse::_internal_mutable_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(GetArena());
+    _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(p);
+  }
+  return _impl_.camera_server_result_;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SetAttitudeQuaternionResponse::mutable_camera_server_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _msg = _internal_mutable_camera_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera_server.SetAttitudeQuaternionResponse.camera_server_result)
+  return _msg;
+}
+inline void SetAttitudeQuaternionResponse::set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.camera_server_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.SetAttitudeQuaternionResponse.camera_server_result)
 }
 
 // -------------------------------------------------------------------

--- a/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.pb.h
+++ b/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.pb.h
@@ -192,6 +192,12 @@ extern SetAttitudeQuaternionRequestDefaultTypeInternal _SetAttitudeQuaternionReq
 class SetAttitudeQuaternionResponse;
 struct SetAttitudeQuaternionResponseDefaultTypeInternal;
 extern SetAttitudeQuaternionResponseDefaultTypeInternal _SetAttitudeQuaternionResponse_default_instance_;
+class SetFieldOfViewRequest;
+struct SetFieldOfViewRequestDefaultTypeInternal;
+extern SetFieldOfViewRequestDefaultTypeInternal _SetFieldOfViewRequest_default_instance_;
+class SetFieldOfViewResponse;
+struct SetFieldOfViewResponseDefaultTypeInternal;
+extern SetFieldOfViewResponseDefaultTypeInternal _SetFieldOfViewResponse_default_instance_;
 class SetInProgressRequest;
 struct SetInProgressRequestDefaultTypeInternal;
 extern SetInProgressRequestDefaultTypeInternal _SetInProgressRequest_default_instance_;
@@ -237,6 +243,12 @@ extern SetVideoStreamingRequestDefaultTypeInternal _SetVideoStreamingRequest_def
 class SetVideoStreamingResponse;
 struct SetVideoStreamingResponseDefaultTypeInternal;
 extern SetVideoStreamingResponseDefaultTypeInternal _SetVideoStreamingResponse_default_instance_;
+class SetZoomFactorRequest;
+struct SetZoomFactorRequestDefaultTypeInternal;
+extern SetZoomFactorRequestDefaultTypeInternal _SetZoomFactorRequest_default_instance_;
+class SetZoomFactorResponse;
+struct SetZoomFactorResponseDefaultTypeInternal;
+extern SetZoomFactorResponseDefaultTypeInternal _SetZoomFactorResponse_default_instance_;
 class StartVideoResponse;
 struct StartVideoResponseDefaultTypeInternal;
 extern StartVideoResponseDefaultTypeInternal _StartVideoResponse_default_instance_;
@@ -1823,7 +1835,7 @@ class TrackRectangle final
     return reinterpret_cast<const TrackRectangle*>(
         &_TrackRectangle_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 93;
+  static constexpr int kIndexInFileMessages = 97;
   friend void swap(TrackRectangle& a, TrackRectangle& b) { a.Swap(&b); }
   inline void Swap(TrackRectangle* other) {
     if (other == this) return;
@@ -2050,7 +2062,7 @@ class TrackPoint final
     return reinterpret_cast<const TrackPoint*>(
         &_TrackPoint_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 92;
+  static constexpr int kIndexInFileMessages = 96;
   friend void swap(TrackPoint& a, TrackPoint& b) { a.Swap(&b); }
   inline void Swap(TrackPoint* other) {
     if (other == this) return;
@@ -6152,6 +6164,197 @@ class StartVideoResponse final
 };
 // -------------------------------------------------------------------
 
+class SetZoomFactorRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SetZoomFactorRequest) */ {
+ public:
+  inline SetZoomFactorRequest() : SetZoomFactorRequest(nullptr) {}
+  ~SetZoomFactorRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SetZoomFactorRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SetZoomFactorRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SetZoomFactorRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SetZoomFactorRequest(const SetZoomFactorRequest& from) : SetZoomFactorRequest(nullptr, from) {}
+  inline SetZoomFactorRequest(SetZoomFactorRequest&& from) noexcept
+      : SetZoomFactorRequest(nullptr, std::move(from)) {}
+  inline SetZoomFactorRequest& operator=(const SetZoomFactorRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetZoomFactorRequest& operator=(SetZoomFactorRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SetZoomFactorRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SetZoomFactorRequest* internal_default_instance() {
+    return reinterpret_cast<const SetZoomFactorRequest*>(
+        &_SetZoomFactorRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 92;
+  friend void swap(SetZoomFactorRequest& a, SetZoomFactorRequest& b) { a.Swap(&b); }
+  inline void Swap(SetZoomFactorRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetZoomFactorRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SetZoomFactorRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<SetZoomFactorRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const SetZoomFactorRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const SetZoomFactorRequest& from) { SetZoomFactorRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(SetZoomFactorRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.SetZoomFactorRequest"; }
+
+ protected:
+  explicit SetZoomFactorRequest(::google::protobuf::Arena* arena);
+  SetZoomFactorRequest(::google::protobuf::Arena* arena, const SetZoomFactorRequest& from);
+  SetZoomFactorRequest(::google::protobuf::Arena* arena, SetZoomFactorRequest&& from) noexcept
+      : SetZoomFactorRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kZoomFactorFieldNumber = 1,
+  };
+  // float zoom_factor = 1;
+  void clear_zoom_factor() ;
+  float zoom_factor() const;
+  void set_zoom_factor(float value);
+
+  private:
+  float _internal_zoom_factor() const;
+  void _internal_set_zoom_factor(float value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SetZoomFactorRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SetZoomFactorRequest& from_msg);
+    float zoom_factor_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
 class SetTrackingRectangleStatusResponse final
     : public ::google::protobuf::internal::ZeroFieldsBase
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SetTrackingRectangleStatusResponse) */ {
@@ -7110,6 +7313,209 @@ class SetInProgressRequest final
                           ::google::protobuf::Arena* arena, const Impl_& from,
                           const SetInProgressRequest& from_msg);
     bool in_progress_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SetFieldOfViewRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SetFieldOfViewRequest) */ {
+ public:
+  inline SetFieldOfViewRequest() : SetFieldOfViewRequest(nullptr) {}
+  ~SetFieldOfViewRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SetFieldOfViewRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SetFieldOfViewRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SetFieldOfViewRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SetFieldOfViewRequest(const SetFieldOfViewRequest& from) : SetFieldOfViewRequest(nullptr, from) {}
+  inline SetFieldOfViewRequest(SetFieldOfViewRequest&& from) noexcept
+      : SetFieldOfViewRequest(nullptr, std::move(from)) {}
+  inline SetFieldOfViewRequest& operator=(const SetFieldOfViewRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetFieldOfViewRequest& operator=(SetFieldOfViewRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SetFieldOfViewRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SetFieldOfViewRequest* internal_default_instance() {
+    return reinterpret_cast<const SetFieldOfViewRequest*>(
+        &_SetFieldOfViewRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 94;
+  friend void swap(SetFieldOfViewRequest& a, SetFieldOfViewRequest& b) { a.Swap(&b); }
+  inline void Swap(SetFieldOfViewRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetFieldOfViewRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SetFieldOfViewRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<SetFieldOfViewRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const SetFieldOfViewRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const SetFieldOfViewRequest& from) { SetFieldOfViewRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(SetFieldOfViewRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.SetFieldOfViewRequest"; }
+
+ protected:
+  explicit SetFieldOfViewRequest(::google::protobuf::Arena* arena);
+  SetFieldOfViewRequest(::google::protobuf::Arena* arena, const SetFieldOfViewRequest& from);
+  SetFieldOfViewRequest(::google::protobuf::Arena* arena, SetFieldOfViewRequest&& from) noexcept
+      : SetFieldOfViewRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kHorizontalFovDegFieldNumber = 1,
+    kVerticalFovDegFieldNumber = 2,
+  };
+  // float horizontal_fov_deg = 1;
+  void clear_horizontal_fov_deg() ;
+  float horizontal_fov_deg() const;
+  void set_horizontal_fov_deg(float value);
+
+  private:
+  float _internal_horizontal_fov_deg() const;
+  void _internal_set_horizontal_fov_deg(float value);
+
+  public:
+  // float vertical_fov_deg = 2;
+  void clear_vertical_fov_deg() ;
+  float vertical_fov_deg() const;
+  void set_vertical_fov_deg(float value);
+
+  private:
+  float _internal_vertical_fov_deg() const;
+  void _internal_set_vertical_fov_deg(float value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SetFieldOfViewRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      1, 2, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SetFieldOfViewRequest& from_msg);
+    float horizontal_fov_deg_;
+    float vertical_fov_deg_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
@@ -12098,6 +12504,203 @@ class TrackingPointCommandResponse final
 };
 // -------------------------------------------------------------------
 
+class SetZoomFactorResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SetZoomFactorResponse) */ {
+ public:
+  inline SetZoomFactorResponse() : SetZoomFactorResponse(nullptr) {}
+  ~SetZoomFactorResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SetZoomFactorResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SetZoomFactorResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SetZoomFactorResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SetZoomFactorResponse(const SetZoomFactorResponse& from) : SetZoomFactorResponse(nullptr, from) {}
+  inline SetZoomFactorResponse(SetZoomFactorResponse&& from) noexcept
+      : SetZoomFactorResponse(nullptr, std::move(from)) {}
+  inline SetZoomFactorResponse& operator=(const SetZoomFactorResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetZoomFactorResponse& operator=(SetZoomFactorResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SetZoomFactorResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SetZoomFactorResponse* internal_default_instance() {
+    return reinterpret_cast<const SetZoomFactorResponse*>(
+        &_SetZoomFactorResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 93;
+  friend void swap(SetZoomFactorResponse& a, SetZoomFactorResponse& b) { a.Swap(&b); }
+  inline void Swap(SetZoomFactorResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetZoomFactorResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SetZoomFactorResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<SetZoomFactorResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const SetZoomFactorResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const SetZoomFactorResponse& from) { SetZoomFactorResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(SetZoomFactorResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.SetZoomFactorResponse"; }
+
+ protected:
+  explicit SetZoomFactorResponse(::google::protobuf::Arena* arena);
+  SetZoomFactorResponse(::google::protobuf::Arena* arena, const SetZoomFactorResponse& from);
+  SetZoomFactorResponse(::google::protobuf::Arena* arena, SetZoomFactorResponse&& from) noexcept
+      : SetZoomFactorResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCameraServerResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+  bool has_camera_server_result() const;
+  void clear_camera_server_result() ;
+  const ::mavsdk::rpc::camera_server::CameraServerResult& camera_server_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera_server::CameraServerResult* release_camera_server_result();
+  ::mavsdk::rpc::camera_server::CameraServerResult* mutable_camera_server_result();
+  void set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  void unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  ::mavsdk::rpc::camera_server::CameraServerResult* unsafe_arena_release_camera_server_result();
+
+  private:
+  const ::mavsdk::rpc::camera_server::CameraServerResult& _internal_camera_server_result() const;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _internal_mutable_camera_server_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SetZoomFactorResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SetZoomFactorResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera_server::CameraServerResult* camera_server_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
 class SetVideoStreamingResponse final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SetVideoStreamingResponse) */ {
@@ -13861,6 +14464,203 @@ class SetInProgressResponse final
     inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
                           ::google::protobuf::Arena* arena, const Impl_& from,
                           const SetInProgressResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera_server::CameraServerResult* camera_server_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SetFieldOfViewResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SetFieldOfViewResponse) */ {
+ public:
+  inline SetFieldOfViewResponse() : SetFieldOfViewResponse(nullptr) {}
+  ~SetFieldOfViewResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SetFieldOfViewResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SetFieldOfViewResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SetFieldOfViewResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SetFieldOfViewResponse(const SetFieldOfViewResponse& from) : SetFieldOfViewResponse(nullptr, from) {}
+  inline SetFieldOfViewResponse(SetFieldOfViewResponse&& from) noexcept
+      : SetFieldOfViewResponse(nullptr, std::move(from)) {}
+  inline SetFieldOfViewResponse& operator=(const SetFieldOfViewResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetFieldOfViewResponse& operator=(SetFieldOfViewResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SetFieldOfViewResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SetFieldOfViewResponse* internal_default_instance() {
+    return reinterpret_cast<const SetFieldOfViewResponse*>(
+        &_SetFieldOfViewResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 95;
+  friend void swap(SetFieldOfViewResponse& a, SetFieldOfViewResponse& b) { a.Swap(&b); }
+  inline void Swap(SetFieldOfViewResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetFieldOfViewResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SetFieldOfViewResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<SetFieldOfViewResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const SetFieldOfViewResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const SetFieldOfViewResponse& from) { SetFieldOfViewResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(SetFieldOfViewResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.SetFieldOfViewResponse"; }
+
+ protected:
+  explicit SetFieldOfViewResponse(::google::protobuf::Arena* arena);
+  SetFieldOfViewResponse(::google::protobuf::Arena* arena, const SetFieldOfViewResponse& from);
+  SetFieldOfViewResponse(::google::protobuf::Arena* arena, SetFieldOfViewResponse&& from) noexcept
+      : SetFieldOfViewResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCameraServerResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+  bool has_camera_server_result() const;
+  void clear_camera_server_result() ;
+  const ::mavsdk::rpc::camera_server::CameraServerResult& camera_server_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera_server::CameraServerResult* release_camera_server_result();
+  ::mavsdk::rpc::camera_server::CameraServerResult* mutable_camera_server_result();
+  void set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  void unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  ::mavsdk::rpc::camera_server::CameraServerResult* unsafe_arena_release_camera_server_result();
+
+  private:
+  const ::mavsdk::rpc::camera_server::CameraServerResult& _internal_camera_server_result() const;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _internal_mutable_camera_server_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SetFieldOfViewResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SetFieldOfViewResponse& from_msg);
     ::google::protobuf::internal::HasBits<1> _has_bits_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     ::mavsdk::rpc::camera_server::CameraServerResult* camera_server_result_;
@@ -24100,6 +24900,280 @@ inline void SetAttitudeQuaternionResponse::set_allocated_camera_server_result(::
 
   _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
   // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.SetAttitudeQuaternionResponse.camera_server_result)
+}
+
+// -------------------------------------------------------------------
+
+// SetZoomFactorRequest
+
+// float zoom_factor = 1;
+inline void SetZoomFactorRequest::clear_zoom_factor() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.zoom_factor_ = 0;
+}
+inline float SetZoomFactorRequest::zoom_factor() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.SetZoomFactorRequest.zoom_factor)
+  return _internal_zoom_factor();
+}
+inline void SetZoomFactorRequest::set_zoom_factor(float value) {
+  _internal_set_zoom_factor(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.SetZoomFactorRequest.zoom_factor)
+}
+inline float SetZoomFactorRequest::_internal_zoom_factor() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.zoom_factor_;
+}
+inline void SetZoomFactorRequest::_internal_set_zoom_factor(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.zoom_factor_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// SetZoomFactorResponse
+
+// .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+inline bool SetZoomFactorResponse::has_camera_server_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_server_result_ != nullptr);
+  return value;
+}
+inline void SetZoomFactorResponse::clear_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ != nullptr) _impl_.camera_server_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& SetZoomFactorResponse::_internal_camera_server_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera_server::CameraServerResult* p = _impl_.camera_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera_server::CameraServerResult&>(::mavsdk::rpc::camera_server::_CameraServerResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& SetZoomFactorResponse::camera_server_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.SetZoomFactorResponse.camera_server_result)
+  return _internal_camera_server_result();
+}
+inline void SetZoomFactorResponse::unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_server_result_);
+  }
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera_server.SetZoomFactorResponse.camera_server_result)
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SetZoomFactorResponse::release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* released = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SetZoomFactorResponse::unsafe_arena_release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera_server.SetZoomFactorResponse.camera_server_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* temp = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SetZoomFactorResponse::_internal_mutable_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(GetArena());
+    _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(p);
+  }
+  return _impl_.camera_server_result_;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SetZoomFactorResponse::mutable_camera_server_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _msg = _internal_mutable_camera_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera_server.SetZoomFactorResponse.camera_server_result)
+  return _msg;
+}
+inline void SetZoomFactorResponse::set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.camera_server_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.SetZoomFactorResponse.camera_server_result)
+}
+
+// -------------------------------------------------------------------
+
+// SetFieldOfViewRequest
+
+// float horizontal_fov_deg = 1;
+inline void SetFieldOfViewRequest::clear_horizontal_fov_deg() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.horizontal_fov_deg_ = 0;
+}
+inline float SetFieldOfViewRequest::horizontal_fov_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.SetFieldOfViewRequest.horizontal_fov_deg)
+  return _internal_horizontal_fov_deg();
+}
+inline void SetFieldOfViewRequest::set_horizontal_fov_deg(float value) {
+  _internal_set_horizontal_fov_deg(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.SetFieldOfViewRequest.horizontal_fov_deg)
+}
+inline float SetFieldOfViewRequest::_internal_horizontal_fov_deg() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.horizontal_fov_deg_;
+}
+inline void SetFieldOfViewRequest::_internal_set_horizontal_fov_deg(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.horizontal_fov_deg_ = value;
+}
+
+// float vertical_fov_deg = 2;
+inline void SetFieldOfViewRequest::clear_vertical_fov_deg() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.vertical_fov_deg_ = 0;
+}
+inline float SetFieldOfViewRequest::vertical_fov_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.SetFieldOfViewRequest.vertical_fov_deg)
+  return _internal_vertical_fov_deg();
+}
+inline void SetFieldOfViewRequest::set_vertical_fov_deg(float value) {
+  _internal_set_vertical_fov_deg(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.SetFieldOfViewRequest.vertical_fov_deg)
+}
+inline float SetFieldOfViewRequest::_internal_vertical_fov_deg() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.vertical_fov_deg_;
+}
+inline void SetFieldOfViewRequest::_internal_set_vertical_fov_deg(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.vertical_fov_deg_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// SetFieldOfViewResponse
+
+// .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+inline bool SetFieldOfViewResponse::has_camera_server_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_server_result_ != nullptr);
+  return value;
+}
+inline void SetFieldOfViewResponse::clear_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ != nullptr) _impl_.camera_server_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& SetFieldOfViewResponse::_internal_camera_server_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera_server::CameraServerResult* p = _impl_.camera_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera_server::CameraServerResult&>(::mavsdk::rpc::camera_server::_CameraServerResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& SetFieldOfViewResponse::camera_server_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.SetFieldOfViewResponse.camera_server_result)
+  return _internal_camera_server_result();
+}
+inline void SetFieldOfViewResponse::unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_server_result_);
+  }
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera_server.SetFieldOfViewResponse.camera_server_result)
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SetFieldOfViewResponse::release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* released = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SetFieldOfViewResponse::unsafe_arena_release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera_server.SetFieldOfViewResponse.camera_server_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* temp = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SetFieldOfViewResponse::_internal_mutable_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(GetArena());
+    _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(p);
+  }
+  return _impl_.camera_server_result_;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* SetFieldOfViewResponse::mutable_camera_server_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _msg = _internal_mutable_camera_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera_server.SetFieldOfViewResponse.camera_server_result)
+  return _msg;
+}
+inline void SetFieldOfViewResponse::set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.camera_server_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.SetFieldOfViewResponse.camera_server_result)
 }
 
 // -------------------------------------------------------------------

--- a/cpp/src/mavsdk_server/src/plugins/camera_server/camera_server_service_impl.hpp
+++ b/cpp/src/mavsdk_server/src/plugins/camera_server/camera_server_service_impl.hpp
@@ -2369,6 +2369,76 @@ public:
         return grpc::Status::OK;
     }
 
+    grpc::Status SetPosition(
+        grpc::ServerContext* /* context */,
+        const rpc::camera_server::SetPositionRequest* request,
+        rpc::camera_server::SetPositionResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                
+                // For server plugins, this should never happen, they should always be constructible.
+                auto result = mavsdk::CameraServer::Result::Unknown;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("SetPosition sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->set_position(translateFromRpcPosition(request->position()));
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status SetAttitudeQuaternion(
+        grpc::ServerContext* /* context */,
+        const rpc::camera_server::SetAttitudeQuaternionRequest* request,
+        rpc::camera_server::SetAttitudeQuaternionResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                
+                // For server plugins, this should never happen, they should always be constructible.
+                auto result = mavsdk::CameraServer::Result::Unknown;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("SetAttitudeQuaternion sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->set_attitude_quaternion(translateFromRpcQuaternion(request->attitude_quaternion()));
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
 
     void stop() {
         _stopped.store(true);

--- a/cpp/src/mavsdk_server/src/plugins/camera_server/camera_server_service_impl.hpp
+++ b/cpp/src/mavsdk_server/src/plugins/camera_server/camera_server_service_impl.hpp
@@ -2439,6 +2439,78 @@ public:
         return grpc::Status::OK;
     }
 
+    grpc::Status SetZoomFactor(
+        grpc::ServerContext* /* context */,
+        const rpc::camera_server::SetZoomFactorRequest* request,
+        rpc::camera_server::SetZoomFactorResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                
+                // For server plugins, this should never happen, they should always be constructible.
+                auto result = mavsdk::CameraServer::Result::Unknown;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("SetZoomFactor sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->set_zoom_factor(request->zoom_factor());
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status SetFieldOfView(
+        grpc::ServerContext* /* context */,
+        const rpc::camera_server::SetFieldOfViewRequest* request,
+        rpc::camera_server::SetFieldOfViewResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                
+                // For server plugins, this should never happen, they should always be constructible.
+                auto result = mavsdk::CameraServer::Result::Unknown;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("SetFieldOfView sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->set_field_of_view(request->horizontal_fov_deg(), request->vertical_fov_deg());
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
 
     void stop() {
         _stopped.store(true);

--- a/docs/en/cpp/api_reference/classmavsdk_1_1_camera_server.md
+++ b/docs/en/cpp/api_reference/classmavsdk_1_1_camera_server.md
@@ -136,6 +136,10 @@ void | [unsubscribe_tracking_off_command](#classmavsdk_1_1_camera_server_1a13d8e
 [Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) | [respond_tracking_point_command](#classmavsdk_1_1_camera_server_1a8749824a1326cc0a7c441fb7c59b9507) ([CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) stop_video_feedback)const | Respond to an incoming tracking point command.
 [Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) | [respond_tracking_rectangle_command](#classmavsdk_1_1_camera_server_1a2de79ab19b5d51e6760eb3173e9c6f77) ([CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) stop_video_feedback)const | Respond to an incoming tracking rectangle command.
 [Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) | [respond_tracking_off_command](#classmavsdk_1_1_camera_server_1a31e8a3a8996ae48afbacbef38d31e209) ([CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) stop_video_feedback)const | Respond to an incoming tracking off command.
+[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) | [set_position](#classmavsdk_1_1_camera_server_1aee649f5b8fa7db7f74deebc18058cbc2) ([Position](structmavsdk_1_1_camera_server_1_1_position.md) position)const | Set the camera's GPS position.
+[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) | [set_attitude_quaternion](#classmavsdk_1_1_camera_server_1aeeafba3a35282f6bb2060c1856d58210) ([Quaternion](structmavsdk_1_1_camera_server_1_1_quaternion.md) attitude_quaternion)const | Set the camera's attitude quaternion.
+[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) | [set_zoom_factor](#classmavsdk_1_1_camera_server_1a7cf67492b8e3de09d0ada977bac5f72d) (float zoom_factor)const | Set the camera's zoom factor for CAMERA_FOV_STATUS reporting.
+[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) | [set_field_of_view](#classmavsdk_1_1_camera_server_1ab2c068c98c0a215041f5115d2844852a) (float horizontal_fov_deg, float vertical_fov_deg)const | Set the field of view explicitly, for cameras that do not report a zoom factor.
 const [CameraServer](classmavsdk_1_1_camera_server.md) & | [operator=](#classmavsdk_1_1_camera_server_1a6b516bbddcbaa2867d1a11be8eda14bd) (const [CameraServer](classmavsdk_1_1_camera_server.md) &)=delete | Equality operator (object is not copyable).
 
 
@@ -1476,6 +1480,79 @@ This function is blocking.
 **Parameters**
 
 * [CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) **stop_video_feedback** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) - Result of request.
+
+### set_position() {#classmavsdk_1_1_camera_server_1aee649f5b8fa7db7f74deebc18058cbc2}
+```cpp
+Result mavsdk::CameraServer::set_position(Position position) const
+```
+
+
+Set the camera's GPS position.
+
+This function is blocking.
+
+**Parameters**
+
+* [Position](structmavsdk_1_1_camera_server_1_1_position.md) **position** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) - Result of request.
+
+### set_attitude_quaternion() {#classmavsdk_1_1_camera_server_1aeeafba3a35282f6bb2060c1856d58210}
+```cpp
+Result mavsdk::CameraServer::set_attitude_quaternion(Quaternion attitude_quaternion) const
+```
+
+
+Set the camera's attitude quaternion.
+
+This function is blocking.
+
+**Parameters**
+
+* [Quaternion](structmavsdk_1_1_camera_server_1_1_quaternion.md) **attitude_quaternion** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) - Result of request.
+
+### set_zoom_factor() {#classmavsdk_1_1_camera_server_1a7cf67492b8e3de09d0ada977bac5f72d}
+```cpp
+Result mavsdk::CameraServer::set_zoom_factor(float zoom_factor) const
+```
+
+
+Set the camera's zoom factor for CAMERA_FOV_STATUS reporting.
+
+This function is blocking.
+
+**Parameters**
+
+* float **zoom_factor** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) - Result of request.
+
+### set_field_of_view() {#classmavsdk_1_1_camera_server_1ab2c068c98c0a215041f5115d2844852a}
+```cpp
+Result mavsdk::CameraServer::set_field_of_view(float horizontal_fov_deg, float vertical_fov_deg) const
+```
+
+
+Set the field of view explicitly, for cameras that do not report a zoom factor.
+
+This function is blocking.
+
+**Parameters**
+
+* float **horizontal_fov_deg** - 
+* float **vertical_fov_deg** - 
 
 **Returns**
 

--- a/py/aiomavsdk/aiomavsdk/plugins/camera_server/camera_server.py
+++ b/py/aiomavsdk/aiomavsdk/plugins/camera_server/camera_server.py
@@ -871,6 +871,78 @@ class CameraServerAsync:
             None, lambda: self._plugin.respond_tracking_off_command(stop_video_feedback)
         )
 
+    async def set_position(self, position):
+        """
+        Set the camera's GPS position.
+
+        Parameters
+        ----------
+        position : Position
+        Raises
+        ------
+        CameraServerError
+            If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self._plugin.set_position(position)
+        )
+
+    async def set_attitude_quaternion(self, attitude_quaternion):
+        """
+        Set the camera's attitude quaternion.
+
+        Parameters
+        ----------
+        attitude_quaternion : Quaternion
+        Raises
+        ------
+        CameraServerError
+            If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self._plugin.set_attitude_quaternion(attitude_quaternion)
+        )
+
+    async def set_zoom_factor(self, zoom_factor):
+        """
+        Set the camera's zoom factor for CAMERA_FOV_STATUS reporting.
+
+        Parameters
+        ----------
+        zoom_factor : float
+        Raises
+        ------
+        CameraServerError
+            If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self._plugin.set_zoom_factor(zoom_factor)
+        )
+
+    async def set_field_of_view(self, horizontal_fov_deg, vertical_fov_deg):
+        """
+        Set the field of view explicitly, for cameras that do not report a zoom factor.
+
+        Parameters
+        ----------
+        horizontal_fov_deg : float
+        vertical_fov_deg : float
+        Raises
+        ------
+        CameraServerError
+            If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None,
+            lambda: self._plugin.set_field_of_view(
+                horizontal_fov_deg, vertical_fov_deg
+            ),
+        )
+
     def destroy(self):
         self._subscription_handles.clear()
         self._plugin.destroy()

--- a/py/mavsdk/mavsdk/plugins/camera_server/camera_server.py
+++ b/py/mavsdk/mavsdk/plugins/camera_server/camera_server.py
@@ -1418,6 +1418,59 @@ class CameraServer:
 
         return result
 
+    def set_position(self, position):
+        """Get set_position (blocking)"""
+
+        result_code = self._lib.mavsdk_camera_server_set_position(
+            self._handle,
+            position.to_c_struct(),
+        )
+        result = CameraServerResult(result_code)
+        if result != CameraServerResult.SUCCESS:
+            raise Exception(f"set_position failed: {result}")
+
+        return result
+
+    def set_attitude_quaternion(self, attitude_quaternion):
+        """Get set_attitude_quaternion (blocking)"""
+
+        result_code = self._lib.mavsdk_camera_server_set_attitude_quaternion(
+            self._handle,
+            attitude_quaternion.to_c_struct(),
+        )
+        result = CameraServerResult(result_code)
+        if result != CameraServerResult.SUCCESS:
+            raise Exception(f"set_attitude_quaternion failed: {result}")
+
+        return result
+
+    def set_zoom_factor(self, zoom_factor):
+        """Get set_zoom_factor (blocking)"""
+
+        result_code = self._lib.mavsdk_camera_server_set_zoom_factor(
+            self._handle,
+            zoom_factor,
+        )
+        result = CameraServerResult(result_code)
+        if result != CameraServerResult.SUCCESS:
+            raise Exception(f"set_zoom_factor failed: {result}")
+
+        return result
+
+    def set_field_of_view(self, horizontal_fov_deg, vertical_fov_deg):
+        """Get set_field_of_view (blocking)"""
+
+        result_code = self._lib.mavsdk_camera_server_set_field_of_view(
+            self._handle,
+            horizontal_fov_deg,
+            vertical_fov_deg,
+        )
+        result = CameraServerResult(result_code)
+        if result != CameraServerResult.SUCCESS:
+            raise Exception(f"set_field_of_view failed: {result}")
+
+        return result
+
     def destroy(self):
         """Destroy the plugin instance"""
         if self._handle:
@@ -1928,3 +1981,32 @@ _cmavsdk_lib.mavsdk_camera_server_respond_tracking_off_command.argtypes = [
 ]
 
 _cmavsdk_lib.mavsdk_camera_server_respond_tracking_off_command.restype = ctypes.c_int
+
+_cmavsdk_lib.mavsdk_camera_server_set_position.argtypes = [
+    ctypes.c_void_p,
+    PositionCStruct,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_set_position.restype = ctypes.c_int
+
+_cmavsdk_lib.mavsdk_camera_server_set_attitude_quaternion.argtypes = [
+    ctypes.c_void_p,
+    QuaternionCStruct,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_set_attitude_quaternion.restype = ctypes.c_int
+
+_cmavsdk_lib.mavsdk_camera_server_set_zoom_factor.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_float,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_set_zoom_factor.restype = ctypes.c_int
+
+_cmavsdk_lib.mavsdk_camera_server_set_field_of_view.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_float,
+    ctypes.c_float,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_set_field_of_view.restype = ctypes.c_int


### PR DESCRIPTION
camera_server: Add CAMERA_FOV_STATUS request support

Adds handling for `REQUEST_MESSAGE` targeting `CAMERA_FOV_STATUS` in the camera_server plugin, needed to support QGC's tap-to-point-gimbal feature (https://github.com/mavlink/qgroundcontrol/pull/13612).

## New APIs

- `send_fov_status()` — called automatically when a `REQUEST_MESSAGE` for `CAMERA_FOV_STATUS` is received
- `set_position(lat, lon, alt_amsl, alt_rel)` — caller provides camera GPS position (separated from the telemetry plugin by design)
- `set_attitude_quaternion(w, x, y, z)` — caller provides camera attitude
- `set_zoom_factor(factor)` — zoom factor (≥1.0); used to compute H/V FOV via atan
- `set_field_of_view(h_deg, v_deg)` — fallback for cameras that cannot report zoom factor; caller sets H/V FOV directly in degrees

**FOV fallback logic**: if neither zoom nor FOV has been explicitly set, `send_fov_status` falls back to computing FOV from the sensor size and focal length in `set_information`.

## Proto changes

Companion proto PR: https://github.com/mavlink/MAVSDK-Proto/pull/419

The `proto` submodule is pointed at the bansiesta fork branch while the proto PR is under review; it will be updated to point to `mavlink/MAVSDK-Proto:main` once merged.

## Testing status

The request/response flow has been manually verified. The position, attitude, zoom, and FOV calculation paths are implemented and compile cleanly but still need hardware integration testing.

Co-authored-by: jnomikos <john.nomikos55@gmail.com>