### PR TITLE
test(core): cover Autopilot stream operator labels

### DIFF
--- a/cpp/src/mavsdk/core/CMakeLists.txt
+++ b/cpp/src/mavsdk/core/CMakeLists.txt
@@ -287,6 +287,7 @@ list(APPEND UNIT_TEST_SOURCES
     ${PROJECT_SOURCE_DIR}/mavsdk/core/flight_mode_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/fs_utils_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/param_value_xml_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/autopilot_test.cpp
 )
 
 if (NOT BUILD_WITHOUT_CURL)

--- a/cpp/src/mavsdk/core/autopilot_test.cpp
+++ b/cpp/src/mavsdk/core/autopilot_test.cpp
@@ -1,0 +1,29 @@
+#include "autopilot.hpp"
+#include <gtest/gtest.h>
+#include <sstream>
+
+using namespace mavsdk;
+
+TEST(Autopilot, StreamOperator)
+{
+    {
+        std::ostringstream oss;
+        oss << Autopilot::Px4;
+        EXPECT_EQ(oss.str(), "Px4");
+    }
+    {
+        std::ostringstream oss;
+        oss << Autopilot::ArduPilot;
+        EXPECT_EQ(oss.str(), "ArduPilot");
+    }
+    {
+        std::ostringstream oss;
+        oss << Autopilot::Unknown;
+        EXPECT_EQ(oss.str(), "Unknown");
+    }
+    {
+        std::ostringstream oss;
+        oss << static_cast<Autopilot>(99);
+        EXPECT_EQ(oss.str(), "Unknown");
+    }
+}


### PR DESCRIPTION
## Summary

- Unit coverage for `operator<<(Autopilot)` including known values and unknown fallback.

## Motivation

Adds focused unit coverage for pure students of failure regression without production behavior change.

## Verification

- `autopilot_test.cpp` registered in core CMake unit test list
- Offline review of assertions against existing APIs
- No flight/arm/geofence paths touched

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h