### PR TITLE
fix(core): restore param_value_xml unit test registration

### DIFF
--- a/cpp/src/mavsdk/core/CMakeLists.txt
+++ b/cpp/src/mavsdk/core/CMakeLists.txt
@@ -290,6 +290,7 @@ list(APPEND UNIT_TEST_SOURCES
     ${PROJECT_SOURCE_DIR}/mavsdk/core/mavlink_parameter_helper_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/vehicle_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/autopilot_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/param_value_xml_test.cpp
 )
 
 if (NOT BUILD_WITHOUT_CURL)


### PR DESCRIPTION
## Summary

- Restore `param_value_xml_test.cpp` in `UNIT_TEST_SOURCES`.
- #2987 swapped that CMAKE line for `connection_result_test.cpp` instead of appending, so the ParamValue XML tests never ran on main after both PRs landed.

## Motivation

Without CORE registration the suite is dead code on CI. Easy win with zero product risk.

## Verification

- Confirmed file exists on `main` and was missing from `CMakeLists.txt` `UNIT_TEST_SOURCES`.
- Did NOT change: test body (only CMake registration).


<!-- tol-internal -->
Claim: sera
Operator: sera
Campaign: aerial-drone
<!-- /tol-internal -->
