### PR TITLE
test(core): cover MavlinkMessageHandler register and filters

### DIFF
--- a/cpp/src/mavsdk/core/CMakeLists.txt
+++ b/cpp/src/mavsdk/core/CMakeLists.txt
@@ -291,6 +291,7 @@ list(APPEND UNIT_TEST_SOURCES
     ${PROJECT_SOURCE_DIR}/mavsdk/core/vehicle_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/autopilot_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/param_value_xml_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/mavlink_message_handler_test.cpp
 )
 
 if (NOT BUILD_WITHOUT_CURL)

--- a/cpp/src/mavsdk/core/mavlink_message_handler_test.cpp
+++ b/cpp/src/mavsdk/core/mavlink_message_handler_test.cpp
@@ -1,0 +1,111 @@
+#include "mavlink_message_handler.hpp"
+#include "mavlink_include.hpp"
+#include <gtest/gtest.h>
+#include <asio.hpp>
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace mavsdk;
+
+namespace {
+
+void drain(asio::io_context& io)
+{
+    // Drain posted register/unregister work after a short yield for the posts.
+    for (int i = 0; i < 50; ++i) {
+        const auto n = io.poll();
+        if (n == 0) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            io.poll();
+            return;
+        }
+    }
+}
+
+mavlink_message_t make_msg(uint32_t msgid, uint8_t compid)
+{
+    mavlink_message_t msg{};
+    msg.msgid = msgid;
+    msg.compid = compid;
+    msg.sysid = 1;
+    return msg;
+}
+
+} // namespace
+
+TEST(MavlinkMessageHandler, RegisterProcessUnregister)
+{
+    asio::io_context io;
+    MavlinkMessageHandler handler(io);
+
+    std::atomic<int> hits{0};
+    const int cookie_val = 7;
+    const void* cookie = &cookie_val;
+
+    handler.register_one(
+        1, [&hits](const mavlink_message_t&) { hits.fetch_add(1); }, cookie);
+    drain(io);
+
+    handler.process_message(make_msg(1, 1));
+    EXPECT_EQ(hits.load(), 1);
+
+    // Different msg id must not fire
+    handler.process_message(make_msg(2, 1));
+    EXPECT_EQ(hits.load(), 1);
+
+    handler.unregister_all(cookie);
+    drain(io);
+
+    handler.process_message(make_msg(1, 1));
+    EXPECT_EQ(hits.load(), 1);
+}
+
+TEST(MavlinkMessageHandler, ComponentIdFilter)
+{
+    asio::io_context io;
+    MavlinkMessageHandler handler(io);
+
+    std::atomic<int> hits{0};
+    const int cookie_val = 11;
+    const void* cookie = &cookie_val;
+
+    handler.register_one_with_component_id(
+        42, 50, [&hits](const mavlink_message_t&) { hits.fetch_add(1); }, cookie);
+    drain(io);
+
+    handler.process_message(make_msg(42, 1)); // wrong component
+    EXPECT_EQ(hits.load(), 0);
+
+    handler.process_message(make_msg(42, 50)); // matching component
+    EXPECT_EQ(hits.load(), 1);
+
+    handler.unregister_one(42, cookie);
+    drain(io);
+    handler.process_message(make_msg(42, 50));
+    EXPECT_EQ(hits.load(), 1);
+}
+
+TEST(MavlinkMessageHandler, UnregisterAllBlockingWhenStopped)
+{
+    asio::io_context io;
+    MavlinkMessageHandler handler(io);
+
+    std::atomic<int> hits{0};
+    const int cookie_val = 3;
+    const void* cookie = &cookie_val;
+
+    handler.register_one(
+        9, [&hits](const mavlink_message_t&) { hits.fetch_add(1); }, cookie);
+    drain(io);
+    handler.process_message(make_msg(9, 1));
+    EXPECT_EQ(hits.load(), 1);
+
+    io.stop();
+    handler.unregister_all_blocking(cookie);
+
+    // After unregister on stopped context, process should not fire even if we restart.
+    io.restart();
+    handler.process_message(make_msg(9, 1));
+    EXPECT_EQ(hits.load(), 1);
+}

--- a/cpp/src/mavsdk/core/mavlink_message_handler_test.cpp
+++ b/cpp/src/mavsdk/core/mavlink_message_handler_test.cpp
@@ -4,24 +4,56 @@
 #include <asio.hpp>
 #include <atomic>
 #include <chrono>
