### PR TITLE
action: optional loiter radius on goto_location (#2853)

### DIFF
--- a/cpp/src/mavsdk/plugins/action/action.cpp
+++ b/cpp/src/mavsdk/plugins/action/action.cpp
@@ -123,15 +123,22 @@ void Action::goto_location_async(
     double longitude_deg,
     float absolute_altitude_m,
     float yaw_deg,
-    const ResultCallback callback)
+    const ResultCallback callback,
+    float loiter_radius_m)
 {
-    _impl->goto_location_async(latitude_deg, longitude_deg, absolute_altitude_m, yaw_deg, callback);
+    _impl->goto_location_async(
+        latitude_deg, longitude_deg, absolute_altitude_m, yaw_deg, loiter_radius_m, callback);
 }
 
 Action::Result Action::goto_location(
-    double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg) const
+    double latitude_deg,
+    double longitude_deg,
+    float absolute_altitude_m,
+    float yaw_deg,
+    float loiter_radius_m) const
 {
-    return _impl->goto_location(latitude_deg, longitude_deg, absolute_altitude_m, yaw_deg);
+    return _impl->goto_location(
+        latitude_deg, longitude_deg, absolute_altitude_m, yaw_deg, loiter_radius_m);
 }
 
 void Action::do_orbit_async(

--- a/cpp/src/mavsdk/plugins/action/action_impl.cpp
+++ b/cpp/src/mavsdk/plugins/action/action_impl.cpp
@@ -156,15 +156,19 @@ Action::Result ActionImpl::goto_location(
     const double latitude_deg,
     const double longitude_deg,
     const float altitude_amsl_m,
-    const float yaw_deg)
+    const float yaw_deg,
+    const float loiter_radius_m)
 {
     auto prom = std::promise<Action::Result>();
     auto fut = prom.get_future();
 
     goto_location_async(
-        latitude_deg, longitude_deg, altitude_amsl_m, yaw_deg, [&prom](Action::Result result) {
-            prom.set_value(result);
-        });
+        latitude_deg,
+        longitude_deg,
+        altitude_amsl_m,
+        yaw_deg,
+        loiter_radius_m,
+        [&prom](Action::Result result) { prom.set_value(result); });
 
     return fut.get();
 }
