### PR TITLE
examples: port log_streaming to subscribe_incoming_messages_json

### DIFF
--- a/cpp/examples/log_streaming/log_streaming.cpp
+++ b/cpp/examples/log_streaming/log_streaming.cpp
@@ -56,9 +56,9 @@ int main(int argc, char** argv)
     // To simulate message drops.
     if (argc == 3 && std::string(argv[2]) == "--drop") {
         std::cout << "Dropping some messages" << std::endl;
-        unsigned counter = 0;
-        mavsdk.intercept_incoming_messages_async(
-            [&](const mavlink_message_t&) { return counter++ % 10 != 0; });
+        auto counter = std::make_shared<unsigned>(0);
+        mavsdk.subscribe_incoming_messages_json(
+            [counter](Mavsdk::MavlinkMessage) { return (*counter)++ % 10 != 0; });
     }
 
     // Wait for autopilot type to be determined (from heartbeat)


### PR DESCRIPTION
## Summary
- `log_streaming` was the last example still calling the deprecated `intercept_incoming_messages_async` (deprecated in #2917), triggering a `-Wdeprecated-declarations` warning during the build.
- Ports the `--drop` message-drop simulation to `subscribe_incoming_messages_json`, matching the pattern already used in the `sniffer` example.
- As part of the port, fixes a latent dangling-reference bug: the drop counter was previously captured by reference from a variable local to the `if` block, which goes out of scope immediately after the (deprecated) subscription call is registered, while the callback is invoked for the lifetime of the program. Now held via `shared_ptr` so it lives as long as the callback.

## Test plan
- [x] Compiled `log_streaming.cpp` standalone against the installed `mavsdk` headers with `-Wall -Wextra -Wdeprecated-declarations`: no deprecation warnings, no errors.
- [x] `clang-format` reports no diff.