### PR TITLE
test(core): cover CompatibilityMode stream labels

### DIFF
--- a/cpp/src/mavsdk/core/CMakeLists.txt
+++ b/cpp/src/mavsdk/core/CMakeLists.txt
@@ -290,6 +290,7 @@ list(APPEND UNIT_TEST_SOURCES
     ${PROJECT_SOURCE_DIR}/mavsdk/core/mavlink_parameter_helper_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/vehicle_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/autopilot_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/compatibility_mode_test.cpp
 )
 
 if (NOT BUILD_WITHOUT_CURL)

--- a/cpp/src/mavsdk/core/compatibility_mode_test.cpp
+++ b/cpp/src/mavsdk/core/compatibility_mode_test.cpp
@@ -1,0 +1,36 @@
+#include "compatibility_mode.hpp"
+#include <gtest/gtest.h>
+#include <sstream>
+
+using namespace mavsdk;
+
+TEST(CompatibilityMode, StreamOperatorKnown)
+{
+    {
+        std::ostringstream oss;
+        oss << CompatibilityMode::Auto;
+        EXPECT_EQ(oss.str(), "Auto");
+    }
+    {
+        std::ostringstream oss;
+        oss << CompatibilityMode::Pure;
+        EXPECT_EQ(oss.str(), "Pure");
+    }
+    {
+        std::ostringstream oss;
+        oss << CompatibilityMode::Px4;
+        EXPECT_EQ(oss.str(), "Px4");
+    }
+    {
+        std::ostringstream oss;
+        oss << CompatibilityMode::ArduPilot;
+        EXPECT_EQ(oss.str(), "ArduPilot");
+    }
+}
+
+TEST(CompatibilityMode, StreamOperatorUnknownFallback)
+{
+    std::ostringstream oss;
+    oss << static_cast<CompatibilityMode>(99);
+    EXPECT_EQ(oss.str(), "Unknown");
+}


### PR DESCRIPTION
## Summary

- Unit tests for `CompatibilityMode` `operator<<` known labels and unknown fallback.

## Motivation

Public stream helper had no direct coverage after related core test waves.

## Verification

- Tests only; export already present (`MAVSDK_TEST_EXPORT`).
- Did NOT change product code.


<!-- tol-internal -->
Claim: sera
Operator: sera
Campaign: aerial-drone
<!-- /tol-internal -->