@@ -491,15 +495,20 @@ void ActionImpl::goto_location_async(
     const double longitude_deg,
     const float altitude_amsl_m,
     const float yaw_deg,
+    const float loiter_radius_m,
     const Action::ResultCallback& callback)
 {
     auto send_do_reposition =
-        [this, callback, yaw_deg, latitude_deg, longitude_deg, altitude_amsl_m]() {
+        [this, callback, yaw_deg, latitude_deg, longitude_deg, altitude_amsl_m, loiter_radius_m]() {
             MavlinkCommandSender::CommandInt command{};
 
             command.command = MAV_CMD_DO_REPOSITION;
             command.target_component_id = _system_impl->get_autopilot_id();
             command.frame = MAV_FRAME_GLOBAL_INT;
+            // param3: fixed-wing loiter radius (MAV_CMD_DO_REPOSITION). 0/NaN ignored.
+            if (std::isfinite(loiter_radius_m) && loiter_radius_m > 0.0f) {
+                command.params.maybe_param3 = loiter_radius_m;
+            }
             command.params.maybe_param4 = static_cast<float>(to_rad_from_deg(yaw_deg));
             command.params.x = int32_t(std::round(latitude_deg * 1e7));
             command.params.y = int32_t(std::round(longitude_deg * 1e7));

--- a/cpp/src/mavsdk/plugins/action/action_impl.hpp
+++ b/cpp/src/mavsdk/plugins/action/action_impl.hpp
@@ -34,7 +34,8 @@ public:
         const double latitude_deg,
         const double longitude_deg,
         const float altitude_amsl_m,
-        const float yaw_deg);
+        const float yaw_deg,
+        const float loiter_radius_m = NAN);
     Action::Result do_orbit(
         const float radius_m,
         const float velocity_ms,
@@ -63,6 +64,7 @@ public:
         const double longitude_deg,
         const float altitude_amsl_m,
         const float yaw_deg,
+        const float loiter_radius_m,
         const Action::ResultCallback& callback);
     void do_orbit_async(
         const float radius_m,

--- a/cpp/src/mavsdk/plugins/action/include/plugins/action/action.hpp
+++ b/cpp/src/mavsdk/plugins/action/include/plugins/action/action.hpp
@@ -463,9 +463,12 @@ public:
      *
      * The yaw angle is in degrees (frame is NED, 0 is North, positive is clockwise).
      *
+     * Optional loiter_radius_m maps to MAV_CMD_DO_REPOSITION param3 (fixed-wing loiter
+     * radius in meters; direction via yaw). Zero or NaN is ignored (default).
+     *
      * This function is non-blocking. See 'goto_location' for the blocking counterpart.
      */
-    void goto_location_async(double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg, const ResultCallback callback);
+    void goto_location_async(double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg, const ResultCallback callback, float loiter_radius_m = NAN);
 
 
 
@@ -483,7 +486,7 @@ public:
      * @return Result of request.
      
      */
-    Result goto_location(double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg) const;
+    Result goto_location(double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg, float loiter_radius_m = NAN) const;
 
 
 

--- a/cpp/src/mavsdk/plugins/action/mocks/action_mock.hpp
+++ b/cpp/src/mavsdk/plugins/action/mocks/action_mock.hpp
@@ -17,7 +17,7 @@ public:
     MOCK_CONST_METHOD0(land, Action::Result()) {};
     MOCK_CONST_METHOD0(reboot, Action::Result()) {};
     MOCK_CONST_METHOD0(shutdown, Action::Result()) {};
-    MOCK_CONST_METHOD4(goto_location, Action::Result(double, double, float, float)) {};
+    MOCK_CONST_METHOD5(goto_location, Action::Result(double, double, float, float, float)) {};
     MOCK_CONST_METHOD6(
         do_orbit, Action::Result(float, float, Action::OrbitYawBehavior, double, double, double)) {
     };

--- a/cpp/src/mavsdk_server/src/plugins/action/action_service_impl.hpp
+++ b/cpp/src/mavsdk_server/src/plugins/action/action_service_impl.hpp
@@ -500,7 +500,7 @@ public:
         
             
         
-        auto result = _lazy_plugin.maybe_plugin()->goto_location(request->latitude_deg(), request->longitude_deg(), request->absolute_altitude_m(), request->yaw_deg());
+        auto result = _lazy_plugin.maybe_plugin()->goto_location(request->latitude_deg(), request->longitude_deg(), request->absolute_altitude_m(), request->yaw_deg(), request->loiter_radius_m());
         
 
         


### PR DESCRIPTION
## Summary
- Add optional `loiter_radius_m` (default `NaN`) to `Action::goto_location` / `_async`
- When finite and > 0, set **MAV_CMD_DO_REPOSITION param3** (fixed-wing loiter radius; direction via yaw)
- Default path unchanged for multicopters / callers that omit the argument

## Motivation
Closes / implements https://github.com/mavlink/MAVSDK/issues/2853  
Reporter needs plane loiter radius on ArduPilot via DO_REPOSITION.

## Proto
Depends on https://github.com/mavlink/MAVSDK-Proto/pull/422 (`GotoLocationRequest.loiter_radius_m`).  
Submodule points at that commit for CI; will retarget to main after proto merge.

## API notes
- C++ default argument preserves source compatibility for existing 4-arg call sites
- gRPC server forwards `loiter_radius_m` once regenerated stubs land with proto merge
- Full binding regen (Python/C/Kotlin) expected after proto merge + `generate_from_protos`

## Verification
- Logic review against MAVLink DO_REPOSITION param3 semantics (0/NaN ignored)
- Existing call sites compile via default parameter
- Full matrix CI on this PR

## Scope discipline
- Issue-backed only (PX4-family policy)
- No flight-safety weakening; additive optional field only

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->