### PR TITLE
py: fix deallocation bugs

### DIFF
--- a/py/mavsdk/mavsdk/plugins/action/action.py
+++ b/py/mavsdk/mavsdk/plugins/action/action.py
@@ -959,6 +959,9 @@ _cmavsdk_lib.mavsdk_action_destroy.argtypes = [ctypes.c_void_p]
 _cmavsdk_lib.mavsdk_action_destroy.restype = None
 
 
+_cmavsdk_lib.mavsdk_action_string_destroy.argtypes = [ctypes.POINTER(ctypes.c_char_p)]
+_cmavsdk_lib.mavsdk_action_string_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_action_arm_async.argtypes = [
     ctypes.c_void_p,
     ArmCallback,

--- a/py/mavsdk/mavsdk/plugins/action_server/action_server.py
+++ b/py/mavsdk/mavsdk/plugins/action_server/action_server.py
@@ -522,11 +522,28 @@ _cmavsdk_lib.mavsdk_action_server_allowable_flight_modes_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_action_server_allowable_flight_modes_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_action_server_allowable_flight_modes_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(AllowableFlightModesCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_action_server_allowable_flight_modes_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_action_server_arm_disarm_destroy.argtypes = [
     ctypes.POINTER(ArmDisarmCStruct)
 ]
 _cmavsdk_lib.mavsdk_action_server_arm_disarm_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_action_server_arm_disarm_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ArmDisarmCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_action_server_arm_disarm_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_action_server_string_destroy.argtypes = [
+    ctypes.POINTER(ctypes.c_char_p)
+]
+_cmavsdk_lib.mavsdk_action_server_string_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_action_server_subscribe_arm_disarm.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/mavsdk/plugins/arm_authorizer_server/arm_authorizer_server.py
+++ b/py/mavsdk/mavsdk/plugins/arm_authorizer_server/arm_authorizer_server.py
@@ -143,6 +143,11 @@ _cmavsdk_lib.mavsdk_arm_authorizer_server_destroy.argtypes = [ctypes.c_void_p]
 _cmavsdk_lib.mavsdk_arm_authorizer_server_destroy.restype = None
 
 
+_cmavsdk_lib.mavsdk_arm_authorizer_server_string_destroy.argtypes = [
+    ctypes.POINTER(ctypes.c_char_p)
+]
+_cmavsdk_lib.mavsdk_arm_authorizer_server_string_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_arm_authorizer_server_subscribe_arm_authorization.argtypes = [
     ctypes.c_void_p,
     ArmAuthorizationCallback,

--- a/py/mavsdk/mavsdk/plugins/calibration/calibration.py
+++ b/py/mavsdk/mavsdk/plugins/calibration/calibration.py
@@ -289,6 +289,17 @@ _cmavsdk_lib.mavsdk_calibration_progress_data_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_calibration_progress_data_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_calibration_progress_data_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ProgressDataCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_calibration_progress_data_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_calibration_string_destroy.argtypes = [
+    ctypes.POINTER(ctypes.c_char_p)
+]
+_cmavsdk_lib.mavsdk_calibration_string_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_calibration_calibrate_gyro_async.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/mavsdk/plugins/camera/camera.py
+++ b/py/mavsdk/mavsdk/plugins/camera/camera.py
@@ -1402,11 +1402,13 @@ class Camera:
                 py_result = CameraResult(result)
 
                 py_data = []
-                if c_data and size.value > 0:
-                    for i in range(size.value):
+                if c_data and size > 0:
+                    for i in range(size):
                         py_data.append(CaptureInfo.from_c_struct(c_data[i]))
 
-                self._lib.mavsdk_camera_capture_info_destroy(c_data)
+                self._lib.mavsdk_camera_capture_info_array_destroy(
+                    ctypes.byref(c_data), size
+                )
 
                 callback(py_result, py_data, user_data)
 
@@ -1440,7 +1442,9 @@ class Camera:
         py_result = [
             CaptureInfo.from_c_struct(result_ptr[i]) for i in range(size.value)
         ]
-        self._lib.mavsdk_camera_capture_info_destroy(result_ptr)
+        self._lib.mavsdk_camera_capture_info_array_destroy(
+            ctypes.byref(result_ptr), size
+        )
         return py_result
 
     def subscribe_camera_list(self, callback: Callable, user_data: Any = None):
@@ -1663,7 +1667,7 @@ class Camera:
             raise Exception(f"get_current_settings failed: {result}")
 
         py_result = [Setting.from_c_struct(result_ptr[i]) for i in range(size.value)]
-        self._lib.mavsdk_camera_setting_destroy(result_ptr)
+        self._lib.mavsdk_camera_setting_array_destroy(ctypes.byref(result_ptr), size)
         return py_result
 
     def subscribe_possible_setting_options(
@@ -1713,7 +1717,9 @@ class Camera:
         py_result = [
             SettingOptions.from_c_struct(result_ptr[i]) for i in range(size.value)
         ]
-        self._lib.mavsdk_camera_setting_options_destroy(result_ptr)
+        self._lib.mavsdk_camera_setting_options_array_destroy(
+            ctypes.byref(result_ptr), size
+        )
         return py_result
 
     def set_setting_async(
@@ -2327,80 +2333,185 @@ _cmavsdk_lib.mavsdk_camera_destroy.restype = None
 _cmavsdk_lib.mavsdk_camera_option_destroy.argtypes = [ctypes.POINTER(OptionCStruct)]
 _cmavsdk_lib.mavsdk_camera_option_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_camera_option_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(OptionCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_option_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_camera_setting_destroy.argtypes = [ctypes.POINTER(SettingCStruct)]
 _cmavsdk_lib.mavsdk_camera_setting_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_camera_setting_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(SettingCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_setting_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_camera_setting_options_destroy.argtypes = [
     ctypes.POINTER(SettingOptionsCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_setting_options_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_camera_setting_options_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(SettingOptionsCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_setting_options_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_camera_video_stream_settings_destroy.argtypes = [
     ctypes.POINTER(VideoStreamSettingsCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_video_stream_settings_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_camera_video_stream_settings_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(VideoStreamSettingsCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_video_stream_settings_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_camera_video_stream_info_destroy.argtypes = [
     ctypes.POINTER(VideoStreamInfoCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_video_stream_info_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_camera_video_stream_info_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(VideoStreamInfoCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_video_stream_info_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_camera_mode_update_destroy.argtypes = [
     ctypes.POINTER(ModeUpdateCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_mode_update_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_camera_mode_update_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ModeUpdateCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_mode_update_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_camera_video_stream_update_destroy.argtypes = [
     ctypes.POINTER(VideoStreamUpdateCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_video_stream_update_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_camera_video_stream_update_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(VideoStreamUpdateCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_video_stream_update_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_camera_storage_destroy.argtypes = [ctypes.POINTER(StorageCStruct)]
 _cmavsdk_lib.mavsdk_camera_storage_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_camera_storage_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(StorageCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_storage_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_camera_storage_update_destroy.argtypes = [
     ctypes.POINTER(StorageUpdateCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_storage_update_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_camera_storage_update_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(StorageUpdateCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_storage_update_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_camera_current_settings_update_destroy.argtypes = [
     ctypes.POINTER(CurrentSettingsUpdateCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_current_settings_update_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_camera_current_settings_update_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(CurrentSettingsUpdateCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_current_settings_update_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_camera_possible_setting_options_update_destroy.argtypes = [
     ctypes.POINTER(PossibleSettingOptionsUpdateCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_possible_setting_options_update_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_camera_possible_setting_options_update_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(PossibleSettingOptionsUpdateCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_possible_setting_options_update_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_camera_position_destroy.argtypes = [ctypes.POINTER(PositionCStruct)]
 _cmavsdk_lib.mavsdk_camera_position_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_camera_position_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(PositionCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_position_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_camera_quaternion_destroy.argtypes = [
     ctypes.POINTER(QuaternionCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_quaternion_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_camera_quaternion_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(QuaternionCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_quaternion_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_camera_euler_angle_destroy.argtypes = [
     ctypes.POINTER(EulerAngleCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_euler_angle_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_camera_euler_angle_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(EulerAngleCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_euler_angle_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_camera_capture_info_destroy.argtypes = [
     ctypes.POINTER(CaptureInfoCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_capture_info_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_camera_capture_info_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(CaptureInfoCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_capture_info_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_camera_information_destroy.argtypes = [
     ctypes.POINTER(InformationCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_information_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_camera_information_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(InformationCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_information_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_camera_camera_list_destroy.argtypes = [
     ctypes.POINTER(CameraListCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_camera_list_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_camera_camera_list_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(CameraListCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_camera_list_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_camera_string_destroy.argtypes = [ctypes.POINTER(ctypes.c_char_p)]
+_cmavsdk_lib.mavsdk_camera_string_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_camera_take_photo_async.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/mavsdk/plugins/camera_server/camera_server.py
+++ b/py/mavsdk/mavsdk/plugins/camera_server/camera_server.py
@@ -1516,45 +1516,105 @@ _cmavsdk_lib.mavsdk_camera_server_information_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_camera_server_information_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_camera_server_information_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(InformationCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_server_information_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_camera_server_video_streaming_destroy.argtypes = [
     ctypes.POINTER(VideoStreamingCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_server_video_streaming_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_camera_server_video_streaming_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(VideoStreamingCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_server_video_streaming_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_camera_server_position_destroy.argtypes = [
     ctypes.POINTER(PositionCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_server_position_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_camera_server_position_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(PositionCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_server_position_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_camera_server_quaternion_destroy.argtypes = [
     ctypes.POINTER(QuaternionCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_server_quaternion_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_camera_server_quaternion_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(QuaternionCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_server_quaternion_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_camera_server_capture_info_destroy.argtypes = [
     ctypes.POINTER(CaptureInfoCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_server_capture_info_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_camera_server_capture_info_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(CaptureInfoCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_server_capture_info_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_camera_server_storage_information_destroy.argtypes = [
     ctypes.POINTER(StorageInformationCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_server_storage_information_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_camera_server_storage_information_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(StorageInformationCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_server_storage_information_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_camera_server_capture_status_destroy.argtypes = [
     ctypes.POINTER(CaptureStatusCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_server_capture_status_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_camera_server_capture_status_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(CaptureStatusCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_server_capture_status_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_camera_server_track_point_destroy.argtypes = [
     ctypes.POINTER(TrackPointCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_server_track_point_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_camera_server_track_point_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(TrackPointCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_server_track_point_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_camera_server_track_rectangle_destroy.argtypes = [
     ctypes.POINTER(TrackRectangleCStruct)
 ]
 _cmavsdk_lib.mavsdk_camera_server_track_rectangle_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_camera_server_track_rectangle_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(TrackRectangleCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_camera_server_track_rectangle_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_camera_server_string_destroy.argtypes = [
+    ctypes.POINTER(ctypes.c_char_p)
+]
+_cmavsdk_lib.mavsdk_camera_server_string_destroy.restype = None
 
 
 _cmavsdk_lib.mavsdk_camera_server_set_information.argtypes = [

--- a/py/mavsdk/mavsdk/plugins/component_metadata/component_metadata.py
+++ b/py/mavsdk/mavsdk/plugins/component_metadata/component_metadata.py
@@ -245,10 +245,28 @@ _cmavsdk_lib.mavsdk_component_metadata_metadata_data_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_component_metadata_metadata_data_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_component_metadata_metadata_data_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(MetadataDataCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_component_metadata_metadata_data_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_component_metadata_metadata_update_destroy.argtypes = [
     ctypes.POINTER(MetadataUpdateCStruct)
 ]
 _cmavsdk_lib.mavsdk_component_metadata_metadata_update_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_component_metadata_metadata_update_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(MetadataUpdateCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_component_metadata_metadata_update_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_component_metadata_string_destroy.argtypes = [
+    ctypes.POINTER(ctypes.c_char_p)
+]
+_cmavsdk_lib.mavsdk_component_metadata_string_destroy.restype = None
 
 
 _cmavsdk_lib.mavsdk_component_metadata_request_component.argtypes = [

--- a/py/mavsdk/mavsdk/plugins/component_metadata_server/component_metadata_server.py
+++ b/py/mavsdk/mavsdk/plugins/component_metadata_server/component_metadata_server.py
@@ -134,6 +134,18 @@ _cmavsdk_lib.mavsdk_component_metadata_server_metadata_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_component_metadata_server_metadata_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_component_metadata_server_metadata_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(MetadataCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_component_metadata_server_metadata_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_component_metadata_server_string_destroy.argtypes = [
+    ctypes.POINTER(ctypes.c_char_p)
+]
+_cmavsdk_lib.mavsdk_component_metadata_server_string_destroy.restype = None
+
 
 _cmavsdk_lib.mavsdk_component_metadata_server_set_metadata.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/mavsdk/plugins/events/events.py
+++ b/py/mavsdk/mavsdk/plugins/events/events.py
@@ -500,26 +500,59 @@ _cmavsdk_lib.mavsdk_events_destroy.restype = None
 _cmavsdk_lib.mavsdk_events_event_destroy.argtypes = [ctypes.POINTER(EventCStruct)]
 _cmavsdk_lib.mavsdk_events_event_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_events_event_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(EventCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_events_event_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_events_health_and_arming_check_problem_destroy.argtypes = [
     ctypes.POINTER(HealthAndArmingCheckProblemCStruct)
 ]
 _cmavsdk_lib.mavsdk_events_health_and_arming_check_problem_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_events_health_and_arming_check_problem_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(HealthAndArmingCheckProblemCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_events_health_and_arming_check_problem_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_events_health_and_arming_check_mode_destroy.argtypes = [
     ctypes.POINTER(HealthAndArmingCheckModeCStruct)
 ]
 _cmavsdk_lib.mavsdk_events_health_and_arming_check_mode_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_events_health_and_arming_check_mode_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(HealthAndArmingCheckModeCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_events_health_and_arming_check_mode_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_events_health_component_report_destroy.argtypes = [
     ctypes.POINTER(HealthComponentReportCStruct)
 ]
 _cmavsdk_lib.mavsdk_events_health_component_report_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_events_health_component_report_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(HealthComponentReportCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_events_health_component_report_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_events_health_and_arming_check_report_destroy.argtypes = [
     ctypes.POINTER(HealthAndArmingCheckReportCStruct)
 ]
 _cmavsdk_lib.mavsdk_events_health_and_arming_check_report_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_events_health_and_arming_check_report_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(HealthAndArmingCheckReportCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_events_health_and_arming_check_report_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_events_string_destroy.argtypes = [ctypes.POINTER(ctypes.c_char_p)]
+_cmavsdk_lib.mavsdk_events_string_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_events_subscribe_events.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/mavsdk/plugins/failure/failure.py
+++ b/py/mavsdk/mavsdk/plugins/failure/failure.py
@@ -131,6 +131,10 @@ _cmavsdk_lib.mavsdk_failure_destroy.argtypes = [ctypes.c_void_p]
 _cmavsdk_lib.mavsdk_failure_destroy.restype = None
 
 
+_cmavsdk_lib.mavsdk_failure_string_destroy.argtypes = [ctypes.POINTER(ctypes.c_char_p)]
+_cmavsdk_lib.mavsdk_failure_string_destroy.restype = None
+
+
 _cmavsdk_lib.mavsdk_failure_inject.argtypes = [
     ctypes.c_void_p,
     ctypes.c_int,

--- a/py/mavsdk/mavsdk/plugins/follow_me/follow_me.py
+++ b/py/mavsdk/mavsdk/plugins/follow_me/follow_me.py
@@ -319,10 +319,28 @@ _cmavsdk_lib.mavsdk_follow_me_destroy.restype = None
 _cmavsdk_lib.mavsdk_follow_me_config_destroy.argtypes = [ctypes.POINTER(ConfigCStruct)]
 _cmavsdk_lib.mavsdk_follow_me_config_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_follow_me_config_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ConfigCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_follow_me_config_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_follow_me_target_location_destroy.argtypes = [
     ctypes.POINTER(TargetLocationCStruct)
 ]
 _cmavsdk_lib.mavsdk_follow_me_target_location_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_follow_me_target_location_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(TargetLocationCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_follow_me_target_location_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_follow_me_string_destroy.argtypes = [
+    ctypes.POINTER(ctypes.c_char_p)
+]
+_cmavsdk_lib.mavsdk_follow_me_string_destroy.restype = None
 
 
 _cmavsdk_lib.mavsdk_follow_me_get_config.argtypes = [

--- a/py/mavsdk/mavsdk/plugins/ftp/ftp.py
+++ b/py/mavsdk/mavsdk/plugins/ftp/ftp.py
@@ -611,16 +611,37 @@ _cmavsdk_lib.mavsdk_ftp_filesystem_entry_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_ftp_filesystem_entry_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_ftp_filesystem_entry_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(FilesystemEntryCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_ftp_filesystem_entry_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_ftp_list_directory_data_destroy.argtypes = [
     ctypes.POINTER(ListDirectoryDataCStruct)
 ]
 _cmavsdk_lib.mavsdk_ftp_list_directory_data_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_ftp_list_directory_data_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ListDirectoryDataCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_ftp_list_directory_data_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_ftp_progress_data_destroy.argtypes = [
     ctypes.POINTER(ProgressDataCStruct)
 ]
 _cmavsdk_lib.mavsdk_ftp_progress_data_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_ftp_progress_data_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ProgressDataCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_ftp_progress_data_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_ftp_string_destroy.argtypes = [ctypes.POINTER(ctypes.c_char_p)]
+_cmavsdk_lib.mavsdk_ftp_string_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_ftp_download_async.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/mavsdk/plugins/ftp_server/ftp_server.py
+++ b/py/mavsdk/mavsdk/plugins/ftp_server/ftp_server.py
@@ -94,6 +94,12 @@ _cmavsdk_lib.mavsdk_ftp_server_destroy.argtypes = [ctypes.c_void_p]
 _cmavsdk_lib.mavsdk_ftp_server_destroy.restype = None
 
 
+_cmavsdk_lib.mavsdk_ftp_server_string_destroy.argtypes = [
+    ctypes.POINTER(ctypes.c_char_p)
+]
+_cmavsdk_lib.mavsdk_ftp_server_string_destroy.restype = None
+
+
 _cmavsdk_lib.mavsdk_ftp_server_set_root_dir.argtypes = [
     ctypes.c_void_p,
     ctypes.c_char_p,

--- a/py/mavsdk/mavsdk/plugins/geofence/geofence.py
+++ b/py/mavsdk/mavsdk/plugins/geofence/geofence.py
@@ -412,17 +412,44 @@ _cmavsdk_lib.mavsdk_geofence_destroy.restype = None
 _cmavsdk_lib.mavsdk_geofence_point_destroy.argtypes = [ctypes.POINTER(PointCStruct)]
 _cmavsdk_lib.mavsdk_geofence_point_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_geofence_point_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(PointCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_geofence_point_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_geofence_polygon_destroy.argtypes = [ctypes.POINTER(PolygonCStruct)]
 _cmavsdk_lib.mavsdk_geofence_polygon_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_geofence_polygon_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(PolygonCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_geofence_polygon_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_geofence_circle_destroy.argtypes = [ctypes.POINTER(CircleCStruct)]
 _cmavsdk_lib.mavsdk_geofence_circle_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_geofence_circle_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(CircleCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_geofence_circle_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_geofence_geofence_data_destroy.argtypes = [
     ctypes.POINTER(GeofenceDataCStruct)
 ]
 _cmavsdk_lib.mavsdk_geofence_geofence_data_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_geofence_geofence_data_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(GeofenceDataCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_geofence_geofence_data_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_geofence_string_destroy.argtypes = [ctypes.POINTER(ctypes.c_char_p)]
+_cmavsdk_lib.mavsdk_geofence_string_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_geofence_upload_geofence_async.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/mavsdk/plugins/gimbal/gimbal.py
+++ b/py/mavsdk/mavsdk/plugins/gimbal/gimbal.py
@@ -933,34 +933,79 @@ _cmavsdk_lib.mavsdk_gimbal_quaternion_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_gimbal_quaternion_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_gimbal_quaternion_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(QuaternionCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_gimbal_quaternion_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_gimbal_euler_angle_destroy.argtypes = [
     ctypes.POINTER(EulerAngleCStruct)
 ]
 _cmavsdk_lib.mavsdk_gimbal_euler_angle_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_gimbal_euler_angle_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(EulerAngleCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_gimbal_euler_angle_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_gimbal_angular_velocity_body_destroy.argtypes = [
     ctypes.POINTER(AngularVelocityBodyCStruct)
 ]
 _cmavsdk_lib.mavsdk_gimbal_angular_velocity_body_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_gimbal_angular_velocity_body_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(AngularVelocityBodyCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_gimbal_angular_velocity_body_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_gimbal_attitude_destroy.argtypes = [ctypes.POINTER(AttitudeCStruct)]
 _cmavsdk_lib.mavsdk_gimbal_attitude_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_gimbal_attitude_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(AttitudeCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_gimbal_attitude_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_gimbal_gimbal_item_destroy.argtypes = [
     ctypes.POINTER(GimbalItemCStruct)
 ]
 _cmavsdk_lib.mavsdk_gimbal_gimbal_item_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_gimbal_gimbal_item_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(GimbalItemCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_gimbal_gimbal_item_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_gimbal_gimbal_list_destroy.argtypes = [
     ctypes.POINTER(GimbalListCStruct)
 ]
 _cmavsdk_lib.mavsdk_gimbal_gimbal_list_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_gimbal_gimbal_list_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(GimbalListCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_gimbal_gimbal_list_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_gimbal_control_status_destroy.argtypes = [
     ctypes.POINTER(ControlStatusCStruct)
 ]
 _cmavsdk_lib.mavsdk_gimbal_control_status_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_gimbal_control_status_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ControlStatusCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_gimbal_control_status_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_gimbal_string_destroy.argtypes = [ctypes.POINTER(ctypes.c_char_p)]
+_cmavsdk_lib.mavsdk_gimbal_string_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_gimbal_set_angles_async.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/mavsdk/plugins/gripper/gripper.py
+++ b/py/mavsdk/mavsdk/plugins/gripper/gripper.py
@@ -154,6 +154,9 @@ _cmavsdk_lib.mavsdk_gripper_destroy.argtypes = [ctypes.c_void_p]
 _cmavsdk_lib.mavsdk_gripper_destroy.restype = None
 
 
+_cmavsdk_lib.mavsdk_gripper_string_destroy.argtypes = [ctypes.POINTER(ctypes.c_char_p)]
+_cmavsdk_lib.mavsdk_gripper_string_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_gripper_grab_async.argtypes = [
     ctypes.c_void_p,
     ctypes.c_uint32,

--- a/py/mavsdk/mavsdk/plugins/info/info.py
+++ b/py/mavsdk/mavsdk/plugins/info/info.py
@@ -446,16 +446,44 @@ _cmavsdk_lib.mavsdk_info_flight_info_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_info_flight_info_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_info_flight_info_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(FlightInfoCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_info_flight_info_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_info_identification_destroy.argtypes = [
     ctypes.POINTER(IdentificationCStruct)
 ]
 _cmavsdk_lib.mavsdk_info_identification_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_info_identification_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(IdentificationCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_info_identification_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_info_product_destroy.argtypes = [ctypes.POINTER(ProductCStruct)]
 _cmavsdk_lib.mavsdk_info_product_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_info_product_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ProductCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_info_product_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_info_version_destroy.argtypes = [ctypes.POINTER(VersionCStruct)]
 _cmavsdk_lib.mavsdk_info_version_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_info_version_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(VersionCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_info_version_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_info_string_destroy.argtypes = [ctypes.POINTER(ctypes.c_char_p)]
+_cmavsdk_lib.mavsdk_info_string_destroy.restype = None
 
 
 _cmavsdk_lib.mavsdk_info_get_identification.argtypes = [

--- a/py/mavsdk/mavsdk/plugins/log_files/log_files.py
+++ b/py/mavsdk/mavsdk/plugins/log_files/log_files.py
@@ -158,11 +158,13 @@ class LogFiles:
                 py_result = LogFilesResult(result)
 
                 py_data = []
-                if c_data and size.value > 0:
-                    for i in range(size.value):
+                if c_data and size > 0:
+                    for i in range(size):
                         py_data.append(Entry.from_c_struct(c_data[i]))
 
-                self._lib.mavsdk_log_files_entry_destroy(c_data)
+                self._lib.mavsdk_log_files_entry_array_destroy(
+                    ctypes.byref(c_data), size
+                )
 
                 callback(py_result, py_data, user_data)
 
@@ -188,7 +190,7 @@ class LogFiles:
             raise Exception(f"get_entries failed: {result}")
 
         py_result = [Entry.from_c_struct(result_ptr[i]) for i in range(size.value)]
-        self._lib.mavsdk_log_files_entry_destroy(result_ptr)
+        self._lib.mavsdk_log_files_entry_array_destroy(ctypes.byref(result_ptr), size)
         return py_result
 
     def download_log_file_async(
@@ -262,9 +264,26 @@ _cmavsdk_lib.mavsdk_log_files_progress_data_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_log_files_progress_data_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_log_files_progress_data_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ProgressDataCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_log_files_progress_data_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_log_files_entry_destroy.argtypes = [ctypes.POINTER(EntryCStruct)]
 _cmavsdk_lib.mavsdk_log_files_entry_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_log_files_entry_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(EntryCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_log_files_entry_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_log_files_string_destroy.argtypes = [
+    ctypes.POINTER(ctypes.c_char_p)
+]
+_cmavsdk_lib.mavsdk_log_files_string_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_log_files_get_entries_async.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/mavsdk/plugins/log_streaming/log_streaming.py
+++ b/py/mavsdk/mavsdk/plugins/log_streaming/log_streaming.py
@@ -216,6 +216,17 @@ _cmavsdk_lib.mavsdk_log_streaming_log_streaming_raw_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_log_streaming_log_streaming_raw_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_log_streaming_log_streaming_raw_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(LogStreamingRawCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_log_streaming_log_streaming_raw_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_log_streaming_string_destroy.argtypes = [
+    ctypes.POINTER(ctypes.c_char_p)
+]
+_cmavsdk_lib.mavsdk_log_streaming_string_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_log_streaming_start_log_streaming_async.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/mavsdk/plugins/manual_control/manual_control.py
+++ b/py/mavsdk/mavsdk/plugins/manual_control/manual_control.py
@@ -172,6 +172,11 @@ _cmavsdk_lib.mavsdk_manual_control_destroy.argtypes = [ctypes.c_void_p]
 _cmavsdk_lib.mavsdk_manual_control_destroy.restype = None
 
 
+_cmavsdk_lib.mavsdk_manual_control_string_destroy.argtypes = [
+    ctypes.POINTER(ctypes.c_char_p)
+]
+_cmavsdk_lib.mavsdk_manual_control_string_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_manual_control_start_position_control_async.argtypes = [
     ctypes.c_void_p,
     StartPositionControlCallback,

--- a/py/mavsdk/mavsdk/plugins/mavlink_direct/mavlink_direct.py
+++ b/py/mavsdk/mavsdk/plugins/mavlink_direct/mavlink_direct.py
@@ -224,6 +224,18 @@ _cmavsdk_lib.mavsdk_mavlink_direct_mavlink_message_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_mavlink_direct_mavlink_message_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_mavlink_direct_mavlink_message_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(MavlinkMessageCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mavlink_direct_mavlink_message_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_mavlink_direct_string_destroy.argtypes = [
+    ctypes.POINTER(ctypes.c_char_p)
+]
+_cmavsdk_lib.mavsdk_mavlink_direct_string_destroy.restype = None
+
 
 _cmavsdk_lib.mavsdk_mavlink_direct_send_message.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/mavsdk/plugins/mission/mission.py
+++ b/py/mavsdk/mavsdk/plugins/mission/mission.py
@@ -816,26 +816,59 @@ _cmavsdk_lib.mavsdk_mission_mission_item_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_mission_mission_item_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_mission_mission_item_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(MissionItemCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mission_mission_item_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_mission_mission_plan_destroy.argtypes = [
     ctypes.POINTER(MissionPlanCStruct)
 ]
 _cmavsdk_lib.mavsdk_mission_mission_plan_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_mission_mission_plan_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(MissionPlanCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mission_mission_plan_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_mission_mission_progress_destroy.argtypes = [
     ctypes.POINTER(MissionProgressCStruct)
 ]
 _cmavsdk_lib.mavsdk_mission_mission_progress_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_mission_mission_progress_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(MissionProgressCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mission_mission_progress_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_mission_progress_data_destroy.argtypes = [
     ctypes.POINTER(ProgressDataCStruct)
 ]
 _cmavsdk_lib.mavsdk_mission_progress_data_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_mission_progress_data_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ProgressDataCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mission_progress_data_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_mission_progress_data_or_mission_destroy.argtypes = [
     ctypes.POINTER(ProgressDataOrMissionCStruct)
 ]
 _cmavsdk_lib.mavsdk_mission_progress_data_or_mission_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_mission_progress_data_or_mission_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ProgressDataOrMissionCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mission_progress_data_or_mission_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_mission_string_destroy.argtypes = [ctypes.POINTER(ctypes.c_char_p)]
+_cmavsdk_lib.mavsdk_mission_string_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_mission_upload_mission_async.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/mavsdk/plugins/mission_raw/mission_raw.py
+++ b/py/mavsdk/mavsdk/plugins/mission_raw/mission_raw.py
@@ -560,11 +560,13 @@ class MissionRaw:
                 py_result = MissionRawResult(result)
 
                 py_data = []
-                if c_data and size.value > 0:
-                    for i in range(size.value):
+                if c_data and size > 0:
+                    for i in range(size):
                         py_data.append(MissionItem.from_c_struct(c_data[i]))
 
-                self._lib.mavsdk_mission_raw_mission_item_destroy(c_data)
+                self._lib.mavsdk_mission_raw_mission_item_array_destroy(
+                    ctypes.byref(c_data), size
+                )
 
                 callback(py_result, py_data, user_data)
 
@@ -592,7 +594,9 @@ class MissionRaw:
         py_result = [
             MissionItem.from_c_struct(result_ptr[i]) for i in range(size.value)
         ]
-        self._lib.mavsdk_mission_raw_mission_item_destroy(result_ptr)
+        self._lib.mavsdk_mission_raw_mission_item_array_destroy(
+            ctypes.byref(result_ptr), size
+        )
         return py_result
 
     def download_geofence_async(self, callback: Callable, user_data: Any = None):
@@ -603,11 +607,13 @@ class MissionRaw:
                 py_result = MissionRawResult(result)
 
                 py_data = []
-                if c_data and size.value > 0:
-                    for i in range(size.value):
+                if c_data and size > 0:
+                    for i in range(size):
                         py_data.append(MissionItem.from_c_struct(c_data[i]))
 
-                self._lib.mavsdk_mission_raw_mission_item_destroy(c_data)
+                self._lib.mavsdk_mission_raw_mission_item_array_destroy(
+                    ctypes.byref(c_data), size
+                )
 
                 callback(py_result, py_data, user_data)
 
@@ -635,7 +641,9 @@ class MissionRaw:
         py_result = [
             MissionItem.from_c_struct(result_ptr[i]) for i in range(size.value)
         ]
-        self._lib.mavsdk_mission_raw_mission_item_destroy(result_ptr)
+        self._lib.mavsdk_mission_raw_mission_item_array_destroy(
+            ctypes.byref(result_ptr), size
+        )
         return py_result
 
     def download_rallypoints_async(self, callback: Callable, user_data: Any = None):
@@ -646,11 +654,13 @@ class MissionRaw:
                 py_result = MissionRawResult(result)
 
                 py_data = []
-                if c_data and size.value > 0:
-                    for i in range(size.value):
+                if c_data and size > 0:
+                    for i in range(size):
                         py_data.append(MissionItem.from_c_struct(c_data[i]))
 
-                self._lib.mavsdk_mission_raw_mission_item_destroy(c_data)
+                self._lib.mavsdk_mission_raw_mission_item_array_destroy(
+                    ctypes.byref(c_data), size
+                )
 
                 callback(py_result, py_data, user_data)
 
@@ -678,7 +688,9 @@ class MissionRaw:
         py_result = [
             MissionItem.from_c_struct(result_ptr[i]) for i in range(size.value)
         ]
-        self._lib.mavsdk_mission_raw_mission_item_destroy(result_ptr)
+        self._lib.mavsdk_mission_raw_mission_item_array_destroy(
+            ctypes.byref(result_ptr), size
+        )
         return py_result
 
     def cancel_mission_download(self):
@@ -1059,26 +1071,61 @@ _cmavsdk_lib.mavsdk_mission_raw_mission_item_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_mission_raw_mission_item_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_mission_raw_mission_item_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(MissionItemCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mission_raw_mission_item_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_mission_raw_mission_plan_destroy.argtypes = [
     ctypes.POINTER(MissionPlanCStruct)
 ]
 _cmavsdk_lib.mavsdk_mission_raw_mission_plan_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_mission_raw_mission_plan_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(MissionPlanCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mission_raw_mission_plan_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_mission_raw_mission_progress_destroy.argtypes = [
     ctypes.POINTER(MissionProgressCStruct)
 ]
 _cmavsdk_lib.mavsdk_mission_raw_mission_progress_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_mission_raw_mission_progress_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(MissionProgressCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mission_raw_mission_progress_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_mission_raw_mission_import_data_destroy.argtypes = [
     ctypes.POINTER(MissionImportDataCStruct)
 ]
 _cmavsdk_lib.mavsdk_mission_raw_mission_import_data_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_mission_raw_mission_import_data_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(MissionImportDataCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mission_raw_mission_import_data_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_mission_raw_progress_data_destroy.argtypes = [
     ctypes.POINTER(ProgressDataCStruct)
 ]
 _cmavsdk_lib.mavsdk_mission_raw_progress_data_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_mission_raw_progress_data_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ProgressDataCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mission_raw_progress_data_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_mission_raw_string_destroy.argtypes = [
+    ctypes.POINTER(ctypes.c_char_p)
+]
+_cmavsdk_lib.mavsdk_mission_raw_string_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_mission_raw_upload_mission_async.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/mavsdk/plugins/mission_raw_server/mission_raw_server.py
+++ b/py/mavsdk/mavsdk/plugins/mission_raw_server/mission_raw_server.py
@@ -396,16 +396,39 @@ _cmavsdk_lib.mavsdk_mission_raw_server_mission_item_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_mission_raw_server_mission_item_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_mission_raw_server_mission_item_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(MissionItemCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mission_raw_server_mission_item_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_mission_raw_server_mission_plan_destroy.argtypes = [
     ctypes.POINTER(MissionPlanCStruct)
 ]
 _cmavsdk_lib.mavsdk_mission_raw_server_mission_plan_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_mission_raw_server_mission_plan_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(MissionPlanCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mission_raw_server_mission_plan_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_mission_raw_server_mission_progress_destroy.argtypes = [
     ctypes.POINTER(MissionProgressCStruct)
 ]
 _cmavsdk_lib.mavsdk_mission_raw_server_mission_progress_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_mission_raw_server_mission_progress_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(MissionProgressCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mission_raw_server_mission_progress_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_mission_raw_server_string_destroy.argtypes = [
+    ctypes.POINTER(ctypes.c_char_p)
+]
+_cmavsdk_lib.mavsdk_mission_raw_server_string_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_mission_raw_server_subscribe_incoming_mission.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/mavsdk/plugins/mocap/mocap.py
+++ b/py/mavsdk/mavsdk/plugins/mocap/mocap.py
@@ -789,51 +789,121 @@ _cmavsdk_lib.mavsdk_mocap_position_body_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_mocap_position_body_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_mocap_position_body_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(PositionBodyCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mocap_position_body_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_mocap_angle_body_destroy.argtypes = [
     ctypes.POINTER(AngleBodyCStruct)
 ]
 _cmavsdk_lib.mavsdk_mocap_angle_body_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_mocap_angle_body_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(AngleBodyCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mocap_angle_body_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_mocap_speed_body_destroy.argtypes = [
     ctypes.POINTER(SpeedBodyCStruct)
 ]
 _cmavsdk_lib.mavsdk_mocap_speed_body_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_mocap_speed_body_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(SpeedBodyCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mocap_speed_body_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_mocap_speed_ned_destroy.argtypes = [ctypes.POINTER(SpeedNedCStruct)]
 _cmavsdk_lib.mavsdk_mocap_speed_ned_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_mocap_speed_ned_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(SpeedNedCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mocap_speed_ned_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_mocap_angular_velocity_body_destroy.argtypes = [
     ctypes.POINTER(AngularVelocityBodyCStruct)
 ]
 _cmavsdk_lib.mavsdk_mocap_angular_velocity_body_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_mocap_angular_velocity_body_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(AngularVelocityBodyCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mocap_angular_velocity_body_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_mocap_covariance_destroy.argtypes = [
     ctypes.POINTER(CovarianceCStruct)
 ]
 _cmavsdk_lib.mavsdk_mocap_covariance_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_mocap_covariance_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(CovarianceCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mocap_covariance_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_mocap_quaternion_destroy.argtypes = [
     ctypes.POINTER(QuaternionCStruct)
 ]
 _cmavsdk_lib.mavsdk_mocap_quaternion_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_mocap_quaternion_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(QuaternionCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mocap_quaternion_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_mocap_vision_position_estimate_destroy.argtypes = [
     ctypes.POINTER(VisionPositionEstimateCStruct)
 ]
 _cmavsdk_lib.mavsdk_mocap_vision_position_estimate_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_mocap_vision_position_estimate_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(VisionPositionEstimateCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mocap_vision_position_estimate_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_mocap_vision_speed_estimate_destroy.argtypes = [
     ctypes.POINTER(VisionSpeedEstimateCStruct)
 ]
 _cmavsdk_lib.mavsdk_mocap_vision_speed_estimate_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_mocap_vision_speed_estimate_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(VisionSpeedEstimateCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mocap_vision_speed_estimate_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_mocap_attitude_position_mocap_destroy.argtypes = [
     ctypes.POINTER(AttitudePositionMocapCStruct)
 ]
 _cmavsdk_lib.mavsdk_mocap_attitude_position_mocap_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_mocap_attitude_position_mocap_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(AttitudePositionMocapCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mocap_attitude_position_mocap_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_mocap_odometry_destroy.argtypes = [ctypes.POINTER(OdometryCStruct)]
 _cmavsdk_lib.mavsdk_mocap_odometry_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_mocap_odometry_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(OdometryCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_mocap_odometry_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_mocap_string_destroy.argtypes = [ctypes.POINTER(ctypes.c_char_p)]
+_cmavsdk_lib.mavsdk_mocap_string_destroy.restype = None
 
 
 _cmavsdk_lib.mavsdk_mocap_set_vision_position_estimate.argtypes = [

--- a/py/mavsdk/mavsdk/plugins/offboard/offboard.py
+++ b/py/mavsdk/mavsdk/plugins/offboard/offboard.py
@@ -804,46 +804,103 @@ _cmavsdk_lib.mavsdk_offboard_attitude_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_offboard_attitude_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_offboard_attitude_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(AttitudeCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_offboard_attitude_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_offboard_actuator_control_group_destroy.argtypes = [
     ctypes.POINTER(ActuatorControlGroupCStruct)
 ]
 _cmavsdk_lib.mavsdk_offboard_actuator_control_group_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_offboard_actuator_control_group_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ActuatorControlGroupCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_offboard_actuator_control_group_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_offboard_actuator_control_destroy.argtypes = [
     ctypes.POINTER(ActuatorControlCStruct)
 ]
 _cmavsdk_lib.mavsdk_offboard_actuator_control_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_offboard_actuator_control_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ActuatorControlCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_offboard_actuator_control_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_offboard_attitude_rate_destroy.argtypes = [
     ctypes.POINTER(AttitudeRateCStruct)
 ]
 _cmavsdk_lib.mavsdk_offboard_attitude_rate_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_offboard_attitude_rate_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(AttitudeRateCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_offboard_attitude_rate_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_offboard_position_ned_yaw_destroy.argtypes = [
     ctypes.POINTER(PositionNedYawCStruct)
 ]
 _cmavsdk_lib.mavsdk_offboard_position_ned_yaw_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_offboard_position_ned_yaw_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(PositionNedYawCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_offboard_position_ned_yaw_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_offboard_position_global_yaw_destroy.argtypes = [
     ctypes.POINTER(PositionGlobalYawCStruct)
 ]
 _cmavsdk_lib.mavsdk_offboard_position_global_yaw_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_offboard_position_global_yaw_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(PositionGlobalYawCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_offboard_position_global_yaw_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_offboard_velocity_body_yawspeed_destroy.argtypes = [
     ctypes.POINTER(VelocityBodyYawspeedCStruct)
 ]
 _cmavsdk_lib.mavsdk_offboard_velocity_body_yawspeed_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_offboard_velocity_body_yawspeed_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(VelocityBodyYawspeedCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_offboard_velocity_body_yawspeed_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_offboard_velocity_ned_yaw_destroy.argtypes = [
     ctypes.POINTER(VelocityNedYawCStruct)
 ]
 _cmavsdk_lib.mavsdk_offboard_velocity_ned_yaw_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_offboard_velocity_ned_yaw_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(VelocityNedYawCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_offboard_velocity_ned_yaw_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_offboard_acceleration_ned_destroy.argtypes = [
     ctypes.POINTER(AccelerationNedCStruct)
 ]
 _cmavsdk_lib.mavsdk_offboard_acceleration_ned_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_offboard_acceleration_ned_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(AccelerationNedCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_offboard_acceleration_ned_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_offboard_string_destroy.argtypes = [ctypes.POINTER(ctypes.c_char_p)]
+_cmavsdk_lib.mavsdk_offboard_string_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_offboard_start_async.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/mavsdk/plugins/param/param.py
+++ b/py/mavsdk/mavsdk/plugins/param/param.py
@@ -365,7 +365,9 @@ class Param:
         if result != ParamResult.SUCCESS:
             raise Exception(f"get_param_custom failed: {result}")
 
-        return result_out.value
+        py_result = result_out.value
+        self._lib.mavsdk_param_string_destroy(ctypes.byref(result_out))
+        return py_result
 
     def set_param_custom(self, name, value):
         """Get set_param_custom (blocking)"""
@@ -428,20 +430,48 @@ _cmavsdk_lib.mavsdk_param_destroy.restype = None
 _cmavsdk_lib.mavsdk_param_int_param_destroy.argtypes = [ctypes.POINTER(IntParamCStruct)]
 _cmavsdk_lib.mavsdk_param_int_param_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_param_int_param_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(IntParamCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_param_int_param_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_param_float_param_destroy.argtypes = [
     ctypes.POINTER(FloatParamCStruct)
 ]
 _cmavsdk_lib.mavsdk_param_float_param_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_param_float_param_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(FloatParamCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_param_float_param_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_param_custom_param_destroy.argtypes = [
     ctypes.POINTER(CustomParamCStruct)
 ]
 _cmavsdk_lib.mavsdk_param_custom_param_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_param_custom_param_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(CustomParamCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_param_custom_param_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_param_all_params_destroy.argtypes = [
     ctypes.POINTER(AllParamsCStruct)
 ]
 _cmavsdk_lib.mavsdk_param_all_params_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_param_all_params_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(AllParamsCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_param_all_params_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_param_string_destroy.argtypes = [ctypes.POINTER(ctypes.c_char_p)]
+_cmavsdk_lib.mavsdk_param_string_destroy.restype = None
 
 
 _cmavsdk_lib.mavsdk_param_get_param_int.argtypes = [

--- a/py/mavsdk/mavsdk/plugins/param_server/param_server.py
+++ b/py/mavsdk/mavsdk/plugins/param_server/param_server.py
@@ -364,7 +364,9 @@ class ParamServer:
         if result != ParamServerResult.SUCCESS:
             raise Exception(f"retrieve_param_custom failed: {result}")
 
-        return result_out.value
+        py_result = result_out.value
+        self._lib.mavsdk_param_server_string_destroy(ctypes.byref(result_out))
+        return py_result
 
     def provide_param_custom(self, name, value):
         """Get provide_param_custom (blocking)"""
@@ -501,20 +503,50 @@ _cmavsdk_lib.mavsdk_param_server_int_param_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_param_server_int_param_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_param_server_int_param_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(IntParamCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_param_server_int_param_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_param_server_float_param_destroy.argtypes = [
     ctypes.POINTER(FloatParamCStruct)
 ]
 _cmavsdk_lib.mavsdk_param_server_float_param_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_param_server_float_param_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(FloatParamCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_param_server_float_param_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_param_server_custom_param_destroy.argtypes = [
     ctypes.POINTER(CustomParamCStruct)
 ]
 _cmavsdk_lib.mavsdk_param_server_custom_param_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_param_server_custom_param_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(CustomParamCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_param_server_custom_param_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_param_server_all_params_destroy.argtypes = [
     ctypes.POINTER(AllParamsCStruct)
 ]
 _cmavsdk_lib.mavsdk_param_server_all_params_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_param_server_all_params_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(AllParamsCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_param_server_all_params_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_param_server_string_destroy.argtypes = [
+    ctypes.POINTER(ctypes.c_char_p)
+]
+_cmavsdk_lib.mavsdk_param_server_string_destroy.restype = None
 
 
 _cmavsdk_lib.mavsdk_param_server_set_protocol.argtypes = [

--- a/py/mavsdk/mavsdk/plugins/rtk/rtk.py
+++ b/py/mavsdk/mavsdk/plugins/rtk/rtk.py
@@ -132,6 +132,16 @@ _cmavsdk_lib.mavsdk_rtk_destroy.restype = None
 _cmavsdk_lib.mavsdk_rtk_rtcm_data_destroy.argtypes = [ctypes.POINTER(RtcmDataCStruct)]
 _cmavsdk_lib.mavsdk_rtk_rtcm_data_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_rtk_rtcm_data_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(RtcmDataCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_rtk_rtcm_data_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_rtk_string_destroy.argtypes = [ctypes.POINTER(ctypes.c_char_p)]
+_cmavsdk_lib.mavsdk_rtk_string_destroy.restype = None
+
 
 _cmavsdk_lib.mavsdk_rtk_send_rtcm_data.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/mavsdk/plugins/server_utility/server_utility.py
+++ b/py/mavsdk/mavsdk/plugins/server_utility/server_utility.py
@@ -107,6 +107,12 @@ _cmavsdk_lib.mavsdk_server_utility_destroy.argtypes = [ctypes.c_void_p]
 _cmavsdk_lib.mavsdk_server_utility_destroy.restype = None
 
 
+_cmavsdk_lib.mavsdk_server_utility_string_destroy.argtypes = [
+    ctypes.POINTER(ctypes.c_char_p)
+]
+_cmavsdk_lib.mavsdk_server_utility_string_destroy.restype = None
+
+
 _cmavsdk_lib.mavsdk_server_utility_send_status_text.argtypes = [
     ctypes.c_void_p,
     ctypes.c_int,

--- a/py/mavsdk/mavsdk/plugins/shell/shell.py
+++ b/py/mavsdk/mavsdk/plugins/shell/shell.py
@@ -83,7 +83,9 @@ class Shell:
 
         def c_callback(c_data, ud):
             try:
-                py_data = c_data
+                _string_ptr = ctypes.cast(c_data, ctypes.c_char_p)
+                py_data = _string_ptr.value
+                self._lib.mavsdk_shell_string_destroy(ctypes.byref(_string_ptr))
 
                 callback(py_data, user_data)
 
@@ -110,7 +112,7 @@ class Shell:
 
 
 # ===== Callback Types =====
-ReceiveCallback = ctypes.CFUNCTYPE(None, ctypes.c_char_p, ctypes.c_void_p)
+ReceiveCallback = ctypes.CFUNCTYPE(None, ctypes.POINTER(ctypes.c_char), ctypes.c_void_p)
 
 # ===== Setup Functions =====
 _cmavsdk_lib.mavsdk_shell_create.argtypes = [ctypes.c_void_p]
@@ -118,6 +120,10 @@ _cmavsdk_lib.mavsdk_shell_create.restype = ctypes.c_void_p
 
 _cmavsdk_lib.mavsdk_shell_destroy.argtypes = [ctypes.c_void_p]
 _cmavsdk_lib.mavsdk_shell_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_shell_string_destroy.argtypes = [ctypes.POINTER(ctypes.c_char_p)]
+_cmavsdk_lib.mavsdk_shell_string_destroy.restype = None
 
 
 _cmavsdk_lib.mavsdk_shell_send.argtypes = [

--- a/py/mavsdk/mavsdk/plugins/telemetry/telemetry.py
+++ b/py/mavsdk/mavsdk/plugins/telemetry/telemetry.py
@@ -4293,153 +4293,350 @@ _cmavsdk_lib.mavsdk_telemetry_position_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_telemetry_position_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_position_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(PositionCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_position_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_heading_destroy.argtypes = [
     ctypes.POINTER(HeadingCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_heading_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_heading_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(HeadingCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_heading_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_quaternion_destroy.argtypes = [
     ctypes.POINTER(QuaternionCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_quaternion_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_quaternion_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(QuaternionCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_quaternion_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_home_position_destroy.argtypes = [
     ctypes.POINTER(HomePositionCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_home_position_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_home_position_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(HomePositionCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_home_position_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_euler_angle_destroy.argtypes = [
     ctypes.POINTER(EulerAngleCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_euler_angle_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_euler_angle_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(EulerAngleCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_euler_angle_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_angular_velocity_body_destroy.argtypes = [
     ctypes.POINTER(AngularVelocityBodyCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_angular_velocity_body_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_angular_velocity_body_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(AngularVelocityBodyCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_angular_velocity_body_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_gps_info_destroy.argtypes = [
     ctypes.POINTER(GpsInfoCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_gps_info_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_gps_info_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(GpsInfoCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_gps_info_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_raw_gps_destroy.argtypes = [ctypes.POINTER(RawGpsCStruct)]
 _cmavsdk_lib.mavsdk_telemetry_raw_gps_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_raw_gps_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(RawGpsCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_raw_gps_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_battery_destroy.argtypes = [
     ctypes.POINTER(BatteryCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_battery_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_battery_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(BatteryCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_battery_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_health_destroy.argtypes = [ctypes.POINTER(HealthCStruct)]
 _cmavsdk_lib.mavsdk_telemetry_health_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_health_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(HealthCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_health_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_rc_status_destroy.argtypes = [
     ctypes.POINTER(RcStatusCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_rc_status_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_rc_status_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(RcStatusCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_rc_status_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_status_text_destroy.argtypes = [
     ctypes.POINTER(StatusTextCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_status_text_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_status_text_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(StatusTextCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_status_text_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_actuator_control_target_destroy.argtypes = [
     ctypes.POINTER(ActuatorControlTargetCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_actuator_control_target_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_actuator_control_target_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ActuatorControlTargetCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_actuator_control_target_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_actuator_output_status_destroy.argtypes = [
     ctypes.POINTER(ActuatorOutputStatusCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_actuator_output_status_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_actuator_output_status_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ActuatorOutputStatusCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_actuator_output_status_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_covariance_destroy.argtypes = [
     ctypes.POINTER(CovarianceCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_covariance_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_covariance_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(CovarianceCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_covariance_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_velocity_body_destroy.argtypes = [
     ctypes.POINTER(VelocityBodyCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_velocity_body_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_velocity_body_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(VelocityBodyCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_velocity_body_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_position_body_destroy.argtypes = [
     ctypes.POINTER(PositionBodyCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_position_body_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_position_body_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(PositionBodyCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_position_body_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_odometry_destroy.argtypes = [
     ctypes.POINTER(OdometryCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_odometry_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_odometry_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(OdometryCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_odometry_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_distance_sensor_destroy.argtypes = [
     ctypes.POINTER(DistanceSensorCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_distance_sensor_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_distance_sensor_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(DistanceSensorCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_distance_sensor_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_scaled_pressure_destroy.argtypes = [
     ctypes.POINTER(ScaledPressureCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_scaled_pressure_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_scaled_pressure_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ScaledPressureCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_scaled_pressure_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_position_ned_destroy.argtypes = [
     ctypes.POINTER(PositionNedCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_position_ned_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_position_ned_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(PositionNedCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_position_ned_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_velocity_ned_destroy.argtypes = [
     ctypes.POINTER(VelocityNedCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_velocity_ned_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_velocity_ned_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(VelocityNedCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_velocity_ned_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_position_velocity_ned_destroy.argtypes = [
     ctypes.POINTER(PositionVelocityNedCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_position_velocity_ned_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_position_velocity_ned_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(PositionVelocityNedCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_position_velocity_ned_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_ground_truth_destroy.argtypes = [
     ctypes.POINTER(GroundTruthCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_ground_truth_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_ground_truth_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(GroundTruthCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_ground_truth_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_fixedwing_metrics_destroy.argtypes = [
     ctypes.POINTER(FixedwingMetricsCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_fixedwing_metrics_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_fixedwing_metrics_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(FixedwingMetricsCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_fixedwing_metrics_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_acceleration_frd_destroy.argtypes = [
     ctypes.POINTER(AccelerationFrdCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_acceleration_frd_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_acceleration_frd_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(AccelerationFrdCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_acceleration_frd_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_angular_velocity_frd_destroy.argtypes = [
     ctypes.POINTER(AngularVelocityFrdCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_angular_velocity_frd_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_angular_velocity_frd_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(AngularVelocityFrdCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_angular_velocity_frd_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_magnetic_field_frd_destroy.argtypes = [
     ctypes.POINTER(MagneticFieldFrdCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_magnetic_field_frd_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_magnetic_field_frd_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(MagneticFieldFrdCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_magnetic_field_frd_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_imu_destroy.argtypes = [ctypes.POINTER(ImuCStruct)]
 _cmavsdk_lib.mavsdk_telemetry_imu_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_imu_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ImuCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_imu_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_gps_global_origin_destroy.argtypes = [
     ctypes.POINTER(GpsGlobalOriginCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_gps_global_origin_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_gps_global_origin_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(GpsGlobalOriginCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_gps_global_origin_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_altitude_destroy.argtypes = [
     ctypes.POINTER(AltitudeCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_altitude_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_altitude_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(AltitudeCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_altitude_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_wind_destroy.argtypes = [ctypes.POINTER(WindCStruct)]
 _cmavsdk_lib.mavsdk_telemetry_wind_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_wind_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(WindCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_wind_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_telemetry_string_destroy.argtypes = [
+    ctypes.POINTER(ctypes.c_char_p)
+]
+_cmavsdk_lib.mavsdk_telemetry_string_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_subscribe_position.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/mavsdk/plugins/telemetry_server/telemetry_server.py
+++ b/py/mavsdk/mavsdk/plugins/telemetry_server/telemetry_server.py
@@ -1896,133 +1896,303 @@ _cmavsdk_lib.mavsdk_telemetry_server_position_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_position_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_server_position_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(PositionCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_position_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_server_heading_destroy.argtypes = [
     ctypes.POINTER(HeadingCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_heading_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_server_heading_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(HeadingCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_heading_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_server_quaternion_destroy.argtypes = [
     ctypes.POINTER(QuaternionCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_quaternion_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_server_quaternion_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(QuaternionCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_quaternion_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_server_euler_angle_destroy.argtypes = [
     ctypes.POINTER(EulerAngleCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_euler_angle_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_server_euler_angle_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(EulerAngleCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_euler_angle_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_server_angular_velocity_body_destroy.argtypes = [
     ctypes.POINTER(AngularVelocityBodyCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_angular_velocity_body_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_server_angular_velocity_body_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(AngularVelocityBodyCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_angular_velocity_body_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_server_gps_info_destroy.argtypes = [
     ctypes.POINTER(GpsInfoCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_gps_info_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_server_gps_info_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(GpsInfoCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_gps_info_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_server_raw_gps_destroy.argtypes = [
     ctypes.POINTER(RawGpsCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_raw_gps_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_server_raw_gps_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(RawGpsCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_raw_gps_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_server_battery_destroy.argtypes = [
     ctypes.POINTER(BatteryCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_battery_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_server_battery_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(BatteryCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_battery_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_server_rc_status_destroy.argtypes = [
     ctypes.POINTER(RcStatusCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_rc_status_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_server_rc_status_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(RcStatusCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_rc_status_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_server_status_text_destroy.argtypes = [
     ctypes.POINTER(StatusTextCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_status_text_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_server_status_text_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(StatusTextCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_status_text_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_server_actuator_control_target_destroy.argtypes = [
     ctypes.POINTER(ActuatorControlTargetCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_actuator_control_target_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_server_actuator_control_target_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ActuatorControlTargetCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_actuator_control_target_array_destroy.restype = (
+    None
+)
+
 _cmavsdk_lib.mavsdk_telemetry_server_actuator_output_status_destroy.argtypes = [
     ctypes.POINTER(ActuatorOutputStatusCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_actuator_output_status_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_server_actuator_output_status_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ActuatorOutputStatusCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_actuator_output_status_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_server_covariance_destroy.argtypes = [
     ctypes.POINTER(CovarianceCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_covariance_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_server_covariance_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(CovarianceCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_covariance_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_server_velocity_body_destroy.argtypes = [
     ctypes.POINTER(VelocityBodyCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_velocity_body_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_server_velocity_body_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(VelocityBodyCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_velocity_body_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_server_position_body_destroy.argtypes = [
     ctypes.POINTER(PositionBodyCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_position_body_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_server_position_body_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(PositionBodyCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_position_body_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_server_odometry_destroy.argtypes = [
     ctypes.POINTER(OdometryCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_odometry_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_server_odometry_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(OdometryCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_odometry_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_server_distance_sensor_destroy.argtypes = [
     ctypes.POINTER(DistanceSensorCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_distance_sensor_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_server_distance_sensor_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(DistanceSensorCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_distance_sensor_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_server_scaled_pressure_destroy.argtypes = [
     ctypes.POINTER(ScaledPressureCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_scaled_pressure_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_server_scaled_pressure_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ScaledPressureCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_scaled_pressure_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_server_position_ned_destroy.argtypes = [
     ctypes.POINTER(PositionNedCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_position_ned_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_server_position_ned_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(PositionNedCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_position_ned_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_server_velocity_ned_destroy.argtypes = [
     ctypes.POINTER(VelocityNedCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_velocity_ned_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_server_velocity_ned_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(VelocityNedCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_velocity_ned_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_server_position_velocity_ned_destroy.argtypes = [
     ctypes.POINTER(PositionVelocityNedCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_position_velocity_ned_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_server_position_velocity_ned_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(PositionVelocityNedCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_position_velocity_ned_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_server_ground_truth_destroy.argtypes = [
     ctypes.POINTER(GroundTruthCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_ground_truth_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_server_ground_truth_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(GroundTruthCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_ground_truth_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_server_fixedwing_metrics_destroy.argtypes = [
     ctypes.POINTER(FixedwingMetricsCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_fixedwing_metrics_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_server_fixedwing_metrics_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(FixedwingMetricsCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_fixedwing_metrics_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_server_acceleration_frd_destroy.argtypes = [
     ctypes.POINTER(AccelerationFrdCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_acceleration_frd_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_server_acceleration_frd_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(AccelerationFrdCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_acceleration_frd_array_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_telemetry_server_angular_velocity_frd_destroy.argtypes = [
     ctypes.POINTER(AngularVelocityFrdCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_angular_velocity_frd_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_server_angular_velocity_frd_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(AngularVelocityFrdCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_angular_velocity_frd_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_server_magnetic_field_frd_destroy.argtypes = [
     ctypes.POINTER(MagneticFieldFrdCStruct)
 ]
 _cmavsdk_lib.mavsdk_telemetry_server_magnetic_field_frd_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_telemetry_server_magnetic_field_frd_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(MagneticFieldFrdCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_magnetic_field_frd_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_telemetry_server_imu_destroy.argtypes = [ctypes.POINTER(ImuCStruct)]
 _cmavsdk_lib.mavsdk_telemetry_server_imu_destroy.restype = None
+
+_cmavsdk_lib.mavsdk_telemetry_server_imu_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ImuCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_telemetry_server_imu_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_telemetry_server_string_destroy.argtypes = [
+    ctypes.POINTER(ctypes.c_char_p)
+]
+_cmavsdk_lib.mavsdk_telemetry_server_string_destroy.restype = None
 
 
 _cmavsdk_lib.mavsdk_telemetry_server_publish_position.argtypes = [

--- a/py/mavsdk/mavsdk/plugins/transponder/transponder.py
+++ b/py/mavsdk/mavsdk/plugins/transponder/transponder.py
@@ -296,6 +296,17 @@ _cmavsdk_lib.mavsdk_transponder_adsb_vehicle_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_transponder_adsb_vehicle_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_transponder_adsb_vehicle_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(AdsbVehicleCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_transponder_adsb_vehicle_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_transponder_string_destroy.argtypes = [
+    ctypes.POINTER(ctypes.c_char_p)
+]
+_cmavsdk_lib.mavsdk_transponder_string_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_transponder_subscribe_transponder.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/mavsdk/plugins/tune/tune.py
+++ b/py/mavsdk/mavsdk/plugins/tune/tune.py
@@ -184,6 +184,15 @@ _cmavsdk_lib.mavsdk_tune_tune_description_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_tune_tune_description_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_tune_tune_description_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(TuneDescriptionCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_tune_tune_description_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_tune_string_destroy.argtypes = [ctypes.POINTER(ctypes.c_char_p)]
+_cmavsdk_lib.mavsdk_tune_string_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_tune_play_tune_async.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/mavsdk/plugins/winch/winch.py
+++ b/py/mavsdk/mavsdk/plugins/winch/winch.py
@@ -664,9 +664,24 @@ _cmavsdk_lib.mavsdk_winch_status_flags_destroy.argtypes = [
 ]
 _cmavsdk_lib.mavsdk_winch_status_flags_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_winch_status_flags_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(StatusFlagsCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_winch_status_flags_array_destroy.restype = None
+
 _cmavsdk_lib.mavsdk_winch_status_destroy.argtypes = [ctypes.POINTER(StatusCStruct)]
 _cmavsdk_lib.mavsdk_winch_status_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_winch_status_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(StatusCStruct)),
+    ctypes.c_size_t,
+]
+_cmavsdk_lib.mavsdk_winch_status_array_destroy.restype = None
+
+
+_cmavsdk_lib.mavsdk_winch_string_destroy.argtypes = [ctypes.POINTER(ctypes.c_char_p)]
+_cmavsdk_lib.mavsdk_winch_string_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_winch_subscribe_status.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/templates/file.py.j2
+++ b/py/mavsdk/templates/file.py.j2
@@ -244,7 +244,16 @@ class {{ plugin_name.upper_camel_case }}:
 
                 {% if method.return_type %}
                 {# Handle return data conversion #}
-                  {% if method.return_type.is_primitive %}
+                  {% if method.return_type.is_string %}
+                  {# MAVSDK hands over a strdup'd copy that is ours to free.
+                     The callback declares this argument as POINTER(c_char)
+                     rather than c_char_p precisely so the pointer survives:
+                     ctypes converts a c_char_p argument to bytes, leaving
+                     nothing to free. #}
+                _string_ptr = ctypes.cast(c_data, ctypes.c_char_p)
+                py_data = _string_ptr.value
+                self._lib.mavsdk_{{ plugin_name.lower_snake_case }}_string_destroy(ctypes.byref(_string_ptr))
+                  {% elif method.return_type.is_primitive %}
                   {# Primitive types - no conversion needed #}
                 py_data = c_data
                   {% elif method.return_type.is_enum %}
@@ -253,18 +262,21 @@ class {{ plugin_name.upper_camel_case }}:
                   {% else %}
                   {# Struct types - convert from CStruct #}
                     {% if method.return_type.is_repeated %}
-                    {# Handle array types #}
+                    {# Handle array types. ctypes converts a size_t callback
+                       argument to a plain Python int, so it has no .value. #}
                 py_data = []
-                if c_data and size.value > 0:
-                    for i in range(size.value):
+                if c_data and size > 0:
+                    for i in range(size):
                         py_data.append({{ method.return_type.inner_name.upper_camel_case }}.from_c_struct(c_data[i]))
                     {% else %}
                 py_data = {{ method.return_type.inner_name.upper_camel_case }}.from_c_struct(c_data)
                     {% endif %}
 
-                    {# Destroy C struct #}
+                    {# Release the memory MAVSDK allocated for the payload. For
+                       an array that means the elements and the array itself,
+                       which is what _array_destroy does. #}
                     {% if method.return_type.is_repeated %}
-                self._lib.mavsdk_{{ plugin_name.lower_snake_case }}_{{ method.return_type.inner_name.lower_snake_case }}_destroy(c_data)
+                self._lib.mavsdk_{{ plugin_name.lower_snake_case }}_{{ method.return_type.inner_name.lower_snake_case }}_array_destroy(ctypes.byref(c_data), size)
                     {% else %}
                 self._lib.mavsdk_{{ plugin_name.lower_snake_case }}_{{ method.return_type.inner_name.lower_snake_case }}_destroy(ctypes.byref(c_data))
                     {% endif %}
@@ -387,10 +399,15 @@ class {{ plugin_name.upper_camel_case }}:
           {% if method.return_type.is_repeated %}
         {# Convert C array to Python list #}
         py_result = [{{ method.return_type.inner_name.upper_camel_case }}.from_c_struct(result_ptr[i]) for i in range(size.value)]
-        self._lib.mavsdk_{{ plugin_name.lower_snake_case }}_{{ method.return_type.inner_name.lower_snake_case }}_destroy(result_ptr)
+        self._lib.mavsdk_{{ plugin_name.lower_snake_case }}_{{ method.return_type.inner_name.lower_snake_case }}_array_destroy(ctypes.byref(result_ptr), size)
         return py_result
           {% else %}
-            {% if method.return_type.is_primitive %}
+            {% if method.return_type.is_string %}
+        {# The string is a strdup'd copy that is ours to free once read. #}
+        py_result = result_out.value
+        self._lib.mavsdk_{{ plugin_name.lower_snake_case }}_string_destroy(ctypes.byref(result_out))
+        return py_result
+            {% elif method.return_type.is_primitive %}
         return result_out.value
             {% elif method.return_type.is_enum %}
         {# Convert C enum to Python enum #}
@@ -427,7 +444,11 @@ class {{ plugin_name.upper_camel_case }}:
     ctypes.c_int,
     {% endif %}
     {% if method.return_type %}
-      {% if method.return_type.is_primitive %}
+      {% if method.return_type.is_string %}
+    {# Not c_char_p: that would arrive as bytes, losing the pointer the
+       callback has to free. #}
+    ctypes.POINTER(ctypes.c_char),
+      {% elif method.return_type.is_primitive %}
     ctypes.{{ method.return_type.name }},
       {% elif method.return_type.is_enum %}
     ctypes.c_int,
@@ -459,8 +480,19 @@ _cmavsdk_lib.mavsdk_{{ plugin_name.lower_snake_case }}_{{ struct.name.lower_snak
 ]
 _cmavsdk_lib.mavsdk_{{ plugin_name.lower_snake_case }}_{{ struct.name.lower_snake_case }}_destroy.restype = None
 
+_cmavsdk_lib.mavsdk_{{ plugin_name.lower_snake_case }}_{{ struct.name.lower_snake_case }}_array_destroy.argtypes = [
+    ctypes.POINTER(ctypes.POINTER({{ struct.name.upper_camel_case }}CStruct)),
+    ctypes.c_size_t
+]
+_cmavsdk_lib.mavsdk_{{ plugin_name.lower_snake_case }}_{{ struct.name.lower_snake_case }}_array_destroy.restype = None
+
   {% endif %}
 {% endfor %}
+
+_cmavsdk_lib.mavsdk_{{ plugin_name.lower_snake_case }}_string_destroy.argtypes = [
+    ctypes.POINTER(ctypes.c_char_p)
+]
+_cmavsdk_lib.mavsdk_{{ plugin_name.lower_snake_case }}_string_destroy.restype = None
 
 {% for method in methods %}
   {% if method.is_async %}


### PR DESCRIPTION
* Destroying an array should call `_array_destroy` instead of `_destroy`.
* Handle strings properly so they get freed.

Note: changes are only in the template file, the rest is auto-generated.