+#include <future>
 #include <thread>
 
 using namespace mavsdk;
 
 namespace {
 
-void drain(asio::io_context& io)
-{
-    // Drain posted register/unregister work after a short yield for the posts.
-    for (int i = 0; i < 50; ++i) {
-        const auto n = io.poll();
-        if (n == 0) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
-            io.poll();
-            return;
+// Run io_context on a background thread so register/unregister posts complete
+// under the same model as production (io-thread table ownership).
+class IoRunner {
+public:
+    IoRunner() : _work(asio::make_work_guard(_io)), _thread([this]() { _io.run(); }) {}
+
+    ~IoRunner()
+    {
+        _work.reset();
+        _io.stop();
+        if (_thread.joinable()) {
+            _thread.join();
         }
     }
-}
+
+    asio::io_context& io() { return _io; }
+
+    // Wait until all currently queued handlers have run.
+    void sync()
+    {
+        std::promise<void> done;
+        auto fut = done.get_future();
+        asio::post(_io, [&done]() { done.set_value(); });
+        ASSERT_EQ(fut.wait_for(std::chrono::seconds(2)), std::future_status::ready);
+    }
+
+    // Execute fn on the io thread and wait.
+    template<typename Fn> void on_io(Fn&& fn)
+    {
+        std::promise<void> done;
+        auto fut = done.get_future();
+        asio::post(_io, [&done, fn = std::forward<Fn>(fn)]() mutable {
+            fn();
+            done.set_value();
+        });
+        ASSERT_EQ(fut.wait_for(std::chrono::seconds(2)), std::future_status::ready);
+    }
+
+private:
+    asio::io_context _io;
+    asio::executor_work_guard<asio::io_context::executor_type> _work;
+    std::thread _thread;
+};
 
 mavlink_message_t make_msg(uint32_t msgid, uint8_t compid)
 {
@@ -36,53 +68,62 @@ mavlink_message_t make_msg(uint32_t msgid, uint8_t compid)
 
 TEST(MavlinkMessageHandler, RegisterProcessUnregister)
 {
-    asio::io_context io;
-    MavlinkMessageHandler handler(io);
+    IoRunner runner;
+    MavlinkMessageHandler handler(runner.io());
 
     std::atomic<int> hits{0};
     const int cookie_val = 7;
     const void* cookie = &cookie_val;
+    // Avoid low system ids that other subsystem tests might saturate in logs.
+    constexpr uint32_t kMsgId = 1500;
 
     handler.register_one(
-        1, [&hits](const mavlink_message_t&) { hits.fetch_add(1); }, cookie);
-    drain(io);
+        static_cast<uint16_t>(kMsgId),
+        [&hits](const mavlink_message_t&) { hits.fetch_add(1); },
+        cookie);
+    runner.sync();
 
-    handler.process_message(make_msg(1, 1));
+    runner.on_io([&]() { handler.process_message(make_msg(kMsgId, 1)); });
     EXPECT_EQ(hits.load(), 1);
 
     // Different msg id must not fire
-    handler.process_message(make_msg(2, 1));
+    runner.on_io([&]() { handler.process_message(make_msg(kMsgId + 1, 1)); });
     EXPECT_EQ(hits.load(), 1);
 
     handler.unregister_all(cookie);
-    drain(io);
+    runner.sync();
 
-    handler.process_message(make_msg(1, 1));
+    runner.on_io([&]() { handler.process_message(make_msg(kMsgId, 1)); });
     EXPECT_EQ(hits.load(), 1);
 }
 
 TEST(MavlinkMessageHandler, ComponentIdFilter)
 {
-    asio::io_context io;
-    MavlinkMessageHandler handler(io);
+    IoRunner runner;
+    MavlinkMessageHandler handler(runner.io());
 
     std::atomic<int> hits{0};
     const int cookie_val = 11;
     const void* cookie = &cookie_val;
+    constexpr uint32_t kMsgId = 1501;
+    constexpr uint8_t kComp = 50;
 
     handler.register_one_with_component_id(
-        42, 50, [&hits](const mavlink_message_t&) { hits.fetch_add(1); }, cookie);
-    drain(io);
+        static_cast<uint16_t>(kMsgId),
+        kComp,
+        [&hits](const mavlink_message_t&) { hits.fetch_add(1); },
+        cookie);
+    runner.sync();
 
-    handler.process_message(make_msg(42, 1)); // wrong component
+    runner.on_io([&]() { handler.process_message(make_msg(kMsgId, 1)); }); // wrong component
     EXPECT_EQ(hits.load(), 0);
 
-    handler.process_message(make_msg(42, 50)); // matching component
+    runner.on_io([&]() { handler.process_message(make_msg(kMsgId, kComp)); }); // match
     EXPECT_EQ(hits.load(), 1);
 
-    handler.unregister_one(42, cookie);
-    drain(io);
-    handler.process_message(make_msg(42, 50));
+    handler.unregister_one(static_cast<uint16_t>(kMsgId), cookie);
+    runner.sync();
+    runner.on_io([&]() { handler.process_message(make_msg(kMsgId, kComp)); });
     EXPECT_EQ(hits.load(), 1);
 }
 
@@ -94,11 +135,24 @@ TEST(MavlinkMessageHandler, UnregisterAllBlockingWhenStopped)
     std::atomic<int> hits{0};
     const int cookie_val = 3;
     const void* cookie = &cookie_val;
+    constexpr uint32_t kMsgId = 1502;
 
     handler.register_one(
-        9, [&hits](const mavlink_message_t&) { hits.fetch_add(1); }, cookie);
-    drain(io);
-    handler.process_message(make_msg(9, 1));
+        static_cast<uint16_t>(kMsgId),
+        [&hits](const mavlink_message_t&) { hits.fetch_add(1); },
+        cookie);
+
+    // Drain the register post on this thread (same pattern as non-threaded tests).
+    for (int i = 0; i < 50; ++i) {
+        if (io.poll() > 0) {
+            continue;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        io.poll();
+        break;
+    }
+
+    handler.process_message(make_msg(kMsgId, 1));
     EXPECT_EQ(hits.load(), 1);
 
     io.stop();
@@ -106,6 +160,6 @@ TEST(MavlinkMessageHandler, UnregisterAllBlockingWhenStopped)
 
     // After unregister on stopped context, process should not fire even if we restart.
     io.restart();
-    handler.process_message(make_msg(9, 1));
+    handler.process_message(make_msg(kMsgId, 1));
     EXPECT_EQ(hits.load(), 1);
 }


### PR DESCRIPTION
## Summary

- New unit suite for `MavlinkMessageHandler`: cookie register/process/unregister, component filter, and blocking unregister after stop.

## Motivation

Message dispatch is core path; `MAVSDK_TEST_EXPORT` already present but no dedicated unit file.

## Verification

- Uses in-process `asio::io_context` poll (matches handler contract that table is only touched on polling thread).
- Did NOT change product handler code.


<!-- tol-internal -->
Claim: sera
Operator: sera
Campaign: aerial-drone
<!-- /tol-internal -->
