### PR TITLE
docs(python): add a migration page for the mavsdk package rename

### DIFF
--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -258,4 +258,5 @@
 * [iOS/Swift](swift/index.md)
 * [Python](python/index.md)
     * [QuickStart](python/quickstart.md)
+    * [Migrating from MAVSDK-Python](python/migration.md)
 * [FAQ](faq.md)

--- a/docs/en/python/index.md
+++ b/docs/en/python/index.md
@@ -1,4 +1,5 @@
-# MAVSDK-Python
+# Python
 
 * [Python QuickStart](quickstart.md)
-* [API documentation](http://mavsdk-python-docs.s3-website.eu-central-1.amazonaws.com/)
+* [Migrating from MAVSDK-Python](migration.md) — the `mavsdk` package on PyPI is changing hands in v4
+* [API documentation for the gRPC wrapper (`mavsdk-grpc`)](http://mavsdk-python-docs.s3-website.eu-central-1.amazonaws.com/)

--- a/docs/en/python/migration.md
+++ b/docs/en/python/migration.md
@@ -47,7 +47,7 @@ This keeps working indefinitely, but receives no further updates.
 
 Beyond the API itself:
 
-- **No `grpcio` dependency**, and no `mavsdk_server` subprocess. The package wraps the MAVSDK C library directly.
+- **No `grpcio` dependency**, and no `mavsdk_server` subprocess. The package wraps the MAVSDK C++ library via the C wrapper directly.
 - **Two interfaces.** `mavsdk` exposes a synchronous, callback-based API; `mavsdk.asyncio` exposes an asyncio API close in spirit to MAVSDK-Python. Both come from the same distribution — there is nothing extra to install.
 - **Explicit system discovery.** MAVSDK-Python hid connection and discovery behind `drone.connect()`. The native binding separates connecting from discovering systems, which matters once more than one vehicle is involved.
 - **Plugins are constructed, not attributes.** `drone.action.arm()` becomes `Action(drone).arm()`.

--- a/docs/en/python/migration.md
+++ b/docs/en/python/migration.md
@@ -1,0 +1,162 @@
+# Migrating from MAVSDK-Python
+
+The `mavsdk` package on PyPI is changing hands.
+
+It used to be [MAVSDK-Python](https://github.com/mavlink/MAVSDK-Python): an asyncio wrapper that talks gRPC to a `mavsdk_server` process bundled inside the package. From MAVSDK v4, the `mavsdk` name refers instead to a native binding that calls the MAVSDK C library directly, with no gRPC and no server process.
+
+The two have different APIs. This page explains what to do about it.
+
+::: warning
+The native binding has not been released to PyPI yet — it will ship as `mavsdk` 4.0.0. Until then, `pip install mavsdk` still gives you the gRPC wrapper. Nothing breaks today; this page is here so the change doesn't surprise you later.
+:::
+
+## The short version
+
+| | Before | From v4 |
+|---|---|---|
+| gRPC wrapper | `mavsdk` | `mavsdk-grpc`, imported as `mavsdk_grpc` |
+| Native binding | *did not exist* | `mavsdk`, imported as `mavsdk` |
+
+The gRPC wrapper deliberately installs under a *different import name* from the native binding, so the two can be installed side by side without overwriting each other.
+
+## Which one do I want?
+
+**Keep the gRPC API, keep getting updates** — switch to `mavsdk-grpc`. It continues to be developed, including releases tracking MAVSDK v4. Change your requirements and one import:
+
+```sh
+pip install mavsdk-grpc
+```
+
+```python
+import mavsdk_grpc as mavsdk           # or: from mavsdk_grpc import System
+```
+
+Nothing else in your code needs to change.
+
+**Change nothing at all** — pin the last release under the old name:
+
+```
+mavsdk<4
+```
+
+This keeps working indefinitely, but receives no further updates.
+
+**Move to the native binding** — read on. It is worth it if you want to drop the `grpcio` dependency, avoid shipping and launching a `mavsdk_server` binary, or use the synchronous API.
+
+## What the native binding changes
+
+Beyond the API itself:
+
+- **No `grpcio` dependency**, and no `mavsdk_server` subprocess. The package wraps the MAVSDK C library directly.
+- **Two interfaces.** `mavsdk` exposes a synchronous, callback-based API; `mavsdk.asyncio` exposes an asyncio API close in spirit to MAVSDK-Python. Both come from the same distribution — there is nothing extra to install.
+- **Explicit system discovery.** MAVSDK-Python hid connection and discovery behind `drone.connect()`. The native binding separates connecting from discovering systems, which matters once more than one vehicle is involved.
+- **Plugins are constructed, not attributes.** `drone.action.arm()` becomes `Action(drone).arm()`.
+
+## API mapping
+
+| MAVSDK-Python | Native binding (asyncio) |
+|---|---|
+| `System()` | `Mavsdk(Configuration.create_with_component_type(...))` |
+| `await drone.connect(system_address=url)` | `await mavsdk.add_any_connection(url)` |
+| implicit in `connect()` | `async for _ in mavsdk.on_new_system(): ...` |
+| `drone.action` | `ActionAsync(system)` |
+| `drone.telemetry` | `TelemetryAsync(system)` |
+| `drone.telemetry.position()` | `telemetry.subscribe_position()` |
+
+## Side by side
+
+Arming and taking off, before:
+
+```python
+import asyncio
+from mavsdk import System
+
+
+async def run():
+    drone = System()
+    await drone.connect(system_address="udpin://0.0.0.0:14540")
+
+    async for state in drone.core.connection_state():
+        if state.is_connected:
+            break
+
+    await drone.action.arm()
+    await drone.action.takeoff()
+    await asyncio.sleep(5)
+    await drone.action.land()
+
+
+asyncio.run(run())
+```
+
+and after, using `mavsdk.asyncio`:
+
+```python
+import asyncio
+from mavsdk.asyncio import Mavsdk, Configuration, ComponentType
+from mavsdk.asyncio.plugins.action import ActionAsync
+
+
+async def run():
+    configuration = Configuration.create_with_component_type(
+        ComponentType.GROUND_STATION
+    )
+    mavsdk = Mavsdk(configuration)
+    await mavsdk.add_any_connection("udpin://0.0.0.0:14540")
+
+    drone = None
+    async for _ in mavsdk.on_new_system():
+        for system in await mavsdk.get_systems():
+            if await system.has_autopilot() and await system.is_connected():
+                drone = system
+                break
+        if drone is not None:
+            break
+
+    action = ActionAsync(drone)
+    await action.arm()
+    await action.takeoff()
+    await asyncio.sleep(5)
+    await action.land()
+
+
+asyncio.run(run())
+```
+
+The same thing synchronously, which has no MAVSDK-Python equivalent:
+
+```python
+import time
+from mavsdk import Mavsdk, Configuration, ComponentType
+from mavsdk.plugins.action import Action
+
+configuration = Configuration.create_with_component_type(ComponentType.GROUND_STATION)
+mavsdk = Mavsdk(configuration)
+mavsdk.add_any_connection("udpin://0.0.0.0:14540")
+
+drone = None
+
+
+def on_new_system(user_data=None):
+    global drone
+    for system in mavsdk.get_systems():
+        if system.has_autopilot() and system.is_connected():
+            drone = system
+            break
+
+
+handle = mavsdk.subscribe_on_new_system(on_new_system)
+while drone is None:
+    time.sleep(1)
+mavsdk.unsubscribe_on_new_system(handle)
+
+action = Action(drone)
+action.arm()
+action.takeoff()
+time.sleep(5)
+action.land()
+```
+
+## Getting help
+
+If something here is wrong, unclear, or your use case isn't covered, please [open an issue](https://github.com/mavlink/MAVSDK/issues).

--- a/docs/en/python/migration.md
+++ b/docs/en/python/migration.md
@@ -1,8 +1,8 @@
 # Migrating from MAVSDK-Python
 
-The `mavsdk` package on PyPI is changing hands.
+The `mavsdk` package on PyPI is changing.
 
-It used to be [MAVSDK-Python](https://github.com/mavlink/MAVSDK-Python): an asyncio wrapper that talks gRPC to a `mavsdk_server` process bundled inside the package. From MAVSDK v4, the `mavsdk` name refers instead to a native binding that calls the MAVSDK C library directly, with no gRPC and no server process.
+It used to be [MAVSDK-Python](https://github.com/mavlink/MAVSDK-Python): an asyncio wrapper that talks gRPC to a `mavsdk_server` process bundled inside the package. From MAVSDK v4, the `mavsdk` name refers instead to a native binding that calls the MAVSDK C++ library directly (via C), with no gRPC and no server process.
 
 The two have different APIs. This page explains what to do about it.
 
@@ -33,7 +33,7 @@ import mavsdk_grpc as mavsdk           # or: from mavsdk_grpc import System
 
 Nothing else in your code needs to change.
 
-**Change nothing at all** — pin the last release under the old name:
+**Change nothing at all** — pin the last release under the old name (e.g. in your requirements.txt)
 
 ```
 mavsdk<4
@@ -51,6 +51,8 @@ Beyond the API itself:
 - **Two interfaces.** `mavsdk` exposes a synchronous, callback-based API; `mavsdk.asyncio` exposes an asyncio API close in spirit to MAVSDK-Python. Both come from the same distribution — there is nothing extra to install.
 - **Explicit system discovery.** MAVSDK-Python hid connection and discovery behind `drone.connect()`. The native binding separates connecting from discovering systems, which matters once more than one vehicle is involved.
 - **Plugins are constructed, not attributes.** `drone.action.arm()` becomes `Action(drone).arm()`.
+- **Support for multiple systems.**
+- **Support for server side plugins.** This allows implementations of things like cameras, or gimbals using plugins such as `CameraServer` and `GimbalServer`.
 
 ## API mapping
 


### PR DESCRIPTION
From v4 the `mavsdk` name on PyPI refers to the native binding rather than the gRPC wrapper, which continues as `mavsdk-grpc` ([mavlink/MAVSDK-Python#826](https://github.com/mavlink/MAVSDK-Python/pull/826)).

The deprecation notices shipped by MAVSDK-Python need somewhere specific to link to. Until now the only candidate was the Python docs index — which documents the *old* gRPC API, so it was exactly the wrong page to land someone on right after telling them their API is changing.

Adds `en/python/migration.md` covering:

- what changed, and the resulting package/import-name table
- the three options: switch to `mavsdk-grpc`, pin `mavsdk<4`, or move to the native binding
- an API mapping table and side-by-side examples for both the asyncio and synchronous interfaces

Also relabels the S3 API reference link on the Python index as belonging to `mavsdk-grpc`, since it will otherwise compete with the native binding docs.

The page carries a `::: warning` noting the native binding is not on PyPI yet — it ships as `mavsdk` 4.0.0. That paragraph should be dropped when it is.

Verified with `npm run docs:build`: the page renders and appears in the sidebar.