### PR TITLE
Action: add GotoLocationFixedwing

### DIFF
--- a/c/src/cmavsdk/plugins/action/action.cpp
+++ b/c/src/cmavsdk/plugins/action/action.cpp
@@ -565,6 +565,50 @@ mavsdk_action_goto_location(
     return translate_result(ret_value);
 }
 
+// GotoLocationFixedwing async
+void mavsdk_action_goto_location_fixedwing_async(
+    mavsdk_action_t action,
+    double latitude_deg,
+    double longitude_deg,
+    float absolute_altitude_m,
+    float loiter_radius_m,
+    mavsdk_action_goto_location_fixedwing_callback_t callback,
+    void* user_data)
+{
+    auto wrapper = reinterpret_cast<mavsdk_action_wrapper*>(action);
+
+    wrapper->cpp_plugin->goto_location_fixedwing_async(
+        latitude_deg,
+        longitude_deg,
+        absolute_altitude_m,
+        loiter_radius_m,
+        [callback, user_data](
+            mavsdk::Action::Result result) {
+                if (callback) {
+                    callback(
+                        translate_result(result),
+                        user_data);
+                }
+        });
+}
+
+
+// GotoLocationFixedwing sync
+mavsdk_action_result_t
+mavsdk_action_goto_location_fixedwing(
+    mavsdk_action_t action,
+    double latitude_deg,
+    double longitude_deg,
+    float absolute_altitude_m,
+    float loiter_radius_m)
+{
+    auto wrapper = reinterpret_cast<mavsdk_action_wrapper*>(action);
+
+    auto ret_value = wrapper->cpp_plugin->goto_location_fixedwing(        latitude_deg,        longitude_deg,        absolute_altitude_m,        loiter_radius_m);
+
+    return translate_result(ret_value);
+}
+
 // DoOrbit async
 void mavsdk_action_do_orbit_async(
     mavsdk_action_t action,

--- a/c/src/cmavsdk/plugins/action/action.h
+++ b/c/src/cmavsdk/plugins/action/action.h
@@ -179,6 +179,7 @@ typedef void (*mavsdk_action_terminate_callback_t)(const mavsdk_action_result_t 
 typedef void (*mavsdk_action_kill_callback_t)(const mavsdk_action_result_t result, void* user_data);
 typedef void (*mavsdk_action_return_to_launch_callback_t)(const mavsdk_action_result_t result, void* user_data);
 typedef void (*mavsdk_action_goto_location_callback_t)(const mavsdk_action_result_t result, void* user_data);
+typedef void (*mavsdk_action_goto_location_fixedwing_callback_t)(const mavsdk_action_result_t result, void* user_data);
 typedef void (*mavsdk_action_do_orbit_callback_t)(const mavsdk_action_result_t result, void* user_data);
 typedef void (*mavsdk_action_hold_callback_t)(const mavsdk_action_result_t result, void* user_data);
 typedef void (*mavsdk_action_set_actuator_callback_t)(const mavsdk_action_result_t result, void* user_data);
@@ -557,6 +558,59 @@ mavsdk_action_goto_location(
     double longitude_deg,
     float absolute_altitude_m,
     float yaw_deg);
+
+
+/**
+ * @brief Send command to the drone to fly to a location for fixed-wing aircraft.
+ * 
+ *  This sends a MAV_CMD_DO_REPOSITION command with a loiter radius.
+ * 
+ *  The latitude and longitude are given in degrees (WGS84 frame) and the altitude
+ *  in meters AMSL (above mean sea level).
+ * 
+ *  The loiter radius defines the radius of the loiter circle in meters, and its sign
+ *  controls the direction: positive is clockwise, negative is counter-clockwise.
+ *  A value of 0 is ignored by the autopilot.
+ *
+ * @param action The action instance.
+ * @param latitude_deg  Latitude (in degrees)
+ * 
+ * @param longitude_deg  Longitude (in degrees)
+ * 
+ * @param absolute_altitude_m  Altitude AMSL (in meters)
+ * 
+ * @param loiter_radius_m  Loiter radius (in meters). Positive: clockwise, negative: counter-clockwise, 0: ignored.
+ * 
+ *
+ * @param callback Function to call when new data is available.
+ * @param user_data User data to pass to the callback.
+ */
+CMAVSDK_EXPORT void mavsdk_action_goto_location_fixedwing_async(
+    mavsdk_action_t action,
+    double latitude_deg,
+    double longitude_deg,
+    float absolute_altitude_m,
+    float loiter_radius_m,
+    mavsdk_action_goto_location_fixedwing_callback_t callback,
+    void* user_data);
+
+
+/**
+ * @brief Get the current goto location fixedwing (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param goto_location_fixedwing_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_action_result_t
+mavsdk_action_goto_location_fixedwing(
+    mavsdk_action_t action,
+    double latitude_deg,
+    double longitude_deg,
+    float absolute_altitude_m,
+    float loiter_radius_m);
 
 
 /**

--- a/cpp/src/mavsdk/plugins/action/action.cpp
+++ b/cpp/src/mavsdk/plugins/action/action.cpp
@@ -146,7 +146,10 @@ void Action::goto_location_fixedwing_async(
 }
 
 Action::Result Action::goto_location_fixedwing(
-    double latitude_deg, double longitude_deg, float absolute_altitude_m, float loiter_radius_m) const
+    double latitude_deg,
+    double longitude_deg,
+    float absolute_altitude_m,
+    float loiter_radius_m) const
 {
     return _impl->goto_location_fixedwing(
         latitude_deg, longitude_deg, absolute_altitude_m, loiter_radius_m);

--- a/cpp/src/mavsdk/plugins/action/action.cpp
+++ b/cpp/src/mavsdk/plugins/action/action.cpp
@@ -134,6 +134,24 @@ Action::Result Action::goto_location(
     return _impl->goto_location(latitude_deg, longitude_deg, absolute_altitude_m, yaw_deg);
 }
 
+void Action::goto_location_fixedwing_async(
+    double latitude_deg,
+    double longitude_deg,
+    float absolute_altitude_m,
+    float loiter_radius_m,
+    const ResultCallback callback)
+{
+    _impl->goto_location_fixedwing_async(
+        latitude_deg, longitude_deg, absolute_altitude_m, loiter_radius_m, callback);
+}
+
+Action::Result Action::goto_location_fixedwing(
+    double latitude_deg, double longitude_deg, float absolute_altitude_m, float loiter_radius_m) const
+{
+    return _impl->goto_location_fixedwing(
+        latitude_deg, longitude_deg, absolute_altitude_m, loiter_radius_m);
+}
+
 void Action::do_orbit_async(
     float radius_m,
     float velocity_ms,

--- a/cpp/src/mavsdk/plugins/action/action_impl.cpp
+++ b/cpp/src/mavsdk/plugins/action/action_impl.cpp
@@ -5,6 +5,7 @@
 #include "px4_custom_mode.hpp"
 #include <cmath>
 #include <future>
+#include <limits>
 
 namespace mavsdk {
 
@@ -165,6 +166,25 @@ Action::Result ActionImpl::goto_location(
         latitude_deg, longitude_deg, altitude_amsl_m, yaw_deg, [&prom](Action::Result result) {
             prom.set_value(result);
         });
+
+    return fut.get();
+}
+
+Action::Result ActionImpl::goto_location_fixedwing(
+    const double latitude_deg,
+    const double longitude_deg,
+    const float altitude_amsl_m,
+    const float loiter_radius_m)
+{
+    auto prom = std::promise<Action::Result>();
+    auto fut = prom.get_future();
+
+    goto_location_fixedwing_async(
+        latitude_deg,
+        longitude_deg,
+        altitude_amsl_m,
+        loiter_radius_m,
+        [&prom](Action::Result result) { prom.set_value(result); });
 
     return fut.get();
 }
@@ -501,6 +521,60 @@ void ActionImpl::goto_location_async(
             command.target_component_id = _system_impl->get_autopilot_id();
             command.frame = MAV_FRAME_GLOBAL_INT;
             command.params.maybe_param4 = static_cast<float>(to_rad_from_deg(yaw_deg));
+            command.params.x = int32_t(std::round(latitude_deg * 1e7));
+            command.params.y = int32_t(std::round(longitude_deg * 1e7));
+            command.params.maybe_z = altitude_amsl_m;
+            command.params.maybe_param2 = static_cast<float>(MAV_DO_REPOSITION_FLAGS_CHANGE_MODE);
+
+            _system_impl->send_command_async(
+                command, [this, callback](MavlinkCommandSender::Result result, float) {
+                    command_result_callback(result, callback);
+                });
+        };
+    // Note: The required flight mode before DO_REPOSITION is not specified in the MAVLink standard.
+    if (_system_impl->effective_autopilot() == Autopilot::Px4 ||
+        _system_impl->effective_autopilot() == Autopilot::ArduPilot) {
+        FlightMode goto_flight_mode;
+        if (_system_impl->effective_autopilot() == Autopilot::Px4) {
+            goto_flight_mode = FlightMode::Hold;
+        } else {
+            goto_flight_mode = FlightMode::Offboard;
+        }
+        if (_system_impl->get_flight_mode() != goto_flight_mode) {
+            _system_impl->set_flight_mode_async(
+                goto_flight_mode,
+                [this, callback, send_do_reposition](MavlinkCommandSender::Result result, float) {
+                    Action::Result action_result = action_result_from_command_result(result);
+                    if (action_result != Action::Result::Success) {
+                        command_result_callback(result, callback);
+                        return;
+                    }
+                    send_do_reposition();
+                });
+            return;
+        }
+    }
+
+    send_do_reposition();
+}
+
+void ActionImpl::goto_location_fixedwing_async(
+    const double latitude_deg,
+    const double longitude_deg,
+    const float altitude_amsl_m,
+    const float loiter_radius_m,
+    const Action::ResultCallback& callback)
+{
+    auto send_do_reposition =
+        [this, callback, loiter_radius_m, latitude_deg, longitude_deg, altitude_amsl_m]() {
+            MavlinkCommandSender::CommandInt command{};
+
+            command.command = MAV_CMD_DO_REPOSITION;
+            command.target_component_id = _system_impl->get_autopilot_id();
+            command.frame = MAV_FRAME_GLOBAL_INT;
+            command.params.maybe_param3 = loiter_radius_m;
+            // Yaw is not meaningful while continuously turning in a loiter.
+            command.params.maybe_param4 = std::numeric_limits<float>::quiet_NaN();
             command.params.x = int32_t(std::round(latitude_deg * 1e7));
             command.params.y = int32_t(std::round(longitude_deg * 1e7));
             command.params.maybe_z = altitude_amsl_m;

--- a/cpp/src/mavsdk/plugins/action/action_impl.hpp
+++ b/cpp/src/mavsdk/plugins/action/action_impl.hpp
@@ -35,6 +35,11 @@ public:
         const double longitude_deg,
         const float altitude_amsl_m,
         const float yaw_deg);
+    Action::Result goto_location_fixedwing(
+        const double latitude_deg,
+        const double longitude_deg,
+        const float altitude_amsl_m,
+        const float loiter_radius_m);
     Action::Result do_orbit(
         const float radius_m,
         const float velocity_ms,
@@ -63,6 +68,12 @@ public:
         const double longitude_deg,
         const float altitude_amsl_m,
         const float yaw_deg,
+        const Action::ResultCallback& callback);
+    void goto_location_fixedwing_async(
+        const double latitude_deg,
+        const double longitude_deg,
+        const float altitude_amsl_m,
+        const float loiter_radius_m,
         const Action::ResultCallback& callback);
     void do_orbit_async(
         const float radius_m,

--- a/cpp/src/mavsdk/plugins/action/include/plugins/action/action.hpp
+++ b/cpp/src/mavsdk/plugins/action/include/plugins/action/action.hpp
@@ -520,9 +520,9 @@ public:
      *
      * This function is blocking. See 'goto_location_fixedwing_async' for the non-blocking counterpart.
      *
-
+     
      * @return Result of request.
-
+     
      */
     Result goto_location_fixedwing(double latitude_deg, double longitude_deg, float absolute_altitude_m, float loiter_radius_m) const;
 

--- a/cpp/src/mavsdk/plugins/action/include/plugins/action/action.hpp
+++ b/cpp/src/mavsdk/plugins/action/include/plugins/action/action.hpp
@@ -489,6 +489,47 @@ public:
 
 
     /**
+     * @brief Send command to the drone to fly to a location for fixed-wing aircraft.
+     *
+     * This sends a MAV_CMD_DO_REPOSITION command with a loiter radius.
+     *
+     * The latitude and longitude are given in degrees (WGS84 frame) and the altitude
+     * in meters AMSL (above mean sea level).
+     *
+     * The loiter radius defines the radius of the loiter circle in meters, and its sign
+     * controls the direction: positive is clockwise, negative is counter-clockwise.
+     * A value of 0 is ignored by the autopilot.
+     *
+     * This function is non-blocking. See 'goto_location_fixedwing' for the blocking counterpart.
+     */
+    void goto_location_fixedwing_async(double latitude_deg, double longitude_deg, float absolute_altitude_m, float loiter_radius_m, const ResultCallback callback);
+
+
+
+    /**
+     * @brief Send command to the drone to fly to a location for fixed-wing aircraft.
+     *
+     * This sends a MAV_CMD_DO_REPOSITION command with a loiter radius.
+     *
+     * The latitude and longitude are given in degrees (WGS84 frame) and the altitude
+     * in meters AMSL (above mean sea level).
+     *
+     * The loiter radius defines the radius of the loiter circle in meters, and its sign
+     * controls the direction: positive is clockwise, negative is counter-clockwise.
+     * A value of 0 is ignored by the autopilot.
+     *
+     * This function is blocking. See 'goto_location_fixedwing_async' for the non-blocking counterpart.
+     *
+
+     * @return Result of request.
+
+     */
+    Result goto_location_fixedwing(double latitude_deg, double longitude_deg, float absolute_altitude_m, float loiter_radius_m) const;
+
+
+
+
+    /**
      * @brief Send command do orbit to the drone.
      *
      * This will run the orbit routine with the given parameters.

--- a/cpp/src/mavsdk/plugins/action/mocks/action_mock.hpp
+++ b/cpp/src/mavsdk/plugins/action/mocks/action_mock.hpp
@@ -18,6 +18,7 @@ public:
     MOCK_CONST_METHOD0(reboot, Action::Result()) {};
     MOCK_CONST_METHOD0(shutdown, Action::Result()) {};
     MOCK_CONST_METHOD4(goto_location, Action::Result(double, double, float, float)) {};
+    MOCK_CONST_METHOD4(goto_location_fixedwing, Action::Result(double, double, float, float)) {};
     MOCK_CONST_METHOD6(
         do_orbit, Action::Result(float, float, Action::OrbitYawBehavior, double, double, double)) {
     };

--- a/cpp/src/mavsdk_server/src/generated/action/action.grpc.pb.cc
+++ b/cpp/src/mavsdk_server/src/generated/action/action.grpc.pb.cc
@@ -35,6 +35,7 @@ static const char* ActionService_method_names[] = {
   "/mavsdk.rpc.action.ActionService/Kill",
   "/mavsdk.rpc.action.ActionService/ReturnToLaunch",
   "/mavsdk.rpc.action.ActionService/GotoLocation",
+  "/mavsdk.rpc.action.ActionService/GotoLocationFixedwing",
   "/mavsdk.rpc.action.ActionService/DoOrbit",
   "/mavsdk.rpc.action.ActionService/Hold",
   "/mavsdk.rpc.action.ActionService/SetActuator",
@@ -68,19 +69,20 @@ ActionService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& chan
   , rpcmethod_Kill_(ActionService_method_names[8], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_ReturnToLaunch_(ActionService_method_names[9], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_GotoLocation_(ActionService_method_names[10], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_DoOrbit_(ActionService_method_names[11], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_Hold_(ActionService_method_names[12], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetActuator_(ActionService_method_names[13], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetRelay_(ActionService_method_names[14], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_TransitionToFixedwing_(ActionService_method_names[15], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_TransitionToMulticopter_(ActionService_method_names[16], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_GetTakeoffAltitude_(ActionService_method_names[17], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetTakeoffAltitude_(ActionService_method_names[18], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_GetReturnToLaunchAltitude_(ActionService_method_names[19], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetReturnToLaunchAltitude_(ActionService_method_names[20], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetCurrentSpeed_(ActionService_method_names[21], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetGpsGlobalOrigin_(ActionService_method_names[22], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetHome_(ActionService_method_names[23], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GotoLocationFixedwing_(ActionService_method_names[11], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_DoOrbit_(ActionService_method_names[12], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_Hold_(ActionService_method_names[13], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetActuator_(ActionService_method_names[14], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetRelay_(ActionService_method_names[15], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_TransitionToFixedwing_(ActionService_method_names[16], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_TransitionToMulticopter_(ActionService_method_names[17], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetTakeoffAltitude_(ActionService_method_names[18], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetTakeoffAltitude_(ActionService_method_names[19], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetReturnToLaunchAltitude_(ActionService_method_names[20], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetReturnToLaunchAltitude_(ActionService_method_names[21], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetCurrentSpeed_(ActionService_method_names[22], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetGpsGlobalOrigin_(ActionService_method_names[23], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetHome_(ActionService_method_names[24], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status ActionService::Stub::Arm(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ArmRequest& request, ::mavsdk::rpc::action::ArmResponse* response) {
@@ -332,6 +334,29 @@ void ActionService::Stub::async::GotoLocation(::grpc::ClientContext* context, co
 ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationResponse>* ActionService::Stub::AsyncGotoLocationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest& request, ::grpc::CompletionQueue* cq) {
   auto* result =
     this->PrepareAsyncGotoLocationRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::Status ActionService::Stub::GotoLocationFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest& request, ::mavsdk::rpc::action::GotoLocationFixedwingResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::action::GotoLocationFixedwingRequest, ::mavsdk::rpc::action::GotoLocationFixedwingResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_GotoLocationFixedwing_, context, request, response);
+}
+
+void ActionService::Stub::async::GotoLocationFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest* request, ::mavsdk::rpc::action::GotoLocationFixedwingResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::action::GotoLocationFixedwingRequest, ::mavsdk::rpc::action::GotoLocationFixedwingResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_GotoLocationFixedwing_, context, request, response, std::move(f));
+}
+
+void ActionService::Stub::async::GotoLocationFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest* request, ::mavsdk::rpc::action::GotoLocationFixedwingResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_GotoLocationFixedwing_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationFixedwingResponse>* ActionService::Stub::PrepareAsyncGotoLocationFixedwingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::action::GotoLocationFixedwingResponse, ::mavsdk::rpc::action::GotoLocationFixedwingRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_GotoLocationFixedwing_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationFixedwingResponse>* ActionService::Stub::AsyncGotoLocationFixedwingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncGotoLocationFixedwingRaw(context, request, cq);
   result->StartCall();
   return result;
 }
@@ -749,6 +774,16 @@ ActionService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       ActionService_method_names[11],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::GotoLocationFixedwingRequest, ::mavsdk::rpc::action::GotoLocationFixedwingResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](ActionService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::action::GotoLocationFixedwingRequest* req,
+             ::mavsdk::rpc::action::GotoLocationFixedwingResponse* resp) {
+               return service->GotoLocationFixedwing(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      ActionService_method_names[12],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::DoOrbitRequest, ::mavsdk::rpc::action::DoOrbitResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](ActionService::Service* service,
              ::grpc::ServerContext* ctx,
@@ -757,7 +792,7 @@ ActionService::Service::Service() {
                return service->DoOrbit(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ActionService_method_names[12],
+      ActionService_method_names[13],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::HoldRequest, ::mavsdk::rpc::action::HoldResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](ActionService::Service* service,
@@ -767,7 +802,7 @@ ActionService::Service::Service() {
                return service->Hold(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ActionService_method_names[13],
+      ActionService_method_names[14],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::SetActuatorRequest, ::mavsdk::rpc::action::SetActuatorResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](ActionService::Service* service,
@@ -777,7 +812,7 @@ ActionService::Service::Service() {
                return service->SetActuator(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ActionService_method_names[14],
+      ActionService_method_names[15],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::SetRelayRequest, ::mavsdk::rpc::action::SetRelayResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](ActionService::Service* service,
@@ -787,7 +822,7 @@ ActionService::Service::Service() {
                return service->SetRelay(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ActionService_method_names[15],
+      ActionService_method_names[16],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::TransitionToFixedwingRequest, ::mavsdk::rpc::action::TransitionToFixedwingResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](ActionService::Service* service,
@@ -797,7 +832,7 @@ ActionService::Service::Service() {
                return service->TransitionToFixedwing(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ActionService_method_names[16],
+      ActionService_method_names[17],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::TransitionToMulticopterRequest, ::mavsdk::rpc::action::TransitionToMulticopterResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](ActionService::Service* service,
@@ -807,7 +842,7 @@ ActionService::Service::Service() {
                return service->TransitionToMulticopter(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ActionService_method_names[17],
+      ActionService_method_names[18],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::GetTakeoffAltitudeRequest, ::mavsdk::rpc::action::GetTakeoffAltitudeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](ActionService::Service* service,
@@ -817,7 +852,7 @@ ActionService::Service::Service() {
                return service->GetTakeoffAltitude(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ActionService_method_names[18],
+      ActionService_method_names[19],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::SetTakeoffAltitudeRequest, ::mavsdk::rpc::action::SetTakeoffAltitudeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](ActionService::Service* service,
@@ -827,7 +862,7 @@ ActionService::Service::Service() {
                return service->SetTakeoffAltitude(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ActionService_method_names[19],
+      ActionService_method_names[20],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::GetReturnToLaunchAltitudeRequest, ::mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](ActionService::Service* service,
@@ -837,7 +872,7 @@ ActionService::Service::Service() {
                return service->GetReturnToLaunchAltitude(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ActionService_method_names[20],
+      ActionService_method_names[21],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest, ::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](ActionService::Service* service,
@@ -847,7 +882,7 @@ ActionService::Service::Service() {
                return service->SetReturnToLaunchAltitude(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ActionService_method_names[21],
+      ActionService_method_names[22],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::SetCurrentSpeedRequest, ::mavsdk::rpc::action::SetCurrentSpeedResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](ActionService::Service* service,
@@ -857,7 +892,7 @@ ActionService::Service::Service() {
                return service->SetCurrentSpeed(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ActionService_method_names[22],
+      ActionService_method_names[23],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::SetGpsGlobalOriginRequest, ::mavsdk::rpc::action::SetGpsGlobalOriginResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](ActionService::Service* service,
@@ -867,7 +902,7 @@ ActionService::Service::Service() {
                return service->SetGpsGlobalOrigin(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ActionService_method_names[23],
+      ActionService_method_names[24],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ActionService::Service, ::mavsdk::rpc::action::SetHomeRequest, ::mavsdk::rpc::action::SetHomeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](ActionService::Service* service,
@@ -952,6 +987,13 @@ ActionService::Service::~Service() {
 }
 
 ::grpc::Status ActionService::Service::GotoLocation(::grpc::ServerContext* context, const ::mavsdk::rpc::action::GotoLocationRequest* request, ::mavsdk::rpc::action::GotoLocationResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status ActionService::Service::GotoLocationFixedwing(::grpc::ServerContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest* request, ::mavsdk::rpc::action::GotoLocationFixedwingResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/cpp/src/mavsdk_server/src/generated/action/action.grpc.pb.h
+++ b/cpp/src/mavsdk_server/src/generated/action/action.grpc.pb.h
@@ -176,6 +176,24 @@ class ActionService final {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::GotoLocationResponse>>(PrepareAsyncGotoLocationRaw(context, request, cq));
     }
     //
+    // Send command to the drone to fly to a location for fixed-wing aircraft.
+    //
+    // This sends a MAV_CMD_DO_REPOSITION command with a loiter radius.
+    //
+    // The latitude and longitude are given in degrees (WGS84 frame) and the altitude
+    // in meters AMSL (above mean sea level).
+    //
+    // The loiter radius defines the radius of the loiter circle in meters, and its sign
+    // controls the direction: positive is clockwise, negative is counter-clockwise.
+    // A value of 0 is ignored by the autopilot.
+    virtual ::grpc::Status GotoLocationFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest& request, ::mavsdk::rpc::action::GotoLocationFixedwingResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::GotoLocationFixedwingResponse>> AsyncGotoLocationFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::GotoLocationFixedwingResponse>>(AsyncGotoLocationFixedwingRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::GotoLocationFixedwingResponse>> PrepareAsyncGotoLocationFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::GotoLocationFixedwingResponse>>(PrepareAsyncGotoLocationFixedwingRaw(context, request, cq));
+    }
+    //
     // Send command do orbit to the drone.
     //
     // This will run the orbit routine with the given parameters.
@@ -406,6 +424,19 @@ class ActionService final {
       virtual void GotoLocation(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest* request, ::mavsdk::rpc::action::GotoLocationResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void GotoLocation(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest* request, ::mavsdk::rpc::action::GotoLocationResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       //
+      // Send command to the drone to fly to a location for fixed-wing aircraft.
+      //
+      // This sends a MAV_CMD_DO_REPOSITION command with a loiter radius.
+      //
+      // The latitude and longitude are given in degrees (WGS84 frame) and the altitude
+      // in meters AMSL (above mean sea level).
+      //
+      // The loiter radius defines the radius of the loiter circle in meters, and its sign
+      // controls the direction: positive is clockwise, negative is counter-clockwise.
+      // A value of 0 is ignored by the autopilot.
+      virtual void GotoLocationFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest* request, ::mavsdk::rpc::action::GotoLocationFixedwingResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void GotoLocationFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest* request, ::mavsdk::rpc::action::GotoLocationFixedwingResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      //
       // Send command do orbit to the drone.
       //
       // This will run the orbit routine with the given parameters.
@@ -512,6 +543,8 @@ class ActionService final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::ReturnToLaunchResponse>* PrepareAsyncReturnToLaunchRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ReturnToLaunchRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::GotoLocationResponse>* AsyncGotoLocationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::GotoLocationResponse>* PrepareAsyncGotoLocationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::GotoLocationFixedwingResponse>* AsyncGotoLocationFixedwingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::GotoLocationFixedwingResponse>* PrepareAsyncGotoLocationFixedwingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::DoOrbitResponse>* AsyncDoOrbitRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::DoOrbitRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::DoOrbitResponse>* PrepareAsyncDoOrbitRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::DoOrbitRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::action::HoldResponse>* AsyncHoldRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::HoldRequest& request, ::grpc::CompletionQueue* cq) = 0;
@@ -618,6 +651,13 @@ class ActionService final {
     }
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationResponse>> PrepareAsyncGotoLocation(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationResponse>>(PrepareAsyncGotoLocationRaw(context, request, cq));
+    }
+    ::grpc::Status GotoLocationFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest& request, ::mavsdk::rpc::action::GotoLocationFixedwingResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationFixedwingResponse>> AsyncGotoLocationFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationFixedwingResponse>>(AsyncGotoLocationFixedwingRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationFixedwingResponse>> PrepareAsyncGotoLocationFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationFixedwingResponse>>(PrepareAsyncGotoLocationFixedwingRaw(context, request, cq));
     }
     ::grpc::Status DoOrbit(::grpc::ClientContext* context, const ::mavsdk::rpc::action::DoOrbitRequest& request, ::mavsdk::rpc::action::DoOrbitResponse* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::DoOrbitResponse>> AsyncDoOrbit(::grpc::ClientContext* context, const ::mavsdk::rpc::action::DoOrbitRequest& request, ::grpc::CompletionQueue* cq) {
@@ -735,6 +775,8 @@ class ActionService final {
       void ReturnToLaunch(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ReturnToLaunchRequest* request, ::mavsdk::rpc::action::ReturnToLaunchResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void GotoLocation(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest* request, ::mavsdk::rpc::action::GotoLocationResponse* response, std::function<void(::grpc::Status)>) override;
       void GotoLocation(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest* request, ::mavsdk::rpc::action::GotoLocationResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void GotoLocationFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest* request, ::mavsdk::rpc::action::GotoLocationFixedwingResponse* response, std::function<void(::grpc::Status)>) override;
+      void GotoLocationFixedwing(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest* request, ::mavsdk::rpc::action::GotoLocationFixedwingResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void DoOrbit(::grpc::ClientContext* context, const ::mavsdk::rpc::action::DoOrbitRequest* request, ::mavsdk::rpc::action::DoOrbitResponse* response, std::function<void(::grpc::Status)>) override;
       void DoOrbit(::grpc::ClientContext* context, const ::mavsdk::rpc::action::DoOrbitRequest* request, ::mavsdk::rpc::action::DoOrbitResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void Hold(::grpc::ClientContext* context, const ::mavsdk::rpc::action::HoldRequest* request, ::mavsdk::rpc::action::HoldResponse* response, std::function<void(::grpc::Status)>) override;
@@ -794,6 +836,8 @@ class ActionService final {
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::ReturnToLaunchResponse>* PrepareAsyncReturnToLaunchRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::ReturnToLaunchRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationResponse>* AsyncGotoLocationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationResponse>* PrepareAsyncGotoLocationRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationFixedwingResponse>* AsyncGotoLocationFixedwingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::GotoLocationFixedwingResponse>* PrepareAsyncGotoLocationFixedwingRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::DoOrbitResponse>* AsyncDoOrbitRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::DoOrbitRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::DoOrbitResponse>* PrepareAsyncDoOrbitRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::DoOrbitRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::action::HoldResponse>* AsyncHoldRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::action::HoldRequest& request, ::grpc::CompletionQueue* cq) override;
@@ -831,6 +875,7 @@ class ActionService final {
     const ::grpc::internal::RpcMethod rpcmethod_Kill_;
     const ::grpc::internal::RpcMethod rpcmethod_ReturnToLaunch_;
     const ::grpc::internal::RpcMethod rpcmethod_GotoLocation_;
+    const ::grpc::internal::RpcMethod rpcmethod_GotoLocationFixedwing_;
     const ::grpc::internal::RpcMethod rpcmethod_DoOrbit_;
     const ::grpc::internal::RpcMethod rpcmethod_Hold_;
     const ::grpc::internal::RpcMethod rpcmethod_SetActuator_;
@@ -922,6 +967,18 @@ class ActionService final {
     //
     // The yaw angle is in degrees (frame is NED, 0 is North, positive is clockwise).
     virtual ::grpc::Status GotoLocation(::grpc::ServerContext* context, const ::mavsdk::rpc::action::GotoLocationRequest* request, ::mavsdk::rpc::action::GotoLocationResponse* response);
+    //
+    // Send command to the drone to fly to a location for fixed-wing aircraft.
+    //
+    // This sends a MAV_CMD_DO_REPOSITION command with a loiter radius.
+    //
+    // The latitude and longitude are given in degrees (WGS84 frame) and the altitude
+    // in meters AMSL (above mean sea level).
+    //
+    // The loiter radius defines the radius of the loiter circle in meters, and its sign
+    // controls the direction: positive is clockwise, negative is counter-clockwise.
+    // A value of 0 is ignored by the autopilot.
+    virtual ::grpc::Status GotoLocationFixedwing(::grpc::ServerContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest* request, ::mavsdk::rpc::action::GotoLocationFixedwingResponse* response);
     //
     // Send command do orbit to the drone.
     //
@@ -1211,12 +1268,32 @@ class ActionService final {
     }
   };
   template <class BaseClass>
+  class WithAsyncMethod_GotoLocationFixedwing : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_GotoLocationFixedwing() {
+      ::grpc::Service::MarkMethodAsync(11);
+    }
+    ~WithAsyncMethod_GotoLocationFixedwing() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GotoLocationFixedwing(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest* /*request*/, ::mavsdk::rpc::action::GotoLocationFixedwingResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestGotoLocationFixedwing(::grpc::ServerContext* context, ::mavsdk::rpc::action::GotoLocationFixedwingRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::GotoLocationFixedwingResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithAsyncMethod_DoOrbit : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_DoOrbit() {
-      ::grpc::Service::MarkMethodAsync(11);
+      ::grpc::Service::MarkMethodAsync(12);
     }
     ~WithAsyncMethod_DoOrbit() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1227,7 +1304,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestDoOrbit(::grpc::ServerContext* context, ::mavsdk::rpc::action::DoOrbitRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::DoOrbitResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1236,7 +1313,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_Hold() {
-      ::grpc::Service::MarkMethodAsync(12);
+      ::grpc::Service::MarkMethodAsync(13);
     }
     ~WithAsyncMethod_Hold() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1247,7 +1324,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestHold(::grpc::ServerContext* context, ::mavsdk::rpc::action::HoldRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::HoldResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1256,7 +1333,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetActuator() {
-      ::grpc::Service::MarkMethodAsync(13);
+      ::grpc::Service::MarkMethodAsync(14);
     }
     ~WithAsyncMethod_SetActuator() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1267,7 +1344,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetActuator(::grpc::ServerContext* context, ::mavsdk::rpc::action::SetActuatorRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::SetActuatorResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1276,7 +1353,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetRelay() {
-      ::grpc::Service::MarkMethodAsync(14);
+      ::grpc::Service::MarkMethodAsync(15);
     }
     ~WithAsyncMethod_SetRelay() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1287,7 +1364,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRelay(::grpc::ServerContext* context, ::mavsdk::rpc::action::SetRelayRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::SetRelayResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1296,7 +1373,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_TransitionToFixedwing() {
-      ::grpc::Service::MarkMethodAsync(15);
+      ::grpc::Service::MarkMethodAsync(16);
     }
     ~WithAsyncMethod_TransitionToFixedwing() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1307,7 +1384,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestTransitionToFixedwing(::grpc::ServerContext* context, ::mavsdk::rpc::action::TransitionToFixedwingRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::TransitionToFixedwingResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1316,7 +1393,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_TransitionToMulticopter() {
-      ::grpc::Service::MarkMethodAsync(16);
+      ::grpc::Service::MarkMethodAsync(17);
     }
     ~WithAsyncMethod_TransitionToMulticopter() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1327,7 +1404,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestTransitionToMulticopter(::grpc::ServerContext* context, ::mavsdk::rpc::action::TransitionToMulticopterRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::TransitionToMulticopterResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(17, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1336,7 +1413,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_GetTakeoffAltitude() {
-      ::grpc::Service::MarkMethodAsync(17);
+      ::grpc::Service::MarkMethodAsync(18);
     }
     ~WithAsyncMethod_GetTakeoffAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1347,7 +1424,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetTakeoffAltitude(::grpc::ServerContext* context, ::mavsdk::rpc::action::GetTakeoffAltitudeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::GetTakeoffAltitudeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(17, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(18, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1356,7 +1433,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetTakeoffAltitude() {
-      ::grpc::Service::MarkMethodAsync(18);
+      ::grpc::Service::MarkMethodAsync(19);
     }
     ~WithAsyncMethod_SetTakeoffAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1367,7 +1444,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetTakeoffAltitude(::grpc::ServerContext* context, ::mavsdk::rpc::action::SetTakeoffAltitudeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::SetTakeoffAltitudeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(18, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(19, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1376,7 +1453,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_GetReturnToLaunchAltitude() {
-      ::grpc::Service::MarkMethodAsync(19);
+      ::grpc::Service::MarkMethodAsync(20);
     }
     ~WithAsyncMethod_GetReturnToLaunchAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1387,7 +1464,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetReturnToLaunchAltitude(::grpc::ServerContext* context, ::mavsdk::rpc::action::GetReturnToLaunchAltitudeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(19, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(20, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1396,7 +1473,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetReturnToLaunchAltitude() {
-      ::grpc::Service::MarkMethodAsync(20);
+      ::grpc::Service::MarkMethodAsync(21);
     }
     ~WithAsyncMethod_SetReturnToLaunchAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1407,7 +1484,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetReturnToLaunchAltitude(::grpc::ServerContext* context, ::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(20, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(21, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1416,7 +1493,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetCurrentSpeed() {
-      ::grpc::Service::MarkMethodAsync(21);
+      ::grpc::Service::MarkMethodAsync(22);
     }
     ~WithAsyncMethod_SetCurrentSpeed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1427,7 +1504,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetCurrentSpeed(::grpc::ServerContext* context, ::mavsdk::rpc::action::SetCurrentSpeedRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::SetCurrentSpeedResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(21, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(22, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1436,7 +1513,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetGpsGlobalOrigin() {
-      ::grpc::Service::MarkMethodAsync(22);
+      ::grpc::Service::MarkMethodAsync(23);
     }
     ~WithAsyncMethod_SetGpsGlobalOrigin() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1447,7 +1524,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetGpsGlobalOrigin(::grpc::ServerContext* context, ::mavsdk::rpc::action::SetGpsGlobalOriginRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::SetGpsGlobalOriginResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(22, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(23, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1456,7 +1533,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetHome() {
-      ::grpc::Service::MarkMethodAsync(23);
+      ::grpc::Service::MarkMethodAsync(24);
     }
     ~WithAsyncMethod_SetHome() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1467,10 +1544,10 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetHome(::grpc::ServerContext* context, ::mavsdk::rpc::action::SetHomeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::action::SetHomeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(23, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(24, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_Arm<WithAsyncMethod_ArmForce<WithAsyncMethod_Disarm<WithAsyncMethod_Takeoff<WithAsyncMethod_Land<WithAsyncMethod_Reboot<WithAsyncMethod_Shutdown<WithAsyncMethod_Terminate<WithAsyncMethod_Kill<WithAsyncMethod_ReturnToLaunch<WithAsyncMethod_GotoLocation<WithAsyncMethod_DoOrbit<WithAsyncMethod_Hold<WithAsyncMethod_SetActuator<WithAsyncMethod_SetRelay<WithAsyncMethod_TransitionToFixedwing<WithAsyncMethod_TransitionToMulticopter<WithAsyncMethod_GetTakeoffAltitude<WithAsyncMethod_SetTakeoffAltitude<WithAsyncMethod_GetReturnToLaunchAltitude<WithAsyncMethod_SetReturnToLaunchAltitude<WithAsyncMethod_SetCurrentSpeed<WithAsyncMethod_SetGpsGlobalOrigin<WithAsyncMethod_SetHome<Service > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
+  typedef WithAsyncMethod_Arm<WithAsyncMethod_ArmForce<WithAsyncMethod_Disarm<WithAsyncMethod_Takeoff<WithAsyncMethod_Land<WithAsyncMethod_Reboot<WithAsyncMethod_Shutdown<WithAsyncMethod_Terminate<WithAsyncMethod_Kill<WithAsyncMethod_ReturnToLaunch<WithAsyncMethod_GotoLocation<WithAsyncMethod_GotoLocationFixedwing<WithAsyncMethod_DoOrbit<WithAsyncMethod_Hold<WithAsyncMethod_SetActuator<WithAsyncMethod_SetRelay<WithAsyncMethod_TransitionToFixedwing<WithAsyncMethod_TransitionToMulticopter<WithAsyncMethod_GetTakeoffAltitude<WithAsyncMethod_SetTakeoffAltitude<WithAsyncMethod_GetReturnToLaunchAltitude<WithAsyncMethod_SetReturnToLaunchAltitude<WithAsyncMethod_SetCurrentSpeed<WithAsyncMethod_SetGpsGlobalOrigin<WithAsyncMethod_SetHome<Service > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_Arm : public BaseClass {
    private:
@@ -1769,18 +1846,45 @@ class ActionService final {
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::action::GotoLocationRequest* /*request*/, ::mavsdk::rpc::action::GotoLocationResponse* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithCallbackMethod_GotoLocationFixedwing : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_GotoLocationFixedwing() {
+      ::grpc::Service::MarkMethodCallback(11,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::GotoLocationFixedwingRequest, ::mavsdk::rpc::action::GotoLocationFixedwingResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest* request, ::mavsdk::rpc::action::GotoLocationFixedwingResponse* response) { return this->GotoLocationFixedwing(context, request, response); }));}
+    void SetMessageAllocatorFor_GotoLocationFixedwing(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::action::GotoLocationFixedwingRequest, ::mavsdk::rpc::action::GotoLocationFixedwingResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(11);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::GotoLocationFixedwingRequest, ::mavsdk::rpc::action::GotoLocationFixedwingResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_GotoLocationFixedwing() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GotoLocationFixedwing(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest* /*request*/, ::mavsdk::rpc::action::GotoLocationFixedwingResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* GotoLocationFixedwing(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest* /*request*/, ::mavsdk::rpc::action::GotoLocationFixedwingResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithCallbackMethod_DoOrbit : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_DoOrbit() {
-      ::grpc::Service::MarkMethodCallback(11,
+      ::grpc::Service::MarkMethodCallback(12,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::DoOrbitRequest, ::mavsdk::rpc::action::DoOrbitResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action::DoOrbitRequest* request, ::mavsdk::rpc::action::DoOrbitResponse* response) { return this->DoOrbit(context, request, response); }));}
     void SetMessageAllocatorFor_DoOrbit(
         ::grpc::MessageAllocator< ::mavsdk::rpc::action::DoOrbitRequest, ::mavsdk::rpc::action::DoOrbitResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(11);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(12);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::DoOrbitRequest, ::mavsdk::rpc::action::DoOrbitResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -1801,13 +1905,13 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_Hold() {
-      ::grpc::Service::MarkMethodCallback(12,
+      ::grpc::Service::MarkMethodCallback(13,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::HoldRequest, ::mavsdk::rpc::action::HoldResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action::HoldRequest* request, ::mavsdk::rpc::action::HoldResponse* response) { return this->Hold(context, request, response); }));}
     void SetMessageAllocatorFor_Hold(
         ::grpc::MessageAllocator< ::mavsdk::rpc::action::HoldRequest, ::mavsdk::rpc::action::HoldResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(12);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(13);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::HoldRequest, ::mavsdk::rpc::action::HoldResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -1828,13 +1932,13 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetActuator() {
-      ::grpc::Service::MarkMethodCallback(13,
+      ::grpc::Service::MarkMethodCallback(14,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetActuatorRequest, ::mavsdk::rpc::action::SetActuatorResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action::SetActuatorRequest* request, ::mavsdk::rpc::action::SetActuatorResponse* response) { return this->SetActuator(context, request, response); }));}
     void SetMessageAllocatorFor_SetActuator(
         ::grpc::MessageAllocator< ::mavsdk::rpc::action::SetActuatorRequest, ::mavsdk::rpc::action::SetActuatorResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(13);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(14);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetActuatorRequest, ::mavsdk::rpc::action::SetActuatorResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -1855,13 +1959,13 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetRelay() {
-      ::grpc::Service::MarkMethodCallback(14,
+      ::grpc::Service::MarkMethodCallback(15,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetRelayRequest, ::mavsdk::rpc::action::SetRelayResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action::SetRelayRequest* request, ::mavsdk::rpc::action::SetRelayResponse* response) { return this->SetRelay(context, request, response); }));}
     void SetMessageAllocatorFor_SetRelay(
         ::grpc::MessageAllocator< ::mavsdk::rpc::action::SetRelayRequest, ::mavsdk::rpc::action::SetRelayResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(14);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(15);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetRelayRequest, ::mavsdk::rpc::action::SetRelayResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -1882,13 +1986,13 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_TransitionToFixedwing() {
-      ::grpc::Service::MarkMethodCallback(15,
+      ::grpc::Service::MarkMethodCallback(16,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::TransitionToFixedwingRequest, ::mavsdk::rpc::action::TransitionToFixedwingResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action::TransitionToFixedwingRequest* request, ::mavsdk::rpc::action::TransitionToFixedwingResponse* response) { return this->TransitionToFixedwing(context, request, response); }));}
     void SetMessageAllocatorFor_TransitionToFixedwing(
         ::grpc::MessageAllocator< ::mavsdk::rpc::action::TransitionToFixedwingRequest, ::mavsdk::rpc::action::TransitionToFixedwingResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(15);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(16);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::TransitionToFixedwingRequest, ::mavsdk::rpc::action::TransitionToFixedwingResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -1909,13 +2013,13 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_TransitionToMulticopter() {
-      ::grpc::Service::MarkMethodCallback(16,
+      ::grpc::Service::MarkMethodCallback(17,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::TransitionToMulticopterRequest, ::mavsdk::rpc::action::TransitionToMulticopterResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action::TransitionToMulticopterRequest* request, ::mavsdk::rpc::action::TransitionToMulticopterResponse* response) { return this->TransitionToMulticopter(context, request, response); }));}
     void SetMessageAllocatorFor_TransitionToMulticopter(
         ::grpc::MessageAllocator< ::mavsdk::rpc::action::TransitionToMulticopterRequest, ::mavsdk::rpc::action::TransitionToMulticopterResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(16);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(17);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::TransitionToMulticopterRequest, ::mavsdk::rpc::action::TransitionToMulticopterResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -1936,13 +2040,13 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_GetTakeoffAltitude() {
-      ::grpc::Service::MarkMethodCallback(17,
+      ::grpc::Service::MarkMethodCallback(18,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::GetTakeoffAltitudeRequest, ::mavsdk::rpc::action::GetTakeoffAltitudeResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action::GetTakeoffAltitudeRequest* request, ::mavsdk::rpc::action::GetTakeoffAltitudeResponse* response) { return this->GetTakeoffAltitude(context, request, response); }));}
     void SetMessageAllocatorFor_GetTakeoffAltitude(
         ::grpc::MessageAllocator< ::mavsdk::rpc::action::GetTakeoffAltitudeRequest, ::mavsdk::rpc::action::GetTakeoffAltitudeResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(17);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(18);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::GetTakeoffAltitudeRequest, ::mavsdk::rpc::action::GetTakeoffAltitudeResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -1963,13 +2067,13 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetTakeoffAltitude() {
-      ::grpc::Service::MarkMethodCallback(18,
+      ::grpc::Service::MarkMethodCallback(19,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetTakeoffAltitudeRequest, ::mavsdk::rpc::action::SetTakeoffAltitudeResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action::SetTakeoffAltitudeRequest* request, ::mavsdk::rpc::action::SetTakeoffAltitudeResponse* response) { return this->SetTakeoffAltitude(context, request, response); }));}
     void SetMessageAllocatorFor_SetTakeoffAltitude(
         ::grpc::MessageAllocator< ::mavsdk::rpc::action::SetTakeoffAltitudeRequest, ::mavsdk::rpc::action::SetTakeoffAltitudeResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(18);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(19);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetTakeoffAltitudeRequest, ::mavsdk::rpc::action::SetTakeoffAltitudeResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -1990,13 +2094,13 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_GetReturnToLaunchAltitude() {
-      ::grpc::Service::MarkMethodCallback(19,
+      ::grpc::Service::MarkMethodCallback(20,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::GetReturnToLaunchAltitudeRequest, ::mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action::GetReturnToLaunchAltitudeRequest* request, ::mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse* response) { return this->GetReturnToLaunchAltitude(context, request, response); }));}
     void SetMessageAllocatorFor_GetReturnToLaunchAltitude(
         ::grpc::MessageAllocator< ::mavsdk::rpc::action::GetReturnToLaunchAltitudeRequest, ::mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(19);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(20);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::GetReturnToLaunchAltitudeRequest, ::mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -2017,13 +2121,13 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetReturnToLaunchAltitude() {
-      ::grpc::Service::MarkMethodCallback(20,
+      ::grpc::Service::MarkMethodCallback(21,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest, ::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest* request, ::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse* response) { return this->SetReturnToLaunchAltitude(context, request, response); }));}
     void SetMessageAllocatorFor_SetReturnToLaunchAltitude(
         ::grpc::MessageAllocator< ::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest, ::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(20);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(21);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest, ::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -2044,13 +2148,13 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetCurrentSpeed() {
-      ::grpc::Service::MarkMethodCallback(21,
+      ::grpc::Service::MarkMethodCallback(22,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetCurrentSpeedRequest, ::mavsdk::rpc::action::SetCurrentSpeedResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action::SetCurrentSpeedRequest* request, ::mavsdk::rpc::action::SetCurrentSpeedResponse* response) { return this->SetCurrentSpeed(context, request, response); }));}
     void SetMessageAllocatorFor_SetCurrentSpeed(
         ::grpc::MessageAllocator< ::mavsdk::rpc::action::SetCurrentSpeedRequest, ::mavsdk::rpc::action::SetCurrentSpeedResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(21);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(22);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetCurrentSpeedRequest, ::mavsdk::rpc::action::SetCurrentSpeedResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -2071,13 +2175,13 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetGpsGlobalOrigin() {
-      ::grpc::Service::MarkMethodCallback(22,
+      ::grpc::Service::MarkMethodCallback(23,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetGpsGlobalOriginRequest, ::mavsdk::rpc::action::SetGpsGlobalOriginResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action::SetGpsGlobalOriginRequest* request, ::mavsdk::rpc::action::SetGpsGlobalOriginResponse* response) { return this->SetGpsGlobalOrigin(context, request, response); }));}
     void SetMessageAllocatorFor_SetGpsGlobalOrigin(
         ::grpc::MessageAllocator< ::mavsdk::rpc::action::SetGpsGlobalOriginRequest, ::mavsdk::rpc::action::SetGpsGlobalOriginResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(22);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(23);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetGpsGlobalOriginRequest, ::mavsdk::rpc::action::SetGpsGlobalOriginResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -2098,13 +2202,13 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetHome() {
-      ::grpc::Service::MarkMethodCallback(23,
+      ::grpc::Service::MarkMethodCallback(24,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetHomeRequest, ::mavsdk::rpc::action::SetHomeResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::action::SetHomeRequest* request, ::mavsdk::rpc::action::SetHomeResponse* response) { return this->SetHome(context, request, response); }));}
     void SetMessageAllocatorFor_SetHome(
         ::grpc::MessageAllocator< ::mavsdk::rpc::action::SetHomeRequest, ::mavsdk::rpc::action::SetHomeResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(23);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(24);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::action::SetHomeRequest, ::mavsdk::rpc::action::SetHomeResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -2119,7 +2223,7 @@ class ActionService final {
     virtual ::grpc::ServerUnaryReactor* SetHome(
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::action::SetHomeRequest* /*request*/, ::mavsdk::rpc::action::SetHomeResponse* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_Arm<WithCallbackMethod_ArmForce<WithCallbackMethod_Disarm<WithCallbackMethod_Takeoff<WithCallbackMethod_Land<WithCallbackMethod_Reboot<WithCallbackMethod_Shutdown<WithCallbackMethod_Terminate<WithCallbackMethod_Kill<WithCallbackMethod_ReturnToLaunch<WithCallbackMethod_GotoLocation<WithCallbackMethod_DoOrbit<WithCallbackMethod_Hold<WithCallbackMethod_SetActuator<WithCallbackMethod_SetRelay<WithCallbackMethod_TransitionToFixedwing<WithCallbackMethod_TransitionToMulticopter<WithCallbackMethod_GetTakeoffAltitude<WithCallbackMethod_SetTakeoffAltitude<WithCallbackMethod_GetReturnToLaunchAltitude<WithCallbackMethod_SetReturnToLaunchAltitude<WithCallbackMethod_SetCurrentSpeed<WithCallbackMethod_SetGpsGlobalOrigin<WithCallbackMethod_SetHome<Service > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
+  typedef WithCallbackMethod_Arm<WithCallbackMethod_ArmForce<WithCallbackMethod_Disarm<WithCallbackMethod_Takeoff<WithCallbackMethod_Land<WithCallbackMethod_Reboot<WithCallbackMethod_Shutdown<WithCallbackMethod_Terminate<WithCallbackMethod_Kill<WithCallbackMethod_ReturnToLaunch<WithCallbackMethod_GotoLocation<WithCallbackMethod_GotoLocationFixedwing<WithCallbackMethod_DoOrbit<WithCallbackMethod_Hold<WithCallbackMethod_SetActuator<WithCallbackMethod_SetRelay<WithCallbackMethod_TransitionToFixedwing<WithCallbackMethod_TransitionToMulticopter<WithCallbackMethod_GetTakeoffAltitude<WithCallbackMethod_SetTakeoffAltitude<WithCallbackMethod_GetReturnToLaunchAltitude<WithCallbackMethod_SetReturnToLaunchAltitude<WithCallbackMethod_SetCurrentSpeed<WithCallbackMethod_SetGpsGlobalOrigin<WithCallbackMethod_SetHome<Service > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_Arm : public BaseClass {
@@ -2309,12 +2413,29 @@ class ActionService final {
     }
   };
   template <class BaseClass>
+  class WithGenericMethod_GotoLocationFixedwing : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_GotoLocationFixedwing() {
+      ::grpc::Service::MarkMethodGeneric(11);
+    }
+    ~WithGenericMethod_GotoLocationFixedwing() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GotoLocationFixedwing(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest* /*request*/, ::mavsdk::rpc::action::GotoLocationFixedwingResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
   class WithGenericMethod_DoOrbit : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_DoOrbit() {
-      ::grpc::Service::MarkMethodGeneric(11);
+      ::grpc::Service::MarkMethodGeneric(12);
     }
     ~WithGenericMethod_DoOrbit() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2331,7 +2452,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_Hold() {
-      ::grpc::Service::MarkMethodGeneric(12);
+      ::grpc::Service::MarkMethodGeneric(13);
     }
     ~WithGenericMethod_Hold() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2348,7 +2469,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetActuator() {
-      ::grpc::Service::MarkMethodGeneric(13);
+      ::grpc::Service::MarkMethodGeneric(14);
     }
     ~WithGenericMethod_SetActuator() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2365,7 +2486,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetRelay() {
-      ::grpc::Service::MarkMethodGeneric(14);
+      ::grpc::Service::MarkMethodGeneric(15);
     }
     ~WithGenericMethod_SetRelay() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2382,7 +2503,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_TransitionToFixedwing() {
-      ::grpc::Service::MarkMethodGeneric(15);
+      ::grpc::Service::MarkMethodGeneric(16);
     }
     ~WithGenericMethod_TransitionToFixedwing() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2399,7 +2520,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_TransitionToMulticopter() {
-      ::grpc::Service::MarkMethodGeneric(16);
+      ::grpc::Service::MarkMethodGeneric(17);
     }
     ~WithGenericMethod_TransitionToMulticopter() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2416,7 +2537,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_GetTakeoffAltitude() {
-      ::grpc::Service::MarkMethodGeneric(17);
+      ::grpc::Service::MarkMethodGeneric(18);
     }
     ~WithGenericMethod_GetTakeoffAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2433,7 +2554,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetTakeoffAltitude() {
-      ::grpc::Service::MarkMethodGeneric(18);
+      ::grpc::Service::MarkMethodGeneric(19);
     }
     ~WithGenericMethod_SetTakeoffAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2450,7 +2571,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_GetReturnToLaunchAltitude() {
-      ::grpc::Service::MarkMethodGeneric(19);
+      ::grpc::Service::MarkMethodGeneric(20);
     }
     ~WithGenericMethod_GetReturnToLaunchAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2467,7 +2588,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetReturnToLaunchAltitude() {
-      ::grpc::Service::MarkMethodGeneric(20);
+      ::grpc::Service::MarkMethodGeneric(21);
     }
     ~WithGenericMethod_SetReturnToLaunchAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2484,7 +2605,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetCurrentSpeed() {
-      ::grpc::Service::MarkMethodGeneric(21);
+      ::grpc::Service::MarkMethodGeneric(22);
     }
     ~WithGenericMethod_SetCurrentSpeed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2501,7 +2622,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetGpsGlobalOrigin() {
-      ::grpc::Service::MarkMethodGeneric(22);
+      ::grpc::Service::MarkMethodGeneric(23);
     }
     ~WithGenericMethod_SetGpsGlobalOrigin() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2518,7 +2639,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetHome() {
-      ::grpc::Service::MarkMethodGeneric(23);
+      ::grpc::Service::MarkMethodGeneric(24);
     }
     ~WithGenericMethod_SetHome() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2750,12 +2871,32 @@ class ActionService final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_GotoLocationFixedwing : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_GotoLocationFixedwing() {
+      ::grpc::Service::MarkMethodRaw(11);
+    }
+    ~WithRawMethod_GotoLocationFixedwing() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GotoLocationFixedwing(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest* /*request*/, ::mavsdk::rpc::action::GotoLocationFixedwingResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestGotoLocationFixedwing(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithRawMethod_DoOrbit : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_DoOrbit() {
-      ::grpc::Service::MarkMethodRaw(11);
+      ::grpc::Service::MarkMethodRaw(12);
     }
     ~WithRawMethod_DoOrbit() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2766,7 +2907,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestDoOrbit(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2775,7 +2916,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_Hold() {
-      ::grpc::Service::MarkMethodRaw(12);
+      ::grpc::Service::MarkMethodRaw(13);
     }
     ~WithRawMethod_Hold() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2786,7 +2927,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestHold(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2795,7 +2936,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetActuator() {
-      ::grpc::Service::MarkMethodRaw(13);
+      ::grpc::Service::MarkMethodRaw(14);
     }
     ~WithRawMethod_SetActuator() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2806,7 +2947,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetActuator(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2815,7 +2956,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetRelay() {
-      ::grpc::Service::MarkMethodRaw(14);
+      ::grpc::Service::MarkMethodRaw(15);
     }
     ~WithRawMethod_SetRelay() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2826,7 +2967,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetRelay(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2835,7 +2976,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_TransitionToFixedwing() {
-      ::grpc::Service::MarkMethodRaw(15);
+      ::grpc::Service::MarkMethodRaw(16);
     }
     ~WithRawMethod_TransitionToFixedwing() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2846,7 +2987,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestTransitionToFixedwing(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2855,7 +2996,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_TransitionToMulticopter() {
-      ::grpc::Service::MarkMethodRaw(16);
+      ::grpc::Service::MarkMethodRaw(17);
     }
     ~WithRawMethod_TransitionToMulticopter() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2866,7 +3007,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestTransitionToMulticopter(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(17, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2875,7 +3016,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_GetTakeoffAltitude() {
-      ::grpc::Service::MarkMethodRaw(17);
+      ::grpc::Service::MarkMethodRaw(18);
     }
     ~WithRawMethod_GetTakeoffAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2886,7 +3027,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetTakeoffAltitude(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(17, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(18, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2895,7 +3036,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetTakeoffAltitude() {
-      ::grpc::Service::MarkMethodRaw(18);
+      ::grpc::Service::MarkMethodRaw(19);
     }
     ~WithRawMethod_SetTakeoffAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2906,7 +3047,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetTakeoffAltitude(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(18, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(19, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2915,7 +3056,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_GetReturnToLaunchAltitude() {
-      ::grpc::Service::MarkMethodRaw(19);
+      ::grpc::Service::MarkMethodRaw(20);
     }
     ~WithRawMethod_GetReturnToLaunchAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2926,7 +3067,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetReturnToLaunchAltitude(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(19, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(20, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2935,7 +3076,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetReturnToLaunchAltitude() {
-      ::grpc::Service::MarkMethodRaw(20);
+      ::grpc::Service::MarkMethodRaw(21);
     }
     ~WithRawMethod_SetReturnToLaunchAltitude() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2946,7 +3087,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetReturnToLaunchAltitude(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(20, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(21, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2955,7 +3096,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetCurrentSpeed() {
-      ::grpc::Service::MarkMethodRaw(21);
+      ::grpc::Service::MarkMethodRaw(22);
     }
     ~WithRawMethod_SetCurrentSpeed() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2966,7 +3107,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetCurrentSpeed(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(21, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(22, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2975,7 +3116,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetGpsGlobalOrigin() {
-      ::grpc::Service::MarkMethodRaw(22);
+      ::grpc::Service::MarkMethodRaw(23);
     }
     ~WithRawMethod_SetGpsGlobalOrigin() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2986,7 +3127,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetGpsGlobalOrigin(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(22, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(23, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2995,7 +3136,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetHome() {
-      ::grpc::Service::MarkMethodRaw(23);
+      ::grpc::Service::MarkMethodRaw(24);
     }
     ~WithRawMethod_SetHome() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3006,7 +3147,7 @@ class ActionService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetHome(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(23, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(24, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -3252,12 +3393,34 @@ class ActionService final {
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithRawCallbackMethod_GotoLocationFixedwing : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_GotoLocationFixedwing() {
+      ::grpc::Service::MarkMethodRawCallback(11,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->GotoLocationFixedwing(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_GotoLocationFixedwing() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GotoLocationFixedwing(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest* /*request*/, ::mavsdk::rpc::action::GotoLocationFixedwingResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* GotoLocationFixedwing(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithRawCallbackMethod_DoOrbit : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_DoOrbit() {
-      ::grpc::Service::MarkMethodRawCallback(11,
+      ::grpc::Service::MarkMethodRawCallback(12,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->DoOrbit(context, request, response); }));
@@ -3279,7 +3442,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_Hold() {
-      ::grpc::Service::MarkMethodRawCallback(12,
+      ::grpc::Service::MarkMethodRawCallback(13,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->Hold(context, request, response); }));
@@ -3301,7 +3464,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetActuator() {
-      ::grpc::Service::MarkMethodRawCallback(13,
+      ::grpc::Service::MarkMethodRawCallback(14,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetActuator(context, request, response); }));
@@ -3323,7 +3486,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetRelay() {
-      ::grpc::Service::MarkMethodRawCallback(14,
+      ::grpc::Service::MarkMethodRawCallback(15,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetRelay(context, request, response); }));
@@ -3345,7 +3508,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_TransitionToFixedwing() {
-      ::grpc::Service::MarkMethodRawCallback(15,
+      ::grpc::Service::MarkMethodRawCallback(16,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->TransitionToFixedwing(context, request, response); }));
@@ -3367,7 +3530,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_TransitionToMulticopter() {
-      ::grpc::Service::MarkMethodRawCallback(16,
+      ::grpc::Service::MarkMethodRawCallback(17,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->TransitionToMulticopter(context, request, response); }));
@@ -3389,7 +3552,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_GetTakeoffAltitude() {
-      ::grpc::Service::MarkMethodRawCallback(17,
+      ::grpc::Service::MarkMethodRawCallback(18,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->GetTakeoffAltitude(context, request, response); }));
@@ -3411,7 +3574,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetTakeoffAltitude() {
-      ::grpc::Service::MarkMethodRawCallback(18,
+      ::grpc::Service::MarkMethodRawCallback(19,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetTakeoffAltitude(context, request, response); }));
@@ -3433,7 +3596,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_GetReturnToLaunchAltitude() {
-      ::grpc::Service::MarkMethodRawCallback(19,
+      ::grpc::Service::MarkMethodRawCallback(20,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->GetReturnToLaunchAltitude(context, request, response); }));
@@ -3455,7 +3618,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetReturnToLaunchAltitude() {
-      ::grpc::Service::MarkMethodRawCallback(20,
+      ::grpc::Service::MarkMethodRawCallback(21,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetReturnToLaunchAltitude(context, request, response); }));
@@ -3477,7 +3640,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetCurrentSpeed() {
-      ::grpc::Service::MarkMethodRawCallback(21,
+      ::grpc::Service::MarkMethodRawCallback(22,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetCurrentSpeed(context, request, response); }));
@@ -3499,7 +3662,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetGpsGlobalOrigin() {
-      ::grpc::Service::MarkMethodRawCallback(22,
+      ::grpc::Service::MarkMethodRawCallback(23,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetGpsGlobalOrigin(context, request, response); }));
@@ -3521,7 +3684,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetHome() {
-      ::grpc::Service::MarkMethodRawCallback(23,
+      ::grpc::Service::MarkMethodRawCallback(24,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetHome(context, request, response); }));
@@ -3835,12 +3998,39 @@ class ActionService final {
     virtual ::grpc::Status StreamedGotoLocation(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::action::GotoLocationRequest,::mavsdk::rpc::action::GotoLocationResponse>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
+  class WithStreamedUnaryMethod_GotoLocationFixedwing : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_GotoLocationFixedwing() {
+      ::grpc::Service::MarkMethodStreamed(11,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::action::GotoLocationFixedwingRequest, ::mavsdk::rpc::action::GotoLocationFixedwingResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::action::GotoLocationFixedwingRequest, ::mavsdk::rpc::action::GotoLocationFixedwingResponse>* streamer) {
+                       return this->StreamedGotoLocationFixedwing(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_GotoLocationFixedwing() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status GotoLocationFixedwing(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::action::GotoLocationFixedwingRequest* /*request*/, ::mavsdk::rpc::action::GotoLocationFixedwingResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedGotoLocationFixedwing(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::action::GotoLocationFixedwingRequest,::mavsdk::rpc::action::GotoLocationFixedwingResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_DoOrbit : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_DoOrbit() {
-      ::grpc::Service::MarkMethodStreamed(11,
+      ::grpc::Service::MarkMethodStreamed(12,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::action::DoOrbitRequest, ::mavsdk::rpc::action::DoOrbitResponse>(
             [this](::grpc::ServerContext* context,
@@ -3867,7 +4057,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_Hold() {
-      ::grpc::Service::MarkMethodStreamed(12,
+      ::grpc::Service::MarkMethodStreamed(13,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::action::HoldRequest, ::mavsdk::rpc::action::HoldResponse>(
             [this](::grpc::ServerContext* context,
@@ -3894,7 +4084,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetActuator() {
-      ::grpc::Service::MarkMethodStreamed(13,
+      ::grpc::Service::MarkMethodStreamed(14,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::action::SetActuatorRequest, ::mavsdk::rpc::action::SetActuatorResponse>(
             [this](::grpc::ServerContext* context,
@@ -3921,7 +4111,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetRelay() {
-      ::grpc::Service::MarkMethodStreamed(14,
+      ::grpc::Service::MarkMethodStreamed(15,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::action::SetRelayRequest, ::mavsdk::rpc::action::SetRelayResponse>(
             [this](::grpc::ServerContext* context,
@@ -3948,7 +4138,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_TransitionToFixedwing() {
-      ::grpc::Service::MarkMethodStreamed(15,
+      ::grpc::Service::MarkMethodStreamed(16,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::action::TransitionToFixedwingRequest, ::mavsdk::rpc::action::TransitionToFixedwingResponse>(
             [this](::grpc::ServerContext* context,
@@ -3975,7 +4165,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_TransitionToMulticopter() {
-      ::grpc::Service::MarkMethodStreamed(16,
+      ::grpc::Service::MarkMethodStreamed(17,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::action::TransitionToMulticopterRequest, ::mavsdk::rpc::action::TransitionToMulticopterResponse>(
             [this](::grpc::ServerContext* context,
@@ -4002,7 +4192,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_GetTakeoffAltitude() {
-      ::grpc::Service::MarkMethodStreamed(17,
+      ::grpc::Service::MarkMethodStreamed(18,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::action::GetTakeoffAltitudeRequest, ::mavsdk::rpc::action::GetTakeoffAltitudeResponse>(
             [this](::grpc::ServerContext* context,
@@ -4029,7 +4219,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetTakeoffAltitude() {
-      ::grpc::Service::MarkMethodStreamed(18,
+      ::grpc::Service::MarkMethodStreamed(19,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::action::SetTakeoffAltitudeRequest, ::mavsdk::rpc::action::SetTakeoffAltitudeResponse>(
             [this](::grpc::ServerContext* context,
@@ -4056,7 +4246,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_GetReturnToLaunchAltitude() {
-      ::grpc::Service::MarkMethodStreamed(19,
+      ::grpc::Service::MarkMethodStreamed(20,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::action::GetReturnToLaunchAltitudeRequest, ::mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse>(
             [this](::grpc::ServerContext* context,
@@ -4083,7 +4273,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetReturnToLaunchAltitude() {
-      ::grpc::Service::MarkMethodStreamed(20,
+      ::grpc::Service::MarkMethodStreamed(21,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest, ::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse>(
             [this](::grpc::ServerContext* context,
@@ -4110,7 +4300,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetCurrentSpeed() {
-      ::grpc::Service::MarkMethodStreamed(21,
+      ::grpc::Service::MarkMethodStreamed(22,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::action::SetCurrentSpeedRequest, ::mavsdk::rpc::action::SetCurrentSpeedResponse>(
             [this](::grpc::ServerContext* context,
@@ -4137,7 +4327,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetGpsGlobalOrigin() {
-      ::grpc::Service::MarkMethodStreamed(22,
+      ::grpc::Service::MarkMethodStreamed(23,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::action::SetGpsGlobalOriginRequest, ::mavsdk::rpc::action::SetGpsGlobalOriginResponse>(
             [this](::grpc::ServerContext* context,
@@ -4164,7 +4354,7 @@ class ActionService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetHome() {
-      ::grpc::Service::MarkMethodStreamed(23,
+      ::grpc::Service::MarkMethodStreamed(24,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::action::SetHomeRequest, ::mavsdk::rpc::action::SetHomeResponse>(
             [this](::grpc::ServerContext* context,
@@ -4185,9 +4375,9 @@ class ActionService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedSetHome(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::action::SetHomeRequest,::mavsdk::rpc::action::SetHomeResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_Arm<WithStreamedUnaryMethod_ArmForce<WithStreamedUnaryMethod_Disarm<WithStreamedUnaryMethod_Takeoff<WithStreamedUnaryMethod_Land<WithStreamedUnaryMethod_Reboot<WithStreamedUnaryMethod_Shutdown<WithStreamedUnaryMethod_Terminate<WithStreamedUnaryMethod_Kill<WithStreamedUnaryMethod_ReturnToLaunch<WithStreamedUnaryMethod_GotoLocation<WithStreamedUnaryMethod_DoOrbit<WithStreamedUnaryMethod_Hold<WithStreamedUnaryMethod_SetActuator<WithStreamedUnaryMethod_SetRelay<WithStreamedUnaryMethod_TransitionToFixedwing<WithStreamedUnaryMethod_TransitionToMulticopter<WithStreamedUnaryMethod_GetTakeoffAltitude<WithStreamedUnaryMethod_SetTakeoffAltitude<WithStreamedUnaryMethod_GetReturnToLaunchAltitude<WithStreamedUnaryMethod_SetReturnToLaunchAltitude<WithStreamedUnaryMethod_SetCurrentSpeed<WithStreamedUnaryMethod_SetGpsGlobalOrigin<WithStreamedUnaryMethod_SetHome<Service > > > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
+  typedef WithStreamedUnaryMethod_Arm<WithStreamedUnaryMethod_ArmForce<WithStreamedUnaryMethod_Disarm<WithStreamedUnaryMethod_Takeoff<WithStreamedUnaryMethod_Land<WithStreamedUnaryMethod_Reboot<WithStreamedUnaryMethod_Shutdown<WithStreamedUnaryMethod_Terminate<WithStreamedUnaryMethod_Kill<WithStreamedUnaryMethod_ReturnToLaunch<WithStreamedUnaryMethod_GotoLocation<WithStreamedUnaryMethod_GotoLocationFixedwing<WithStreamedUnaryMethod_DoOrbit<WithStreamedUnaryMethod_Hold<WithStreamedUnaryMethod_SetActuator<WithStreamedUnaryMethod_SetRelay<WithStreamedUnaryMethod_TransitionToFixedwing<WithStreamedUnaryMethod_TransitionToMulticopter<WithStreamedUnaryMethod_GetTakeoffAltitude<WithStreamedUnaryMethod_SetTakeoffAltitude<WithStreamedUnaryMethod_GetReturnToLaunchAltitude<WithStreamedUnaryMethod_SetReturnToLaunchAltitude<WithStreamedUnaryMethod_SetCurrentSpeed<WithStreamedUnaryMethod_SetGpsGlobalOrigin<WithStreamedUnaryMethod_SetHome<Service > > > > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
   typedef Service SplitStreamedService;
-  typedef WithStreamedUnaryMethod_Arm<WithStreamedUnaryMethod_ArmForce<WithStreamedUnaryMethod_Disarm<WithStreamedUnaryMethod_Takeoff<WithStreamedUnaryMethod_Land<WithStreamedUnaryMethod_Reboot<WithStreamedUnaryMethod_Shutdown<WithStreamedUnaryMethod_Terminate<WithStreamedUnaryMethod_Kill<WithStreamedUnaryMethod_ReturnToLaunch<WithStreamedUnaryMethod_GotoLocation<WithStreamedUnaryMethod_DoOrbit<WithStreamedUnaryMethod_Hold<WithStreamedUnaryMethod_SetActuator<WithStreamedUnaryMethod_SetRelay<WithStreamedUnaryMethod_TransitionToFixedwing<WithStreamedUnaryMethod_TransitionToMulticopter<WithStreamedUnaryMethod_GetTakeoffAltitude<WithStreamedUnaryMethod_SetTakeoffAltitude<WithStreamedUnaryMethod_GetReturnToLaunchAltitude<WithStreamedUnaryMethod_SetReturnToLaunchAltitude<WithStreamedUnaryMethod_SetCurrentSpeed<WithStreamedUnaryMethod_SetGpsGlobalOrigin<WithStreamedUnaryMethod_SetHome<Service > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_Arm<WithStreamedUnaryMethod_ArmForce<WithStreamedUnaryMethod_Disarm<WithStreamedUnaryMethod_Takeoff<WithStreamedUnaryMethod_Land<WithStreamedUnaryMethod_Reboot<WithStreamedUnaryMethod_Shutdown<WithStreamedUnaryMethod_Terminate<WithStreamedUnaryMethod_Kill<WithStreamedUnaryMethod_ReturnToLaunch<WithStreamedUnaryMethod_GotoLocation<WithStreamedUnaryMethod_GotoLocationFixedwing<WithStreamedUnaryMethod_DoOrbit<WithStreamedUnaryMethod_Hold<WithStreamedUnaryMethod_SetActuator<WithStreamedUnaryMethod_SetRelay<WithStreamedUnaryMethod_TransitionToFixedwing<WithStreamedUnaryMethod_TransitionToMulticopter<WithStreamedUnaryMethod_GetTakeoffAltitude<WithStreamedUnaryMethod_SetTakeoffAltitude<WithStreamedUnaryMethod_GetReturnToLaunchAltitude<WithStreamedUnaryMethod_SetReturnToLaunchAltitude<WithStreamedUnaryMethod_SetCurrentSpeed<WithStreamedUnaryMethod_SetGpsGlobalOrigin<WithStreamedUnaryMethod_SetHome<Service > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace action

--- a/cpp/src/mavsdk_server/src/generated/action/action.pb.cc
+++ b/cpp/src/mavsdk_server/src/generated/action/action.pb.cc
@@ -417,6 +417,34 @@ struct GotoLocationRequestDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 GotoLocationRequestDefaultTypeInternal _GotoLocationRequest_default_instance_;
+
+inline constexpr GotoLocationFixedwingRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : latitude_deg_{0},
+        longitude_deg_{0},
+        absolute_altitude_m_{0},
+        loiter_radius_m_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR GotoLocationFixedwingRequest::GotoLocationFixedwingRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct GotoLocationFixedwingRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR GotoLocationFixedwingRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~GotoLocationFixedwingRequestDefaultTypeInternal() {}
+  union {
+    GotoLocationFixedwingRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 GotoLocationFixedwingRequestDefaultTypeInternal _GotoLocationFixedwingRequest_default_instance_;
               template <typename>
 PROTOBUF_CONSTEXPR GetTakeoffAltitudeRequest::GetTakeoffAltitudeRequest(::_pbi::ConstantInitialized)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
@@ -1016,6 +1044,31 @@ struct GotoLocationResponseDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 GotoLocationResponseDefaultTypeInternal _GotoLocationResponse_default_instance_;
 
+inline constexpr GotoLocationFixedwingResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        action_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR GotoLocationFixedwingResponse::GotoLocationFixedwingResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct GotoLocationFixedwingResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR GotoLocationFixedwingResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~GotoLocationFixedwingResponseDefaultTypeInternal() {}
+  union {
+    GotoLocationFixedwingResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 GotoLocationFixedwingResponseDefaultTypeInternal _GotoLocationFixedwingResponse_default_instance_;
+
 inline constexpr GetTakeoffAltitudeResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : _cached_size_{0},
@@ -1379,6 +1432,28 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::GotoLocationResponse, _impl_.action_result_),
         0,
         ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::GotoLocationFixedwingRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::GotoLocationFixedwingRequest, _impl_.latitude_deg_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::GotoLocationFixedwingRequest, _impl_.longitude_deg_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::GotoLocationFixedwingRequest, _impl_.absolute_altitude_m_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::GotoLocationFixedwingRequest, _impl_.loiter_radius_m_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::GotoLocationFixedwingResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::GotoLocationFixedwingResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::GotoLocationFixedwingResponse, _impl_.action_result_),
+        0,
+        ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::action::DoOrbitRequest, _internal_metadata_),
         ~0u,  // no _extensions_
         ~0u,  // no _oneof_case_
@@ -1672,33 +1747,35 @@ static const ::_pbi::MigrationSchema
         {170, 179, -1, sizeof(::mavsdk::rpc::action::ReturnToLaunchResponse)},
         {180, -1, -1, sizeof(::mavsdk::rpc::action::GotoLocationRequest)},
         {192, 201, -1, sizeof(::mavsdk::rpc::action::GotoLocationResponse)},
-        {202, -1, -1, sizeof(::mavsdk::rpc::action::DoOrbitRequest)},
-        {216, 225, -1, sizeof(::mavsdk::rpc::action::DoOrbitResponse)},
-        {226, -1, -1, sizeof(::mavsdk::rpc::action::HoldRequest)},
-        {234, 243, -1, sizeof(::mavsdk::rpc::action::HoldResponse)},
-        {244, -1, -1, sizeof(::mavsdk::rpc::action::SetActuatorRequest)},
-        {254, 263, -1, sizeof(::mavsdk::rpc::action::SetActuatorResponse)},
-        {264, -1, -1, sizeof(::mavsdk::rpc::action::SetRelayRequest)},
-        {274, 283, -1, sizeof(::mavsdk::rpc::action::SetRelayResponse)},
-        {284, -1, -1, sizeof(::mavsdk::rpc::action::TransitionToFixedwingRequest)},
-        {292, 301, -1, sizeof(::mavsdk::rpc::action::TransitionToFixedwingResponse)},
-        {302, -1, -1, sizeof(::mavsdk::rpc::action::TransitionToMulticopterRequest)},
-        {310, 319, -1, sizeof(::mavsdk::rpc::action::TransitionToMulticopterResponse)},
-        {320, -1, -1, sizeof(::mavsdk::rpc::action::GetTakeoffAltitudeRequest)},
-        {328, 338, -1, sizeof(::mavsdk::rpc::action::GetTakeoffAltitudeResponse)},
-        {340, -1, -1, sizeof(::mavsdk::rpc::action::SetTakeoffAltitudeRequest)},
-        {349, 358, -1, sizeof(::mavsdk::rpc::action::SetTakeoffAltitudeResponse)},
-        {359, -1, -1, sizeof(::mavsdk::rpc::action::GetReturnToLaunchAltitudeRequest)},
-        {367, 377, -1, sizeof(::mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse)},
-        {379, -1, -1, sizeof(::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest)},
-        {388, 397, -1, sizeof(::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse)},
-        {398, -1, -1, sizeof(::mavsdk::rpc::action::SetCurrentSpeedRequest)},
-        {407, 416, -1, sizeof(::mavsdk::rpc::action::SetCurrentSpeedResponse)},
-        {417, -1, -1, sizeof(::mavsdk::rpc::action::SetGpsGlobalOriginRequest)},
-        {428, 437, -1, sizeof(::mavsdk::rpc::action::SetGpsGlobalOriginResponse)},
-        {438, -1, -1, sizeof(::mavsdk::rpc::action::SetHomeRequest)},
-        {450, 459, -1, sizeof(::mavsdk::rpc::action::SetHomeResponse)},
-        {460, -1, -1, sizeof(::mavsdk::rpc::action::ActionResult)},
+        {202, -1, -1, sizeof(::mavsdk::rpc::action::GotoLocationFixedwingRequest)},
+        {214, 223, -1, sizeof(::mavsdk::rpc::action::GotoLocationFixedwingResponse)},
+        {224, -1, -1, sizeof(::mavsdk::rpc::action::DoOrbitRequest)},
+        {238, 247, -1, sizeof(::mavsdk::rpc::action::DoOrbitResponse)},
+        {248, -1, -1, sizeof(::mavsdk::rpc::action::HoldRequest)},
+        {256, 265, -1, sizeof(::mavsdk::rpc::action::HoldResponse)},
+        {266, -1, -1, sizeof(::mavsdk::rpc::action::SetActuatorRequest)},
+        {276, 285, -1, sizeof(::mavsdk::rpc::action::SetActuatorResponse)},
+        {286, -1, -1, sizeof(::mavsdk::rpc::action::SetRelayRequest)},
+        {296, 305, -1, sizeof(::mavsdk::rpc::action::SetRelayResponse)},
+        {306, -1, -1, sizeof(::mavsdk::rpc::action::TransitionToFixedwingRequest)},
+        {314, 323, -1, sizeof(::mavsdk::rpc::action::TransitionToFixedwingResponse)},
+        {324, -1, -1, sizeof(::mavsdk::rpc::action::TransitionToMulticopterRequest)},
+        {332, 341, -1, sizeof(::mavsdk::rpc::action::TransitionToMulticopterResponse)},
+        {342, -1, -1, sizeof(::mavsdk::rpc::action::GetTakeoffAltitudeRequest)},
+        {350, 360, -1, sizeof(::mavsdk::rpc::action::GetTakeoffAltitudeResponse)},
+        {362, -1, -1, sizeof(::mavsdk::rpc::action::SetTakeoffAltitudeRequest)},
+        {371, 380, -1, sizeof(::mavsdk::rpc::action::SetTakeoffAltitudeResponse)},
+        {381, -1, -1, sizeof(::mavsdk::rpc::action::GetReturnToLaunchAltitudeRequest)},
+        {389, 399, -1, sizeof(::mavsdk::rpc::action::GetReturnToLaunchAltitudeResponse)},
+        {401, -1, -1, sizeof(::mavsdk::rpc::action::SetReturnToLaunchAltitudeRequest)},
+        {410, 419, -1, sizeof(::mavsdk::rpc::action::SetReturnToLaunchAltitudeResponse)},
+        {420, -1, -1, sizeof(::mavsdk::rpc::action::SetCurrentSpeedRequest)},
+        {429, 438, -1, sizeof(::mavsdk::rpc::action::SetCurrentSpeedResponse)},
+        {439, -1, -1, sizeof(::mavsdk::rpc::action::SetGpsGlobalOriginRequest)},
+        {450, 459, -1, sizeof(::mavsdk::rpc::action::SetGpsGlobalOriginResponse)},
+        {460, -1, -1, sizeof(::mavsdk::rpc::action::SetHomeRequest)},
+        {472, 481, -1, sizeof(::mavsdk::rpc::action::SetHomeResponse)},
+        {482, -1, -1, sizeof(::mavsdk::rpc::action::ActionResult)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::action::_ArmRequest_default_instance_._instance,
@@ -1723,6 +1800,8 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::action::_ReturnToLaunchResponse_default_instance_._instance,
     &::mavsdk::rpc::action::_GotoLocationRequest_default_instance_._instance,
     &::mavsdk::rpc::action::_GotoLocationResponse_default_instance_._instance,
+    &::mavsdk::rpc::action::_GotoLocationFixedwingRequest_default_instance_._instance,
+    &::mavsdk::rpc::action::_GotoLocationFixedwingResponse_default_instance_._instance,
     &::mavsdk::rpc::action::_DoOrbitRequest_default_instance_._instance,
     &::mavsdk::rpc::action::_DoOrbitResponse_default_instance_._instance,
     &::mavsdk::rpc::action::_HoldRequest_default_instance_._instance,
@@ -1782,139 +1861,148 @@ const char descriptor_table_protodef_action_2faction_2eproto[] ABSL_ATTRIBUTE_SE
     "ongitude_deg\030\002 \001(\001\022\033\n\023absolute_altitude_"
     "m\030\003 \001(\002\022\017\n\007yaw_deg\030\004 \001(\002\"N\n\024GotoLocation"
     "Response\0226\n\raction_result\030\001 \001(\0132\037.mavsdk"
-    ".rpc.action.ActionResult\"\327\001\n\016DoOrbitRequ"
-    "est\022\020\n\010radius_m\030\001 \001(\002\022\023\n\013velocity_ms\030\002 \001"
-    "(\002\0229\n\014yaw_behavior\030\003 \001(\0162#.mavsdk.rpc.ac"
-    "tion.OrbitYawBehavior\022\035\n\014latitude_deg\030\005 "
-    "\001(\001B\007\202\265\030\003NaN\022\036\n\rlongitude_deg\030\006 \001(\001B\007\202\265\030"
-    "\003NaN\022$\n\023absolute_altitude_m\030\007 \001(\001B\007\202\265\030\003N"
-    "aN\"I\n\017DoOrbitResponse\0226\n\raction_result\030\001"
-    " \001(\0132\037.mavsdk.rpc.action.ActionResult\"\r\n"
-    "\013HoldRequest\"F\n\014HoldResponse\0226\n\raction_r"
-    "esult\030\001 \001(\0132\037.mavsdk.rpc.action.ActionRe"
-    "sult\"2\n\022SetActuatorRequest\022\r\n\005index\030\001 \001("
-    "\005\022\r\n\005value\030\002 \001(\002\"M\n\023SetActuatorResponse\022"
-    "6\n\raction_result\030\001 \001(\0132\037.mavsdk.rpc.acti"
-    "on.ActionResult\"R\n\017SetRelayRequest\022\r\n\005in"
-    "dex\030\001 \001(\005\0220\n\007setting\030\002 \001(\0162\037.mavsdk.rpc."
-    "action.RelayCommand\"J\n\020SetRelayResponse\022"
-    "6\n\raction_result\030\001 \001(\0132\037.mavsdk.rpc.acti"
-    "on.ActionResult\"\036\n\034TransitionToFixedwing"
-    "Request\"W\n\035TransitionToFixedwingResponse"
-    "\0226\n\raction_result\030\001 \001(\0132\037.mavsdk.rpc.act"
-    "ion.ActionResult\" \n\036TransitionToMulticop"
-    "terRequest\"Y\n\037TransitionToMulticopterRes"
+    ".rpc.action.ActionResult\"\201\001\n\034GotoLocatio"
+    "nFixedwingRequest\022\024\n\014latitude_deg\030\001 \001(\001\022"
+    "\025\n\rlongitude_deg\030\002 \001(\001\022\033\n\023absolute_altit"
+    "ude_m\030\003 \001(\002\022\027\n\017loiter_radius_m\030\004 \001(\002\"W\n\035"
+    "GotoLocationFixedwingResponse\0226\n\raction_"
+    "result\030\001 \001(\0132\037.mavsdk.rpc.action.ActionR"
+    "esult\"\327\001\n\016DoOrbitRequest\022\020\n\010radius_m\030\001 \001"
+    "(\002\022\023\n\013velocity_ms\030\002 \001(\002\0229\n\014yaw_behavior\030"
+    "\003 \001(\0162#.mavsdk.rpc.action.OrbitYawBehavi"
+    "or\022\035\n\014latitude_deg\030\005 \001(\001B\007\202\265\030\003NaN\022\036\n\rlon"
+    "gitude_deg\030\006 \001(\001B\007\202\265\030\003NaN\022$\n\023absolute_al"
+    "titude_m\030\007 \001(\001B\007\202\265\030\003NaN\"I\n\017DoOrbitRespon"
+    "se\0226\n\raction_result\030\001 \001(\0132\037.mavsdk.rpc.a"
+    "ction.ActionResult\"\r\n\013HoldRequest\"F\n\014Hol"
+    "dResponse\0226\n\raction_result\030\001 \001(\0132\037.mavsd"
+    "k.rpc.action.ActionResult\"2\n\022SetActuator"
+    "Request\022\r\n\005index\030\001 \001(\005\022\r\n\005value\030\002 \001(\002\"M\n"
+    "\023SetActuatorResponse\0226\n\raction_result\030\001 "
+    "\001(\0132\037.mavsdk.rpc.action.ActionResult\"R\n\017"
+    "SetRelayRequest\022\r\n\005index\030\001 \001(\005\0220\n\007settin"
+    "g\030\002 \001(\0162\037.mavsdk.rpc.action.RelayCommand"
+    "\"J\n\020SetRelayResponse\0226\n\raction_result\030\001 "
+    "\001(\0132\037.mavsdk.rpc.action.ActionResult\"\036\n\034"
+    "TransitionToFixedwingRequest\"W\n\035Transiti"
+    "onToFixedwingResponse\0226\n\raction_result\030\001"
+    " \001(\0132\037.mavsdk.rpc.action.ActionResult\" \n"
+    "\036TransitionToMulticopterRequest\"Y\n\037Trans"
+    "itionToMulticopterResponse\0226\n\raction_res"
+    "ult\030\001 \001(\0132\037.mavsdk.rpc.action.ActionResu"
+    "lt\"\033\n\031GetTakeoffAltitudeRequest\"f\n\032GetTa"
+    "keoffAltitudeResponse\0226\n\raction_result\030\001"
+    " \001(\0132\037.mavsdk.rpc.action.ActionResult\022\020\n"
+    "\010altitude\030\002 \001(\002\"-\n\031SetTakeoffAltitudeReq"
+    "uest\022\020\n\010altitude\030\001 \001(\002\"T\n\032SetTakeoffAlti"
+    "tudeResponse\0226\n\raction_result\030\001 \001(\0132\037.ma"
+    "vsdk.rpc.action.ActionResult\"\"\n GetRetur"
+    "nToLaunchAltitudeRequest\"x\n!GetReturnToL"
+    "aunchAltitudeResponse\0226\n\raction_result\030\001"
+    " \001(\0132\037.mavsdk.rpc.action.ActionResult\022\033\n"
+    "\023relative_altitude_m\030\002 \001(\002\"\?\n SetReturnT"
+    "oLaunchAltitudeRequest\022\033\n\023relative_altit"
+    "ude_m\030\001 \001(\002\"[\n!SetReturnToLaunchAltitude"
+    "Response\0226\n\raction_result\030\001 \001(\0132\037.mavsdk"
+    ".rpc.action.ActionResult\"+\n\026SetCurrentSp"
+    "eedRequest\022\021\n\tspeed_m_s\030\001 \001(\002\"Q\n\027SetCurr"
+    "entSpeedResponse\0226\n\raction_result\030\001 \001(\0132"
+    "\037.mavsdk.rpc.action.ActionResult\"e\n\031SetG"
+    "psGlobalOriginRequest\022\024\n\014latitude_deg\030\001 "
+    "\001(\001\022\025\n\rlongitude_deg\030\002 \001(\001\022\033\n\023absolute_a"
+    "ltitude_m\030\003 \001(\002\"T\n\032SetGpsGlobalOriginRes"
     "ponse\0226\n\raction_result\030\001 \001(\0132\037.mavsdk.rp"
-    "c.action.ActionResult\"\033\n\031GetTakeoffAltit"
-    "udeRequest\"f\n\032GetTakeoffAltitudeResponse"
-    "\0226\n\raction_result\030\001 \001(\0132\037.mavsdk.rpc.act"
-    "ion.ActionResult\022\020\n\010altitude\030\002 \001(\002\"-\n\031Se"
-    "tTakeoffAltitudeRequest\022\020\n\010altitude\030\001 \001("
-    "\002\"T\n\032SetTakeoffAltitudeResponse\0226\n\ractio"
-    "n_result\030\001 \001(\0132\037.mavsdk.rpc.action.Actio"
-    "nResult\"\"\n GetReturnToLaunchAltitudeRequ"
-    "est\"x\n!GetReturnToLaunchAltitudeResponse"
-    "\0226\n\raction_result\030\001 \001(\0132\037.mavsdk.rpc.act"
-    "ion.ActionResult\022\033\n\023relative_altitude_m\030"
-    "\002 \001(\002\"\?\n SetReturnToLaunchAltitudeReques"
-    "t\022\033\n\023relative_altitude_m\030\001 \001(\002\"[\n!SetRet"
-    "urnToLaunchAltitudeResponse\0226\n\raction_re"
-    "sult\030\001 \001(\0132\037.mavsdk.rpc.action.ActionRes"
-    "ult\"+\n\026SetCurrentSpeedRequest\022\021\n\tspeed_m"
-    "_s\030\001 \001(\002\"Q\n\027SetCurrentSpeedResponse\0226\n\ra"
-    "ction_result\030\001 \001(\0132\037.mavsdk.rpc.action.A"
-    "ctionResult\"e\n\031SetGpsGlobalOriginRequest"
-    "\022\024\n\014latitude_deg\030\001 \001(\001\022\025\n\rlongitude_deg\030"
-    "\002 \001(\001\022\033\n\023absolute_altitude_m\030\003 \001(\002\"T\n\032Se"
-    "tGpsGlobalOriginResponse\0226\n\raction_resul"
-    "t\030\001 \001(\0132\037.mavsdk.rpc.action.ActionResult"
-    "\"x\n\016SetHomeRequest\022\034\n\024use_current_locati"
-    "on\030\001 \001(\010\022\024\n\014latitude_deg\030\002 \001(\001\022\025\n\rlongit"
-    "ude_deg\030\003 \001(\001\022\033\n\023absolute_altitude_m\030\004 \001"
-    "(\002\"I\n\017SetHomeResponse\0226\n\raction_result\030\001"
-    " \001(\0132\037.mavsdk.rpc.action.ActionResult\"\215\004"
-    "\n\014ActionResult\0226\n\006result\030\001 \001(\0162&.mavsdk."
-    "rpc.action.ActionResult.Result\022\022\n\nresult"
-    "_str\030\002 \001(\t\"\260\003\n\006Result\022\022\n\016RESULT_UNKNOWN\020"
-    "\000\022\022\n\016RESULT_SUCCESS\020\001\022\024\n\020RESULT_NO_SYSTE"
-    "M\020\002\022\033\n\027RESULT_CONNECTION_ERROR\020\003\022\017\n\013RESU"
-    "LT_BUSY\020\004\022\031\n\025RESULT_COMMAND_DENIED\020\005\022.\n*"
-    "RESULT_COMMAND_DENIED_LANDED_STATE_UNKNO"
-    "WN\020\006\022$\n RESULT_COMMAND_DENIED_NOT_LANDED"
-    "\020\007\022\022\n\016RESULT_TIMEOUT\020\010\022*\n&RESULT_VTOL_TR"
-    "ANSITION_SUPPORT_UNKNOWN\020\t\022%\n!RESULT_NO_"
-    "VTOL_TRANSITION_SUPPORT\020\n\022\032\n\026RESULT_PARA"
-    "METER_ERROR\020\013\022\026\n\022RESULT_UNSUPPORTED\020\014\022\021\n"
-    "\rRESULT_FAILED\020\r\022\033\n\027RESULT_INVALID_ARGUM"
-    "ENT\020\016*\363\001\n\020OrbitYawBehavior\0222\n.ORBIT_YAW_"
-    "BEHAVIOR_HOLD_FRONT_TO_CIRCLE_CENTER\020\000\022+"
-    "\n\'ORBIT_YAW_BEHAVIOR_HOLD_INITIAL_HEADIN"
-    "G\020\001\022#\n\037ORBIT_YAW_BEHAVIOR_UNCONTROLLED\020\002"
-    "\0223\n/ORBIT_YAW_BEHAVIOR_HOLD_FRONT_TANGEN"
-    "T_TO_CIRCLE\020\003\022$\n ORBIT_YAW_BEHAVIOR_RC_C"
-    "ONTROLLED\020\004*;\n\014RelayCommand\022\024\n\020RELAY_COM"
-    "MAND_ON\020\000\022\025\n\021RELAY_COMMAND_OFF\020\0012\315\022\n\rAct"
-    "ionService\022F\n\003Arm\022\035.mavsdk.rpc.action.Ar"
-    "mRequest\032\036.mavsdk.rpc.action.ArmResponse"
-    "\"\000\022U\n\010ArmForce\022\".mavsdk.rpc.action.ArmFo"
-    "rceRequest\032#.mavsdk.rpc.action.ArmForceR"
-    "esponse\"\000\022O\n\006Disarm\022 .mavsdk.rpc.action."
-    "DisarmRequest\032!.mavsdk.rpc.action.Disarm"
-    "Response\"\000\022R\n\007Takeoff\022!.mavsdk.rpc.actio"
-    "n.TakeoffRequest\032\".mavsdk.rpc.action.Tak"
-    "eoffResponse\"\000\022I\n\004Land\022\036.mavsdk.rpc.acti"
-    "on.LandRequest\032\037.mavsdk.rpc.action.LandR"
-    "esponse\"\000\022O\n\006Reboot\022 .mavsdk.rpc.action."
-    "RebootRequest\032!.mavsdk.rpc.action.Reboot"
-    "Response\"\000\022U\n\010Shutdown\022\".mavsdk.rpc.acti"
-    "on.ShutdownRequest\032#.mavsdk.rpc.action.S"
-    "hutdownResponse\"\000\022X\n\tTerminate\022#.mavsdk."
-    "rpc.action.TerminateRequest\032$.mavsdk.rpc"
-    ".action.TerminateResponse\"\000\022I\n\004Kill\022\036.ma"
-    "vsdk.rpc.action.KillRequest\032\037.mavsdk.rpc"
-    ".action.KillResponse\"\000\022g\n\016ReturnToLaunch"
-    "\022(.mavsdk.rpc.action.ReturnToLaunchReque"
-    "st\032).mavsdk.rpc.action.ReturnToLaunchRes"
-    "ponse\"\000\022a\n\014GotoLocation\022&.mavsdk.rpc.act"
-    "ion.GotoLocationRequest\032\'.mavsdk.rpc.act"
-    "ion.GotoLocationResponse\"\000\022R\n\007DoOrbit\022!."
-    "mavsdk.rpc.action.DoOrbitRequest\032\".mavsd"
-    "k.rpc.action.DoOrbitResponse\"\000\022I\n\004Hold\022\036"
-    ".mavsdk.rpc.action.HoldRequest\032\037.mavsdk."
-    "rpc.action.HoldResponse\"\000\022^\n\013SetActuator"
-    "\022%.mavsdk.rpc.action.SetActuatorRequest\032"
-    "&.mavsdk.rpc.action.SetActuatorResponse\""
-    "\000\022U\n\010SetRelay\022\".mavsdk.rpc.action.SetRel"
-    "ayRequest\032#.mavsdk.rpc.action.SetRelayRe"
-    "sponse\"\000\022|\n\025TransitionToFixedwing\022/.mavs"
-    "dk.rpc.action.TransitionToFixedwingReque"
-    "st\0320.mavsdk.rpc.action.TransitionToFixed"
-    "wingResponse\"\000\022\202\001\n\027TransitionToMulticopt"
-    "er\0221.mavsdk.rpc.action.TransitionToMulti"
-    "copterRequest\0322.mavsdk.rpc.action.Transi"
-    "tionToMulticopterResponse\"\000\022s\n\022GetTakeof"
-    "fAltitude\022,.mavsdk.rpc.action.GetTakeoff"
-    "AltitudeRequest\032-.mavsdk.rpc.action.GetT"
-    "akeoffAltitudeResponse\"\000\022s\n\022SetTakeoffAl"
-    "titude\022,.mavsdk.rpc.action.SetTakeoffAlt"
-    "itudeRequest\032-.mavsdk.rpc.action.SetTake"
-    "offAltitudeResponse\"\000\022\210\001\n\031GetReturnToLau"
-    "nchAltitude\0223.mavsdk.rpc.action.GetRetur"
-    "nToLaunchAltitudeRequest\0324.mavsdk.rpc.ac"
-    "tion.GetReturnToLaunchAltitudeResponse\"\000"
-    "\022\210\001\n\031SetReturnToLaunchAltitude\0223.mavsdk."
-    "rpc.action.SetReturnToLaunchAltitudeRequ"
-    "est\0324.mavsdk.rpc.action.SetReturnToLaunc"
-    "hAltitudeResponse\"\000\022j\n\017SetCurrentSpeed\022)"
-    ".mavsdk.rpc.action.SetCurrentSpeedReques"
-    "t\032*.mavsdk.rpc.action.SetCurrentSpeedRes"
-    "ponse\"\000\022w\n\022SetGpsGlobalOrigin\022,.mavsdk.r"
-    "pc.action.SetGpsGlobalOriginRequest\032-.ma"
-    "vsdk.rpc.action.SetGpsGlobalOriginRespon"
-    "se\"\004\200\265\030\001\022V\n\007SetHome\022!.mavsdk.rpc.action."
-    "SetHomeRequest\032\".mavsdk.rpc.action.SetHo"
-    "meResponse\"\004\200\265\030\001B\037\n\020io.mavsdk.actionB\013Ac"
-    "tionProtob\006proto3"
+    "c.action.ActionResult\"x\n\016SetHomeRequest\022"
+    "\034\n\024use_current_location\030\001 \001(\010\022\024\n\014latitud"
+    "e_deg\030\002 \001(\001\022\025\n\rlongitude_deg\030\003 \001(\001\022\033\n\023ab"
+    "solute_altitude_m\030\004 \001(\002\"I\n\017SetHomeRespon"
+    "se\0226\n\raction_result\030\001 \001(\0132\037.mavsdk.rpc.a"
+    "ction.ActionResult\"\215\004\n\014ActionResult\0226\n\006r"
+    "esult\030\001 \001(\0162&.mavsdk.rpc.action.ActionRe"
+    "sult.Result\022\022\n\nresult_str\030\002 \001(\t\"\260\003\n\006Resu"
+    "lt\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCCESS"
+    "\020\001\022\024\n\020RESULT_NO_SYSTEM\020\002\022\033\n\027RESULT_CONNE"
+    "CTION_ERROR\020\003\022\017\n\013RESULT_BUSY\020\004\022\031\n\025RESULT"
+    "_COMMAND_DENIED\020\005\022.\n*RESULT_COMMAND_DENI"
+    "ED_LANDED_STATE_UNKNOWN\020\006\022$\n RESULT_COMM"
+    "AND_DENIED_NOT_LANDED\020\007\022\022\n\016RESULT_TIMEOU"
+    "T\020\010\022*\n&RESULT_VTOL_TRANSITION_SUPPORT_UN"
+    "KNOWN\020\t\022%\n!RESULT_NO_VTOL_TRANSITION_SUP"
+    "PORT\020\n\022\032\n\026RESULT_PARAMETER_ERROR\020\013\022\026\n\022RE"
+    "SULT_UNSUPPORTED\020\014\022\021\n\rRESULT_FAILED\020\r\022\033\n"
+    "\027RESULT_INVALID_ARGUMENT\020\016*\363\001\n\020OrbitYawB"
+    "ehavior\0222\n.ORBIT_YAW_BEHAVIOR_HOLD_FRONT"
+    "_TO_CIRCLE_CENTER\020\000\022+\n\'ORBIT_YAW_BEHAVIO"
+    "R_HOLD_INITIAL_HEADING\020\001\022#\n\037ORBIT_YAW_BE"
+    "HAVIOR_UNCONTROLLED\020\002\0223\n/ORBIT_YAW_BEHAV"
+    "IOR_HOLD_FRONT_TANGENT_TO_CIRCLE\020\003\022$\n OR"
+    "BIT_YAW_BEHAVIOR_RC_CONTROLLED\020\004*;\n\014Rela"
+    "yCommand\022\024\n\020RELAY_COMMAND_ON\020\000\022\025\n\021RELAY_"
+    "COMMAND_OFF\020\0012\313\023\n\rActionService\022F\n\003Arm\022\035"
+    ".mavsdk.rpc.action.ArmRequest\032\036.mavsdk.r"
+    "pc.action.ArmResponse\"\000\022U\n\010ArmForce\022\".ma"
+    "vsdk.rpc.action.ArmForceRequest\032#.mavsdk"
+    ".rpc.action.ArmForceResponse\"\000\022O\n\006Disarm"
+    "\022 .mavsdk.rpc.action.DisarmRequest\032!.mav"
+    "sdk.rpc.action.DisarmResponse\"\000\022R\n\007Takeo"
+    "ff\022!.mavsdk.rpc.action.TakeoffRequest\032\"."
+    "mavsdk.rpc.action.TakeoffResponse\"\000\022I\n\004L"
+    "and\022\036.mavsdk.rpc.action.LandRequest\032\037.ma"
+    "vsdk.rpc.action.LandResponse\"\000\022O\n\006Reboot"
+    "\022 .mavsdk.rpc.action.RebootRequest\032!.mav"
+    "sdk.rpc.action.RebootResponse\"\000\022U\n\010Shutd"
+    "own\022\".mavsdk.rpc.action.ShutdownRequest\032"
+    "#.mavsdk.rpc.action.ShutdownResponse\"\000\022X"
+    "\n\tTerminate\022#.mavsdk.rpc.action.Terminat"
+    "eRequest\032$.mavsdk.rpc.action.TerminateRe"
+    "sponse\"\000\022I\n\004Kill\022\036.mavsdk.rpc.action.Kil"
+    "lRequest\032\037.mavsdk.rpc.action.KillRespons"
+    "e\"\000\022g\n\016ReturnToLaunch\022(.mavsdk.rpc.actio"
+    "n.ReturnToLaunchRequest\032).mavsdk.rpc.act"
+    "ion.ReturnToLaunchResponse\"\000\022a\n\014GotoLoca"
+    "tion\022&.mavsdk.rpc.action.GotoLocationReq"
+    "uest\032\'.mavsdk.rpc.action.GotoLocationRes"
+    "ponse\"\000\022|\n\025GotoLocationFixedwing\022/.mavsd"
+    "k.rpc.action.GotoLocationFixedwingReques"
+    "t\0320.mavsdk.rpc.action.GotoLocationFixedw"
+    "ingResponse\"\000\022R\n\007DoOrbit\022!.mavsdk.rpc.ac"
+    "tion.DoOrbitRequest\032\".mavsdk.rpc.action."
+    "DoOrbitResponse\"\000\022I\n\004Hold\022\036.mavsdk.rpc.a"
+    "ction.HoldRequest\032\037.mavsdk.rpc.action.Ho"
+    "ldResponse\"\000\022^\n\013SetActuator\022%.mavsdk.rpc"
+    ".action.SetActuatorRequest\032&.mavsdk.rpc."
+    "action.SetActuatorResponse\"\000\022U\n\010SetRelay"
+    "\022\".mavsdk.rpc.action.SetRelayRequest\032#.m"
+    "avsdk.rpc.action.SetRelayResponse\"\000\022|\n\025T"
+    "ransitionToFixedwing\022/.mavsdk.rpc.action"
+    ".TransitionToFixedwingRequest\0320.mavsdk.r"
+    "pc.action.TransitionToFixedwingResponse\""
+    "\000\022\202\001\n\027TransitionToMulticopter\0221.mavsdk.r"
+    "pc.action.TransitionToMulticopterRequest"
+    "\0322.mavsdk.rpc.action.TransitionToMultico"
+    "pterResponse\"\000\022s\n\022GetTakeoffAltitude\022,.m"
+    "avsdk.rpc.action.GetTakeoffAltitudeReque"
+    "st\032-.mavsdk.rpc.action.GetTakeoffAltitud"
+    "eResponse\"\000\022s\n\022SetTakeoffAltitude\022,.mavs"
+    "dk.rpc.action.SetTakeoffAltitudeRequest\032"
+    "-.mavsdk.rpc.action.SetTakeoffAltitudeRe"
+    "sponse\"\000\022\210\001\n\031GetReturnToLaunchAltitude\0223"
+    ".mavsdk.rpc.action.GetReturnToLaunchAlti"
+    "tudeRequest\0324.mavsdk.rpc.action.GetRetur"
+    "nToLaunchAltitudeResponse\"\000\022\210\001\n\031SetRetur"
+    "nToLaunchAltitude\0223.mavsdk.rpc.action.Se"
+    "tReturnToLaunchAltitudeRequest\0324.mavsdk."
+    "rpc.action.SetReturnToLaunchAltitudeResp"
+    "onse\"\000\022j\n\017SetCurrentSpeed\022).mavsdk.rpc.a"
+    "ction.SetCurrentSpeedRequest\032*.mavsdk.rp"
+    "c.action.SetCurrentSpeedResponse\"\000\022w\n\022Se"
+    "tGpsGlobalOrigin\022,.mavsdk.rpc.action.Set"
+    "GpsGlobalOriginRequest\032-.mavsdk.rpc.acti"
+    "on.SetGpsGlobalOriginResponse\"\004\200\265\030\001\022V\n\007S"
+    "etHome\022!.mavsdk.rpc.action.SetHomeReques"
+    "t\032\".mavsdk.rpc.action.SetHomeResponse\"\004\200"
+    "\265\030\001B\037\n\020io.mavsdk.actionB\013ActionProtob\006pr"
+    "oto3"
 };
 static const ::_pbi::DescriptorTable* const descriptor_table_action_2faction_2eproto_deps[1] =
     {
@@ -1924,13 +2012,13 @@ static ::absl::once_flag descriptor_table_action_2faction_2eproto_once;
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_action_2faction_2eproto = {
     false,
     false,
-    6457,
+    6804,
     descriptor_table_protodef_action_2faction_2eproto,
     "action/action.proto",
     &descriptor_table_action_2faction_2eproto_once,
     descriptor_table_action_2faction_2eproto_deps,
     1,
-    49,
+    51,
     schemas,
     file_default_instances,
     TableStruct_action_2faction_2eproto::offsets,
@@ -6048,6 +6136,535 @@ void GotoLocationResponse::InternalSwap(GotoLocationResponse* PROTOBUF_RESTRICT 
 }
 
 ::google::protobuf::Metadata GotoLocationResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class GotoLocationFixedwingRequest::_Internal {
+ public:
+};
+
+GotoLocationFixedwingRequest::GotoLocationFixedwingRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.action.GotoLocationFixedwingRequest)
+}
+GotoLocationFixedwingRequest::GotoLocationFixedwingRequest(
+    ::google::protobuf::Arena* arena, const GotoLocationFixedwingRequest& from)
+    : GotoLocationFixedwingRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE GotoLocationFixedwingRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void GotoLocationFixedwingRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  ::memset(reinterpret_cast<char *>(&_impl_) +
+               offsetof(Impl_, latitude_deg_),
+           0,
+           offsetof(Impl_, loiter_radius_m_) -
+               offsetof(Impl_, latitude_deg_) +
+               sizeof(Impl_::loiter_radius_m_));
+}
+GotoLocationFixedwingRequest::~GotoLocationFixedwingRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.action.GotoLocationFixedwingRequest)
+  SharedDtor(*this);
+}
+inline void GotoLocationFixedwingRequest::SharedDtor(MessageLite& self) {
+  GotoLocationFixedwingRequest& this_ = static_cast<GotoLocationFixedwingRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* GotoLocationFixedwingRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) GotoLocationFixedwingRequest(arena);
+}
+constexpr auto GotoLocationFixedwingRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(GotoLocationFixedwingRequest),
+                                            alignof(GotoLocationFixedwingRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull GotoLocationFixedwingRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_GotoLocationFixedwingRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &GotoLocationFixedwingRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<GotoLocationFixedwingRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &GotoLocationFixedwingRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<GotoLocationFixedwingRequest>(), &GotoLocationFixedwingRequest::ByteSizeLong,
+            &GotoLocationFixedwingRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(GotoLocationFixedwingRequest, _impl_._cached_size_),
+        false,
+    },
+    &GotoLocationFixedwingRequest::kDescriptorMethods,
+    &descriptor_table_action_2faction_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* GotoLocationFixedwingRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<2, 4, 0, 0, 2> GotoLocationFixedwingRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    4, 24,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967280,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    4,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::action::GotoLocationFixedwingRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // float loiter_radius_m = 4;
+    {::_pbi::TcParser::FastF32S1,
+     {37, 63, 0, PROTOBUF_FIELD_OFFSET(GotoLocationFixedwingRequest, _impl_.loiter_radius_m_)}},
+    // double latitude_deg = 1;
+    {::_pbi::TcParser::FastF64S1,
+     {9, 63, 0, PROTOBUF_FIELD_OFFSET(GotoLocationFixedwingRequest, _impl_.latitude_deg_)}},
+    // double longitude_deg = 2;
+    {::_pbi::TcParser::FastF64S1,
+     {17, 63, 0, PROTOBUF_FIELD_OFFSET(GotoLocationFixedwingRequest, _impl_.longitude_deg_)}},
+    // float absolute_altitude_m = 3;
+    {::_pbi::TcParser::FastF32S1,
+     {29, 63, 0, PROTOBUF_FIELD_OFFSET(GotoLocationFixedwingRequest, _impl_.absolute_altitude_m_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // double latitude_deg = 1;
+    {PROTOBUF_FIELD_OFFSET(GotoLocationFixedwingRequest, _impl_.latitude_deg_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kDouble)},
+    // double longitude_deg = 2;
+    {PROTOBUF_FIELD_OFFSET(GotoLocationFixedwingRequest, _impl_.longitude_deg_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kDouble)},
+    // float absolute_altitude_m = 3;
+    {PROTOBUF_FIELD_OFFSET(GotoLocationFixedwingRequest, _impl_.absolute_altitude_m_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+    // float loiter_radius_m = 4;
+    {PROTOBUF_FIELD_OFFSET(GotoLocationFixedwingRequest, _impl_.loiter_radius_m_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void GotoLocationFixedwingRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action.GotoLocationFixedwingRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  ::memset(&_impl_.latitude_deg_, 0, static_cast<::size_t>(
+      reinterpret_cast<char*>(&_impl_.loiter_radius_m_) -
+      reinterpret_cast<char*>(&_impl_.latitude_deg_)) + sizeof(_impl_.loiter_radius_m_));
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* GotoLocationFixedwingRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const GotoLocationFixedwingRequest& this_ = static_cast<const GotoLocationFixedwingRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* GotoLocationFixedwingRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const GotoLocationFixedwingRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action.GotoLocationFixedwingRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // double latitude_deg = 1;
+          if (::absl::bit_cast<::uint64_t>(this_._internal_latitude_deg()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteDoubleToArray(
+                1, this_._internal_latitude_deg(), target);
+          }
+
+          // double longitude_deg = 2;
+          if (::absl::bit_cast<::uint64_t>(this_._internal_longitude_deg()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteDoubleToArray(
+                2, this_._internal_longitude_deg(), target);
+          }
+
+          // float absolute_altitude_m = 3;
+          if (::absl::bit_cast<::uint32_t>(this_._internal_absolute_altitude_m()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                3, this_._internal_absolute_altitude_m(), target);
+          }
+
+          // float loiter_radius_m = 4;
+          if (::absl::bit_cast<::uint32_t>(this_._internal_loiter_radius_m()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                4, this_._internal_loiter_radius_m(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action.GotoLocationFixedwingRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t GotoLocationFixedwingRequest::ByteSizeLong(const MessageLite& base) {
+          const GotoLocationFixedwingRequest& this_ = static_cast<const GotoLocationFixedwingRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t GotoLocationFixedwingRequest::ByteSizeLong() const {
+          const GotoLocationFixedwingRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action.GotoLocationFixedwingRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+          ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+           {
+            // double latitude_deg = 1;
+            if (::absl::bit_cast<::uint64_t>(this_._internal_latitude_deg()) != 0) {
+              total_size += 9;
+            }
+            // double longitude_deg = 2;
+            if (::absl::bit_cast<::uint64_t>(this_._internal_longitude_deg()) != 0) {
+              total_size += 9;
+            }
+            // float absolute_altitude_m = 3;
+            if (::absl::bit_cast<::uint32_t>(this_._internal_absolute_altitude_m()) != 0) {
+              total_size += 5;
+            }
+            // float loiter_radius_m = 4;
+            if (::absl::bit_cast<::uint32_t>(this_._internal_loiter_radius_m()) != 0) {
+              total_size += 5;
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void GotoLocationFixedwingRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<GotoLocationFixedwingRequest*>(&to_msg);
+  auto& from = static_cast<const GotoLocationFixedwingRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action.GotoLocationFixedwingRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (::absl::bit_cast<::uint64_t>(from._internal_latitude_deg()) != 0) {
+    _this->_impl_.latitude_deg_ = from._impl_.latitude_deg_;
+  }
+  if (::absl::bit_cast<::uint64_t>(from._internal_longitude_deg()) != 0) {
+    _this->_impl_.longitude_deg_ = from._impl_.longitude_deg_;
+  }
+  if (::absl::bit_cast<::uint32_t>(from._internal_absolute_altitude_m()) != 0) {
+    _this->_impl_.absolute_altitude_m_ = from._impl_.absolute_altitude_m_;
+  }
+  if (::absl::bit_cast<::uint32_t>(from._internal_loiter_radius_m()) != 0) {
+    _this->_impl_.loiter_radius_m_ = from._impl_.loiter_radius_m_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void GotoLocationFixedwingRequest::CopyFrom(const GotoLocationFixedwingRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action.GotoLocationFixedwingRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void GotoLocationFixedwingRequest::InternalSwap(GotoLocationFixedwingRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::google::protobuf::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(GotoLocationFixedwingRequest, _impl_.loiter_radius_m_)
+      + sizeof(GotoLocationFixedwingRequest::_impl_.loiter_radius_m_)
+      - PROTOBUF_FIELD_OFFSET(GotoLocationFixedwingRequest, _impl_.latitude_deg_)>(
+          reinterpret_cast<char*>(&_impl_.latitude_deg_),
+          reinterpret_cast<char*>(&other->_impl_.latitude_deg_));
+}
+
+::google::protobuf::Metadata GotoLocationFixedwingRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class GotoLocationFixedwingResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<GotoLocationFixedwingResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(GotoLocationFixedwingResponse, _impl_._has_bits_);
+};
+
+GotoLocationFixedwingResponse::GotoLocationFixedwingResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.action.GotoLocationFixedwingResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE GotoLocationFixedwingResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::action::GotoLocationFixedwingResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+GotoLocationFixedwingResponse::GotoLocationFixedwingResponse(
+    ::google::protobuf::Arena* arena,
+    const GotoLocationFixedwingResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  GotoLocationFixedwingResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.action_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::action::ActionResult>(
+                              arena, *from._impl_.action_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.action.GotoLocationFixedwingResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE GotoLocationFixedwingResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void GotoLocationFixedwingResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.action_result_ = {};
+}
+GotoLocationFixedwingResponse::~GotoLocationFixedwingResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.action.GotoLocationFixedwingResponse)
+  SharedDtor(*this);
+}
+inline void GotoLocationFixedwingResponse::SharedDtor(MessageLite& self) {
+  GotoLocationFixedwingResponse& this_ = static_cast<GotoLocationFixedwingResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.action_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* GotoLocationFixedwingResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) GotoLocationFixedwingResponse(arena);
+}
+constexpr auto GotoLocationFixedwingResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(GotoLocationFixedwingResponse),
+                                            alignof(GotoLocationFixedwingResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull GotoLocationFixedwingResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_GotoLocationFixedwingResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &GotoLocationFixedwingResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<GotoLocationFixedwingResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &GotoLocationFixedwingResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<GotoLocationFixedwingResponse>(), &GotoLocationFixedwingResponse::ByteSizeLong,
+            &GotoLocationFixedwingResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(GotoLocationFixedwingResponse, _impl_._cached_size_),
+        false,
+    },
+    &GotoLocationFixedwingResponse::kDescriptorMethods,
+    &descriptor_table_action_2faction_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* GotoLocationFixedwingResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> GotoLocationFixedwingResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(GotoLocationFixedwingResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::action::GotoLocationFixedwingResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.action.ActionResult action_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(GotoLocationFixedwingResponse, _impl_.action_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.action.ActionResult action_result = 1;
+    {PROTOBUF_FIELD_OFFSET(GotoLocationFixedwingResponse, _impl_.action_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::action::ActionResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void GotoLocationFixedwingResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.action.GotoLocationFixedwingResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.action_result_ != nullptr);
+    _impl_.action_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* GotoLocationFixedwingResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const GotoLocationFixedwingResponse& this_ = static_cast<const GotoLocationFixedwingResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* GotoLocationFixedwingResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const GotoLocationFixedwingResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.action.GotoLocationFixedwingResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.action.ActionResult action_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.action_result_, this_._impl_.action_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.action.GotoLocationFixedwingResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t GotoLocationFixedwingResponse::ByteSizeLong(const MessageLite& base) {
+          const GotoLocationFixedwingResponse& this_ = static_cast<const GotoLocationFixedwingResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t GotoLocationFixedwingResponse::ByteSizeLong() const {
+          const GotoLocationFixedwingResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.action.GotoLocationFixedwingResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.action.ActionResult action_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.action_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void GotoLocationFixedwingResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<GotoLocationFixedwingResponse*>(&to_msg);
+  auto& from = static_cast<const GotoLocationFixedwingResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.action.GotoLocationFixedwingResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.action_result_ != nullptr);
+    if (_this->_impl_.action_result_ == nullptr) {
+      _this->_impl_.action_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::action::ActionResult>(arena, *from._impl_.action_result_);
+    } else {
+      _this->_impl_.action_result_->MergeFrom(*from._impl_.action_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void GotoLocationFixedwingResponse::CopyFrom(const GotoLocationFixedwingResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.action.GotoLocationFixedwingResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void GotoLocationFixedwingResponse::InternalSwap(GotoLocationFixedwingResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.action_result_, other->_impl_.action_result_);
+}
+
+::google::protobuf::Metadata GotoLocationFixedwingResponse::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================

--- a/cpp/src/mavsdk_server/src/generated/action/action.pb.h
+++ b/cpp/src/mavsdk_server/src/generated/action/action.pb.h
@@ -96,6 +96,12 @@ extern GetTakeoffAltitudeRequestDefaultTypeInternal _GetTakeoffAltitudeRequest_d
 class GetTakeoffAltitudeResponse;
 struct GetTakeoffAltitudeResponseDefaultTypeInternal;
 extern GetTakeoffAltitudeResponseDefaultTypeInternal _GetTakeoffAltitudeResponse_default_instance_;
+class GotoLocationFixedwingRequest;
+struct GotoLocationFixedwingRequestDefaultTypeInternal;
+extern GotoLocationFixedwingRequestDefaultTypeInternal _GotoLocationFixedwingRequest_default_instance_;
+class GotoLocationFixedwingResponse;
+struct GotoLocationFixedwingResponseDefaultTypeInternal;
+extern GotoLocationFixedwingResponseDefaultTypeInternal _GotoLocationFixedwingResponse_default_instance_;
 class GotoLocationRequest;
 struct GotoLocationRequestDefaultTypeInternal;
 extern GotoLocationRequestDefaultTypeInternal _GotoLocationRequest_default_instance_;
@@ -395,7 +401,7 @@ class TransitionToMulticopterRequest final
     return reinterpret_cast<const TransitionToMulticopterRequest*>(
         &_TransitionToMulticopterRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 32;
+  static constexpr int kIndexInFileMessages = 34;
   friend void swap(TransitionToMulticopterRequest& a, TransitionToMulticopterRequest& b) { a.Swap(&b); }
   inline void Swap(TransitionToMulticopterRequest* other) {
     if (other == this) return;
@@ -541,7 +547,7 @@ class TransitionToFixedwingRequest final
     return reinterpret_cast<const TransitionToFixedwingRequest*>(
         &_TransitionToFixedwingRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 30;
+  static constexpr int kIndexInFileMessages = 32;
   friend void swap(TransitionToFixedwingRequest& a, TransitionToFixedwingRequest& b) { a.Swap(&b); }
   inline void Swap(TransitionToFixedwingRequest* other) {
     if (other == this) return;
@@ -1126,7 +1132,7 @@ class SetTakeoffAltitudeRequest final
     return reinterpret_cast<const SetTakeoffAltitudeRequest*>(
         &_SetTakeoffAltitudeRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 36;
+  static constexpr int kIndexInFileMessages = 38;
   friend void swap(SetTakeoffAltitudeRequest& a, SetTakeoffAltitudeRequest& b) { a.Swap(&b); }
   inline void Swap(SetTakeoffAltitudeRequest* other) {
     if (other == this) return;
@@ -1317,7 +1323,7 @@ class SetReturnToLaunchAltitudeRequest final
     return reinterpret_cast<const SetReturnToLaunchAltitudeRequest*>(
         &_SetReturnToLaunchAltitudeRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 40;
+  static constexpr int kIndexInFileMessages = 42;
   friend void swap(SetReturnToLaunchAltitudeRequest& a, SetReturnToLaunchAltitudeRequest& b) { a.Swap(&b); }
   inline void Swap(SetReturnToLaunchAltitudeRequest* other) {
     if (other == this) return;
@@ -1508,7 +1514,7 @@ class SetRelayRequest final
     return reinterpret_cast<const SetRelayRequest*>(
         &_SetRelayRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 28;
+  static constexpr int kIndexInFileMessages = 30;
   friend void swap(SetRelayRequest& a, SetRelayRequest& b) { a.Swap(&b); }
   inline void Swap(SetRelayRequest* other) {
     if (other == this) return;
@@ -1711,7 +1717,7 @@ class SetHomeRequest final
     return reinterpret_cast<const SetHomeRequest*>(
         &_SetHomeRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 46;
+  static constexpr int kIndexInFileMessages = 48;
   friend void swap(SetHomeRequest& a, SetHomeRequest& b) { a.Swap(&b); }
   inline void Swap(SetHomeRequest* other) {
     if (other == this) return;
@@ -1938,7 +1944,7 @@ class SetGpsGlobalOriginRequest final
     return reinterpret_cast<const SetGpsGlobalOriginRequest*>(
         &_SetGpsGlobalOriginRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 44;
+  static constexpr int kIndexInFileMessages = 46;
   friend void swap(SetGpsGlobalOriginRequest& a, SetGpsGlobalOriginRequest& b) { a.Swap(&b); }
   inline void Swap(SetGpsGlobalOriginRequest* other) {
     if (other == this) return;
@@ -2153,7 +2159,7 @@ class SetCurrentSpeedRequest final
     return reinterpret_cast<const SetCurrentSpeedRequest*>(
         &_SetCurrentSpeedRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 42;
+  static constexpr int kIndexInFileMessages = 44;
   friend void swap(SetCurrentSpeedRequest& a, SetCurrentSpeedRequest& b) { a.Swap(&b); }
   inline void Swap(SetCurrentSpeedRequest* other) {
     if (other == this) return;
@@ -2344,7 +2350,7 @@ class SetActuatorRequest final
     return reinterpret_cast<const SetActuatorRequest*>(
         &_SetActuatorRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 26;
+  static constexpr int kIndexInFileMessages = 28;
   friend void swap(SetActuatorRequest& a, SetActuatorRequest& b) { a.Swap(&b); }
   inline void Swap(SetActuatorRequest* other) {
     if (other == this) return;
@@ -3130,7 +3136,7 @@ class HoldRequest final
     return reinterpret_cast<const HoldRequest*>(
         &_HoldRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 24;
+  static constexpr int kIndexInFileMessages = 26;
   friend void swap(HoldRequest& a, HoldRequest& b) { a.Swap(&b); }
   inline void Swap(HoldRequest* other) {
     if (other == this) return;
@@ -3444,6 +3450,233 @@ class GotoLocationRequest final
 };
 // -------------------------------------------------------------------
 
+class GotoLocationFixedwingRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.action.GotoLocationFixedwingRequest) */ {
+ public:
+  inline GotoLocationFixedwingRequest() : GotoLocationFixedwingRequest(nullptr) {}
+  ~GotoLocationFixedwingRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(GotoLocationFixedwingRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(GotoLocationFixedwingRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR GotoLocationFixedwingRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline GotoLocationFixedwingRequest(const GotoLocationFixedwingRequest& from) : GotoLocationFixedwingRequest(nullptr, from) {}
+  inline GotoLocationFixedwingRequest(GotoLocationFixedwingRequest&& from) noexcept
+      : GotoLocationFixedwingRequest(nullptr, std::move(from)) {}
+  inline GotoLocationFixedwingRequest& operator=(const GotoLocationFixedwingRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline GotoLocationFixedwingRequest& operator=(GotoLocationFixedwingRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const GotoLocationFixedwingRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const GotoLocationFixedwingRequest* internal_default_instance() {
+    return reinterpret_cast<const GotoLocationFixedwingRequest*>(
+        &_GotoLocationFixedwingRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 22;
+  friend void swap(GotoLocationFixedwingRequest& a, GotoLocationFixedwingRequest& b) { a.Swap(&b); }
+  inline void Swap(GotoLocationFixedwingRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(GotoLocationFixedwingRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  GotoLocationFixedwingRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<GotoLocationFixedwingRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const GotoLocationFixedwingRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const GotoLocationFixedwingRequest& from) { GotoLocationFixedwingRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(GotoLocationFixedwingRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.action.GotoLocationFixedwingRequest"; }
+
+ protected:
+  explicit GotoLocationFixedwingRequest(::google::protobuf::Arena* arena);
+  GotoLocationFixedwingRequest(::google::protobuf::Arena* arena, const GotoLocationFixedwingRequest& from);
+  GotoLocationFixedwingRequest(::google::protobuf::Arena* arena, GotoLocationFixedwingRequest&& from) noexcept
+      : GotoLocationFixedwingRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kLatitudeDegFieldNumber = 1,
+    kLongitudeDegFieldNumber = 2,
+    kAbsoluteAltitudeMFieldNumber = 3,
+    kLoiterRadiusMFieldNumber = 4,
+  };
+  // double latitude_deg = 1;
+  void clear_latitude_deg() ;
+  double latitude_deg() const;
+  void set_latitude_deg(double value);
+
+  private:
+  double _internal_latitude_deg() const;
+  void _internal_set_latitude_deg(double value);
+
+  public:
+  // double longitude_deg = 2;
+  void clear_longitude_deg() ;
+  double longitude_deg() const;
+  void set_longitude_deg(double value);
+
+  private:
+  double _internal_longitude_deg() const;
+  void _internal_set_longitude_deg(double value);
+
+  public:
+  // float absolute_altitude_m = 3;
+  void clear_absolute_altitude_m() ;
+  float absolute_altitude_m() const;
+  void set_absolute_altitude_m(float value);
+
+  private:
+  float _internal_absolute_altitude_m() const;
+  void _internal_set_absolute_altitude_m(float value);
+
+  public:
+  // float loiter_radius_m = 4;
+  void clear_loiter_radius_m() ;
+  float loiter_radius_m() const;
+  void set_loiter_radius_m(float value);
+
+  private:
+  float _internal_loiter_radius_m() const;
+  void _internal_set_loiter_radius_m(float value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action.GotoLocationFixedwingRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      2, 4, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const GotoLocationFixedwingRequest& from_msg);
+    double latitude_deg_;
+    double longitude_deg_;
+    float absolute_altitude_m_;
+    float loiter_radius_m_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_action_2faction_2eproto;
+};
+// -------------------------------------------------------------------
+
 class GetTakeoffAltitudeRequest final
     : public ::google::protobuf::internal::ZeroFieldsBase
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action.GetTakeoffAltitudeRequest) */ {
@@ -3503,7 +3736,7 @@ class GetTakeoffAltitudeRequest final
     return reinterpret_cast<const GetTakeoffAltitudeRequest*>(
         &_GetTakeoffAltitudeRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 34;
+  static constexpr int kIndexInFileMessages = 36;
   friend void swap(GetTakeoffAltitudeRequest& a, GetTakeoffAltitudeRequest& b) { a.Swap(&b); }
   inline void Swap(GetTakeoffAltitudeRequest* other) {
     if (other == this) return;
@@ -3649,7 +3882,7 @@ class GetReturnToLaunchAltitudeRequest final
     return reinterpret_cast<const GetReturnToLaunchAltitudeRequest*>(
         &_GetReturnToLaunchAltitudeRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 38;
+  static constexpr int kIndexInFileMessages = 40;
   friend void swap(GetReturnToLaunchAltitudeRequest& a, GetReturnToLaunchAltitudeRequest& b) { a.Swap(&b); }
   inline void Swap(GetReturnToLaunchAltitudeRequest* other) {
     if (other == this) return;
@@ -3796,7 +4029,7 @@ class DoOrbitRequest final
     return reinterpret_cast<const DoOrbitRequest*>(
         &_DoOrbitRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 22;
+  static constexpr int kIndexInFileMessages = 24;
   friend void swap(DoOrbitRequest& a, DoOrbitRequest& b) { a.Swap(&b); }
   inline void Swap(DoOrbitRequest* other) {
     if (other == this) return;
@@ -4485,7 +4718,7 @@ class ActionResult final
     return reinterpret_cast<const ActionResult*>(
         &_ActionResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 48;
+  static constexpr int kIndexInFileMessages = 50;
   friend void swap(ActionResult& a, ActionResult& b) { a.Swap(&b); }
   inline void Swap(ActionResult* other) {
     if (other == this) return;
@@ -4726,7 +4959,7 @@ class TransitionToMulticopterResponse final
     return reinterpret_cast<const TransitionToMulticopterResponse*>(
         &_TransitionToMulticopterResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 33;
+  static constexpr int kIndexInFileMessages = 35;
   friend void swap(TransitionToMulticopterResponse& a, TransitionToMulticopterResponse& b) { a.Swap(&b); }
   inline void Swap(TransitionToMulticopterResponse* other) {
     if (other == this) return;
@@ -4923,7 +5156,7 @@ class TransitionToFixedwingResponse final
     return reinterpret_cast<const TransitionToFixedwingResponse*>(
         &_TransitionToFixedwingResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 31;
+  static constexpr int kIndexInFileMessages = 33;
   friend void swap(TransitionToFixedwingResponse& a, TransitionToFixedwingResponse& b) { a.Swap(&b); }
   inline void Swap(TransitionToFixedwingResponse* other) {
     if (other == this) return;
@@ -5711,7 +5944,7 @@ class SetTakeoffAltitudeResponse final
     return reinterpret_cast<const SetTakeoffAltitudeResponse*>(
         &_SetTakeoffAltitudeResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 37;
+  static constexpr int kIndexInFileMessages = 39;
   friend void swap(SetTakeoffAltitudeResponse& a, SetTakeoffAltitudeResponse& b) { a.Swap(&b); }
   inline void Swap(SetTakeoffAltitudeResponse* other) {
     if (other == this) return;
@@ -5908,7 +6141,7 @@ class SetReturnToLaunchAltitudeResponse final
     return reinterpret_cast<const SetReturnToLaunchAltitudeResponse*>(
         &_SetReturnToLaunchAltitudeResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 41;
+  static constexpr int kIndexInFileMessages = 43;
   friend void swap(SetReturnToLaunchAltitudeResponse& a, SetReturnToLaunchAltitudeResponse& b) { a.Swap(&b); }
   inline void Swap(SetReturnToLaunchAltitudeResponse* other) {
     if (other == this) return;
@@ -6105,7 +6338,7 @@ class SetRelayResponse final
     return reinterpret_cast<const SetRelayResponse*>(
         &_SetRelayResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 29;
+  static constexpr int kIndexInFileMessages = 31;
   friend void swap(SetRelayResponse& a, SetRelayResponse& b) { a.Swap(&b); }
   inline void Swap(SetRelayResponse* other) {
     if (other == this) return;
@@ -6302,7 +6535,7 @@ class SetHomeResponse final
     return reinterpret_cast<const SetHomeResponse*>(
         &_SetHomeResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 47;
+  static constexpr int kIndexInFileMessages = 49;
   friend void swap(SetHomeResponse& a, SetHomeResponse& b) { a.Swap(&b); }
   inline void Swap(SetHomeResponse* other) {
     if (other == this) return;
@@ -6499,7 +6732,7 @@ class SetGpsGlobalOriginResponse final
     return reinterpret_cast<const SetGpsGlobalOriginResponse*>(
         &_SetGpsGlobalOriginResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 45;
+  static constexpr int kIndexInFileMessages = 47;
   friend void swap(SetGpsGlobalOriginResponse& a, SetGpsGlobalOriginResponse& b) { a.Swap(&b); }
   inline void Swap(SetGpsGlobalOriginResponse* other) {
     if (other == this) return;
@@ -6696,7 +6929,7 @@ class SetCurrentSpeedResponse final
     return reinterpret_cast<const SetCurrentSpeedResponse*>(
         &_SetCurrentSpeedResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 43;
+  static constexpr int kIndexInFileMessages = 45;
   friend void swap(SetCurrentSpeedResponse& a, SetCurrentSpeedResponse& b) { a.Swap(&b); }
   inline void Swap(SetCurrentSpeedResponse* other) {
     if (other == this) return;
@@ -6893,7 +7126,7 @@ class SetActuatorResponse final
     return reinterpret_cast<const SetActuatorResponse*>(
         &_SetActuatorResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 27;
+  static constexpr int kIndexInFileMessages = 29;
   friend void swap(SetActuatorResponse& a, SetActuatorResponse& b) { a.Swap(&b); }
   inline void Swap(SetActuatorResponse* other) {
     if (other == this) return;
@@ -7878,7 +8111,7 @@ class HoldResponse final
     return reinterpret_cast<const HoldResponse*>(
         &_HoldResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 25;
+  static constexpr int kIndexInFileMessages = 27;
   friend void swap(HoldResponse& a, HoldResponse& b) { a.Swap(&b); }
   inline void Swap(HoldResponse* other) {
     if (other == this) return;
@@ -8212,6 +8445,203 @@ class GotoLocationResponse final
 };
 // -------------------------------------------------------------------
 
+class GotoLocationFixedwingResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.action.GotoLocationFixedwingResponse) */ {
+ public:
+  inline GotoLocationFixedwingResponse() : GotoLocationFixedwingResponse(nullptr) {}
+  ~GotoLocationFixedwingResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(GotoLocationFixedwingResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(GotoLocationFixedwingResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR GotoLocationFixedwingResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline GotoLocationFixedwingResponse(const GotoLocationFixedwingResponse& from) : GotoLocationFixedwingResponse(nullptr, from) {}
+  inline GotoLocationFixedwingResponse(GotoLocationFixedwingResponse&& from) noexcept
+      : GotoLocationFixedwingResponse(nullptr, std::move(from)) {}
+  inline GotoLocationFixedwingResponse& operator=(const GotoLocationFixedwingResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline GotoLocationFixedwingResponse& operator=(GotoLocationFixedwingResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const GotoLocationFixedwingResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const GotoLocationFixedwingResponse* internal_default_instance() {
+    return reinterpret_cast<const GotoLocationFixedwingResponse*>(
+        &_GotoLocationFixedwingResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 23;
+  friend void swap(GotoLocationFixedwingResponse& a, GotoLocationFixedwingResponse& b) { a.Swap(&b); }
+  inline void Swap(GotoLocationFixedwingResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(GotoLocationFixedwingResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  GotoLocationFixedwingResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<GotoLocationFixedwingResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const GotoLocationFixedwingResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const GotoLocationFixedwingResponse& from) { GotoLocationFixedwingResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(GotoLocationFixedwingResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.action.GotoLocationFixedwingResponse"; }
+
+ protected:
+  explicit GotoLocationFixedwingResponse(::google::protobuf::Arena* arena);
+  GotoLocationFixedwingResponse(::google::protobuf::Arena* arena, const GotoLocationFixedwingResponse& from);
+  GotoLocationFixedwingResponse(::google::protobuf::Arena* arena, GotoLocationFixedwingResponse&& from) noexcept
+      : GotoLocationFixedwingResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kActionResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.action.ActionResult action_result = 1;
+  bool has_action_result() const;
+  void clear_action_result() ;
+  const ::mavsdk::rpc::action::ActionResult& action_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::action::ActionResult* release_action_result();
+  ::mavsdk::rpc::action::ActionResult* mutable_action_result();
+  void set_allocated_action_result(::mavsdk::rpc::action::ActionResult* value);
+  void unsafe_arena_set_allocated_action_result(::mavsdk::rpc::action::ActionResult* value);
+  ::mavsdk::rpc::action::ActionResult* unsafe_arena_release_action_result();
+
+  private:
+  const ::mavsdk::rpc::action::ActionResult& _internal_action_result() const;
+  ::mavsdk::rpc::action::ActionResult* _internal_mutable_action_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.action.GotoLocationFixedwingResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const GotoLocationFixedwingResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::action::ActionResult* action_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_action_2faction_2eproto;
+};
+// -------------------------------------------------------------------
+
 class GetTakeoffAltitudeResponse final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.action.GetTakeoffAltitudeResponse) */ {
@@ -8272,7 +8702,7 @@ class GetTakeoffAltitudeResponse final
     return reinterpret_cast<const GetTakeoffAltitudeResponse*>(
         &_GetTakeoffAltitudeResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 35;
+  static constexpr int kIndexInFileMessages = 37;
   friend void swap(GetTakeoffAltitudeResponse& a, GetTakeoffAltitudeResponse& b) { a.Swap(&b); }
   inline void Swap(GetTakeoffAltitudeResponse* other) {
     if (other == this) return;
@@ -8481,7 +8911,7 @@ class GetReturnToLaunchAltitudeResponse final
     return reinterpret_cast<const GetReturnToLaunchAltitudeResponse*>(
         &_GetReturnToLaunchAltitudeResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 39;
+  static constexpr int kIndexInFileMessages = 41;
   friend void swap(GetReturnToLaunchAltitudeResponse& a, GetReturnToLaunchAltitudeResponse& b) { a.Swap(&b); }
   inline void Swap(GetReturnToLaunchAltitudeResponse* other) {
     if (other == this) return;
@@ -8690,7 +9120,7 @@ class DoOrbitResponse final
     return reinterpret_cast<const DoOrbitResponse*>(
         &_DoOrbitResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 23;
+  static constexpr int kIndexInFileMessages = 25;
   friend void swap(DoOrbitResponse& a, DoOrbitResponse& b) { a.Swap(&b); }
   inline void Swap(DoOrbitResponse* other) {
     if (other == this) return;
@@ -10659,6 +11089,198 @@ inline void GotoLocationResponse::set_allocated_action_result(::mavsdk::rpc::act
 
   _impl_.action_result_ = reinterpret_cast<::mavsdk::rpc::action::ActionResult*>(value);
   // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.action.GotoLocationResponse.action_result)
+}
+
+// -------------------------------------------------------------------
+
+// GotoLocationFixedwingRequest
+
+// double latitude_deg = 1;
+inline void GotoLocationFixedwingRequest::clear_latitude_deg() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.latitude_deg_ = 0;
+}
+inline double GotoLocationFixedwingRequest::latitude_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action.GotoLocationFixedwingRequest.latitude_deg)
+  return _internal_latitude_deg();
+}
+inline void GotoLocationFixedwingRequest::set_latitude_deg(double value) {
+  _internal_set_latitude_deg(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.action.GotoLocationFixedwingRequest.latitude_deg)
+}
+inline double GotoLocationFixedwingRequest::_internal_latitude_deg() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.latitude_deg_;
+}
+inline void GotoLocationFixedwingRequest::_internal_set_latitude_deg(double value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.latitude_deg_ = value;
+}
+
+// double longitude_deg = 2;
+inline void GotoLocationFixedwingRequest::clear_longitude_deg() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.longitude_deg_ = 0;
+}
+inline double GotoLocationFixedwingRequest::longitude_deg() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action.GotoLocationFixedwingRequest.longitude_deg)
+  return _internal_longitude_deg();
+}
+inline void GotoLocationFixedwingRequest::set_longitude_deg(double value) {
+  _internal_set_longitude_deg(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.action.GotoLocationFixedwingRequest.longitude_deg)
+}
+inline double GotoLocationFixedwingRequest::_internal_longitude_deg() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.longitude_deg_;
+}
+inline void GotoLocationFixedwingRequest::_internal_set_longitude_deg(double value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.longitude_deg_ = value;
+}
+
+// float absolute_altitude_m = 3;
+inline void GotoLocationFixedwingRequest::clear_absolute_altitude_m() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.absolute_altitude_m_ = 0;
+}
+inline float GotoLocationFixedwingRequest::absolute_altitude_m() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action.GotoLocationFixedwingRequest.absolute_altitude_m)
+  return _internal_absolute_altitude_m();
+}
+inline void GotoLocationFixedwingRequest::set_absolute_altitude_m(float value) {
+  _internal_set_absolute_altitude_m(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.action.GotoLocationFixedwingRequest.absolute_altitude_m)
+}
+inline float GotoLocationFixedwingRequest::_internal_absolute_altitude_m() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.absolute_altitude_m_;
+}
+inline void GotoLocationFixedwingRequest::_internal_set_absolute_altitude_m(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.absolute_altitude_m_ = value;
+}
+
+// float loiter_radius_m = 4;
+inline void GotoLocationFixedwingRequest::clear_loiter_radius_m() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.loiter_radius_m_ = 0;
+}
+inline float GotoLocationFixedwingRequest::loiter_radius_m() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action.GotoLocationFixedwingRequest.loiter_radius_m)
+  return _internal_loiter_radius_m();
+}
+inline void GotoLocationFixedwingRequest::set_loiter_radius_m(float value) {
+  _internal_set_loiter_radius_m(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.action.GotoLocationFixedwingRequest.loiter_radius_m)
+}
+inline float GotoLocationFixedwingRequest::_internal_loiter_radius_m() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.loiter_radius_m_;
+}
+inline void GotoLocationFixedwingRequest::_internal_set_loiter_radius_m(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.loiter_radius_m_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// GotoLocationFixedwingResponse
+
+// .mavsdk.rpc.action.ActionResult action_result = 1;
+inline bool GotoLocationFixedwingResponse::has_action_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.action_result_ != nullptr);
+  return value;
+}
+inline void GotoLocationFixedwingResponse::clear_action_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.action_result_ != nullptr) _impl_.action_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::action::ActionResult& GotoLocationFixedwingResponse::_internal_action_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::action::ActionResult* p = _impl_.action_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::action::ActionResult&>(::mavsdk::rpc::action::_ActionResult_default_instance_);
+}
+inline const ::mavsdk::rpc::action::ActionResult& GotoLocationFixedwingResponse::action_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.action.GotoLocationFixedwingResponse.action_result)
+  return _internal_action_result();
+}
+inline void GotoLocationFixedwingResponse::unsafe_arena_set_allocated_action_result(::mavsdk::rpc::action::ActionResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.action_result_);
+  }
+  _impl_.action_result_ = reinterpret_cast<::mavsdk::rpc::action::ActionResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.action.GotoLocationFixedwingResponse.action_result)
+}
+inline ::mavsdk::rpc::action::ActionResult* GotoLocationFixedwingResponse::release_action_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::action::ActionResult* released = _impl_.action_result_;
+  _impl_.action_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::action::ActionResult* GotoLocationFixedwingResponse::unsafe_arena_release_action_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.action.GotoLocationFixedwingResponse.action_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::action::ActionResult* temp = _impl_.action_result_;
+  _impl_.action_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::action::ActionResult* GotoLocationFixedwingResponse::_internal_mutable_action_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.action_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::action::ActionResult>(GetArena());
+    _impl_.action_result_ = reinterpret_cast<::mavsdk::rpc::action::ActionResult*>(p);
+  }
+  return _impl_.action_result_;
+}
+inline ::mavsdk::rpc::action::ActionResult* GotoLocationFixedwingResponse::mutable_action_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::action::ActionResult* _msg = _internal_mutable_action_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.action.GotoLocationFixedwingResponse.action_result)
+  return _msg;
+}
+inline void GotoLocationFixedwingResponse::set_allocated_action_result(::mavsdk::rpc::action::ActionResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.action_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.action_result_ = reinterpret_cast<::mavsdk::rpc::action::ActionResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.action.GotoLocationFixedwingResponse.action_result)
 }
 
 // -------------------------------------------------------------------

--- a/cpp/src/mavsdk_server/src/plugins/action/action_service_impl.hpp
+++ b/cpp/src/mavsdk_server/src/plugins/action/action_service_impl.hpp
@@ -501,13 +501,13 @@ public:
             
         
         auto result = _lazy_plugin.maybe_plugin()->goto_location(request->latitude_deg(), request->longitude_deg(), request->absolute_altitude_m(), request->yaw_deg());
+        
 
-
-
+        
         if (response != nullptr) {
             fillResponseWithResult(response, result);
         }
-
+        
 
         return grpc::Status::OK;
     }
@@ -518,12 +518,12 @@ public:
         rpc::action::GotoLocationFixedwingResponse* response) override
     {
         if (_lazy_plugin.maybe_plugin() == nullptr) {
-
+            
             if (response != nullptr) {
                 auto result = mavsdk::Action::Result::NoSystem;
                 fillResponseWithResult(response, result);
             }
-
+            
             return grpc::Status::OK;
         }
 
@@ -531,22 +531,22 @@ public:
             LogWarn("GotoLocationFixedwing sent with a null request! Ignoring...");
             return grpc::Status::OK;
         }
-
-
-
-
-
-
-
-
+            
+        
+            
+        
+            
+        
+            
+        
         auto result = _lazy_plugin.maybe_plugin()->goto_location_fixedwing(request->latitude_deg(), request->longitude_deg(), request->absolute_altitude_m(), request->loiter_radius_m());
+        
 
-
-
+        
         if (response != nullptr) {
             fillResponseWithResult(response, result);
         }
-
+        
 
         return grpc::Status::OK;
     }

--- a/cpp/src/mavsdk_server/src/plugins/action/action_service_impl.hpp
+++ b/cpp/src/mavsdk_server/src/plugins/action/action_service_impl.hpp
@@ -501,13 +501,52 @@ public:
             
         
         auto result = _lazy_plugin.maybe_plugin()->goto_location(request->latitude_deg(), request->longitude_deg(), request->absolute_altitude_m(), request->yaw_deg());
-        
 
-        
+
+
         if (response != nullptr) {
             fillResponseWithResult(response, result);
         }
-        
+
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status GotoLocationFixedwing(
+        grpc::ServerContext* /* context */,
+        const rpc::action::GotoLocationFixedwingRequest* request,
+        rpc::action::GotoLocationFixedwingResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+
+            if (response != nullptr) {
+                auto result = mavsdk::Action::Result::NoSystem;
+                fillResponseWithResult(response, result);
+            }
+
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("GotoLocationFixedwing sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+
+
+
+
+
+
+
+
+        auto result = _lazy_plugin.maybe_plugin()->goto_location_fixedwing(request->latitude_deg(), request->longitude_deg(), request->absolute_altitude_m(), request->loiter_radius_m());
+
+
+
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+
 
         return grpc::Status::OK;
     }

--- a/docs/en/cpp/api_reference/classmavsdk_1_1_action.md
+++ b/docs/en/cpp/api_reference/classmavsdk_1_1_action.md
@@ -50,6 +50,8 @@ void | [return_to_launch_async](#classmavsdk_1_1_action_1abe5bd426de588b246644ee
 [Result](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1adc2e13257ef13de0e7610cf879a0ec51) | [return_to_launch](#classmavsdk_1_1_action_1afd7c225df0495b0947f00e7d2dd64877) () const | Send command to return to the launch (takeoff) position and land.
 void | [goto_location_async](#classmavsdk_1_1_action_1a6fd615e5571d6e7e3c53a79d2160ffc5) (double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg, const [ResultCallback](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a70a7b6e742d0c86728dc2e1827dacccd) callback) | Send command to move the vehicle to a specific global position.
 [Result](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1adc2e13257ef13de0e7610cf879a0ec51) | [goto_location](#classmavsdk_1_1_action_1afb3546fa994357e491816f2032716818) (double latitude_deg, double longitude_deg, float absolute_altitude_m, float yaw_deg)const | Send command to move the vehicle to a specific global position.
+void | [goto_location_fixedwing_async](#classmavsdk_1_1_action_1a190e73b01370e11c65d3ac8d799f39c7) (double latitude_deg, double longitude_deg, float absolute_altitude_m, float loiter_radius_m, const [ResultCallback](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a70a7b6e742d0c86728dc2e1827dacccd) callback) | Send command to the drone to fly to a location for fixed-wing aircraft.
+[Result](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1adc2e13257ef13de0e7610cf879a0ec51) | [goto_location_fixedwing](#classmavsdk_1_1_action_1a775ba7387dd5a4018606da2892c5f041) (double latitude_deg, double longitude_deg, float absolute_altitude_m, float loiter_radius_m)const | Send command to the drone to fly to a location for fixed-wing aircraft.
 void | [do_orbit_async](#classmavsdk_1_1_action_1aac9a2ac57a6e8f734b25c2e6dc0729ba) (float radius_m, float velocity_ms, [OrbitYawBehavior](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1ad9dd7c5e85dda1ae188df75998375c92) yaw_behavior, double latitude_deg, double longitude_deg, double absolute_altitude_m, const [ResultCallback](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a70a7b6e742d0c86728dc2e1827dacccd) callback) | Send command do orbit to the drone.
 [Result](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1adc2e13257ef13de0e7610cf879a0ec51) | [do_orbit](#classmavsdk_1_1_action_1ac7447a86016bee3576643563079288b9) (float radius_m, float velocity_ms, [OrbitYawBehavior](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1ad9dd7c5e85dda1ae188df75998375c92) yaw_behavior, double latitude_deg, double longitude_deg, double absolute_altitude_m)const | Send command do orbit to the drone.
 void | [hold_async](#classmavsdk_1_1_action_1aad198c883e7ace1cf4556c3b15bd8ad8) (const [ResultCallback](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a70a7b6e742d0c86728dc2e1827dacccd) callback) | Send command to hold position (a.k.a. "Loiter").
@@ -624,6 +626,63 @@ This function is blocking. See 'goto_location_async' for the non-blocking counte
 * double **longitude_deg** - 
 * float **absolute_altitude_m** - 
 * float **yaw_deg** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1adc2e13257ef13de0e7610cf879a0ec51) - Result of request.
+
+### goto_location_fixedwing_async() {#classmavsdk_1_1_action_1a190e73b01370e11c65d3ac8d799f39c7}
+```cpp
+void mavsdk::Action::goto_location_fixedwing_async(double latitude_deg, double longitude_deg, float absolute_altitude_m, float loiter_radius_m, const ResultCallback callback)
+```
+
+
+Send command to the drone to fly to a location for fixed-wing aircraft.
+
+This sends a MAV_CMD_DO_REPOSITION command with a loiter radius.
+
+
+The latitude and longitude are given in degrees (WGS84 frame) and the altitude in meters AMSL (above mean sea level).
+
+
+The loiter radius defines the radius of the loiter circle in meters, and its sign controls the direction: positive is clockwise, negative is counter-clockwise. A value of 0 is ignored by the autopilot.
+
+
+This function is non-blocking. See 'goto_location_fixedwing' for the blocking counterpart.
+
+**Parameters**
+
+* double **latitude_deg** - 
+* double **longitude_deg** - 
+* float **absolute_altitude_m** - 
+* float **loiter_radius_m** - 
+* const [ResultCallback](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a70a7b6e742d0c86728dc2e1827dacccd) **callback** - 
+
+### goto_location_fixedwing() {#classmavsdk_1_1_action_1a775ba7387dd5a4018606da2892c5f041}
+```cpp
+Result mavsdk::Action::goto_location_fixedwing(double latitude_deg, double longitude_deg, float absolute_altitude_m, float loiter_radius_m) const
+```
+
+
+Send command to the drone to fly to a location for fixed-wing aircraft.
+
+This sends a MAV_CMD_DO_REPOSITION command with a loiter radius.
+
+
+The latitude and longitude are given in degrees (WGS84 frame) and the altitude in meters AMSL (above mean sea level).
+
+
+The loiter radius defines the radius of the loiter circle in meters, and its sign controls the direction: positive is clockwise, negative is counter-clockwise. A value of 0 is ignored by the autopilot.
+
+
+This function is blocking. See 'goto_location_fixedwing_async' for the non-blocking counterpart.
+
+**Parameters**
+
+* double **latitude_deg** - 
+* double **longitude_deg** - 
+* float **absolute_altitude_m** - 
+* float **loiter_radius_m** - 
 
 **Returns**
 

--- a/jni/jvm/src/main/java/io/mavsdk/jni/plugins/action/NativeAction.java
+++ b/jni/jvm/src/main/java/io/mavsdk/jni/plugins/action/NativeAction.java
@@ -70,6 +70,11 @@ public final class NativeAction {
     }
 
     @FunctionalInterface
+    public interface GotoLocationFixedwingCallback {
+        void invoke(int result);
+    }
+
+    @FunctionalInterface
     public interface DoOrbitCallback {
         void invoke(int result);
     }
@@ -171,6 +176,10 @@ public final class NativeAction {
     public static native int gotoLocation(long pluginHandle, double latitudeDeg, double longitudeDeg, float absoluteAltitudeM, float yawDeg);
 
     public static native void gotoLocationAsync(long pluginHandle, double latitudeDeg, double longitudeDeg, float absoluteAltitudeM, float yawDeg, GotoLocationCallback callback);
+
+    public static native int gotoLocationFixedwing(long pluginHandle, double latitudeDeg, double longitudeDeg, float absoluteAltitudeM, float loiterRadiusM);
+
+    public static native void gotoLocationFixedwingAsync(long pluginHandle, double latitudeDeg, double longitudeDeg, float absoluteAltitudeM, float loiterRadiusM, GotoLocationFixedwingCallback callback);
 
     public static native int doOrbit(long pluginHandle, float radiusM, float velocityMs, int yawBehavior, double latitudeDeg, double longitudeDeg, double absoluteAltitudeM);
 

--- a/jni/plugins/action/action_jni.cpp
+++ b/jni/plugins/action/action_jni.cpp
@@ -385,6 +385,39 @@ struct GotoLocationCallbackWrapper {
         }
     }
 };
+struct GotoLocationFixedwingCallbackWrapper {
+    GlobalRefHolder callback;
+    jmethodID invokeMethod;
+
+    GotoLocationFixedwingCallbackWrapper(JNIEnv* env, jobject callbackObject)
+        : callback(env, callbackObject), invokeMethod(nullptr) {
+        if (callback.isValid()) {
+            jclass callbackClass = env->GetObjectClass(callbackObject);
+            invokeMethod = env->GetMethodID(callbackClass, "invoke", "(I)V");
+            env->DeleteLocalRef(callbackClass);
+        }
+    }
+
+    void operator()(
+        const mavsdk_action_result_t result    ) const {
+
+        if (!callback.isValid() || !invokeMethod || !g_jvm) {
+            return;
+        }
+        JavaVMAttacher attacher(g_jvm);
+        JNIEnv* env = attacher.getEnv();
+        if (!env) {
+            return;
+        }
+        env->CallVoidMethod(callback.get(), invokeMethod
+            , static_cast<jint>(result)
+        );
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+    }
+};
 struct DoOrbitCallbackWrapper {
     GlobalRefHolder callback;
     jmethodID invokeMethod;
@@ -1210,6 +1243,60 @@ Java_io_mavsdk_jni_plugins_action_NativeAction_gotoLocationAsync(
         [](const mavsdk_action_result_t result, void* userData) {
             auto* callbackWrapper =
                 static_cast<GotoLocationCallbackWrapper*>(userData);
+            (*callbackWrapper)(result);
+            delete callbackWrapper;
+        },
+        wrapper);
+}
+
+JNIEXPORT
+jint
+JNICALL Java_io_mavsdk_jni_plugins_action_NativeAction_gotoLocationFixedwing(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jdouble latitude_deg,
+    jdouble longitude_deg,
+    jfloat absolute_altitude_m,
+    jfloat loiter_radius_m) {
+    if (!requireHandle(env, handle, "Action plugin")) {
+        return {};
+    }
+
+    mavsdk_action_result_t result =
+        mavsdk_action_goto_location_fixedwing(
+            reinterpret_cast<mavsdk_action_t>(handle),
+            static_cast<double>(latitude_deg),
+            static_cast<double>(longitude_deg),
+            static_cast<float>(absolute_altitude_m),
+            static_cast<float>(loiter_radius_m));
+    return static_cast<jint>(result);
+}
+
+JNIEXPORT void JNICALL
+Java_io_mavsdk_jni_plugins_action_NativeAction_gotoLocationFixedwingAsync(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jdouble latitude_deg,
+    jdouble longitude_deg,
+    jfloat absolute_altitude_m,
+    jfloat loiter_radius_m,
+    jobject callback) {
+    if (!requireHandle(env, handle, "Action plugin") || !callback) {
+        return;
+    }
+
+    auto* wrapper = new GotoLocationFixedwingCallbackWrapper(env, callback);
+    mavsdk_action_goto_location_fixedwing_async(
+        reinterpret_cast<mavsdk_action_t>(handle),
+        static_cast<double>(latitude_deg),
+        static_cast<double>(longitude_deg),
+        static_cast<float>(absolute_altitude_m),
+        static_cast<float>(loiter_radius_m),
+        [](const mavsdk_action_result_t result, void* userData) {
+            auto* callbackWrapper =
+                static_cast<GotoLocationFixedwingCallbackWrapper*>(userData);
             (*callbackWrapper)(result);
             delete callbackWrapper;
         },

--- a/kt/mavsdk-kotlin/src/commonMain/kotlin/io/mavsdk/kotlin/plugins/action/Action.kt
+++ b/kt/mavsdk-kotlin/src/commonMain/kotlin/io/mavsdk/kotlin/plugins/action/Action.kt
@@ -297,6 +297,45 @@ class Action internal constructor(private val native: ActionNative) {
     }
 
     /**
+     * Send command to the drone to fly to a location for fixed-wing aircraft.
+     *
+     * This sends a MAV_CMD_DO_REPOSITION command with a loiter radius.
+     *
+     * The latitude and longitude are given in degrees (WGS84 frame) and the altitude in meters AMSL
+     * (above mean sea level).
+     *
+     * The loiter radius defines the radius of the loiter circle in meters, and its sign controls
+     * the direction: positive is clockwise, negative is counter-clockwise. A value of 0 is ignored
+     * by the autopilot.
+     *
+     * @param latitudeDeg Latitude (in degrees)
+     * @param longitudeDeg Longitude (in degrees)
+     * @param absoluteAltitudeM Altitude AMSL (in meters)
+     * @param loiterRadiusM Loiter radius (in meters). Positive: clockwise, negative:
+     *   counter-clockwise, 0: ignored.
+     * @return The result of the request.
+     */
+    suspend fun gotoLocationFixedwing(
+        latitudeDeg: Double,
+        longitudeDeg: Double,
+        absoluteAltitudeM: Float,
+        loiterRadiusM: Float,
+    ): Result = suspendCancellableCoroutine { continuation ->
+        val callbackGuard = ActionCallbackGuard()
+        native.gotoLocationFixedwingAsync(
+            latitudeDeg,
+            longitudeDeg,
+            absoluteAltitudeM,
+            loiterRadiusM,
+        ) { result ->
+            val parsedResult = Result.fromValue(result)
+            if (continuation.isActive && true && callbackGuard.tryClaim()) {
+                continuation.resume(parsedResult)
+            }
+        }
+    }
+
+    /**
      * Send command do orbit to the drone.
      *
      * This will run the orbit routine with the given parameters.
@@ -615,6 +654,14 @@ internal interface ActionNative {
         longitudeDeg: Double,
         absoluteAltitudeM: Float,
         yawDeg: Float,
+        callback: (Int) -> Unit,
+    )
+
+    fun gotoLocationFixedwingAsync(
+        latitudeDeg: Double,
+        longitudeDeg: Double,
+        absoluteAltitudeM: Float,
+        loiterRadiusM: Float,
         callback: (Int) -> Unit,
     )
 

--- a/kt/mavsdk-kotlin/src/jvmAndroidMain/kotlin/io/mavsdk/kotlin/plugins/action/ActionNative.kt
+++ b/kt/mavsdk-kotlin/src/jvmAndroidMain/kotlin/io/mavsdk/kotlin/plugins/action/ActionNative.kt
@@ -123,6 +123,25 @@ private class ActionNativeImpl(private val handle: Long) : ActionNative {
         }
     }
 
+    override fun gotoLocationFixedwingAsync(
+        latitudeDeg: Double,
+        longitudeDeg: Double,
+        absoluteAltitudeM: Float,
+        loiterRadiusM: Float,
+        callback: (Int) -> Unit,
+    ) {
+        withOpen {
+            NativeAction.gotoLocationFixedwingAsync(
+                handle,
+                latitudeDeg,
+                longitudeDeg,
+                absoluteAltitudeM,
+                loiterRadiusM,
+                NativeAction.GotoLocationFixedwingCallback { result -> callback(result) },
+            )
+        }
+    }
+
     override fun doOrbitAsync(
         radiusM: Float,
         velocityMs: Float,

--- a/py/aiomavsdk/aiomavsdk/plugins/action/action.py
+++ b/py/aiomavsdk/aiomavsdk/plugins/action/action.py
@@ -223,6 +223,40 @@ class ActionAsync:
             ),
         )
 
+    async def goto_location_fixedwing(
+        self, latitude_deg, longitude_deg, absolute_altitude_m, loiter_radius_m
+    ):
+        """
+               Send command to the drone to fly to a location for fixed-wing aircraft.
+
+        This sends a MAV_CMD_DO_REPOSITION command with a loiter radius.
+
+        The latitude and longitude are given in degrees (WGS84 frame) and the altitude
+        in meters AMSL (above mean sea level).
+
+        The loiter radius defines the radius of the loiter circle in meters, and its sign
+        controls the direction: positive is clockwise, negative is counter-clockwise.
+        A value of 0 is ignored by the autopilot.
+
+               Parameters
+               ----------
+               latitude_deg : float
+               longitude_deg : float
+               absolute_altitude_m : float
+               loiter_radius_m : float
+               Raises
+               ------
+               ActionError
+                   If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None,
+            lambda: self._plugin.goto_location_fixedwing(
+                latitude_deg, longitude_deg, absolute_altitude_m, loiter_radius_m
+            ),
+        )
+
     async def do_orbit(
         self,
         radius_m,

--- a/py/mavsdk/mavsdk/plugins/action/action.py
+++ b/py/mavsdk/mavsdk/plugins/action/action.py
@@ -463,6 +463,66 @@ class Action:
 
         return result
 
+    def goto_location_fixedwing_async(
+        self,
+        latitude_deg,
+        longitude_deg,
+        absolute_altitude_m,
+        loiter_radius_m,
+        callback: Callable,
+        user_data: Any = None,
+    ):
+        """Send command to the drone to fly to a location for fixed-wing aircraft.
+
+        This sends a MAV_CMD_DO_REPOSITION command with a loiter radius.
+
+        The latitude and longitude are given in degrees (WGS84 frame) and the altitude
+        in meters AMSL (above mean sea level).
+
+        The loiter radius defines the radius of the loiter circle in meters, and its sign
+        controls the direction: positive is clockwise, negative is counter-clockwise.
+        A value of 0 is ignored by the autopilot."""
+
+        def c_callback(result, ud):
+            try:
+                py_result = ActionResult(result)
+
+                callback(py_result, user_data)
+
+            except Exception as e:
+                print(f"Error in goto_location_fixedwing callback: {e}")
+
+        cb = GotoLocationFixedwingCallback(c_callback)
+        self._callbacks.append(cb)
+
+        self._lib.mavsdk_action_goto_location_fixedwing_async(
+            self._handle,
+            latitude_deg,
+            longitude_deg,
+            absolute_altitude_m,
+            loiter_radius_m,
+            cb,
+            None,
+        )
+
+    def goto_location_fixedwing(
+        self, latitude_deg, longitude_deg, absolute_altitude_m, loiter_radius_m
+    ):
+        """Get goto_location_fixedwing (blocking)"""
+
+        result_code = self._lib.mavsdk_action_goto_location_fixedwing(
+            self._handle,
+            latitude_deg,
+            longitude_deg,
+            absolute_altitude_m,
+            loiter_radius_m,
+        )
+        result = ActionResult(result_code)
+        if result != ActionResult.SUCCESS:
+            raise Exception(f"goto_location_fixedwing failed: {result}")
+
+        return result
+
     def do_orbit_async(
         self,
         radius_m,
@@ -932,6 +992,7 @@ TerminateCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
 KillCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
 ReturnToLaunchCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
 GotoLocationCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
+GotoLocationFixedwingCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
 DoOrbitCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
 HoldCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
 SetActuatorCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
@@ -1112,6 +1173,27 @@ _cmavsdk_lib.mavsdk_action_goto_location.argtypes = [
 ]
 
 _cmavsdk_lib.mavsdk_action_goto_location.restype = ctypes.c_int
+_cmavsdk_lib.mavsdk_action_goto_location_fixedwing_async.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_double,
+    ctypes.c_double,
+    ctypes.c_float,
+    ctypes.c_float,
+    GotoLocationFixedwingCallback,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_action_goto_location_fixedwing_async.restype = None
+
+_cmavsdk_lib.mavsdk_action_goto_location_fixedwing.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_double,
+    ctypes.c_double,
+    ctypes.c_float,
+    ctypes.c_float,
+]
+
+_cmavsdk_lib.mavsdk_action_goto_location_fixedwing.restype = ctypes.c_int
 _cmavsdk_lib.mavsdk_action_do_orbit_async.argtypes = [
     ctypes.c_void_p,
     ctypes.c_float,


### PR DESCRIPTION
## Summary

Adds the `goto_location_fixedwing` action, a fixed-wing-friendly variant of `goto_location` that accepts a `loiter_radius_m` parameter instead of a yaw angle. Under the hood it sends `MAV_CMD_DO_REPOSITION` with param3 = loiter radius (positive: clockwise, negative: counter-clockwise, 0: ignored by the autopilot) and param4 (yaw) = NaN, since yaw isn't meaningful while a fixed-wing aircraft is continuously turning in a loiter.

Mirrors mavlink/MAVSDK-Proto#412.

## Changes

- `cpp/src/mavsdk/plugins/action/action_impl.cpp`/`.hpp`: new `goto_location_fixedwing`/`goto_location_fixedwing_async`, packing `MAV_CMD_DO_REPOSITION` with the loiter radius on param3 and NaN yaw on param4. Reuses the existing PX4/ArduPilot flight-mode gating before sending the command.
- `cpp/src/mavsdk/plugins/action/action.cpp`/`include/plugins/action/action.hpp`: public API wrappers, matching `goto_location`'s pattern.
- `cpp/src/mavsdk/plugins/action/mocks/action_mock.hpp`: mock method for unit tests.
- `cpp/src/mavsdk_server/src/plugins/action/action_service_impl.hpp`: gRPC server translation for the new `GotoLocationFixedwing` RPC.
- `proto` submodule: pinned to MAVSDK-Proto#412's branch head so this compiles against the new `GotoLocationFixedwingRequest`/`Response` messages. **This needs to be updated to MAVSDK-Proto's `main` once #412 merges.**

Closes #2853.

## Test plan

- [ ] MAVSDK-Proto#412 merges and the `proto` submodule pointer here is updated to `main`
- [ ] CI build passes (C++ core + mavsdk_server gRPC layer)
- [ ] Manual SITL check: `action.goto_location_fixedwing(...)` on a fixed-wing airframe holds a loiter of the commanded radius/direction at the target location

I wasn't able to do a full local build/test — the `proto` submodule isn't populated in this environment and MAVSDK-Proto#412 (which defines the new messages) isn't merged yet, so the gRPC layer can't be compiled here. The core plugin changes follow the exact pattern of the neighboring `goto_location` implementation.