### PR TITLE
test(core): cover cache directory path and tmp dir create

### DIFF
--- a/cpp/src/mavsdk/core/fs_utils_test.cpp
+++ b/cpp/src/mavsdk/core/fs_utils_test.cpp
@@ -1,5 +1,7 @@
 #include "fs_utils.hpp"
 #include <gtest/gtest.h>
+#include <filesystem>
+#include <string>
 
 using namespace mavsdk;
 
@@ -20,4 +22,35 @@ TEST(FsUtils, ReplaceNonAscii)
     // UTF-8 multi-byte bytes are >127 and must become underscores.
     const std::string input = std::string("id-") + "\xC3\xA9" + "-x"; // "é"
     EXPECT_EQ(replace_non_ascii_and_whitespace(input), "id-__-x");
+}
+
+
+TEST(FsUtils, GetCacheDirectoryHasMavsdkSegment)
+{
+    auto path = get_cache_directory();
+    ASSERT_TRUE(path.has_value());
+    const auto s = path->string();
+    // Platform path contains a mavsdk-named leaf (Linux ~/.cache/mavsdk, macOS Library/Caches/mavsdk).
+    EXPECT_NE(s.find("mavsdk"), std::string::npos);
+    EXPECT_FALSE(s.empty());
+}
+
+TEST(FsUtils, CreateTmpDirectoryUniqueAndExists)
+{
+    auto a = create_tmp_directory("mavsdk-ut");
+    auto b = create_tmp_directory("mavsdk-ut");
+    ASSERT_TRUE(a.has_value());
+    ASSERT_TRUE(b.has_value());
+    EXPECT_NE(*a, *b);
+    EXPECT_TRUE(std::filesystem::is_directory(*a));
+    EXPECT_TRUE(std::filesystem::is_directory(*b));
+    std::error_code ec;
+    std::filesystem::remove_all(*a, ec);
+    std::filesystem::remove_all(*b, ec);
+}
+
+TEST(FsUtils, ReplaceAsciiControlCharactersAsWhitespace)
+{
+    // \\r and form-feed are whitespace via isspace → underscore.
+    EXPECT_EQ(replace_non_ascii_and_whitespace(std::string("a") + "\r\f" + "b"), "a__b");
 }

--- a/cpp/src/mavsdk/core/fs_utils_test.cpp
+++ b/cpp/src/mavsdk/core/fs_utils_test.cpp
@@ -24,13 +24,13 @@ TEST(FsUtils, ReplaceNonAscii)
     EXPECT_EQ(replace_non_ascii_and_whitespace(input), "id-__-x");
 }
 
-
 TEST(FsUtils, GetCacheDirectoryHasMavsdkSegment)
 {
     auto path = get_cache_directory();
     ASSERT_TRUE(path.has_value());
     const auto s = path->string();
-    // Platform path contains a mavsdk-named leaf (Linux ~/.cache/mavsdk, macOS Library/Caches/mavsdk).
+    // Platform path contains a mavsdk-named leaf (Linux ~/.cache/mavsdk, macOS
+    // Library/Caches/mavsdk).
     EXPECT_NE(s.find("mavsdk"), std::string::npos);
     EXPECT_FALSE(s.empty());
 }


### PR DESCRIPTION
## Summary

- Extend `fs_utils_test.cpp` for cache path shape, unique tmp dirs, and control-char whitespace sanitization.

## Motivation

Only `replace_non_ascii_and_whitespace` was unit-tested; cache/tmp helpers drive FileCache and temp plugins.

## Verification

- Append-only; cleans up created tmp dirs in the test.
- Did NOT change product `fs_utils.cpp`.


<!-- tol-internal -->
Claim: sera
Operator: sera
Campaign: aerial-drone
<!-- /tol-internal -->
