### PR TITLE
core: add possible "unknown" value for param count

### DIFF
--- a/cpp/src/mavsdk/core/mavlink_parameter_server.cpp
+++ b/cpp/src/mavsdk/core/mavlink_parameter_server.cpp
@@ -722,12 +722,16 @@ void MavlinkParameterServer::mark_protocol_seen(bool extended)
 void MavlinkParameterServer::enqueue_value_broadcast(
     const std::string& name, const ParamValue& param_value, bool extended)
 {
+    const auto param_opt { _param_cache.param_by_id(name, extended) };
+    const uint16_t param_index { param_opt ? param_opt->index : std::numeric_limits<std::uint16_t>::max() };
+    const uint16_t param_count { _param_cache.count(extended) };
+
     auto new_work = std::make_shared<WorkItem>(
         name,
         param_value,
         WorkItemValue{
-            std::numeric_limits<std::uint16_t>::max(),
-            std::numeric_limits<std::uint16_t>::max(),
+            param_index,
+            param_count,
             extended});
     asio::post(_io_context, [this, new_work]() {
         const bool was_empty = _work_queue.empty();

--- a/cpp/src/mavsdk/core/mavlink_parameter_server.cpp
+++ b/cpp/src/mavsdk/core/mavlink_parameter_server.cpp
@@ -722,17 +722,13 @@ void MavlinkParameterServer::mark_protocol_seen(bool extended)
 void MavlinkParameterServer::enqueue_value_broadcast(
     const std::string& name, const ParamValue& param_value, bool extended)
 {
-    const auto param_opt { _param_cache.param_by_id(name, extended) };
-    const uint16_t param_index { param_opt ? param_opt->index : std::numeric_limits<std::uint16_t>::max() };
-    const uint16_t param_count { _param_cache.count(extended) };
+    const auto param_opt{_param_cache.param_by_id(name, extended)};
+    const uint16_t param_index{
+        param_opt ? param_opt->index : std::numeric_limits<std::uint16_t>::max()};
+    const uint16_t param_count{_param_cache.count(extended)};
 
     auto new_work = std::make_shared<WorkItem>(
-        name,
-        param_value,
-        WorkItemValue{
-            param_index,
-            param_count,
-            extended});
+        name, param_value, WorkItemValue{param_index, param_count, extended});
     asio::post(_io_context, [this, new_work]() {
         const bool was_empty = _work_queue.empty();
         _work_queue.push_back(new_work);


### PR DESCRIPTION
### Issue:
`enqueue_value_broadcast` filled both the param index and count with 0xFFFF.
Component anounces 65535 parameters. GCS starts requesting for missing params that are out of range.

If you register only 9 new params: 
```
param at 1204 out of bounds (9)
Ignoring request_read message - param index not found: 1204
```
### Fix:
Get actual index and count from `_param_cache`