### PR TITLE
test(core): cover ParamValue XML set and typed getters

### DIFF
--- a/cpp/src/mavsdk/core/CMakeLists.txt
+++ b/cpp/src/mavsdk/core/CMakeLists.txt
@@ -286,6 +286,7 @@ list(APPEND UNIT_TEST_SOURCES
     ${PROJECT_SOURCE_DIR}/mavsdk/core/crc32_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/flight_mode_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/fs_utils_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/param_value_xml_test.cpp
 )
 
 if (NOT BUILD_WITHOUT_CURL)

--- a/cpp/src/mavsdk/core/param_value_xml_test.cpp
+++ b/cpp/src/mavsdk/core/param_value_xml_test.cpp
@@ -1,0 +1,77 @@
+#include "param_value.hpp"
+#include <gtest/gtest.h>
+#include <cmath>
+
+using namespace mavsdk;
+
+TEST(ParamValue, SetFromXmlCommonTypes)
+{
+    ParamValue v;
+    ASSERT_TRUE(v.set_from_xml("float", "1.25"));
+    ASSERT_TRUE(v.get_float().has_value());
+    EXPECT_FLOAT_EQ(v.get_float().value(), 1.25f);
+    EXPECT_EQ(v.typestr(), "float");
+
+    ASSERT_TRUE(v.set_from_xml("int32", "42"));
+    ASSERT_TRUE(v.get_int().has_value());
+    EXPECT_EQ(v.get_int().value(), 42);
+    EXPECT_EQ(v.typestr(), "int32_t");
+
+    ASSERT_TRUE(v.set_from_xml("int8", "-5"));
+    ASSERT_TRUE(v.get_int().has_value());
+    EXPECT_EQ(v.get_int().value(), -5);
+
+    ASSERT_TRUE(v.set_from_xml("uint16", "65535"));
+    ASSERT_TRUE(v.get_int().has_value());
+    EXPECT_EQ(v.get_int().value(), 65535);
+
+    ASSERT_TRUE(v.set_empty_type_from_xml("float"));
+    EXPECT_EQ(v.typestr(), "float");
+    ASSERT_TRUE(v.get_float().has_value());
+}
+
+TEST(ParamValue, SetAsSameTypePreservesKind)
+{
+    ParamValue f;
+    f.set(0.0f);
+    ASSERT_TRUE(f.set_as_same_type("3.5"));
+    ASSERT_TRUE(f.get_float().has_value());
+    EXPECT_FLOAT_EQ(f.get_float().value(), 3.5f);
+
+    ParamValue i;
+    i.set(static_cast<int32_t>(1));
+    ASSERT_TRUE(i.set_as_same_type("99"));
+    ASSERT_TRUE(i.get_int().has_value());
+    EXPECT_EQ(i.get_int().value(), 99);
+}
+
+TEST(ParamValue, GetIntFloatCustomOptional)
+{
+    ParamValue i;
+    i.set(static_cast<int16_t>(-7));
+    ASSERT_TRUE(i.get_int().has_value());
+    EXPECT_EQ(i.get_int().value(), -7);
+    EXPECT_FALSE(i.get_float().has_value());
+    EXPECT_FALSE(i.get_custom().has_value());
+
+    ParamValue f;
+    f.set(2.0f);
+    ASSERT_TRUE(f.get_float().has_value());
+    EXPECT_FALSE(f.get_int().has_value());
+
+    ParamValue s;
+    s.set(std::string("tag"));
+    ASSERT_TRUE(s.get_custom().has_value());
+    EXPECT_EQ(s.get_custom().value(), "tag");
+    EXPECT_FALSE(s.get_int().has_value());
+}
+
+TEST(ParamValue, UpdateValueTypesafe)
+{
+    ParamValue a;
+    a.set(static_cast<int32_t>(1));
+    ParamValue b;
+    b.set(static_cast<int32_t>(9));
+    a.update_value_typesafe(b);
+    EXPECT_EQ(a.get_int().value(), 9);
+}


### PR DESCRIPTION
## Summary

- Cover set_from_xml / set_empty_type_from_xml / set_as_same_type.\n- Cover get_int/get_float/get_custom optionals and update_value_typesafe.

## Motivation

Adds focused unit coverage for pure helpers steading regression detection without production behavior change.

## Verification

- `param_value_xml_test.cpp` registered in core CMake unit test list
- Offline review of assertions against existing APIs
- No flight/arm/geofence paths touched

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h