### PR TITLE
fix(system_tests): avoid TSAN data race in Camera.ListCameras

### DIFF
--- a/cpp/src/system_tests/camera_list_cameras.cpp
+++ b/cpp/src/system_tests/camera_list_cameras.cpp
@@ -2,6 +2,7 @@
 #include "plugins/camera/camera.hpp"
 #include "plugins/camera_server/camera_server.hpp"
 #include "log.hpp"
+#include <atomic>
 #include <future>
 #include <mutex>
 #include <thread>
@@ -48,7 +49,7 @@ TEST(Camera, ListCameras)
 
     auto camera = Camera{system};
 
-    bool found_camera = false;
+    std::atomic<bool> found_camera{false};
     auto camera_list_handle = camera.subscribe_camera_list([&](Camera::CameraList camera_list) {
         if (!camera_list.cameras.empty()) {
             found_camera = true;


### PR DESCRIPTION
## Summary
- `found_camera` in `Camera_ListCameras_Test` was a plain `bool`, written from the camera-list callback thread and read on the main thread after only a `sleep_for`, which gives TSAN no happens-before edge — it's been flagging a data race on every ThreadSanitizer CI run (e.g. #2905, #3010), unrelated to the PRs it shows up on.
- Change it to `std::atomic<bool>`, matching the pattern already used for equivalent flags elsewhere in `system_tests` (`intercept.cpp`, `telemetry_*.cpp`).

## Test plan
- [ ] CI: Ubuntu 24.04 (ThreadSanitizer) job passes `Camera.ListCameras` without a data race warning