### PR TITLE
Various python fixes

### DIFF
--- a/c/src/cmavsdk/mavsdk.cpp
+++ b/c/src/cmavsdk/mavsdk.cpp
@@ -367,6 +367,10 @@ mavsdk_server_component_t mavsdk_server_component(
     return nullptr;
 }
 
+void mavsdk_server_component_destroy(mavsdk_server_component_t server_component) {
+    delete reinterpret_cast<std::shared_ptr<ServerComponent>*>(server_component);
+}
+
 mavsdk_server_component_t mavsdk_server_component_by_type(
     mavsdk_t mavsdk,
     mavsdk_component_type_t component_type,

--- a/c/src/cmavsdk/mavsdk.h
+++ b/c/src/cmavsdk/mavsdk.h
@@ -169,6 +169,9 @@ CMAVSDK_EXPORT mavsdk_server_component_t mavsdk_server_component(
     mavsdk_t mavsdk,
     unsigned int instance
 );
+CMAVSDK_EXPORT void mavsdk_server_component_destroy(
+    mavsdk_server_component_t server_component
+);
 CMAVSDK_EXPORT mavsdk_server_component_t mavsdk_server_component_by_type(
     mavsdk_t mavsdk,
     mavsdk_component_type_t component_type,

--- a/c/src/cmavsdk/system.cpp
+++ b/c/src/cmavsdk/system.cpp
@@ -3,6 +3,7 @@
 #include <mavsdk/system.hpp>
 #include <mavsdk/component_type.hpp>
 #include <cstring>
+#include <memory>
 #include <vector>
 
 using namespace mavsdk;
@@ -11,44 +12,44 @@ extern "C" {
 
 // --- Creation / Destruction ---
 void mavsdk_system_destroy(mavsdk_system_t system) {
-    auto* cpp_system_ptr = static_cast<System**>(system);
+    auto* cpp_system_ptr = reinterpret_cast<std::shared_ptr<System>*>(system);
     delete cpp_system_ptr;
 }
 
 // --- Basic Queries ---
 bool mavsdk_system_has_autopilot(mavsdk_system_t system) {
-    auto* cpp_system_ptr = static_cast<System**>(system);
+    auto* cpp_system_ptr = reinterpret_cast<std::shared_ptr<System>*>(system);
     return (*cpp_system_ptr)->has_autopilot();
 }
 
 bool mavsdk_system_is_standalone(mavsdk_system_t system) {
-    auto* cpp_system_ptr = static_cast<System**>(system);
+    auto* cpp_system_ptr = reinterpret_cast<std::shared_ptr<System>*>(system);
     return (*cpp_system_ptr)->is_standalone();
 }
 
 bool mavsdk_system_has_camera(mavsdk_system_t system, int camera_id) {
-    auto* cpp_system_ptr = static_cast<System**>(system);
+    auto* cpp_system_ptr = reinterpret_cast<std::shared_ptr<System>*>(system);
     return (*cpp_system_ptr)->has_camera(camera_id);
 }
 
 bool mavsdk_system_has_gimbal(mavsdk_system_t system) {
-    auto* cpp_system_ptr = static_cast<System**>(system);
+    auto* cpp_system_ptr = reinterpret_cast<std::shared_ptr<System>*>(system);
     return (*cpp_system_ptr)->has_gimbal();
 }
 
 bool mavsdk_system_is_connected(mavsdk_system_t system) {
-    auto* cpp_system_ptr = static_cast<System**>(system);
+    auto* cpp_system_ptr = reinterpret_cast<std::shared_ptr<System>*>(system);
     return (*cpp_system_ptr)->is_connected();
 }
 
 uint8_t mavsdk_system_get_system_id(mavsdk_system_t system) {
-    auto* cpp_system_ptr = static_cast<System**>(system);
+    auto* cpp_system_ptr = reinterpret_cast<std::shared_ptr<System>*>(system);
     return (*cpp_system_ptr)->get_system_id();
 }
 
 // --- Component IDs ---
 uint8_t* mavsdk_system_component_ids(mavsdk_system_t system, size_t* count) {
-    auto* cpp_system_ptr = static_cast<System**>(system);
+    auto* cpp_system_ptr = reinterpret_cast<std::shared_ptr<System>*>(system);
     auto ids = (*cpp_system_ptr)->component_ids();
     *count = ids.size();
     if (ids.empty()) {
@@ -87,7 +88,7 @@ mavsdk_is_connected_handle_t mavsdk_system_subscribe_is_connected(
     mavsdk_is_connected_callback_t callback,
     void* user_data)
 {
-    auto* cpp_system_ptr = static_cast<System**>(system);
+    auto* cpp_system_ptr = reinterpret_cast<std::shared_ptr<System>*>(system);
     
     auto* wrapper = new IsConnectedCallbackWrapper{callback, user_data};
     
@@ -111,7 +112,7 @@ void mavsdk_system_unsubscribe_is_connected(
     mavsdk_system_t system,
     mavsdk_is_connected_handle_t handle)
 {
-    auto* cpp_system_ptr = static_cast<System**>(system);
+    auto* cpp_system_ptr = reinterpret_cast<std::shared_ptr<System>*>(system);
     auto* handle_pair = static_cast<std::pair<System::IsConnectedHandle, IsConnectedCallbackWrapper*>*>(handle);
     
     if (handle_pair) {
@@ -127,7 +128,7 @@ mavsdk_component_discovered_handle_t mavsdk_system_subscribe_component_discovere
     mavsdk_component_discovered_callback_t callback,
     void* user_data)
 {
-    auto* cpp_system_ptr = static_cast<System**>(system);
+    auto* cpp_system_ptr = reinterpret_cast<std::shared_ptr<System>*>(system);
     
     auto* wrapper = new ComponentDiscoveredCallbackWrapper{callback, user_data};
     
@@ -150,7 +151,7 @@ void mavsdk_system_unsubscribe_component_discovered(
     mavsdk_system_t system,
     mavsdk_component_discovered_handle_t handle)
 {
-    auto* cpp_system_ptr = static_cast<System**>(system);
+    auto* cpp_system_ptr = reinterpret_cast<std::shared_ptr<System>*>(system);
     auto* handle_pair = static_cast<std::pair<System::ComponentDiscoveredHandle, ComponentDiscoveredCallbackWrapper*>*>(handle);
     
     if (handle_pair) {
@@ -166,7 +167,7 @@ mavsdk_component_discovered_id_handle_t mavsdk_system_subscribe_component_discov
     mavsdk_component_discovered_id_callback_t callback,
     void* user_data)
 {
-    auto* cpp_system_ptr = static_cast<System**>(system);
+    auto* cpp_system_ptr = reinterpret_cast<std::shared_ptr<System>*>(system);
     
     auto* wrapper = new ComponentDiscoveredIdCallbackWrapper{callback, user_data};
     
@@ -189,7 +190,7 @@ void mavsdk_system_unsubscribe_component_discovered_id(
     mavsdk_system_t system,
     mavsdk_component_discovered_id_handle_t handle)
 {
-    auto* cpp_system_ptr = static_cast<System**>(system);
+    auto* cpp_system_ptr = reinterpret_cast<std::shared_ptr<System>*>(system);
     auto* handle_pair = static_cast<std::pair<System::ComponentDiscoveredIdHandle, ComponentDiscoveredIdCallbackWrapper*>*>(handle);
     
     if (handle_pair) {
@@ -201,12 +202,12 @@ void mavsdk_system_unsubscribe_component_discovered_id(
 
 // --- Other System Functions ---
 void mavsdk_system_enable_timesync(mavsdk_system_t system) {
-    auto* cpp_system_ptr = static_cast<System**>(system);
+    auto* cpp_system_ptr = reinterpret_cast<std::shared_ptr<System>*>(system);
     (*cpp_system_ptr)->enable_timesync();
 }
 
 mavsdk_autopilot_t mavsdk_system_autopilot_type(mavsdk_system_t system) {
-    auto* cpp_system_ptr = static_cast<System**>(system);
+    auto* cpp_system_ptr = reinterpret_cast<std::shared_ptr<System>*>(system);
     switch ((*cpp_system_ptr)->autopilot_type()) {
         case Autopilot::Px4: return MAVSDK_AUTOPILOT_PX4;
         case Autopilot::ArduPilot: return MAVSDK_AUTOPILOT_ARDUPILOT;
@@ -216,7 +217,7 @@ mavsdk_autopilot_t mavsdk_system_autopilot_type(mavsdk_system_t system) {
 }
 
 mavsdk_vehicle_t mavsdk_system_vehicle_type(mavsdk_system_t system) {
-    auto* cpp_system_ptr = static_cast<System**>(system);
+    auto* cpp_system_ptr = reinterpret_cast<std::shared_ptr<System>*>(system);
     switch ((*cpp_system_ptr)->vehicle_type()) {
         case Vehicle::FixedWing: return MAVSDK_VEHICLE_FIXED_WING;
         case Vehicle::Quadrotor:

--- a/c/src/cmavsdk/system.h
+++ b/c/src/cmavsdk/system.h
@@ -20,6 +20,7 @@ typedef void* mavsdk_component_discovered_handle_t;
 typedef void* mavsdk_component_discovered_id_handle_t;
 
 // ===== Basic System Queries =====
+CMAVSDK_EXPORT void mavsdk_system_destroy(mavsdk_system_t system);
 CMAVSDK_EXPORT bool mavsdk_system_has_autopilot(mavsdk_system_t system);
 CMAVSDK_EXPORT bool mavsdk_system_is_standalone(mavsdk_system_t system);
 CMAVSDK_EXPORT bool mavsdk_system_has_camera(mavsdk_system_t system, int camera_id);

--- a/py/aiomavsdk/aiomavsdk/system.py
+++ b/py/aiomavsdk/aiomavsdk/system.py
@@ -4,7 +4,9 @@ import asyncio
 
 from typing import AsyncGenerator, List
 
+from mavsdk.autopilot import Autopilot
 from mavsdk.system import System as _System
+from mavsdk.vehicle import Vehicle
 
 
 class System:
@@ -49,6 +51,14 @@ class System:
     async def enable_timesync(self) -> None:
         """Enable time synchronization using the TIMESYNC messages."""
         self._system.enable_timesync()
+
+    async def autopilot_type(self) -> Autopilot:
+        """Get the autopilot type reported by this system."""
+        return self._system.autopilot_type()
+
+    async def vehicle_type(self) -> Vehicle:
+        """Get the vehicle type reported by this system."""
+        return self._system.vehicle_type()
 
     # ------------------------------------------------------------------
     # Potentially blocking accessors — offloaded to executor

--- a/py/mavsdk/mavsdk/mavsdk.py
+++ b/py/mavsdk/mavsdk/mavsdk.py
@@ -2,6 +2,7 @@
 
 import atexit
 import ctypes
+import weakref
 
 from typing import Optional, List, Callable, Any
 
@@ -84,11 +85,22 @@ class Mavsdk:
 
         self._callbacks = {}  # Keep references to prevent GC: { handle: callback }
 
+        # Systems and server components own a handle each and must be released before
+        # mavsdk_destroy runs, since Python's GC gives no ordering guarantee between
+        # them and this object. The set is weak so that a System dropped by the caller
+        # is still collected promptly; destroy() only has to sweep whatever survives.
+        self._children = weakref.WeakSet()
+
         self._handle = self._lib.mavsdk_create(configuration._handle)
         self._destroyed = False
         configuration._handle = None
 
         atexit.register(self.destroy)
+
+    def _track(self, child):
+        """Register a handle-owning child so destroy() can release it."""
+        self._children.add(child)
+        return child
 
     def version(self) -> str:
         """Get MAVSDK version string"""
@@ -155,8 +167,12 @@ class Mavsdk:
         if not systems_ptr:
             return []
 
-        systems = [System(self._lib, systems_ptr[i]) for i in range(count.value)]
+        systems = [
+            self._track(System(self._lib, systems_ptr[i])) for i in range(count.value)
+        ]
 
+        # Frees the array of pointers only; each element is a separate allocation
+        # now owned by the System wrapper above.
         self._lib.mavsdk_free_systems_array(systems_ptr)
         return systems
 
@@ -164,7 +180,7 @@ class Mavsdk:
         """Wait for and return first autopilot system"""
         handle = self._lib.mavsdk_first_autopilot(self._handle, timeout_s)
         if handle:
-            return System(self._lib, handle)
+            return self._track(System(self._lib, handle))
         return None
 
     def subscribe_on_new_system(
@@ -182,7 +198,13 @@ class Mavsdk:
         return handle
 
     def unsubscribe_on_new_system(self, handle: ctypes.c_void_p):
-        """Unsubscribe from new system discoveries"""
+        """Unsubscribe from new system discoveries
+
+        A no-op once this instance is destroyed, so that callers unsubscribing from
+        a ``finally`` block during teardown do not pass a null handle into C.
+        """
+        if not self._handle:
+            return
         self._lib.mavsdk_unsubscribe_on_new_system(self._handle, handle)
         self._callbacks.pop(handle, None)
 
@@ -190,7 +212,7 @@ class Mavsdk:
         """Get server component by instance"""
         handle = self._lib.mavsdk_server_component(self._handle, instance)
         if handle:
-            return ServerComponent(self._lib, handle)
+            return self._track(ServerComponent(self._lib, handle))
         return None
 
     def server_component_by_type(
@@ -201,14 +223,14 @@ class Mavsdk:
             self._handle, int(component_type), instance
         )
         if handle:
-            return ServerComponent(self._lib, handle)
+            return self._track(ServerComponent(self._lib, handle))
         return None
 
     def server_component_by_id(self, component_id: int):
         """Get server component by component ID"""
         handle = self._lib.mavsdk_server_component_by_id(self._handle, component_id)
         if handle:
-            return ServerComponent(self._lib, handle)
+            return self._track(ServerComponent(self._lib, handle))
         return None
 
     def pass_received_raw_bytes(self, data: bytes):
@@ -241,8 +263,20 @@ class Mavsdk:
     def destroy(self):
         """Destroy the Mavsdk instance"""
         if not self._destroyed and self._handle:
-            self._callbacks.clear()
+            # Release systems and server components first. Their handles are
+            # shared_ptrs into objects owned by this instance, so they must not
+            # outlive mavsdk_destroy. Snapshot the weak set before iterating, since
+            # destroy() can drop the last reference and mutate it underneath us.
+            for child in list(self._children):
+                child.destroy()
+            self._children.clear()
+
             self._lib.mavsdk_destroy(self._handle)
+
+            # Only now drop the ctypes trampolines. mavsdk_destroy stops the
+            # callback thread, so releasing them earlier would leave a window in
+            # which a callback could jump into collected memory.
+            self._callbacks.clear()
             self._handle = None
             self._destroyed = True
 

--- a/py/mavsdk/mavsdk/plugins/action/action.py
+++ b/py/mavsdk/mavsdk/plugins/action/action.py
@@ -8,7 +8,6 @@
 Enable simple actions such as arming, taking off, and landing.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -85,7 +84,7 @@ class Action:
                 "Failed to create Action plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def arm_async(self, callback: Callable, user_data: Any = None):
         """Send command to arm the drone.

--- a/py/mavsdk/mavsdk/plugins/action_server/action_server.py
+++ b/py/mavsdk/mavsdk/plugins/action_server/action_server.py
@@ -8,7 +8,6 @@
 Provide vehicle actions (as a server) such as arming, taking off, and landing.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -206,7 +205,7 @@ class ActionServer:
                 "Failed to create ActionServer plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        server_component._track_plugin(self)
 
     def subscribe_arm_disarm(self, callback: Callable, user_data: Any = None):
         """Subscribe to ARM/DISARM commands"""

--- a/py/mavsdk/mavsdk/plugins/arm_authorizer_server/arm_authorizer_server.py
+++ b/py/mavsdk/mavsdk/plugins/arm_authorizer_server/arm_authorizer_server.py
@@ -8,7 +8,6 @@
 Use arm authorization.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -67,7 +66,7 @@ class ArmAuthorizerServer:
                 "Failed to create ArmAuthorizerServer plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        server_component._track_plugin(self)
 
     def subscribe_arm_authorization(self, callback: Callable, user_data: Any = None):
         """Subscribe to arm authorization request messages. Each request received should respond to using RespondArmAuthorization"""

--- a/py/mavsdk/mavsdk/plugins/calibration/calibration.py
+++ b/py/mavsdk/mavsdk/plugins/calibration/calibration.py
@@ -8,7 +8,6 @@
 Enable to calibrate sensors of a drone such as gyro, accelerometer, and magnetometer.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -121,7 +120,7 @@ class Calibration:
                 "Failed to create Calibration plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def calibrate_gyro_async(self, callback: Callable, user_data: Any = None):
         """Perform gyro calibration."""

--- a/py/mavsdk/mavsdk/plugins/camera/camera.py
+++ b/py/mavsdk/mavsdk/plugins/camera/camera.py
@@ -14,7 +14,6 @@ Can be used to manage cameras that implement the MAVLink
  `select_camera`.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -1162,7 +1161,7 @@ class Camera:
                 "Failed to create Camera plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def take_photo_async(self, component_id, callback: Callable, user_data: Any = None):
         """Take one photo."""

--- a/py/mavsdk/mavsdk/plugins/camera_server/camera_server.py
+++ b/py/mavsdk/mavsdk/plugins/camera_server/camera_server.py
@@ -8,7 +8,6 @@
 Provides handling of camera interface
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -723,7 +722,7 @@ class CameraServer:
                 "Failed to create CameraServer plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        server_component._track_plugin(self)
 
     def set_information(self, information):
         """Get set_information (blocking)"""

--- a/py/mavsdk/mavsdk/plugins/component_metadata/component_metadata.py
+++ b/py/mavsdk/mavsdk/plugins/component_metadata/component_metadata.py
@@ -8,7 +8,6 @@
 Access component metadata json definitions, such as parameters.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -154,7 +153,7 @@ class ComponentMetadata:
                 "Failed to create ComponentMetadata plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def request_component(self, compid):
         """Get request_component (blocking)"""

--- a/py/mavsdk/mavsdk/plugins/component_metadata_server/component_metadata_server.py
+++ b/py/mavsdk/mavsdk/plugins/component_metadata_server/component_metadata_server.py
@@ -8,7 +8,6 @@
 Provide component metadata json definitions, such as parameters.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -100,7 +99,7 @@ class ComponentMetadataServer:
                 "Failed to create ComponentMetadataServer plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        server_component._track_plugin(self)
 
     def set_metadata(self, metadata):
         """Get set_metadata (blocking)"""

--- a/py/mavsdk/mavsdk/plugins/events/events.py
+++ b/py/mavsdk/mavsdk/plugins/events/events.py
@@ -8,7 +8,6 @@
 Get event notifications, such as takeoff, or arming checks
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -400,7 +399,7 @@ class Events:
                 "Failed to create Events plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def subscribe_events(self, callback: Callable, user_data: Any = None):
         """Subscribe to event updates."""

--- a/py/mavsdk/mavsdk/plugins/failure/failure.py
+++ b/py/mavsdk/mavsdk/plugins/failure/failure.py
@@ -8,7 +8,6 @@
 Inject failures into system to test failsafes.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -94,7 +93,7 @@ class Failure:
                 "Failed to create Failure plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def inject(self, failure_unit, failure_type, instance):
         """Get inject (blocking)"""

--- a/py/mavsdk/mavsdk/plugins/follow_me/follow_me.py
+++ b/py/mavsdk/mavsdk/plugins/follow_me/follow_me.py
@@ -9,7 +9,6 @@ Allow users to command the vehicle to follow a specific target.
  The target is provided as a GPS coordinate and altitude.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -212,7 +211,7 @@ class FollowMe:
                 "Failed to create FollowMe plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def get_config(self):
         """Get get_config (blocking)"""

--- a/py/mavsdk/mavsdk/plugins/ftp/ftp.py
+++ b/py/mavsdk/mavsdk/plugins/ftp/ftp.py
@@ -8,7 +8,6 @@
 Implements file transfer functionality using MAVLink FTP.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -220,7 +219,7 @@ class Ftp:
                 "Failed to create Ftp plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def download_async(
         self,

--- a/py/mavsdk/mavsdk/plugins/ftp_server/ftp_server.py
+++ b/py/mavsdk/mavsdk/plugins/ftp_server/ftp_server.py
@@ -8,7 +8,6 @@
 Provide files or directories to transfer.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -59,7 +58,7 @@ class FtpServer:
                 "Failed to create FtpServer plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        server_component._track_plugin(self)
 
     def set_root_dir(self, path):
         """Get set_root_dir (blocking)"""

--- a/py/mavsdk/mavsdk/plugins/geofence/geofence.py
+++ b/py/mavsdk/mavsdk/plugins/geofence/geofence.py
@@ -8,7 +8,6 @@
 Enable setting a geofence.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -278,7 +277,7 @@ class Geofence:
                 "Failed to create Geofence plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def upload_geofence_async(
         self, geofence_data, callback: Callable, user_data: Any = None

--- a/py/mavsdk/mavsdk/plugins/gimbal/gimbal.py
+++ b/py/mavsdk/mavsdk/plugins/gimbal/gimbal.py
@@ -9,7 +9,6 @@ Provide control over a gimbal within the MAVLink
  Gimbal Protocol: https://mavlink.io/en/services/gimbal_v2.html
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -520,7 +519,7 @@ class Gimbal:
                 "Failed to create Gimbal plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def set_angles_async(
         self,

--- a/py/mavsdk/mavsdk/plugins/gripper/gripper.py
+++ b/py/mavsdk/mavsdk/plugins/gripper/gripper.py
@@ -8,7 +8,6 @@
 Allows users to send gripper actions.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -70,7 +69,7 @@ class Gripper:
                 "Failed to create Gripper plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def grab_async(self, instance, callback: Callable, user_data: Any = None):
         """Gripper grab cargo."""

--- a/py/mavsdk/mavsdk/plugins/info/info.py
+++ b/py/mavsdk/mavsdk/plugins/info/info.py
@@ -8,7 +8,6 @@
 Provide information about the hardware and/or software of a system.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -332,7 +331,7 @@ class Info:
                 "Failed to create Info plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def get_identification(self):
         """Get get_identification (blocking)"""

--- a/py/mavsdk/mavsdk/plugins/log_files/log_files.py
+++ b/py/mavsdk/mavsdk/plugins/log_files/log_files.py
@@ -9,7 +9,6 @@ Allow to download log files from the vehicle after a flight is complete.
  For log streaming during flight check the logging plugin.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -148,7 +147,7 @@ class LogFiles:
                 "Failed to create LogFiles plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def get_entries_async(self, callback: Callable, user_data: Any = None):
         """Get List of log files."""

--- a/py/mavsdk/mavsdk/plugins/log_streaming/log_streaming.py
+++ b/py/mavsdk/mavsdk/plugins/log_streaming/log_streaming.py
@@ -8,7 +8,6 @@
 Provide log streaming data.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -98,7 +97,7 @@ class LogStreaming:
                 "Failed to create LogStreaming plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def start_log_streaming_async(self, callback: Callable, user_data: Any = None):
         """Start streaming logging data."""

--- a/py/mavsdk/mavsdk/plugins/manual_control/manual_control.py
+++ b/py/mavsdk/mavsdk/plugins/manual_control/manual_control.py
@@ -8,7 +8,6 @@
 Enable manual control using e.g. a joystick or gamepad.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -64,7 +63,7 @@ class ManualControl:
                 "Failed to create ManualControl plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def start_position_control_async(self, callback: Callable, user_data: Any = None):
         """Start position control using e.g. joystick input.

--- a/py/mavsdk/mavsdk/plugins/mavlink_direct/mavlink_direct.py
+++ b/py/mavsdk/mavsdk/plugins/mavlink_direct/mavlink_direct.py
@@ -8,7 +8,6 @@
 Enable direct MAVLink communication using libmav.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -131,7 +130,7 @@ class MavlinkDirect:
                 "Failed to create MavlinkDirect plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def send_message(self, message):
         """Get send_message (blocking)"""

--- a/py/mavsdk/mavsdk/plugins/mission/mission.py
+++ b/py/mavsdk/mavsdk/plugins/mission/mission.py
@@ -8,7 +8,6 @@
 Enable waypoint missions.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -401,7 +400,7 @@ class Mission:
                 "Failed to create Mission plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def upload_mission_async(
         self, mission_plan, callback: Callable, user_data: Any = None

--- a/py/mavsdk/mavsdk/plugins/mission_raw/mission_raw.py
+++ b/py/mavsdk/mavsdk/plugins/mission_raw/mission_raw.py
@@ -8,7 +8,6 @@
 Enable raw missions as exposed by MAVLink.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -408,7 +407,7 @@ class MissionRaw:
                 "Failed to create MissionRaw plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def upload_mission_async(
         self, mission_items, callback: Callable, user_data: Any = None

--- a/py/mavsdk/mavsdk/plugins/mission_raw_server/mission_raw_server.py
+++ b/py/mavsdk/mavsdk/plugins/mission_raw_server/mission_raw_server.py
@@ -9,7 +9,6 @@ Acts as a vehicle and receives incoming missions from GCS (in raw MAVLINK format
  Provides current mission item state, so the server can progress through missions.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -275,7 +274,7 @@ class MissionRawServer:
                 "Failed to create MissionRawServer plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        server_component._track_plugin(self)
 
     def subscribe_incoming_mission(self, callback: Callable, user_data: Any = None):
         """Subscribe to when a new mission is uploaded (asynchronous)."""

--- a/py/mavsdk/mavsdk/plugins/mocap/mocap.py
+++ b/py/mavsdk/mavsdk/plugins/mocap/mocap.py
@@ -10,7 +10,6 @@ Allows interfacing a vehicle with a motion capture system in
  (e.g. indoors, or when flying under a bridge. etc.).
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -711,7 +710,7 @@ class Mocap:
                 "Failed to create Mocap plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def set_vision_position_estimate(self, vision_position_estimate):
         """Get set_vision_position_estimate (blocking)"""

--- a/py/mavsdk/mavsdk/plugins/offboard/offboard.py
+++ b/py/mavsdk/mavsdk/plugins/offboard/offboard.py
@@ -15,7 +15,6 @@ Control a drone with position, velocity, attitude or motor commands.
  are minimally sent at 2Hz).
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -572,7 +571,7 @@ class Offboard:
                 "Failed to create Offboard plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def start_async(self, callback: Callable, user_data: Any = None):
         """Start offboard control."""

--- a/py/mavsdk/mavsdk/plugins/param/param.py
+++ b/py/mavsdk/mavsdk/plugins/param/param.py
@@ -8,7 +8,6 @@
 Provide raw access to get and set parameters.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -289,7 +288,7 @@ class Param:
                 "Failed to create Param plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def get_param_int(self, name):
         """Get get_param_int (blocking)"""

--- a/py/mavsdk/mavsdk/plugins/param_server/param_server.py
+++ b/py/mavsdk/mavsdk/plugins/param_server/param_server.py
@@ -8,7 +8,6 @@
 Provide raw access to retrieve and provide server parameters.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -275,7 +274,7 @@ class ParamServer:
                 "Failed to create ParamServer plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        server_component._track_plugin(self)
 
     def set_protocol(self, extended_protocol):
         """Get set_protocol (blocking)"""

--- a/py/mavsdk/mavsdk/plugins/rtk/rtk.py
+++ b/py/mavsdk/mavsdk/plugins/rtk/rtk.py
@@ -8,7 +8,6 @@
 Service to send RTK corrections to the vehicle.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -95,7 +94,7 @@ class Rtk:
                 "Failed to create Rtk plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def send_rtcm_data(self, rtcm_data):
         """Get send_rtcm_data (blocking)"""

--- a/py/mavsdk/mavsdk/plugins/server_utility/server_utility.py
+++ b/py/mavsdk/mavsdk/plugins/server_utility/server_utility.py
@@ -8,7 +8,6 @@
 Utility for onboard MAVSDK instances for common "server" tasks.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -71,7 +70,7 @@ class ServerUtility:
                 "Failed to create ServerUtility plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def send_status_text(self, type, text):
         """Get send_status_text (blocking)"""

--- a/py/mavsdk/mavsdk/plugins/shell/shell.py
+++ b/py/mavsdk/mavsdk/plugins/shell/shell.py
@@ -8,7 +8,6 @@
 Allow to communicate with the vehicle's system shell.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -61,7 +60,7 @@ class Shell:
                 "Failed to create Shell plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def send(self, command):
         """Get send (blocking)"""

--- a/py/mavsdk/mavsdk/plugins/telemetry/telemetry.py
+++ b/py/mavsdk/mavsdk/plugins/telemetry/telemetry.py
@@ -10,7 +10,6 @@ Allow users to get vehicle telemetry and state information
  Certain Telemetry Topics such as, Position or Velocity_Ned require GPS Fix before data gets published.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -2140,7 +2139,7 @@ class Telemetry:
                 "Failed to create Telemetry plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def subscribe_position(self, callback: Callable, user_data: Any = None):
         """Subscribe to 'position' updates."""

--- a/py/mavsdk/mavsdk/plugins/telemetry_server/telemetry_server.py
+++ b/py/mavsdk/mavsdk/plugins/telemetry_server/telemetry_server.py
@@ -9,7 +9,6 @@ Allow users to provide vehicle telemetry and state information
  (e.g. battery, GPS, RC connection, flight mode etc.) and set telemetry update rates.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -1631,7 +1630,7 @@ class TelemetryServer:
                 "Failed to create TelemetryServer plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        server_component._track_plugin(self)
 
     def publish_position(self, position, velocity_ned, heading):
         """Get publish_position (blocking)"""

--- a/py/mavsdk/mavsdk/plugins/transponder/transponder.py
+++ b/py/mavsdk/mavsdk/plugins/transponder/transponder.py
@@ -9,7 +9,6 @@ Allow users to get ADS-B information
  and set ADS-B update rates.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -198,7 +197,7 @@ class Transponder:
                 "Failed to create Transponder plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def subscribe_transponder(self, callback: Callable, user_data: Any = None):
         """Subscribe to 'transponder' updates."""

--- a/py/mavsdk/mavsdk/plugins/tune/tune.py
+++ b/py/mavsdk/mavsdk/plugins/tune/tune.py
@@ -8,7 +8,6 @@
 Enable creating and sending a tune to be played on the system.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -125,7 +124,7 @@ class Tune:
                 "Failed to create Tune plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def play_tune_async(
         self, tune_description, callback: Callable, user_data: Any = None

--- a/py/mavsdk/mavsdk/plugins/winch/winch.py
+++ b/py/mavsdk/mavsdk/plugins/winch/winch.py
@@ -8,7 +8,6 @@
 Allows users to send winch actions, as well as receive status information from winch systems.
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -280,7 +279,7 @@ class Winch:
                 "Failed to create Winch plugin - C function returned null handle"
             )
 
-        atexit.register(self.destroy)
+        system._track_plugin(self)
 
     def subscribe_status(self, callback: Callable, user_data: Any = None):
         """Subscribe to 'winch status' updates."""

--- a/py/mavsdk/mavsdk/server_component.py
+++ b/py/mavsdk/mavsdk/server_component.py
@@ -1,4 +1,5 @@
 import ctypes
+import weakref
 
 from .cmavsdk_loader import _cmavsdk_lib
 
@@ -15,10 +16,23 @@ class ServerComponent:
     def __init__(self, lib: ctypes.CDLL, handle: ctypes.c_void_p):
         self._lib = lib
         self._handle = handle
+        self._plugins = weakref.WeakSet()
+
+    def _track_plugin(self, plugin) -> None:
+        """Register a server plugin so it is destroyed before this component goes.
+
+        Same reasoning as :meth:`mavsdk.system.System._track_plugin`: the plugin
+        owns a C++ object reaching into MavsdkImpl and must not outlive it.
+        """
+        self._plugins.add(plugin)
 
     def destroy(self) -> None:
         """Release the underlying server component handle. Idempotent."""
         if self._handle:
+            for plugin in list(self._plugins):
+                plugin.destroy()
+            self._plugins.clear()
+
             self._lib.mavsdk_server_component_destroy(self._handle)
             self._handle = None
 

--- a/py/mavsdk/mavsdk/server_component.py
+++ b/py/mavsdk/mavsdk/server_component.py
@@ -4,12 +4,38 @@ from .cmavsdk_loader import _cmavsdk_lib
 
 
 class ServerComponent:
-    """Wrapper for mavsdk_server_component_t"""
+    """Wrapper for mavsdk_server_component_t
+
+    Like :class:`~mavsdk.system.System`, each instance owns its handle: the
+    ``mavsdk_server_component*`` family allocates a fresh ``shared_ptr`` per call,
+    even when the same underlying component is returned. Instances are registered
+    with the owning Mavsdk so they are released before it destroys itself.
+    """
 
     def __init__(self, lib: ctypes.CDLL, handle: ctypes.c_void_p):
         self._lib = lib
         self._handle = handle
 
+    def destroy(self) -> None:
+        """Release the underlying server component handle. Idempotent."""
+        if self._handle:
+            self._lib.mavsdk_server_component_destroy(self._handle)
+            self._handle = None
+
+    def __del__(self):
+        self.destroy()
+
+    def _require_handle(self) -> ctypes.c_void_p:
+        if not self._handle:
+            raise RuntimeError(
+                "ServerComponent has been destroyed (its Mavsdk was destroyed, "
+                "or destroy() was called explicitly)"
+            )
+        return self._handle
+
+
+_cmavsdk_lib.mavsdk_server_component_destroy.argtypes = [ctypes.c_void_p]
+_cmavsdk_lib.mavsdk_server_component_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_server_component.argtypes = [ctypes.c_void_p, ctypes.c_uint]
 _cmavsdk_lib.mavsdk_server_component.restype = ctypes.c_void_p

--- a/py/mavsdk/mavsdk/system.py
+++ b/py/mavsdk/mavsdk/system.py
@@ -2,46 +2,90 @@ import ctypes
 
 from typing import Any, Callable, List
 
+from .autopilot import Autopilot
 from .cmavsdk_loader import _cmavsdk_lib
+from .vehicle import Vehicle
 
 
 class System:
-    """Wrapper for mavsdk_system_t"""
+    """Wrapper for mavsdk_system_t
+
+    Each instance owns its handle. ``mavsdk_get_systems`` and
+    ``mavsdk_first_autopilot`` hand out a fresh ``shared_ptr<System>`` per call --
+    ``mavsdk_free_systems_array`` only frees the array, not the elements -- so every
+    wrapper must release exactly one handle. Instances are registered with the owning
+    :class:`~mavsdk.mavsdk.Mavsdk`, which destroys any that are still alive before it
+    destroys itself, because Python's garbage collector gives no ordering guarantee
+    between the two.
+    """
 
     def __init__(self, lib: ctypes.CDLL, handle: ctypes.c_void_p):
         self._lib = lib
         self._handle = handle
-        self._callbacks = []  # Keep references to prevent GC
+        # Keep references to prevent GC: { subscription handle: callback }
+        self._callbacks = {}
+
+    def destroy(self) -> None:
+        """Release the underlying system handle. Idempotent."""
+        if self._handle:
+            # Unsubscribe before releasing the handle. Dropping our shared_ptr does
+            # not destroy the C++ System -- MavsdkImpl owns it -- so any subscription
+            # left active would keep firing into ctypes trampolines that are about to
+            # be garbage collected.
+            for subscription_handle in list(self._callbacks):
+                self._lib.mavsdk_system_unsubscribe_is_connected(
+                    self._handle, subscription_handle
+                )
+            self._callbacks.clear()
+
+            self._lib.mavsdk_system_destroy(self._handle)
+            self._handle = None
+
+    def __del__(self):
+        self.destroy()
+
+    def _require_handle(self) -> ctypes.c_void_p:
+        """Fail loudly rather than dereferencing a null handle in C.
+
+        Before the handle was ever released this could not happen; now that it is,
+        using a System after its Mavsdk is gone would segfault without this check.
+        """
+        if not self._handle:
+            raise RuntimeError(
+                "System has been destroyed (its Mavsdk was destroyed, "
+                "or destroy() was called explicitly)"
+            )
+        return self._handle
 
     def has_autopilot(self) -> bool:
         """Check if system has autopilot"""
-        return self._lib.mavsdk_system_has_autopilot(self._handle)
+        return self._lib.mavsdk_system_has_autopilot(self._require_handle())
 
     def is_standalone(self) -> bool:
         """Check if system is standalone"""
-        return self._lib.mavsdk_system_is_standalone(self._handle)
+        return self._lib.mavsdk_system_is_standalone(self._require_handle())
 
     def has_camera(self, camera_id: int = -1) -> bool:
         """Check if system has camera"""
-        return self._lib.mavsdk_system_has_camera(self._handle, camera_id)
+        return self._lib.mavsdk_system_has_camera(self._require_handle(), camera_id)
 
     def has_gimbal(self) -> bool:
         """Check if system has gimbal"""
-        return self._lib.mavsdk_system_has_gimbal(self._handle)
+        return self._lib.mavsdk_system_has_gimbal(self._require_handle())
 
     def is_connected(self) -> bool:
         """Check if system is connected"""
-        return self._lib.mavsdk_system_is_connected(self._handle)
+        return self._lib.mavsdk_system_is_connected(self._require_handle())
 
     def get_system_id(self) -> int:
         """Get system ID"""
-        return self._lib.mavsdk_system_get_system_id(self._handle)
+        return self._lib.mavsdk_system_get_system_id(self._require_handle())
 
     def component_ids(self) -> List[int]:
         """Get list of component IDs"""
         count = ctypes.c_size_t()
         ids_ptr = self._lib.mavsdk_system_component_ids(
-            self._handle, ctypes.byref(count)
+            self._require_handle(), ctypes.byref(count)
         )
 
         if not ids_ptr:
@@ -53,19 +97,55 @@ class System:
 
     def subscribe_is_connected(
         self, callback: Callable[[bool, Any], None], user_data: Any = None
-    ):
-        """Subscribe to connection state changes"""
+    ) -> ctypes.c_void_p:
+        """Subscribe to connection state changes
+
+        Returns the subscription handle to pass to
+        :meth:`unsubscribe_is_connected`.
+        """
         c_callback = IsConnectedCallback(
             lambda connected, ud: callback(connected, user_data)
         )
-        self._callbacks.append(c_callback)
+
+        subscription_handle = self._lib.mavsdk_system_subscribe_is_connected(
+            self._require_handle(), c_callback, None
+        )
+
+        # Held until unsubscribe: if the trampoline is collected while MAVSDK still
+        # holds the pointer, the next callback jumps into freed memory.
+        self._callbacks[subscription_handle] = c_callback
+
+        return subscription_handle
+
+    def unsubscribe_is_connected(self, handle: ctypes.c_void_p) -> None:
+        """Unsubscribe from connection state changes
+
+        A no-op if the system is already destroyed, which unsubscribed everything
+        anyway. Callers unsubscribe from ``finally`` blocks that race teardown, so
+        this must not raise there.
+        """
+        if not self._handle:
+            return
+        self._lib.mavsdk_system_unsubscribe_is_connected(self._handle, handle)
+        self._callbacks.pop(handle, None)
 
     def enable_timesync(self) -> None:
         """Enable time synchronization using the TIMESYNC messages."""
-        self._lib.mavsdk_system_enable_timesync(self._handle)
+        self._lib.mavsdk_system_enable_timesync(self._require_handle())
+
+    def autopilot_type(self) -> Autopilot:
+        """Get the autopilot type reported by this system"""
+        return Autopilot(self._lib.mavsdk_system_autopilot_type(self._require_handle()))
+
+    def vehicle_type(self) -> Vehicle:
+        """Get the vehicle type reported by this system"""
+        return Vehicle(self._lib.mavsdk_system_vehicle_type(self._require_handle()))
 
 
 IsConnectedCallback = ctypes.CFUNCTYPE(None, ctypes.c_bool, ctypes.c_void_p)
+
+_cmavsdk_lib.mavsdk_system_destroy.argtypes = [ctypes.c_void_p]
+_cmavsdk_lib.mavsdk_system_destroy.restype = None
 
 _cmavsdk_lib.mavsdk_system_has_autopilot.argtypes = [ctypes.c_void_p]
 _cmavsdk_lib.mavsdk_system_has_autopilot.restype = ctypes.c_bool

--- a/py/mavsdk/mavsdk/system.py
+++ b/py/mavsdk/mavsdk/system.py
@@ -1,4 +1,5 @@
 import ctypes
+import weakref
 
 from typing import Any, Callable, List
 
@@ -24,10 +25,26 @@ class System:
         self._handle = handle
         # Keep references to prevent GC: { subscription handle: callback }
         self._callbacks = {}
+        self._plugins = weakref.WeakSet()
+
+    def _track_plugin(self, plugin) -> None:
+        """Register a plugin so it is destroyed before this system goes away.
+
+        A plugin owns a C++ object that reaches back into MavsdkImpl, so it must not
+        outlive mavsdk_destroy. Plugins register themselves from their constructor.
+        The set is weak so that a plugin the caller drops is collected promptly
+        rather than pinned for the lifetime of the system.
+        """
+        self._plugins.add(plugin)
 
     def destroy(self) -> None:
         """Release the underlying system handle. Idempotent."""
         if self._handle:
+            # Plugins first -- they are the ones holding references into MavsdkImpl.
+            for plugin in list(self._plugins):
+                plugin.destroy()
+            self._plugins.clear()
+
             # Unsubscribe before releasing the handle. Dropping our shared_ptr does
             # not destroy the C++ System -- MavsdkImpl owns it -- so any subscription
             # left active would keep firing into ctypes trampolines that are about to

--- a/py/mavsdk/templates/file.py.j2
+++ b/py/mavsdk/templates/file.py.j2
@@ -8,7 +8,6 @@
 {{ class_description }}
 """
 
-import atexit
 import ctypes
 
 from typing import Callable, Any
@@ -228,7 +227,11 @@ class {{ plugin_name.upper_camel_case }}:
         if not self._handle:
             raise RuntimeError("Failed to create {{ plugin_name.upper_camel_case }} plugin - C function returned null handle")
 
-        atexit.register(self.destroy)
+        {% if is_server %}
+        server_component._track_plugin(self)
+        {% else %}
+        system._track_plugin(self)
+        {% endif %}
 
     {% for method in methods %}
 


### PR DESCRIPTION
* `System` and `ServerComponent` never freed their handle.
* Plugins were pinned forever by `atexit` and outlived `mavsdk_destroy()`. They now  get destroyed with their system.
* Added missing `autopilot_type()` and `vehicle_type()`.

The `c/` changes are needed for this: `mavsdk_system_destroy()` didn't have `CMAVSDK_EXPORT`, so with `-visibility=hidden` it was disappearing.

Note: for the plugins only the template changed, the rest is auto-generated.