### PR TITLE
CI: fix GitHub regression

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -767,7 +767,7 @@ jobs:
           echo "cmake_prefix_path=-DCMAKE_PREFIX_PATH=/work/build/manylinux/cpp/third_party/install" >> $GITHUB_ENV
       - name: configure cpp
         working-directory: .
-        run: ./dockcross-${{ matrix.arch_name }} /bin/bash -c "yum install -y perl-core && cmake $superbuild $cmake_prefix_path -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=build/manylinux/cpp/install -DBUILD_MAVSDK_SERVER=OFF -Bbuild/manylinux/cpp -Scpp"
+        run: ./dockcross-${{ matrix.arch_name }} /bin/bash -c "sudo yum install -y perl-core && cmake $superbuild $cmake_prefix_path -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=build/manylinux/cpp/install -DBUILD_MAVSDK_SERVER=OFF -Bbuild/manylinux/cpp -Scpp"
       - name: build cpp
         working-directory: .
         run: ./dockcross-${{ matrix.arch_name }} cmake --build build/manylinux/cpp -j$(nproc) --target install
@@ -786,8 +786,8 @@ jobs:
       - name: build mavsdk wheel
         working-directory: .
         run: ./dockcross-${{ matrix.arch_name }} bash -c "
-          ${{ matrix.python_exec_pip }} install -r /work/py/requirements-dev.txt auditwheel &&
-          ${{ matrix.python_exec_auditwheel }} -m pip install auditwheel &&
+          sudo ${{ matrix.python_exec_pip }} install -r /work/py/requirements-dev.txt auditwheel &&
+          sudo ${{ matrix.python_exec_auditwheel }} -m pip install auditwheel &&
           mkdir -p /work/py/mavsdk/mavsdk/lib &&
           cp /work/build/manylinux/c/install/lib/libcmavsdk.so /work/py/mavsdk/mavsdk/lib/libcmavsdk.so &&
           cd /work/py/mavsdk &&
@@ -804,7 +804,7 @@ jobs:
         if: matrix.artifact_arch == 'x86_64'
         working-directory: .
         run: ./dockcross-${{ matrix.arch_name }} bash -c "
-          ${{ matrix.python_exec_pip }} install -r /work/py/requirements-dev.txt &&
+          sudo ${{ matrix.python_exec_pip }} install -r /work/py/requirements-dev.txt &&
           cd /work/py/aiomavsdk &&
           ${{ matrix.python_exec }} setup.py bdist_wheel"
       - name: upload aiomavsdk wheel

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -557,6 +557,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       ARG_IMAGE: docker.io/mavsdk/mavsdk-dockcross-linux-${{ matrix.docker_name }}-custom:${{ needs.check-docker-changes.outputs.docker_tag }}
+      OCI_EXE: docker
     strategy:
       fail-fast: false
       matrix:
@@ -680,6 +681,8 @@ jobs:
   dockcross-linux-musl:
     name: ${{ matrix.arch_name }}
     runs-on: ubuntu-24.04
+    env:
+      OCI_EXE: docker
     strategy:
       fail-fast: false
       matrix:
@@ -724,6 +727,8 @@ jobs:
   dockcross-manylinux:
     name: ${{ matrix.arch_name }}
     runs-on: ubuntu-24.04
+    env:
+      OCI_EXE: docker
     strategy:
       fail-fast: false
       matrix:
@@ -813,6 +818,8 @@ jobs:
   dockcross-android:
     name: ${{ matrix.name }}
     runs-on: ubuntu-24.04
+    env:
+      OCI_EXE: docker
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -792,7 +792,7 @@ jobs:
           cp /work/build/manylinux/c/install/lib/libcmavsdk.so /work/py/mavsdk/mavsdk/lib/libcmavsdk.so &&
           cd /work/py/mavsdk &&
           ${{ matrix.python_exec }} setup.py bdist_wheel ${{ matrix.python_plat_name_arg }} &&
-          ${{ matrix.python_exec_auditwheel }} -m auditwheel repair --plat ${{ matrix.auditwheel_plat }} dist/mavsdk4-*-linux_*.whl"
+          sudo ${{ matrix.python_exec_auditwheel }} -m auditwheel repair --plat ${{ matrix.auditwheel_plat }} dist/mavsdk4-*-linux_*.whl"
       - name: upload mavsdk wheel
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
There seems to be an issue with podman following GitHub changes on some machines, resulting in errors like:

```
Run ./dockcross-linux-armv6-musl /bin/bash -c "cmake $superbuild $cmake_prefix_path -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/linux-armv6-musl/install -DBUILD_MAVSDK_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_MAVSDK_SERVER=ON -DWERROR=ON -Bbuild/linux-armv6-musl -H."
Resolving "dockcross/linux-armv6-musl" using unqualified-search registries (/etc/containers/registries.conf)
Trying to pull docker.io/dockcross/linux-armv6-musl:20250818-0a27819...
Getting image source signatures
Copying blob sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
Copying blob sha256:b1badc6e50664185acfaa0ca255d8076061c2a9d881cecaaad281ae11af000ce
Copying blob sha256:3fb5983793213bde9abfc3fcc3dd86a2d0b7ec6d596386bc535ab331b324472a
Copying blob sha256:4ab940ad7bf4dfa77c33274236b2ac3c48469d660a00fde18cfc889d749e6eab
Copying blob sha256:2575536e2962eabc6539610d6a9f949e74817e9f0a49c17b6793704975bf53a3
Copying blob sha256:8890500bae6a4ff2051b07b9e728da0d8b982511ca834232f799bc8efa86a77c
Copying blob sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
Copying blob sha256:a1b388d2270a167bfda10bbd45f82dfb554daad13b89f4fccfa3744d14625f95
Copying blob sha256:56780bcb2a8f18f8dd950a9a42d18834154446eb5a0510ea09f17e4e9762afa2
Copying blob sha256:9a984b42e4db6609902a6e7b184ed8419f87a24945899bed17c0530a2d070baf
Copying blob sha256:3861cd583188027368cda9f104c45d7569d0a2b01427cf10f285b6ab4b3a4e59
Copying blob sha256:7d9d5d5d215b65caa303bccfe1298e3b30e5d17951047a7422b171cb7a492c60
Copying blob sha256:ed5292a11f2bd6ce8008dd29c0960e5eadda02dee24a8d53d32dddacd1c24454
Copying blob sha256:ab7e20762d6f453d2d508c1344edc7077fa16dd72434feb7c850fd1ea11b8d1d
Copying blob sha256:dd529e553399eb30d8f739db2312f5b39edcf6b5b93fc19d00aef576e3440481
Copying blob sha256:50f6e8bf1a3a73a67cddecab49127fe397f980698121765ccde0e9f7dfd26123
Copying blob sha256:a73333503f22a4f33d5a6f1db6fadd8e8274a2aa2d0bff205c94dcf3ab99dacd
Copying config sha256:b5663500cbf7fdb84db6a366dfbb9bba6aad8dcbc61dcff27ae5d6569b303325
Writing manifest to image destination
Error: OCI runtime error: crun: unknown version specified
Error: Process completed with exit code 126.
```

My solution is to use docker instead of podman, which requires a couple `sudo`s in the manylinux builds 🙈