### PR TITLE
ci(linux): retry dockcross image pull to handle registry flakiness

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -581,7 +581,14 @@ jobs:
         uses: jlumbroso/free-disk-space@v1.3.1
         continue-on-error: true
       - name: setup dockcross
-        run: docker run --rm ${{ env.ARG_IMAGE }} > ./dockcross-linux-${{ matrix.docker_name }}-custom; chmod +x ./dockcross-linux-${{ matrix.docker_name }}-custom
+        run: |
+          for i in 1 2 3 4 5; do
+            docker run --rm ${{ env.ARG_IMAGE }} > ./dockcross-linux-${{ matrix.docker_name }}-custom && break
+            echo "::warning::docker run for dockcross image failed (attempt $i/5), retrying in 15s"
+            sleep 15
+          done
+          chmod +x ./dockcross-linux-${{ matrix.docker_name }}-custom
+          test -s ./dockcross-linux-${{ matrix.docker_name }}-custom
       - uses: actions/cache@v5
         id: cache
         with:
@@ -697,7 +704,14 @@ jobs:
           submodules: recursive
           fetch-depth: 0
       - name: setup dockcross
-        run: docker run --rm dockcross/${{ matrix.arch_name }}:20250818-0a27819 > ./dockcross-${{ matrix.arch_name }}; chmod +x ./dockcross-${{ matrix.arch_name }}
+        run: |
+          for i in 1 2 3 4 5; do
+            docker run --rm dockcross/${{ matrix.arch_name }}:20250818-0a27819 > ./dockcross-${{ matrix.arch_name }} && break
+            echo "::warning::docker run for dockcross image failed (attempt $i/5), retrying in 15s"
+            sleep 15
+          done
+          chmod +x ./dockcross-${{ matrix.arch_name }}
+          test -s ./dockcross-${{ matrix.arch_name }}
       - uses: actions/cache@v5
         id: cache
         with:
@@ -758,7 +772,14 @@ jobs:
           fetch-depth: 0
       - name: setup dockcross
         working-directory: .
-        run: docker run --rm dockcross/${{ matrix.arch_name }}:latest > ./dockcross-${{ matrix.arch_name }}; chmod +x ./dockcross-${{ matrix.arch_name }}
+        run: |
+          for i in 1 2 3 4 5; do
+            docker run --rm dockcross/${{ matrix.arch_name }}:latest > ./dockcross-${{ matrix.arch_name }} && break
+            echo "::warning::docker run for dockcross image failed (attempt $i/5), retrying in 15s"
+            sleep 15
+          done
+          chmod +x ./dockcross-${{ matrix.arch_name }}
+          test -s ./dockcross-${{ matrix.arch_name }}
       - uses: actions/cache@v5
         id: cache
         with:
@@ -845,7 +866,14 @@ jobs:
         uses: jlumbroso/free-disk-space@v1.3.1
         continue-on-error: true
       - name: setup dockcross
-        run: docker run --rm dockcross/${{ matrix.name }}:20250818-0a27819 > ./dockcross-${{ matrix.name }}; chmod +x ./dockcross-${{ matrix.name }}
+        run: |
+          for i in 1 2 3 4 5; do
+            docker run --rm dockcross/${{ matrix.name }}:20250818-0a27819 > ./dockcross-${{ matrix.name }} && break
+            echo "::warning::docker run for dockcross image failed (attempt $i/5), retrying in 15s"
+            sleep 15
+          done
+          chmod +x ./dockcross-${{ matrix.name }}
+          test -s ./dockcross-${{ matrix.name }}
       - uses: actions/cache@v5
         id: cache
         with:


### PR DESCRIPTION
## Summary
- The `setup dockcross` step (`docker run --rm <image> > script`) has been intermittently failing across `dockcross-linux`, `dockcross-linux-musl`, `dockcross-manylinux`, and `dockcross-android` matrix legs, e.g. on #3034's `android-x86_64` job (https://github.com/mavlink/MAVSDK/actions/runs/31289435379/job/93184004724): `docker: Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded`. Other recent instances showed `context deadline exceeded` during auth token fetch and `crun: unknown version specified` — all transient runner/registry issues, unrelated to the code changes in the PRs where they showed up.
- Wrap each `setup dockcross` step in a retry loop (5 attempts, 15s backoff) and fail loudly if the resulting dockcross script ends up empty, instead of failing CI on the first transient pull error.

## Test plan
- [ ] CI: dockcross matrix jobs complete without needing a manual re-run