### PR TITLE
test(core): cover Vehicle MAV_TYPE mapping and stream operator

### DIFF
--- a/cpp/src/mavsdk/core/CMakeLists.txt
+++ b/cpp/src/mavsdk/core/CMakeLists.txt
@@ -287,6 +287,7 @@ list(APPEND UNIT_TEST_SOURCES
     ${PROJECT_SOURCE_DIR}/mavsdk/core/flight_mode_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/fs_utils_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/param_value_xml_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/vehicle_test.cpp
 )
 
 if (NOT BUILD_WITHOUT_CURL)

--- a/cpp/src/mavsdk/core/include/mavsdk/vehicle.hpp
+++ b/cpp/src/mavsdk/core/include/mavsdk/vehicle.hpp
@@ -2,6 +2,7 @@
 
 #include <sstream>
 #include "mavlink_include.hpp"
+#include "mavsdk_export.h"
 
 namespace mavsdk {
 
@@ -44,13 +45,13 @@ enum class Vehicle {
  *
  * @return A reference to the stream.
  */
-std::ostream& operator<<(std::ostream& os, const Vehicle& vehicle);
+MAVSDK_PUBLIC std::ostream& operator<<(std::ostream& os, const Vehicle& vehicle);
 
 /**
  * @brief Convert a 'MAV_TYPE' to a `Vehicle`.
  *
  * @return The corresponding `Vehicle`.
  */
-Vehicle to_vehicle_from_mav_type(MAV_TYPE type);
+MAVSDK_PUBLIC Vehicle to_vehicle_from_mav_type(MAV_TYPE type);
 
 } // namespace mavsdk

--- a/cpp/src/mavsdk/core/vehicle_test.cpp
+++ b/cpp/src/mavsdk/core/vehicle_test.cpp
@@ -1,0 +1,58 @@
+#include "vehicle.hpp"
+#include <gtest/gtest.h>
+#include <sstream>
+
+using namespace mavsdk;
+
+TEST(Vehicle, ToVehicleFromMavTypeCommon)
+{
+    EXPECT_EQ(to_vehicle_from_mav_type(MAV_TYPE_GENERIC), Vehicle::Generic);
+    EXPECT_EQ(to_vehicle_from_mav_type(MAV_TYPE_FIXED_WING), Vehicle::FixedWing);
+    EXPECT_EQ(to_vehicle_from_mav_type(MAV_TYPE_QUADROTOR), Vehicle::Quadrotor);
+    EXPECT_EQ(to_vehicle_from_mav_type(MAV_TYPE_HELICOPTER), Vehicle::Helicopter);
+    EXPECT_EQ(to_vehicle_from_mav_type(MAV_TYPE_GROUND_ROVER), Vehicle::GroundRover);
+    EXPECT_EQ(to_vehicle_from_mav_type(MAV_TYPE_SURFACE_BOAT), Vehicle::SurfaceBoat);
+    EXPECT_EQ(to_vehicle_from_mav_type(MAV_TYPE_SUBMARINE), Vehicle::Submarine);
+    EXPECT_EQ(to_vehicle_from_mav_type(MAV_TYPE_HEXAROTOR), Vehicle::Hexarotor);
+    EXPECT_EQ(to_vehicle_from_mav_type(MAV_TYPE_OCTOROTOR), Vehicle::Octorotor);
+    EXPECT_EQ(to_vehicle_from_mav_type(MAV_TYPE_TRICOPTER), Vehicle::Tricopter);
+    EXPECT_EQ(to_vehicle_from_mav_type(MAV_TYPE_VTOL_TILTROTOR), Vehicle::VtolTiltrotor);
+    EXPECT_EQ(to_vehicle_from_mav_type(MAV_TYPE_GENERIC_MULTIROTOR), Vehicle::GenericMultirotor);
+}
+
+TEST(Vehicle, ToVehicleFromMavTypeUnknownFallback)
+{
+    auto bogus = static_cast<MAV_TYPE>(250);
+    EXPECT_EQ(to_vehicle_from_mav_type(bogus), Vehicle::Unknown);
+}
+
+TEST(Vehicle, StreamOperatorKnownAndUnknown)
+{
+    {
+        std::ostringstream oss;
+        oss << Vehicle::Quadrotor;
+        EXPECT_EQ(oss.str(), "Quadrotor");
+    }
+    {
+        std::ostringstream oss;
+        oss << Vehicle::FixedWing;
+        EXPECT_EQ(oss.str(), "FixedWing");
+    }
+    {
+        std::ostringstream oss;
+        oss << Vehicle::Unknown;
+        EXPECT_EQ(oss.str(), "Unknown");
+    }
+    {
+        std::ostringstream oss;
+        oss << static_cast<Vehicle>(250);
+        EXPECT_EQ(oss.str(), "Unknown");
+    }
+}
+
+TEST(Vehicle, VtolAndExoticStream)
+{
+    std::ostringstream oss;
+    oss << Vehicle::VtolTailsitter << "," << Vehicle::Parachute << "," << Vehicle::Dodecarotor;
+    EXPECT_EQ(oss.str(), "VtolTailsitter,Parachute,Dodecarotor");
+}


### PR DESCRIPTION
## Summary

- Unit coverage for `to_vehicle_from_mav_type` on common airframes and unknown fallback.\n- Stream operator labels for common, VTOL, and exotic vehicle enums.

## Motivation

Adds focused unit coverage for pure students of failure regression without production behavior change.

## Verification

- `vehicle_test.cpp` registered in core CMake unit test list
- Offline review of assertions against existing APIs
- No flight/arm/geofence paths touched

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h