### PR TITLE
camera_server_impl: Send CAMERA_IMAGE_CAPTURED with fail result on busy or fail

### DIFF
--- a/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
+++ b/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
@@ -356,14 +356,14 @@ CameraServer::Result CameraServerImpl::respond_take_photo(
                 auto command_ack = _server_component_impl->make_command_ack_message(
                     _last_take_photo_command, MAV_RESULT_TEMPORARILY_REJECTED);
                 _server_component_impl->send_command_ack(command_ack);
-                return CameraServer::Result::Success;
+                break;
             }
 
             case CameraServer::CameraFeedback::Failed: {
                 auto command_ack = _server_component_impl->make_command_ack_message(
                     _last_take_photo_command, MAV_RESULT_FAILED);
                 _server_component_impl->send_command_ack(command_ack);
-                return CameraServer::Result::Success;
+                break;
             }
         }
 


### PR DESCRIPTION
MAVSDK camera server is currently not following spec by not sending `CAMERA_IMAGE_CAPTURED` on a failure to take photos. 

But it is useful during missions to track failed CAMERA_IMAGE_CAPTURED, so I can store diagnostic data on a GCS or show failure points on a map in red.

This change simply modifies camera_server_impl to send `CAMERA_IMAGE_CAPTURED` on failure or busy with capture_result false.